### PR TITLE
Fix JS and TypeScript skill detection

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -11,9 +11,9 @@ The skill extractor is missing JavaScript and TypeScript in cases where the text
 
 **Branch name:** fix/148-skill-extractor-js-ts-detection
 
-**Setup confirmation:** [ ] App runs locally at localhost:5173
+**Setup confirmation:** [x] App runs locally at localhost:5173
 
-**Cohort ledger:** [ ] Issue added to cohort ledger
+**Cohort ledger:** [x] Issue added to cohort ledger
 
 **Selection notes:**
-I checked the issue against the project layout and the branch naming rules in `docs/CONTRIBUTING.md`. The issue is narrow, reproducible, and centered in a single parser module, which keeps it realistic for Week 7. It also passed the "right for me" scope check because I already validated the local environment and confirmed the affected area before making the fix.
+I checked the issue against the project layout and the branch naming rules in `docs/CONTRIBUTING.md`. The issue is narrow, reproducible, and centered in a single parser module, which keeps it realistic for Week 7. It also passed the "right for me" scope check because I validated the local environment, confirmed the app runs locally at `localhost:5173`, and verified the affected area before making the fix.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,19 @@
+## Week 7 — Issue selection
+
+**Issue link:** [https://github.com/ascherj/pathreview/issues/148](https://github.com/ascherj/pathreview/issues/148)
+
+**Issue title:** Skill extractor fails to detect JavaScript and TypeScript
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The skill extractor is missing JavaScript and TypeScript in cases where the text clearly shows JS or TS work. The current implementation relies too much on filename hints and a narrow set of import patterns, so it misses common syntax like `const`, `require(...)`, `export interface`, and `.tsx` references in prose. A successful fix should make JS/TS detection reliable on resume and repository text while keeping the rest of the extractor behavior stable. This issue is a good fit because the affected code lives in `ingestion/parsers/skill_extractor.py` and the scope is small enough to understand and verify locally.
+
+**Branch name:** fix/148-skill-extractor-js-ts-detection
+
+**Setup confirmation:** [ ] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger
+
+**Selection notes:**
+I checked the issue against the project layout and the branch naming rules in `docs/CONTRIBUTING.md`. The issue is narrow, reproducible, and centered in a single parser module, which keeps it realistic for Week 7. It also passed the "right for me" scope check because I already validated the local environment and confirmed the affected area before making the fix.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -17,3 +17,20 @@ The skill extractor is missing JavaScript and TypeScript in cases where the text
 
 **Selection notes:**
 I checked the issue against the project layout and the branch naming rules in `docs/CONTRIBUTING.md`. The issue is narrow, reproducible, and centered in a single parser module, which keeps it realistic for Week 7. It also passed the "right for me" scope check because I validated the local environment, confirmed the app runs locally at `localhost:5173`, and verified the affected area before making the fix.
+
+## Week 8 — Reproduction & Solution Planning
+
+**Reproduction commit link:**
+[Add the GitHub URL to the commit where you documented reproducing the issue.]
+
+**Reproduction summary:**
+I reproduced the issue by reviewing the failing unit tests referenced in the GitHub issue and testing the skill extractor with sample resume text containing JavaScript, TypeScript, and `.js`, `.ts`, and `.tsx` file references. The extractor failed to recognize JavaScript and TypeScript as skills, confirming the behavior described in the issue.
+
+**PLAN.md link:**
+https://github.com/nxxis/pathreview/blob/fix/148-skill-extractor-js-ts-detection/PLAN.md
+
+**Walkthrough video (recommended):**
+Not recorded yet. I plan to record it after finalizing my solution plan and reviewing the relevant code.
+
+**Blockers or open questions:**
+I want to verify whether the project expects JavaScript and TypeScript detection to rely only on explicit keywords or whether it should also recognize language-specific syntax such as `const`, `require()`, `export interface`, and common file extensions while avoiding false positives.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -21,7 +21,7 @@ I checked the issue against the project layout and the branch naming rules in `d
 ## Week 8 — Reproduction & Solution Planning
 
 **Reproduction commit link:**
-[Add the GitHub URL to the commit where you documented reproducing the issue.]
+N/A
 
 **Reproduction summary:**
 I reproduced the issue by reviewing the failing unit tests referenced in the GitHub issue and testing the skill extractor with sample resume text containing JavaScript, TypeScript, and `.js`, `.ts`, and `.tsx` file references. The extractor failed to recognize JavaScript and TypeScript as skills, confirming the behavior described in the issue.
@@ -30,7 +30,7 @@ I reproduced the issue by reviewing the failing unit tests referenced in the Git
 https://github.com/nxxis/pathreview/blob/fix/148-skill-extractor-js-ts-detection/PLAN.md
 
 **Walkthrough video (recommended):**
-Not recorded yet. I plan to record it after finalizing my solution plan and reviewing the relevant code.
+Not recorded yet.
 
 **Blockers or open questions:**
 I want to verify whether the project expects JavaScript and TypeScript detection to rely only on explicit keywords or whether it should also recognize language-specific syntax such as `const`, `require()`, `export interface`, and common file extensions while avoiding false positives.
@@ -65,3 +65,34 @@ I updated `tests/unit/test_skill_extractor.py`, which already contained the issu
 **Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No reviewer or maintainer feedback came in on the PR by the end of the week. The pull request page showed no reviews or review comments, so there was nothing to respond to beyond keeping the branch ready for review.
+
+**How you responded:**
+
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The hardest part was not the extractor logic itself, but proving that the change was narrow enough to be safe. JavaScript and TypeScript detection sat inside a larger heuristic system that also handles React, Docker, databases, and file-name inference, so every new pattern had the potential to tilt confidence scores or create accidental matches. I spent more time than expected checking that the fix handled real syntax like `const`, `require(...)`, and `interface` without breaking unrelated detections.
+
+**What did you learn about working in a large codebase?**
+The main lesson was to treat the existing structure as a contract, not a suggestion. In a codebase like this, a small parser change can have ripple effects across tests, docs, and reviewer expectations, so it helps to stay close to the failing behavior and validate only the touched slice first. I also learned that maintaining scope discipline matters more than trying to make the code "better" everywhere at once.
+
+**How did AI tools help — and where did they fall short?**
+AI tools were most useful for quickly locating the relevant parser, summarizing nearby test coverage, and helping me organize the journal and PR notes. They were less useful for judging whether a heuristic was actually appropriate for this project, because that required reading the code carefully and checking real examples against the project’s existing detection style. The final decision about what to change had to come from me, because only local evidence could tell me whether a pattern was truly missing or just uncovered by the current tests.
+
+**What would you do differently if you started over?**
+I would tighten the issue-selection and validation loop earlier. I think I could have identified the important syntax patterns and the likely regression surface sooner, which would have reduced some back-and-forth while building the fix. I would also write the PR summary and validation notes earlier so the final submission stage felt like a review of completed work instead of a last-minute documentation pass.
+
+**What are you most proud of from this module?**
+I am most proud that the final fix matched the shape of the actual problem instead of papering over it with filename-based heuristics. The extractor now recognizes JavaScript and TypeScript from real code signals, and the regression tests make that behavior explicit. That felt like a solid contribution because it improved the tool in a way that should hold up under future examples, not just the one reported issue.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -52,7 +52,7 @@ The repo still has unrelated pre-existing failures in broader checks such as `ma
 
 ### Check-in 2 (end of week)
 
-**PR link:** [add submitted pull request URL]
+**PR link:** https://github.com/ascherj/pathreview/pull/174
 
 **Branch:** `fix/148-skill-extractor-js-ts-detection`
 
@@ -60,7 +60,7 @@ The repo still has unrelated pre-existing failures in broader checks such as `ma
 I expanded the skill extractor so it detects JavaScript and TypeScript from common syntax patterns like `const`, `let`, `var`, `require(...)`, `export`, `interface`, and type annotations, while still preserving the existing extractor behavior for other technologies. I also added focused regression coverage for the reported JS/TS cases.
 
 **Tests added or updated:**
-I updated `tests/unit/test_skill_extractor.py` to cover JavaScript detection, TypeScript detection, Docker and Docker Compose detection, and the related regression cases for issue 148.
+I updated `tests/unit/test_skill_extractor.py`, which already contained the issue-focused regression cases, and confirmed they now pass against the new extractor logic. The suite covers Python import and type-annotation detection, TypeScript detection from `export interface` / typed members, JavaScript detection from `const` / `require(...)`, mixed-language text, React detection, PostgreSQL inference from client libraries, Dockerfile and Docker Compose patterns, filename-based detection, cloud tooling, empty-input handling, confidence scoring, and the `SkillDetection` dataclass structure. I also fixed one assertion typo in the PostgreSQL test so the file runs cleanly.
 
 **Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -34,3 +34,34 @@ Not recorded yet. I plan to record it after finalizing my solution plan and revi
 
 **Blockers or open questions:**
 I want to verify whether the project expects JavaScript and TypeScript detection to rely only on explicit keywords or whether it should also recognize language-specific syntax such as `const`, `require()`, `export interface`, and common file extensions while avoiding false positives.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+I implemented the skill extractor fix for issue 148 in `ingestion/parsers/skill_extractor.py` and added regression coverage in `tests/unit/test_skill_extractor.py`. The extractor now recognizes JavaScript and TypeScript from real-world syntax patterns instead of relying mostly on filenames and imports, and the affected unit tests pass.
+
+**Next steps:**
+Finish the PR submission details, keep the branch scoped to the issue fix, and document the validation status clearly in the PR description and journal.
+
+**Blockers:**
+The repo still has unrelated pre-existing failures in broader checks such as `make test-integration` and `make typecheck`, so I am keeping this PR scoped to the issue-specific fix and its direct validation.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [add submitted pull request URL]
+
+**Branch:** `fix/148-skill-extractor-js-ts-detection`
+
+**What you built:**
+I expanded the skill extractor so it detects JavaScript and TypeScript from common syntax patterns like `const`, `let`, `var`, `require(...)`, `export`, `interface`, and type annotations, while still preserving the existing extractor behavior for other technologies. I also added focused regression coverage for the reported JS/TS cases.
+
+**Tests added or updated:**
+I updated `tests/unit/test_skill_extractor.py` to cover JavaScript detection, TypeScript detection, Docker and Docker Compose detection, and the related regression cases for issue 148.
+
+**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+
+**Draft PR feedback received from:** none

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,66 @@
+# Solution Plan
+
+**Issue:** Skill extractor fails to detect JavaScript and TypeScript
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/148
+
+## Understand
+
+The skill extractor currently misses JavaScript and TypeScript when analyzing resume or repository text. The existing implementation relies on a limited set of filename hints and import patterns, causing it to overlook common JavaScript and TypeScript syntax such as `const`, `require()`, `export interface`, and `.tsx` references.
+
+**Expected behavior:**
+The extractor should correctly identify JavaScript and TypeScript whenever they are clearly represented in the input while continuing to detect other supported technologies.
+
+**Actual behavior:**
+JavaScript and TypeScript are omitted from the extracted skill list even though they appear in the input.
+
+---
+
+## Map
+
+Files I expect to review or modify:
+
+* `ingestion/parsers/skill_extractor.py`
+* `tests/unit/test_skill_extractor.py`
+
+I may also inspect any helper functions or configuration files used by the skill extraction logic if necessary.
+
+---
+
+## Plan
+
+1. Review the current JavaScript and TypeScript detection logic in the skill extractor.
+2. Identify why common JavaScript and TypeScript syntax is not being recognized.
+3. Update the detection patterns to include additional language indicators while avoiding false positives.
+4. Run the existing unit tests and verify that JavaScript and TypeScript are detected correctly.
+5. Confirm that existing skill detection behavior for other technologies remains unchanged.
+
+---
+
+## Inputs & Outputs
+
+**Input**
+
+Resume or repository text containing technologies such as JavaScript, TypeScript, React, `.js`, `.ts`, `.tsx`, `const`, `require()`, or `export interface`.
+
+**Output**
+
+The extracted skill list should correctly include JavaScript and TypeScript along with any other supported technologies found in the text.
+
+---
+
+## Risks & Unknowns
+
+* Expanding detection patterns may introduce false positives if the matching becomes too broad.
+* There may be shared helper functions that also require updates.
+* I need to confirm the project's preferred approach for balancing broader detection with precision.
+
+---
+
+## Edge Cases
+
+* Different capitalization (JavaScript, javascript, JAVASCRIPT)
+* `.js`, `.ts`, and `.tsx` file references
+* Text containing both JavaScript and TypeScript
+* Resumes mentioning React together with JavaScript or TypeScript
+* Existing detection for other languages and frameworks should continue to work correctly without regression.

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -40,7 +40,7 @@ Install Docker Engine and the Docker Compose plugin (not the standalone `docker-
 # 1. Clone your fork
 git clone https://github.com/<your-username>/pathreview.git
 cd pathreview
-git remote add upstream https://github.com/jamjamgobambam/pathreview.git
+git remote add upstream https://github.com/ascherj/pathreview.git
 
 # 2. Configure environment
 cp .env.example .env

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -99,7 +99,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -449,7 +448,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -473,7 +471,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1561,7 +1558,6 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1579,7 +1575,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1972,7 +1967,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3507,7 +3501,6 @@
       "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^2.0.1",
         "cssstyle": "^4.0.1",
@@ -4094,7 +4087,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4107,7 +4099,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4771,7 +4762,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/ingestion/parsers/skill_extractor.py
+++ b/ingestion/parsers/skill_extractor.py
@@ -51,8 +51,6 @@ class SkillExtractor:
         "useRef",
         "createContext",
         "ReactDOM.render",
-        ".jsx",
-        ".tsx",
     }
 
     FRAMEWORKS = {
@@ -148,10 +146,11 @@ class SkillExtractor:
     ) -> None:
         """Detect programming languages."""
         text_lower = text.lower()
+        filename_lower = str(filename or "").lower()
 
         # Python detection
         python_evidence = []
-        if ".py" in str(filename or "").lower():
+        if ".py" in filename_lower:
             python_evidence.append("Python file extension (.py)")
         if re.search(r"\bimport\s+\w+", text):
             python_evidence.append("Python import statements")
@@ -172,20 +171,55 @@ class SkillExtractor:
 
         # JavaScript/TypeScript detection
         js_evidence = []
-        if ".js" in str(filename or "").lower():
+        ts_evidence = []
+
+        if ".js" in filename_lower:
             js_evidence.append("JavaScript file extension (.js)")
-        if ".ts" in str(filename or "").lower():
-            js_evidence.append("TypeScript file extension (.ts)")
-        if re.search(r"\b(import|require)\s+", text):
-            js_evidence.append("CommonJS or ES6 imports")
+        if ".jsx" in filename_lower:
+            js_evidence.append("JavaScript React file extension (.jsx)")
+        if ".ts" in filename_lower or ".tsx" in filename_lower:
+            ts_evidence.append("TypeScript file extension (.ts/.tsx)")
+
+        if re.search(r"\bconst\s+\w+", text):
+            js_evidence.append("JavaScript const declarations")
+        if re.search(r"\blet\s+\w+", text):
+            js_evidence.append("JavaScript let declarations")
+        if re.search(r"\bvar\s+\w+", text):
+            js_evidence.append("JavaScript var declarations")
+        if re.search(r"\brequire\s*\(", text):
+            js_evidence.append("CommonJS require calls")
+        if re.search(r"\bexport\b", text):
+            js_evidence.append("ES module exports")
+        if re.search(r"=>", text):
+            js_evidence.append("Arrow function syntax")
+        if re.search(r"\bimport\s+type\b", text):
+            ts_evidence.append("TypeScript type-only imports")
+        if re.search(r"\b(interface|type|enum|implements|readonly|public|private|protected)\b", text):
+            ts_evidence.append("TypeScript syntax keywords")
+        if re.search(
+            r":\s*(string|number|boolean|any|unknown|never|void|Promise<|Array<|Record<|\w+\[\])",
+            text,
+        ):
+            ts_evidence.append("TypeScript type annotations")
+        if "typescript" in text_lower:
+            ts_evidence.append("TypeScript mentioned in content")
+        if ".ts" in text_lower or ".tsx" in text_lower:
+            ts_evidence.append("TypeScript file reference in content")
         if "package.json" in text_lower:
             js_evidence.append("package.json found")
 
-        if js_evidence:
+        if ts_evidence:
+            confidence = min(0.95, 0.6 + len(ts_evidence) * 0.1)
+            skills_dict["TypeScript"] = SkillDetection(
+                name="TypeScript",
+                category="Language",
+                confidence=confidence,
+                evidence=ts_evidence,
+            )
+        elif js_evidence:
             confidence = min(0.95, 0.6 + len(js_evidence) * 0.1)
-            lang = "TypeScript" if ".ts" in str(filename or "").lower() else "JavaScript"
-            skills_dict[lang] = SkillDetection(
-                name=lang,
+            skills_dict["JavaScript"] = SkillDetection(
+                name="JavaScript",
                 category="Language",
                 confidence=confidence,
                 evidence=js_evidence,
@@ -263,6 +297,26 @@ class SkillExtractor:
     def _detect_tools(self, text: str, skills_dict: dict) -> None:
         """Detect tools and DevOps technologies."""
         text_lower = text.lower()
+
+        docker_evidence = []
+        if re.search(r"(?m)^\s*FROM\s+\S+", text):
+            docker_evidence.append("Dockerfile FROM instruction")
+        if re.search(r"(?m)^\s*(RUN|COPY|CMD|ENTRYPOINT|WORKDIR|ENV|EXPOSE|ADD|ARG)\b", text):
+            docker_evidence.append("Dockerfile instruction")
+        if re.search(r"(?m)^\s*services\s*:\s*$", text):
+            docker_evidence.append("docker-compose services block")
+        if re.search(r"(?m)^\s*(build|image|ports|volumes|depends_on)\s*:\s*", text):
+            docker_evidence.append("docker-compose service configuration")
+        if "docker compose" in text_lower or "docker-compose" in text_lower:
+            docker_evidence.append("Docker Compose reference")
+
+        if docker_evidence and "Docker" not in skills_dict:
+            skills_dict["Docker"] = SkillDetection(
+                name="Docker",
+                category="Tool",
+                confidence=min(0.95, 0.7 + len(docker_evidence) * 0.1),
+                evidence=docker_evidence,
+            )
 
         for tool, confidence in self.TOOLS.items():
             if tool in text_lower:

--- a/ingestion/parsers/skill_extractor.py
+++ b/ingestion/parsers/skill_extractor.py
@@ -1,11 +1,11 @@
 import re
 from dataclasses import dataclass
-from typing import Optional
 
 
 @dataclass
 class SkillDetection:
     """Result of detecting a skill."""
+
     name: str
     category: str
     confidence: float
@@ -103,7 +103,7 @@ class SkillExtractor:
         "ansible": 0.85,
     }
 
-    def extract_skills(self, text: str, filename: Optional[str] = None) -> list[SkillDetection]:
+    def extract_skills(self, text: str, filename: str | None = None) -> list[SkillDetection]:
         """
         Extract skills from source code or documentation text.
 
@@ -141,7 +141,7 @@ class SkillExtractor:
     def _detect_languages(
         self,
         text: str,
-        filename: Optional[str],
+        filename: str | None,
         skills_dict: dict,
     ) -> None:
         """Detect programming languages."""
@@ -194,7 +194,10 @@ class SkillExtractor:
             js_evidence.append("Arrow function syntax")
         if re.search(r"\bimport\s+type\b", text):
             ts_evidence.append("TypeScript type-only imports")
-        if re.search(r"\b(interface|type|enum|implements|readonly|public|private|protected)\b", text):
+        if re.search(
+            r"\b(interface|type|enum|implements|readonly|public|private|protected)\b",
+            text,
+        ):
             ts_evidence.append("TypeScript syntax keywords")
         if re.search(
             r":\s*(string|number|boolean|any|unknown|never|void|Promise<|Array<|Record<|\w+\[\])",
@@ -282,6 +285,20 @@ class SkillExtractor:
     def _detect_databases(self, text: str, skills_dict: dict) -> None:
         """Detect databases."""
         text_lower = text.lower()
+
+        if (
+            any(
+                indicator in text_lower
+                for indicator in ("psycopg", "asyncpg", "pg8000", "postgres", "postgresql")
+            )
+            and "Postgresql" not in skills_dict
+        ):
+            skills_dict["Postgresql"] = SkillDetection(
+                name="Postgresql",
+                category="Database",
+                confidence=0.95,
+                evidence=["Found PostgreSQL client library reference in content"],
+            )
 
         for db, confidence in self.DATABASES.items():
             if db in text_lower:

--- a/tests/unit/test_skill_extractor.py
+++ b/tests/unit/test_skill_extractor.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from ingestion.parsers.skill_extractor import SkillExtractor, SkillDetection
+from ingestion.parsers.skill_extractor import SkillDetection, SkillExtractor
 
 
 @pytest.mark.unit
@@ -135,7 +135,7 @@ class TestSkillExtractor:
         """
         result = extractor.extract_skills(text)
 
-        skill_names = [s.name for s in skill_names]
+        skill_names = [s.name for s in result]
         # Should detect PostgreSQL
         assert any("postgres" in s.lower() or "sql" in s.lower() for s in skill_names)
 
@@ -232,10 +232,7 @@ class TestSkillExtractor:
     def test_skill_detection_dataclass(self):
         """Test SkillDetection dataclass structure."""
         skill = SkillDetection(
-            name="Python",
-            category="Language",
-            confidence=0.95,
-            evidence=["import statement"]
+            name="Python", category="Language", confidence=0.95, evidence=["import statement"]
         )
 
         assert skill.name == "Python"


### PR DESCRIPTION
## Summary
This PR fixes the skill extractor so it correctly detects JavaScript and TypeScript from real-world code patterns instead of relying mostly on filenames and imports. It also improves Docker and Docker Compose detection from common file content, so the extractor now handles the cases reported in issue 148.

## Issue
Closes #148

## Changes
* Expanded JavaScript detection to recognize common syntax such as `const`, `let`, `var`, `require(...)`, `export`, and arrow functions.
* Added TypeScript-specific detection for syntax like `interface`, `type`, `implements`, type annotations, and `.ts` / `.tsx` references.
* Removed `.jsx` and `.tsx` from React-only indicators so TypeScript samples do not get mislabeled as React.
* Added Docker and Docker Compose heuristics for Dockerfile and compose YAML patterns.
* Added PostgreSQL inference from common client libraries such as `psycopg2` and `asyncpg` so database detection remains accurate.

## Testing
* [x] Unit tests pass for the affected area (`.venv/bin/pytest -q tests/unit/test_skill_extractor.py`)
* [x] Linter passes for the affected files (`.venv/bin/ruff check skill_extractor.py tests/unit/test_skill_extractor.py`)
* [x] New/updated tests cover the changes
* [ ] Integration tests pass (`make test-integration`)
* [ ] Type checker passes (`make typecheck`)

Validated with:
* `.venv/bin/pytest -q tests/unit/test_skill_extractor.py`
* `.venv/bin/ruff check skill_extractor.py tests/unit/test_skill_extractor.py`

## Screenshots / Demo
N/A

## Notes for Reviewers
The parser logic change is intentionally narrow and focused on the failure mode reported in issue 148. The repo-wide integration and type-check targets are still out of scope for this PR.