### PR TITLE
fix: structural chunker keeps heading-less documents

### DIFF
--- a/ingestion/chunking/structural_chunker.py
+++ b/ingestion/chunking/structural_chunker.py
@@ -39,6 +39,10 @@ class StructuralChunker(BaseChunker):
         sections = self._extract_sections(text)
 
         chunks = []
+        if not sections:
+            # No headings: fall back to a single section so the document is
+            # indexed instead of silently dropped. Preserve hierarchy as empty.
+            sections = [{"content": text.strip(), "path": [], "level": 0}]
         for section in sections:
             heading_path = " > ".join(section["path"])
             section_text = section["content"]


### PR DESCRIPTION
## Summary
Fixes #149: documents without markdown headings produced zero chunks and were excluded from the RAG index.

- Fall back to a single root section when no headings are found
- Preserves existing heading-path behavior for real headings

## Test plan
- [x] `chunk(\"plain text ...\", {})` returns ≥1 chunk
