### PR TITLE
fix(rag): support short claims in faithfulness checker

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,113 @@
+# Project journal
+
+## Week 7 - Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/152
+
+**Issue title:** Faithfulness checker can never mark short claims as supported
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The checker requires two matching non-stopword terms, so a short claim such as
+`Knows Python` cannot be supported even when Python appears in the retrieved context.
+The work is centered on `rag/evaluator/faithfulness_checker.py` and its unit tests. I
+also included the related `text=None` failure from #153 at this checker's input
+boundary, without claiming the separate suite-level path is fixed.
+
+**Branch name:** `fix/152-faithfulness-short-claims`
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger
+
+### Is this right for me?
+
+- This is a Tier 1 change isolated to one evaluator and its tests.
+- The issue provides a concrete input and expected score that can be reproduced first.
+- Existing faithfulness tests provide a clear before-and-after target.
+- General natural-language inference remains outside the scope of this lexical
+  checker.
+
+## Week 8 - Reproduction and solution planning
+
+**Planning record commit:**
+[d907e28](https://github.com/ahmedtaha100/pathreview/commit/d907e28083e80d84f5d5a9a308dd373eac4e7281)
+
+**Failing reproduction commit:**
+[1eb292b](https://github.com/ahmedtaha100/pathreview/commit/1eb292b3d11455a0f1995010d7334d637507450c)
+
+**Reproduction summary:**
+The exact `Knows Python. Knows SQL.` example returned `0.0` despite both facts being
+present. Passing `{"text": None}` directly to `FaithfulnessChecker.check()` also
+raised `TypeError`. At the reproduction commit, the two focused regression tests fail
+for those reasons before the implementation is applied.
+
+**PLAN.md:**
+[Solution plan](https://github.com/ahmedtaha100/pathreview/blob/fix/152-faithfulness-short-claims/PLAN.md)
+
+**Walkthrough video (recommended):** Not recorded.
+
+**Blockers or open questions:**
+The checker compares terms rather than meaning, so negation and entity attribution
+remain known limitations. The repository also has unrelated baseline check failures,
+which require a same-environment comparison.
+
+**Working branch:**
+[fix/152-faithfulness-short-claims](https://github.com/ahmedtaha100/pathreview/tree/fix/152-faithfulness-short-claims)
+
+## Week 9 - Solution building and PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+The exact #152 and checker-level #153 failures are reproduced. The implementation now
+extracts narrowly reporter-led short claims, preserves the ordinary two-term support
+rule, and skips malformed context text. Focused regression coverage is in place.
+
+**Next steps:**
+Run false-positive and technical-identifier probes, compare the complete unit failure
+set with a fresh `main` worktree, finish the contribution checks, and make the PR
+description match only the verified behavior.
+
+**Blockers:**
+The repository has unrelated unit, lint, formatting, and type-check failures on
+`main`, so verification must use the course's documented no-new-failures process.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/211
+
+**Branch:** `fix/152-faithfulness-short-claims`
+
+**What you built:**
+I updated the faithfulness checker so one-fact claims are scoreable only after a narrow
+reporting verb such as `knows`. Ordinary claims keep the original two-term support
+threshold, partial evidence receives proportional credit below that threshold, and
+malformed context text is skipped without hiding valid sibling chunks.
+
+**Tests added or updated:**
+`tests/unit/test_faithfulness_checker.py` now covers the exact #152 reproduction, the
+checker boundary from #153, supported and unrelated short claims, subject stripping,
+the ten-claim cap, partial scores, punctuation, PascalCase dotted names, common
+technical identifiers, and Unicode apostrophe and in-word hyphen variants. The
+focused run passes all 55 collected cases with warnings treated as errors, reaching
+100% checker coverage (86/86 statements and 28/28 branches).
+
+The `make test-unit` equivalent reports `412 passed / 49 failed`, compared with
+`375 passed / 53 failed` on a fresh same-environment `main`
+worktree. The four original faithfulness failures now pass, and the remaining 49
+failure node IDs are identical on both revisions.
+
+**Self-review confirmation:** [x] `make check` passes*  [x] `make test-unit` passes*
+
+\* GNU Make is unavailable in this Windows environment, so I ran each Makefile command
+directly. Under the course's pre-existing-failure policy, these boxes mean the change
+adds no failure: Ruff reports 180 existing errors versus 182 on `main`; Black
+`--check` reports 50 files versus 52; and mypy reports the same 103 errors in 26 files
+on both. Both changed Python files pass Ruff and Black, and the checker passes strict
+mypy. Integration collection exits 5 with no tests on both revisions.
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -111,3 +111,98 @@ on both. Both changed Python files pass Ruff and Black, and the checker passes s
 mypy. Integration collection exits 5 with no tests on both revisions.
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — no review arrived
+
+**Summary of feedback:** The Summer 2026 project instructions state that reviewer
+feedback is not provided for this iteration of the course. I also checked PR #211 on
+August 9, 2026; it has no conversation comments, inline review comments, submitted
+reviews, requested changes, or review threads.
+
+**How you responded:** Not applicable — no reviewer feedback was received, so there was
+no response or reviewer-requested change to make. If maintainer feedback arrives later,
+I will document the comment, my decision, the change or explanation I provided, and the
+verification result within the repository's 48-hour response window.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+
+The hardest part was not reproducing #152; it was defining a fix narrow enough to avoid
+creating false support elsewhere. The obvious rule — let one matching word count — made
+`Knows Python` work, but could also make an ordinary claim such as `Python expert` look
+supported by context that mentioned only Python. I had to preserve the normal two-term
+threshold while recognizing only a specific reporter-led one-fact form in
+`rag/evaluator/faithfulness_checker.py`.
+
+The repository's inherited failures also made verification harder than a normal green
+test run. Instead of relying on totals, I compared the exact failing test node IDs on the
+branch and the same-environment baseline. That proved the four original faithfulness
+failures were repaired without replacing them with different failures elsewhere.
+
+**What did you learn about working in a large codebase?**
+
+I learned that contributing to someone else's codebase means treating existing behavior,
+tests, contribution rules, and module boundaries as contracts. Before changing the
+checker, I had to read `docs/CONTRIBUTING.md`, follow the repository's branch and commit
+conventions, study the existing unit tests, and understand how the checker fits into the
+larger RAG evaluation path.
+
+Scope mattered as much as implementation. The change safely handles `text=None` at the
+`FaithfulnessChecker.check()` boundary, but `RelevanceScorer.score()` can still reject
+that input earlier inside `EvalSuite.run()`. Naming that boundary honestly was better
+than claiming the related issue was fixed everywhere.
+
+**How did AI tools help — and where did they fall short?**
+
+AI coding tools helped me navigate an unfamiliar repository, form debugging hypotheses,
+and generate adversarial tests for punctuation, technical identifiers, malformed context
+chunks, Unicode variants, and the claim limit. They were most useful as a fast source of
+questions to investigate, especially when a small parser rule had effects I did not see
+immediately.
+
+They fell short when suggestions treated the lexical checker like a general language
+understanding system. Several broader ideas involving stop words, negation, or semantic
+rules changed unrelated behavior or created new false positives. I had to reject or
+rework those suggestions and use executable regressions, coverage, style/type checks,
+and an exact branch-versus-baseline comparison as the evidence for each final decision.
+
+**What would you do differently if you started over?**
+
+I would write the acceptance matrix before changing the scorer. It would include the
+positive issue example, unrelated one-word controls, material mismatches, partial
+evidence, malformed inputs, technical identifiers, and the first-ten-claims behavior
+from the beginning. I would also capture the baseline failure IDs immediately instead of
+first relying on pass/fail totals.
+
+I would follow the course's literal six-section PLAN structure and keep the draft PR open
+long enough to request peer or mentor feedback before marking it ready. I would also
+publish the midweek check-in at the actual midpoint instead of adding both entries in the
+final Sunday journal commit. Those process improvements would make the work easier to
+review and the course record stronger, even though the implementation itself would stay
+narrow.
+
+The Week 9 course feedback also called out how the reporting-verb, subject-stripping,
+role-noun, and technical-identifier rules interact. I would respond by splitting those
+concerns into smaller helpers and adding short why-comments around non-obvious branches,
+so a future maintainer would not need to reverse-engineer the intent from all 55 tests.
+
+**What are you most proud of from this module?**
+
+I am most proud that the final PR fixes the exact `Knows Python. Knows SQL.` failure while
+keeping unrelated one-word feedback unscoreable. The submitted checker reaches 100%
+statement and branch coverage, and the full-suite comparison shows the same 49 inherited
+failure identities rather than introducing a new one.
+
+I am also proud that the contribution states its limits clearly. It preserves technical
+identifiers such as `C++`, `.NET`, and `Node.js`, handles malformed sibling chunks, and
+does not pretend lexical overlap can solve negation, contradiction, or entity
+attribution. That combination of a useful fix, reproducible evidence, and honest scope is
+the part of the module I would be most comfortable explaining to a maintainer or
+interviewer.

--- a/PLAN.md
+++ b/PLAN.md
@@ -31,8 +31,9 @@ binary supported/unsupported result cannot satisfy that contract for a single cl
 ## Implementation
 
 1. Tokenize claims and context consistently, removing surrounding punctuation while
-   preserving common technical identifiers such as `C++`, `C#`, `.NET`, `Node.js`,
-   `Objective-C`, `R&D`, and `I/O`.
+   normalizing common apostrophe and in-word hyphen variants and preserving technical
+   identifiers such as `C++`, `C#`, `.NET`, `Node.js`, `Objective-C`, `R&D`, and
+   `I/O`.
 2. Preserve the existing first-ten-claims limit and the ordinary two-term support
    threshold.
 3. Recognize a narrow short-claim form only after removing a leading reporting verb,
@@ -40,7 +41,8 @@ binary supported/unsupported result cannot satisfy that contract for a single cl
    unscoreable.
 4. Keep role nouns material unless they occur directly before a reporting verb.
 5. Return `1.0` for claims meeting the support threshold and proportional lexical
-   credit otherwise, then average the per-claim scores.
+   credit for other multi-term claims, then average the per-claim scores. Ordinary
+   one-term fragments remain unscoreable.
 6. Ignore missing, `None`, and non-string chunk text while retaining valid sibling
    chunks and logging how many malformed chunks were skipped.
 
@@ -48,8 +50,8 @@ binary supported/unsupported result cannot satisfy that contract for a single cl
 
 - The exact #152 example scores `1.0`; unrelated short claims score `0.0`.
 - Subject-led reporter forms work without making ordinary role nouns optional.
-- Context punctuation and no-space sentence boundaries do not hide supported facts or
-  split the covered technical identifiers.
+- Punctuation and reporter-led no-space sentence boundaries do not hide supported
+  facts or split the covered technical identifiers.
 - Malformed context values do not raise or hide valid sibling evidence.
 - The first-ten-claims limit and ordinary two-term threshold remain intact.
 - Focused tests pass with warnings treated as errors and cover every statement and
@@ -61,4 +63,7 @@ binary supported/unsupported result cannot satisfy that contract for a single cl
 
 This is deterministic lexical overlap, not semantic entailment. It cannot reliably
 detect negation, contradiction, or entity attribution, and equivalent ideas expressed
-with unrelated vocabulary will not match.
+with unrelated vocabulary will not match. A dotted identifier whose final component
+is a covered reporting verb followed by a space, such as `MessageBox.Show and ...`, is
+read as a sentence boundary because it is lexically indistinguishable from
+`Python.Knows SQL`.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,64 @@
+# Solution plan: faithfulness checker short claims
+
+## Goal
+
+Fix [#152](https://github.com/ascherj/pathreview/issues/152), where supported short
+claims such as `Knows Python. Knows SQL.` cannot be marked faithful. Also make
+`FaithfulnessChecker.check()` tolerate a chunk whose `text` value is `None`, the
+checker-level failure described in
+[#153](https://github.com/ascherj/pathreview/issues/153).
+
+## Diagnosis
+
+The checker currently discards sentences of ten characters or fewer and requires two
+matching non-stopword tokens for every remaining claim. A reporter-led claim such as
+`Knows SQL` has only one fact token after the reporting verb is removed, so applying
+the ordinary two-token rule can never support it. Context text is also joined without
+validating each value, so `None` raises `TypeError` before scoring.
+
+Several existing tests also require partial evidence to produce a middle score. A
+binary supported/unsupported result cannot satisfy that contract for a single claim.
+
+## Scope
+
+- Update `rag/evaluator/faithfulness_checker.py`.
+- Reproduce the failures and add focused unit coverage in
+  `tests/unit/test_faithfulness_checker.py`.
+- Keep retrieval, generation, prompts, APIs, and other evaluators unchanged.
+- Treat #153 only at the `FaithfulnessChecker.check()` boundary; do not claim the
+  separate `EvalSuite` path is fixed.
+
+## Implementation
+
+1. Tokenize claims and context consistently, removing surrounding punctuation while
+   preserving common technical identifiers such as `C++`, `C#`, `.NET`, `Node.js`,
+   `Objective-C`, `R&D`, and `I/O`.
+2. Preserve the existing first-ten-claims limit and the ordinary two-term support
+   threshold.
+3. Recognize a narrow short-claim form only after removing a leading reporting verb,
+   optionally preceded by a role or pronoun. Bare one-word feedback remains
+   unscoreable.
+4. Keep role nouns material unless they occur directly before a reporting verb.
+5. Return `1.0` for claims meeting the support threshold and proportional lexical
+   credit otherwise, then average the per-claim scores.
+6. Ignore missing, `None`, and non-string chunk text while retaining valid sibling
+   chunks and logging how many malformed chunks were skipped.
+
+## Tests and acceptance criteria
+
+- The exact #152 example scores `1.0`; unrelated short claims score `0.0`.
+- Subject-led reporter forms work without making ordinary role nouns optional.
+- Context punctuation and no-space sentence boundaries do not hide supported facts or
+  split the covered technical identifiers.
+- Malformed context values do not raise or hide valid sibling evidence.
+- The first-ten-claims limit and ordinary two-term threshold remain intact.
+- Focused tests pass with warnings treated as errors and cover every statement and
+  branch in the checker.
+- Changed Python files pass Ruff and Black; the checker passes strict mypy.
+- A same-environment full-unit comparison introduces no failure absent from `main`.
+
+## Known limitation
+
+This is deterministic lexical overlap, not semantic entailment. It cannot reliably
+detect negation, contradiction, or entity attribution, and equivalent ideas expressed
+with unrelated vocabulary will not match.

--- a/rag/evaluator/faithfulness_checker.py
+++ b/rag/evaluator/faithfulness_checker.py
@@ -1,88 +1,162 @@
 """Check if generated feedback is supported by retrieved context."""
 
 import re
+from collections.abc import Mapping, Sequence
+
 import structlog
 
 logger = structlog.get_logger()
 
 
-class FaithfulnessChecker:
-    """Verify that feedback claims are supported by context."""
+def _word_set(words: str) -> frozenset[str]:
+    """Build an immutable word set from a compact space-delimited string."""
+    return frozenset(words.split())
 
-    def check(self, feedback: str, context_chunks: list[dict]) -> float:
-        """Check faithfulness of feedback to context.
+
+_STOP_WORDS = _word_set("a an and are be been but for in is of or that the to was were")
+_ROLE_SUBJECTS = _word_set(
+    "candidate candidates developer developers engineer engineers he i it she they we you"
+)
+_REPORTING_VERBS = _word_set("has have know knows show shows")
+
+# Normalize Unicode apostrophe and in-word hyphen variants to their ASCII forms.
+_TOKEN_TRANSLATION = str.maketrans(
+    {
+        "\u02bc": "'",
+        "\u2010": "-",
+        "\u2011": "-",
+        "\u2018": "'",
+        "\u2019": "'",
+        "\uff07": "'",
+    }
+)
+# Preserve common technical identifiers and apostrophized words while trimming punctuation.
+_WORD_RE = re.compile(r"\.?[^\W_]+(?:[-._&/'][^\W_]+|[+#]+)*")
+# Split punctuation and adjacent reporter-led sentences without breaking dotted names.
+# Keep the reporter alternation in sync with _REPORTING_VERBS.
+_CLAIM_BOUNDARY_RE = re.compile(r"[!?]+|\.(?=\s|$)|\.(?=(?:Has|Have|Know|Knows|Show|Shows)\s)")
+
+
+class FaithfulnessChecker:
+    """Score lexical grounding of feedback claims against retrieved context."""
+
+    def check(self, feedback: str, context_chunks: Sequence[Mapping[str, object]]) -> float:
+        """Return mean lexical support for extracted feedback claims.
 
         Args:
-            feedback: Generated feedback text
-            context_chunks: Retrieved context chunks
+            feedback: Generated feedback text.
+            context_chunks: Retrieved context dictionaries.
 
         Returns:
-            Faithfulness score 0.0-1.0 (ratio of supported claims)
+            Mean per-claim evidence in the inclusive range 0.0 to 1.0. Claims
+            meeting their support threshold contribute 1.0; other multi-term
+            claims contribute their matched-term proportion. Ordinary one-term
+            claims contribute 0.0. Empty inputs return 0.0, while feedback with
+            no extractable claim returns the neutral score 0.5.
         """
         if not feedback or not context_chunks:
-            logger.info("faithfulness_empty_input", has_feedback=bool(feedback),
-                       has_chunks=bool(context_chunks))
+            logger.info(
+                "faithfulness_empty_input",
+                has_feedback=bool(feedback),
+                has_chunks=bool(context_chunks),
+            )
             return 0.0
 
-        # Extract key claims from feedback (sentences)
         claims = self._extract_claims(feedback)
         if not claims:
             logger.info("faithfulness_no_claims_extracted")
-            return 0.5  # Default to neutral if no extractable claims
+            return 0.5
 
-        # Concatenate context text
-        context_text = " ".join([
-            chunk.get("text", "") for chunk in context_chunks
-        ])
+        valid_text: list[str] = []
+        skipped_chunks = 0
+        for chunk in context_chunks:
+            chunk_text = chunk.get("text")
+            if isinstance(chunk_text, str):
+                valid_text.append(chunk_text)
+            else:
+                skipped_chunks += 1
 
-        # Check each claim for support
-        supported = 0
+        if skipped_chunks:
+            logger.warning(
+                "faithfulness_context_chunks_skipped",
+                skipped_count=skipped_chunks,
+                total_count=len(context_chunks),
+            )
+
+        context_terms = self._context_terms(" ".join(valid_text))
+        scores: list[float] = []
+        supported_count = 0
         for claim in claims:
-            if self._is_supported(claim, context_text):
-                supported += 1
+            required, reporter_led = self._claim_terms(claim)
+            score, supported = self._score_terms(required, context_terms, allow_single=reporter_led)
+            scores.append(score)
+            supported_count += int(supported)
 
-        score = supported / len(claims) if claims else 0.0
+        result = sum(scores) / len(scores)
+        logger.info(
+            "faithfulness_checked",
+            claims_count=len(claims),
+            supported_count=supported_count,
+            score=result,
+        )
+        return result
 
-        logger.info("faithfulness_checked", claims_count=len(claims),
-                   supported_count=supported, score=score)
-
-        return score
+    @classmethod
+    def _extract_claims(cls, text: str) -> list[str]:
+        """Extract at most ten conventional, scoreable sentences."""
+        claims: list[str] = []
+        for fragment in _CLAIM_BOUNDARY_RE.split(text):
+            claim = fragment.strip()
+            if not claim:
+                continue
+            terms, reporter_led = cls._claim_terms(claim)
+            if len(claim) > 10 or (reporter_led and terms):
+                claims.append(claim)
+            if len(claims) == 10:
+                break
+        return claims
 
     @staticmethod
-    def _extract_claims(text: str) -> list[str]:
-        """Extract key claims from feedback text.
+    def _tokenize(text: str) -> list[str]:
+        """Return case-folded words and common technical identifiers."""
+        return _WORD_RE.findall(text.translate(_TOKEN_TRANSLATION).casefold())
 
-        Args:
-            text: Feedback text
+    @classmethod
+    def _context_terms(cls, context: str) -> set[str]:
+        """Return content terms after removing sentence-boundary punctuation."""
+        return set(cls._tokenize(_CLAIM_BOUNDARY_RE.sub(" ", context))) - _STOP_WORDS
 
-        Returns:
-            List of claims (sentences)
-        """
-        # Split by sentence (simple regex)
-        sentences = re.split(r'[.!?]+', text)
-        claims = [s.strip() for s in sentences if s.strip() and len(s.strip()) > 10]
-        return claims[:10]  # Limit to 10 claims for scoring
+    @classmethod
+    def _claim_terms(cls, claim: str) -> tuple[set[str], bool]:
+        """Return content terms and whether a leading reporter was removed."""
+        terms = [token for token in cls._tokenize(claim) if token not in _STOP_WORDS]
+        if len(terms) > 1 and terms[0] in _ROLE_SUBJECTS and terms[1] in _REPORTING_VERBS:
+            terms = terms[1:]
+
+        reporter_led = bool(terms and terms[0] in _REPORTING_VERBS)
+        if reporter_led:
+            terms = terms[1:]
+        return set(terms), reporter_led
 
     @staticmethod
-    def _is_supported(claim: str, context: str) -> bool:
-        """Check if a claim is supported by context.
+    def _score_terms(
+        required: set[str], context: set[str], *, allow_single: bool = False
+    ) -> tuple[float, bool]:
+        """Return partial evidence and whether the applicable threshold is met."""
+        if not required:
+            return 0.0, False
+        if len(required) == 1 and not allow_single:
+            return 0.0, False
+        overlap_count = len(required & context)
+        minimum_overlap = 1 if allow_single and len(required) == 1 else 2
+        supported = overlap_count >= minimum_overlap
+        score = 1.0 if supported else overlap_count / len(required)
+        return score, supported
 
-        Args:
-            claim: Claim text
-            context: Context text
-
-        Returns:
-            True if claim is supported
-        """
-        # Tokenize and check for keyword overlap
-        claim_tokens = set(claim.lower().split())
-        context_tokens = set(context.lower().split())
-
-        # Require at least some meaningful overlap
-        overlap = claim_tokens & context_tokens
-        # Filter out common stop words
-        stop_words = {'a', 'an', 'the', 'is', 'are', 'was', 'were', 'be', 'been',
-                     'and', 'or', 'but', 'in', 'of', 'to', 'for', 'that'}
-        meaningful_overlap = overlap - stop_words
-
-        return len(meaningful_overlap) >= 2
+    @classmethod
+    def _is_supported(cls, claim: str, context: str) -> bool:
+        """Return whether a claim meets its lexical-overlap threshold."""
+        required, reporter_led = cls._claim_terms(claim)
+        context_terms = cls._context_terms(context)
+        _, supported = cls._score_terms(required, context_terms, allow_single=reporter_led)
+        return supported

--- a/tests/unit/test_faithfulness_checker.py
+++ b/tests/unit/test_faithfulness_checker.py
@@ -18,9 +18,7 @@ class TestFaithfulnessChecker:
         """Test feedback fully supported by context returns score close to 1.0."""
         feedback = "The developer has strong Python skills and experience with Django."
         context_chunks = [
-            {
-                "text": "The portfolio shows Python expertise and Django framework experience."
-            },
+            {"text": "The portfolio shows Python expertise and Django framework experience."},
         ]
 
         score = checker.check(feedback, context_chunks)
@@ -34,9 +32,7 @@ class TestFaithfulnessChecker:
         """Test feedback with no support in context returns score close to 0.0."""
         feedback = "This developer is an expert in Rust systems programming."
         context_chunks = [
-            {
-                "text": "The developer has Python and JavaScript experience."
-            },
+            {"text": "The developer has Python and JavaScript experience."},
         ]
 
         score = checker.check(feedback, context_chunks)
@@ -48,24 +44,20 @@ class TestFaithfulnessChecker:
         """Test partial support returns score between 0 and 1."""
         feedback = "The developer shows Python expertise and Kubernetes knowledge."
         context_chunks = [
-            {
-                "text": "Strong Python programming skills demonstrated in projects."
-            },
+            {"text": "Strong Python programming skills demonstrated in projects."},
         ]
 
         score = checker.check(feedback, context_chunks)
 
         assert isinstance(score, float)
         assert 0.0 <= score <= 1.0
-        # Partial support should be middle range
-        assert 0.2 < score < 0.8
+        # One of four required terms matches.
+        assert score == pytest.approx(0.25)
 
     def test_empty_feedback_returns_zero(self, checker):
         """Test empty feedback returns 0.0."""
         feedback = ""
-        context_chunks = [
-            {"text": "Some context"}
-        ]
+        context_chunks = [{"text": "Some context"}]
 
         score = checker.check(feedback, context_chunks)
 
@@ -102,25 +94,25 @@ class TestFaithfulnessChecker:
 
         assert isinstance(score, float)
         assert 0.0 <= score <= 1.0
-        # All three claims supported
-        assert score > 0.5
+        assert score == pytest.approx(1.0)
 
     def test_extract_claims(self, checker):
         """Test claim extraction from feedback."""
         feedback = "The developer is skilled. They have experience. They work well."
         claims = checker._extract_claims(feedback)
 
-        assert isinstance(claims, list)
-        assert len(claims) > 0
-        assert all(isinstance(c, str) for c in claims)
+        assert claims == [
+            "The developer is skilled",
+            "They have experience",
+            "They work well",
+        ]
 
     def test_extract_claims_with_punctuation(self, checker):
         """Test claim extraction handles various punctuation."""
         feedback = "First claim! Second claim? Third claim. Fourth claim"
         claims = checker._extract_claims(feedback)
 
-        assert isinstance(claims, list)
-        # Should extract at least some claims
+        assert claims == ["First claim", "Second claim", "Third claim", "Fourth claim"]
 
     def test_is_supported_with_keyword_overlap(self, checker):
         """Test that claim is marked as supported with keyword overlap."""
@@ -155,15 +147,11 @@ class TestFaithfulnessChecker:
         """Test that score varies with input, never hardcoded 1.0 or 0.0."""
         # First test: fully supported
         score1 = checker.check(
-            "Python and JavaScript skills",
-            [{"text": "Expert in Python and JavaScript"}]
+            "Python and JavaScript skills", [{"text": "Expert in Python and JavaScript"}]
         )
 
         # Second test: no support
-        score2 = checker.check(
-            "Rust expertise",
-            [{"text": "Java programming background"}]
-        )
+        score2 = checker.check("Rust expertise", [{"text": "Java programming background"}])
 
         # Scores should be different
         assert score1 != score2
@@ -173,15 +161,12 @@ class TestFaithfulnessChecker:
     def test_multiple_claims_varying_support(self, checker):
         """Test scoring with multiple claims of varying support."""
         feedback = "Python expert. Knows Rust. Skilled with Docker."
-        context_chunks = [
-            {"text": "Python and Docker expertise shown in projects."}
-        ]
+        context_chunks = [{"text": "Python and Docker expertise shown in projects."}]
 
         score = checker.check(feedback, context_chunks)
 
-        # Two claims supported, one not
-        assert isinstance(score, float)
-        assert 0.2 < score < 0.8
+        # (1/2 + 0 + 1/3) / 3
+        assert score == pytest.approx(5 / 18)
 
     def test_supported_short_claims_score_fully(self, checker):
         """Reproduce issue #152 for two supported one-fact claims."""
@@ -192,12 +177,158 @@ class TestFaithfulnessChecker:
 
         assert score == pytest.approx(1.0)
 
+    def test_short_claim_requires_its_fact_in_context(self, checker):
+        """Keep the short-claim path from accepting unrelated evidence."""
+        score = checker.check("Knows Rust.", [{"text": "Python and SQL projects"}])
+
+        assert score == 0.0
+        assert checker.check("Knows Python.", [{"text": "non_python work"}]) == 0.0
+
+    def test_mixed_short_claims_keep_per_claim_proportions(self, checker):
+        """One grounded and one ungrounded short claim score one half."""
+        score = checker.check(
+            "Knows Python. Knows Rust.",
+            [{"text": "Python projects"}],
+        )
+
+        assert score == pytest.approx(0.5)
+
+    @pytest.mark.parametrize(
+        "feedback",
+        [
+            "Candidate knows Python.",
+            "He knows Python.",
+            "It shows Python.",
+            "The developer has Python.",
+        ],
+    )
+    def test_subject_led_short_claims_are_supported(self, checker, feedback):
+        """Strip a leading role or pronoun before a narrow reporting verb."""
+        assert checker.check(feedback, [{"text": "Python projects"}]) == 1.0
+
+    def test_bare_one_word_feedback_remains_unscoreable(self, checker):
+        """Do not turn arbitrary one-word fragments into supported claims."""
+        # Preserve main's neutral score when no claim is extracted.
+        assert checker.check("Python.", [{"text": "Python projects"}]) == 0.5
+        assert checker._is_supported("Python", "Python projects") is False
+        assert checker._is_supported("Candidate Python", "Python projects") is False
+        assert checker.check("The and that were to be.", [{"text": "anything"}]) == 0.0
+
+    def test_context_punctuation_does_not_block_short_claim_support(self, checker):
+        """Match a fact even when it ends the context sentence."""
+        assert checker.check("Knows SQL.", [{"text": "Uses Python and SQL."}]) == 1.0
+        assert (
+            checker.check(
+                "Knows Python. Knows SQL.",
+                [{"text": "Uses Python.Knows SQL"}],
+            )
+            == 1.0
+        )
+
+    @pytest.mark.parametrize(
+        "technology",
+        ["Python", "Node.js", "C++", "C#", ".NET", "I/O", "R&D", "Objective-C"],
+    )
+    def test_no_space_sentence_boundary_still_splits_claims(self, checker, technology):
+        """Split adjacent reporter-led sentences after technical identifiers."""
+        assert (
+            checker.check(
+                f"Knows {technology}.Knows SQL.",
+                [{"text": f"{technology} and SQL"}],
+            )
+            == 1.0
+        )
+
+    def test_claim_limit_preserves_existing_first_ten_contract(self, checker):
+        """Score only the first ten extracted claims, as on main."""
+        feedback = " ".join(f"Knows Skill{index}." for index in range(11))
+        context = " ".join(f"Skill{index}" for index in range(10))
+
+        assert checker.check(feedback, [{"text": context}]) == 1.0
+
+    def test_none_chunk_does_not_hide_valid_sibling_context(self, checker):
+        """Skip a malformed chunk while retaining valid evidence for #153."""
+        score = checker.check(
+            "Knows Python.",
+            [{"text": None}, {"text": "Python projects"}],
+        )
+
+        assert score == 1.0
+
+    @pytest.mark.parametrize(
+        ("claim", "context"),
+        [
+            ("Python expert", "Python novice"),
+            ("Uses Kubernetes", "Avoids Kubernetes"),
+        ],
+    )
+    def test_one_shared_fact_does_not_support_material_mismatch(self, checker, claim, context):
+        """Preserve the two-term overlap floor for ordinary claims."""
+        assert checker._is_supported(claim, context) is False
+
+    def test_common_technical_identifiers_remain_whole(self, checker):
+        """Tokenize common symbolic and compound technology names intact."""
+        assert checker._tokenize("C++ C# .NET Node.js Objective-C R&D I/O non_python") == [
+            "c++",
+            "c#",
+            ".net",
+            "node.js",
+            "objective-c",
+            "r&d",
+            "i/o",
+            "non_python",
+        ]
+        assert checker._extract_claims("Uses Node.js. Knows SQL.") == [
+            "Uses Node.js",
+            "Knows SQL",
+        ]
+        assert checker._is_supported("I/O systems", "O systems") is False
+
+    @pytest.mark.parametrize("identifier", ["System.Text.Json", "Microsoft.Azure", "System.Show"])
+    def test_pascal_case_dotted_identifiers_remain_whole(self, checker, identifier):
+        """Do not mistake a dotted identifier for adjacent sentences."""
+        assert checker._tokenize(identifier) == [identifier.casefold()]
+        assert checker._extract_claims(f"Knows {identifier}. Knows SQL.") == [
+            f"Knows {identifier}",
+            "Knows SQL",
+        ]
+        assert checker.check(f"Knows {identifier}.", [{"text": identifier}]) == 1.0
+
+    @pytest.mark.parametrize("apostrophe", ["'", "\u02bc", "\u2018", "\u2019", "\uff07"])
+    def test_apostrophe_fragments_do_not_satisfy_overlap_floor(self, checker, apostrophe):
+        """Keep a possessive suffix from becoming a second shared term."""
+        developer = f"developer{apostrophe}s"
+        candidate = f"candidate{apostrophe}s"
+
+        assert checker._tokenize(developer) == ["developer's"]
+        assert (
+            checker._is_supported(
+                f"The {developer} Rust work",
+                f"The {candidate} Rust hobby",
+            )
+            is False
+        )
+
+    @pytest.mark.parametrize("hyphen", ["\u2010", "\u2011"])
+    def test_compound_hyphen_fragments_do_not_satisfy_overlap_floor(self, checker, hyphen):
+        """Normalize in-word hyphens without creating a shared fragment."""
+        front_end = f"front{hyphen}end"
+        back_end = f"back{hyphen}end"
+
+        assert checker._tokenize(front_end) == ["front-end"]
+        assert (
+            checker._is_supported(
+                f"{front_end} Rust work",
+                f"{back_end} Rust hobby",
+            )
+            is False
+        )
+        assert checker.check(f"Knows {front_end}.", [{"text": "front-end"}]) == 1.0
+
     def test_very_long_feedback(self, checker):
         """Test handling of very long feedback text."""
         feedback = "The developer. " * 100
-        context_chunks = [
-            {"text": "Developer portfolio content"}
-        ]
+        context_chunks = [{"text": "Developer portfolio content"}]
 
         score = checker.check(feedback, context_chunks)
 
@@ -207,9 +338,7 @@ class TestFaithfulnessChecker:
     def test_very_long_context(self, checker):
         """Test handling of very long context."""
         feedback = "The developer has Python skills."
-        context_chunks = [
-            {"text": "Python " * 1000}
-        ]
+        context_chunks = [{"text": "Python " * 1000}]
 
         score = checker.check(feedback, context_chunks)
 
@@ -224,8 +353,19 @@ class TestFaithfulnessChecker:
 
         supported = checker._is_supported(claim, context)
 
-        # Despite word overlap, should look for meaningful overlap (not stop words)
-        # This depends on implementation
+        # Lexical overlap cannot detect the contradiction, but stop words do not decide it.
+        assert supported is True
+
+    def test_role_noun_is_preserved_without_a_reporting_verb(self, checker):
+        """Keep an ordinary role noun when it is part of the claim evidence."""
+        assert (
+            checker.check(
+                "The developer is skilled.",
+                [{"text": "developer skilled"}],
+            )
+            == 1.0
+        )
+        assert checker._is_supported("Their show has great production", "show production") is True
 
     def test_minimum_overlap_required(self, checker):
         """Test that minimum meaningful overlap is required for support."""
@@ -234,15 +374,15 @@ class TestFaithfulnessChecker:
 
         supported = checker._is_supported(claim, context)
 
-        assert isinstance(supported, bool)
-        # Need at least 2 meaningful tokens for support
+        assert supported is False
+        assert checker._is_supported("the and", "Python") is False
+        # Preserve the original stop-word table: "with" remains a content term.
+        assert checker._is_supported("Built with Python", "with Python") is True
 
     def test_none_context_chunk_text(self, checker):
         """Reproduce issue #153 at the checker boundary."""
         feedback = "Has Python skills"
-        context_chunks = [
-            {"text": None}
-        ]
+        context_chunks = [{"text": None}]
 
         score = checker.check(feedback, context_chunks)
 
@@ -251,15 +391,11 @@ class TestFaithfulnessChecker:
     def test_missing_text_key_in_chunk(self, checker):
         """Test handling of missing 'text' key in context chunk."""
         feedback = "Has Python skills"
-        context_chunks = [
-            {"content": "Python skills"}  # Wrong key
-        ]
+        context_chunks = [{"content": "Python skills"}]  # Wrong key
 
         score = checker.check(feedback, context_chunks)
 
-        # Should handle gracefully
-        assert isinstance(score, float)
-        assert 0.0 <= score <= 1.0
+        assert score == 0.0
 
     def test_score_consistency(self, checker):
         """Test that same input produces same score."""

--- a/tests/unit/test_faithfulness_checker.py
+++ b/tests/unit/test_faithfulness_checker.py
@@ -183,6 +183,15 @@ class TestFaithfulnessChecker:
         assert isinstance(score, float)
         assert 0.2 < score < 0.8
 
+    def test_supported_short_claims_score_fully(self, checker):
+        """Reproduce issue #152 for two supported one-fact claims."""
+        score = checker.check(
+            "Knows Python. Knows SQL.",
+            [{"text": "python expert"}, {"text": "sql expert"}],
+        )
+
+        assert score == pytest.approx(1.0)
+
     def test_very_long_feedback(self, checker):
         """Test handling of very long feedback text."""
         feedback = "The developer. " * 100
@@ -229,7 +238,7 @@ class TestFaithfulnessChecker:
         # Need at least 2 meaningful tokens for support
 
     def test_none_context_chunk_text(self, checker):
-        """Test handling of None in context chunk text."""
+        """Reproduce issue #153 at the checker boundary."""
         feedback = "Has Python skills"
         context_chunks = [
             {"text": None}
@@ -237,9 +246,7 @@ class TestFaithfulnessChecker:
 
         score = checker.check(feedback, context_chunks)
 
-        # Should handle gracefully
-        assert isinstance(score, float)
-        assert 0.0 <= score <= 1.0
+        assert score == 0.0
 
     def test_missing_text_key_in_chunk(self, checker):
         """Test handling of missing 'text' key in context chunk."""


### PR DESCRIPTION
## Summary

The faithfulness checker discarded short claims and required two matching terms for
every claim, so the issue's `Knows Python. Knows SQL.` example scored `0.0` even when
both facts were retrieved. This change adds a narrow reporter-led one-fact path,
preserves the ordinary two-term support rule, and safely skips malformed context text.

## Issue

Closes #152

Addresses the `FaithfulnessChecker.check()` boundary described in #153.

## Changes

- Extract a short one-fact claim only after removing a leading reporting verb,
  optionally preceded by a role or pronoun; bare one-word feedback remains
  unscoreable.
- Preserve role nouns outside that reporter position and retain the original
  two-matching-term support threshold for ordinary claims.
- Return full credit when the applicable threshold is met and proportional lexical
  credit below it for multi-term claims. Ordinary one-term fragments remain
  unscoreable.
- Tokenize feedback and context consistently while preserving `C++`, `C#`, `.NET`,
  `Node.js`, `Objective-C`, `R&D`, and `I/O`, and normalizing common apostrophe and
  in-word hyphen variants.
- Preserve the first-ten-claims limit and handle reporter-led adjacent sentences
  without breaking the covered dotted identifiers.
- Skip missing, `None`, and non-string chunk text while continuing to use valid
  sibling chunks.
- Add focused regressions for the issue examples, false-positive controls, partial
  support, punctuation, claim limits, and technical identifiers.
- Update four previously failing faithfulness assertions and replace related loose
  ranges with exact expected scores. The touched test file is also Black-formatted,
  which accounts for its whitespace-only hunks.
- Add the course-required `PLAN.md` and `JOURNAL.md` submission records at the
  repository root.

## Testing

- [x] Unit tests pass under the documented baseline policy: the branch reports
  `412 passed / 49 failed`, compared with `375 passed / 53 failed` on a fresh
  same-environment `main` worktree. The four faithfulness failures on `main` pass here,
  and the remaining 49 failure node IDs are identical.
- [ ] Integration tests pass: neither revision collects integration tests, so both
  exit 5.
- [x] Linter passes under the baseline policy: both changed Python files pass Ruff;
  repository-wide Ruff reports 180 existing errors versus 182 on `main`.
- [x] Type checker passes under the baseline policy: the checker passes strict mypy;
  repository-wide mypy reports the same 103 errors in 26 files on both revisions.
- [x] New/updated tests cover the changes: 55 focused cases pass with warnings treated
  as errors, with 100% checker coverage (86/86 statements and 28/28 branches).

Additional checks:

- Both changed Python files pass Black `--check`; repository-wide Black reports 50
  files requiring formatting versus 52 on `main`.
- `git diff --check` passes.
- The exact #152 reproduction scores `1.0`, while an unrelated short claim scores
  `0.0`.

## Screenshots / Demo

Not applicable; this is backend scoring logic with no visual change.

## Notes for Reviewers

The full repository is not all green. The comparisons above follow the documented
pre-existing-failure process and show that this change introduces no branch-only
failure.

This checker remains a deterministic lexical heuristic, not semantic entailment. A
fact mentioned inside negated context can still match, and the checker does not
establish which entity a sentence describes.

Partially grounded claims now receive proportional credit instead of `0.0`, so a
downstream threshold on this score can observe higher values.

A dotted identifier whose final component is a covered reporting verb followed by a
space, such as `MessageBox.Show and ...`, is read as a sentence boundary because it
is lexically indistinguishable from `Python.Knows SQL`.

`RelevanceScorer.score()` still rejects the malformed chunk before
`FaithfulnessChecker.check()` runs inside `EvalSuite.run()`. This PR therefore
addresses #153 only at the checker boundary and does not close the suite-level issue.
