### PR TITLE
test: add shared sample_user_profile fixture (#106)

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,44 @@
+# PathReview — Module 3 Journal
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/jamjamgobambam/pathreview/issues/106
+
+**Issue title:** Shared test fixture for a sample user profile is missing from `tests/fixtures/`
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The test suite has no reusable fixture representing a sample user profile, so
+tests that need profile data either invent ad-hoc `Mock` objects or duplicate
+setup. For example, `tests/unit/test_review_service.py` defines its own local
+`mock_profile` fixture, and `tests/conftest.py` only provides `sample_resume_text`
+and `sample_readme_text` — there is no shared profile fixture and no
+`tests/fixtures/` directory at all. This affects the test layer around the
+`Profile` model in `core/models/profile.py` (fields: `id`, `user_id`,
+`github_username`, `resume_filename`, `resume_text`, `portfolio_url`,
+`created_at`, `updated_at`). A successful fix adds a shared `sample_user_profile`
+fixture that mirrors the real `Profile` schema, so any test can depend on
+consistent, realistic profile data instead of redefining it, reducing
+duplication and drift.
+
+**"Is this right for me?" checklist notes:**
+- **Scope** — Small and well-bounded: add one shared fixture (plus a short test
+  that consumes it). No production code changes required.
+- **Effort** — Matches the Tier 1 estimate; a single self-contained fixture.
+- **Dependencies** — None external. Runs entirely under `pytest`; no DB, API
+  keys, or services needed since the fixture is in-memory data.
+- **Understanding** — I verified the gap directly: no `tests/fixtures/` dir and
+  no profile fixture in `conftest.py`. I read the `Profile` model to know exactly
+  which fields the fixture should carry.
+- **Verification** — I can prove it works with `make test-unit`.
+
+**Branch name:** `test/106-sample-user-profile-fixture`
+
+**Setup confirmation:** [ ] App runs locally at localhost:5173
+<!-- Not yet verified: initial `make setup` stopped at the DB migration step
+because the Docker services were not running. Will re-run `docker compose up -d`
+then `make setup`, confirm http://localhost:5173, and check this box. -->
+
+**Cohort ledger:** [ ] Issue added to cohort ledger
+<!-- To be completed from my GitHub account using the instructor-provided ledger link. -->

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -42,3 +42,26 @@ then `make setup`, confirm http://localhost:5173, and check this box. -->
 
 **Cohort ledger:** [ ] Issue added to cohort ledger
 <!-- To be completed from my GitHub account using the instructor-provided ledger link. -->
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/sravanibhamidipaty/pathreview/commit/40761cc6a4243ed83c4bf3cbe91192496f449cbb
+
+**Reproduction summary:**
+I added a unit test (`tests/unit/test_sample_user_profile_fixture.py`) that
+requests a `sample_user_profile` fixture and ran it with `pytest`. It fails at
+setup with `fixture 'sample_user_profile' not found`, and the reported available
+fixtures list shows only `sample_readme_text` and `sample_resume_text` — proving
+the shared profile fixture is genuinely missing from `tests/conftest.py`.
+
+**PLAN.md link:** https://github.com/sravanibhamidipaty/pathreview/blob/test/106-sample-user-profile-fixture/PLAN.md
+
+**Walkthrough video (recommended):** _(not recorded)_
+
+**Blockers or open questions:**
+Open question for the maintainer: the issue title says the fixture should live in
+`tests/fixtures/`, but the existing sample fixtures (`sample_resume_text`,
+`sample_readme_text`) live in `tests/conftest.py`. I plan to follow the current
+`conftest.py` convention and confirm in the PR. Also deciding whether the fixture
+should return a transient `Profile` ORM instance vs. a plain dict — leaning toward
+the `Profile` instance for production parity.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -65,3 +65,56 @@ Open question for the maintainer: the issue title says the fixture should live i
 `conftest.py` convention and confirm in the PR. Also deciding whether the fixture
 should return a transient `Profile` ORM instance vs. a plain dict — leaning toward
 the `Profile` instance for production parity.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the core of the fix from PLAN.md. Sub-tasks 1–3 are done: decided the
+fixture returns a transient `Profile` ORM instance (production parity, no DB
+needed), added the `sample_user_profile` fixture to `tests/conftest.py`, and
+converted the Week 8 reproduction test into a passing verification test
+(`tests/unit/test_sample_user_profile_fixture.py`, 4 assertions covering type,
+all fields non-null, valid UUIDs, and timezone-aware timestamps).
+
+**Next steps:**
+Run the full `make check` / `make test-unit` gates to confirm no new failures,
+open a draft PR for peer feedback, and finalize the PR description. Sub-task 4
+(refactoring `test_review_service.py::mock_profile` to reuse the fixture) is
+optional — deferring it to keep this PR focused and avoid entangling with that
+file's pre-existing failures.
+
+**Blockers:**
+None. Noted that the repo ships with many pre-existing failures unrelated to
+#106; documenting them so they aren't mistaken for regressions.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/jamjamgobambam/pathreview/pull/133
+<!-- Currently opened as a DRAFT for peer feedback. Mark "Ready for review"
+before the deadline once peer/mentor feedback is addressed. -->
+
+**Branch:** `test/106-sample-user-profile-fixture`
+
+**What you built:**
+A shared `sample_user_profile` pytest fixture in `tests/conftest.py` that returns
+a deterministic, in-memory `Profile` model instance with realistic, non-null
+values for every column. Any test can now inject consistent profile data via the
+`sample_user_profile` parameter instead of hand-rolling mocks.
+
+**Tests added or updated:**
+`tests/unit/test_sample_user_profile_fixture.py` — 4 unit tests asserting the
+fixture is a `Profile` instance, exposes all fields non-null, uses valid UUID
+strings for `id`/`user_id`, and uses timezone-aware `created_at`/`updated_at`.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+<!-- Interpreted per the assignment for a codebase with documented pre-existing
+failures: my changes introduce NO new failures. Baseline before my change:
+53 failing / 375 passing unit tests; ruff ~182 errors; mypy stub errors — all
+pre-existing and unrelated to #106. After my change: same 53 failing, 379 passing
+(4 new tests). My changed files pass ruff, black, and the mypy pre-commit hook. -->
+
+**Draft PR feedback received from:** none yet (draft opened for peer/mentor review)

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,90 @@
+## Solution plan
+
+**Issue:** Shared test fixture for a sample user profile is missing from `tests/fixtures/` — https://github.com/jamjamgobambam/pathreview/issues/106
+
+### Understand
+The test suite lacks a shared, reusable fixture that represents a realistic user
+profile. Today, tests that need profile data either build one-off `Mock` objects
+(e.g. the local `mock_profile` fixture in `tests/unit/test_review_service.py`) or
+go without. The shared `tests/conftest.py` only exposes `sample_resume_text` and
+`sample_readme_text`, and there is no `tests/fixtures/` directory at all.
+
+- **Expected:** A shared `sample_user_profile` fixture is available to every test,
+  exposing the fields defined on the `Profile` model so tests can rely on
+  consistent, realistic data.
+- **Actual:** No such fixture exists. A test that requests `sample_user_profile`
+  errors at setup with `fixture 'sample_user_profile' not found` (see the Week 8
+  reproduction commit `tests/unit/test_sample_user_profile_fixture.py`).
+
+Root cause: the fixture was simply never authored; it is a missing test-support
+asset, not a code bug.
+
+### Map
+Files/modules involved:
+- `tests/conftest.py` — **add** the new `sample_user_profile` fixture here so it
+  is shared across the whole suite (this is where the existing sample fixtures
+  live). Primary file I expect to touch.
+- `core/models/profile.py` — **read-only reference** for the exact field set:
+  `id`, `user_id`, `github_username`, `resume_filename`, `resume_text`,
+  `portfolio_url`, `created_at`, `updated_at`.
+- `tests/unit/test_sample_user_profile_fixture.py` — **update** the Week 8
+  reproduction test into a real assertion test that the fixture matches the
+  `Profile` shape (turns the failing repro green).
+- `tests/unit/test_review_service.py` — **optional follow-up**: its local
+  `mock_profile` could be replaced by the shared fixture to prove reuse (only if
+  low-risk).
+
+### Plan
+1. Decide the fixture's return shape. Return a real transient
+   `core.models.profile.Profile` instance (not persisted to a DB) populated with
+   deterministic sample values, so consumers get the same attribute access as
+   production code. Document the choice in the fixture docstring.
+2. Implement the `sample_user_profile` fixture in `tests/conftest.py` with fixed,
+   readable values (e.g. `github_username="janedoe"`, a stable UUID string for
+   `id`/`user_id`, a short `resume_text`, a `portfolio_url`).
+3. Convert `tests/unit/test_sample_user_profile_fixture.py` from a reproduction
+   into a passing verification test that asserts every `Profile` field is present
+   and correctly typed.
+4. (Optional) Refactor `test_review_service.py::mock_profile` to consume the
+   shared fixture, demonstrating reuse without changing test behavior.
+5. Run `make check` (ruff + black + mypy) and `make test-unit`; confirm the
+   previously failing test now passes and nothing else regresses.
+
+### Inputs & outputs
+- **Input:** None at runtime — the fixture takes no arguments; it produces
+  in-memory sample data. (If it returns a `Profile` instance, it depends only on
+  importing the model, not on a database session.)
+- **Output:** A `sample_user_profile` object exposing all `Profile` fields with
+  deterministic values, injectable into any test via the `sample_user_profile`
+  parameter.
+- **Net change:** New fixture in `conftest.py`; one reproduction test flips from
+  ERROR to PASS.
+
+### Risks & unknowns
+- **Return-shape decision (`Profile` instance vs. dict vs. Pydantic schema).**
+  Returning a `Profile` ORM instance is closest to production but could surprise
+  tests expecting a mapping. Mitigation: pick the ORM instance, document it, and
+  keep the verification test's assertions attribute-based.
+- **Constructing `Profile` without a DB session.** SQLAlchemy models can be
+  instantiated as transient objects, but `created_at`/`updated_at` column
+  defaults only apply on flush. Mitigation: set `created_at`/`updated_at`
+  explicitly in the fixture so they are always populated.
+- **mypy strictness.** The pre-commit `mypy` hook rejects untyped defs (already
+  hit this once). Mitigation: fully annotate the fixture signature and return type.
+- **Unknown:** whether maintainers expect the fixture to live in `conftest.py`
+  (matching current convention) or literally under a new `tests/fixtures/`
+  directory as the issue title implies. Mitigation: follow the existing
+  `conftest.py` convention and note the choice in the PR description for reviewer
+  confirmation.
+
+### Edge cases
+- A consumer accessing `resume_filename`/`resume_text` when they are `None` — the
+  fixture should provide non-null sample values so nullable fields are exercised
+  with realistic data, while still matching the `str | None` types.
+- UUID fields (`id`, `user_id`) must be valid UUID strings, matching the model's
+  `UUID(as_uuid=False)` column type, so tests that parse or compare them don't
+  break.
+- Timestamp fields (`created_at`, `updated_at`) must be timezone-aware
+  `datetime` values, matching `DateTime(timezone=True)`.
+- Fixture must remain deterministic across runs (no random values that would make
+  assertions flaky).

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,35 @@
 """Shared test fixtures for PathReview."""
 
+from datetime import UTC, datetime
+
 import pytest
+
+from core.models.profile import Profile
+
+
+@pytest.fixture
+def sample_user_profile() -> Profile:
+    """Return a sample ``Profile`` instance for testing.
+
+    Provides a deterministic, in-memory :class:`core.models.profile.Profile`
+    (not persisted to a database) populated with realistic, non-null values for
+    every column on the model. Shared here so tests that need profile data can
+    depend on consistent sample values instead of building ad-hoc mocks.
+    """
+    created = datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
+    return Profile(
+        id="11111111-1111-4111-8111-111111111111",
+        user_id="22222222-2222-4222-8222-222222222222",
+        github_username="janedoe",
+        resume_filename="jane_doe_resume.pdf",
+        resume_text=(
+            "Jane Doe — Software Engineer. Built REST APIs with Python, "
+            "FastAPI, React, and PostgreSQL."
+        ),
+        portfolio_url="https://janedoe.dev",
+        created_at=created,
+        updated_at=created,
+    )
 
 
 @pytest.fixture

--- a/tests/unit/test_sample_user_profile_fixture.py
+++ b/tests/unit/test_sample_user_profile_fixture.py
@@ -1,0 +1,32 @@
+"""Reproduction for issue #106 — missing shared `sample_user_profile` fixture.
+
+https://github.com/jamjamgobambam/pathreview/issues/106
+
+This test documents the gap: there is no shared `sample_user_profile` fixture
+in `tests/conftest.py` (nor a `tests/fixtures/` directory). Running this test
+therefore fails at collection/setup with:
+
+    E       fixture 'sample_user_profile' not found
+
+Once the fixture is added in the Week 9 fix, this test should pass by asserting
+the fixture exposes the fields defined on `core.models.profile.Profile`.
+"""
+
+from typing import Any
+
+import pytest
+
+
+@pytest.mark.unit
+def test_sample_user_profile_fixture_is_available(sample_user_profile: Any) -> None:
+    """A shared sample user profile fixture should exist and expose Profile fields."""
+    # These are the fields defined on core/models/profile.py::Profile.
+    for field in (
+        "id",
+        "user_id",
+        "github_username",
+        "resume_filename",
+        "resume_text",
+        "portfolio_url",
+    ):
+        assert hasattr(sample_user_profile, field) or field in sample_user_profile

--- a/tests/unit/test_sample_user_profile_fixture.py
+++ b/tests/unit/test_sample_user_profile_fixture.py
@@ -1,32 +1,58 @@
-"""Reproduction for issue #106 — missing shared `sample_user_profile` fixture.
+"""Verification test for the shared ``sample_user_profile`` fixture (issue #106).
 
 https://github.com/jamjamgobambam/pathreview/issues/106
 
-This test documents the gap: there is no shared `sample_user_profile` fixture
-in `tests/conftest.py` (nor a `tests/fixtures/` directory). Running this test
-therefore fails at collection/setup with:
-
-    E       fixture 'sample_user_profile' not found
-
-Once the fixture is added in the Week 9 fix, this test should pass by asserting
-the fixture exposes the fields defined on `core.models.profile.Profile`.
+Originally this test reproduced the gap — requesting the fixture raised
+``fixture 'sample_user_profile' not found``. Now that the fixture exists in
+``tests/conftest.py``, this test verifies it exposes every field defined on
+``core.models.profile.Profile`` with the correct, non-null types.
 """
 
-from typing import Any
+from datetime import datetime
+from uuid import UUID
 
 import pytest
 
+from core.models.profile import Profile
+
+PROFILE_FIELDS = (
+    "id",
+    "user_id",
+    "github_username",
+    "resume_filename",
+    "resume_text",
+    "portfolio_url",
+    "created_at",
+    "updated_at",
+)
+
 
 @pytest.mark.unit
-def test_sample_user_profile_fixture_is_available(sample_user_profile: Any) -> None:
-    """A shared sample user profile fixture should exist and expose Profile fields."""
-    # These are the fields defined on core/models/profile.py::Profile.
-    for field in (
-        "id",
-        "user_id",
-        "github_username",
-        "resume_filename",
-        "resume_text",
-        "portfolio_url",
-    ):
-        assert hasattr(sample_user_profile, field) or field in sample_user_profile
+def test_sample_user_profile_is_a_profile_instance(sample_user_profile: Profile) -> None:
+    """The fixture returns a ``Profile`` model instance."""
+    assert isinstance(sample_user_profile, Profile)
+
+
+@pytest.mark.unit
+def test_sample_user_profile_exposes_all_fields(sample_user_profile: Profile) -> None:
+    """Every column defined on ``Profile`` is present and populated (non-null)."""
+    for field in PROFILE_FIELDS:
+        assert hasattr(sample_user_profile, field), f"missing field: {field}"
+        assert getattr(sample_user_profile, field) is not None, f"null field: {field}"
+
+
+@pytest.mark.unit
+def test_sample_user_profile_ids_are_valid_uuids(sample_user_profile: Profile) -> None:
+    """``id`` and ``user_id`` are valid UUID strings (matching the model column)."""
+    UUID(sample_user_profile.id)
+    UUID(sample_user_profile.user_id)
+
+
+@pytest.mark.unit
+def test_sample_user_profile_timestamps_are_timezone_aware(
+    sample_user_profile: Profile,
+) -> None:
+    """``created_at``/``updated_at`` are timezone-aware datetimes."""
+    for ts in (sample_user_profile.created_at, sample_user_profile.updated_at):
+        assert isinstance(ts, datetime)
+        assert ts.tzinfo is not None


### PR DESCRIPTION
## Summary

The test suite had no shared fixture representing a user profile, so tests that
needed profile data built ad-hoc `Mock` objects (e.g. the local `mock_profile`
in `tests/unit/test_review_service.py`) while `tests/conftest.py` only provided
`sample_resume_text` and `sample_readme_text`. This PR adds a shared
`sample_user_profile` fixture so tests can depend on consistent, realistic
profile data that mirrors the real `Profile` model.

## Issue
Closes #106

## Changes
- Added a `sample_user_profile` fixture to `tests/conftest.py` that returns a
  deterministic, in-memory `core.models.profile.Profile` instance populated with
  non-null values for every column (`id`, `user_id`, `github_username`,
  `resume_filename`, `resume_text`, `portfolio_url`, `created_at`, `updated_at`).
- Added `tests/unit/test_sample_user_profile_fixture.py` verifying the fixture is
  a `Profile` instance, exposes all fields non-null, uses valid UUID strings for
  the ID columns, and uses timezone-aware datetimes for the timestamps.
- Followed the existing `conftest.py` convention for shared fixtures rather than
  creating a new `tests/fixtures/` directory (see note below).

## Testing
- [x] Unit tests pass (`make test-unit`) — *no new failures*; see pre-existing note
- [ ] Integration tests pass (`make test-integration`) — not run (requires Docker services)
- [x] Linter passes (`make lint`) — on changed files; see pre-existing note
- [x] Type checker passes (`make typecheck`) — on changed files; see pre-existing note
- [x] New/updated tests cover the changes

**New test results:** the 4 new tests pass. Suite went from 375 → 379 passing,
with the same 53 failures before and after my change (0 new failures, 0 new errors).

## Notes for Reviewers

**Convention choice:** the issue title mentions `tests/fixtures/`, but the repo's
existing sample fixtures live in `tests/conftest.py`. I followed that existing
convention so the fixture is auto-discovered suite-wide. Happy to relocate it to
`tests/fixtures/` if maintainers prefer.

**Pre-existing failures (unrelated to this change):** the repo currently ships
with failures that exist independently of #106. I recorded them before and after
my change:
- `make test-unit`: **53 pre-existing failures** (e.g. `test_pii_scrubber`,
  `test_resume_parser`, `test_review_service`, `test_skill_extractor`,
  `test_tech_detector`). Unchanged by this PR (375→379 passing as 4 new tests
  were added; still 53 failing).
- `make lint` (ruff): ~182 pre-existing errors across the repo; my changed files
  are clean (`ruff check` passes on them).
- `make typecheck` (mypy): pre-existing errors from missing third-party stubs;
  my changed files pass the project's pre-commit `mypy` hook.

This PR does not touch any of the pre-existing-failing modules and introduces no
new failures.
