### PR TITLE
Expand bias detector patterns for common educational bias phrasing

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,17 +1,20 @@
-# Week 7 Journal
+## Week 7 — Issue selection
 
-## Issue Link
+**Issue link:** https://github.com/ascherj/pathreview/issues/151
 
-Repository: https://github.com/eyobedmerhawi/pathreview
+**Issue title:** Bias detector patterns are too narrow to match common phrasings
 
-Assigned issue: **Issue #151 – Bias detector patterns are too narrow to match common phrasings**
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
 
-## Issue Selection
+**Problem summary:**
+The bias detector in `safety/bias_detector.py` uses regular-expression patterns to identify potentially biased language in generated feedback. The existing educational-bias patterns were too narrow, so common statements about bootcamp graduates, self-taught developers, and online-course students were not consistently detected. This meant biased wording could pass through the detector even though it expressed the same assumptions as phrases the system already recognized. A successful fix would broaden the patterns while preserving the detector’s existing behavior and would include regression tests confirming that the additional phrasings are detected.
 
-I selected **Issue #151 (Tier 1)** because it matched my current familiarity with the codebase. The issue has a clearly defined scope and focuses on improving existing functionality instead of requiring major architectural changes. It gave me an opportunity to work with regular expressions, testing, and debugging while contributing a meaningful improvement.
+**Branch name:** `fix/bias-detector-patterns-151`
 
-## Problem Summary
+**Setup confirmation:** [ ] App runs locally at localhost:5173
 
-The bias detector was missing several common educational bias statements because its matching patterns were too narrow. As a result, phrases such as "bootcamp graduates are not prepared" or "self-taught developers lack a strong technical foundation" were not consistently detected.
+**Cohort ledger:** [ ] Issue added to cohort ledger
 
-To fix this issue, I expanded the detector's regex patterns to recognize additional common educational bias phrasings and added regression tests to verify the new behavior. A successful fix ensures these statements are correctly identified while preserving existing functionality.
+### Issue selection notes — “Is this right for me?”
+
+I selected a Tier 1 issue because this was my first contribution to a large, multi-module codebase and I wanted an issue with a focused and realistic scope. The change was limited mainly to `safety/bias_detector.py` and its unit tests, so I could understand the affected behavior without making architectural changes across the application. The issue matched my familiarity with Python, regular expressions, testing, and debugging. I also confirmed that the expected result could be validated with clear regression tests, which made the issue appropriate for my current skill level.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,17 @@
+# Week 7 Journal
+
+## Issue Link
+
+Repository: https://github.com/eyobedmerhawi/pathreview
+
+Assigned issue: **Issue #151 – Bias detector patterns are too narrow to match common phrasings**
+
+## Issue Selection
+
+I selected **Issue #151 (Tier 1)** because it matched my current familiarity with the codebase. The issue has a clearly defined scope and focuses on improving existing functionality instead of requiring major architectural changes. It gave me an opportunity to work with regular expressions, testing, and debugging while contributing a meaningful improvement.
+
+## Problem Summary
+
+The bias detector was missing several common educational bias statements because its matching patterns were too narrow. As a result, phrases such as "bootcamp graduates are not prepared" or "self-taught developers lack a strong technical foundation" were not consistently detected.
+
+To fix this issue, I expanded the detector's regex patterns to recognize additional common educational bias phrasings and added regression tests to verify the new behavior. A successful fix ensures these statements are correctly identified while preserving existing functionality.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -68,3 +68,38 @@ Updated `tests/unit/test_bias_detector.py` with regression tests covering additi
 
 **Draft PR feedback received from:**
 None
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No reviewer feedback was provided during the Summer 2026 contribution cycle. My pull request was submitted and the CI workflow was awaiting maintainer approval, but I did not receive specific code review comments that required changes.
+
+**How you responded:**
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+
+The Git and contribution workflow was harder than I expected. The actual change to the bias detector was fairly focused, but working through branches, commits, pre-commit hooks, formatting requirements, repository links, and pull requests required much more attention than I expected. I also ran into Ruff, Black, and mypy issues while preparing the changes. Some of those problems were not directly related to the logic of my fix, so I had to learn how to separate problems caused by my changes from problems involving formatting, tooling, or the existing repository.
+
+**What did you learn about working in a large codebase?**
+
+I learned that making a change in a large codebase requires understanding more than just the file being edited. For Issue #151, most of my implementation involved `safety/bias_detector.py` and `tests/unit/test_bias_detector.py`, but I still needed to understand the project's testing, formatting, type-checking, Git, and contribution conventions. I also learned not to modify unrelated files just because automated tools change them. Compared with my own projects, contributing to someone else's code requires being much more careful about limiting the scope of a change and following the standards that already exist.
+
+**How did AI tools help — and where did they fall short?**
+
+AI tools were most useful for helping me understand unfamiliar errors, reason about the regex patterns, troubleshoot Git commands, and interpret output from Ruff, Black, mypy, and pytest. AI also helped me break the issue into smaller steps instead of trying to understand the entire repository at once. However, I learned that I could not blindly follow every suggested command or change. At different points I still needed to inspect the actual repository, terminal output, Git status, and assignment requirements myself. For example, repository and branch links had to be verified against my actual fork rather than assumed. AI was most effective as a guide, but I still had to verify that its suggestions matched the real state of the project.
+
+**What would you do differently if you started over?**
+
+I would read the assignment templates and `CONTRIBUTING.md` more carefully before making my first commit. I initially focused mostly on solving the technical issue, but later learned that the journal format, correct branch URL, commit structure, and contribution process were also important parts of the assignment. I would also check `git status` more frequently and make smaller commits so unrelated formatting changes could be identified immediately. That would have made the process cleaner and saved time later.
+
+**What are you most proud of from this module?**
+
+I am most proud that I worked through a real open-source contribution workflow instead of only getting the code to work locally. I expanded the educational bias detection patterns, added regression tests, got all 35 bias detector tests passing, worked through the project's formatting and type-checking requirements, and submitted the change as a pull request. More importantly, I now have a much better understanding of how to move from identifying an issue to planning, implementing, testing, documenting, and submitting a contribution for review.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -21,11 +21,12 @@ I selected a Tier 1 issue because this was my first contribution to a large, mul
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** https://github.com/ascherj/pathreview/commit/b253583edc74cb4f662c6fe0f0974aa44395c1cb
+**Reproduction commit link:** https://github.com/eyobedmerhawi/pathreview/commit/b253583edc74cb4f662c6fe0f0974aa44395c1cb
+
 **Reproduction summary:**
 I reproduced the issue by testing common educational-bias statements against the detector in `safety/bias_detector.py`. Statements involving bootcamp graduates, self-taught developers, and online-course students were not consistently detected because the existing regex patterns were too narrow.
 
-**PLAN.md link:** https://github.com/ascherj/pathreview/blob/fix/bias-detector-patterns-151/PLAN.md
+**PLAN.md link:** https://github.com/eyobedmerhawi/pathreview/blob/fix/bias-detector-patterns-151/PLAN.md
 
 **Walkthrough video (recommended):** Not recorded
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -21,12 +21,12 @@ I selected a Tier 1 issue because this was my first contribution to a large, mul
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [add after committing]
+**Reproduction commit link:** https://github.com/ascherj/pathreview/commit/b253583
 
 **Reproduction summary:**
 I reproduced the issue by testing common educational-bias statements against the detector in `safety/bias_detector.py`. Statements involving bootcamp graduates, self-taught developers, and online-course students were not consistently detected because the existing regex patterns were too narrow.
 
-**PLAN.md link:** [add after creating PLAN.md]
+**PLAN.md link:** https://github.com/ascherj/pathreview/blob/fix/bias-detector-patterns-151/PLAN.md
 
 **Walkthrough video (recommended):** Not recorded
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -18,3 +18,17 @@ The bias detector in `safety/bias_detector.py` uses regular-expression patterns 
 ### Issue selection notes — “Is this right for me?”
 
 I selected a Tier 1 issue because this was my first contribution to a large, multi-module codebase and I wanted an issue with a focused and realistic scope. The change was limited mainly to `safety/bias_detector.py` and its unit tests, so I could understand the affected behavior without making architectural changes across the application. The issue matched my familiarity with Python, regular expressions, testing, and debugging. I also confirmed that the expected result could be validated with clear regression tests, which made the issue appropriate for my current skill level.
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [add after committing]
+
+**Reproduction summary:**
+I reproduced the issue by testing common educational-bias statements against the detector in `safety/bias_detector.py`. Statements involving bootcamp graduates, self-taught developers, and online-course students were not consistently detected because the existing regex patterns were too narrow.
+
+**PLAN.md link:** [add after creating PLAN.md]
+
+**Walkthrough video (recommended):** Not recorded
+
+**Blockers or open questions:**
+The main risk is expanding the regex patterns too broadly and causing neutral statements to be flagged as biased.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -32,3 +32,39 @@ I reproduced the issue by testing common educational-bias statements against the
 
 **Blockers or open questions:**
 The main risk is expanding the regex patterns too broadly and causing neutral statements to be flagged as biased.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+I identified the root cause of the issue in `safety/bias_detector.py`, expanded the educational bias regex patterns, and added regression tests in `tests/unit/test_bias_detector.py`. I also verified the new patterns using the updated unit tests.
+
+**Next steps:**
+Run the project's quality checks, finalize the pull request, update the documentation, and submit the completed work for review.
+
+**Blockers:**
+None.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:**
+https://github.com/ascherj/pathreview/pull/204
+
+**Branch:**
+`fix/bias-detector-patterns-151`
+
+**What you built:**
+Expanded the educational bias detection regex patterns in `safety/bias_detector.py` to recognize additional common educational bias statements. I also added regression tests to verify the new behavior while preserving the detector's existing functionality.
+
+**Tests added or updated:**
+Updated `tests/unit/test_bias_detector.py` with regression tests covering additional educational bias statements involving bootcamp graduates, self-taught developers, and online-course students.
+
+**Self-review confirmation:**
+- [x] make check passes
+- [ ] make test-unit passes (repository contains pre-existing unrelated failing tests; my changes introduced no new failures. All 35 bias detector tests pass.)
+
+**Draft PR feedback received from:**
+None

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -11,9 +11,9 @@ The bias detector in `safety/bias_detector.py` uses regular-expression patterns 
 
 **Branch name:** `fix/bias-detector-patterns-151`
 
-**Setup confirmation:** [ ] App runs locally at localhost:5173
+**Setup confirmation:** [x] App runs locally at localhost:5173
 
-**Cohort ledger:** [ ] Issue added to cohort ledger
+**Cohort ledger:** [x] Issue added to cohort ledger
 
 ### Issue selection notes — “Is this right for me?”
 
@@ -21,8 +21,7 @@ I selected a Tier 1 issue because this was my first contribution to a large, mul
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** https://github.com/ascherj/pathreview/commit/b253583
-
+**Reproduction commit link:** https://github.com/ascherj/pathreview/commit/b253583edc74cb4f662c6fe0f0974aa44395c1cb
 **Reproduction summary:**
 I reproduced the issue by testing common educational-bias statements against the detector in `safety/bias_detector.py`. Statements involving bootcamp graduates, self-taught developers, and online-course students were not consistently detected because the existing regex patterns were too narrow.
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,94 @@
+\# Solution plan
+
+
+
+\*\*Issue:\*\* Bias detector patterns are too narrow to match common phrasings
+
+Issue link: https://github.com/ascherj/pathreview/issues/151
+
+
+
+\## Understand
+
+
+
+The root cause of this issue is that the educational bias detector in `safety/bias\_detector.py` uses regular-expression patterns that only recognize a limited set of educational bias statements. Common statements about bootcamp graduates, self-taught developers, and online-course students are not consistently detected. The expected behavior is for these common variations to be recognized while preserving the detector's existing behavior.
+
+
+
+\## Map
+
+
+
+Files involved:
+
+
+
+\* `safety/bias\_detector.py` – contains the educational bias detection patterns.
+
+\* `tests/unit/test\_bias\_detector.py` – contains the unit tests that verify the detector's behavior.
+
+
+
+\## Plan
+
+
+
+1\. Review the existing regex patterns in `safety/bias\_detector.py`.
+
+2\. Identify common educational bias statements that are currently not detected.
+
+3\. Expand the regex patterns to recognize these additional phrasings without creating overly broad matches.
+
+4\. Add regression tests to `tests/unit/test\_bias\_detector.py` for the newly supported examples.
+
+5\. Run Ruff, Black, mypy, and the unit tests to ensure the changes do not introduce regressions.
+
+
+
+\## Inputs \& outputs
+
+
+
+\*\*Inputs\*\*
+
+
+
+\* User-generated text that is analyzed for educational bias.
+
+
+
+\*\*Outputs\*\*
+
+
+
+\* The detector correctly identifies additional educational bias statements that were previously missed while continuing to recognize existing supported patterns.
+
+
+
+\## Risks \& unknowns
+
+
+
+\* Regex patterns may become too broad and incorrectly flag neutral statements.
+
+\* Changes could unintentionally affect existing educational bias detection behavior.
+
+\* Additional edge cases may appear during testing that require refining the regex patterns.
+
+
+
+\## Edge cases
+
+
+
+\* Different wording that expresses the same educational bias.
+
+\* Uppercase and lowercase variations.
+
+\* Statements containing punctuation.
+
+\* Neutral discussions of educational backgrounds should not be flagged as biased.
+
+
+

--- a/safety/bias_detector.py
+++ b/safety/bias_detector.py
@@ -1,6 +1,7 @@
 """Bias detection in generated feedback."""
 
 import re
+
 import structlog
 
 logger = structlog.get_logger()
@@ -11,16 +12,21 @@ class BiasDetector:
 
     # Genuinely dismissive phrases about educational background
     DISMISSIVE_PATTERNS = [
-        r"(?:bootcamp|self-taught|online\s+course)\s+(?:education|training)\s+is\s+(?:insufficient|inadequate|lacks)",
-        r"(?:bootcamp|self-taught)\s+(?:graduates?|developers?)\s+(?:lack|missing)\s+(?:rigor|fundamentals|proper\s+training)",
+        r"(?:bootcamp|self-taught|online\s+course)\s+(?:education|training)\s+(?:is\s+(?:insufficient|inadequate)|lacks)",
+        r"(?:bootcamp|self-taught)\s+(?:graduates?|developers?|students?|programmers?)\s+(?:usually\s+)?(?:lack|missing)\s+(?:a\s+)?(?:strong\s+)?(?:technical\s+)?(?:foundation|rigor|fundamentals|proper\s+training)",
         r"(?:bootcamp|coding\s+bootcamp)\s+(?:doesn't|does\s+not)\s+prepare\s+(?:you|developers?)",
         r"(?:self-taught|bootcamp)\s+is\s+(?:not|never)\s+(?:equal|comparable)\s+to\s+(?:university|traditional|formal)",
+        r"(?:bootcamp|coding\s+bootcamp)\s+graduates?\s+are\s+not\s+prepared\s+for\s+real\s+\w+\s+work",
+        r"(?:bootcamp|coding\s+bootcamp)\s+(?:graduates?|developers?|programmers?)\s+(?:can't|cannot|won't)\s+(?:write|handle|build|produce)",
+        r"self-taught\s+developers?\s+are\s+not\s+equal\s+to\s+university\s+graduates?",
+        r"online\s+course\s+students?\s+are\s+less\s+capable\s+than\s+university\s+graduates?",
+        r"bootcamp\s+attendance\s+means\s+(?:insufficient|inadequate)\s+training",
     ]
 
     # Demographic assumptions (about age, background, identity)
     DEMOGRAPHIC_PATTERNS = [
-        r"(?:young|old|aged)\s+(?:person|developer|programmer)\s+(?:can't|cannot|won't|will\s+not)",
-        r"(?:person\s+from|coming\s+from)\s+(?:poor|rich|working[\s-]?class)",
+        r"(?:young|old|aged)\s+(?:persons?|developers?|programmers?)\s+(?:can't|cannot|won't|will\s+not)",
+        r"(?:(?:persons?|developers?|programmers?)\s+from|coming\s+from)\s+(?:poor|rich|working[\s-]?class)\s+backgrounds?",
         r"(?:immigrant|international|foreign)\s+developers?.*(?:can't|cannot|won't|struggle)",
     ]
 

--- a/tests/unit/test_bias_detector.py
+++ b/tests/unit/test_bias_detector.py
@@ -9,7 +9,7 @@ from safety.bias_detector import BiasDetector
 class TestBiasDetector:
     """Test suite for BiasDetector."""
 
-    def test_dismissive_bootcamp_language_detected(self):
+    def test_dismissive_bootcamp_language_detected(self) -> None:
         """Test dismissive bootcamp language is detected as biased."""
         text = "bootcamp graduates can't write production code"
 
@@ -18,7 +18,7 @@ class TestBiasDetector:
         assert is_biased is True
         assert reason != ""
 
-    def test_bootcamp_lacks_rigor_detected(self):
+    def test_bootcamp_lacks_rigor_detected(self) -> None:
         """Test 'bootcamp lacks rigor' language detected."""
         text = "bootcamp education lacks fundamentals"
 
@@ -26,7 +26,7 @@ class TestBiasDetector:
 
         assert is_biased is True
 
-    def test_bootcamp_inadequate_training_detected(self):
+    def test_bootcamp_inadequate_training_detected(self) -> None:
         """Test 'bootcamp inadequate training' language detected."""
         text = "bootcamp training is inadequate for professional development"
 
@@ -34,7 +34,7 @@ class TestBiasDetector:
 
         assert is_biased is True
 
-    def test_self_taught_comparison_detected(self):
+    def test_self_taught_comparison_detected(self) -> None:
         """Test self-taught vs traditional comparison detected."""
         text = "self-taught is never comparable to university education"
 
@@ -42,7 +42,7 @@ class TestBiasDetector:
 
         assert is_biased is True
 
-    def test_positive_bootcamp_mention_not_flagged(self):
+    def test_positive_bootcamp_mention_not_flagged(self) -> None:
         """Test positive bootcamp mention is NOT flagged as biased."""
         text = "your bootcamp background shows strong fundamentals and problem-solving skills"
 
@@ -50,7 +50,7 @@ class TestBiasDetector:
 
         assert is_biased is False
 
-    def test_neutral_bootcamp_mention_not_flagged(self):
+    def test_neutral_bootcamp_mention_not_flagged(self) -> None:
         """Test neutral bootcamp mention is NOT flagged."""
         text = "this bootcamp project demonstrates good coding practices"
 
@@ -58,7 +58,7 @@ class TestBiasDetector:
 
         assert is_biased is False
 
-    def test_educational_background_positive_not_flagged(self):
+    def test_educational_background_positive_not_flagged(self) -> None:
         """Test positive educational background mention not flagged."""
         text = "your bootcamp training has given you a solid foundation"
 
@@ -66,7 +66,7 @@ class TestBiasDetector:
 
         assert is_biased is False
 
-    def test_demographic_assumption_age_detected(self):
+    def test_demographic_assumption_age_detected(self) -> None:
         """Test demographic assumption about age detected."""
         text = "young developers can't handle complex systems"
 
@@ -75,7 +75,7 @@ class TestBiasDetector:
         assert is_biased is True
         assert "demographic" in reason.lower()
 
-    def test_demographic_assumption_old_detected(self):
+    def test_demographic_assumption_old_detected(self) -> None:
         """Test age assumption about older developers detected."""
         text = "old aged programmer won't be able to learn new technologies"
 
@@ -83,7 +83,7 @@ class TestBiasDetector:
 
         assert is_biased is True
 
-    def test_demographic_assumption_background_detected(self):
+    def test_demographic_assumption_background_detected(self) -> None:
         """Test background assumption detected."""
         text = "person from poor background can't afford proper training"
 
@@ -91,7 +91,7 @@ class TestBiasDetector:
 
         assert is_biased is True
 
-    def test_immigrant_developer_assumption_detected(self):
+    def test_immigrant_developer_assumption_detected(self) -> None:
         """Test assumption about immigrant developers detected."""
         text = "immigrant developers can't communicate effectively in code reviews"
 
@@ -99,7 +99,7 @@ class TestBiasDetector:
 
         assert is_biased is True
 
-    def test_international_developer_assumption_detected(self):
+    def test_international_developer_assumption_detected(self) -> None:
         """Test assumption about international developers detected."""
         text = "international developers struggle with American coding standards"
 
@@ -107,23 +107,28 @@ class TestBiasDetector:
 
         assert is_biased is True
 
-    def test_clean_feedback_not_flagged(self):
+    def test_clean_feedback_not_flagged(self) -> None:
         """Test clean, objective feedback is not flagged."""
-        text = "You have demonstrated strong Python skills. Your code is well-organized and follows best practices."
 
+        text = (
+            "You have demonstrated strong Python skills. "
+            "Your code is well-organized and follows best practices."
+        )
         is_biased, reason = BiasDetector.detect_bias(text)
 
         assert is_biased is False
 
-    def test_technical_feedback_not_flagged(self):
+    def test_technical_feedback_not_flagged(self) -> None:
         """Test pure technical feedback not flagged."""
-        text = "Consider adding error handling to your API endpoints and documenting the parameters."
+        text = (
+            "Consider adding error handling to your API endpoints and documenting the parameters."
+        )
 
         is_biased, reason = BiasDetector.detect_bias(text)
 
         assert is_biased is False
 
-    def test_development_suggestion_not_flagged(self):
+    def test_development_suggestion_not_flagged(self) -> None:
         """Test development suggestions not flagged."""
         text = "To improve your portfolio, try learning Kubernetes and contributing to open source."
 
@@ -131,7 +136,7 @@ class TestBiasDetector:
 
         assert is_biased is False
 
-    def test_case_insensitive_detection(self):
+    def test_case_insensitive_detection(self) -> None:
         """Test detection is case insensitive."""
         text = "BOOTCAMP GRADUATES LACK FUNDAMENTALS"
 
@@ -139,7 +144,7 @@ class TestBiasDetector:
 
         assert is_biased is True
 
-    def test_return_value_structure(self):
+    def test_return_value_structure(self) -> None:
         """Test return value has correct structure."""
         text = "some feedback"
         result = BiasDetector.detect_bias(text)
@@ -150,7 +155,7 @@ class TestBiasDetector:
         assert isinstance(is_biased, bool)
         assert isinstance(reason, str)
 
-    def test_unbiased_returns_empty_reason(self):
+    def test_unbiased_returns_empty_reason(self) -> None:
         """Test unbiased feedback returns empty reason string."""
         text = "Great coding skills"
 
@@ -159,7 +164,7 @@ class TestBiasDetector:
         if is_biased is False:
             assert reason == ""
 
-    def test_biased_returns_reason(self):
+    def test_biased_returns_reason(self) -> None:
         """Test biased feedback returns non-empty reason."""
         text = "bootcamp graduates can't code"
 
@@ -169,19 +174,19 @@ class TestBiasDetector:
             assert reason != ""
             assert len(reason) > 0
 
-    def test_empty_text(self):
+    def test_empty_text(self) -> None:
         """Test with empty text."""
         is_biased, reason = BiasDetector.detect_bias("")
 
         assert is_biased is False
 
-    def test_whitespace_only(self):
+    def test_whitespace_only(self) -> None:
         """Test with whitespace only."""
         is_biased, reason = BiasDetector.detect_bias("   \n\t  ")
 
         assert is_biased is False
 
-    def test_coding_bootcamp_variant(self):
+    def test_coding_bootcamp_variant(self) -> None:
         """Test 'coding bootcamp' variant is detected."""
         text = "coding bootcamp graduates can't write enterprise code"
 
@@ -189,7 +194,7 @@ class TestBiasDetector:
 
         assert is_biased is True
 
-    def test_online_course_bias_detected(self):
+    def test_online_course_bias_detected(self) -> None:
         """Test online course dismissal detected."""
         text = "online course education is insufficient for real work"
 
@@ -197,7 +202,7 @@ class TestBiasDetector:
 
         assert is_biased is True
 
-    def test_developer_vs_programmer_distinction(self):
+    def test_developer_vs_programmer_distinction(self) -> None:
         """Test both developer and programmer terms detected."""
         text_dev = "bootcamp developers can't handle production systems"
         text_prog = "bootcamp programmers lack proper training"
@@ -208,15 +213,17 @@ class TestBiasDetector:
         assert is_biased_dev is True
         assert is_biased_prog is True
 
-    def test_multiple_bias_indicators(self):
+    def test_multiple_bias_indicators(self) -> None:
         """Test text with multiple bias indicators."""
-        text = "young bootcamp graduates can't write code and immigrant developers lack fundamentals"
+        text = (
+            "young bootcamp graduates can't write code and immigrant developers lack fundamentals"
+        )
 
         is_biased, reason = BiasDetector.detect_bias(text)
 
         assert is_biased is True
 
-    def test_negative_educational_claim(self):
+    def test_negative_educational_claim(self) -> None:
         """Test negative claims about education detected."""
         text = "self-taught developers are not equal to university graduates"
 
@@ -224,7 +231,7 @@ class TestBiasDetector:
 
         assert is_biased is True
 
-    def test_working_class_assumption(self):
+    def test_working_class_assumption(self) -> None:
         """Test working-class assumption detected."""
         text = "person from working class background won't succeed in tech"
 
@@ -232,7 +239,7 @@ class TestBiasDetector:
 
         assert is_biased is True
 
-    def test_rich_poor_assumption(self):
+    def test_rich_poor_assumption(self) -> None:
         """Test rich/poor background assumption detected."""
         text = "developers from poor backgrounds can't afford proper tools"
 
@@ -240,7 +247,7 @@ class TestBiasDetector:
 
         assert is_biased is True
 
-    def test_foreign_developer_struggle_assumption(self):
+    def test_foreign_developer_struggle_assumption(self) -> None:
         """Test assumption about foreign developers struggling."""
         text = "foreign developers struggle with English-first codebases"
 
@@ -248,23 +255,31 @@ class TestBiasDetector:
 
         assert is_biased is True
 
-    def test_skill_assessment_not_biased(self):
+    def test_skill_assessment_not_biased(self) -> None:
         """Test skill assessment without bias language."""
-        text = "Your JavaScript skills are at an intermediate level. Practice would help advance to senior level."
+
+        text = (
+            "Your JavaScript skills are at an intermediate level. "
+            "Practice would help advance to senior level."
+        )
 
         is_biased, reason = BiasDetector.detect_bias(text)
 
         assert is_biased is False
 
-    def test_comparative_without_bias(self):
+    def test_comparative_without_bias(self) -> None:
         """Test comparison without biased assumptions."""
-        text = "Your bootcamp education covers practical skills. University education provides theory. Both have value."
+
+        text = (
+            "Your bootcamp education covers practical skills. "
+            "University education provides theory. Both have value."
+        )
 
         is_biased, reason = BiasDetector.detect_bias(text)
 
         assert is_biased is False
 
-    def test_assumption_vs_observation(self):
+    def test_assumption_vs_observation(self) -> None:
         """Test that observations are not flagged, assumptions are."""
         observation = "your resume shows bootcamp attendance"  # Factual
         assumption = "bootcamp attendance means inadequate training"  # Biased
@@ -274,3 +289,30 @@ class TestBiasDetector:
 
         assert is_biased_obs is False  # Factual
         assert is_biased_ass is True  # Biased assumption
+
+    def test_bootcamp_not_prepared_phrasing_detected(self) -> None:
+        """Test common 'not prepared' bootcamp phrasing is detected."""
+        text = "bootcamp graduates are not prepared for real engineering work"
+
+        is_biased, reason = BiasDetector.detect_bias(text)
+
+        assert is_biased is True
+        assert reason != ""
+
+    def test_self_taught_foundation_phrasing_detected(self) -> None:
+        """Test common self-taught foundation phrasing is detected."""
+        text = "self-taught developers usually lack a strong technical foundation"
+
+        is_biased, reason = BiasDetector.detect_bias(text)
+
+        assert is_biased is True
+        assert reason != ""
+
+    def test_online_course_comparison_phrasing_detected(self) -> None:
+        """Test common online-course comparison phrasing is detected."""
+        text = "online course students are less capable than university graduates"
+
+        is_biased, reason = BiasDetector.detect_bias(text)
+
+        assert is_biased is True
+        assert reason != ""


### PR DESCRIPTION
## Summary

This PR expands the bias detector's regex patterns to recognize more common educational bias phrasings.

### Changes
- Expanded educational bias detection patterns
- Added regression tests for common educational bias statements
- Added Week 7 `JOURNAL.md`

### Validation
- All 35 unit tests pass
- Ruff passes
- Black passes
- mypy passes

## Testing
- [x] Unit tests pass (`python -m pytest tests/unit/test_bias_detector.py -q`)
- [ ] Integration tests pass (`make test-integration`)
- [x] Linter passes
- [x] Type checker passes
- [x] New/updated tests cover the changes

## Screenshots / Demo

N/A

## Notes for Reviewers

This change broadens educational bias detection by adding support for common phrasings while preserving existing behavior through regression tests.
