### PR TITLE
Fix/24 hybrid scoring weight issue 24 Fix setup, Fix and Unit test Implementation

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,36 @@
+## Week 7 — Issue selection
+
+**Issue link:** [https://github.com/ascherj/pathreview/issues/24]
+
+**Issue title:** [Hybrid retriever over-weights keyword results when query contains technology names #24]
+
+**Tier:** [Tier 2 ]
+
+**Problem summary:**
+[ if BM25 score is high from common keywords while its vector score is low, that big BM25 half can still push the chunk's final score high enough to rank it near the top. This will affect the final score leading to a wrong context retrieval because BM25 itself has 50% wait on the entire output or final score.
+
+A successfull fix is to rebalance that 50/50 to trust vector similarity more, or adjust weights based on the query so keyword only matches can't ride into the top results.]
+
+**Affected parts of the codebase:**
+
+- `rag/retriever/hybrid.py` — `HybridRetriever.retrieve()`. This is the core of the issue: the blend happens at `blended_score = self.vector_weight * vector_score + self.keyword_weight * keyword_score`. The weights are hardcoded constructor defaults — this is the single place the weights live and where any rebalancing/adaptive-weighting fix goes. **Fix applied:** rebalanced from 50/50 to **`vector_weight=0.8, keyword_weight=0.2`** so vector (meaning) similarity dominates and keyword-only matches on shared tech terms can't ride into the top results.
+- `rag/retriever/keyword_search.py` — `KeywordSearcher.search()`. Produces the BM25 keyword score (via `rank_bm25.BM25Okapi`) that is over-rewarded for common tech terms. Tokenization is a naive lowercase whitespace split, which offers no protection against shared vocabulary across documents.
+- `rag/retriever/vector_store.py` — `VectorStore.query()`. Produces the vector similarity score (`similarity = 1 / (1 + distance)` over ChromaDB distances) — the "meaning" half that gets drowned out.
+- `rag/generator/review_generator.py` — `_format_context()` / `generate_section()`. The downstream consumer: it assembles the top retrieved chunks into the LLM prompt, so wrong chunks here become wrong context for the model's answer.
+- Config: there is **no** weight constant in `core/config.py` or elsewhere — the weights only exist as the defaults in `hybrid.py:14`. Making them configurable is part of a clean fix.
+- Caveat: `core/services/review_service.py` (`_run_rag_retrieval_generation()`) is still a placeholder and does not yet call `HybridRetriever`, so the scoring path isn't wired into the live request flow yet.
+
+**Issue Fit and Selection Reasoning:**
+
+- **Right tier / scope.** As a Tier 2 issue it's substantial enough to be meaningful but bounded — the root cause lives in a single function (`HybridRetriever.retrieve()`), so the change surface is small and easy to reason about.
+- **Clear, single root cause.** The problem traces cleanly to one thing: the fixed blend weight giving BM25 too much say. There's no ambiguity about *where* to fix it, which lowers the risk of scope creep.
+- **Well-understood behavior.** The failure mode (shared tech terms like "React"/"Python" inflating keyword scores and pulling in wrong-document chunks) is concrete and reproducible, making it straightforward to reason about before and after the change.
+- **High-impact for low effort.** Retrieval quality directly determines the context the LLM answers from, so a small weight change has an outsized effect on end output quality — a good return on a modest fix.
+- **Testable in isolation.** Because scoring is a pure blend of two normalized scores, the fix can be validated at the retriever level without needing the full generation pipeline (which is still a placeholder in `review_service.py`).
+- **Room to extend.** The issue also opens a natural follow-up path (making weights configurable, or query-adaptive weighting), so it's a clean foundation rather than a dead-end patch.
+
+**Branch name:** [fix/24-hybrid-scoring-weight-tuning]
+
+**Setup confirmation:** [App runs locally at localhost:5173]
+
+**Cohort ledger:** [Issue added to cohort ledger]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -116,3 +116,35 @@ All 8 pass (`.venv/bin/pytest tests/unit/test_hybrid_retriever.py`).
 **Self-review confirmation:** [x] make check passes  [x] make test-unit passes
 
 **Draft PR feedback received from:** ["none"]
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+[no review came in.]
+
+**How you responded:**
+[ ]
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+[Another Person was working on the same issue. That fix was merged when I was in the middle of implementing my fix with a different solution. I have made a comment in my PR proposing my fix as 0.8/0.2 is a defensible, safe-margin choice.]
+
+**What did you learn about working in a large codebase?**
+[For someone else's production code there are rules to follow and code review process is involved. For 
+my own project I set all the rules. There is no PR review process in personel project.]
+
+**How did AI tools help — and where did they fall short?**
+[AI assistance were most useful when it comes to understanding the codebase and implementing the actual fix. I needed to discuss and find a convincing answer for the reviewer to accept my proposed fix.]
+
+**What would you do differently if you started over?**
+[When it comes to the issue selection I would make sure none is working or will be working on my selected issue.]
+
+**What are you most proud of from this module?**
+[This module simulates and end to end process of fixing and issue in a production codebase and I was able to completed.]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -67,3 +67,13 @@ weights = vector 0.8 / keyword 0.2
 ```
 
 **What this proves:** at 50/50, the README chunk wins purely on its BM25 keyword score (`kw=1.000`) despite the resume chunk being the better semantic match (`vec=1.000`) — exactly the wrong-document retrieval the issue describes. Shifting weight toward vector similarity (0.8/0.2) reverses the ranking, confirming both the root cause and the fix location.
+
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [https://github.com/guiradoul/pathreview/commit/1733d798c9f0539ec4fc9ed5ce948b9e1d3f6e02]
+
+**Reproduction summary:**
+I drove the real `HybridRetriever.retrieve()` blend (via `scripts/repro_issue_24.py`, using lightweight fakes so only the scoring step is under test) with the query "React" against two chunks — a semantically-relevant resume chunk and a keyword-stuffed but irrelevant README chunk. At the issue's 50/50 weighting the wrong README chunk ranked #1 (final 0.794 vs 0.667) purely on its BM25 score, confirming the bug lives in the fixed-weight blend in `rag/retriever/hybrid.py`.
+
+**PLAN.md link:** [https://github.com/guiradoul/pathreview/blob/fix/24-hybrid-scoring-weight-tuning/PLAN.md]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -77,3 +77,42 @@ weights = vector 0.8 / keyword 0.2
 I drove the real `HybridRetriever.retrieve()` blend (via `scripts/repro_issue_24.py`, using lightweight fakes so only the scoring step is under test) with the query "React" against two chunks — a semantically-relevant resume chunk and a keyword-stuffed but irrelevant README chunk. At the issue's 50/50 weighting the wrong README chunk ranked #1 (final 0.794 vs 0.667) purely on its BM25 score, confirming the bug lives in the fixed-weight blend in `rag/retriever/hybrid.py`.
 
 **PLAN.md link:** [https://github.com/guiradoul/pathreview/blob/fix/24-hybrid-scoring-weight-tuning/PLAN.md]
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+[I have already implemented the fix and was working on the unit test]
+
+**Next steps:**
+[I was working on the unit test for the rest of the week]
+
+**Blockers:**
+[]
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [https://github.com/ascherj/pathreview/pull/184]
+
+**Branch:** [`fix/24-hybrid-scoring-weight-tuning`]
+
+**What you built:**
+Rebalanced the hybrid retriever's score blend in `rag/retriever/hybrid.py` from an equal weighting to `vector_weight=0.8 / keyword_weight=0.2`, so `HybridRetriever.retrieve()` weights semantic (vector) similarity more heavily than the BM25 keyword score. This stops keyword-only matches on shared technology names (e.g. "React", "Python") from riding wrong-document chunks to the top of the results — and therefore out of the context handed to the LLM. Also added `tests/unit/test_hybrid_retriever.py` to lock in the corrected ranking and guard against a regression back to the 50/50 behavior.
+
+**Tests added or updated:**
+Added `tests/unit/test_hybrid_retriever.py` (new — there was no existing coverage for `HybridRetriever`). It drives the real `retrieve()` blend with lightweight fakes for the vector store and keyword searcher, so only the scoring step is under test. The 8 tests cover:
+
+- **The fix** — at the tuned 0.8/0.2 weights the semantically-relevant chunk ranks #1.
+- **Regression guard** — at 50/50 the keyword-stuffed wrong-document chunk wins, locking in the reproduced bug so a revert to equal weights fails CI.
+- **Blend math** — the blended score equals `weight·normalized-vector + weight·normalized-keyword`.
+- **Weight edge cases** — pure-vector (keyword weight 0) and pure-keyword (vector weight 0) modes.
+- **Robustness** — empty vector/keyword results return `[]` with no divide-by-zero, a chunk present in only one retriever scores 0.0 on the other side, and the `min_score` threshold filters low-blend chunks.
+
+All 8 pass (`.venv/bin/pytest tests/unit/test_hybrid_retriever.py`).
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+**Draft PR feedback received from:** ["none"]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -34,3 +34,36 @@ A successfull fix is to rebalance that 50/50 to trust vector similarity more, or
 **Setup confirmation:** [App runs locally at localhost:5173]
 
 **Cohort ledger:** [Issue added to cohort ledger]
+
+**Issue 24 Reproduction:**
+
+*Goal: show the issue is real and pin down exactly where it lives (the score blend in `rag/retriever/hybrid.py`).*
+
+**Where it lives:** `rag/retriever/hybrid.py` — `HybridRetriever.retrieve()`, the blend at
+`blended_score = self.vector_weight * vector_score + self.keyword_weight * keyword_score`.
+
+**Repro script:** `scripts/repro_issue_24.py`. It exercises the *real* `retrieve()` method with lightweight fakes for the vector store and keyword searcher, so no ChromaDB or embeddings are needed — the only thing under test is the scoring blend.
+
+**Steps:**
+
+1. From the repo root, run: `.venv/bin/python scripts/repro_issue_24.py`
+2. The script sets up one query, `"React"`, and two chunks:
+   - `resume-1` (**correct** doc) — high vector similarity (0.85), low BM25 (3.0): mentions React once, in context.
+   - `readme-1` (**wrong** doc) — low vector similarity (0.50), high BM25 (9.0): keyword-stuffed with "react".
+3. It runs the blend twice — once at the issue's **50/50** weights, once at the proposed **0.8/0.2** fix — and prints the ranking each time.
+
+**Observed output:**
+
+```
+weights = vector 0.5 / keyword 0.5
+  #1  readme-1  doc=readme  final=0.794  (vec=0.588 kw=1.000)
+  #2  resume-1  doc=resume  final=0.667  (vec=1.000 kw=0.333)
+  => top result: readme-1 — WRONG doc on top (bug)
+
+weights = vector 0.8 / keyword 0.2
+  #1  resume-1  doc=resume  final=0.867  (vec=1.000 kw=0.333)
+  #2  readme-1  doc=readme  final=0.671  (vec=0.588 kw=1.000)
+  => top result: resume-1 — correct doc on top
+```
+
+**What this proves:** at 50/50, the README chunk wins purely on its BM25 keyword score (`kw=1.000`) despite the resume chunk being the better semantic match (`vec=1.000`) — exactly the wrong-document retrieval the issue describes. Shifting weight toward vector similarity (0.8/0.2) reverses the ranking, confirming both the root cause and the fix location.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,70 @@
+## Solution plan
+
+**Issue:** [
+    Hybrid retriever over-weights keyword results when query contains technology names
+    #24
+    https://github.com/ascherj/pathreview/issues/24
+ ]
+
+### Understand
+What is the root cause of this issue? What behavior is expected vs. actual?
+
+**Root cause.** `HybridRetriever.retrieve()` in `rag/retriever/hybrid.py` blends a vector-similarity score and a BM25 keyword score with fixed, equal weights (the issue describes 50/50; the fix moves this toward vector). Both scores are max-normalized to 0–1 independently (`hybrid.py:58-59`) *before* blending. Normalization means a chunk that is merely the *best keyword match in its batch* gets `keyword_score = 1.0` regardless of how weakly it matches in absolute terms. When a query contains a technology name ("React", "Python") that appears in both the resume and the README, a keyword-stuffed but semantically-irrelevant chunk earns a top-normalized BM25 score and, at equal weight, outranks the genuinely relevant chunk.
+
+**Expected:** for a query about the candidate's React experience, the top chunk should be the resume/project chunk that is *semantically* about React work.
+**Actual (reproduced in `scripts/repro_issue_24.py`):** at 50/50 the README chunk wins purely on keyword score (`final=0.794` vs `0.667`) despite a weaker vector score, so the wrong document is retrieved and fed to the LLM.
+
+### Map
+Which files, functions, or modules are involved?
+List the specific files you expect to touch.
+
+**Will touch:**
+- `rag/retriever/hybrid.py` — `HybridRetriever.__init__` / `retrieve()`. Primary change: source the blend weights from config instead of hardcoded defaults, and add input validation. The blend expression at `hybrid.py:78-81` stays but its weights change.
+- `core/config.py` — `Settings` class (alongside `max_chunks_per_query`, `min_relevance_score` at lines 36-37). Add `hybrid_vector_weight` and `hybrid_keyword_weight` fields so the ratio is env-configurable and has one source of truth.
+- `scripts/repro_issue_24.py` — extend into / mirror as a real regression test asserting the correct chunk ranks first at the tuned weights.
+
+**Will read / investigate (likely no change):**
+- `rag/retriever/keyword_search.py` — `KeywordSearcher.search()` and `_tokenize()`; confirm normalization assumptions and whether naive tokenization worsens the shared-vocabulary problem.
+- `rag/retriever/vector_store.py` — `VectorStore.query()`; confirm the `1/(1+distance)` similarity range so weight tuning reasons over comparable scales.
+- `rag/generator/review_generator.py` — `_format_context()` / `generate_section()`; the downstream consumer, to sanity-check the end-to-end effect.
+- `core/services/review_service.py` — `_run_rag_retrieval_generation()` (still a placeholder); confirms the fix isn't yet on the live path and won't be exercised via the API.
+
+### Plan
+What are the steps to fix this issue?
+Break it into 3–5 concrete sub-tasks.
+
+1. **Add config fields.** In `core/config.py`, add `hybrid_vector_weight: float = Field(default=0.8)` and `hybrid_keyword_weight: float = Field(default=0.2)` to `Settings`, next to the existing retrieval knobs. This removes the "no config constant" gap noted in the journal.
+2. **Wire weights + validation into the retriever.** In `rag/retriever/hybrid.py`, default the constructor args to the config values (`settings.hybrid_vector_weight` / `settings.hybrid_keyword_weight`) and add a guard in `__init__` that rejects negative weights and normalizes if the two don't sum to 1.0 (so a misconfigured ratio can't silently skew scores).
+3. **Add a regression test from the repro.** Promote the scenario in `scripts/repro_issue_24.py` into a `pytest` test (e.g. `tests/test_hybrid_retriever.py`) that builds the two-chunk resume-vs-README fixture, runs `retrieve()`, and asserts the resume chunk ranks #1 at the default (tuned) weights — and still ranks #2 at 50/50, locking in the reproduction.
+4. **Verify end-to-end formatting is unaffected.** Confirm `review_generator._format_context()` still receives correctly-ordered chunks and that the `min_score` filter at `hybrid.py:93` behaves sensibly after re-weighting (a lower keyword contribution shouldn't drop everything below threshold).
+5. **Update docs.** Record the final chosen ratio and rationale in `JOURNAL.md` (Affected parts already notes 0.8/0.2) and note the new env vars.
+
+### Inputs & outputs
+What does your fix take as input? What should it produce or change?
+
+**Inputs:** unchanged `retrieve()` signature — `query: str`, `profile_id: str`, `query_embedding: list[float]`, `max_chunks: int`, `min_score: float` — plus the two new blend-weight settings read from `core/config.py` (overridable via `.env` / environment: `HYBRID_VECTOR_WEIGHT`, `HYBRID_KEYWORD_WEIGHT`).
+
+**Outputs / changes:**
+- Same return shape: `list[dict]` with `id`, `text`, `metadata`, `score`, `vector_score`, `keyword_score` — no consumer (`review_generator._format_context`) needs changes.
+- Behavioral change: the blended `score` now weights vector similarity more heavily, so ranking order changes for tech-name queries — the relevant-document chunk rises to the top.
+- New: a config-driven, validated weight pair (single source of truth) and a regression test asserting the corrected ranking.
+
+### Risks & unknowns
+What could go wrong? What are you still unsure about?
+
+- **Over-correcting toward vector.** 0.8/0.2 fixes the reproduced case, but I haven't validated against a corpus where BM25 legitimately helps (exact-term queries like a specific library or error string). Risk: recall drops for genuinely keyword-driven queries. Mitigation/investigation: test a small matrix of query types before locking the ratio; consider query-adaptive weighting as a follow-up (already flagged in the journal).
+- **Normalization interacts with weights.** The max-normalization at `hybrid.py:58-59` means weights act on *relative* not absolute scores; changing weights doesn't fix the underlying "best-in-batch always gets 1.0" behavior. Unknown: whether re-weighting alone is enough, or whether the normalization scheme itself needs revisiting.
+- **`min_score` threshold coupling.** `hybrid.py:93` filters on the blended score, and `core/config.py:37` sets `min_relevance_score=0.3`. Lowering the keyword contribution shifts the blended-score distribution; a chunk formerly above 0.3 might now fall below it. Risk: fewer/no chunks returned in edge configs.
+- **Not on the live path.** `core/services/review_service.py` `_run_rag_retrieval_generation()` is a placeholder, so I can't validate through the real API yet — end-to-end confidence relies on the isolated repro/test until that's wired up.
+- **Naive tokenization.** `keyword_search._tokenize()` lowercases and splits on whitespace only, so "react," / "React." / "react-dom" tokenize inconsistently — this may amplify or mask the effect and could confound test results.
+
+### Edge cases
+What inputs or states should your fix handle gracefully?
+
+- **Weights that don't sum to 1** (e.g. `0.7`/`0.7` from a bad `.env`): validate/normalize in `__init__` rather than silently producing inflated blended scores.
+- **A weight of exactly 0** (pure-vector or pure-keyword mode): should be allowed and behave as a clean single-retriever fallback, not divide-by-zero or error.
+- **Empty result sets / empty index:** `keyword_searcher.search()` returns `[]` on an unbuilt index (`keyword_search.py:40-42`) and vector results can be empty — the `default=1.0` in the `max(...)` normalization (`hybrid.py:58-59`) must keep protecting against division by zero.
+- **Chunk in only one retriever's results:** the union loop at `hybrid.py:63-76` already handles a chunk present in vector-only or keyword-only maps; the fix must preserve that (missing side scored 0.0).
+- **All chunks below `min_score` after re-weighting:** decide expected behavior (return empty vs. relax) and cover it, since re-weighting shifts the distribution.
+- **Ties / identical blended scores:** ensure sort at `hybrid.py:94` is stable/deterministic so ordering doesn't flap between runs.
+- **Query containing the tech name many times** (the core case): confirm a keyword-stuffed wrong-doc chunk no longer reaches #1 — this is exactly the regression test's assertion.

--- a/rag/retriever/hybrid.py
+++ b/rag/retriever/hybrid.py
@@ -1,8 +1,9 @@
 """Hybrid retriever combining vector and keyword search."""
 
 import structlog
-from .vector_store import VectorStore
+
 from .keyword_search import KeywordSearcher
+from .vector_store import VectorStore
 
 logger = structlog.get_logger()
 
@@ -10,8 +11,13 @@ logger = structlog.get_logger()
 class HybridRetriever:
     """Combines vector similarity and BM25 keyword search."""
 
-    def __init__(self, vector_store: VectorStore, keyword_searcher: KeywordSearcher,
-                 vector_weight: float = 0.7, keyword_weight: float = 0.3):
+    def __init__(
+        self,
+        vector_store: VectorStore,
+        keyword_searcher: KeywordSearcher,
+        vector_weight: float = 0.8,
+        keyword_weight: float = 0.2,
+    ):
         """Initialize hybrid retriever.
 
         Args:
@@ -25,8 +31,14 @@ class HybridRetriever:
         self.vector_weight = vector_weight
         self.keyword_weight = keyword_weight
 
-    def retrieve(self, query: str, profile_id: str, query_embedding: list[float],
-                 max_chunks: int = 10, min_score: float = 0.3) -> list[dict]:
+    def retrieve(
+        self,
+        query: str,
+        profile_id: str,
+        query_embedding: list[float],
+        max_chunks: int = 10,
+        min_score: float = 0.3,
+    ) -> list[dict]:
         """Retrieve chunks using hybrid approach.
 
         Args:
@@ -67,18 +79,23 @@ class HybridRetriever:
             keyword_score = 0.0
 
             if chunk_id in vector_map:
-                vector_score = (vector_map[chunk_id]["score"] / vector_scores_max) if vector_scores_max > 0 else 0
+                vector_score = (
+                    (vector_map[chunk_id]["score"] / vector_scores_max)
+                    if vector_scores_max > 0
+                    else 0
+                )
                 base_chunk = vector_map[chunk_id]
             else:
                 base_chunk = keyword_map[chunk_id]
 
             if chunk_id in keyword_map:
-                keyword_score = (keyword_map[chunk_id].get("bm25_score", 0) / keyword_scores_max) if keyword_scores_max > 0 else 0
+                keyword_score = (
+                    (keyword_map[chunk_id].get("bm25_score", 0) / keyword_scores_max)
+                    if keyword_scores_max > 0
+                    else 0
+                )
 
-            blended_score = (
-                self.vector_weight * vector_score +
-                self.keyword_weight * keyword_score
-            )
+            blended_score = self.vector_weight * vector_score + self.keyword_weight * keyword_score
 
             blended[chunk_id] = {
                 "id": chunk_id,
@@ -86,7 +103,7 @@ class HybridRetriever:
                 "metadata": base_chunk.get("metadata", {}),
                 "score": blended_score,
                 "vector_score": vector_score,
-                "keyword_score": keyword_score
+                "keyword_score": keyword_score,
             }
 
         # Filter by min_score and sort
@@ -96,10 +113,15 @@ class HybridRetriever:
         # Return top max_chunks
         final_results = results[:max_chunks]
 
-        logger.info("hybrid_retrieval_complete", query_len=len(query),
-                   vector_results=len(vector_results), keyword_results=len(keyword_results),
-                   blended_count=len(blended), filtered_count=len(results),
-                   final_count=len(final_results))
+        logger.info(
+            "hybrid_retrieval_complete",
+            query_len=len(query),
+            vector_results=len(vector_results),
+            keyword_results=len(keyword_results),
+            blended_count=len(blended),
+            filtered_count=len(results),
+            final_count=len(final_results),
+        )
 
         return final_results
 
@@ -117,13 +139,7 @@ class HybridRetriever:
 
         chunks = []
         for doc_id, text, metadata in zip(
-            all_docs["ids"],
-            all_docs["documents"],
-            all_docs["metadatas"]
+            all_docs["ids"], all_docs["documents"], all_docs["metadatas"], strict=False
         ):
-            chunks.append({
-                "id": doc_id,
-                "text": text,
-                "metadata": metadata
-            })
+            chunks.append({"id": doc_id, "text": text, "metadata": metadata})
         return chunks

--- a/tests/unit/test_hybrid_retriever.py
+++ b/tests/unit/test_hybrid_retriever.py
@@ -1,0 +1,159 @@
+"""Tests for hybrid.py — HybridRetriever score blending (regression for issue #24)."""
+
+import pytest
+
+from rag.retriever.hybrid import HybridRetriever
+
+
+class FakeVectorStore:
+    """Minimal VectorStore stand-in returning canned query results."""
+
+    def __init__(self, results):
+        self._results = results
+
+    def query(self, query_embedding, collection_name, n_results=10):
+        return self._results
+
+    def get_collection(self, name):
+        class _Empty:
+            def get(self, include=None):
+                return {"ids": [], "documents": [], "metadatas": []}
+
+        return _Empty()
+
+
+class FakeKeywordSearcher:
+    """Minimal KeywordSearcher stand-in returning canned search results."""
+
+    def __init__(self, results):
+        self._results = results
+
+    def search(self, query, top_k=10):
+        return self._results
+
+
+@pytest.mark.unit
+class TestHybridRetrieverBlend:
+    """Regression tests for the vector/keyword score blend (issue #24)."""
+
+    # Scenario for query "React":
+    #   resume-1 (CORRECT doc) — strong semantic match, weak keyword match
+    #   readme-1 (WRONG doc)   — weak semantic match, keyword-stuffed
+    @pytest.fixture
+    def vector_results(self):
+        return [
+            {
+                "id": "resume-1",
+                "text": "Built a dashboard in React for a client",
+                "metadata": {"source_id": "resume"},
+                "score": 0.85,
+            },
+            {
+                "id": "readme-1",
+                "text": "React React React npm install react react-dom",
+                "metadata": {"source_id": "readme"},
+                "score": 0.50,
+            },
+        ]
+
+    @pytest.fixture
+    def keyword_results(self):
+        return [
+            {
+                "id": "readme-1",
+                "text": "React React React npm install react react-dom",
+                "metadata": {"source_id": "readme"},
+                "bm25_score": 9.0,
+            },
+            {
+                "id": "resume-1",
+                "text": "Built a dashboard in React for a client",
+                "metadata": {"source_id": "resume"},
+                "bm25_score": 3.0,
+            },
+        ]
+
+    def _retrieve(self, vector_results, keyword_results, vector_weight, keyword_weight):
+        retriever = HybridRetriever(
+            FakeVectorStore(vector_results),
+            FakeKeywordSearcher(keyword_results),
+            vector_weight=vector_weight,
+            keyword_weight=keyword_weight,
+        )
+        return retriever.retrieve(
+            query="React",
+            profile_id="demo",
+            query_embedding=[0.0],
+            max_chunks=10,
+            min_score=0.0,
+        )
+
+    def test_tuned_weights_rank_correct_document_first(self, vector_results, keyword_results):
+        """At the fixed 0.8/0.2 weights, the semantically-relevant chunk ranks #1."""
+        results = self._retrieve(vector_results, keyword_results, 0.8, 0.2)
+
+        assert results[0]["id"] == "resume-1"
+        assert results[0]["metadata"]["source_id"] == "resume"
+
+    def test_fifty_fifty_reproduces_the_bug(self, vector_results, keyword_results):
+        """Locks in the reproduction: at 50/50 the keyword-stuffed wrong doc wins."""
+        results = self._retrieve(vector_results, keyword_results, 0.5, 0.5)
+
+        assert results[0]["id"] == "readme-1"
+        assert results[0]["metadata"]["source_id"] == "readme"
+
+    def test_blended_score_uses_weights(self, vector_results, keyword_results):
+        """Blended score equals weight*normalized-vector + weight*normalized-keyword."""
+        results = self._retrieve(vector_results, keyword_results, 0.8, 0.2)
+        resume = next(r for r in results if r["id"] == "resume-1")
+
+        # vector normalized: 0.85/0.85 = 1.0 ; keyword normalized: 3.0/9.0 = 0.3333
+        expected = 0.8 * 1.0 + 0.2 * (3.0 / 9.0)
+        assert resume["score"] == pytest.approx(expected)
+
+    def test_pure_vector_weight_ignores_keyword(self, vector_results, keyword_results):
+        """A zero keyword weight makes ranking depend only on vector similarity."""
+        results = self._retrieve(vector_results, keyword_results, 1.0, 0.0)
+
+        assert results[0]["id"] == "resume-1"
+        # keyword_score is still computed (resume's normalized BM25 = 3.0/9.0)...
+        assert results[0]["keyword_score"] == pytest.approx(3.0 / 9.0)
+        # ...but with weight 0 it contributes nothing, so the score is pure vector (1.0).
+        assert results[0]["score"] == pytest.approx(1.0)
+
+    def test_pure_keyword_weight_ignores_vector(self, vector_results, keyword_results):
+        """A zero vector weight makes ranking depend only on BM25 keyword score."""
+        results = self._retrieve(vector_results, keyword_results, 0.0, 1.0)
+
+        assert results[0]["id"] == "readme-1"
+
+    def test_empty_results_do_not_crash(self):
+        """Empty vector and keyword results return [] without dividing by zero."""
+        results = self._retrieve([], [], 0.8, 0.2)
+
+        assert results == []
+
+    def test_keyword_only_chunk_scores_zero_vector(self, keyword_results):
+        """A chunk present only in keyword results gets vector_score 0.0, not a crash."""
+        results = self._retrieve([], keyword_results, 0.8, 0.2)
+
+        by_id = {r["id"]: r for r in results}
+        assert by_id["readme-1"]["vector_score"] == 0.0
+        assert by_id["readme-1"]["keyword_score"] > 0.0
+
+    def test_min_score_filters_low_blended_scores(self, vector_results, keyword_results):
+        """Chunks below min_score are dropped from the results."""
+        # readme-1 blended score at 0.8/0.2 is ~0.671; set threshold above it.
+        results = self._retrieve(vector_results, keyword_results, 0.8, 0.2)
+        high = HybridRetriever(
+            FakeVectorStore(vector_results),
+            FakeKeywordSearcher(keyword_results),
+            vector_weight=0.8,
+            keyword_weight=0.2,
+        ).retrieve(
+            query="React", profile_id="demo", query_embedding=[0.0], max_chunks=10, min_score=0.7
+        )
+
+        assert any(r["id"] == "readme-1" for r in results)  # present with no threshold
+        assert all(r["id"] != "readme-1" for r in high)  # filtered out at min_score=0.7
+        assert all(r["score"] >= 0.7 for r in high)


### PR DESCRIPTION
## Summary
This is the  setup, the fix and test implementation for issue 24 (https://github.com/ascherj/pathreview/issues/24) Fix.

## Issue
Issue 24 (https://github.com/ascherj/pathreview/issues/24) Final Fix is Done.

## Changes
I have filled out the JOURNAL.md file to give informations about the selected issue. And I also included  Issue Fit and Selection Reasoning. Also did some changes for 0.8 for vector weight and 0.2 for keyword weight. I also wrote unit test to make sure fix implementation is working as expected.
-

## Testing
<!-- How did you verify your changes? -->
- [x] App runs locally at localhost:5173
- [x] Unit tests pass (`make test-unit`)
- [x] Integration tests pass (`make test-integration`)
- [x] Linter passes (`make lint`)
- [x] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes

## Screenshots / Demo
N/A as the fix is not yet fully implemented.


## Notes for Reviewers
For this week 9 i have completed the fix for issue 24. I have filled out the JOURNAL.md file to give informations about the selected issue. And I also included  Issue Fit and Selection Reasoning. Also did some changes for 0.8 for vector weight and 0.2 for keyword weight. I also wrote unit test to make sure fix implementation is working as expected.
