### PR TITLE
fix(api): enforce profile ownership when creating reviews

### DIFF
--- a/api/routes/reviews.py
+++ b/api/routes/reviews.py
@@ -39,6 +39,11 @@ async def create_review_endpoint(
             user_id=current_user.id,
         )
 
+        if review is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Profile not found",
+            )
         # Add background task for processing
         background_tasks.add_task(process_review, db, review.id, data.profile_id)
 

--- a/core/services/review_service.py
+++ b/core/services/review_service.py
@@ -16,10 +16,18 @@ async def create_review(
     db,
     profile_id: UUID,
     user_id: UUID,
-) -> Review:
+) -> Review | None:
     """
     Create a new review with status="pending".
     """
+    profile_stmt = select(Profile).where(
+        and_(Profile.id == profile_id, Profile.user_id == user_id)
+    )
+    profile_result = await db.execute(profile_stmt)
+    
+    if profile_result.scalars().first() is None:
+        return None
+        
     review = Review(
         profile_id=profile_id,
         status="pending",

--- a/tests/unit/test_review_ownership.py
+++ b/tests/unit/test_review_ownership.py
@@ -1,0 +1,26 @@
+from unittest.mock import AsyncMock
+from unittest.mock import Mock
+from uuid import uuid4
+
+import pytest
+
+from core.services.review_service import create_review
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_create_review_rejects_profile_owned_by_another_user():
+    db = Mock()
+    profile_result = Mock()
+    profile_result.scalars.return_value.first.return_value = None
+    db.execute = AsyncMock(return_value=profile_result)
+    db.add = Mock()
+    db.commit = AsyncMock()
+    db.refresh = AsyncMock()
+
+    result = await create_review(db, uuid4(), uuid4())
+
+    assert result is None
+    db.add.assert_not_called()
+    db.commit.assert_not_awaited()
+    db.refresh.assert_not_awaited()


### PR DESCRIPTION
## Summary

- Enforce profile ownership before creating a review.
- Return `404 Profile not found` when the requested profile is not owned by the authenticated user.
- Add a regression test for cross-user review creation.
- Update the existing service test fixture to model the authorized profile lookup.

## Problem

`POST /reviews` passes the authenticated user's ID to `create_review()`, but the service ignored that argument and created a review for any supplied `profile_id`. An authenticated user who knows another user's profile UUID could therefore create a review for that profile.

The read paths already scope reviews through `Profile.user_id`, so this change applies the same ownership check to the create path.

## Changes

- Query `Profile` by both `profile_id` and `user_id` before creating the review.
- Return `None` from the service when the profile is missing or belongs to another user.
- Convert that result to a `404` response in the API route.
- Add a unit test verifying that unauthorized creation does not add or commit a review.
- Update the existing review service mock session so authorized create tests continue to pass after the ownership query is added.

## Testing

- `python -m py_compile api/routes/reviews.py core/services/review_service.py tests/unit/test_review_ownership.py`
- `pytest tests/unit/test_review_ownership.py tests/unit/test_review_service.py -v`
- `pytest tests/unit -v --tb=short`

Fixes #<163>
