### PR TITLE
feat: add portfolio website URL ingestion (#11)

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,27 @@
+# JOURNAL
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/11
+
+**Issue title:** Add support for ingesting a portfolio website URL
+
+**Tier:** [x] Tier 2
+
+**Problem summary:**
+Right now the ingestion pipeline only pulls a candidate's profile data from their resume upload and their GitHub repos (READMEs and repo metadata) — there's no way to bring in content from a personal portfolio site, even though the `Profile` model already has a `portfolio_url` field sitting unused. This means bio text and project write-ups that only live on someone's portfolio page never make it into the vector store, so the review agent can't reference them when generating feedback. A successful fix adds a way to fetch that URL's HTML, strip out navigation/boilerplate, pull out the meaningful text (About/bio and project descriptions), and run it through the same chunk-and-embed flow the other sources use, storing it alongside the resume and GitHub content. It touches the ingestion layer (a new `web_parser.py` parser and a new method on `ingestion/pipeline.py`) and the profile API schema.
+
+**Branch name:** 11-portfolio-url-ingestion
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger
+
+---
+
+### Selection notes ("is this right for me?" checklist reasoning)
+
+- **Scope fits a Tier 2 issue:** touches one new parser file plus small, well-scoped additions to the existing pipeline and schema — not a cross-cutting refactor.
+- **Clear acceptance criteria:** the issue names the exact files to touch (`ingestion/parsers/`, `ingestion/pipeline.py`, `api/schemas/profile.py`), which matches the estimated 5–8 hour effort.
+- **Follows an existing pattern:** `ResumeParser`/`ReadmeParser` + `IngestionPipeline.ingest_resume`/`ingest_readme` are direct templates to mirror, so the unknowns are mostly in the new part (fetching an arbitrary user-supplied URL safely) rather than in the whole pipeline shape.
+- **New risk worth flagging early:** unlike the other sources, this one fetches a URL the user supplies, so SSRF protection (blocking internal/private addresses, restricting redirects) needs to be part of the implementation, not an afterthought.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -25,3 +25,17 @@ Right now the ingestion pipeline only pulls a candidate's profile data from thei
 - **Clear acceptance criteria:** the issue names the exact files to touch (`ingestion/parsers/`, `ingestion/pipeline.py`, `api/schemas/profile.py`), which matches the estimated 5–8 hour effort.
 - **Follows an existing pattern:** `ResumeParser`/`ReadmeParser` + `IngestionPipeline.ingest_resume`/`ingest_readme` are direct templates to mirror, so the unknowns are mostly in the new part (fetching an arbitrary user-supplied URL safely) rather than in the whole pipeline shape.
 - **New risk worth flagging early:** unlike the other sources, this one fetches a URL the user supplies, so SSRF protection (blocking internal/private addresses, restricting redirects) needs to be part of the implementation, not an afterthought.
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/NadaFeteiha/pathreview/commit/7f7b868
+
+**Reproduction summary:**
+Since this issue describes a missing feature rather than a crash, I reproduced it by inspecting `main` along both paths a portfolio URL could take. I confirmed `ingestion/pipeline.py` has no `ingest_portfolio` method and `ingestion/parsers/` has no web/HTML parser, and that `api/routes/profiles.py` stores `portfolio_url` but never reads it back to fetch anything. I also found that `core/services/review_service.py::_run_ingestion_pipeline` references `profile.portfolio_url`, but only inside an explicit `# Placeholder: actual portfolio ingestion logic` block that fabricates a string instead of fetching real content. Full trail in `docs/issue-11-repro.md`.
+
+**PLAN.md link:** https://github.com/NadaFeteiha/pathreview/blob/11-portfolio-url-ingestion/PLAN.md
+
+**Walkthrough video (recommended):** Not recorded.
+
+**Blockers or open questions:**
+`core/services/review_service.py` has a review-generation-time placeholder for portfolio (and github/resume) data that this fix does not touch — see the Risks section in PLAN.md. Worth confirming with a mentor whether that's tracked as a separate issue or expected to be addressed later, since without it the ingested portfolio content isn't yet surfaced end-to-end in a generated review.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -71,3 +71,34 @@ A `WebParser` that fetches a portfolio URL (with an SSRF guard covering redirect
 (Both checked under the documented pre-existing-failure carve-out: `main` already has 53 failing unit tests and repo-wide ruff/black/mypy failures unrelated to this change. On the 9 files this PR touches, ruff/black/mypy introduce 0 new errors — full breakdown in the PR's Notes for Reviewers.)
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No reviews or comments have landed on PR #168 as of this entry (confirmed via `gh pr view 168 --json reviews,comments` — both empty). I shared it in the cohort Slack channel; nothing back yet.
+
+**How you responded:**
+N/A — nothing to respond to yet. If feedback comes in after this entry, I'll add a follow-up note rather than edit this section, so the record of what happened when stays honest.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Getting the ingestion logic itself right was the easy part — `ResumeParser`/`ReadmeParser` and `ingest_resume`/`ingest_readme` were direct templates, so the new parser and pipeline method almost wrote themselves. What actually took real effort was everything *around* the happy path. I shipped a first version of `fetch_url` with an SSRF guard that checked the URL's host before fetching — but I'd left `httpx`'s `follow_redirects=True` on, which meant a public URL could 302 straight into `169.254.169.254` and the guard would never see it. That only surfaced because I asked for a dedicated senior-engineer review pass after the "working" version was already committed. If I'd shipped that first version, I would have merged a security control that looked correct in every test I'd written but didn't actually hold under the one attack it existed to stop. The same review pass caught a second, non-security bug: I was writing `extracted_sections` (a list) and `title` (nullable) straight into chunk metadata, and ChromaDB only accepts scalar values — so the feature would have silently failed on every real ingestion despite all 20 of my original tests passing, because none of those tests exercised the actual vector-store write path.
+
+**What did you learn about working in a large codebase?**
+The most useful skill wasn't writing new code, it was reading old code carefully before touching anything. Confirming issue #11's scope meant diffing against `main` and grepping the *whole* codebase for `portfolio_url`, not just the three files the issue listed — that's how I found `core/services/review_service.py::_run_ingestion_pipeline`, a completely separate, review-generation-time code path that also references `portfolio_url` but only inside a hardcoded placeholder. It would have been easy to either miss it entirely or, worse, assume it was in scope and start "fixing" it, expanding a 5–8 hour issue into something much bigger. I also learned to distrust my own local `make check`/`make test-unit` runs until I'd established a baseline on `main` first — this repo has 53 pre-existing failing unit tests and 168 pre-existing ruff errors that have nothing to do with issue #11, and without checking `main` first I could easily have either panicked over failures I didn't cause or, worse, missed a real regression buried in the noise.
+
+**How did AI tools help — and where did they fall short?**
+AI was fastest at the mechanical parts: finding the exact sibling pattern to mirror (`ResumeParser`, `ingest_resume`), scaffolding a new parser and pipeline method consistently with house style, running `pytest`/`ruff`/`black` in a tight loop, and diffing against `main` to separate what I broke from what was already broken. Where it fell short was catching subtle correctness and security issues on the first pass — the redirect-based SSRF bypass and the ChromaDB list/`None` metadata bug both survived an initial "it works and the tests pass" implementation and only surfaced when I explicitly asked for an adversarial review rather than a "does this look done" pass. The lesson isn't "don't use AI for security-sensitive code," it's that a first implementation pass and a critical review pass are different modes and need to be asked for separately — treating the first green test run as the finish line would have shipped both bugs.
+
+**What would you do differently if you started over?**
+Two concrete things. First, I'd nail down the branch naming convention before opening the PR, not after — I renamed the branch mid-stream to match `CONTRIBUTING.md`, discovered GitHub can't retarget an open PR's head branch, and had to unwind the rename to avoid closing and reopening PR #168, which cost time and left a documented (but avoidable) deviation in the final PR. Second, I'd run the adversarial/security review pass as its own explicit step right after the first working version, instead of treating "tests pass" as a stopping point and only requesting a deeper review afterward — both real bugs I found came from that second pass, and they should be a standard step in my process, not something I ask for occasionally.
+
+**What are you most proud of from this module?**
+Not the feature working — catching the SSRF redirect bypass before it shipped. It's the kind of bug that passes every functional test, looks like exactly the right defense in the diff, and would only ever be found by someone deliberately trying to break it rather than confirm it works. Building the habit of asking "how would this fail against someone trying to abuse it" as a separate step from "does this do what I intended" feels like the most transferable thing I'm taking out of this module.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -39,3 +39,35 @@ Since this issue describes a missing feature rather than a crash, I reproduced i
 
 **Blockers or open questions:**
 `core/services/review_service.py` has a review-generation-time placeholder for portfolio (and github/resume) data that this fix does not touch — see the Risks section in PLAN.md. Worth confirming with a mentor whether that's tracked as a separate issue or expected to be addressed later, since without it the ingested portfolio content isn't yet surfaced end-to-end in a generated review.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+All 5 sub-tasks from PLAN.md are implemented: `WebParser` with SSRF-guarded `fetch_url` (including manual redirect re-validation), `IngestionPipeline.ingest_portfolio()` with metadata sanitization and stale-chunk cleanup, `portfolio_url` schema validation, the `BackgroundTasks` wiring in `api/routes/profiles.py` backed by a cached pipeline factory in `api/dependencies/ingestion.py`, and 31 unit tests across `test_web_parser.py` and `test_ingestion_pipeline.py`, all passing.
+
+**Next steps:**
+Run `make check`/`make test-unit` against `main` to establish a pre-existing-failure baseline, self-review the diff against `CONTRIBUTING.md` and the pre-submission checklist, rewrite the PR description to the repo's template, and finalize.
+
+**Blockers:**
+None blocking; the review_service.py placeholder noted in Week 8 remains an open question for a mentor, not a blocker for this PR's scope.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/168
+
+**Branch:** `11-portfolio-url-ingestion` (see Notes for Reviewers on the PR for why this doesn't carry the `feat/` prefix required by `CONTRIBUTING.md` — GitHub doesn't support retargeting an open PR to a renamed branch, so the rename was reverted to avoid closing/reopening the PR)
+
+**What you built:**
+A `WebParser` that fetches a portfolio URL (with an SSRF guard covering redirects) and extracts clean bio/project text, plus an `IngestionPipeline.ingest_portfolio()` method that chunks, embeds, and stores that text in the vector store — triggered automatically in the background when a profile is created or updated with a `portfolio_url`.
+
+**Tests added or updated:**
+`tests/unit/test_web_parser.py` (20 tests: parsing, boilerplate stripping, metadata, SSRF guard, redirect handling) and `tests/unit/test_ingestion_pipeline.py` (11 tests: metadata sanitization, stale-chunk cleanup, ingest success/failure paths) — 31 total, all passing.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+(Both checked under the documented pre-existing-failure carve-out: `main` already has 53 failing unit tests and repo-wide ruff/black/mypy failures unrelated to this change. On the 9 files this PR touches, ruff/black/mypy introduce 0 new errors — full breakdown in the PR's Notes for Reviewers.)
+
+**Draft PR feedback received from:** none

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,111 @@
+# Solution plan
+
+**Issue:** [Add support for ingesting a portfolio website URL (#11)](https://github.com/ascherj/pathreview/issues/11)
+
+### Understand
+
+`portfolio_url` is captured in `ProfileCreate`/`ProfileUpdate` and stored on
+the `Profile` model, but nothing in the ingestion layer ever fetches or
+parses it. Expected behavior per the issue: submitting a portfolio URL
+should result in its bio/project text being fetched, extracted, chunked,
+embedded, and stored in the vector store alongside resume and GitHub data,
+so the review agent can reference it. Actual behavior: the URL is inert —
+just a string sitting in Postgres. The one place code *mentions* portfolio
+ingestion (`core/services/review_service.py::_run_ingestion_pipeline`) is an
+explicit placeholder that fabricates a string instead of fetching real
+content, and never touches the vector store. See `docs/issue-11-repro.md`
+for the full reproduction trail.
+
+### Map
+
+- `ingestion/parsers/base.py` — existing `BaseParser`/`ParseResult`
+  interface to implement against (no changes needed).
+- `ingestion/parsers/web_parser.py` (new) — HTML fetch + text extraction,
+  mirroring `ResumeParser`/`ReadmeParser`.
+- `ingestion/pipeline.py` — add `IngestionPipeline.ingest_portfolio()`,
+  following the shape of `ingest_resume`/`ingest_readme`/`ingest_repo_metadata`.
+- `api/schemas/profile.py` — validate `portfolio_url` is a well-formed
+  http(s) URL before it's ever stored.
+- `api/dependencies/ingestion.py` (new) — builds the `IngestionPipeline`
+  (vector store + embedding provider) so a route can call `ingest_portfolio`.
+- `api/routes/profiles.py` — trigger `ingest_portfolio` in the background on
+  profile create/update.
+- `core/services/review_service.py` — **not touched in this pass**; still
+  holds the review-generation-time placeholder for portfolio data (see
+  Risks below).
+
+### Plan
+
+1. Build `WebParser` (`ingestion/parsers/web_parser.py`): strip boilerplate
+   tags (`script`/`style`/`nav`/`footer`/`header`/`aside`), extract bio and
+   project text plus lightweight metadata (title, section hints), and guard
+   against SSRF (block non-http(s) schemes and loopback/private/link-local
+   addresses, including on redirect hops).
+2. Add `IngestionPipeline.ingest_portfolio(profile_id, url)`: fetch → parse
+   → chunk (reusing `StrategySelector`) → embed → store, matching the
+   skip/hash/record pattern of the other `ingest_*` methods.
+3. Validate `portfolio_url` in `ProfileCreate`/`ProfileUpdate` (reject
+   non-http(s) or malformed values) so bad input never reaches the pipeline.
+4. Wire a `BackgroundTasks` trigger in `api/routes/profiles.py` so profile
+   create/update kicks off ingestion without blocking the request, backed by
+   a cached pipeline factory in `api/dependencies/ingestion.py`.
+5. Add unit tests for the parser (extraction, boilerplate stripping, error
+   cases), the SSRF guard (blocked hosts/schemes, redirect re-validation),
+   and pipeline tests for metadata sanitization and stale-chunk cleanup on
+   re-ingestion.
+
+### Inputs & outputs
+
+- **Input:** a `portfolio_url` string (from `ProfileCreate`/`ProfileUpdate`)
+  and the `profile_id` it belongs to.
+- **Output:** chunks of cleaned portfolio text, embedded and upserted into
+  the ChromaDB collection, tagged with `source_type="portfolio"` and
+  `profile_id`, retrievable the same way resume/README chunks are.
+- **Side effects:** an `IngestResult` (chunk count, skip status) is logged;
+  the HTTP response shape is unchanged — ingestion runs after the response
+  is already prepared, in the background.
+
+### Risks & unknowns
+
+- **SSRF via redirects:** a public URL can redirect to an internal address
+  (e.g. the cloud metadata IP `169.254.169.254`); `httpx`'s default
+  `follow_redirects=True` does not re-check the SSRF guard on each hop, so
+  redirects need to be followed manually with re-validation at every step.
+- **ChromaDB metadata constraints:** `extracted_sections` is naturally a
+  list and `title` can be `None`; ChromaDB only accepts scalar metadata
+  values, so both need sanitizing before every vector-store write or
+  ingestion fails silently at that step.
+- **Stale vectors on URL change:** without deleting a profile's prior
+  portfolio chunks before re-ingesting, changing the URL leaves orphaned old
+  content behind, and re-ingesting the same URL risks colliding on
+  duplicate chunk IDs.
+- **Known gap, intentionally not fixed in this pass:**
+  `core/services/review_service.py::_run_ingestion_pipeline` (used at
+  review-generation time, a separate code path from profile-creation-time
+  ingestion) still contains a hardcoded placeholder for portfolio data, and
+  `_run_rag_retrieval_generation` doesn't query the vector store at all —
+  it returns fully hardcoded feedback sections. So even with real ingestion
+  in place, the review-generation flow doesn't yet surface it end-to-end.
+  This looks like broader, pre-existing scaffolding (the same placeholder
+  pattern also covers `github` and `resume`), likely a separate issue's
+  scope — flagging it here since it affects whether this fix is visible to
+  a user in the product, not just in the vector store.
+- **No existing pipeline instantiation anywhere in the app** before this
+  change — `IngestionPipeline` had never been wired up with real
+  dependencies (vector store, embedding provider), so that plumbing had to
+  be built from scratch in `api/dependencies/ingestion.py`.
+
+### Edge cases
+
+- Non-existent / unreachable URL (DNS failure, connection refused, timeout)
+  → fails gracefully and logs, without crashing profile creation.
+- Non-HTML response (JSON API, PDF, etc.) → rejected with a clear error.
+- Empty page, or a JS-only SPA shell with no server-rendered text → raises
+  rather than silently storing an empty embedding.
+- Extremely large pages → size-capped before parsing.
+- URL pointing at localhost, a private network address, or the cloud
+  metadata endpoint → blocked outright, including when reached via redirect.
+- User updates `portfolio_url` to a new site → old portfolio chunks for
+  that profile are removed, not just appended to.
+- User submits the exact same URL twice → does not create duplicate chunk
+  IDs in the vector store.

--- a/api/dependencies/ingestion.py
+++ b/api/dependencies/ingestion.py
@@ -1,0 +1,54 @@
+"""Factory and background task helpers for portfolio ingestion."""
+
+import structlog
+
+from core.config import settings
+from ingestion.embeddings.provider import get_embedding_provider
+from ingestion.pipeline import IngestionPipeline
+from rag.retriever.vector_store import VectorStore
+
+log = structlog.get_logger()
+
+
+def build_ingestion_pipeline() -> IngestionPipeline:
+    """
+    Construct an IngestionPipeline from application settings.
+
+    Uses the configured embedding provider and a ChromaDB collection from the
+    persistent vector store.
+    """
+    vector_store = VectorStore(persist_dir=settings.chroma_persist_dir)
+    collection = vector_store.get_collection(settings.vector_collection_name)
+    embedding_provider = get_embedding_provider(settings.embedding_provider)
+
+    return IngestionPipeline(
+        vector_db=collection,
+        db_session=None,
+        embedding_provider=embedding_provider,
+    )
+
+
+def run_portfolio_ingestion(profile_id: str, url: str) -> None:
+    """
+    Fetch, parse, and ingest a portfolio URL.
+
+    Intended to run as a FastAPI BackgroundTask. Failures are logged rather than
+    raised so they never affect the originating request/response.
+    """
+    try:
+        pipeline = build_ingestion_pipeline()
+        result = pipeline.ingest_portfolio(profile_id=profile_id, url=url)
+        log.info(
+            "portfolio_ingestion_completed",
+            profile_id=profile_id,
+            url=url,
+            chunk_count=result.chunk_count,
+            skipped=result.skipped,
+        )
+    except Exception as exc:
+        log.error(
+            "portfolio_ingestion_failed",
+            profile_id=profile_id,
+            url=url,
+            error=str(exc),
+        )

--- a/api/dependencies/ingestion.py
+++ b/api/dependencies/ingestion.py
@@ -1,5 +1,7 @@
 """Factory and background task helpers for portfolio ingestion."""
 
+from functools import lru_cache
+
 import structlog
 
 from core.config import settings
@@ -10,12 +12,15 @@ from rag.retriever.vector_store import VectorStore
 log = structlog.get_logger()
 
 
+@lru_cache(maxsize=1)
 def build_ingestion_pipeline() -> IngestionPipeline:
     """
-    Construct an IngestionPipeline from application settings.
+    Construct (once) an IngestionPipeline from application settings.
 
-    Uses the configured embedding provider and a ChromaDB collection from the
-    persistent vector store.
+    Cached so the ChromaDB client and embedding provider are reused across
+    requests rather than rebuilt on every ingestion. Uses the configured
+    embedding provider and a ChromaDB collection from the persistent vector
+    store.
     """
     vector_store = VectorStore(persist_dir=settings.chroma_persist_dir)
     collection = vector_store.get_collection(settings.vector_collection_name)

--- a/api/routes/profiles.py
+++ b/api/routes/profiles.py
@@ -1,18 +1,28 @@
-from fastapi import APIRouter, Depends, HTTPException, status, UploadFile, File, Form
-from uuid import UUID
-import structlog
 import mimetypes
+from uuid import UUID
 
-from api.schemas.profile import ProfileCreate, ProfileResponse, ProfileUpdate
+import structlog
+from fastapi import (
+    APIRouter,
+    BackgroundTasks,
+    Depends,
+    File,
+    Form,
+    HTTPException,
+    UploadFile,
+    status,
+)
+
+from api.dependencies.ingestion import run_portfolio_ingestion
 from api.middleware.auth import get_current_user
-from core.models.user import User
-from core.models.profile import Profile
+from api.schemas.profile import ProfileCreate, ProfileResponse, ProfileUpdate
 from core.database import get_db
+from core.models.user import User
 from core.services.profile_service import (
     create_profile,
+    delete_profile,
     get_profile,
     update_profile,
-    delete_profile,
 )
 
 log = structlog.get_logger()
@@ -22,6 +32,7 @@ router = APIRouter(prefix="/profiles", tags=["profiles"])
 
 @router.post("", response_model=ProfileResponse)
 async def create_profile_endpoint(
+    background_tasks: BackgroundTasks,
     github_username: str = Form(default=None),
     portfolio_url: str = Form(default=None),
     resume_file: UploadFile = File(default=None),
@@ -59,10 +70,9 @@ async def create_profile_endpoint(
             if file_mime == "application/pdf":
                 try:
                     import PyPDF2
+
                     pdf_reader = PyPDF2.PdfReader(content)
-                    resume_text = "\n".join(
-                        page.extract_text() for page in pdf_reader.pages
-                    )
+                    resume_text = "\n".join(page.extract_text() for page in pdf_reader.pages)
                 except Exception as exc:
                     log.error("pdf_parsing_failed", error=str(exc))
                     raise HTTPException(
@@ -94,6 +104,14 @@ async def create_profile_endpoint(
             profile_id=str(new_profile.id),
             user_id=str(current_user.id),
         )
+
+        # Ingest portfolio content in the background if a URL was provided.
+        if new_profile.portfolio_url:
+            background_tasks.add_task(
+                run_portfolio_ingestion,
+                str(new_profile.id),
+                new_profile.portfolio_url,
+            )
 
         return ProfileResponse.model_validate(new_profile)
 
@@ -148,6 +166,7 @@ async def get_profile_endpoint(
 async def update_profile_endpoint(
     profile_id: UUID,
     data: ProfileUpdate,
+    background_tasks: BackgroundTasks,
     current_user: User = Depends(get_current_user),
     db=Depends(get_db),
 ):
@@ -179,6 +198,14 @@ async def update_profile_endpoint(
             profile_id=str(profile_id),
             user_id=str(current_user.id),
         )
+
+        # Re-ingest portfolio content when a URL was provided in this update.
+        if data.portfolio_url and updated_profile.portfolio_url:
+            background_tasks.add_task(
+                run_portfolio_ingestion,
+                str(updated_profile.id),
+                updated_profile.portfolio_url,
+            )
 
         return ProfileResponse.model_validate(updated_profile)
 

--- a/api/schemas/profile.py
+++ b/api/schemas/profile.py
@@ -1,25 +1,43 @@
-from pydantic import BaseModel, Field
 from datetime import datetime
+from urllib.parse import urlparse
 from uuid import UUID
-from typing import Optional
+
+from pydantic import BaseModel, Field, field_validator
+
+
+def _validate_portfolio_url(value: str | None) -> str | None:
+    """Ensure a portfolio URL, if provided, is a well-formed http(s) URL."""
+    if value is None:
+        return value
+    value = value.strip()
+    if not value:
+        return None
+    parsed = urlparse(value)
+    if parsed.scheme not in ("http", "https") or not parsed.netloc:
+        raise ValueError("portfolio_url must be a valid http or https URL")
+    return value
 
 
 class ProfileCreate(BaseModel):
-    github_username: Optional[str] = Field(default=None, max_length=255)
-    portfolio_url: Optional[str] = Field(default=None, max_length=500)
+    github_username: str | None = Field(default=None, max_length=255)
+    portfolio_url: str | None = Field(default=None, max_length=500)
+
+    _validate_portfolio_url = field_validator("portfolio_url")(_validate_portfolio_url)
 
 
 class ProfileUpdate(BaseModel):
-    github_username: Optional[str] = Field(default=None, max_length=255)
-    portfolio_url: Optional[str] = Field(default=None, max_length=500)
+    github_username: str | None = Field(default=None, max_length=255)
+    portfolio_url: str | None = Field(default=None, max_length=500)
+
+    _validate_portfolio_url = field_validator("portfolio_url")(_validate_portfolio_url)
 
 
 class ProfileResponse(BaseModel):
     id: UUID
     user_id: UUID
-    github_username: Optional[str]
-    portfolio_url: Optional[str]
+    github_username: str | None
+    portfolio_url: str | None
     created_at: datetime
-    resume_filename: Optional[str]
+    resume_filename: str | None
 
     model_config = {"from_attributes": True}

--- a/core/config.py
+++ b/core/config.py
@@ -8,9 +8,16 @@ class Settings(BaseSettings):
     """Application settings with support for .env file and environment variables."""
 
     # Database
-    database_url: str = Field(default="postgresql+asyncpg://pathreview:pathreview@localhost:5432/pathreview_dev")
+    database_url: str = Field(
+        default="postgresql+asyncpg://pathreview:pathreview@localhost:5432/pathreview_dev"
+    )
     redis_url: str = Field(default="redis://localhost:6379/0")
     vector_db_url: str = Field(default="http://localhost:8001")
+
+    # Vector store / embeddings
+    embedding_provider: str = Field(default="mock")
+    chroma_persist_dir: str = Field(default=".chromadb")
+    vector_collection_name: str = Field(default="portfolio_chunks")
 
     # LLM Configuration
     llm_provider: str = Field(default="mock")

--- a/docs/issue-11-repro.md
+++ b/docs/issue-11-repro.md
@@ -1,0 +1,83 @@
+# Reproducing Issue #11 — Portfolio URL Ingestion Gap
+
+**Issue:** [Add support for ingesting a portfolio website URL](https://github.com/ascherj/pathreview/issues/11)
+
+## How I reproduced it
+
+This issue describes a missing feature rather than a crash, so "reproducing" it
+means confirming exactly what's absent and where. I inspected `main` (the
+pre-fix state) along the two paths a portfolio URL could take: ingestion time
+(profile creation) and review-generation time (review processing).
+
+### 1. The ingestion pipeline has no portfolio path
+
+```
+$ git show main:ingestion/pipeline.py | grep -n "def ingest"
+55:    def ingest_resume(
+126:    def ingest_readme(
+201:    def ingest_repo_metadata(
+```
+
+No `ingest_portfolio` method exists. `ingestion/parsers/` on `main` has no
+web/HTML parser either:
+
+```
+$ git ls-tree main ingestion/parsers/
+__init__.py  base.py  readme_parser.py  repo_analyzer.py  resume_parser.py  skill_extractor.py
+```
+
+### 2. `portfolio_url` is stored but never processed
+
+`api/routes/profiles.py` on `main` accepts and stores `portfolio_url` on
+profile create/update, but nothing reads it back afterward to fetch or parse
+the page:
+
+```
+$ git show main:api/routes/profiles.py | grep -n portfolio_url
+26:    portfolio_url: str = Form(default=None),
+81:            portfolio_url=portfolio_url,
+```
+
+### 3. The one place that *mentions* portfolio ingestion is a stub
+
+`core/services/review_service.py::_run_ingestion_pipeline` (run during
+`process_review`, i.e. at review-generation time, not profile-creation time)
+does reference `profile.portfolio_url`, but only inside an explicit
+placeholder:
+
+```python
+# Ingest from portfolio URL if available
+if profile.portfolio_url:
+    try:
+        # Placeholder: actual portfolio ingestion logic
+        portfolio_data = {
+            "source_type": "portfolio",
+            "url": profile.portfolio_url,
+            "data": f"Portfolio data from {profile.portfolio_url}",
+        }
+```
+
+No HTTP fetch, no HTML parsing, no chunking, no embeddings — just a
+hardcoded string built from the URL itself. The same placeholder pattern
+also exists for the `github` and `resume` branches in that function, and
+`_run_rag_retrieval_generation` further down returns fully hardcoded
+feedback sections rather than querying the vector store. This means it's
+pre-existing scaffolding across the whole review-generation flow, not
+something specific to issue #11 — see `PLAN.md` risks for how this affects
+this fix.
+
+## Observed outcome (pre-fix)
+
+A user could submit a portfolio URL when creating a profile. It saved to the
+database correctly, but no content from that URL ever reached the vector
+store, so the review agent had no way to reference the user's actual
+portfolio bio or project descriptions — confirming the gap as described in
+the issue.
+
+## What a successful fix needs to do
+
+Per the issue text: fetch the page content, extract relevant text (bio,
+project descriptions), and include it in the vector store alongside GitHub
+and resume data. That means building the missing *ingestion-time* path (a
+new parser plus a new `IngestionPipeline` method) — not the review-time
+placeholder described above, which is out of scope for this issue.

--- a/ingestion/parsers/web_parser.py
+++ b/ingestion/parsers/web_parser.py
@@ -1,0 +1,180 @@
+import ipaddress
+import re
+import socket
+from urllib.parse import urlparse
+
+import httpx
+from bs4 import BeautifulSoup
+
+from .base import BaseParser, ParseResult
+
+# Tags whose text is boilerplate/navigation rather than portfolio content.
+_BOILERPLATE_TAGS = ("script", "style", "nav", "footer", "header", "aside", "noscript")
+
+# Elements that typically hold the meaningful content of a portfolio page.
+_CONTENT_SECTION_KEYWORDS = ("about", "bio", "project", "experience", "work", "skill")
+
+_FETCH_TIMEOUT_SECONDS = 10.0
+_MAX_CONTENT_BYTES = 5 * 1024 * 1024  # 5 MB
+_USER_AGENT = "PathReviewBot/1.0 (+https://github.com/ascherj/pathreview)"
+
+
+class WebParserError(ValueError):
+    """Raised when a portfolio URL cannot be fetched or parsed."""
+
+
+def _is_blocked_address(host: str) -> bool:
+    """
+    Return True if the host resolves to a non-public address.
+
+    Blocks loopback, private, link-local, and other reserved ranges to guard
+    against SSRF via user-supplied portfolio URLs.
+    """
+    try:
+        addr_infos = socket.getaddrinfo(host, None)
+    except socket.gaierror:
+        # Cannot resolve - treat as blocked (nothing safe to fetch).
+        return True
+
+    for info in addr_infos:
+        ip_str = info[4][0]
+        try:
+            ip = ipaddress.ip_address(ip_str)
+        except ValueError:
+            return True
+        if (
+            ip.is_private
+            or ip.is_loopback
+            or ip.is_link_local
+            or ip.is_reserved
+            or ip.is_multicast
+            or ip.is_unspecified
+        ):
+            return True
+    return False
+
+
+def fetch_url(url: str, *, timeout: float = _FETCH_TIMEOUT_SECONDS) -> str:
+    """
+    Fetch the HTML content of a portfolio URL.
+
+    Args:
+        url: The portfolio URL to fetch (must be http/https).
+        timeout: Request timeout in seconds.
+
+    Returns:
+        The raw HTML content as a string.
+
+    Raises:
+        WebParserError: If the URL is invalid, blocked (SSRF), unreachable,
+            or does not return HTML content.
+    """
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise WebParserError(f"URL must use http or https scheme, got: {parsed.scheme!r}")
+    if not parsed.hostname:
+        raise WebParserError("URL must include a hostname")
+
+    if _is_blocked_address(parsed.hostname):
+        raise WebParserError("Refusing to fetch internal or non-public address")
+
+    try:
+        response = httpx.get(
+            url,
+            timeout=timeout,
+            follow_redirects=True,
+            headers={"User-Agent": _USER_AGENT},
+        )
+        response.raise_for_status()
+    except httpx.HTTPError as exc:
+        raise WebParserError(f"Failed to fetch URL: {exc}") from exc
+
+    content_type = response.headers.get("content-type", "")
+    if "html" not in content_type.lower():
+        raise WebParserError(f"Expected HTML content, got: {content_type!r}")
+
+    if len(response.content) > _MAX_CONTENT_BYTES:
+        raise WebParserError("Page content exceeds maximum allowed size")
+
+    return response.text
+
+
+class WebParser(BaseParser):
+    """Parser for portfolio website HTML content."""
+
+    def parse(self, content: str | bytes) -> ParseResult:
+        """
+        Parse raw HTML from a portfolio page into clean text.
+
+        Args:
+            content: Raw HTML as a string or bytes.
+
+        Returns:
+            ParseResult with extracted text and metadata.
+
+        Raises:
+            WebParserError: If content is empty or yields no extractable text.
+        """
+        if isinstance(content, bytes):
+            content = content.decode("utf-8", errors="replace")
+        elif not isinstance(content, str):
+            raise WebParserError("Content must be a string or bytes")
+
+        if not content.strip():
+            raise WebParserError("Content is empty")
+
+        soup = BeautifulSoup(content, "html.parser")
+
+        title = soup.title.get_text(strip=True) if soup.title else None
+
+        # Remove boilerplate before extracting text.
+        for tag in soup(_BOILERPLATE_TAGS):
+            tag.decompose()
+
+        link_count = len(soup.find_all("a"))
+        extracted_sections = self._extract_sections(soup)
+
+        text = self._normalize_whitespace(soup.get_text(separator="\n"))
+        if not text:
+            raise WebParserError("No extractable text found in page")
+
+        word_count = len(text.split())
+
+        metadata = {
+            "source_type": "portfolio",
+            "title": title,
+            "word_count": word_count,
+            "link_count": link_count,
+            "extracted_sections": extracted_sections,
+        }
+
+        return ParseResult(
+            text=text,
+            metadata=metadata,
+            source_type="portfolio",
+        )
+
+    def _extract_sections(self, soup: BeautifulSoup) -> list[str]:
+        """Detect likely portfolio sections from headings and id/class hints."""
+        detected: set[str] = set()
+
+        for heading in soup.find_all(["h1", "h2", "h3"]):
+            heading_text = heading.get_text(strip=True).lower()
+            for keyword in _CONTENT_SECTION_KEYWORDS:
+                if keyword in heading_text:
+                    detected.add(keyword)
+
+        for element in soup.find_all(attrs={"id": True}):
+            identifier = element.get("id", "").lower()
+            for keyword in _CONTENT_SECTION_KEYWORDS:
+                if keyword in identifier:
+                    detected.add(keyword)
+
+        return sorted(detected)
+
+    def _normalize_whitespace(self, text: str) -> str:
+        """Collapse excess whitespace and blank lines."""
+        lines = [line.strip() for line in text.splitlines()]
+        non_empty = [line for line in lines if line]
+        collapsed = "\n".join(non_empty)
+        return re.sub(r"\n{3,}", "\n\n", collapsed).strip()

--- a/ingestion/parsers/web_parser.py
+++ b/ingestion/parsers/web_parser.py
@@ -1,7 +1,7 @@
 import ipaddress
 import re
 import socket
-from urllib.parse import urlparse
+from urllib.parse import urljoin, urlparse
 
 import httpx
 from bs4 import BeautifulSoup
@@ -16,6 +16,7 @@ _CONTENT_SECTION_KEYWORDS = ("about", "bio", "project", "experience", "work", "s
 
 _FETCH_TIMEOUT_SECONDS = 10.0
 _MAX_CONTENT_BYTES = 5 * 1024 * 1024  # 5 MB
+_MAX_REDIRECTS = 5
 _USER_AGENT = "PathReviewBot/1.0 (+https://github.com/ascherj/pathreview)"
 
 
@@ -54,6 +55,23 @@ def _is_blocked_address(host: str) -> bool:
     return False
 
 
+def _validate_url(url: str) -> None:
+    """
+    Validate that a URL is safe to fetch.
+
+    Raises:
+        WebParserError: If the scheme is not http/https, the hostname is
+            missing, or the host resolves to a non-public address.
+    """
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise WebParserError(f"URL must use http or https scheme, got: {parsed.scheme!r}")
+    if not parsed.hostname:
+        raise WebParserError("URL must include a hostname")
+    if _is_blocked_address(parsed.hostname):
+        raise WebParserError("Refusing to fetch internal or non-public address")
+
+
 def fetch_url(url: str, *, timeout: float = _FETCH_TIMEOUT_SECONDS) -> str:
     """
     Fetch the HTML content of a portfolio URL.
@@ -69,23 +87,31 @@ def fetch_url(url: str, *, timeout: float = _FETCH_TIMEOUT_SECONDS) -> str:
         WebParserError: If the URL is invalid, blocked (SSRF), unreachable,
             or does not return HTML content.
     """
-    parsed = urlparse(url)
-    if parsed.scheme not in ("http", "https"):
-        raise WebParserError(f"URL must use http or https scheme, got: {parsed.scheme!r}")
-    if not parsed.hostname:
-        raise WebParserError("URL must include a hostname")
+    _validate_url(url)
 
-    if _is_blocked_address(parsed.hostname):
-        raise WebParserError("Refusing to fetch internal or non-public address")
-
+    # Follow redirects manually so every hop is re-validated against the SSRF
+    # guard. httpx's follow_redirects would otherwise skip the guard and allow a
+    # public URL to redirect into an internal address.
+    current_url = url
     try:
-        response = httpx.get(
-            url,
-            timeout=timeout,
-            follow_redirects=True,
-            headers={"User-Agent": _USER_AGENT},
-        )
-        response.raise_for_status()
+        for _ in range(_MAX_REDIRECTS + 1):
+            response = httpx.get(
+                current_url,
+                timeout=timeout,
+                follow_redirects=False,
+                headers={"User-Agent": _USER_AGENT},
+            )
+            if response.is_redirect:
+                location = response.headers.get("location")
+                if not location:
+                    break
+                current_url = urljoin(current_url, location)
+                _validate_url(current_url)
+                continue
+            response.raise_for_status()
+            break
+        else:
+            raise WebParserError("Too many redirects")
     except httpx.HTTPError as exc:
         raise WebParserError(f"Failed to fetch URL: {exc}") from exc
 

--- a/ingestion/pipeline.py
+++ b/ingestion/pipeline.py
@@ -314,6 +314,11 @@ class IngestionPipeline:
             return skip_result
 
         try:
+            # Remove any prior portfolio chunks for this profile so a changed
+            # URL does not leave stale vectors and re-ingestion does not collide
+            # on duplicate chunk IDs.
+            self._delete_existing_portfolio(profile_id)
+
             # Fetch and parse the portfolio page
             html = fetch_url(url)
             parse_result = self.web_parser.parse(html)
@@ -334,6 +339,8 @@ class IngestionPipeline:
                     "source_type": "portfolio",
                 }
             )
+            # Coerce to ChromaDB-compatible scalar values (no lists/None).
+            metadata = self._sanitize_metadata(metadata)
 
             # Chunk the content
             chunks = self.strategy_selector.chunk(parse_result.text, metadata)
@@ -360,6 +367,49 @@ class IngestionPipeline:
                 error=str(e),
             )
             raise
+
+    def _delete_existing_portfolio(self, profile_id: str) -> None:
+        """
+        Delete previously ingested portfolio chunks for a profile.
+
+        Best-effort: failures are logged but do not block ingestion.
+        """
+        try:
+            self.vector_db.delete(
+                where={
+                    "$and": [
+                        {"profile_id": profile_id},
+                        {"source_type": "portfolio"},
+                    ]
+                }
+            )
+        except Exception as e:
+            logger.warning(
+                "Could not delete existing portfolio chunks",
+                profile_id=profile_id,
+                error=str(e),
+            )
+
+    @staticmethod
+    def _sanitize_metadata(metadata: dict) -> dict:
+        """
+        Coerce metadata values into ChromaDB-compatible scalars.
+
+        ChromaDB only accepts str/int/float/bool metadata values. Lists are
+        joined into comma-separated strings and None values are dropped so the
+        vector-store write does not fail.
+        """
+        sanitized: dict = {}
+        for key, value in metadata.items():
+            if value is None:
+                continue
+            if isinstance(value, (list, tuple, set)):
+                sanitized[key] = ",".join(str(item) for item in value)
+            elif isinstance(value, (str, int, float, bool)):
+                sanitized[key] = value
+            else:
+                sanitized[key] = str(value)
+        return sanitized
 
     def _hash_content(self, content: str | bytes) -> str:
         """Generate a hash of content for deduplication."""

--- a/ingestion/pipeline.py
+++ b/ingestion/pipeline.py
@@ -1,6 +1,5 @@
 import hashlib
 from dataclasses import dataclass
-from typing import Optional
 
 import structlog
 
@@ -10,7 +9,7 @@ from .embeddings.provider import EmbeddingProvider
 from .parsers.readme_parser import ReadmeParser
 from .parsers.repo_analyzer import RepoAnalyzer
 from .parsers.resume_parser import ResumeParser
-
+from .parsers.web_parser import WebParser, fetch_url
 
 logger = structlog.get_logger()
 
@@ -18,10 +17,11 @@ logger = structlog.get_logger()
 @dataclass
 class IngestResult:
     """Result of ingesting a source."""
+
     source_id: str
     chunk_count: int
     skipped: bool
-    skip_reason: Optional[str] = None
+    skip_reason: str | None = None
 
 
 class IngestionPipeline:
@@ -51,6 +51,7 @@ class IngestionPipeline:
         self.resume_parser = ResumeParser()
         self.readme_parser = ReadmeParser()
         self.repo_analyzer = RepoAnalyzer()
+        self.web_parser = WebParser()
 
     def ingest_resume(
         self,
@@ -86,16 +87,21 @@ class IngestionPipeline:
         try:
             # Parse resume
             parse_result = self.resume_parser.parse(content)
-            logger.info("Resume parsed successfully", sections=parse_result.metadata.get("detected_sections"))
+            logger.info(
+                "Resume parsed successfully",
+                sections=parse_result.metadata.get("detected_sections"),
+            )
 
             # Prepare metadata
             metadata = parse_result.metadata.copy()
-            metadata.update({
-                "source_id": source_id,
-                "profile_id": profile_id,
-                "filename": filename,
-                "source_type": "resume",
-            })
+            metadata.update(
+                {
+                    "source_id": source_id,
+                    "profile_id": profile_id,
+                    "filename": filename,
+                    "source_type": "resume",
+                }
+            )
 
             # Chunk the content
             chunks = self.strategy_selector.chunk(parse_result.text, metadata)
@@ -165,12 +171,14 @@ class IngestionPipeline:
 
             # Prepare metadata
             metadata = parse_result.metadata.copy()
-            metadata.update({
-                "source_id": source_id,
-                "profile_id": profile_id,
-                "repo_name": repo_name,
-                "source_type": "readme",
-            })
+            metadata.update(
+                {
+                    "source_id": source_id,
+                    "profile_id": profile_id,
+                    "repo_name": repo_name,
+                    "source_type": "readme",
+                }
+            )
 
             # Chunk the content
             chunks = self.strategy_selector.chunk(parse_result.text, metadata)
@@ -239,11 +247,13 @@ class IngestionPipeline:
 
             # Prepare metadata
             metadata = parse_result.metadata.copy()
-            metadata.update({
-                "source_id": source_id,
-                "profile_id": profile_id,
-                "source_type": "repo",
-            })
+            metadata.update(
+                {
+                    "source_id": source_id,
+                    "profile_id": profile_id,
+                    "source_type": "repo",
+                }
+            )
 
             # Chunk the content
             chunks = self.strategy_selector.chunk(parse_result.text, metadata)
@@ -271,13 +281,93 @@ class IngestionPipeline:
             )
             raise
 
+    def ingest_portfolio(
+        self,
+        profile_id: str,
+        url: str,
+    ) -> IngestResult:
+        """
+        Ingest a portfolio website.
+
+        Fetches the page at the given URL, extracts the relevant text
+        (bio, project descriptions), and stores it in the vector store.
+
+        Args:
+            profile_id: ID of the profile owner
+            url: Portfolio website URL (http/https)
+
+        Returns:
+            IngestResult with ingestion status
+        """
+        source_id = f"portfolio_{profile_id}_{self._hash_content(url)}"
+
+        logger.info(
+            "Starting portfolio ingestion",
+            profile_id=profile_id,
+            url=url,
+            source_id=source_id,
+        )
+
+        # Check if already ingested
+        skip_result = self._check_skip(source_id, "portfolio")
+        if skip_result:
+            return skip_result
+
+        try:
+            # Fetch and parse the portfolio page
+            html = fetch_url(url)
+            parse_result = self.web_parser.parse(html)
+            logger.info(
+                "Portfolio parsed successfully",
+                title=parse_result.metadata.get("title"),
+                word_count=parse_result.metadata.get("word_count"),
+                extracted_sections=parse_result.metadata.get("extracted_sections"),
+            )
+
+            # Prepare metadata
+            metadata = parse_result.metadata.copy()
+            metadata.update(
+                {
+                    "source_id": source_id,
+                    "profile_id": profile_id,
+                    "url": url,
+                    "source_type": "portfolio",
+                }
+            )
+
+            # Chunk the content
+            chunks = self.strategy_selector.chunk(parse_result.text, metadata)
+            logger.info("Portfolio chunked successfully", chunk_count=len(chunks))
+
+            # Generate embeddings and store
+            self.batch_processor.process(chunks)
+            logger.info("Portfolio embeddings stored", chunk_count=len(chunks))
+
+            # Record in database
+            self._record_ingested_source(source_id, "portfolio", profile_id, len(chunks))
+
+            return IngestResult(
+                source_id=source_id,
+                chunk_count=len(chunks),
+                skipped=False,
+            )
+
+        except Exception as e:
+            logger.error(
+                "Portfolio ingestion failed",
+                profile_id=profile_id,
+                url=url,
+                error=str(e),
+            )
+            raise
+
     def _hash_content(self, content: str | bytes) -> str:
         """Generate a hash of content for deduplication."""
         if isinstance(content, str):
             content = content.encode()
         return hashlib.sha256(content).hexdigest()[:16]
 
-    def _check_skip(self, source_id: str, source_type: str) -> Optional[IngestResult]:
+    def _check_skip(self, source_id: str, source_type: str) -> IngestResult | None:
         """
         Check if source has already been ingested.
 
@@ -286,9 +376,11 @@ class IngestionPipeline:
         try:
             # Query database for existing source
             # This assumes a table/model named IngestedSource
-            existing = self.db_session.query(
-                "IngestedSource"  # Placeholder - actual query depends on ORM
-            ).filter_by(source_id=source_id).first()
+            existing = (
+                self.db_session.query("IngestedSource")  # Placeholder - actual query depends on ORM
+                .filter_by(source_id=source_id)
+                .first()
+            )
 
             if existing:
                 logger.info("Source already ingested, skipping", source_id=source_id)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "redis>=5.0.0",
     "httpx>=0.26.0",
     "pypdf>=3.17.0",
+    "beautifulsoup4>=4.12.0",
     "tiktoken>=0.5.2",
     "tenacity>=8.2.0",
     "structlog>=24.1.0",

--- a/tests/unit/test_ingestion_pipeline.py
+++ b/tests/unit/test_ingestion_pipeline.py
@@ -1,0 +1,129 @@
+"""Tests for pipeline.py portfolio ingestion, metadata sanitization, and
+stale-chunk cleanup."""
+
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+from ingestion.pipeline import IngestionPipeline
+
+
+@pytest.mark.unit
+class TestSanitizeMetadata:
+    """Test suite for IngestionPipeline._sanitize_metadata."""
+
+    def test_drops_none_values(self):
+        result = IngestionPipeline._sanitize_metadata({"title": None, "word_count": 5})
+        assert "title" not in result
+        assert result["word_count"] == 5
+
+    def test_joins_list_values(self):
+        result = IngestionPipeline._sanitize_metadata({"extracted_sections": ["about", "project"]})
+        assert result["extracted_sections"] == "about,project"
+
+    def test_joins_tuple_and_set_values(self):
+        result = IngestionPipeline._sanitize_metadata({"a": ("x", "y"), "b": {"z"}})
+        assert result["a"] == "x,y"
+        assert result["b"] == "z"
+
+    def test_preserves_scalars(self):
+        result = IngestionPipeline._sanitize_metadata(
+            {"title": "Jane Dev", "word_count": 10, "ratio": 0.5, "flag": True}
+        )
+        assert result == {"title": "Jane Dev", "word_count": 10, "ratio": 0.5, "flag": True}
+
+    def test_stringifies_unknown_types(self):
+        class Weird:
+            def __str__(self):
+                return "weird-value"
+
+        result = IngestionPipeline._sanitize_metadata({"thing": Weird()})
+        assert result["thing"] == "weird-value"
+
+    def test_empty_list_becomes_empty_string(self):
+        result = IngestionPipeline._sanitize_metadata({"extracted_sections": []})
+        assert result["extracted_sections"] == ""
+
+
+@pytest.mark.unit
+class TestIngestPortfolio:
+    """Test suite for IngestionPipeline.ingest_portfolio."""
+
+    @pytest.fixture
+    def mock_vector_db(self):
+        db = MagicMock()
+        return db
+
+    @pytest.fixture
+    def mock_embedding_provider(self):
+        provider = Mock()
+        provider.embed = Mock(return_value=[[0.1] * 1536])
+        return provider
+
+    @pytest.fixture
+    def pipeline(self, mock_vector_db, mock_embedding_provider):
+        db_session = Mock()
+        db_session.query.side_effect = Exception("no db configured")
+        return IngestionPipeline(
+            vector_db=mock_vector_db,
+            db_session=db_session,
+            embedding_provider=mock_embedding_provider,
+        )
+
+    def test_deletes_existing_chunks_before_ingesting(self, pipeline, mock_vector_db):
+        """A prior portfolio's chunks are removed before the new ones are stored."""
+        html = "<html><body>Bio text here</body></html>"
+        with patch("ingestion.pipeline.fetch_url", return_value=html):
+            pipeline.ingest_portfolio(profile_id="p1", url="https://jane.dev")
+
+        mock_vector_db.delete.assert_called_once()
+        where_clause = mock_vector_db.delete.call_args.kwargs["where"]
+        assert {"profile_id": "p1"} in where_clause["$and"]
+        assert {"source_type": "portfolio"} in where_clause["$and"]
+
+    def test_delete_failure_does_not_block_ingestion(self, pipeline, mock_vector_db):
+        """If deleting stale chunks fails, ingestion still proceeds."""
+        mock_vector_db.delete.side_effect = Exception("boom")
+
+        html = "<html><body>Bio text here</body></html>"
+        with patch("ingestion.pipeline.fetch_url", return_value=html):
+            result = pipeline.ingest_portfolio(profile_id="p1", url="https://jane.dev")
+
+        assert result.skipped is False
+        assert result.chunk_count > 0
+
+    def test_metadata_written_has_no_lists_or_none(self, pipeline, mock_vector_db):
+        """Chunks stored in the vector DB never carry list or None metadata values."""
+        html = (
+            "<html><head><title>Jane</title></head>"
+            "<body><h1>About</h1><p>Bio text here.</p></body></html>"
+        )
+
+        with patch("ingestion.pipeline.fetch_url", return_value=html):
+            pipeline.ingest_portfolio(profile_id="p1", url="https://jane.dev")
+
+        assert mock_vector_db.add.called
+        for call in mock_vector_db.add.call_args_list:
+            for metadata in call.kwargs["metadatas"]:
+                for value in metadata.values():
+                    assert not isinstance(value, (list, tuple, set))
+                    assert value is not None
+
+    def test_ingest_result_on_success(self, pipeline):
+        html = "<html><body>Bio text here</body></html>"
+        with patch("ingestion.pipeline.fetch_url", return_value=html):
+            result = pipeline.ingest_portfolio(profile_id="p1", url="https://jane.dev")
+
+        assert result.skipped is False
+        assert result.chunk_count > 0
+        assert result.source_id.startswith("portfolio_p1_")
+
+    def test_fetch_failure_propagates(self, pipeline):
+        """A fetch/parse failure raises rather than silently succeeding."""
+        from ingestion.parsers.web_parser import WebParserError
+
+        with (
+            patch("ingestion.pipeline.fetch_url", side_effect=WebParserError("blocked")),
+            pytest.raises(WebParserError),
+        ):
+            pipeline.ingest_portfolio(profile_id="p1", url="http://localhost")

--- a/tests/unit/test_web_parser.py
+++ b/tests/unit/test_web_parser.py
@@ -1,0 +1,184 @@
+"""Tests for web_parser.py"""
+
+import httpx
+import pytest
+
+from ingestion.parsers.base import ParseResult
+from ingestion.parsers.web_parser import (
+    WebParser,
+    WebParserError,
+    fetch_url,
+)
+
+SAMPLE_HTML = """
+<html>
+  <head><title>Jane Dev Portfolio</title></head>
+  <body>
+    <nav>Home About Projects Contact</nav>
+    <header>Site banner</header>
+    <h1>About Me</h1>
+    <p>I am a software engineer who builds web apps.</p>
+    <section id="projects">
+      <h2>Projects</h2>
+      <p>Weather App: a React forecasting tool.</p>
+    </section>
+    <script>console.log("tracking");</script>
+    <style>.hidden { display: none; }</style>
+    <footer>Copyright 2026</footer>
+  </body>
+</html>
+"""
+
+
+@pytest.mark.unit
+class TestWebParser:
+    """Test suite for WebParser."""
+
+    @pytest.fixture
+    def parser(self):
+        """Create a WebParser instance."""
+        return WebParser()
+
+    def test_parse_returns_parse_result(self, parser):
+        """Parsing HTML returns a ParseResult with portfolio source type."""
+        result = parser.parse(SAMPLE_HTML)
+
+        assert isinstance(result, ParseResult)
+        assert result.source_type == "portfolio"
+        assert result.metadata["source_type"] == "portfolio"
+
+    def test_parse_extracts_content_text(self, parser):
+        """Meaningful content text is extracted."""
+        result = parser.parse(SAMPLE_HTML)
+
+        assert "I am a software engineer" in result.text
+        assert "Weather App" in result.text
+
+    def test_parse_strips_boilerplate(self, parser):
+        """Script, style, nav, and footer content is removed."""
+        result = parser.parse(SAMPLE_HTML)
+
+        assert "tracking" not in result.text
+        assert "display: none" not in result.text
+        assert "Copyright 2026" not in result.text
+        assert "Site banner" not in result.text
+
+    def test_parse_metadata_fields(self, parser):
+        """Metadata contains title, counts, and detected sections."""
+        result = parser.parse(SAMPLE_HTML)
+
+        assert result.metadata["title"] == "Jane Dev Portfolio"
+        assert result.metadata["word_count"] > 0
+        assert "about" in result.metadata["extracted_sections"]
+        assert "project" in result.metadata["extracted_sections"]
+
+    def test_parse_accepts_bytes(self, parser):
+        """Bytes input is decoded and parsed."""
+        result = parser.parse(SAMPLE_HTML.encode("utf-8"))
+
+        assert "software engineer" in result.text
+
+    def test_parse_empty_content_raises(self, parser):
+        """Empty content raises WebParserError."""
+        with pytest.raises(WebParserError):
+            parser.parse("   ")
+
+    def test_parse_no_text_raises(self, parser):
+        """HTML with no extractable text raises WebParserError."""
+        with pytest.raises(WebParserError):
+            parser.parse("<html><body><script>x=1</script></body></html>")
+
+    def test_parse_invalid_type_raises(self, parser):
+        """Non-string/bytes content raises WebParserError."""
+        with pytest.raises(WebParserError):
+            parser.parse(12345)
+
+
+@pytest.mark.unit
+class TestFetchUrl:
+    """Test suite for fetch_url and its SSRF guard."""
+
+    def test_rejects_non_http_scheme(self):
+        """Non-http(s) schemes are rejected."""
+        with pytest.raises(WebParserError, match="http or https"):
+            fetch_url("ftp://example.com/resource")
+
+    def test_rejects_missing_hostname(self):
+        """A URL without a hostname is rejected."""
+        with pytest.raises(WebParserError):
+            fetch_url("http://")
+
+    def test_blocks_localhost(self):
+        """localhost resolves to loopback and is blocked."""
+        with pytest.raises(WebParserError, match="internal or non-public"):
+            fetch_url("http://localhost/admin")
+
+    def test_blocks_loopback_ip(self):
+        """Loopback IPs are blocked."""
+        with pytest.raises(WebParserError, match="internal or non-public"):
+            fetch_url("http://127.0.0.1/")
+
+    def test_blocks_cloud_metadata_endpoint(self):
+        """The link-local cloud metadata address is blocked."""
+        with pytest.raises(WebParserError, match="internal or non-public"):
+            fetch_url("http://169.254.169.254/latest/meta-data/")
+
+    def test_blocks_private_ip(self):
+        """Private-range IPs are blocked."""
+        with pytest.raises(WebParserError, match="internal or non-public"):
+            fetch_url("http://10.0.0.5/")
+
+    def test_fetch_success(self, monkeypatch):
+        """A public HTML response is returned as text."""
+        monkeypatch.setattr(
+            "ingestion.parsers.web_parser._is_blocked_address",
+            lambda host: False,
+        )
+
+        def fake_get(url, **kwargs):
+            return httpx.Response(
+                200,
+                headers={"content-type": "text/html; charset=utf-8"},
+                text="<html><body>hi</body></html>",
+                request=httpx.Request("GET", url),
+            )
+
+        monkeypatch.setattr(httpx, "get", fake_get)
+
+        html = fetch_url("https://example.com")
+        assert "hi" in html
+
+    def test_fetch_rejects_non_html(self, monkeypatch):
+        """Non-HTML content types are rejected."""
+        monkeypatch.setattr(
+            "ingestion.parsers.web_parser._is_blocked_address",
+            lambda host: False,
+        )
+
+        def fake_get(url, **kwargs):
+            return httpx.Response(
+                200,
+                headers={"content-type": "application/json"},
+                text="{}",
+                request=httpx.Request("GET", url),
+            )
+
+        monkeypatch.setattr(httpx, "get", fake_get)
+
+        with pytest.raises(WebParserError, match="Expected HTML"):
+            fetch_url("https://example.com/api")
+
+    def test_fetch_http_error_wrapped(self, monkeypatch):
+        """HTTP errors are wrapped in WebParserError."""
+        monkeypatch.setattr(
+            "ingestion.parsers.web_parser._is_blocked_address",
+            lambda host: False,
+        )
+
+        def fake_get(url, **kwargs):
+            raise httpx.ConnectError("connection refused")
+
+        monkeypatch.setattr(httpx, "get", fake_get)
+
+        with pytest.raises(WebParserError, match="Failed to fetch"):
+            fetch_url("https://example.com")

--- a/tests/unit/test_web_parser.py
+++ b/tests/unit/test_web_parser.py
@@ -182,3 +182,72 @@ class TestFetchUrl:
 
         with pytest.raises(WebParserError, match="Failed to fetch"):
             fetch_url("https://example.com")
+
+    def test_redirect_to_internal_is_blocked(self, monkeypatch):
+        """A redirect from a public URL to an internal address is rejected."""
+        # Only the redirect target (link-local metadata IP) is blocked.
+        monkeypatch.setattr(
+            "ingestion.parsers.web_parser._is_blocked_address",
+            lambda host: host == "169.254.169.254",
+        )
+
+        def fake_get(url, **kwargs):
+            return httpx.Response(
+                302,
+                headers={"location": "http://169.254.169.254/latest/meta-data/"},
+                request=httpx.Request("GET", url),
+            )
+
+        monkeypatch.setattr(httpx, "get", fake_get)
+
+        with pytest.raises(WebParserError, match="internal or non-public"):
+            fetch_url("https://public-site.example.com")
+
+    def test_redirect_to_public_is_followed(self, monkeypatch):
+        """A redirect to another public URL is followed and its HTML returned."""
+        monkeypatch.setattr(
+            "ingestion.parsers.web_parser._is_blocked_address",
+            lambda host: False,
+        )
+
+        calls = {"n": 0}
+
+        def fake_get(url, **kwargs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return httpx.Response(
+                    301,
+                    headers={"location": "https://www.example.com/home"},
+                    request=httpx.Request("GET", url),
+                )
+            return httpx.Response(
+                200,
+                headers={"content-type": "text/html"},
+                text="<html><body>final</body></html>",
+                request=httpx.Request("GET", url),
+            )
+
+        monkeypatch.setattr(httpx, "get", fake_get)
+
+        html = fetch_url("https://example.com")
+        assert "final" in html
+        assert calls["n"] == 2
+
+    def test_too_many_redirects(self, monkeypatch):
+        """An endless redirect loop is stopped."""
+        monkeypatch.setattr(
+            "ingestion.parsers.web_parser._is_blocked_address",
+            lambda host: False,
+        )
+
+        def fake_get(url, **kwargs):
+            return httpx.Response(
+                302,
+                headers={"location": "https://example.com/next"},
+                request=httpx.Request("GET", url),
+            )
+
+        monkeypatch.setattr(httpx, "get", fake_get)
+
+        with pytest.raises(WebParserError, match="Too many redirects"):
+            fetch_url("https://example.com")


### PR DESCRIPTION
## Summary

`portfolio_url` was captured on `Profile` create/update but nothing ever fetched or processed it — the ingestion pipeline had no path for portfolio content, so a user's bio and project write-ups never reached the vector store. This PR adds a `WebParser` that fetches and cleans a portfolio page's HTML, a new `IngestionPipeline.ingest_portfolio()` method that chunks and embeds that content, and wiring so profile create/update triggers ingestion in the background.

## Issue

Closes #11

## Changes

Root cause: `ingestion/pipeline.py` had `ingest_resume`/`ingest_readme`/`ingest_repo_metadata` but no portfolio equivalent, and `ingestion/parsers/` had no HTML parser at all — see `docs/issue-11-repro.md` for the full reproduction trail, including the one place code *mentioned* portfolio ingestion (`core/services/review_service.py`), which turned out to be an explicit placeholder that fabricates a string instead of fetching real content.

- `ingestion/parsers/web_parser.py` (new) — `WebParser` strips boilerplate (`script`/`style`/`nav`/`footer`/`header`/`aside`), extracts clean text plus metadata (`title`, `word_count`, `link_count`, `extracted_sections`). `fetch_url()` performs the HTTP GET with an SSRF guard: rejects non-http(s) schemes, blocks loopback/private/link-local/reserved/multicast addresses (e.g. `localhost`, `169.254.169.254`, `10.0.0.0/8`), and manually re-validates every redirect hop (`follow_redirects=True` would otherwise skip the guard entirely and let a public URL bounce into an internal address).
- `ingestion/pipeline.py` — `ingest_portfolio(profile_id, url)` mirrors the existing `ingest_*` methods (skip-check → delete stale chunks → fetch → parse → chunk → embed → record). `_sanitize_metadata()` coerces list/`None` metadata values into ChromaDB-compatible scalars before storage — `extracted_sections` is naturally a list and `title` can be `None`, and ChromaDB only accepts scalar metadata, so without this the vector-store write fails. `_delete_existing_portfolio()` removes a profile's prior portfolio chunks before storing new ones so a changed URL doesn't leave stale vectors behind and re-ingesting the same URL doesn't collide on duplicate chunk IDs.
- `api/schemas/profile.py` — `portfolio_url` validated as a well-formed http(s) URL on create/update.
- `api/dependencies/ingestion.py` (new) — `build_ingestion_pipeline()` is cached (`lru_cache`) so the ChromaDB client and embedding provider are built once; `run_portfolio_ingestion()` runs the pipeline and logs failures instead of raising, since it executes in a background task.
- `api/routes/profiles.py` — profile create/update schedule ingestion via FastAPI `BackgroundTasks` when a `portfolio_url` is present, so the fetch never blocks the response and a fetch failure never fails profile creation.
- `core/config.py` — `embedding_provider`, `chroma_persist_dir`, `vector_collection_name` settings.
- `pyproject.toml` — `beautifulsoup4` dependency.

## Testing

- [x] Unit tests pass (`make test-unit`) — 31 new tests pass; 53 pre-existing failures are unchanged (see Notes for Reviewers)
- [ ] Integration tests pass (`make test-integration`) — not run; this change has no integration test coverage in the repo yet
- [x] Linter passes (`make lint`) — 0 new ruff errors introduced (see Notes for Reviewers for the pre-existing count)
- [ ] Type checker passes (`make typecheck`) — does not pass repo-wide; see Notes for Reviewers, this PR introduces 0 new mypy errors
- [x] New/updated tests cover the changes

**Reproduce the original gap (before this fix, on `main`):**
1. `git show main:ingestion/pipeline.py | grep "def ingest"` — no `ingest_portfolio` method exists
2. `git ls-tree main ingestion/parsers/` — no web/HTML parser exists
3. Create a profile with a `portfolio_url` — it saves to Postgres, but nothing ever fetches the page or stores its content in the vector store

**Verify the fix (on this branch):**
1. `git checkout 11-portfolio-url-ingestion`
2. `pytest tests/unit/test_web_parser.py tests/unit/test_ingestion_pipeline.py -v` — 31 tests, all pass
3. Or manually: create/update a profile with a `portfolio_url` via the API — a background task fetches the page, parses it with `WebParser`, chunks and embeds the text, and stores it in the ChromaDB collection tagged `source_type="portfolio"` and `profile_id`

## Screenshots / Demo

N/A — backend-only ingestion change; the observable effect is new chunks appearing in the vector store, exercised by the verification steps above and by the unit tests.

## Notes for Reviewers

- **Pre-existing `make check`/`make test-unit` failures, confirmed unaffected by this PR:** I ran both the full unit suite and lint/format/typecheck on `main` before starting and again on this branch. `main` already has 53 failing unit tests (across `test_bias_detector.py`, `test_pii_scrubber.py`, `test_review_service.py`, `test_resume_parser.py`, `test_readme_parser.py`, and others unrelated to this change) and mypy already fails repo-wide (`PyPDF2` missing stubs, a `rank_bm25` missing-stubs warning, and a numpy/mypy version mismatch that halts analysis). Ruff has 168 pre-existing errors repo-wide. On the 9 files this PR actually touches: ruff introduces 0 new errors (and incidentally fixes 2 pre-existing ones in `api/routes/profiles.py`), black is clean, and mypy's 2 errors on touched files are both pre-existing (missing `PyPDF2` stubs, and the numpy/mypy environment issue). None of the 53 failing tests are in files this PR touches, and the counts are identical before and after.
- **Known branch-naming deviation:** this branch is named `11-portfolio-url-ingestion` rather than `feat/11-portfolio-url-ingestion` per `CONTRIBUTING.md`. It was originally renamed to comply, but GitHub doesn't support retargeting an open PR's head branch, so I reverted the rename to avoid closing and reopening this PR. Flagging this transparently rather than leaving it unexplained.
- **Known follow-up, intentionally out of scope:** `core/services/review_service.py::_run_ingestion_pipeline` (used at review-generation time, a separate code path from the profile-creation-time ingestion this PR adds) still has a hardcoded placeholder for portfolio data, and `_run_rag_retrieval_generation` doesn't query the vector store at all. So real portfolio content now reaches the vector store, but isn't yet surfaced end-to-end in a generated review. The same placeholder pattern also covers `github` and `resume` in that function, so this looks like broader pre-existing scaffolding rather than something specific to issue #11 — documented in `docs/issue-11-repro.md` and `PLAN.md`.
