### PR TITLE
Fixed section detection for text with leading whitespace

### DIFF
--- a/ingestion/parsers/resume_parser.py
+++ b/ingestion/parsers/resume_parser.py
@@ -130,12 +130,12 @@ class ResumeParser(BaseParser):
         text_lower = text.lower()
 
         for section in SECTION_HEADERS:
-            # Look for section header patterns
+            '''
+             Allow optional leading spaces/tabs before the header, since, text extracted from PDFs commonly preserves indentation.
+            '''
             patterns = [
-                rf"^{re.escape(section)}\s*$",
-                rf"^{re.escape(section)}\s*[:|-]",
-                rf"\n{re.escape(section)}\s*$",
-                rf"\n{re.escape(section)}\s*[:|-]",
+                rf"^[ \t]*{re.escape(section)}\s*$",
+                rf"^[ \t]*{re.escape(section)}\s*[:|-]",
             ]
 
             for pattern in patterns:

--- a/ingestion/parsers/resume_parser.py
+++ b/ingestion/parsers/resume_parser.py
@@ -125,14 +125,13 @@ class ResumeParser(BaseParser):
         return text.strip()
 
     def _detect_sections(self, text: str) -> list[str]:
-        """Detect common resume sections from text."""
+        """Detect common resume sections from text, tolerating leading indentation."""
         detected = []
         text_lower = text.lower()
 
         for section in SECTION_HEADERS:
-            '''
-             Allow optional leading spaces/tabs before the header, since, text extracted from PDFs commonly preserves indentation.
-            '''
+            # PDF text extraction often keeps leading indentation, so allow
+            # optional spaces before the header
             patterns = [
                 rf"^[ \t]*{re.escape(section)}\s*$",
                 rf"^[ \t]*{re.escape(section)}\s*[:|-]",

--- a/tests/unit/test_resume_parser.py
+++ b/tests/unit/test_resume_parser.py
@@ -143,6 +143,64 @@ class TestResumeParser:
         assert any("education" in s for s in sections_lower)
         assert any("skills" in s for s in sections_lower)
 
+    def test_detect_sections_with_leading_whitespace(self, parser):
+        """Test that indented section headers (e.g. from PDF extraction) are detected."""
+        text = """
+        Education:
+        - B.S. Computer Science
+
+        Skills: Python
+        """
+        sections = parser._detect_sections(text)
+
+        sections_lower = [s.lower() for s in sections]
+        assert any("education" in s for s in sections_lower)
+        assert any("skills" in s for s in sections_lower)
+
+    def test_detect_sections_with_leading_whitespace_no_punctuation(self, parser):
+        """Test that an indented header with no trailing punctuation is still detected."""
+        text = """
+        Summary
+        Experienced backend engineer.
+
+        Skills: Python
+        """
+        sections = parser._detect_sections(text)
+
+        sections_lower = [s.lower() for s in sections]
+        assert any("summary" in s for s in sections_lower)
+
+    def test_detect_sections_with_tab_indentation(self, parser):
+        """Test that tab-indented section headers are detected."""
+        text = "\tEducation:\n\tBS Computer Science\n\n\tSkills: Python"
+        sections = parser._detect_sections(text)
+
+        sections_lower = [s.lower() for s in sections]
+        assert any("education" in s for s in sections_lower)
+        assert any("skills" in s for s in sections_lower)
+
+    def test_detect_sections_ignores_keyword_mid_sentence(self, parser):
+        """Test that a section keyword used mid-sentence isn't flagged as a header."""
+        text = """
+        I have five years of experience building web applications.
+
+        Skills: Python
+        """
+        sections = parser._detect_sections(text)
+
+        sections_lower = [s.lower() for s in sections]
+        assert not any(s.lower() == "experience" for s in sections_lower)
+        assert any("skills" in s for s in sections_lower)
+
+    def test_detect_sections_without_leading_whitespace_still_works(self, parser):
+        """Test that non-indented section headers (the original working case) are unaffected."""
+        text = "Education:\nBS Computer Science\n\nSkills: Python"
+        sections = parser._detect_sections(text)
+
+        sections_lower = [s.lower() for s in sections]
+        assert any("education" in s for s in sections_lower)
+        assert any("skills" in s for s in sections_lower)
+
     def test_strip_markdown_syntax(self, parser):
         """Test markdown syntax stripping."""
         markdown_text = """


### PR DESCRIPTION
## Summary
Fixes section detection in `_detect_sections()` so it correctly matches section headers (Experience, Education, Skills, etc.) in text with leading whitespace/indentation, which is common in text extracted from PDFs.

## Issue
Closes 147

## Changes

- Added `[ \t]*` to the anchor patterns in `_detect_sections()` so leading spaces/tabs before a section header no longer block detection
- Removed the two redundant `\n`-anchored patterns, since `^` under `re.MULTILINE` already covers line starts
- Updated the method's docstring to note the whitespace tolerance
- Added 5 new unit tests: indented header with punctuation, indented header without punctuation, tab indentation, mid-sentence keyword false-positive check, non-indented regression guard


## Testing

Manual verification — run this in a Python shell from the repo root:
```python
from ingestion.parsers.resume_parser import ResumeParser
r = ResumeParser()
res = r.parse('\n    John Smith\n    john@example.com\n\n    Education:\n    - B.S. Computer Science\n\n    Skills: Python\n')
print(res.metadata['detected_sections'])
# Before this fix: []
# After this fix: ['Education', 'Skills']
```

- [x] Unit tests pass (`make test-unit`) — all 8 tests covering `_detect_sections()` pass (3 originally-failing tests from the issue + 5 new edge-case tests)
- [ ] Integration tests pass (`make test-integration`) — not run; this change doesn't touch integration-tested paths
- [x] Linter passes (`make lint`) on the changed files — `resume_parser.py` has 3 pre-existing style issues (import spacing, missing `raise ... from e`, no trailing newline) predating this change; this PR introduces no new lint failures
- [x] Type checker passes (`make typecheck`) on the changed files — `mypy` on `resume_parser.py` specifically is clean; repo-wide `make typecheck` fails on unrelated pre-existing issues elsewhere
- [x] New/updated tests cover the changes


## Notes for Reviewers

Verified against the issue's repro case and the three previously failing tests: `test_parse_single_column_resume_text`, `test_parse_resume_no_work_experience`, `test_detect_sections`. Added 5 more edge-case tests (indented headers with/without punctuation, tabs, mid-sentence false-positive check, non-indented regression guard) - all 8 pass.

Scoped to `_detect_sections()` only; other methods untouched. Whitespace tolerance covers spaces/tabs, not other whitespace chars (e.g. non-breaking spaces) — not seen in current fixtures, so kept scoped to the common case.

Two pre-existing issues found while testing, unrelated to this change: `test_parse_markdown_resume` and `test_strip_markdown_syntax` fail on `main` independently (same bug class, different method — `_strip_markdown()`, out of scope for #147); `ruff` also flags 3 pre-existing style issues in `resume_parser.py` (import spacing, missing `raise ... from e`, no trailing newline), left untouched to keep this diff scoped.