### PR TITLE
fix(api): wrap health check SQL in text() for SQLAlchemy 2.x

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -23,9 +23,9 @@ accompanying unit test.
 
 **Branch name:** fix/154-health-check-sql-text
 
-**Setup confirmation:** [ ] App runs locally at localhost:5173
+**Setup confirmation:** [x] App runs locally at localhost:5173
 
-**Cohort ledger:** [ ] Issue added to cohort ledger
+**Cohort ledger:** [x] Issue added to cohort ledger
 
 ---
 
@@ -43,3 +43,10 @@ accompanying unit test.
   any external AI service.
 - **Correct difficulty match.** Labeled `good first issue` + `tier-1`, which
   fits a first contribution to a large codebase.
+
+**Reproduction confirmed locally:** With the stack running, `GET
+http://localhost:8000/health` returns HTTP 503 with `postgres: "unhealthy"`,
+even though PostgreSQL is up (seeding connected successfully and the Docker
+container reports healthy). The handler in `api/routes/health.py` catches the
+SQLAlchemy 2.x `ArgumentError` from the unwrapped `SELECT 1` and mislabels the
+database as down — exactly the behavior described in the issue.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,45 @@
+# Module 3 Journal
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/154
+
+**Issue title:** Health check DB probe passes a raw SQL string, which fails under SQLAlchemy 2.x
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The `/health` endpoint's PostgreSQL probe in `api/routes/health.py` runs
+`await db.execute("SELECT 1")`, passing the query as a bare Python string.
+SQLAlchemy 2.x no longer accepts raw textual statements and raises an
+`ArgumentError` telling you to wrap them in `text()`. Because the health
+handler catches that exception, Postgres gets reported as `unhealthy` and the
+endpoint returns a 503 even when the database is actually up and reachable — a
+false-negative outage. A successful fix wraps the query with
+`sqlalchemy.text()` (`db.execute(text("SELECT 1"))`) so the probe runs, the
+endpoint reports accurate database status, and monitoring stops firing on a
+healthy DB. The change is confined to the API module's health route and its
+accompanying unit test.
+
+**Branch name:** fix/154-health-check-sql-text
+
+**Setup confirmation:** [ ] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger
+
+---
+
+### Selection notes — "Is this right for me?" reasoning
+
+- **Scope is tiny and localized.** The fix is one import plus one line in a
+  single file (`api/routes/health.py`), plus a unit test — no sprawling change.
+- **No cross-module knowledge required.** It lives entirely in the API module;
+  I don't need to understand the RAG, agent, or ingestion pipelines to fix it.
+- **Well-defined bug with a standard, known fix.** SQLAlchemy 2.x's `text()`
+  requirement is documented behavior, so there's little ambiguity about the
+  correct solution.
+- **Reproducible and testable without secrets.** It can be exercised via a unit
+  test against a DB session and doesn't depend on the `OPENROUTER_API_KEY` or
+  any external AI service.
+- **Correct difficulty match.** Labeled `good first issue` + `tier-1`, which
+  fits a first contribution to a large codebase.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -139,3 +139,83 @@ reachable, instead of catching the error and returning a false 503.
 
 **Draft PR feedback received from:** none yet _(PR #177 is open and available for
 peer review — will share in the cohort Slack channel)_
+
+---
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No reviewer or maintainer feedback came in. As of this entry, PR #177 has 0
+comments and 0 reviews (also consistent with the Summer 2026 note that reviewer
+feedback isn't a feature this term). The PR is open and marked ready for review.
+
+**How you responded:**
+N/A — no feedback to respond to. The PR is in a ready-to-review state with a
+fully filled-in template and a documented before/after check of pre-existing
+failures, so it's ready if a review arrives later.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The one-line code fix was the easy part; everything *around* it was harder. Two
+things stand out. First, getting the app running on Windows: `make setup`
+reported a failure and aborted before `npm install`, but the real story was
+subtle — the database had actually seeded fine, and the script only crashed at
+the very end trying to print a `✓` character that the Windows cp1252 console
+can't encode (`UnicodeEncodeError`). Reading the traceback carefully to see
+"Database seeding completed successfully" *above* the crash was the difference
+between "setup is broken" and "setup worked, one cosmetic print failed." Second,
+the pre-commit/CI hooks fail on pre-existing code, so even a tiny, correct
+change to `health.py` gets blocked by `mypy`/`ruff` errors that were already
+there — I had to learn to reason about "my delta" instead of "is CI green."
+
+**What did you learn about working in a large codebase?**
+Scope discipline is everything. `api/routes/health.py` actually contains *two*
+separate bugs — the SQLAlchemy `text()` issue I picked (#154) and a broken
+`settings.redis_host` reference (#155) that belongs to another contributor.
+Fixing "just mine" and deliberately leaving the redis bug alone — even though it
+was five lines away and I could see it — felt unnatural but is exactly right in
+a shared codebase: overreaching would create merge conflicts and step on
+someone else's issue. I also learned to match existing patterns instead of my
+own preferences (Conventional Commits with the repo's scopes; copying the
+`@pytest.mark.unit` + `AsyncMock` style from `test_review_service.py`), and to
+prove non-regression by measuring failures before vs. after rather than assuming
+a green suite. Contributing to production code is less "build the thing" and
+more "change one thing without disturbing the other thousand."
+
+**How did AI tools help — and where did they fall short?**
+AI was strongest at fast navigation of unfamiliar code: locating the exact
+buggy line, explaining *why* SQLAlchemy 2.x rejects a raw string, and mirroring
+the repo's test conventions so my new file didn't look out of place. It was also
+good at the rigor — designing the before/after baseline comparison to isolate my
+change's impact. Where it fell short was judgment and environment reality: the
+cp1252 crash needed someone to read actual runtime output and diagnose it, not
+generate code; and the genuinely contestable calls — whether to also fix #155,
+whether bypassing a hook that fails on pre-existing debt is acceptable, how to
+keep the diff honest — were decisions to *make and own*, not answers to look up.
+
+**What would you do differently if you started over?**
+I'd run `make check` and `make test-unit` on a clean `main` *first*, before
+writing any code, and record the baseline of pre-existing failures. I did this
+eventually, but doing it up front would have saved confusion about which
+failures were "mine." I'd also set up tooling correctly at the start —
+configuring the GitHub token scopes (`read:org`) so `gh` PR commands work, and
+knowing the Windows `PYTHONUTF8=1` workaround before hitting the seed crash.
+On issue selection, #154 was a good tier-1 choice, but I'd have looked one level
+deeper sooner to notice #155 living in the same file, which shaped the whole
+scope conversation.
+
+**What are you most proud of?**
+Turning a trivial-looking one-line fix into a genuinely trustworthy
+contribution: a regression test that fails on the old code and passes on the
+new, an end-to-end verification showing `/health` flip from `unhealthy` to
+`healthy` against a real database, and a documented before/after proof that my
+change introduces zero new test/lint/type failures. The fix is one line; the
+confidence that it's *correct and doesn't make anything worse* is the part I
+actually earned.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -50,3 +50,31 @@ even though PostgreSQL is up (seeding connected successfully and the Docker
 container reports healthy). The handler in `api/routes/health.py` catches the
 SQLAlchemy 2.x `ArgumentError` from the unwrapped `SELECT 1` and mislabels the
 database as down — exactly the behavior described in the issue.
+
+---
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/p-disha/pathreview/commit/0f4619152141b1806092c640b65e8ca2651564ed
+
+**Reproduction summary:**
+With the full stack running locally, I called `GET
+http://localhost:8000/health` and observed **HTTP 503** with
+`postgres: "unhealthy"` even though PostgreSQL was up — seeding had just
+connected to it and the Docker `db` container reported healthy. The bare
+`SELECT 1` string raises SQLAlchemy 2.x's `ArgumentError`, which the handler's
+broad `except` swallows and mislabels the DB as down. The commit above records
+these steps in `JOURNAL.md`; the regression-guard unit test in
+`tests/unit/test_health.py` (commit `aca8cf0`) captures the same behavior as a
+test that fails on the raw string and passes once it is wrapped in `text()`.
+
+**PLAN.md link:** https://github.com/p-disha/pathreview/blob/fix/154-health-check-sql-text/PLAN.md
+
+**Walkthrough video (recommended):** _(optional — not recorded)_
+
+**Blockers or open questions:**
+The handler's broad `except Exception` also masks the sibling Redis bug (#155,
+`settings.redis_host`) in the same file, so `/health` still returns 503 overall
+until #155 is fixed even though postgres now reads healthy. Open question for
+mentors: is a #154-only PR (postgres healthy, redis still failing) the expected
+scope, or should the redis fix be bundled?

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -78,3 +78,64 @@ The handler's broad `except Exception` also masks the sibling Redis bug (#155,
 until #155 is fixed even though postgres now reads healthy. Open question for
 mentors: is a #154-only PR (postgres healthy, redis still failing) the expected
 scope, or should the redis fix be bundled?
+
+---
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+All PLAN.md sub-tasks are implemented. `api/routes/health.py` now imports `text`
+and runs `db.execute(text("SELECT 1"))` (sub-tasks 1–2). `tests/unit/test_health.py`
+adds three tests — a regression guard asserting a `TextClause` (not a raw string)
+is executed, plus the healthy and failure paths (sub-task 3). Verified locally:
+`pytest tests/unit/test_health.py` is 3/3 green, and a live `GET /health` flips
+postgres from `unhealthy` to `healthy` (sub-task 4). Scope held to #154 — the
+sibling redis bug (#155) left untouched (sub-task 5).
+
+**Next steps:**
+Run the full self-review (`make check` / `make test-unit`) to baseline the
+pre-existing failures and confirm my change adds none, finalize the PR
+description, and request peer feedback in Slack.
+
+**Blockers:**
+None. Carrying the Week 8 open question about #155/scope into review.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/177
+
+**Branch:** `fix/154-health-check-sql-text`
+
+**What you built:**
+The `/health` PostgreSQL probe now wraps its `SELECT 1` liveness query in
+`sqlalchemy.text()`, so it executes under SQLAlchemy 2.x instead of raising
+`ArgumentError`. The endpoint reports `postgres: "healthy"` when the database is
+reachable, instead of catching the error and returning a false 503.
+
+**Tests added or updated:**
+`tests/unit/test_health.py` (new): `test_probe_wraps_query_in_text_clause`
+(regression guard — asserts a `TextClause`, not a raw string, is executed),
+`test_postgres_reported_healthy_when_query_succeeds`, and
+`test_postgres_reported_unhealthy_when_query_fails`. All three pass.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+> Interpreted per this week's guidance as "introduces no new failures," since
+> this codebase ships documented pre-existing failures. Measured before/after on
+> this branch:
+> - `make test-unit`: **base 53 failed / 375 passed** → **mine 53 failed / 378
+>   passed** — same 53 pre-existing failures, +3 new passing tests, **0 new
+>   failures**.
+> - `ruff check .`: **182 errors base → 182 with my change** (net zero; my new
+>   test file is ruff-clean).
+> - `mypy`: 1 pre-existing blocking error in both states — none added.
+> - The 53 pre-existing test failures are unrelated seeded bugs in other modules
+>   (e.g. #148, #149, #150, #158) plus the redis `settings.redis_host` issue
+>   (#155) in this same file, which is deliberately out of scope.
+
+**Draft PR feedback received from:** none yet _(PR #177 is open and available for
+peer review — will share in the cohort Slack channel)_

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,84 @@
+# Solution plan
+
+**Issue:** Health check DB probe passes a raw SQL string, which fails under
+SQLAlchemy 2.x — https://github.com/ascherj/pathreview/issues/154
+
+### Understand
+
+**Root cause.** In `api/routes/health.py`, the PostgreSQL liveness probe calls
+`await db.execute("SELECT 1")`, passing a bare Python string. SQLAlchemy 2.x
+removed the implicit conversion of plain strings into executable statements, so
+`AsyncSession.execute()` now rejects a raw string and raises
+`sqlalchemy.exc.ArgumentError: Textual SQL expression 'SELECT 1' should be
+explicitly declared as text('SELECT 1')`.
+
+**Expected vs. actual.**
+- *Expected:* with a reachable database, the probe succeeds and `/health`
+  reports `postgres: "healthy"`.
+- *Actual:* the probe throws `ArgumentError`; the handler's broad
+  `except Exception` swallows it, sets `postgres: "unhealthy"` and the overall
+  `status: "unhealthy"`, and the endpoint returns **HTTP 503** even though
+  PostgreSQL is up — a false-negative outage that would page on-call and fail
+  readiness checks in a deploy.
+
+### Map
+
+Files / functions involved:
+- **`api/routes/health.py`** → `health_check()`, specifically the imports and
+  the `# Check PostgreSQL` block. **Primary change.**
+- `core/database.py` → `get_db` provides the `AsyncSession` injected via
+  `Depends`. Context only; no change expected.
+- **`tests/unit/test_health.py`** → no health tests exist today; add one.
+
+Files I expect to touch: `api/routes/health.py`, `tests/unit/test_health.py`.
+
+### Plan
+
+1. **Import the construct** — add `from sqlalchemy import text` to
+   `api/routes/health.py`.
+2. **Wrap the query** — change `await db.execute("SELECT 1")` to
+   `await db.execute(text("SELECT 1"))`.
+3. **Add unit tests** in `tests/unit/test_health.py` following the repo's
+   `@pytest.mark.unit` / `@pytest.mark.asyncio` + `AsyncMock` conventions:
+   (a) a regression guard asserting the probe passes a SQLAlchemy `TextClause`
+   rather than a `str`; (b) the healthy path; (c) the failure path reports
+   `unhealthy` without crashing.
+4. **Verify** — run `pytest tests/unit/test_health.py -v`, then confirm live:
+   `GET http://localhost:8000/health` should flip `postgres` from
+   `"unhealthy"` to `"healthy"` against the running stack.
+5. **Hold scope to #154** — do not touch the sibling Redis bug in the same file
+   (`settings.redis_host`, issue #155); it belongs to a separate contributor.
+
+### Inputs & outputs
+
+- **Input:** an async SQLAlchemy session (`db`) from `Depends(get_db)`; the
+  probe issues a trivial `SELECT 1` liveness query and does not read rows.
+- **Output / change:** the probe executes a valid `TextClause`; on success
+  `health_status["dependencies"]["postgres"]` becomes `"healthy"`. When every
+  dependency is healthy the endpoint returns 200. No schema, response-shape,
+  data, or public-API changes.
+
+### Risks & unknowns
+
+- **Broad `except Exception` masks a sibling bug.** The same handler also fails
+  on `settings.redis_host` (issue #155), so even after my fix `/health` may
+  still return 503 overall (redis `unhealthy`). Reviewers expecting a green
+  `/health` need to know postgres is fixed independently of redis.
+- **Repo-wide CI is pre-red.** `ruff check .`, `black --check .`, and `mypy`
+  fail on pre-existing seeded bugs — including `redis_host` in *this* file — so
+  a #154-scoped change cannot make the whole file pass `mypy` without poaching
+  #155. Plan: call this out explicitly in the PR notes.
+- **Unknown — preferred idiom.** Maintainers might prefer `sqlalchemy.select(1)`
+  over `text("SELECT 1")`. I'm going with `text("SELECT 1")` as the minimal fix
+  that matches the issue's wording and the error message's suggestion.
+
+### Edge cases
+
+- **Database genuinely down / connection refused** → the probe must still be
+  caught and report `postgres: "unhealthy"` (covered by test (c)).
+- **Unconsumed result object** → we never read rows, so a returned result that
+  isn't iterated must not raise; only execution matters.
+- **No stray transaction state** → `SELECT 1` is read-only and needs no commit;
+  the fix must not leave an open transaction on the shared session.
+- **Exact SQL text** → `text("SELECT 1")` must stringify to exactly
+  `"SELECT 1"` (asserted in the test) with no accidental parameter binding.

--- a/api/routes/health.py
+++ b/api/routes/health.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, HTTPException, status, Depends
 import structlog
 from datetime import datetime, timedelta
+from sqlalchemy import text
 
 from core.database import get_db
 
@@ -28,7 +29,9 @@ async def health_check(db=Depends(get_db)):
 
     try:
         # Check PostgreSQL
-        await db.execute("SELECT 1")
+        # SQLAlchemy 2.x requires textual SQL to be wrapped in text();
+        # passing a raw string raises ArgumentError.
+        await db.execute(text("SELECT 1"))
         health_status["dependencies"]["postgres"] = "healthy"
         log.debug("postgres_health_check_passed")
     except Exception as exc:

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -1,0 +1,69 @@
+"""Tests for the /health route's database probe (issue #154).
+
+The PostgreSQL health probe must execute its liveness query as a SQLAlchemy
+textual clause. Under SQLAlchemy 2.x, passing a raw string to
+``Session.execute`` raises ``ArgumentError``, which the handler would swallow
+and report the database as unhealthy even when it is reachable.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, Mock
+
+from fastapi import HTTPException
+from sqlalchemy.sql.elements import TextClause
+
+from api.routes.health import health_check
+
+
+async def _run_health_check(db):
+    """Invoke the handler and return its status dict.
+
+    The handler raises ``HTTPException`` (503) when any dependency is down and
+    stashes the status dict in ``detail``; unwrap it so these tests can assert
+    on the PostgreSQL result without being coupled to the other dependencies.
+    """
+    try:
+        return await health_check(db=db)
+    except HTTPException as exc:
+        return exc.detail
+
+
+@pytest.mark.unit
+class TestHealthCheckDatabaseProbe:
+    """Test suite for the PostgreSQL probe in the health check route."""
+
+    @pytest.fixture
+    def healthy_db(self):
+        """A mock async session whose execute() succeeds."""
+        session = AsyncMock()
+        session.execute = AsyncMock(return_value=Mock())
+        return session
+
+    @pytest.mark.asyncio
+    async def test_probe_wraps_query_in_text_clause(self, healthy_db):
+        """The probe must pass a SQLAlchemy TextClause, not a raw string.
+
+        This is the regression guard for #154: a bare ``"SELECT 1"`` string
+        raises ArgumentError under SQLAlchemy 2.x.
+        """
+        await _run_health_check(healthy_db)
+
+        healthy_db.execute.assert_awaited_once()
+        executed = healthy_db.execute.await_args.args[0]
+        assert isinstance(executed, TextClause), "health probe must wrap SQL in sqlalchemy.text()"
+        assert str(executed) == "SELECT 1"
+
+    @pytest.mark.asyncio
+    async def test_postgres_reported_healthy_when_query_succeeds(self, healthy_db):
+        """A successful probe reports postgres as healthy."""
+        result = await _run_health_check(healthy_db)
+        assert result["dependencies"]["postgres"] == "healthy"
+
+    @pytest.mark.asyncio
+    async def test_postgres_reported_unhealthy_when_query_fails(self):
+        """A failing probe reports postgres as unhealthy (and does not crash)."""
+        db = AsyncMock()
+        db.execute = AsyncMock(side_effect=Exception("connection refused"))
+
+        result = await _run_health_check(db)
+        assert result["dependencies"]["postgres"] == "unhealthy"

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -6,9 +6,9 @@ textual clause. Under SQLAlchemy 2.x, passing a raw string to
 and report the database as unhealthy even when it is reachable.
 """
 
-import pytest
 from unittest.mock import AsyncMock, Mock
 
+import pytest
 from fastapi import HTTPException
 from sqlalchemy.sql.elements import TextClause
 


### PR DESCRIPTION
## Summary
The `/health` endpoint's PostgreSQL probe executed a raw `"SELECT 1"` string. Under SQLAlchemy 2.x, textual SQL must be wrapped in `sqlalchemy.text()`, so the bare string raised `ArgumentError`. The handler caught that exception and reported PostgreSQL as `unhealthy`, causing `/health` to return `503` even when the database was up and reachable — a false-negative outage. This PR wraps the probe query in `text()` so it executes correctly and the endpoint reports accurate database status.

## Issue
Closes #154

## Changes
- `api/routes/health.py`: import `text` from `sqlalchemy` and wrap the liveness query as `db.execute(text("SELECT 1"))`.
- `tests/unit/test_health.py` (new): unit tests for the database probe —
  - asserts the probe passes a SQLAlchemy `TextClause` rather than a raw string (regression guard for this bug);
  - asserts PostgreSQL is reported `healthy` when the query succeeds;
  - asserts PostgreSQL is reported `unhealthy` (without crashing) when the query fails.

## Testing
- [x] New/updated tests cover the changes
- [x] The new `tests/unit/test_health.py` suite passes (3/3)
- [x] `make test-unit` — introduces **no new failures** (details below)
- [ ] Integration tests pass (`make test-integration`) — not run (require Docker services)
- [x] `make lint` (`ruff`) — introduces **no new errors** (details below)
- [x] `make typecheck` (`mypy`) — introduces **no new errors** (details below)

**Verified locally end-to-end:** with the stack running, `GET http://localhost:8000/health` reported `postgres: "unhealthy"` before the change and `postgres: "healthy"` after it, confirmed against the real database.

### Pre-existing failures (measured before/after on this branch)
This repo ships with documented pre-existing failures unrelated to this issue. I measured the baseline (branch reverted to `upstream/main` for `health.py`, my new test removed) versus my change:

| Check | Base (`upstream/main`) | With my change | New introduced |
|---|---|---|---|
| `make test-unit` | 53 failed / 375 passed | 53 failed / **378** passed | **0** (same 53, +3 new passing) |
| `ruff check .` | 182 errors | 182 errors | **0** |
| `mypy` (api/core/…) | 1 blocking error | 1 blocking error | **0** |

The 53 pre-existing test failures are seeded bugs in other modules (e.g. #148, #149, #150, #158). The pre-existing `ruff`/`mypy` findings in `api/routes/health.py` (unused `timedelta` import, `Depends`-in-default `B008`, and the `mypy` error on `settings.redis_host` — which is issue **#155**) predate this PR and are left untouched to keep the change scoped. **My changes do not affect them.**

## Screenshots / Demo
Before: `{"dependencies": {"postgres": "unhealthy", ...}}` (503)
After:  `{"dependencies": {"postgres": "healthy", ...}}`

## Notes for Reviewers
- The change is intentionally scoped to issue #154 only.
- Repo-wide `make lint` / `make typecheck` / full `make test-unit` do **not** pass on this branch, but the failures are **pre-existing** and unrelated to this change:
  - `mypy` on `api/routes/health.py` flags `settings.redis_host` / `settings.redis_port`, which is the separate, already-tracked bug **#155**. I deliberately left that alone to avoid overlapping with that issue.
  - `ruff` flags pre-existing items in the same file (an unused `timedelta` import, a FastAPI `Depends`-in-default `B008`, import ordering) that predate this PR.
  - The full unit-test suite has other failures that correspond to other seeded issues in the tracker (e.g. #148, #149, #150, #158), none of which touch `health.py`.
- Happy to expand scope if the maintainers would prefer these addressed together.
