### PR TITLE
fix: handle None context chunk text in FaithfulnessChecker

### DIFF
--- a/rag/evaluator/faithfulness_checker.py
+++ b/rag/evaluator/faithfulness_checker.py
@@ -30,10 +30,10 @@ class FaithfulnessChecker:
             logger.info("faithfulness_no_claims_extracted")
             return 0.5  # Default to neutral if no extractable claims
 
-        # Concatenate context text
-        context_text = " ".join([
-            chunk.get("text", "") for chunk in context_chunks
-        ])
+        # Concatenate context text (treat missing/None text as empty)
+        context_text = " ".join(
+            (chunk.get("text") or "") for chunk in context_chunks
+        )
 
         # Check each claim for support
         supported = 0


### PR DESCRIPTION
## Summary
Fixes #153: `FaithfulnessChecker.check()` crashed with `TypeError` when a context chunk had `"text": None`, because `dict.get("text", "")` only falls back when the key is missing.

Coalesce with `(chunk.get("text") or "")` so missing and `None` both become empty strings before joining.

## Testing
- Local import smoke: `FaithfulnessChecker().check("Has Python skills", [{"text": None}])` returns a float in `[0, 1]`
