### PR TITLE
fix: health check uses SQLAlchemy text() and settings.redis_url

### DIFF
--- a/api/routes/health.py
+++ b/api/routes/health.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, HTTPException, status, Depends
 import structlog
 from datetime import datetime, timedelta
+from sqlalchemy import text
 
 from core.database import get_db
 
@@ -28,7 +29,7 @@ async def health_check(db=Depends(get_db)):
 
     try:
         # Check PostgreSQL
-        await db.execute("SELECT 1")
+        await db.execute(text("SELECT 1"))
         health_status["dependencies"]["postgres"] = "healthy"
         log.debug("postgres_health_check_passed")
     except Exception as exc:
@@ -41,10 +42,8 @@ async def health_check(db=Depends(get_db)):
         import redis
         from core.config import settings
 
-        r = redis.Redis(
-            host=settings.redis_host,
-            port=settings.redis_port,
-            db=0,
+        r = redis.Redis.from_url(
+            settings.redis_url,
             decode_responses=True,
         )
         r.ping()


### PR DESCRIPTION
## Summary
Fixes #154 and #155 in the health route.

- DB probe now uses `sqlalchemy.text(\"SELECT 1\")` for SQLAlchemy 2.x
- Redis probe reads `settings.redis_url` (`redis://host:port/db`) instead of the non-existent `settings.redis_host` / `redis_port`

## Test plan
- [x] `py_compile api/routes/health.py`
- [ ] `GET /health` with a live stack returns postgres/redis healthy
