### PR TITLE
fix: use settings.redis_url in health check

### DIFF
--- a/api/routes/health.py
+++ b/api/routes/health.py
@@ -41,12 +41,8 @@ async def health_check(db=Depends(get_db)):
         import redis
         from core.config import settings
 
-        r = redis.Redis(
-            host=settings.redis_host,
-            port=settings.redis_port,
-            db=0,
-            decode_responses=True,
-        )
+        # Settings exposes redis_url (not redis_host/redis_port)
+        r = redis.Redis.from_url(settings.redis_url, decode_responses=True)
         r.ping()
         health_status["dependencies"]["redis"] = "healthy"
         log.debug("redis_health_check_passed")


### PR DESCRIPTION
## Summary
Fixes #155: health check referenced missing `settings.redis_host` / `settings.redis_port`.

Use `settings.redis_url` with `redis.Redis.from_url(...)`.
