### PR TITLE
fix(api): include profile_id in profile creation response

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -77,3 +77,66 @@ One open question for implementation (not a blocker): whether to keep the existi
 for backward compatibility, pending a quick check of `frontend/src/` for existing
 consumers of `.id`.
 
+---
+
+## Week 9 — Solution Building & PR Submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+- Sub-task 1 (reproduction) — done in Week 8: `tests/unit/test_profile_schema.py`.
+- Sub-task 2 (expose `profile_id`) — done: added a Pydantic `@computed_field`
+  property `profile_id` to `ProfileResponse` in `api/schemas/profile.py` that
+  returns `self.id`, keeping the existing `id` field.
+- Sub-task 3 (verify the shared schema / route layer) — done: confirmed
+  `ProfileResponse` is reused by the create, get, and update endpoints in
+  `api/routes/profiles.py`, so all three now include `profile_id` (additive).
+- Resolved the Week 8 open question: searched `frontend/src/` and found
+  `ProfileForm.tsx` reads `profile.id` from the create response, so replacing
+  `id` would break the frontend. Decision: keep `id`, add `profile_id`.
+
+**Next steps:**
+- Expand test coverage (sub-task 4): backward-compat (`id` still present), UUID
+  JSON serialization, and optional-fields-null cases — then finalize the PR.
+- Open a draft PR and request peer feedback before marking ready.
+
+**Blockers:**
+None. Note: the repo has pre-existing `make check` and `make test-unit` failures
+in unrelated modules (see Check-in 2); confirmed my changes don't add to them.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** <!-- paste the URL of PR on jamjamgobambam/pathreview, e.g. https://github.com/jamjamgobambam/pathreview/pull/<n> -->
+
+**Branch:** `fix/78-profile-response-missing-profile-id`
+
+**What you built:**
+Added a `profile_id` field to the `ProfileResponse` schema
+(`api/schemas/profile.py`) via a Pydantic `@computed_field` that returns the
+existing `id` value. Profile responses (create, get, and update, which share the
+schema) now include `profile_id` for clients while keeping `id` unchanged, so no
+existing consumer breaks.
+
+**Tests added or updated:**
+Added `tests/unit/test_profile_schema.py` (5 tests) covering: `profile_id` is
+present in the serialized response; `profile_id` equals both the source `id` and
+the response `id`; `id` is still present (backward compatibility); `profile_id`
+serializes to the same UUID string as `id` in JSON; and `profile_id` is returned
+even when all optional fields (`github_username`, `portfolio_url`,
+`resume_filename`) are `None`.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+> Note on "passes": the repo has documented pre-existing failures on `main`
+> unrelated to this issue — `make check` reports ~161 ruff errors (e.g.
+> `test_tech_detector.py`, `test_skill_extractor.py`) and `make test-unit`
+> reports 55 failing tests, in modules this PR does not touch. After my changes
+> the counts do not increase (unit failures: 55 → 53; my 5 new tests pass), so
+> my contribution introduces no new failures. My two changed files
+> (`api/schemas/profile.py`, `tests/unit/test_profile_schema.py`) individually
+> pass ruff, black, and mypy.
+
+**Draft PR feedback received from:** <!-- name or Discord handle, or "none" -->
+

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -140,3 +140,62 @@ even when all optional fields (`github_username`, `portfolio_url`,
 
 **Draft PR feedback received from:** <!-- name or Discord handle, or "none" -->
 
+---
+
+## Week 10 — Iteration & Reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+[What did reviewers comment on? Or note that no review came in.]
+
+**How you responded:**
+[What changes did you make, or what did you reply? If no feedback, leave blank.]
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Finding the relevant code was harder than the fix itself. Before I could plan
+anything I had to search the codebase to confirm where the bug actually lived and
+trace the path from the `ProfileResponse` schema to the `Profile` model to the route
+in `api/routes/profiles.py`. I expected the "hard part" to be writing the fix, but
+the actual code change ended up being a few lines. The real work was locating the
+right file and understanding how the pieces connected well enough to be sure a change
+wouldn't break something else.
+
+**What did you learn about working in a large codebase?**
+That documentation matters more than pure coding. On my own projects I mostly just
+write code, but here the fix was tiny and most of my effort went into the JOURNAL,
+the PLAN, and the PR description, plus following someone else's conventions (branch
+naming, conventional commit messages, and the pre-commit hooks). Contributing to
+someone else's production code means fitting into their standards and proving your
+change is safe, not just making it work on your machine. A good example was deciding
+to keep the existing `id` field instead of replacing it, which I only felt confident
+about after checking that the frontend reads `profile.id`.
+
+**How did AI tools help — and where did they fall short?**
+This was my first time contributing to open source, and AI was most useful as a guide
+through the parts I had never done before: the fork vs. upstream git workflow, reading
+an unfamiliar multi-service codebase quickly, and understanding why the pre-commit
+mypy hook failed when my local mypy passed. Where it fell short was the actual
+decisions. I still had to choose which issue to take, decide to keep `id` for backward
+compatibility, and judge that the pre-existing test failures were unrelated to my
+change and safe to document rather than fix. AI could surface the options, but the
+calls were mine to make.
+
+**What would you do differently if you started over?**
+I would probably take a more challenging issue. Now that I have seen how straightforward
+the overall process is once you understand the workflow, a Tier 1 fix felt very
+contained. Starting over, I would pick something closer to Tier 2 that touches more than
+one module, since the parts that intimidated me (git, conventions, reproducing the issue)
+turned out to be the manageable parts.
+
+**What are you most proud of from this module?**
+Contributing to open source for the first time. Going from never having opened a PR on
+someone else's project to a complete, standards-following contribution with tests and
+documentation is the thing I am most proud of.
+

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -108,7 +108,7 @@ in unrelated modules (see Check-in 2); confirmed my changes don't add to them.
 
 ### Check-in 2 (end of week)
 
-**PR link:** <!-- paste the URL of PR on jamjamgobambam/pathreview, e.g. https://github.com/jamjamgobambam/pathreview/pull/<n> -->
+**PR link:** https://github.com/jamjamgobambam/pathreview/pull/144
 
 **Branch:** `fix/78-profile-response-missing-profile-id`
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -24,7 +24,7 @@ existing behavior intact. This is scoped to the API layer, primarily the
 
 **Setup confirmation:** [x] App runs locally at localhost:5173.  
 
-**Cohort ledger:** [ ] Issue added to cohort ledger
+**Cohort ledger:** [x] Issue added to cohort ledger
 
 ---
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -51,3 +51,29 @@ existing behavior intact. This is scoped to the API layer, primarily the
 - *Estimated Effort*: The issue is estimated at 1–2 hours, plus time for writing tests, which makes it achievable before the Week 9 deadline.
 - *Blockers or Dependencies*: No blockers or external dependencies are mentioned in the issue.
 - *Claim Status*: I commented on the issue to claim it. The cohort ledger entry is still pending because I am waiting for the ledger link, and I will complete it before starting Week 8.
+
+---
+
+## Week 8 — Reproduction & Solution Planning
+
+**Reproduction commit link:** https://github.com/sehr-abrar/pathreview/commit/35edb900b56be115e46fc8ac91c9386f707a0d56
+
+
+**Reproduction summary:**
+I reproduced the issue with a new failing test, `tests/unit/test_profile_schema.py`,
+which validates a Profile-like object through `ProfileResponse` and asserts the
+serialized payload contains a `profile_id` field. Running
+`pytest tests/unit/test_profile_schema.py` fails with
+`AssertionError: ProfileResponse is missing the 'profile_id' field (issue #78)`,
+and the dumped payload confirms the response contains `id` but no `profile_id`.
+
+**PLAN.md link:** https://github.com/sehr-abrar/pathreview/blob/fix/78-profile-response-missing-profile-id/PLAN.md
+
+**Walkthrough video (recommended):** N/A — not recorded.
+
+**Blockers or open questions:**
+One open question for implementation (not a blocker): whether to keep the existing
+`id` field alongside the new `profile_id` or replace it. My current plan keeps both
+for backward compatibility, pending a quick check of `frontend/src/` for existing
+consumers of `.id`.
+

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,53 @@
+# Module 3 Journal
+
+## Week 7 — Issue Selection
+
+**Issue link:** https://github.com/jamjamgobambam/pathreview/issues/78
+
+**Issue title:** API response for profile creation doesn't include the profile_id field
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+When a client creates a profile via `POST /profiles`, the API returns a
+`ProfileResponse` that exposes the record's primary key under the name `id`,
+but never under the name `profile_id` that clients rely on for follow-up
+requests (for example `GET /profiles/{profile_id}`). The value itself exists on
+the database model, but the response schema in `api/schemas/profile.py` doesn't
+surface a `profile_id` field, so clients have no field by that name to read. A
+successful fix adds `profile_id` to the profile creation response, mapped from
+the model's `id`, so the API contract matches what clients expect while keeping
+existing behavior intact. This is scoped to the API layer, primarily the
+`ProfileResponse` schema.
+
+**Branch name:** `fix/78-profile-response-missing-profile-id`
+
+**Setup confirmation:** [x] App runs locally at localhost:5173.  
+
+**Cohort ledger:** [ ] Issue added to cohort ledger
+
+---
+
+### Selection Notes — "Is This Issue Right for Me?" Checklist
+
+*Part 1: Understanding the Issue*
+
+- *In My Own Words*: When a profile is created, the API currently returns the profile identifier as `id` instead of `profile_id`. Since clients need the `profile_id` field for future requests, the response is missing a field they depend on.
+- *Part of The App Affected*: This issue is in the API layer, specifically the response schema in `api/schemas/profile.py`. This schema is used by the `POST /profiles` route in `api/routes/profiles.py`. I located and reviewed both files in the repository.
+- *Before and After*: Before the fix, `POST /profiles` returns a response containing `{"id": ...}` but does not include `profile_id`. After the fix, the response should include `profile_id` with the profile's identifier.
+
+*Part 2: Tier Fit*
+
+- *Why This Tier Fits*: Tier 1 is the right match because this change is scoped to the `ProfileResponse` schema in a single file. It does not require major changes across different parts of the application or a deep understanding of the entire codebase. For a first open-source contribution, this is a manageable and well-defined issue.
+
+*Part 3: Codebase Readiness*
+
+- *Files Reviewed*: I looked through `ProfileResponse` in `api/schemas/profile.py`, the `Profile` model in `core/models/profile.py` (where the primary key is stored as `id`), and the `create_profile_endpoint` route that creates responses using `ProfileResponse.model_validate(new_profile)`.
+- *Important Constraint Discovered*: The schema uses `from_attributes`, meaning new fields need to map to attributes that already exist on the ORM object. Since the model has `.id` but not `.profile_id`, simply adding a `profile_id` field may not work without additional mapping logic.
+- *Testing Plan*: There is currently no dedicated profile test file under `tests/unit/`, so I plan to add tests for this behavior while following the structure of existing test files, such as `tests/unit/test_review_service.py`.
+
+*Part 4: Scope And Time*
+
+- *Estimated Effort*: The issue is estimated at 1–2 hours, plus time for writing tests, which makes it achievable before the Week 9 deadline.
+- *Blockers or Dependencies*: No blockers or external dependencies are mentioned in the issue.
+- *Claim Status*: I commented on the issue to claim it. The cohort ledger entry is still pending because I am waiting for the ledger link, and I will complete it before starting Week 8.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -138,7 +138,7 @@ even when all optional fields (`github_username`, `portfolio_url`,
 > (`api/schemas/profile.py`, `tests/unit/test_profile_schema.py`) individually
 > pass ruff, black, and mypy.
 
-**Draft PR feedback received from:** <!-- name or Discord handle, or "none" -->
+**Draft PR feedback received from:** None
 
 ---
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -149,10 +149,10 @@ even when all optional fields (`github_username`, `portfolio_url`,
 **Feedback received:** [ ] Yes  [x] No — still awaiting review
 
 **Summary of feedback:**
-[What did reviewers comment on? Or note that no review came in.]
+No review came in.
 
 **How you responded:**
-[What changes did you make, or what did you reply? If no feedback, leave blank.]
+N/A
 
 ---
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,64 @@
+# Solution Plan
+
+**Issue:** API response for profile creation doesn't include the `profile_id` field:  
+https://github.com/jamjamgobambam/pathreview/issues/78
+
+## Understand
+
+**Root Cause:** The profile creation response model, `ProfileResponse` in `api/schemas/profile.py`, exposes the record's primary key only as `id`. The underlying database model (`core/models/profile.py`) also stores the primary key in the `id` column, and the route builds the response using `ProfileResponse.model_validate(new_profile)`. Because `ProfileResponse` doesn't define a `profile_id` field, it never appears in the serialized response.
+
+**Expected vs. Actual**
+
+- **Actual:** `POST /profiles` returns `{"id": ..., "user_id": ..., "github_username": ..., "portfolio_url": ..., "created_at": ..., "resume_filename": ...}` with no `profile_id`.
+- **Expected:** The response also includes a `profile_id` field containing the same identifier so clients can immediately use it with endpoints such as `GET /profiles/{profile_id}`.
+
+**Key Constraint:** `ProfileResponse` uses `model_config = {"from_attributes": True}` and is populated via `model_validate(new_profile)` from the ORM object. The ORM object has an `id` attribute but **does not** have a `profile_id` attribute. Simply adding `profile_id: UUID` to the schema would therefore fail validation because Pydantic has no source attribute to populate it from. The fix must derive `profile_id` from the existing `id` field rather than expecting a new ORM attribute.
+
+## Map
+
+**Files Involved**
+
+- `api/schemas/profile.py` — `ProfileResponse` (the only production file that should require changes).
+- `api/routes/profiles.py` — `create_profile_endpoint`, which builds the response using `ProfileResponse.model_validate(...)`. Also verify that `get_profile_endpoint` and `update_profile_endpoint`, which reuse the same schema, continue to work correctly.
+- `core/models/profile.py` — `Profile` model, which confirms that the primary key attribute is `id`.
+- `tests/unit/test_profile_schema.py` — new test file created during reproduction that will contain assertions validating the fix.
+
+## Plan
+
+1. **Confirm the Reproduction (done).** `tests/unit/test_profile_schema.py` validates a Profile-like object using `ProfileResponse` and asserts that `profile_id` is present and equal to `id`. This test currently fails.
+2. **Expose `profile_id` in `ProfileResponse`.** Add a `profile_id` field that maps to the model's existing `id` value. The preferred approach is a Pydantic `@computed_field` that returns `self.id`, which is straightforward and backward compatible. Another option is to use `validation_alias="id"`. Keep the existing `id` field so current clients are not broken.
+3. **Verify the Route Layer.** Confirm that `create_profile_endpoint`, along with the GET and UPDATE endpoints that reuse `ProfileResponse`, correctly includes `profile_id` when validating ORM objects and that the generated OpenAPI schema documents the new field.
+4. **Update and Expand Test Coverage.** Make the reproduction test pass and add an assertion that `id` is still present to preserve backward compatibility.
+5. **Run Project Checks.** Ensure `make check` (Ruff, Black, and MyPy) and `make test-unit` both pass before opening the PR.
+
+## Inputs and Outputs
+
+**Input:** A persisted `Profile` ORM object (or equivalent object with an `id` attribute) passed to `ProfileResponse.model_validate(...)`.
+
+**Output:** The serialized `ProfileResponse` now includes a `profile_id: UUID` field whose value matches `id`. The JSON returned by `POST /profiles` (and by the GET and PUT endpoints that reuse the same schema) changes from:
+
+```json
+{"id": ...}
+```
+
+to:
+
+```json
+{"id": ..., "profile_id": ...}
+```
+
+No request schemas (`ProfileCreate` or `ProfileUpdate`) are modified. The OpenAPI response schema also gains a `profile_id` property.
+
+## Risks and Unknowns
+
+- **Attribute Mapping.** Because `ProfileResponse` is populated with `from_attributes=True`, a plain `profile_id: UUID` field would fail validation due to the missing ORM attribute. Using `@computed_field` or `validation_alias` avoids this issue, and the reproduction test verifies the behavior.
+- **Serialization Behavior.** Confirm that the chosen implementation appears in `model_dump()`, `model_dump_json()`, and the generated OpenAPI schema by asserting against the serialized output, not just the Python attribute.
+- **Backward Compatibility.** Replacing `id` with `profile_id` could break existing clients. Before considering that approach, search `frontend/src/` and any API consumers for references to `.id`. The current plan is additive and keeps both fields.
+- **Shared Response Schema.** Since `ProfileResponse` is used by the create, get, and update endpoints, the change affects all three responses. This should be acceptable because it only adds a new field, but it should still be verified.
+
+## Edge Cases
+
+- **Optional Fields.** A profile with no resume, `github_username`, or `portfolio_url` should still include a valid `profile_id`. The identifier is always required, regardless of optional fields.
+- **Consistent Identifiers.** `profile_id` must always match `id`. The implementation should derive one from the other rather than storing duplicate values.
+- **UUID Serialization.** Both `id` and `profile_id` should serialize to the same UUID string in JSON.
+- **Shared Endpoints.** Responses from `GET /profiles/{id}` and `PUT /profiles/{id}` should also include `profile_id`, not just `POST /profiles`.

--- a/api/schemas/profile.py
+++ b/api/schemas/profile.py
@@ -1,25 +1,37 @@
-from pydantic import BaseModel, Field
 from datetime import datetime
 from uuid import UUID
-from typing import Optional
+
+from pydantic import BaseModel, Field, computed_field
 
 
 class ProfileCreate(BaseModel):
-    github_username: Optional[str] = Field(default=None, max_length=255)
-    portfolio_url: Optional[str] = Field(default=None, max_length=500)
+    github_username: str | None = Field(default=None, max_length=255)
+    portfolio_url: str | None = Field(default=None, max_length=500)
 
 
 class ProfileUpdate(BaseModel):
-    github_username: Optional[str] = Field(default=None, max_length=255)
-    portfolio_url: Optional[str] = Field(default=None, max_length=500)
+    github_username: str | None = Field(default=None, max_length=255)
+    portfolio_url: str | None = Field(default=None, max_length=500)
 
 
 class ProfileResponse(BaseModel):
     id: UUID
     user_id: UUID
-    github_username: Optional[str]
-    portfolio_url: Optional[str]
+    github_username: str | None
+    portfolio_url: str | None
     created_at: datetime
-    resume_filename: Optional[str]
+    resume_filename: str | None
 
     model_config = {"from_attributes": True}
+
+    @computed_field  # type: ignore[misc, prop-decorator]
+    @property
+    def profile_id(self) -> UUID:
+        """Return the profile identifier under the name clients expect.
+
+        The database model stores the primary key as ``id``, but API clients
+        rely on a ``profile_id`` field for subsequent requests (for example
+        ``GET /profiles/{profile_id}``). This exposes the same value under that
+        name while keeping ``id`` for backward compatibility.
+        """
+        return self.id

--- a/tests/unit/test_profile_schema.py
+++ b/tests/unit/test_profile_schema.py
@@ -1,0 +1,57 @@
+"""Tests for the profile API response schema.
+
+Reproduces issue #78
+(https://github.com/jamjamgobambam/pathreview/issues/78): after creating a
+profile, the response schema exposes the identifier only as ``id`` and is
+missing the ``profile_id`` field that clients need to make subsequent requests.
+"""
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from api.schemas.profile import ProfileResponse
+
+
+@pytest.mark.unit
+class TestProfileResponseSchema:
+    """Schema-level tests for ProfileResponse (issue #78)."""
+
+    @pytest.fixture
+    def profile_row(self) -> SimpleNamespace:
+        """Stand-in for a persisted Profile ORM row.
+
+        Mirrors ``core.models.profile.Profile``: the primary key is stored as
+        ``id`` and there is no ``profile_id`` attribute. ``ProfileResponse``
+        uses ``from_attributes``, so it reads these attributes directly.
+        """
+        return SimpleNamespace(
+            id=uuid4(),
+            user_id=uuid4(),
+            github_username="janedoe",
+            portfolio_url="https://janedoe.dev",
+            created_at=datetime.now(UTC),
+            resume_filename="resume.pdf",
+        )
+
+    def test_response_includes_profile_id(self, profile_row: SimpleNamespace) -> None:
+        """The creation response must expose a ``profile_id`` field.
+
+        Currently FAILS (documents issue #78): ``ProfileResponse`` only defines
+        ``id``, so ``profile_id`` never appears in the serialized payload.
+        """
+        response = ProfileResponse.model_validate(profile_row)
+        payload = response.model_dump()
+
+        assert (
+            "profile_id" in payload
+        ), "ProfileResponse is missing the 'profile_id' field (issue #78)"
+
+    def test_profile_id_matches_id(self, profile_row: SimpleNamespace) -> None:
+        """``profile_id`` should carry the same value as the record's ``id``."""
+        response = ProfileResponse.model_validate(profile_row)
+        payload = response.model_dump()
+
+        assert payload.get("profile_id") == profile_row.id

--- a/tests/unit/test_profile_schema.py
+++ b/tests/unit/test_profile_schema.py
@@ -1,11 +1,14 @@
 """Tests for the profile API response schema.
 
-Reproduces issue #78
-(https://github.com/jamjamgobambam/pathreview/issues/78): after creating a
-profile, the response schema exposes the identifier only as ``id`` and is
-missing the ``profile_id`` field that clients need to make subsequent requests.
+Covers issue #78
+(https://github.com/jamjamgobambam/pathreview/issues/78): the profile response
+schema exposed the identifier only as ``id`` and was missing the ``profile_id``
+field that clients need to make subsequent requests. These tests assert that
+``ProfileResponse`` now exposes ``profile_id`` (mapped from ``id``) while keeping
+``id`` for backward compatibility.
 """
 
+import json
 from datetime import UTC, datetime
 from types import SimpleNamespace
 from uuid import uuid4
@@ -37,11 +40,7 @@ class TestProfileResponseSchema:
         )
 
     def test_response_includes_profile_id(self, profile_row: SimpleNamespace) -> None:
-        """The creation response must expose a ``profile_id`` field.
-
-        Currently FAILS (documents issue #78): ``ProfileResponse`` only defines
-        ``id``, so ``profile_id`` never appears in the serialized payload.
-        """
+        """The creation response must expose a ``profile_id`` field (issue #78)."""
         response = ProfileResponse.model_validate(profile_row)
         payload = response.model_dump()
 
@@ -54,4 +53,35 @@ class TestProfileResponseSchema:
         response = ProfileResponse.model_validate(profile_row)
         payload = response.model_dump()
 
-        assert payload.get("profile_id") == profile_row.id
+        assert payload["profile_id"] == profile_row.id
+        assert payload["profile_id"] == payload["id"]
+
+    def test_id_field_still_present(self, profile_row: SimpleNamespace) -> None:
+        """``id`` must remain in the payload so existing clients don't break."""
+        response = ProfileResponse.model_validate(profile_row)
+        payload = response.model_dump()
+
+        assert payload["id"] == profile_row.id
+
+    def test_profile_id_serializes_as_uuid_string(self, profile_row: SimpleNamespace) -> None:
+        """``profile_id`` must serialize to the same UUID string as ``id``."""
+        response = ProfileResponse.model_validate(profile_row)
+        payload = json.loads(response.model_dump_json())
+
+        assert payload["profile_id"] == str(profile_row.id)
+        assert payload["profile_id"] == payload["id"]
+
+    def test_profile_id_present_when_optional_fields_missing(self) -> None:
+        """``profile_id`` is returned even when optional fields are ``None``."""
+        row = SimpleNamespace(
+            id=uuid4(),
+            user_id=uuid4(),
+            github_username=None,
+            portfolio_url=None,
+            created_at=datetime.now(UTC),
+            resume_filename=None,
+        )
+
+        payload = ProfileResponse.model_validate(row).model_dump()
+
+        assert payload["profile_id"] == row.id


### PR DESCRIPTION
## Summary

Profile creation returned the identifier only as `id`, but clients expect a
`profile_id` field to use in follow-up requests like `GET /profiles/{profile_id}`.
This PR adds `profile_id` to the `ProfileResponse` schema, mapped from the existing
`id`. The `id` field is unchanged, so the change is additive and backward-compatible.

## Issue

Closes #78

## Changes

- `api/schemas/profile.py`: added a `profile_id` computed field to `ProfileResponse`
  that returns the model's `id`. A plain `profile_id: UUID` field would not work
  because the schema uses `from_attributes` and the ORM object has `.id`, not
  `.profile_id`, so the value is derived from `id` instead.
- `tests/unit/test_profile_schema.py`: new test module (5 tests) for the new field
  and backward compatibility.

## Testing

- [x] Unit tests pass (`make test-unit`) (see pre-existing failures note)
- [x] Integration tests pass (`make test-integration`) (N/A; the repo has no integration tests yet, so this collects 0 tests)
- [x] Linter passes (`make lint`) (see pre-existing failures note)
- [x] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes

New tests in `tests/unit/test_profile_schema.py` cover: `profile_id` is present in
the response, it equals both the source `id` and the response `id`, `id` is still
present for backward compatibility, `profile_id` serializes to the same UUID string
as `id` in JSON, and `profile_id` is present when all optional fields are `None`.

Manual verification:
1. `git checkout fix/78-profile-response-missing-profile-id`
2. `python -m pytest tests/unit/test_profile_schema.py -v` (expect 5 passed)
3. With the app running, `POST /profiles` and confirm the JSON body now includes
   `profile_id` alongside `id`.

Pre-existing failures (unrelated to this PR): `main` already fails checks in modules
this PR does not touch. On `main`, `make test-unit` reports 55 failing tests (e.g.
`test_tech_detector.py`, `test_skill_extractor.py`) and `make lint` reports about 161
ruff errors in those same modules. After this PR the counts do not increase (unit
failures 55 to 53, with the 5 new tests passing), and the two files I changed pass
ruff, black, and mypy individually. This PR does not try to fix the pre-existing failures.

## Notes for Reviewers

- Kept `id` on purpose: `frontend/src/components/ProfileForm.tsx` reads `profile.id`
  from the create response, so removing or renaming it would break the frontend.
  The change only adds `profile_id`.
- `ProfileResponse` is shared by the create, get, and update endpoints in
  `api/routes/profiles.py`, so `profile_id` now appears in all three responses.
  This is intended and safe since it only adds a field.