### PR TITLE
test: add shared sample_user_profile fixture (#106)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,35 @@
 """Shared test fixtures for PathReview."""
 
+from datetime import UTC, datetime
+
 import pytest
+
+from core.models.profile import Profile
+
+
+@pytest.fixture
+def sample_user_profile() -> Profile:
+    """Return a sample ``Profile`` instance for testing.
+
+    Provides a deterministic, in-memory :class:`core.models.profile.Profile`
+    (not persisted to a database) populated with realistic, non-null values for
+    every column on the model. Shared here so tests that need profile data can
+    depend on consistent sample values instead of building ad-hoc mocks.
+    """
+    created = datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
+    return Profile(
+        id="11111111-1111-4111-8111-111111111111",
+        user_id="22222222-2222-4222-8222-222222222222",
+        github_username="janedoe",
+        resume_filename="jane_doe_resume.pdf",
+        resume_text=(
+            "Jane Doe — Software Engineer. Built REST APIs with Python, "
+            "FastAPI, React, and PostgreSQL."
+        ),
+        portfolio_url="https://janedoe.dev",
+        created_at=created,
+        updated_at=created,
+    )
 
 
 @pytest.fixture

--- a/tests/unit/test_sample_user_profile_fixture.py
+++ b/tests/unit/test_sample_user_profile_fixture.py
@@ -1,0 +1,58 @@
+"""Verification test for the shared ``sample_user_profile`` fixture (issue #106).
+
+https://github.com/jamjamgobambam/pathreview/issues/106
+
+Originally this test reproduced the gap — requesting the fixture raised
+``fixture 'sample_user_profile' not found``. Now that the fixture exists in
+``tests/conftest.py``, this test verifies it exposes every field defined on
+``core.models.profile.Profile`` with the correct, non-null types.
+"""
+
+from datetime import datetime
+from uuid import UUID
+
+import pytest
+
+from core.models.profile import Profile
+
+PROFILE_FIELDS = (
+    "id",
+    "user_id",
+    "github_username",
+    "resume_filename",
+    "resume_text",
+    "portfolio_url",
+    "created_at",
+    "updated_at",
+)
+
+
+@pytest.mark.unit
+def test_sample_user_profile_is_a_profile_instance(sample_user_profile: Profile) -> None:
+    """The fixture returns a ``Profile`` model instance."""
+    assert isinstance(sample_user_profile, Profile)
+
+
+@pytest.mark.unit
+def test_sample_user_profile_exposes_all_fields(sample_user_profile: Profile) -> None:
+    """Every column defined on ``Profile`` is present and populated (non-null)."""
+    for field in PROFILE_FIELDS:
+        assert hasattr(sample_user_profile, field), f"missing field: {field}"
+        assert getattr(sample_user_profile, field) is not None, f"null field: {field}"
+
+
+@pytest.mark.unit
+def test_sample_user_profile_ids_are_valid_uuids(sample_user_profile: Profile) -> None:
+    """``id`` and ``user_id`` are valid UUID strings (matching the model column)."""
+    UUID(sample_user_profile.id)
+    UUID(sample_user_profile.user_id)
+
+
+@pytest.mark.unit
+def test_sample_user_profile_timestamps_are_timezone_aware(
+    sample_user_profile: Profile,
+) -> None:
+    """``created_at``/``updated_at`` are timezone-aware datetimes."""
+    for ts in (sample_user_profile.created_at, sample_user_profile.updated_at):
+        assert isinstance(ts, datetime)
+        assert ts.tzinfo is not None


### PR DESCRIPTION
## Summary

The test suite had no shared fixture representing a user profile, so tests that
needed profile data built ad-hoc `Mock` objects (e.g. the local `mock_profile`
in `tests/unit/test_review_service.py`) while `tests/conftest.py` only provided
`sample_resume_text` and `sample_readme_text`. This PR adds a shared
`sample_user_profile` fixture so tests can depend on consistent, realistic
profile data that mirrors the real `Profile` model.

## Issue
Closes #106

## Changes
- Added a `sample_user_profile` fixture to `tests/conftest.py` that returns a
  deterministic, in-memory `core.models.profile.Profile` instance populated with
  non-null values for every column (`id`, `user_id`, `github_username`,
  `resume_filename`, `resume_text`, `portfolio_url`, `created_at`, `updated_at`).
- Added `tests/unit/test_sample_user_profile_fixture.py` verifying the fixture is
  a `Profile` instance, exposes all fields non-null, uses valid UUID strings for
  the ID columns, and uses timezone-aware datetimes for the timestamps.
- Followed the existing `conftest.py` convention for shared fixtures rather than
  creating a new `tests/fixtures/` directory (see note below).

## Testing
- [x] Unit tests pass (`make test-unit`) — *no new failures*; see pre-existing note
- [ ] Integration tests pass (`make test-integration`) — not run (requires Docker services)
- [x] Linter passes (`make lint`) — on changed files; see pre-existing note
- [x] Type checker passes (`make typecheck`) — on changed files; see pre-existing note
- [x] New/updated tests cover the changes

**New test results:** the 4 new tests pass. Suite went from 375 → 379 passing,
with the same 53 failures before and after my change (0 new failures, 0 new errors).

## Notes for Reviewers

**Convention choice:** the issue title mentions `tests/fixtures/`, but the repo's
existing sample fixtures live in `tests/conftest.py`. I followed that existing
convention so the fixture is auto-discovered suite-wide. Happy to relocate it to
`tests/fixtures/` if maintainers prefer.

**Pre-existing failures (unrelated to this change):** the repo currently ships
with failures that exist independently of #106. I recorded them before and after
my change:
- `make test-unit`: **53 pre-existing failures** (e.g. `test_pii_scrubber`,
  `test_resume_parser`, `test_review_service`, `test_skill_extractor`,
  `test_tech_detector`). Unchanged by this PR (375→379 passing as 4 new tests
  were added; still 53 failing).
- `make lint` (ruff): ~182 pre-existing errors across the repo; my changed files
  are clean (`ruff check` passes on them).
- `make typecheck` (mypy): pre-existing errors from missing third-party stubs;
  my changed files pass the project's pre-commit `mypy` hook.

This PR does not touch any of the pre-existing-failing modules and introduces no
new failures.
