### PR TITLE
Fix: Update upstream repository URL in setup instructions

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -40,7 +40,7 @@ Install Docker Engine and the Docker Compose plugin (not the standalone `docker-
 # 1. Clone your fork
 git clone https://github.com/<your-username>/pathreview.git
 cd pathreview
-git remote add upstream https://github.com/jamjamgobambam/pathreview.git
+git remote add upstream https://github.com/ascherj/pathreview.git
 
 # 2. Configure environment
 cp .env.example .env


### PR DESCRIPTION
Setup instructions for Windows still pointed at old copy

## Summary
Updates residual https://github.com/jamjamgobambam/pathreview.git to https://github.com/ascherj/pathreview.git

## Issue
N/A

## Changes

- Updates https://github.com/jamjamgobambam/pathreview.git to https://github.com/ascherj/pathreview.git in Setup.md

## Testing
<!-- How did you verify your changes? -->
- [ ] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`)
- [ ] Linter passes (`make lint`)
- [ ] Type checker passes (`make typecheck`)
- [ ] New/updated tests cover the changes

Searched file, no outdated references

## Screenshots / Demo
<!-- If applicable, add screenshots or a link to a demo video -->

N/A

## Notes for Reviewers
<!-- Anything the reviewer should pay particular attention to -->

This came up in class
