### PR TITLE
fix(agent): checkpoint orchestrator progress after every tool, not just at the end

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -39,7 +39,7 @@ isn't obvious from the issue title alone.
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [docs: reproduce issue #47 and add PLAN.md](JOURNAL.md) (see this commit on branch `fix/47-persist-agent-progress-across-restarts`)
+**Reproduction commit link:** [4c0550b — docs: reproduce issue #47 and add Week 8 solution plan](https://github.com/LuisMend12/pathreview/commit/4c0550b)
 
 **Reproduction summary:**
 The fix for #47 (`cb5cc09`) and its regression tests

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -36,3 +36,46 @@ isn't obvious from the issue title alone.
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [ ] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [docs: reproduce issue #47 and add PLAN.md](JOURNAL.md) (see this commit on branch `fix/47-persist-agent-progress-across-restarts`)
+
+**Reproduction summary:**
+The fix for #47 (`cb5cc09`) and its regression tests
+(`tests/unit/test_orchestrator.py`) were already committed on this branch
+before I got to this week's reproduction step, so instead of writing a new
+failing test from scratch I reproduced the original bug directly: I
+temporarily replaced `agent/orchestrator.py` with its pre-fix version
+(`git show cb5cc09^:agent/orchestrator.py`) and reran the existing
+regression suite against it.
+
+```
+$ ./.venv/Scripts/python -m pytest tests/unit/test_orchestrator.py -q
+...
+FAILED tests/unit/test_orchestrator.py::TestOrchestratorCheckpointing::test_progress_is_checkpointed_after_each_tool_not_only_at_the_end
+FAILED tests/unit/test_orchestrator.py::TestOrchestratorCheckpointing::test_restart_mid_review_resumes_without_rerunning_completed_tools
+FAILED tests/unit/test_orchestrator.py::TestOrchestratorCheckpointing::test_previously_failed_tool_is_retried_on_resume
+3 failed, 1 passed in 1.62s
+```
+
+The failure in `test_previously_failed_tool_is_retried_on_resume` shows the
+bug concretely: `tools["tool_a"].execute.call_count` is `1` when it should
+be `0` — the pre-fix orchestrator re-executes a tool that a prior run
+(simulated via a seeded `session_store`) had already completed
+successfully, because the loop in `Orchestrator.run()` never checked
+existing session state per-tool and only persisted results once, after the
+whole loop finished. I then restored `agent/orchestrator.py` via
+`git checkout -- agent/orchestrator.py` and confirmed all 4 tests pass again
+on the fixed version. This confirms the bug is real and pins it exactly to
+the loop body in `Orchestrator.run()` described in `PLAN.md`.
+
+**PLAN.md link:** [PLAN.md](PLAN.md)
+
+**Walkthrough video (recommended):** _not recorded this week_
+
+**Blockers or open questions:**
+None blocking. Open question carried into Week 9: whether the "already
+done" check should key off something more explicit than dict shape
+(`success` key) so a future tool with a different result shape can't be
+misread as complete — see Risks & unknowns in `PLAN.md`.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,38 @@
+# JOURNAL
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/47
+
+**Issue title:** Agent state isn't persisted across API restarts, causing in-progress reviews to be lost
+
+**Tier:** [ ] Tier 1  [ ] Tier 2  [x] Tier 3
+
+**Problem summary:**
+When the agent runs a long review (multiple repos/tools), it tracks progress only
+in the orchestrator's local memory and writes that progress to Redis a single
+time, after every tool in the plan has finished. If the API process restarts
+while a review is still in progress — a deploy, a crash, anything — none of the
+work done so far is saved, and the review has to start completely over. The
+code lives in `agent/orchestrator.py` (the `Orchestrator.run()` loop) and
+`agent/memory/session_store.py` (the Redis-backed store it writes to). A
+successful fix checkpoints each tool's result to Redis as soon as that tool
+finishes, and on a fresh run checks that saved state first so completed tools
+are skipped and only the unfinished ones actually re-execute.
+
+**Scope reasoning ("Is this right for me?"):** This is a Tier 3 issue, a bigger
+jump than the recommended Tier 1 starting point for a first contribution. I
+chose it deliberately over the smaller Tier 1 health-check bug I'd originally
+selected (#154). It's still tractable: it touches two files I could read in
+full, the fix is a scoped change to *when* an existing Redis write happens
+(not a new subsystem), and I verified my understanding by reading both files
+end-to-end before writing any code. The estimated effort in the issue (7–10
+hours) is real, mostly because a correct fix needs a second behavior beyond
+checkpointing — actually skipping already-completed tools on resume — which
+isn't obvious from the issue title alone.
+
+**Branch name:** fix/47-persist-agent-progress-across-restarts
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -138,3 +138,75 @@ PR description)_
 **Draft PR feedback received from:** none yet — PR was already open
 (not draft) from before Week 8; requesting peer/mentor review in Slack
 this week
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No review has come in. Su26 note: reviewer feedback isn't a feature this
+term, so this is expected rather than a stall. I confirmed directly via
+`gh pr view 199 --repo ascherj/pathreview --json comments,reviews` that
+PR #199 has zero comments and zero reviews as of the Week 10 deadline.
+
+**How you responded:**
+N/A — nothing to respond to. I left the PR description as finalized in
+Week 9 rather than editing it speculatively.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Understanding `agent/orchestrator.py`'s flow before I could touch it safely.
+The bug itself (checkpoint once at the end instead of per-tool) is a
+one-line-sounding description, but `Orchestrator.run()` interacts with
+`agent/memory/session_store.py` and `agent/error_handling.py` in ways that
+aren't obvious from reading any single file — I had to trace how a tool
+result becomes a Redis write, and separately how a fresh run decides
+whether a tool is "already done," before I trusted myself to change the
+loop. The Week 8 reproduction step (reverting to the pre-fix version and
+watching specific tests fail) is what actually made the control flow click;
+reading the code alone didn't.
+
+**What did you learn about working in a large codebase?**
+Existing conventions constrain the fix more than the bug report does. I
+couldn't just design the "was this tool already done" check however I
+wanted — it had to match the shape `session_store.py` already used to
+persist results (the `success` key that Week 8's open question flagged as
+fragile), because introducing a new convention just for this fix would
+have meant touching more of the codebase than the issue warranted. In my
+own projects I'd have just redesigned the storage shape; here the scope of
+"correct" is set by what's already there, not by what's cleanest.
+
+**How did AI tools help — and where did they fall short?**
+AI assistance was most useful for test scaffolding — generating the
+boilerplate for `tests/unit/test_orchestrator.py`'s four cases (incremental
+checkpointing, resume across two `Orchestrator` instances sharing one
+`session_store`, retry of a failed tool, and the `session_store=None`
+no-op path) so I could focus on getting the assertions right. It fell short
+on the actual domain logic: deciding what "already done" should mean for a
+tool result, and whether keying off a `success` field was robust enough,
+required reasoning about this specific codebase's data shapes that no
+amount of prompting substituted for. That's still an open question I
+flagged in Week 8 and didn't fully resolve.
+
+**What would you do differently if you started over?**
+I'd record a walkthrough video during Week 8 instead of skipping it. I
+noted "not recorded this week" in the Week 8 entry, and in hindsight a
+short recording of the reproduction (reverting to `cb5cc09^`, showing the
+three tests fail, restoring the fix) would have been useful both as a
+reviewer aid and as documentation I could point back to instead of
+re-deriving the failure details from memory while writing this journal.
+
+**What are you most proud of from this module?**
+Choosing the Tier 3 issue (#47) over the smaller Tier 1 health-check bug
+(#154) I'd originally picked. It was a real jump in scope — a two-file,
+cross-cutting fix instead of an isolated bug — but I made that call
+deliberately in Week 7 after confirming I could read both files end-to-end,
+and it held up: the fix needed a second behavior (skipping completed tools
+on resume, not just checkpointing) that wasn't obvious from the issue title,
+and I only caught that because I'd taken the issue seriously enough to plan
+it properly instead of picking the safe option.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -35,7 +35,7 @@ isn't obvious from the issue title alone.
 
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
-**Cohort ledger:** [ ] Issue added to cohort ledger
+**Cohort ledger:** [x] Issue added to cohort ledger
 
 ## Week 8 — Reproduction & solution planning
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -100,8 +100,10 @@ it touched, and none of the 5 changed files have any lint/typecheck/format
 issues of their own.
 
 **Next steps:**
-Open a draft PR against `ascherj/pathreview` for early feedback, then
-request a peer/mentor review in Slack before marking it ready for review.
+PR #199 against `ascherj/pathreview` was already open from before Week 8
+but had an empty template body — filled it in with the real summary,
+changes, and testing/verification details this week. Still need to
+request peer/mentor review in Slack.
 
 **Blockers:**
 None.
@@ -110,7 +112,7 @@ None.
 
 ### Check-in 2 (end of week)
 
-**PR link:** _pending — added once opened_
+**PR link:** https://github.com/ascherj/pathreview/pull/199
 
 **Branch:** `fix/47-persist-agent-progress-across-restarts`
 
@@ -133,5 +135,6 @@ _(both confirmed with zero new failures relative to this branch's base
 commit — see Check-in 1 for the verification method; full breakdown in the
 PR description)_
 
-**Draft PR feedback received from:** _pending — requesting review in Slack
-after opening the draft PR_
+**Draft PR feedback received from:** none yet — PR was already open
+(not draft) from before Week 8; requesting peer/mentor review in Slack
+this week

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -79,3 +79,59 @@ None blocking. Open question carried into Week 9: whether the "already
 done" check should key off something more explicit than dict shape
 (`success` key) so a future tool with a different result shape can't be
 misread as complete — see Risks & unknowns in `PLAN.md`.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+The implementation and its tests (`agent/orchestrator.py`,
+`agent/memory/session_store.py`/`context_manager.py`,
+`agent/error_handling.py`, `tests/unit/test_orchestrator.py`) were already
+complete going into this week — all 5 sub-tasks from `PLAN.md`'s Plan
+section are done. This week's work was verification and PR prep, not new
+implementation: I ran `make test-unit` and confirmed the 53 failing tests
+in the suite are pre-existing by diffing the failure list against the same
+run on this branch's base commit (`54cc749`) — identical set, so this
+change introduces no new failures. Same check for `ruff`/`mypy`: repo-wide
+error counts went *down* (182→175 lint, 103→90 typecheck) because the fix
+commit's type annotations closed 13 pre-existing mypy errors in the files
+it touched, and none of the 5 changed files have any lint/typecheck/format
+issues of their own.
+
+**Next steps:**
+Open a draft PR against `ascherj/pathreview` for early feedback, then
+request a peer/mentor review in Slack before marking it ready for review.
+
+**Blockers:**
+None.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** _pending — added once opened_
+
+**Branch:** `fix/47-persist-agent-progress-across-restarts`
+
+**What you built:**
+`Orchestrator.run()` now checkpoints each tool's result to Redis
+immediately after it completes, instead of once at the very end of the
+tool loop, and checks previously-saved session state before running each
+tool so a restart resumes from where it left off — completed tools are
+skipped, failed ones are retried.
+
+**Tests added or updated:**
+`tests/unit/test_orchestrator.py` (new, 4 tests): incremental
+checkpointing after each tool, resume-after-restart across two
+`Orchestrator` instances sharing one `session_store`, retry of a
+previously-failed tool, and unchanged no-persistence behavior when
+`session_store=None`.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+_(both confirmed with zero new failures relative to this branch's base
+commit — see Check-in 1 for the verification method; full breakdown in the
+PR description)_
+
+**Draft PR feedback received from:** _pending — requesting review in Slack
+after opening the draft PR_

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,108 @@
+# Solution plan
+
+**Issue:** [Agent state isn't persisted across API restarts, causing in-progress reviews to be lost (#47)](https://github.com/ascherj/pathreview/issues/47)
+
+## Understand
+
+**Root cause:** `Orchestrator.run()` in `agent/orchestrator.py` loaded prior
+session state from Redis at the top of the method, but never consulted it
+inside the tool-execution loop. Every tool in the plan ran unconditionally on
+every call, regardless of whether a previous run had already completed it.
+On top of that, the merged results were only written back to Redis once,
+after the entire loop finished (`session_state.update(results)` +
+`self.session_store.set(...)` sat *after* the `for` loop, not inside it).
+
+**Expected behavior:** if the API process restarts mid-review, a fresh
+`Orchestrator.run()` call for the same `profile_id` should skip tools that
+already succeeded and only execute the tools that hadn't finished yet.
+
+**Actual behavior (pre-fix):** a restart mid-review loses all progress. Even
+in the narrow window where a full run *did* complete and got persisted, a
+second call would still re-execute every tool from scratch, because nothing
+in the loop ever read from the loaded `session_state` — it only used it as
+the base dict to `.update()` at the very end.
+
+## Map
+
+- `agent/orchestrator.py` — `Orchestrator.run()` (the tool-execution loop and
+  the checkpoint write) is the primary fix location.
+- `agent/memory/session_store.py` — `SessionStore.get()` / `SessionStore.set()`,
+  the Redis-backed store the orchestrator reads/writes. No behavior change
+  needed here, but its `dict | None` return shape is what `run()` has to
+  handle correctly (missing type annotations here were also blocking the
+  mypy pre-commit hook on any orchestrator change).
+- `agent/memory/context_manager.py` — imported by `orchestrator.py`; needed
+  type-annotation fixes for the same pre-commit reason.
+- `agent/error_handling.py` — `retry_with_backoff`, used by
+  `_execute_with_timeout`; same pre-commit blocker.
+- `tests/unit/test_orchestrator.py` — new test file; simulates a restart by
+  constructing two `Orchestrator` instances that share one `session_store`.
+
+## Plan
+
+1. Load the previous session state at the top of `run()` (already existed)
+   and, inside the tool loop, check per-tool whether `results.get(tool_name)`
+   already holds a successful result. If so, log `tool_resumed_from_checkpoint`
+   and `continue` instead of re-executing.
+2. Treat a previously *failed* tool (`{"success": False, ...}`) as not-done,
+   so it gets retried rather than skipped.
+3. Move the `self.session_store.set(profile_id, results)` call inside the
+   loop, immediately after each tool's result (success or failure) is
+   recorded, so a crash between tool N and N+1 only loses the in-flight
+   tool, not everything.
+4. Add regression tests that simulate the exact restart scenario: run an
+   `Orchestrator` through a partial plan, construct a second `Orchestrator`
+   sharing the same `session_store`, and assert already-completed tools are
+   not re-invoked (`tool.execute.call_count`) while incomplete/failed ones
+   are.
+5. Fix the missing type annotations in `error_handling.py`,
+   `context_manager.py`, and `session_store.py` that were otherwise blocking
+   the mypy pre-commit hook on this change.
+
+## Inputs & outputs
+
+- **Input:** `profile_id: str`, `profile_data: dict` (drives `_build_plan`),
+  and whatever `self.session_store.get(profile_id)` returns — either `None`
+  (no prior run) or a `dict` mapping `tool_name -> result` from an earlier,
+  possibly-interrupted run.
+- **Output:** an incrementally-updated Redis entry at `session:{profile_id}`
+  (one `setex` call per completed tool, TTL 3600s), and the same return
+  shape `run()` always produced: `{"profile_id", "tool_results", "cached_results"}`.
+
+## Risks & unknowns
+
+- `SessionStore.set()` round-trips through `json.dumps`/`json.loads`
+  (`agent/memory/session_store.py:61`), so any tool result that isn't
+  JSON-serializable would silently fail to persist (the `except Exception`
+  there only logs). Not currently an issue with existing tools, but a new
+  tool returning something like a `datetime` would break checkpointing
+  quietly.
+- "Already done" is inferred from dict shape
+  (`previous.get("success") is False` means retry, anything else means
+  skip) — a tool that returns a truthy dict without a `success` key on
+  partial failure would be incorrectly treated as complete.
+- The Redis TTL is a fixed 3600s (`session_store.py:56`). A review that
+  stays interrupted for longer than an hour loses its checkpoints entirely,
+  which the fix doesn't address — resuming from a very stale restart still
+  reverts to running everything.
+- No coverage for two orchestrator instances processing the same
+  `profile_id` concurrently (race on the Redis key) — not a scenario the
+  current single-worker deployment hits, but worth flagging if that changes.
+
+## Edge cases
+
+- All tools in the plan already have successful results in
+  `session_store` → `run()` should execute nothing and just return the
+  cached results.
+- A tool previously recorded `{"success": False, ...}` → must be retried,
+  not skipped.
+- `session_store` is `None` (persistence not configured) → behavior must be
+  unchanged from before the fix: every tool executes, nothing is checkpointed,
+  no exception raised.
+- `profile_data` changes between the interrupted run and the resumed run
+  (e.g., a project's `github_repo` changes), so `_build_plan` produces a
+  tool name that isn't a key in the old `results` dict → treated as not-done
+  and executed normally, since `results.get(tool_name)` returns `None`.
+- Redis returns corrupted/non-JSON data on `get()` → already handled by
+  `SessionStore.get()`'s `except json.JSONDecodeError: return None`, so the
+  orchestrator falls back to running everything rather than crashing.

--- a/PLAN.md
+++ b/PLAN.md
@@ -2,107 +2,174 @@
 
 **Issue:** [Agent state isn't persisted across API restarts, causing in-progress reviews to be lost (#47)](https://github.com/ascherj/pathreview/issues/47)
 
-## Understand
+### Understand
 
-**Root cause:** `Orchestrator.run()` in `agent/orchestrator.py` loaded prior
-session state from Redis at the top of the method, but never consulted it
-inside the tool-execution loop. Every tool in the plan ran unconditionally on
-every call, regardless of whether a previous run had already completed it.
-On top of that, the merged results were only written back to Redis once,
-after the entire loop finished (`session_state.update(results)` +
-`self.session_store.set(...)` sat *after* the `for` loop, not inside it).
+`Orchestrator.run()` (`agent/orchestrator.py`) loaded prior session state
+from Redis at the top of the method (pre-fix line 47:
+`session_state = self.session_store.get(profile_id) or {}`), but the tool
+loop right below it never read from that dict — it called every tool in
+`plan` unconditionally. The merged results were only written back to Redis
+once, *after* the loop finished (pre-fix lines 64–66:
+`session_state.update(results); self.session_store.set(...)`), not inside
+it. So there were two independent bugs, not one:
 
-**Expected behavior:** if the API process restarts mid-review, a fresh
-`Orchestrator.run()` call for the same `profile_id` should skip tools that
-already succeeded and only execute the tools that hadn't finished yet.
+1. Nothing was persisted until the whole plan finished, so a crash
+   mid-review had nothing checkpointed to resume from.
+2. Even on a run where a prior checkpoint *did* exist, the loop had no
+   logic to consult it — every tool re-executed regardless of `results`.
 
-**Actual behavior (pre-fix):** a restart mid-review loses all progress. Even
-in the narrow window where a full run *did* complete and got persisted, a
-second call would still re-execute every tool from scratch, because nothing
-in the loop ever read from the loaded `session_state` — it only used it as
-the base dict to `.update()` at the very end.
+**Root cause:** missing per-tool "already done" check in the loop body,
+combined with a checkpoint write placed after the loop instead of inside it.
 
-## Map
+**Expected behavior:** a restart mid-review resumes — completed tools are
+skipped, only unfinished/failed tools re-execute.
+**Actual (pre-fix) behavior:** a restart always re-runs the entire plan from
+scratch, confirmed in reproduction (see `JOURNAL.md`, Week 8): 3 of 4
+regression tests fail when `agent/orchestrator.py` is reverted to
+`cb5cc09^`.
 
-- `agent/orchestrator.py` — `Orchestrator.run()` (the tool-execution loop and
-  the checkpoint write) is the primary fix location.
-- `agent/memory/session_store.py` — `SessionStore.get()` / `SessionStore.set()`,
-  the Redis-backed store the orchestrator reads/writes. No behavior change
-  needed here, but its `dict | None` return shape is what `run()` has to
-  handle correctly (missing type annotations here were also blocking the
-  mypy pre-commit hook on any orchestrator change).
-- `agent/memory/context_manager.py` — imported by `orchestrator.py`; needed
-  type-annotation fixes for the same pre-commit reason.
-- `agent/error_handling.py` — `retry_with_backoff`, used by
-  `_execute_with_timeout`; same pre-commit blocker.
-- `tests/unit/test_orchestrator.py` — new test file; simulates a restart by
-  constructing two `Orchestrator` instances that share one `session_store`.
+### Map
 
-## Plan
+Files touched (current, post-fix line numbers):
 
-1. Load the previous session state at the top of `run()` (already existed)
-   and, inside the tool loop, check per-tool whether `results.get(tool_name)`
-   already holds a successful result. If so, log `tool_resumed_from_checkpoint`
-   and `continue` instead of re-executing.
-2. Treat a previously *failed* tool (`{"success": False, ...}`) as not-done,
-   so it gets retried rather than skipped.
-3. Move the `self.session_store.set(profile_id, results)` call inside the
-   loop, immediately after each tool's result (success or failure) is
-   recorded, so a crash between tool N and N+1 only loses the in-flight
-   tool, not everything.
-4. Add regression tests that simulate the exact restart scenario: run an
-   `Orchestrator` through a partial plan, construct a second `Orchestrator`
-   sharing the same `session_store`, and assert already-completed tools are
-   not re-invoked (`tool.execute.call_count`) while incomplete/failed ones
-   are.
-5. Fix the missing type annotations in `error_handling.py`,
-   `context_manager.py`, and `session_store.py` that were otherwise blocking
-   the mypy pre-commit hook on this change.
+- `agent/orchestrator.py`
+  - `run()`, line 33 — loop that now checks `results.get(tool_name)` per
+    tool (lines 56–60: `already_done` check) before executing, and
+    persists after every tool instead of once (lines 76–77:
+    `self.session_store.set(profile_id, results)` moved inside the loop).
+  - `_build_plan()` (line 87), `_execute_tool()` (line 142),
+    `_execute_with_timeout()` (line 181) — unchanged in behavior, only
+    reformatted/retyped (see below).
+- `agent/memory/session_store.py` — `get()` (line 22) / `set()` (line 50):
+  no behavior change, but `run()`'s per-tool check depends on `get()`'s
+  `dict | None` contract, and `set()`'s `ttl_seconds=3600` default
+  (line 50) bounds how long a checkpoint survives (see Risks below).
+- `agent/memory/context_manager.py`, `agent/error_handling.py` — missing
+  type annotations here blocked the mypy pre-commit hook on any change to
+  `orchestrator.py` (which imports both), so both needed annotation fixes
+  before the real change could be committed.
+- `tests/unit/test_orchestrator.py` (new file, 180 lines) — four tests in
+  `TestOrchestratorCheckpointing` (lines 57–180+):
+  `test_progress_is_checkpointed_after_each_tool_not_only_at_the_end` (64),
+  `test_restart_mid_review_resumes_without_rerunning_completed_tools` (88),
+  `test_previously_failed_tool_is_retried_on_resume` (133),
+  `test_no_session_store_runs_without_persistence` (164).
 
-## Inputs & outputs
+### Plan
 
-- **Input:** `profile_id: str`, `profile_data: dict` (drives `_build_plan`),
-  and whatever `self.session_store.get(profile_id)` returns — either `None`
-  (no prior run) or a `dict` mapping `tool_name -> result` from an earlier,
-  possibly-interrupted run.
-- **Output:** an incrementally-updated Redis entry at `session:{profile_id}`
-  (one `setex` call per completed tool, TTL 3600s), and the same return
-  shape `run()` always produced: `{"profile_id", "tool_results", "cached_results"}`.
+1. Read `agent/orchestrator.py` end-to-end and confirm exactly where
+   `session_state` was loaded vs. where it was (not) consulted, and where
+   the single end-of-loop `session_store.set()` call sat.
+2. Read `agent/memory/session_store.py` to confirm `get()`/`set()`'s
+   contract (`dict | None`, JSON round-trip, TTL) so the per-tool check in
+   `run()` matches what's actually stored (a `tool_name -> result` dict, not
+   some wrapper object).
+3. In `run()`, replace the unconditional loop with one that checks
+   `previous = results.get(tool_name)` first; treat `previous is not None`
+   and not `{"success": False}` as done → `continue`; otherwise execute and
+   immediately call `self.session_store.set(profile_id, results)` before
+   moving to the next tool (not after the loop).
+4. Write regression tests that simulate a restart: run one `Orchestrator`
+   through a partial plan, build a second `Orchestrator` sharing the same
+   `session_store`, run it against the full plan, and assert
+   `tool.execute.call_count` for the already-completed tools stays at 1
+   (not re-invoked) while the remaining tool(s) do execute. Include a
+   variant seeding a failed tool result to confirm it's retried, not
+   skipped, and a variant with `session_store=None` to confirm unchanged
+   no-persistence behavior.
+5. Fix the missing annotations in `error_handling.py`, `context_manager.py`,
+   `session_store.py` so `pre-commit` (mypy) passes on the changed files.
+6. Run `pytest tests/unit/test_orchestrator.py -q` before and after the
+   change (before: expect failures on the new tests against old behavior;
+   after: all pass) — this is the same command used for reproduction in
+   `JOURNAL.md`.
 
-## Risks & unknowns
+### Inputs & outputs
 
-- `SessionStore.set()` round-trips through `json.dumps`/`json.loads`
-  (`agent/memory/session_store.py:61`), so any tool result that isn't
-  JSON-serializable would silently fail to persist (the `except Exception`
-  there only logs). Not currently an issue with existing tools, but a new
-  tool returning something like a `datetime` would break checkpointing
-  quietly.
-- "Already done" is inferred from dict shape
-  (`previous.get("success") is False` means retry, anything else means
-  skip) — a tool that returns a truthy dict without a `success` key on
-  partial failure would be incorrectly treated as complete.
-- The Redis TTL is a fixed 3600s (`session_store.py:56`). A review that
-  stays interrupted for longer than an hour loses its checkpoints entirely,
-  which the fix doesn't address — resuming from a very stale restart still
-  reverts to running everything.
-- No coverage for two orchestrator instances processing the same
-  `profile_id` concurrently (race on the Redis key) — not a scenario the
-  current single-worker deployment hits, but worth flagging if that changes.
+**Function changed:** `Orchestrator.run(profile_id: str, profile_data: dict) -> dict`
 
-## Edge cases
+**Existing happy path (no restart):** input a `profile_data` dict with no
+prior session state → every tool in `_build_plan()`'s plan executes once,
+output is `{"profile_id", "tool_results", "cached_results"}` as before.
 
-- All tools in the plan already have successful results in
-  `session_store` → `run()` should execute nothing and just return the
-  cached results.
-- A tool previously recorded `{"success": False, ...}` → must be retried,
-  not skipped.
-- `session_store` is `None` (persistence not configured) → behavior must be
-  unchanged from before the fix: every tool executes, nothing is checkpointed,
-  no exception raised.
-- `profile_data` changes between the interrupted run and the resumed run
-  (e.g., a project's `github_repo` changes), so `_build_plan` produces a
-  tool name that isn't a key in the old `results` dict → treated as not-done
-  and executed normally, since `results.get(tool_name)` returns `None`.
+**New behavior (resume after restart):**
+- Input: same `profile_id`, and a `session_store` whose `get(profile_id)`
+  returns a dict where some tool names already have successful results.
+- Expected output: `run()` returns the same shape, but
+  `tool.execute.call_count == 0` for every tool already present with a
+  successful result, and `== 1` for tools that were missing or previously
+  failed.
+
+**Test drafted (already implemented, `tests/unit/test_orchestrator.py:88`):**
+
+```python
+def test_restart_mid_review_resumes_without_rerunning_completed_tools(
+    self, session_store: FakeSessionStore
+) -> None:
+    tools = {
+        "tool_a": make_tool("tool_a", result={"result": "a"}),
+        "tool_b": make_tool("tool_b", result={"result": "b"}),
+        "tool_c": make_tool("tool_c", result={"result": "c"}),
+    }
+    full_plan = [("tool_a", {}), ("tool_b", {}), ("tool_c", {})]
+
+    # First "process": stops after tool_a and tool_b (simulated restart).
+    before = Orchestrator(tools, session_store=session_store)
+    with patch.object(before, "_build_plan", return_value=full_plan[:2]):
+        before.run("profile-1", {})
+
+    # "Restart": fresh Orchestrator, same session_store, full plan.
+    after = Orchestrator(tools, session_store=session_store)
+    with patch.object(after, "_build_plan", return_value=full_plan):
+        after.run("profile-1", {})
+
+    assert tools["tool_a"].execute.call_count == 1  # not re-run
+    assert tools["tool_b"].execute.call_count == 1  # not re-run
+    assert tools["tool_c"].execute.call_count == 1  # runs for the first time
+```
+
+### Risks & unknowns
+
+1. **JSON-serializability of tool results.** `SessionStore.set()`
+   (`agent/memory/session_store.py:61`) does `json.dumps(data)` inside a
+   bare `try/except Exception` that only logs on failure
+   (lines 65–66) — a tool that ever returns something non-JSON-serializable
+   (e.g. a `datetime`) would silently fail to checkpoint, with no visible
+   error to the caller. Not an issue for current tools; worth a comment if
+   a new tool is added later.
+2. **"Done" is inferred from dict shape**, not an explicit status field:
+   `previous is not None and not (isinstance(previous, dict) and
+   previous.get("success") is False)` (orchestrator.py:57–59). A tool
+   returning a truthy dict without a `success` key on partial failure would
+   be misread as complete. Confirmed this isn't currently possible by
+   checking `_execute_tool` (line 142) — failures always produce
+   `{"error": ..., "success": False}` — but it's a convention, not an
+   enforced contract.
+3. **Fixed 3600s TTL** (`session_store.py:50` default `ttl_seconds=3600`).
+   A review interrupted for longer than an hour loses its checkpoint
+   entirely and a "resume" silently becomes a full re-run. The fix doesn't
+   address this; flagging it as a known limitation rather than solving it,
+   since making TTL dynamic is out of scope for #47.
+4. **No coverage for two `Orchestrator` instances hitting the same
+   `profile_id` concurrently** (a race on the Redis key). Not reachable in
+   the current single-worker deployment, but would need a lock or
+   optimistic-concurrency check if that changes.
+
+### Edge cases
+
+- All tools in the plan already have successful results in `session_store`
+  → `run()` executes nothing new, returns cached results
+  (covered by `test_restart_mid_review_resumes_without_rerunning_completed_tools`).
+- A tool previously recorded `{"success": False, ...}` → retried, not
+  skipped (covered by `test_previously_failed_tool_is_retried_on_resume`).
+- `session_store=None` (persistence not configured) → identical to
+  pre-fix behavior: every tool executes, nothing is checkpointed, no
+  exception (covered by `test_no_session_store_runs_without_persistence`).
+- `profile_data` changes between the interrupted run and the resume (e.g. a
+  project's `github_repo` changes) so `_build_plan()` produces a tool name
+  absent from the old `results` dict → `results.get(tool_name)` returns
+  `None`, tool executes normally, not silently dropped.
 - Redis returns corrupted/non-JSON data on `get()` → already handled by
-  `SessionStore.get()`'s `except json.JSONDecodeError: return None`, so the
-  orchestrator falls back to running everything rather than crashing.
+  `SessionStore.get()`'s `except json.JSONDecodeError: return None`
+  (session_store.py:43–45), so `run()` falls back to treating it as no
+  prior state rather than crashing.

--- a/agent/error_handling.py
+++ b/agent/error_handling.py
@@ -1,14 +1,18 @@
 """Retry logic with exponential backoff."""
 
-import time
 import functools
+import time
+from collections.abc import Callable
+from typing import Any
+
 import structlog
 
 logger = structlog.get_logger()
 
 
-def retry_with_backoff(max_retries: int = 3, backoff_factor: float = 2.0,
-                       exceptions: tuple = (Exception,)):
+def retry_with_backoff(
+    max_retries: int = 3, backoff_factor: float = 2.0, exceptions: tuple = (Exception,)
+) -> Callable:
     """Decorator for retry logic with exponential backoff.
 
     Args:
@@ -19,9 +23,10 @@ def retry_with_backoff(max_retries: int = 3, backoff_factor: float = 2.0,
     Returns:
         Decorated function
     """
-    def decorator(func):
+
+    def decorator(func: Callable) -> Callable:
         @functools.wraps(func)
-        def wrapper(*args, **kwargs):
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
             attempt = 0
             last_exception = None
 
@@ -36,26 +41,37 @@ def retry_with_backoff(max_retries: int = 3, backoff_factor: float = 2.0,
 
                     if attempt < max_retries:
                         wait_time = backoff_factor ** (attempt - 1)
-                        logger.warning("retry_attempt", func=func.__name__,
-                                     attempt=attempt, max_retries=max_retries,
-                                     wait_seconds=wait_time, error=str(e))
+                        logger.warning(
+                            "retry_attempt",
+                            func=func.__name__,
+                            attempt=attempt,
+                            max_retries=max_retries,
+                            wait_seconds=wait_time,
+                            error=str(e),
+                        )
                         time.sleep(wait_time)
                     else:
-                        logger.error("retry_exhausted", func=func.__name__,
-                                   max_retries=max_retries, error=str(e))
+                        logger.error(
+                            "retry_exhausted",
+                            func=func.__name__,
+                            max_retries=max_retries,
+                            error=str(e),
+                        )
 
             if last_exception:
                 raise last_exception
 
         return wrapper
+
     return decorator
 
 
 class RetryContext:
     """Context manager for retry logic with exponential backoff."""
 
-    def __init__(self, max_retries: int = 3, backoff_factor: float = 2.0,
-                 exceptions: tuple = (Exception,)):
+    def __init__(
+        self, max_retries: int = 3, backoff_factor: float = 2.0, exceptions: tuple = (Exception,)
+    ):
         """Initialize retry context.
 
         Args:
@@ -67,13 +83,15 @@ class RetryContext:
         self.backoff_factor = backoff_factor
         self.exceptions = exceptions
         self.attempt = 0
-        self.last_exception = None
+        self.last_exception: BaseException | None = None
 
-    def __enter__(self):
+    def __enter__(self) -> "RetryContext":
         """Enter context."""
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(
+        self, exc_type: type[BaseException] | None, exc_val: BaseException | None, exc_tb: Any
+    ) -> bool:
         """Exit context and handle retries."""
         if exc_type is None:
             return False
@@ -86,12 +104,20 @@ class RetryContext:
 
         if self.attempt < self.max_retries:
             wait_time = self.backoff_factor ** (self.attempt - 1)
-            logger.warning("retry_context_attempt", attempt=self.attempt,
-                         max_retries=self.max_retries, wait_seconds=wait_time,
-                         error=str(exc_val))
+            logger.warning(
+                "retry_context_attempt",
+                attempt=self.attempt,
+                max_retries=self.max_retries,
+                wait_seconds=wait_time,
+                error=str(exc_val),
+            )
             time.sleep(wait_time)
             return True  # Suppress exception and retry
 
-        logger.error("retry_context_exhausted", attempt=self.attempt,
-                   max_retries=self.max_retries, error=str(exc_val))
+        logger.error(
+            "retry_context_exhausted",
+            attempt=self.attempt,
+            max_retries=self.max_retries,
+            error=str(exc_val),
+        )
         return False  # Re-raise exception

--- a/agent/memory/context_manager.py
+++ b/agent/memory/context_manager.py
@@ -2,6 +2,8 @@
 
 import hashlib
 import json
+from typing import Any
+
 import structlog
 
 logger = structlog.get_logger()
@@ -10,12 +12,11 @@ logger = structlog.get_logger()
 class ContextManager:
     """In-memory context manager for within-session memoization."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize context manager."""
-        self.results = {}
+        self.results: dict[str, Any] = {}
 
-    def store_tool_result(self, tool_name: str, input_hash: str,
-                         result) -> None:
+    def store_tool_result(self, tool_name: str, input_hash: str, result: Any) -> None:
         """Store tool execution result.
 
         Args:
@@ -27,7 +28,7 @@ class ContextManager:
         self.results[key] = result
         logger.info("tool_result_stored", tool=tool_name, key=key)
 
-    def get_tool_result(self, tool_name: str, input_hash: str):
+    def get_tool_result(self, tool_name: str, input_hash: str) -> Any | None:
         """Get cached tool result.
 
         Args:
@@ -47,7 +48,7 @@ class ContextManager:
 
         return result
 
-    def get_all_results(self) -> dict:
+    def get_all_results(self) -> dict[str, Any]:
         """Get all cached results.
 
         Returns:

--- a/agent/memory/session_store.py
+++ b/agent/memory/session_store.py
@@ -1,9 +1,9 @@
 """Redis-backed session store."""
 
-import redis
 import json
+
+import redis
 import structlog
-from typing import Optional
 
 logger = structlog.get_logger()
 
@@ -19,7 +19,7 @@ class SessionStore:
         """
         self.redis = redis_client
 
-    def get(self, session_id: str) -> Optional[dict]:
+    def get(self, session_id: str) -> dict | None:
         """Get session data.
 
         Args:
@@ -36,7 +36,7 @@ class SessionStore:
                 logger.info("session_not_found", session_id=session_id)
                 return None
 
-            parsed = json.loads(data)
+            parsed: dict = json.loads(data)
             logger.info("session_retrieved", session_id=session_id)
             return parsed
 

--- a/agent/orchestrator.py
+++ b/agent/orchestrator.py
@@ -1,12 +1,13 @@
 """Plan-execute orchestrator for agent tools."""
 
 import time
-import structlog
-from typing import Optional
+from typing import Any
 
-from .memory.session_store import SessionStore
-from .memory.context_manager import ContextManager
+import structlog
+
 from .error_handling import retry_with_backoff
+from .memory.context_manager import ContextManager
+from .memory.session_store import SessionStore
 
 logger = structlog.get_logger()
 
@@ -14,8 +15,9 @@ logger = structlog.get_logger()
 class Orchestrator:
     """Orchestrate tool execution with planning and memoization."""
 
-    def __init__(self, tools: dict, session_store: Optional[SessionStore] = None,
-                 tool_timeout: float = 30.0):
+    def __init__(
+        self, tools: dict, session_store: SessionStore | None = None, tool_timeout: float = 30.0
+    ):
         """Initialize orchestrator.
 
         Args:
@@ -43,17 +45,25 @@ class Orchestrator:
         # Build execution plan
         plan = self._build_plan(profile_data)
 
-        # Load previous session state if available
-        session_state = {}
-        if self.session_store:
-            session_state = self.session_store.get(profile_id) or {}
-
-        # Execute plan
+        # Load previous session state if available (resume support)
         results = {}
+        if self.session_store:
+            results = self.session_store.get(profile_id) or {}
+
+        # Execute plan, skipping tools a prior run already completed
+        # successfully so a restart resumes instead of starting over.
         for tool_name, tool_input in plan:
+            previous = results.get(tool_name)
+            already_done = previous is not None and not (
+                isinstance(previous, dict) and previous.get("success") is False
+            )
+            if already_done:
+                logger.info("tool_resumed_from_checkpoint", tool=tool_name)
+                continue
+
             try:
                 result = self._execute_tool(tool_name, tool_input)
-                results[tool_name] = result.data if hasattr(result, 'data') else result
+                results[tool_name] = result.data if hasattr(result, "data") else result
 
                 logger.info("tool_executed", tool=tool_name, success=True)
 
@@ -61,18 +71,17 @@ class Orchestrator:
                 logger.error("tool_execution_failed", tool=tool_name, error=str(e))
                 results[tool_name] = {"error": str(e), "success": False}
 
-        # Persist state
-        if self.session_store:
-            session_state.update(results)
-            self.session_store.set(profile_id, session_state)
+            # Checkpoint after every tool, not just at the end, so an API
+            # restart mid-run only loses the in-flight tool, not everything.
+            if self.session_store:
+                self.session_store.set(profile_id, results)
 
-        logger.info("orchestrator_complete", profile_id=profile_id,
-                   tools_executed=len(results))
+        logger.info("orchestrator_complete", profile_id=profile_id, tools_executed=len(results))
 
         return {
             "profile_id": profile_id,
             "tool_results": results,
-            "cached_results": self.context_manager.get_all_results()
+            "cached_results": self.context_manager.get_all_results(),
         }
 
     def _build_plan(self, profile_data: dict) -> list[tuple[str, dict]]:
@@ -90,50 +99,47 @@ class Orchestrator:
         if profile_data.get("github_username"):
             for project in profile_data.get("projects", []):
                 if project.get("github_repo"):
-                    plan.append((
-                        "github_tool",
-                        {
-                            "github_username": profile_data["github_username"],
-                            "repo_name": project["github_repo"]
-                        }
-                    ))
+                    plan.append(
+                        (
+                            "github_tool",
+                            {
+                                "github_username": profile_data["github_username"],
+                                "repo_name": project["github_repo"],
+                            },
+                        )
+                    )
                     break  # Only process first repo for now
 
         # Tech detector (if files available)
         if profile_data.get("files"):
-            plan.append((
-                "tech_detector",
-                {"files": profile_data["files"]}
-            ))
+            plan.append(("tech_detector", {"files": profile_data["files"]}))
 
         # README scorer
         if profile_data.get("readme_content"):
-            plan.append((
-                "readme_scorer",
-                {"readme_content": profile_data["readme_content"]}
-            ))
+            plan.append(("readme_scorer", {"readme_content": profile_data["readme_content"]}))
 
         # Skill extractor
         if profile_data.get("resume_text"):
-            plan.append((
-                "skill_extractor",
-                {
-                    "resume_text": profile_data["resume_text"],
-                    "repo_metadata": profile_data.get("repo_metadata", {})
-                }
-            ))
+            plan.append(
+                (
+                    "skill_extractor",
+                    {
+                        "resume_text": profile_data["resume_text"],
+                        "repo_metadata": profile_data.get("repo_metadata", {}),
+                    },
+                )
+            )
 
         # Market analyzer (if skills detected)
         if plan:  # Only if other tools executed
-            plan.append((
-                "market_analyzer",
-                {"detected_skills": {}}  # Will be populated by context
-            ))
+            plan.append(
+                ("market_analyzer", {"detected_skills": {}})  # Will be populated by context
+            )
 
         logger.info("plan_built", plan_size=len(plan))
         return plan
 
-    def _execute_tool(self, tool_name: str, tool_input: dict):
+    def _execute_tool(self, tool_name: str, tool_input: dict) -> Any:
         """Execute a single tool with retry and memoization.
 
         Args:
@@ -172,7 +178,9 @@ class Orchestrator:
             logger.error("tool_execution_error", tool=tool_name, error=str(e))
             raise
 
-    def _execute_with_timeout(self, tool, tool_input: dict, timeout: Optional[float] = None):
+    def _execute_with_timeout(
+        self, tool: Any, tool_input: dict, timeout: float | None = None
+    ) -> Any:
         """Execute tool with timeout.
 
         Args:
@@ -189,7 +197,7 @@ class Orchestrator:
         timeout = timeout or self.tool_timeout
 
         @retry_with_backoff(max_retries=2, backoff_factor=1.5)
-        def _execute():
+        def _execute() -> Any:
             return tool.execute(tool_input)
 
         start = time.time()

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -1,0 +1,180 @@
+"""Tests for orchestrator.py"""
+
+import json
+from typing import Any
+from unittest.mock import Mock, patch
+
+import pytest
+
+from agent.memory.session_store import SessionStore
+from agent.orchestrator import Orchestrator
+from agent.tools.base import ToolResult
+
+Plan = list[tuple[str, dict]]
+
+
+class FakeSessionStore(SessionStore):
+    """In-memory stand-in for the Redis-backed SessionStore.
+
+    Round-trips data through json (like the real store does) so tests catch
+    bugs that only show up after a real serialize/deserialize cycle, and
+    records every set() call so tests can assert checkpointing happens
+    incrementally rather than once at the end.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(redis_client=Mock())
+        self._data: dict[str, dict] = {}
+        self.set_calls: list[dict] = []
+
+    def get(self, session_id: str) -> dict | None:
+        return self._data.get(session_id)
+
+    def set(self, session_id: str, data: dict, ttl_seconds: int = 3600) -> None:
+        snapshot = json.loads(json.dumps(data))
+        self._data[session_id] = snapshot
+        self.set_calls.append(snapshot)
+
+
+@pytest.fixture(autouse=True)
+def no_retry_sleep() -> Any:
+    """Skip real sleeps in the retry-with-backoff decorator during tests."""
+    with patch("agent.error_handling.time.sleep"):
+        yield
+
+
+def make_tool(name: str, result: dict | None = None, error: Exception | None = None) -> Mock:
+    tool = Mock()
+    tool.name = name
+    if error is not None:
+        tool.execute = Mock(side_effect=error)
+    else:
+        tool.execute = Mock(return_value=ToolResult(success=True, data=result or {}))
+    return tool
+
+
+@pytest.mark.unit
+class TestOrchestratorCheckpointing:
+    """Test suite for orchestrator progress persistence across restarts."""
+
+    @pytest.fixture
+    def session_store(self) -> FakeSessionStore:
+        return FakeSessionStore()
+
+    def test_progress_is_checkpointed_after_each_tool_not_only_at_the_end(
+        self, session_store: FakeSessionStore
+    ) -> None:
+        """Regression test: checkpointing used to happen once, after the
+        whole loop finished, which meant a mid-loop crash lost everything.
+        Redis should be written to after every tool completes."""
+        tools = {
+            "tool_a": make_tool("tool_a", result={"result": "a"}),
+            "tool_b": make_tool("tool_b", result={"result": "b"}),
+        }
+        plan: Plan = [("tool_a", {}), ("tool_b", {})]
+
+        orchestrator = Orchestrator(tools, session_store=session_store)
+        with patch.object(orchestrator, "_build_plan", return_value=plan):
+            orchestrator.run("profile-1", {})
+
+        # One checkpoint per tool, not a single checkpoint at the end.
+        assert len(session_store.set_calls) == 2
+        assert session_store.set_calls[0] == {"tool_a": {"result": "a"}}
+        assert session_store.set_calls[1] == {
+            "tool_a": {"result": "a"},
+            "tool_b": {"result": "b"},
+        }
+
+    def test_restart_mid_review_resumes_without_rerunning_completed_tools(
+        self, session_store: FakeSessionStore
+    ) -> None:
+        """Simulates the exact bug from issue #47: a long review spanning
+        multiple repos/tools gets interrupted by a server restart partway
+        through. A fresh Orchestrator sharing the same session_store (the
+        only thing that survives a restart) should pick up where the
+        previous one left off, not repeat completed work."""
+        tools = {
+            "tool_a": make_tool("tool_a", result={"result": "a"}),
+            "tool_b": make_tool("tool_b", result={"result": "b"}),
+            "tool_c": make_tool("tool_c", result={"result": "c"}),
+        }
+        full_plan: Plan = [("tool_a", {}), ("tool_b", {}), ("tool_c", {})]
+
+        # First "process": only gets through tool_a and tool_b before the
+        # restart happens (modeled as simply never reaching tool_c).
+        orchestrator_before_restart = Orchestrator(tools, session_store=session_store)
+        with patch.object(orchestrator_before_restart, "_build_plan", return_value=full_plan[:2]):
+            orchestrator_before_restart.run("profile-1", {})
+
+        assert tools["tool_a"].execute.call_count == 1
+        assert tools["tool_b"].execute.call_count == 1
+        assert tools["tool_c"].execute.call_count == 0
+
+        # "Restart": brand new Orchestrator instance, sharing only the
+        # session_store, now sees the full plan (including the tool that
+        # never got a chance to run).
+        orchestrator_after_restart = Orchestrator(tools, session_store=session_store)
+        with patch.object(orchestrator_after_restart, "_build_plan", return_value=full_plan):
+            result = orchestrator_after_restart.run("profile-1", {})
+
+        # tool_a and tool_b already succeeded and were checkpointed before
+        # the restart -> must not be re-executed.
+        assert tools["tool_a"].execute.call_count == 1
+        assert tools["tool_b"].execute.call_count == 1
+        # tool_c never ran -> must execute now.
+        assert tools["tool_c"].execute.call_count == 1
+
+        assert result["tool_results"] == {
+            "tool_a": {"result": "a"},
+            "tool_b": {"result": "b"},
+            "tool_c": {"result": "c"},
+        }
+
+    def test_previously_failed_tool_is_retried_on_resume(
+        self, session_store: FakeSessionStore
+    ) -> None:
+        """A tool that failed before the restart is not "done" and should
+        be retried, not skipped like a successful checkpoint."""
+        # Seed the store as if a previous run recorded tool_a succeeding
+        # and tool_b failing.
+        session_store.set(
+            "profile-1",
+            {
+                "tool_a": {"result": "a"},
+                "tool_b": {"error": "simulated crash", "success": False},
+            },
+        )
+
+        tools = {
+            "tool_a": make_tool("tool_a", result={"result": "a"}),
+            "tool_b": make_tool("tool_b", result={"result": "b-retry-succeeded"}),
+        }
+        plan: Plan = [("tool_a", {}), ("tool_b", {})]
+
+        orchestrator = Orchestrator(tools, session_store=session_store)
+        with patch.object(orchestrator, "_build_plan", return_value=plan):
+            result = orchestrator.run("profile-1", {})
+
+        # tool_a was already done -> skipped.
+        assert tools["tool_a"].execute.call_count == 0
+        # tool_b previously failed -> retried, and succeeds this time.
+        assert tools["tool_b"].execute.call_count == 1
+        assert result["tool_results"]["tool_b"] == {"result": "b-retry-succeeded"}
+
+    def test_no_session_store_runs_without_persistence(self) -> None:
+        """Orchestrator without a session_store should still run every tool
+        normally; persistence is optional, not required for correctness."""
+        tools = {
+            "tool_a": make_tool("tool_a", result={"result": "a"}),
+            "tool_b": make_tool("tool_b", result={"result": "b"}),
+        }
+        plan: Plan = [("tool_a", {}), ("tool_b", {})]
+
+        orchestrator = Orchestrator(tools, session_store=None)
+        with patch.object(orchestrator, "_build_plan", return_value=plan):
+            result = orchestrator.run("profile-1", {})
+
+        assert result["tool_results"] == {
+            "tool_a": {"result": "a"},
+            "tool_b": {"result": "b"},
+        }


### PR DESCRIPTION
## Summary
Fixes progress loss on API restart during a review. `Orchestrator.run()` only wrote checkpoints to Redis once, after its entire tool loop finished, and never checked prior checkpoint state before re-running a tool. A restart mid-review — a deploy, a crash — lost all progress and reran the whole plan from scratch, even in cases where an earlier checkpoint existed. This PR checkpoints each tool's result to Redis immediately after it completes, and has a fresh `run()` call skip tools that already have a successful checkpointed result while retrying ones that previously failed.

## Issue
Closes #47

## Changes
- `agent/orchestrator.py`: moved the `session_store.set()` checkpoint write from after the tool loop to inside it (runs after every tool, not just once at the end); added a per-tool check against loaded session state so already-succeeded tools are skipped on resume and previously-failed tools are retried.
- `agent/error_handling.py`, `agent/memory/context_manager.py`, `agent/memory/session_store.py`: added missing type annotations (no behavior change) — these are imported by `orchestrator.py` and were blocking the mypy pre-commit hook on any change to it.
- `tests/unit/test_orchestrator.py` (new): 4 tests covering incremental checkpointing, resume-after-restart (two `Orchestrator` instances sharing one `session_store`), retry-on-previous-failure, and unchanged behavior when `session_store=None`.

## Testing
- [x] Unit tests pass (`make test-unit`)
- [x] Integration tests pass (`make test-integration`) — `tests/integration/` currently has no test modules (0 collected), so this is vacuous rather than a real check
- [x] Linter passes (`make lint`) — on changed files (see note below)
- [x] Type checker passes (`make typecheck`) — on changed files (see note below)
- [x] New/updated tests cover the changes

**Pre-existing failures (documented per CONTRIBUTING.md guidance):**
This repo has pre-existing, unrelated failures on `main`. I diffed the full `make test-unit` failure list on this branch against the same suite run on the branch's base commit (`54cc749`, pre-fix) and confirmed the sets are **identical**: 53 failures, none touching `orchestrator` or `session_store`. This branch adds 4 new orchestrator tests, all passing, for a net 379 passed / 53 failed (vs. 375/53 on base).

Similarly for `make check`:
- `ruff`: 182 errors on base → 175 on this branch (repo-wide). None in the 5 files this PR touches — those are 100% clean under `ruff check`.
- `mypy`: 103 errors on base → 90 on this branch (repo-wide). All 13 closed errors are in the 4 files this PR touches (`orchestrator.py`, `error_handling.py`, `context_manager.py`, `session_store.py`), which now type-check cleanly — these were the annotations mentioned above.
- `black`: the 5 changed/added files pass `black --check` cleanly.

None of the pre-existing failures/errors are introduced or affected by this change; the whole-repo counts only went down.

## Screenshots / Demo
N/A — backend orchestration change, no UI surface.

## Notes for Reviewers
- The "already done" check (`orchestrator.py`) infers completion from the result dict's shape (`previous.get("success") is False` means retry; anything else means skip). This matches the existing convention `_execute_tool` already used for failures, but it's a convention rather than an enforced contract — flagging in case a reviewer wants an explicit status field instead.
- Checkpoints inherit `SessionStore`'s existing fixed 1-hour TTL (`session_store.py`, unchanged). A review interrupted for longer than that still loses its checkpoint and falls back to a full re-run. Out of scope for this fix; noted as a known limitation in `PLAN.md`.
- Reproduction/verification steps (including the pre-existing-failure diff above) are documented in this branch's `JOURNAL.md` (Week 8 and Week 9 entries) and `PLAN.md`.
