### PR TITLE
fix: handle None text in context chunks for faithfulness checker (closes #153)

### DIFF
--- a/rag/evaluator/faithfulness_checker.py
+++ b/rag/evaluator/faithfulness_checker.py
@@ -32,7 +32,7 @@ class FaithfulnessChecker:
 
         # Concatenate context text
         context_text = " ".join([
-            chunk.get("text", "") for chunk in context_chunks
+            chunk.get("text") or "" for chunk in context_chunks
         ])
 
         # Check each claim for support


### PR DESCRIPTION
## Fix for #153

The `FaithfulnessChecker.check()` method used `chunk.get("text", "")` to extract text from context chunks. However, when the key `"text"` exists but its value is `None`, `.get()` returns `None` (the default only applies to missing keys). This caused a `TypeError` when `" ".join(...)` tried to join `None` values.

**Fix:** Changed to `chunk.get("text") or ""` which normalizes `None` to empty string.

**Test:** The existing test `test_none_context_chunk_text` in `tests/unit/test_faithfulness_checker.py` now passes.

Closes #153