### PR TITLE
Fix Redis health check to use redis_url from settings

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -74,3 +74,4 @@ Focused issue tests now pass locally:
 
 ```powershell
 .\.venv\Scripts\python -m pytest tests/unit/test_health.py -v
+.\.venv\Scripts\python -m pytest tests/unit/test_health.py tests/unit/test_rate_limiter.py -v

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,16 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/155
+
+**Issue title:** Health check references `settings.redis_host`, which does not exist on Settings
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The `/health` endpoint appears to read `settings.redis_host`, but that field is not defined on the app’s Settings model. Because of that, the health check can raise an AttributeError before it can report Redis status. A successful fix would make the health endpoint use Redis configuration that actually exists and return health information without crashing.
+
+**Branch name:** fix/155-health-check-redis-settings
+
+**Setup confirmation:** [ ] App runs locally at `localhost:5173`
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -7,10 +7,70 @@
 **Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
 
 **Problem summary:**
-The `/health` endpoint appears to read `settings.redis_host`, but that field is not defined on the app’s Settings model. Because of that, the health check can raise an AttributeError before it can report Redis status. A successful fix would make the health endpoint use Redis configuration that actually exists and return health information without crashing.
+The `/health` endpoint checks PostgreSQL, Redis, and vector DB status, but its Redis check originally read `settings.redis_host` and `settings.redis_port` even though the app’s `Settings` model only defines `redis_url`. Because of that mismatch, the Redis check could not use the configured Redis connection information correctly and would mark Redis as unhealthy, contributing to a 503 response.
 
-**Branch name:** fix/155-health-check-redis-settings
+**Why I chose this issue:**
+I chose this issue because it is a clearly scoped Tier 1 backend bug and it touches service health/configuration, which I find interesting. It also seemed like a good fit for a first contribution because the affected area was narrow and the bug could be traced to a specific mismatch between the route code and the settings model.
 
-**Setup confirmation:** [ ] App runs locally at `localhost:5173`
+**Affected area:**
+- `api/routes/health.py`
+- `core/config.py`
+
+**Confirmed investigation notes:**
+- `health.py` originally used `settings.redis_host` and `settings.redis_port`
+- `core/config.py` defines `redis_url`, but not `redis_host` or `redis_port`
+- The Redis exception is caught inside the route, so the issue is not an uncaught crash
+- Instead, Redis is marked unhealthy and the route can return HTTP 503
+
+**Known unknowns during investigation:**
+- Whether the smallest clean fix should parse the URL manually or use a Redis URL-based constructor
+- Whether there was already an existing health-route test pattern in the repo
+- Whether Docker would be required for all validation or whether mocked unit tests would be enough for this issue
+
+**Scope estimate:**
+Small Tier 1 backend fix, likely 1 source file plus 1 focused test file.
+
+**Branch name:** `fix/155-health-check-redis-settings`
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+**Issue claim:** [x] Comment posted on GitHub issue
+
+**Setup progress:**
+- [x] Forked repo
+- [x] Cloned repo
+- [x] Created virtual environment
+- [x] Installed Python dependencies with editable install
+- [x] Repaired WSL/Docker startup issue on Windows
+- [ ] App fully runs locally at `localhost:5173`
+
+**Docker / environment blocker:**
+Docker image pulls for local services were blocked by repeated EOF errors while downloading:
+- `postgres:16-alpine`
+- `redis:7-alpine`
+- `chromadb/chroma:0.4.22`
+
+Because of that, I could not fully bring up the repo’s Docker-backed services locally. However, I was still able to continue issue investigation and write focused mocked unit tests for this issue.
+
+**Testing investigation:**
+There were no existing FastAPI `TestClient` tests or health-route tests in the repo. The best nearby patterns were:
+- `tests/unit/test_review_service.py` for `AsyncMock` database usage
+- `tests/unit/test_rate_limiter.py` for Redis mocking
+
+Based on that, I created:
+- `tests/unit/test_health.py`
+
+**Tests added:**
+1. `test_health_check_returns_healthy_when_dependencies_are_healthy`
+2. `test_health_check_uses_redis_url_from_settings`
+
+These tests call `health_check()` directly with mocked dependencies instead of relying on Docker services.
+
+**Implementation progress:**
+I updated the Redis health check in `api/routes/health.py` to use the existing `settings.redis_url` configuration rather than missing `redis_host` / `redis_port` settings.
+
+**Validation status:**
+Focused issue tests now pass locally:
+
+```powershell
+.\.venv\Scripts\python -m pytest tests/unit/test_health.py -v

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -6,8 +6,10 @@
 
 **Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
 
+**Branch name:** `fix/155-health-check-redis-settings`
+
 **Problem summary:**
-The `/health` endpoint checks PostgreSQL, Redis, and vector DB status, but its Redis check originally read `settings.redis_host` and `settings.redis_port` even though the app’s `Settings` model only defines `redis_url`. Because of that mismatch, the Redis check could not use the configured Redis connection information correctly and would mark Redis as unhealthy, contributing to a 503 response.
+The `/health` endpoint checks PostgreSQL, Redis, and vector DB status, but its Redis check originally read `settings.redis_host` and `settings.redis_port` even though the app's `Settings` model only defines `redis_url`. Because of that mismatch, the Redis check could not use the configured Redis connection information correctly and would mark Redis as unhealthy, contributing to a 503 response.
 
 **Why I chose this issue:**
 I chose this issue because it is a clearly scoped Tier 1 backend bug and it touches service health/configuration, which I find interesting. It also seemed like a good fit for a first contribution because the affected area was narrow and the bug could be traced to a specific mismatch between the route code and the settings model.
@@ -30,8 +32,6 @@ I chose this issue because it is a clearly scoped Tier 1 backend bug and it touc
 **Scope estimate:**
 Small Tier 1 backend fix, likely 1 source file plus 1 focused test file.
 
-**Branch name:** `fix/155-health-check-redis-settings`
-
 **Cohort ledger:** [x] Issue added to cohort ledger
 
 **Issue claim:** [x] Comment posted on GitHub issue
@@ -50,7 +50,7 @@ Docker image pulls for local services were blocked by repeated EOF errors while 
 - `redis:7-alpine`
 - `chromadb/chroma:0.4.22`
 
-Because of that, I could not fully bring up the repo’s Docker-backed services locally. However, I was still able to continue issue investigation and write focused mocked unit tests for this issue.
+Because of that, I could not fully bring up the repo's Docker-backed services locally. However, I was still able to continue issue investigation and write focused mocked unit tests for this issue.
 
 **Testing investigation:**
 There were no existing FastAPI `TestClient` tests or health-route tests in the repo. The best nearby patterns were:
@@ -75,3 +75,59 @@ Focused issue tests now pass locally:
 ```powershell
 .\.venv\Scripts\python -m pytest tests/unit/test_health.py -v
 .\.venv\Scripts\python -m pytest tests/unit/test_health.py tests/unit/test_rate_limiter.py -v
+```
+
+Result:
+
+* 21 passed
+
+**Current status:**
+Issue claimed and added to ledger, working branch created and pushed, journal updated, focused fix implemented, PR opened, and focused validation completed with 21 passing unit tests.
+
+## Week 8 — Reproduction and planning
+
+**Reproduced issue:**
+I reproduced the issue by tracing the Redis health check in `api/routes/health.py` and confirming it used `settings.redis_host` and `settings.redis_port`, while `core/config.py` only defines `redis_url`. Before the fix, focused tests failed because Redis was marked unhealthy and the route returned HTTP 503.
+
+**Observed behavior:**
+Before the fix, the Redis health check raised an internally caught `AttributeError` because `Settings` had no `redis_host` attribute. The route then marked Redis as unhealthy and raised HTTP 503.
+
+**Expected behavior:**
+The health route should use the application's existing Redis configuration source, `settings.redis_url`. When Redis responds to `ping()`, the route should report Redis as healthy without requiring duplicate `redis_host` or `redis_port` settings.
+
+**Plan summary:**
+My plan was to keep the fix minimal by using the existing `settings.redis_url` configuration instead of introducing new settings fields. Since Docker-backed services were blocked by image pull EOF errors, I used mocked unit tests to validate the health route behavior without relying on live Postgres, Redis, or Chroma containers.
+
+**Approach:**
+
+1. Add focused tests in `tests/unit/test_health.py`
+2. Mock database and Redis behavior directly
+3. Update the Redis health check to use `settings.redis_url`
+4. Re-run focused tests and nearby Redis-related unit tests
+
+**Relevant files:**
+
+* `api/routes/health.py`
+* `core/config.py`
+* `tests/unit/test_health.py`
+* `tests/unit/test_review_service.py`
+* `tests/unit/test_rate_limiter.py`
+
+**Known unknowns resolved:**
+
+* I confirmed there were no existing FastAPI `TestClient` tests or health-route tests.
+* I confirmed direct async testing of `health_check()` with mocks was enough for focused unit validation.
+* I confirmed `redis_url` was the existing source of truth for Redis configuration.
+* I confirmed Docker was not required for the focused mocked unit tests.
+
+**Validation for plan/fix:**
+
+* `tests/unit/test_health.py` passed
+* `tests/unit/test_health.py` and `tests/unit/test_rate_limiter.py` passed
+* Total: 21 passing tests
+
+**Blockers:**
+Docker image pulls for local services were blocked by repeated EOF errors, so full Docker-backed runtime verification was not possible on my machine.
+
+**Week 8 current status:**
+`PLAN.md` has been created, the issue has been reproduced, the solution plan is documented, the focused fix is implemented, the PR is open, and relevant mocked unit tests are passing.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -131,3 +131,41 @@ Docker image pulls for local services were blocked by repeated EOF errors, so fu
 
 **Week 8 current status:**
 `PLAN.md` has been created, the issue has been reproduced, the solution plan is documented, the focused fix is implemented, the PR is open, and relevant mocked unit tests are passing.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+The solution is complete. I updated `api/routes/health.py` so the Redis health check uses the existing `settings.redis_url` configuration, and I added focused mocked unit tests in `tests/unit/test_health.py`. The PR is already open.
+
+**Next steps:**
+Review the changed files and PR, keep the journal current, and complete any additional validation that is available locally.
+
+**Blockers:**
+Docker-backed runtime validation is blocked by repeated EOF errors while pulling `postgres:16-alpine`, `redis:7-alpine`, and `chromadb/chroma:0.4.22`. The full Docker environment could not be started. `make check` and `make test-unit` were not run, so they are not marked as passing.
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/171
+
+**Branch:** `fix/155-health-check-redis-settings`
+
+**What I built:**
+I fixed the Redis health check to construct its client from `settings.redis_url` instead of the missing `settings.redis_host` and `settings.redis_port` settings.
+
+**Tests added or updated:**
+Added `tests/unit/test_health.py` with mocked tests covering a healthy health check and verification that the configured Redis URL is used. The focused commands passed with 21 tests total:
+
+```powershell
+.\.venv\Scripts\python -m pytest tests/unit/test_health.py -v
+.\.venv\Scripts\python -m pytest tests/unit/test_health.py tests/unit/test_rate_limiter.py -v
+```
+
+`make check` and `make test-unit` were not run locally. Docker-backed validation remains blocked by the image pull EOF errors described above.
+
+**Self-review confirmation:**
+I reviewed the implementation and tests for scope, correctness, and valid Markdown formatting. The fix remains limited to the Redis settings mismatch and its focused tests.
+
+**Draft PR feedback received from:**
+none yet

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -169,3 +169,34 @@ I reviewed the implementation and tests for scope, correctness, and valid Markdo
 
 **Draft PR feedback received from:**
 none yet
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No reviewer feedback has come in yet. Summer 2026 notes indicate that reviewer feedback is not provided, so there is no feedback to summarize at this time.
+
+**How you responded:**
+No response or code changes were needed because no reviewer feedback has been received yet.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The environment and setup were harder than the code fix itself. Docker-backed validation repeatedly failed with EOF errors while pulling `postgres:16-alpine`, `redis:7-alpine`, and `chromadb/chroma:0.4.22`. That made full local runtime validation harder even though the implementation was a small configuration correction. The focused mocked tests still provided useful evidence for the route behavior, but I could not verify the complete Docker environment locally.
+
+**What did you learn about working in a large codebase?**
+I learned that fixing a route often requires tracing behavior across the route code, configuration definitions, and existing test patterns instead of editing only the obvious file. Checking how Redis was configured in `core/config.py` helped confirm that `settings.redis_url` was the existing source of truth. Matching the project's conventions and keeping the change scoped made the fix easier to test and review.
+
+**How did AI tools help — and where did they fall short?**
+AI tools helped with codebase navigation, test planning, drafting the journal and `PLAN.md`, and organizing a debugging strategy. They could not solve the external Docker image pull and network issues directly, however. Their suggestions still needed to be checked against the repository's actual files and the output from the test commands before I could rely on them.
+
+**What would you do differently if you started over?**
+I would check the configuration definitions earlier and write the focused reproduction test sooner. I would also avoid spending too long trying to force the full Docker setup once it was clear that external image pull EOF errors were blocking it.
+
+**What are you most proud of from this module?**
+I am most proud of taking a real open-source issue from selection through reproduction, planning, implementation, tests, PR submission, and documentation. I kept the fix small and evidence-based, using the project's existing Redis configuration and focused tests rather than introducing unnecessary settings or unrelated changes.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,245 @@
+# Issue #155 — Reproduction and Solution Plan
+
+## Issue
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/155
+
+**Issue title:** Health check references `settings.redis_host`, which does not exist on Settings
+
+**Tier:** Tier 1
+
+**Branch:** `fix/155-health-check-redis-settings`
+
+## Problem summary
+
+The `/health` endpoint checks PostgreSQL, Redis, and vector database status. Its Redis check originally attempted to use `settings.redis_host` and `settings.redis_port`, but the application's `Settings` model only defines `redis_url`.
+
+Because those attributes do not exist, the Redis check raises an `AttributeError`. The exception is caught by the health route, which marks Redis as unhealthy and causes the endpoint to return HTTP 503 even when the configured Redis URL may be valid.
+
+A successful fix should make the health route use the existing `settings.redis_url` configuration and verify Redis connectivity without introducing duplicate host and port settings.
+
+## Reproduction steps
+
+1. Open `api/routes/health.py`.
+2. Locate the Redis health-check block.
+3. Confirm that the Redis client is created using:
+
+```python
+settings.redis_host
+settings.redis_port
+```
+
+4. Open `core/config.py`.
+5. Confirm that `Settings` defines:
+
+```python
+redis_url
+```
+
+but does not define `redis_host` or `redis_port`.
+
+6. Run the focused health tests before applying the fix:
+
+```powershell
+.\.venv\Scripts\python -m pytest tests/unit/test_health.py -v
+```
+
+7. Observe that the tests fail because:
+
+   * PostgreSQL is marked healthy by the mocked database.
+   * Vector DB is marked healthy because a URL is configured.
+   * Redis is marked unhealthy because `Settings` has no `redis_host` attribute.
+   * The route raises HTTP 503.
+
+## Observed behavior
+
+Before the fix, the focused tests produced an error showing:
+
+```text
+'Settings' object has no attribute 'redis_host'
+```
+
+The route caught that exception, marked Redis as unhealthy, and raised an HTTP 503 response.
+
+This is not an uncaught application crash. It is a caught configuration error that causes the health endpoint to incorrectly report an unhealthy Redis dependency.
+
+## Expected behavior
+
+The health route should use the application's existing Redis configuration source:
+
+```python
+settings.redis_url
+```
+
+When the Redis client successfully responds to `ping()`, the route should report Redis as healthy.
+
+The fix should not require adding new `redis_host` or `redis_port` fields to `core/config.py`.
+
+## Relevant files
+
+### Production code
+
+* `api/routes/health.py`
+
+  * Contains the `/health` route and Redis health-check logic.
+
+* `core/config.py`
+
+  * Defines `redis_url`, `database_url`, and `vector_db_url`.
+
+### Tests
+
+* `tests/unit/test_health.py`
+
+  * New focused tests for the health route.
+
+* `tests/unit/test_review_service.py`
+
+  * Existing example of using `AsyncMock` for database sessions.
+
+* `tests/unit/test_rate_limiter.py`
+
+  * Existing example of mocking Redis behavior.
+
+## Known unknowns
+
+During investigation, the main unknowns were:
+
+1. Whether the Redis URL should be parsed manually or passed directly to a Redis URL-based constructor.
+2. Whether the repository already had a FastAPI route-test pattern.
+3. Whether Docker-backed PostgreSQL and Redis services were required to reproduce and validate the issue.
+4. Whether introducing new host and port settings would be expected or would duplicate the existing `redis_url` configuration.
+
+Investigation showed that:
+
+* No existing FastAPI `TestClient` or health-route tests were present.
+* Direct async testing of `health_check()` with mocked dependencies was sufficient.
+* The existing full Redis URL is the clearest source of truth.
+* Docker is not required for focused mocked unit tests.
+
+## Proposed approach
+
+1. Create focused tests in `tests/unit/test_health.py`.
+2. Call `health_check()` directly instead of introducing a new `TestClient` setup.
+3. Mock the async database session with `AsyncMock`.
+4. Mock the Redis client and its `ping()` method.
+5. Add a happy-path test where all dependencies are reported healthy.
+6. Add a test confirming the health route uses `settings.redis_url`.
+7. Update only the Redis client construction in `api/routes/health.py`.
+8. Leave `core/config.py` unchanged.
+9. Run the focused health tests.
+10. Run nearby Redis-related unit tests to check for regressions.
+
+## Tests added
+
+### Happy-path test
+
+`test_health_check_returns_healthy_when_dependencies_are_healthy`
+
+This test:
+
+* mocks `db.execute()` successfully;
+* mocks Redis `ping()` successfully;
+* provides a nonempty vector DB URL;
+* calls `health_check()` directly;
+* asserts the overall status is healthy;
+* asserts PostgreSQL, Redis, and vector DB are each healthy.
+
+### Redis configuration test
+
+`test_health_check_uses_redis_url_from_settings`
+
+This test:
+
+* assigns a known sentinel value to `settings.redis_url`;
+* patches the Redis URL-based client factory;
+* calls `health_check()` directly;
+* asserts the Redis client is created using the configured URL;
+* asserts Redis `ping()` is called;
+* asserts Redis is reported healthy.
+
+## Smallest implementation change
+
+I updated the Redis health-check block in `api/routes/health.py` to use the existing Redis URL configuration.
+
+The implemented direction is:
+
+```python
+redis.from_url(
+    settings.redis_url,
+    decode_responses=True,
+)
+```
+
+This keeps the change small and preserves the full configured Redis URL, including its host, port, and database number.
+
+No new configuration fields were added to `core/config.py`.
+
+## Risks
+
+The main implementation risks were:
+
+* accidentally ignoring the Redis database number included in the URL;
+* introducing duplicate Redis configuration fields;
+* changing unrelated health-route behavior;
+* adding a new testing framework or route harness that was unnecessary for this Tier 1 issue.
+
+Using the complete existing `redis_url` and limiting the code change to the Redis construction path minimized these risks.
+
+## Scope estimate
+
+Expected scope:
+
+* one production file: `api/routes/health.py`;
+* one new test file: `tests/unit/test_health.py`.
+
+Estimated complexity:
+
+* investigation: low;
+* implementation: low;
+* unit testing: low to moderate;
+* full runtime validation: blocked by Docker image pull failures.
+
+## Validation plan
+
+Run the focused health tests:
+
+```powershell
+.\.venv\Scripts\python -m pytest tests/unit/test_health.py -v
+```
+
+Run the focused health tests together with nearby Redis-related tests:
+
+```powershell
+.\.venv\Scripts\python -m pytest tests/unit/test_health.py tests/unit/test_rate_limiter.py -v
+```
+
+Current result:
+
+```text
+21 passed
+```
+
+## Environment blocker
+
+The normal Docker-backed setup could not be completed because image pulls repeatedly failed with EOF errors for:
+
+* `postgres:16-alpine`;
+* `redis:7-alpine`;
+* `chromadb/chroma:0.4.22`.
+
+Because of that, full local runtime validation with live PostgreSQL, Redis, and Chroma services was not possible.
+
+The issue was still reproduced and validated through focused mocked unit tests that directly exercise the health route's behavior.
+
+## Current status
+
+* Issue claimed on GitHub
+* Issue added to the cohort ledger
+* Branch created and pushed
+* `JOURNAL.md` updated
+* `PLAN.md` created
+* Focused tests added
+* Fix implemented
+* 21 relevant tests passing
+* Pull request opened

--- a/api/routes/health.py
+++ b/api/routes/health.py
@@ -41,12 +41,7 @@ async def health_check(db=Depends(get_db)):
         import redis
         from core.config import settings
 
-        r = redis.Redis(
-            host=settings.redis_host,
-            port=settings.redis_port,
-            db=0,
-            decode_responses=True,
-        )
+        r = redis.from_url(settings.redis_url, decode_responses=True)
         r.ping()
         health_status["dependencies"]["redis"] = "healthy"
         log.debug("redis_health_check_passed")

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -1,0 +1,49 @@
+"""Tests for the health check route."""
+
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from api.routes.health import health_check
+from core.config import settings
+
+
+@pytest.mark.unit
+class TestHealthCheck:
+    """Test the health check route with mocked dependencies."""
+
+    @pytest.mark.asyncio
+    async def test_health_check_returns_healthy_when_dependencies_are_healthy(self):
+        db = AsyncMock()
+        redis_client = Mock()
+        redis_client.ping = Mock()
+
+        with patch("redis.from_url", return_value=redis_client), patch.object(
+            settings, "vector_db_url", "http://test-vector-db:8000"
+        ):
+            result = await health_check(db)
+
+        assert result["status"] == "healthy"
+        assert result["dependencies"] == {
+            "postgres": "healthy",
+            "redis": "healthy",
+            "vector_db": "healthy",
+        }
+        db.execute.assert_awaited_once_with("SELECT 1")
+        redis_client.ping.assert_called_once_with()
+
+    @pytest.mark.asyncio
+    async def test_health_check_uses_redis_url_from_settings(self):
+        db = AsyncMock()
+        redis_client = Mock()
+        redis_client.ping = Mock()
+        redis_url = "redis://test-host:6380/3"
+
+        with patch.object(settings, "redis_url", redis_url), patch.object(
+            settings, "vector_db_url", "http://test-vector-db:8000"
+        ), patch("redis.from_url", return_value=redis_client) as redis_factory:
+            result = await health_check(db)
+
+        redis_factory.assert_called_once_with(redis_url, decode_responses=True)
+        redis_client.ping.assert_called_once_with()
+        assert result["dependencies"]["redis"] == "healthy"


### PR DESCRIPTION
## Summary
This PR fixes the Redis health check configuration mismatch in `api/routes/health.py`.

The health route was using `settings.redis_host` and `settings.redis_port`, but the app’s settings model only defines `redis_url`. Because of that, the Redis health check could incorrectly mark Redis as unhealthy and contribute to a 503 response.

## Changes
- Updated the Redis health check to use the existing `settings.redis_url`
- Added focused unit tests in `tests/unit/test_health.py`

## Validation
Ran:

```powershell
.\.venv\Scripts\python -m pytest tests/unit/test_health.py -v
.\.venv\Scripts\python -m pytest tests/unit/test_health.py tests/unit/test_rate_limiter.py -v