### PR TITLE
fix: make resume section detection whitespace-tolerant for leading spaces/tabs

### DIFF
--- a/ingestion/parsers/resume_parser.py
+++ b/ingestion/parsers/resume_parser.py
@@ -99,7 +99,7 @@ class ResumeParser(BaseParser):
     def _strip_markdown(self, content: str) -> str:
         """Remove markdown syntax from content."""
         # Remove markdown headers
-        text = re.sub(r"^#+\s+", "", content, flags=re.MULTILINE)
+        text = re.sub(r"^\s*#+\s+", "", content, flags=re.MULTILINE)
 
         # Remove markdown links [text](url)
         text = re.sub(r"\[([^\]]+)\]\(([^\)]+)\)", r"\1", text)
@@ -132,10 +132,10 @@ class ResumeParser(BaseParser):
         for section in SECTION_HEADERS:
             # Look for section header patterns
             patterns = [
-                rf"^{re.escape(section)}\s*$",
-                rf"^{re.escape(section)}\s*[:|-]",
-                rf"\n{re.escape(section)}\s*$",
-                rf"\n{re.escape(section)}\s*[:|-]",
+                rf"^\s*{re.escape(section)}\s*$",
+                rf"^\s*{re.escape(section)}\s*[:|-]",
+                rf"\n\s*{re.escape(section)}\s*$",
+                rf"\n\s*{re.escape(section)}\s*[:|-]",
             ]
 
             for pattern in patterns:


### PR DESCRIPTION
## Description

Fixes #147 — `_detect_sections()` regex patterns were anchored at `^` (start of line), but PDF-extracted text often has leading whitespace/spaces before section headers like `    Education:`.

Same issue existed in `_strip_markdown()` — markdown headers like `  ## Skills` weren't being stripped because `^#+` expected no leading whitespace.

## Changes

**`ingestion/parsers/resume_parser.py`**

| Method | Old Pattern | New Pattern |
|---|---|---|
| `_detect_sections` | `^education` | `^\s*education` |
| `_detect_sections` | `\neducation` | `\n\s*education` |
| `_strip_markdown` | `^#+\s+` | `^\s*#+\s+` |

## Verification

- ✅ `"    Education:\n    - BS CS"` → detects `['Education']`
- ✅ Clean text without whitespace still works
- ✅ Tab-prefixed headers work
- ✅ Heavy indentation works
- ✅ All 10 resume parser tests pass
- ✅ All pre-existing test failures unchanged (not caused by this fix)

## Testing

Run `pytest tests/` to verify. The 10 resume parser tests all pass.