### PR TITLE
fix(safety): support common street address formats

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,40 @@
+# Contribution Journal
+
+## Week 7 - Issue selection
+
+**Issue link:** https://github.com/jamjamgobambam/pathreview/issues/73
+
+**Issue title:** `pii_scrubber.py` test coverage doesn't include address formats
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The PII scrubber includes a regular expression for street addresses, but its
+unit tests do not meaningfully verify common US address formats. The existing
+address-variations test loops over examples without making an assertion, so it
+would pass even if no address were redacted. This affects the safety layer's
+ability to prevent resume addresses from appearing in generated feedback. A
+successful fix will add focused assertions for representative full and
+abbreviated street suffixes while ensuring ordinary non-address text remains
+unchanged.
+
+**Branch name:** `test/73-address-format-coverage`
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger
+
+### Selection notes - "Is this right for me?"
+
+- **Reproducible:** Yes. `test_address_variations` currently has no assertion,
+  and the remaining address test checks a single full `Street` form with a weak
+  either/or assertion.
+- **Scope:** The stated work is limited to `tests/unit/test_pii_scrubber.py` and
+  should take the estimated 2-3 hours. Production changes are out of scope
+  unless a valid address case demonstrates a scrubber defect.
+- **Context:** I located the address pattern in `safety/pii_scrubber.py`, the
+  relevant unit test class, and the repository's pytest conventions.
+- **Verification plan:** Run the focused PII scrubber tests first, followed by
+  `make check` and `make test-unit` before opening the pull request.
+- **Coordination:** The issue had no assignee or claim comments when selected. I
+  posted a claim comment describing the reproduced gap and intended branch.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -22,7 +22,7 @@ unchanged.
 
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
-**Cohort ledger:** [ ] Issue added to cohort ledger
+**Cohort ledger:** N/A - TA advance validation, not a cohort claim
 
 ### Selection notes - "Is this right for me?"
 
@@ -37,4 +37,27 @@ unchanged.
 - **Verification plan:** Run the focused PII scrubber tests first, followed by
   `make check` and `make test-unit` before opening the pull request.
 - **Coordination:** The issue had no assignee or claim comments when selected. I
-  posted a claim comment describing the reproduced gap and intended branch.
+  posted a claim comment describing the reproduced gap and intended branch. I
+  am completing the project in advance as a TA, so no cohort ledger or course
+  portal submission is required.
+
+## Week 8 - Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/JPL11/pathreview/commit/8cceea475c19de9efa3ea8c9b99fb1b77eb8665b
+
+**Reproduction summary:**
+I added a parameterized test for a numbered street name and a dotted cardinal
+direction. The scrubber only partially redacts `456 West 42nd Street` and does
+not redact `789 N. Oak Avenue`, so both cases fail reliably.
+
+**PLAN.md link:** https://github.com/JPL11/pathreview/blob/test/73-address-format-coverage/PLAN.md
+
+**Walkthrough video (recommended):** Not recorded; this is a TA advance
+validation and the video is not graded.
+
+**Blockers or open questions:**
+The repository's current PII test module has unrelated baseline failures for
+parenthesized phone numbers and a false-positive address match inside regular
+prose. The implementation must distinguish those upstream failures from this
+issue's results. I also need to confirm whether apartment/unit designators are
+expected to be included in the same redaction or handled as a separate pattern.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,91 @@
+# Address Format Coverage Plan
+
+## Solution plan
+
+**Issue:** [`pii_scrubber.py` test coverage doesn't include address formats
+(#73)](https://github.com/jamjamgobambam/pathreview/issues/73)
+
+### Understand
+
+`PIIScrubber.PII_PATTERNS["street_address"]` recognizes a house number, an
+alphabetic street name, and a known street suffix. The existing
+`test_address_variations` iterates over three inputs without asserting anything,
+so it cannot catch a regression. The pattern also excludes digits and periods
+from the street-name portion: it partially redacts `456 West 42nd Street` as
+`[REDACTED] 42nd Street` and misses `789 N. Oak Avenue` entirely. In addition,
+the suffix alternatives have no final word boundary, which can match short
+suffixes such as `Ct` inside ordinary words.
+
+Expected behavior is for a recognized street address to be replaced as one
+complete `[REDACTED]` value and reported by `detect()` as `street_address` with
+positions covering the complete match. Actual behavior ranges from full
+redaction for a simple address to partial redaction, missed detection, and false
+positives for more complex text.
+
+### Map
+
+- `safety/pii_scrubber.py`
+  - `PIIScrubber.PII_PATTERNS["street_address"]` defines detection boundaries.
+  - `PIIScrubber.scrub()` replaces each regex match.
+  - `PIIScrubber.detect()` exposes the matched value and source positions.
+- `tests/unit/test_pii_scrubber.py`
+  - `test_street_address_redaction` covers one simple full-suffix form.
+  - `test_address_variations` currently has no assertions.
+  - `test_common_street_address_formats_are_fully_redacted` is the failing
+    reproduction added in Week 8.
+
+### Plan
+
+1. Replace the assertion-free address loop with parameterized cases covering
+   full and abbreviated suffixes, numbered street names, and cardinal
+   directions with and without periods.
+2. Add exact assertions for both `scrub()` output and `detect()` metadata so a
+   partial match cannot pass merely because some `[REDACTED]` text appears.
+3. Refine the `street_address` pattern to accept common ordinal/directional
+   tokens and add explicit match boundaries around suffix alternatives.
+4. Add negative cases based on resume prose, including years of experience and
+   words containing short suffix text, to prevent the broader pattern from
+   increasing false positives.
+5. Run the focused address tests, the complete PII scrubber module, and
+   `make check && make test-unit`; separate any known upstream failures from
+   regressions introduced by this change.
+
+### Inputs & outputs
+
+The input is free-form resume or portfolio text that may contain a US street
+address. Representative inputs include `123 Main Street`, `456 West 42nd
+Street`, `789 N. Oak Avenue`, and suffix abbreviations such as `Ave` or `Rd`.
+
+For `scrub()`, the output should preserve surrounding non-PII text while
+replacing the entire recognized address with one `[REDACTED]` marker. For
+`detect()`, the output should include one `street_address` item whose value and
+start/end offsets identify the complete address. Text without an address should
+remain unchanged and produce no street-address detection.
+
+### Risks & unknowns
+
+- Expanding allowed street-name characters in `safety/pii_scrubber.py` could
+  increase false positives in resume prose; the existing match inside
+  `applications` demonstrates that this risk is real.
+- The issue asks for test coverage, but the new reproduction proves production
+  behavior is also incorrect. The final PR should explain why a narrowly scoped
+  pattern correction is necessary for the tests to represent useful behavior.
+- Apartment, suite, and unit designators may be considered part of the address,
+  but the current pattern stops at the street suffix. Maintainer expectations
+  should determine whether this issue includes unit text.
+- The PII module already has unrelated phone-test failures and legacy Ruff/Mypy
+  failures. Verification must report these separately rather than weakening new
+  address assertions to obtain a green suite.
+
+### Edge cases
+
+- Full and abbreviated suffixes: `Street`/`St`, `Avenue`/`Ave`, `Road`/`Rd`.
+- Numbered and ordinal names such as `42nd Street` and `5th Avenue`.
+- Cardinal directionals such as `N Oak Ave`, `N. Oak Avenue`, and `SW Main Rd`.
+- Hyphenated or apostrophized street names without consuming nearby prose.
+- Optional punctuation after a suffix and, pending scope confirmation,
+  apartment/suite designators.
+- Ordinary numbers and words that are not addresses, including years of
+  experience, version numbers, and words containing `St`, `Dr`, or `Ct`.
+- Multiple addresses in one string, empty input, and repeated scrubbing, which
+  should remain idempotent.

--- a/safety/pii_scrubber.py
+++ b/safety/pii_scrubber.py
@@ -1,6 +1,7 @@
 """PII detection and scrubbing."""
 
 import re
+
 import structlog
 
 logger = structlog.get_logger()
@@ -9,13 +10,24 @@ logger = structlog.get_logger()
 class PIIScrubber:
     """Detect and redact personally identifiable information."""
 
+    STREET_SUFFIXES = (
+        r"Street|St|Avenue|Ave|Road|Rd|Boulevard|Blvd|Drive|Dr|Lane|Ln|"
+        r"Court|Ct|Circle|Cir|Park|Place|Plaza|Pl|Way|Parkway|Pkwy|Point|"
+        r"Pt|Pike|Run|Summit|Terrace|Ter|Trail|Trl|Tunnel|Turnpike|View|"
+        r"Vista|Village|Vlg|Valley|Vly"
+    )
+
     # Regex patterns for common PII
     PII_PATTERNS = {
         "email": r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b",
         "phone_us": r"\b(?:\+?1[-.]?)?\(?([0-9]{3})\)?[-.]?([0-9]{3})[-.]?([0-9]{4})\b",
         "phone_intl": r"\+[0-9]{1,3}[-.]?[0-9]{1,14}",
         "ssn": r"\b(?!000|666)[0-9]{3}-(?!00)[0-9]{2}-(?!0000)[0-9]{4}\b",
-        "street_address": r"\b\d+\s+[A-Za-z\s]+(?:Street|St|Avenue|Ave|Road|Rd|Boulevard|Blvd|Drive|Dr|Lane|Ln|Court|Ct|Circle|Cir|Park|Pl|Plaza|Place|Drive|Dr|Way|Parkway|Pkwy|Point|Pt|Pike|Run|Summit|Summit|Terrace|Ter|Trail|Trl|Tunnel|Turnpike|View|Vista|Vlg|Village|Vly|Valley)",
+        "street_address": (
+            r"\b\d+[A-Za-z]?(?:-\d+[A-Za-z]?)?\s+"
+            r"(?:[A-Za-z0-9]+(?:[.'-][A-Za-z0-9]+)*\.?\s+){1,6}"
+            rf"(?:{STREET_SUFFIXES})\b\.?"
+        ),
     }
 
     def scrub(self, text: str) -> str:
@@ -29,7 +41,7 @@ class PIIScrubber:
         """
         scrubbed = text
 
-        for pii_type, pattern in self.PII_PATTERNS.items():
+        for pattern in self.PII_PATTERNS.values():
             scrubbed = re.sub(pattern, "[REDACTED]", scrubbed, flags=re.IGNORECASE)
 
         return scrubbed
@@ -47,13 +59,17 @@ class PIIScrubber:
 
         for pii_type, pattern in self.PII_PATTERNS.items():
             for match in re.finditer(pattern, text, flags=re.IGNORECASE):
-                detected.append({
-                    "type": pii_type,
-                    "value": match.group(),
-                    "start": match.start(),
-                    "end": match.end()
-                })
+                detected.append(
+                    {
+                        "type": pii_type,
+                        "value": match.group(),
+                        "start": match.start(),
+                        "end": match.end(),
+                    }
+                )
 
-        logger.info("pii_detected", count=len(detected), types=len(set(d["type"] for d in detected)))
+        logger.info(
+            "pii_detected", count=len(detected), types=len(set(d["type"] for d in detected))
+        )
 
         return detected

--- a/tests/unit/test_pii_scrubber.py
+++ b/tests/unit/test_pii_scrubber.py
@@ -203,6 +203,17 @@ class TestPIIScrubber:
             scrubbed = scrubber.scrub(text)
             # Should attempt to redact addresses
 
+    @pytest.mark.parametrize(
+        "address",
+        [
+            "456 West 42nd Street",
+            "789 N. Oak Avenue",
+        ],
+    )
+    def test_common_street_address_formats_are_fully_redacted(self, scrubber, address):
+        """Reproduce incomplete redaction of common US street addresses."""
+        assert scrubber.scrub(address) == "[REDACTED]"
+
     def test_empty_text(self, scrubber):
         """Test with empty text."""
         text = ""

--- a/tests/unit/test_pii_scrubber.py
+++ b/tests/unit/test_pii_scrubber.py
@@ -86,7 +86,7 @@ class TestPIIScrubber:
         text = "Address: 123 Main Street, Apt 4"
         scrubbed = scrubber.scrub(text)
 
-        assert "[REDACTED]" in scrubbed or "123" not in scrubbed
+        assert scrubbed == "Address: [REDACTED], Apt 4"
 
     def test_text_with_no_pii(self, scrubber):
         """Test text with no PII is returned unchanged."""
@@ -201,7 +201,7 @@ class TestPIIScrubber:
         for addr in addresses:
             text = f"Address: {addr}"
             scrubbed = scrubber.scrub(text)
-            # Should attempt to redact addresses
+            assert scrubbed == "Address: [REDACTED]"
 
     @pytest.mark.parametrize(
         "address",
@@ -211,8 +211,25 @@ class TestPIIScrubber:
         ],
     )
     def test_common_street_address_formats_are_fully_redacted(self, scrubber, address):
-        """Reproduce incomplete redaction of common US street addresses."""
+        """Test numbered streets and dotted directionals are fully redacted."""
         assert scrubber.scrub(address) == "[REDACTED]"
+
+        detections = scrubber.detect(address)
+        assert detections == [
+            {
+                "type": "street_address",
+                "value": address,
+                "start": 0,
+                "end": len(address),
+            }
+        ]
+
+    def test_street_address_pattern_does_not_redact_resume_prose(self, scrubber):
+        """Test short street suffixes do not match inside ordinary words."""
+        text = "I worked for 5 years developing Python applications."
+
+        assert scrubber.scrub(text) == text
+        assert not any(item["type"] == "street_address" for item in scrubber.detect(text))
 
     def test_empty_text(self, scrubber):
         """Test with empty text."""
@@ -263,3 +280,4 @@ class TestPIIScrubber:
 
         # Should be minimal or no detections
         # (version number shouldn't be flagged as SSN)
+        assert detected == []


### PR DESCRIPTION
## Summary
Improve street-address PII matching so numbered street names and dotted cardinal directions are fully redacted. The change also adds suffix boundaries to prevent short abbreviations such as `Ct` from matching inside ordinary resume prose.

## Issue
Closes #73

## Changes
- Add token-aware support for ordinal street names, dotted directions, and suffix punctuation.
- Require street suffixes to end at a word boundary to reduce false positives.
- Strengthen existing address tests with exact output assertions.
- Verify `detect()` values and offsets for common formats.
- Add a resume-prose false-positive regression test.

## Testing
- [ ] Unit tests pass (`make test-unit`) - repository baseline has 54 failures and 31 errors; after this change it has 51 failures and the same 31 errors.
- [ ] Integration tests pass (`make test-integration`) - not required for this isolated regex/unit-test change.
- [ ] Linter passes (`make lint`) - repository baseline has 182 Ruff errors; after this change it has 176.
- [ ] Type checker passes (`make typecheck`) - repository-wide pre-existing type errors remain.
- [x] New/updated tests cover the changes
- [x] Changed files pass Ruff and Black.
- [x] Address-focused tests pass: 7 passed.

## Screenshots / Demo
Not applicable; this change affects backend PII scrubbing behavior.

## Notes for Reviewers
The address-specific tests pass. Four pre-existing phone-format failures remain in `tests/unit/test_pii_scrubber.py`; this PR does not modify phone matching. Repository-wide `make check` and `make test-unit` were run before and after the change, and the failure counts did not increase. Please pay particular attention to the balance between supporting ordinal/directional tokens and avoiding false positives in resume prose.