### PR TITLE
feat: add has_tests boolean to repo analysis output (#50)

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,21 @@
+# Module 3 Journal
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/50
+
+**Issue title:** Add a `has_tests` boolean to the repo analysis output
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The analysis output for a repo currently has no signal for whether it has tests. This logic lives in `agent/tools/github_tool.py`, in the `GitHubTool` class, which already fetches things like star count, language, and `has_readme` from the GitHub API. The pattern to follow already exists: there's a `_has_readme()` method that checks a repo via a GitHub API call, and `has_tests` would work the same way — checking for a `tests/`/`test/` folder, a `pytest.ini` file, or files matching `test_*.py`. This matters because the issue explicitly calls test coverage "a strong portfolio signal," so this feature makes the tool smarter about what makes a repo look good. Success looks like a new `has_tests` boolean appearing in the repo metadata dict alongside `has_readme` and `star_count`, backed by a test I write myself, since no test file exists yet for `github_tool.py`.
+
+**Selection notes (is this issue right for me?):**
+This task aligns well with my experience working on Python projects and navigating existing codebases. I've worked with repository structures and testing frameworks like pytest, and I'm confident I can contribute by implementing reliable test detection logic and integrating it cleanly into the analysis output.
+
+**Branch name:** feat/50-has-tests-detection
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -19,3 +19,17 @@ This task aligns well with my experience working on Python projects and navigati
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [ ] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/Itsurguy2/pathreview/commit/98887e14dd3ee6ac5c5f41359c88305333593d1c
+
+**Reproduction summary:**
+Wrote a test in `tests/unit/test_github_tool.py` asserting that `GitHubTool.execute()` returns `has_tests: True` for a repo containing a `tests/` directory. Ran it locally and confirmed it fails today with `AssertionError: assert None is True`, since no `has_tests` key exists in the output at all.
+
+**PLAN.md link:** https://github.com/Itsurguy2/pathreview/blob/feat/50-has-tests-detection/PLAN.md
+
+**Walkthrough video (recommended):** [not recorded]
+
+**Blockers or open questions:**
+Still deciding between the GitHub Contents API vs. the recursive Git Trees API for finding test files anywhere in the repo (not just the root directory) — leaning toward the Trees API but need to check how it behaves on very large repos (truncation) before committing to it in Week 9.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -65,3 +65,41 @@ Added a `has_tests` boolean to the repo analysis output. `GitHubTool` now checks
 *(Both checked per the pre-existing-failures rule documented in the PR: `agent/tools/github_tool.py` and `tests/unit/test_github_tool.py` individually pass ruff/black/mypy with zero errors, and `tests/unit` went from 54 pre-existing failures to 53 — this change introduces no new failures anywhere in the suite. The repo-wide `make check`/`make test-unit` commands still fail overall due to unrelated pre-existing issues across ~26 other files, documented in the PR's "Notes for Reviewers.")*
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [x] Yes  [ ] No — still awaiting review
+
+**Summary of feedback:**
+Reviewer feedback covered three points on the `_has_tests()` implementation and its tests:
+1. Praised the pattern-matching against the existing `_has_readme()` method and the choice of a single recursive Git Trees API call over per-path requests.
+2. Praised the 6-case test suite's coverage, but suggested making each test's mock data more minimal and explicitly tied to the signal under test.
+3. Flagged that the truncation limitation noted in my Week 8/9 journal entries (`"truncated": true` on very large repos) had no corresponding test — pointed out that a test documenting a known limitation is valuable because it turns an assumption into executable documentation.
+The review also suggested logging a warning inside the `except Exception: return False` block for better debuggability, while explicitly noting the existing bare-except pattern was "the right call for consistency" with `_has_readme()`.
+
+**How you responded:**
+Posted a written reply on the PR (commit `7c89497`, [PR comment](https://github.com/ascherj/pathreview/pull/221#issuecomment-5235871091)) addressing all three points individually:
+- **Implemented** the suggested truncation test — `test_has_tests_does_not_special_case_truncated_response` — which pins down the current (imperfect but intentional) behavior as documented scope rather than a silent gap.
+- **Acknowledged but did not change** the logging suggestion, since the reviewer's own note validated the existing pattern's consistency with `_has_readme()` in the same file — noted as a takeaway for future projects instead.
+- **Acknowledged but did not change** the mock-clarity suggestion, reasoning that each test's fixture is already small (1-3 entries), so the signal-to-test mapping stays readable without further isolation — framed as feedback for larger fixture sets in future work, not a flaw in this PR.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+[fill in]
+
+**What did you learn about working in a large codebase?**
+[fill in]
+
+**How did AI tools help — and where did they fall short?**
+[fill in]
+
+**What would you do differently if you started over?**
+[fill in]
+
+**What are you most proud of from this module?**
+[fill in]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -46,3 +46,22 @@ Open the PR (as a draft first) and get peer/mentor feedback in Slack before mark
 
 **Blockers:**
 None. The truncation question from Week 8 is still open as a known limitation, not a blocker — noted in the PR description for reviewers.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/221
+
+**Branch:** `feat/50-has-tests-detection`
+
+**What you built:**
+Added a `has_tests` boolean to the repo analysis output. `GitHubTool` now checks — via a single recursive call to GitHub's Git Trees API — whether a repo contains a `tests/`/`test/` directory, a `pytest.ini` file, or any `test_*.py` file anywhere in the tree, and surfaces the result alongside the existing `has_readme` and `star_count` fields.
+
+**Tests added or updated:**
+`tests/unit/test_github_tool.py` — grew from the single Week 8 reproduction test to 6 cases: a `tests/` directory, a nested `test/` directory, a `pytest.ini` file, a loose `test_*.py` file, the negative case (no signals present), and graceful degradation to `False` when the GitHub API call fails.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+*(Both checked per the pre-existing-failures rule documented in the PR: `agent/tools/github_tool.py` and `tests/unit/test_github_tool.py` individually pass ruff/black/mypy with zero errors, and `tests/unit` went from 54 pre-existing failures to 53 — this change introduces no new failures anywhere in the suite. The repo-wide `make check`/`make test-unit` commands still fail overall due to unrelated pre-existing issues across ~26 other files, documented in the PR's "Notes for Reviewers.")*
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -33,3 +33,16 @@ Wrote a test in `tests/unit/test_github_tool.py` asserting that `GitHubTool.exec
 
 **Blockers or open questions:**
 Still deciding between the GitHub Contents API vs. the recursive Git Trees API for finding test files anywhere in the repo (not just the root directory) — leaning toward the Trees API but need to check how it behaves on very large repos (truncation) before committing to it in Week 9.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+All 5 sub-tasks from `PLAN.md` are done. Went with the recursive Git Trees API (`GET /repos/{u}/{r}/git/trees/{default_branch}?recursive=1`) — one call gets the whole file tree instead of walking directories one at a time. Added `_has_tests()` to `GitHubTool`, mirroring `_has_readme()`'s structure, and wired the result into `_fetch_repo_metadata()`'s output. Expanded `tests/unit/test_github_tool.py` from the single Week 8 reproduction test to 6 cases: `tests/` dir, a nested `test/` dir, `pytest.ini`, a loose `test_*.py` file, the negative case, and graceful handling when the tree API call fails. Ran the full `tests/unit` suite before and after: 54 pre-existing failures before (unrelated files — PII scrubber, resume parser, tech detector, etc.), 53 after — the drop is our own test flipping from failing to passing, and no new failures anywhere else. Confirmed `agent/tools/github_tool.py` and `tests/unit/test_github_tool.py` individually pass ruff, black, and mypy with zero errors.
+
+**Next steps:**
+Open the PR (as a draft first) and get peer/mentor feedback in Slack before marking it ready for review.
+
+**Blockers:**
+None. The truncation question from Week 8 is still open as a known limitation, not a blocker — noted in the PR description for reviewers.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -90,16 +90,16 @@ Posted a written reply on the PR (commit `7c89497`, [PR comment](https://github.
 ### Reflection
 
 **What was harder than you expected?**
-[fill in]
+What was hardest was choosing what to work on, because I wanted to pick something that would be good to show as a skill to future clients or employers — that made the decision feel high-stakes. The process of figuring out how to approach a situation, and building the confidence to do it, was also difficult. Another thing that's often hard for me is understanding exactly what a question or task is asking — I frequently have to read it multiple times and research specific parts of it before I feel like I actually understand what's being asked.
 
 **What did you learn about working in a large codebase?**
-[fill in]
+I learned that many things can go wrong in a large codebase. I also learned that although something might seem hard at first, it becomes simple once you break it down and understand each piece individually.
 
 **How did AI tools help — and where did they fall short?**
-[fill in]
+AI helped me better understand the situation and how to approach it. AI taught me how to think about solving problems and find patterns. Where it fell short: AI would sometimes do things without explanation, which caused small errors — nothing extreme, but it meant I had to slow down and ask for clarification rather than assume everything was correct.
 
 **What would you do differently if you started over?**
-[fill in]
+I would give myself more time to understand things before diving in, and I would plan more thoroughly up front.
 
 **What are you most proud of from this module?**
-[fill in]
+I am proud of being a part of CodePath and having instructors and staff who helped me finish the course. I am proud to have had the privilege to learn a skill — in many countries, children can't learn a skill because of the conditions they live in. I hope I can help as many people as I can, because life is short. I hope I can be an asset to humanity in a way that creates new possibilities people thought weren't possible.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,35 @@
+## Solution plan
+
+**Issue:** Add a `has_tests` boolean to the repo analysis output ([#50](https://github.com/ascherj/pathreview/issues/50))
+
+### Understand
+The repo analysis output (`GitHubTool.execute()` in `agent/tools/github_tool.py`) has no signal for whether a repository contains tests. Expected behavior: the output metadata dict should include a `has_tests: bool` field, `True` if the repo contains a `tests/` or `test/` directory, a `pytest.ini` file, or files matching `test_*.py` anywhere in the tree. Actual behavior, confirmed locally: the field doesn't exist at all. I wrote a reproduction test (`tests/unit/test_github_tool.py`, commit `98887e14dd3ee6ac5c5f41359c88305333593d1c`) that asserts `result.data.get("has_tests") is True` for a repo with a `tests/` dir — it fails today with `AssertionError: assert None is True`, since no `_has_tests()` method exists, unlike the sibling `_has_readme()` method that already handles a similar existence check.
+
+### Map
+- `agent/tools/github_tool.py` — add a new `_has_tests()` method to `GitHubTool`, and call it from `_fetch_repo_metadata()` alongside the existing `_has_readme()` call
+- `tests/unit/test_github_tool.py` — extend beyond the single reproduction test with cases for each detection signal (tests/ dir, pytest.ini, test_*.py) and the negative case
+- No changes expected in `agent/orchestrator.py` — `has_tests` will just pass through the existing `tool_results` dict unchanged; only touch if implementation reveals otherwise
+
+### Plan
+1. Decide the GitHub API call for detecting test presence. `_has_readme()` uses a single `HEAD /repos/{u}/{r}/readme` request, but tests can live anywhere in the tree, so a single-directory Contents API call (`GET /repos/{u}/{r}/contents/`) won't catch nested `test_*.py` files. Likely need the Git Trees API (`GET /repos/{u}/{r}/git/trees/{default_branch}?recursive=1`) to get the full file list in one call.
+2. Implement `_has_tests(username, repo_name)` on `GitHubTool`, mirroring `_has_readme()`'s structure and error handling (return `False` on any request failure rather than raising).
+3. Wire the new field into `_fetch_repo_metadata()`'s returned `metadata` dict, next to `has_readme`.
+4. Extend `tests/unit/test_github_tool.py` with cases: `tests/` directory present, `test_*.py` files present with no `tests/` dir, neither present (expect `False`), and an API-error case.
+5. Run the full test file and confirm the Week 8 reproduction test now passes.
+
+### Inputs & outputs
+- **Input:** unchanged — `{"github_username": str, "repo_name": str}`
+- **Output:** the existing metadata dict, now including `"has_tests": bool`
+
+### Risks & unknowns
+- Need the repo's default branch name before calling the recursive tree API — the existing repo metadata response already includes `default_branch`, so I'll need to capture that value in `_fetch_repo_metadata()` rather than adding a separate lookup call.
+- The recursive tree API can be truncated for very large repos (response includes `"truncated": true`) — undecided whether to handle this explicitly or accept it as a known limitation for v1.
+- Unauthenticated GitHub API requests are capped at 60/hour; this adds a second call on top of the existing metadata + readme calls, so rate limiting is more likely to bite during grading/demo.
+- Issue text doesn't specify whether nested test directories (e.g. `backend/tests/`) should count, or only top-level — assuming yes (any depth) since that matches how the recursive tree API naturally works, but calling this out as an assumption.
+
+### Edge cases
+- Repo has no tests anywhere → `has_tests: False`
+- Repo API call fails or 404s → should degrade gracefully to `False`, same as `_has_readme()` does today, not raise
+- Empty repository (no commits yet) → the tree API can return a 409 Conflict; needs a fallback to `False`
+- Case sensitivity of directory/file names (`Tests/` vs `tests/`)
+- Private repo accessed without an API token → same 403/404 handling already present in `execute()`'s exception handling should cover this, but worth a explicit test case

--- a/agent/tools/github_tool.py
+++ b/agent/tools/github_tool.py
@@ -2,6 +2,7 @@
 
 import httpx
 import structlog
+
 from .base import BaseTool, ToolResult
 
 logger = structlog.get_logger()
@@ -35,44 +36,30 @@ class GitHubTool(BaseTool):
         repo_name = input_data.get("repo_name")
 
         if not username or not repo_name:
-            return ToolResult(
-                success=False,
-                data={},
-                error="Missing github_username or repo_name"
-            )
+            return ToolResult(success=False, data={}, error="Missing github_username or repo_name")
 
         try:
             repo_data = self._fetch_repo_metadata(username, repo_name)
             return ToolResult(success=True, data=repo_data)
 
         except httpx.HTTPStatusError as e:
-            logger.error("github_request_failed", status=e.response.status_code,
-                        username=username, repo=repo_name)
+            logger.error(
+                "github_request_failed",
+                status=e.response.status_code,
+                username=username,
+                repo=repo_name,
+            )
             if e.response.status_code == 404:
-                return ToolResult(
-                    success=False,
-                    data={},
-                    error="Repository not found"
-                )
+                return ToolResult(success=False, data={}, error="Repository not found")
             elif e.response.status_code == 403:
-                return ToolResult(
-                    success=False,
-                    data={},
-                    error="Rate limited or access denied"
-                )
+                return ToolResult(success=False, data={}, error="Rate limited or access denied")
             return ToolResult(
-                success=False,
-                data={},
-                error=f"GitHub API error: {e.response.status_code}"
+                success=False, data={}, error=f"GitHub API error: {e.response.status_code}"
             )
 
         except Exception as e:
             logger.error("github_tool_error", error=str(e))
-            return ToolResult(
-                success=False,
-                data={},
-                error=str(e)
-            )
+            return ToolResult(success=False, data={}, error=str(e))
 
     def _fetch_repo_metadata(self, username: str, repo_name: str) -> dict:
         """Fetch repository metadata from GitHub API.
@@ -109,8 +96,13 @@ class GitHubTool(BaseTool):
             "homepage": repo_json.get("homepage") or "",
         }
 
-        logger.info("github_repo_fetched", username=username, repo=repo_name,
-                   language=metadata["primary_language"], stars=metadata["star_count"])
+        logger.info(
+            "github_repo_fetched",
+            username=username,
+            repo=repo_name,
+            language=metadata["primary_language"],
+            stars=metadata["star_count"],
+        )
 
         return metadata
 
@@ -132,6 +124,6 @@ class GitHubTool(BaseTool):
 
         try:
             response = httpx.head(url, headers=headers, timeout=5.0)
-            return response.status_code == 200
+            return bool(response.status_code == 200)
         except Exception:
             return False

--- a/agent/tools/github_tool.py
+++ b/agent/tools/github_tool.py
@@ -92,6 +92,9 @@ class GitHubTool(BaseTool):
             "open_issues_count": repo_json.get("open_issues_count", 0),
             "last_commit_date": repo_json.get("pushed_at", ""),
             "has_readme": self._has_readme(username, repo_name),
+            "has_tests": self._has_tests(
+                username, repo_name, repo_json.get("default_branch") or "main"
+            ),
             "topics": repo_json.get("topics", []),
             "homepage": repo_json.get("homepage") or "",
         }
@@ -125,5 +128,46 @@ class GitHubTool(BaseTool):
         try:
             response = httpx.head(url, headers=headers, timeout=5.0)
             return bool(response.status_code == 200)
+        except Exception:
+            return False
+
+    def _has_tests(self, username: str, repo_name: str, default_branch: str) -> bool:
+        """Check if repository contains tests.
+
+        Looks for a tests/ or test/ directory, a pytest.ini file, or any
+        test_*.py file anywhere in the repo, via a single recursive tree
+        listing rather than one request per candidate path.
+
+        Args:
+            username: GitHub username
+            repo_name: Repository name
+            default_branch: Branch to list the tree from
+
+        Returns:
+            True if any test signal is found
+        """
+        url = f"{self.base_url}/repos/{username}/{repo_name}/git/trees/{default_branch}"
+
+        headers = {}
+        if self.api_token:
+            headers["Authorization"] = f"token {self.api_token}"
+
+        try:
+            response = httpx.get(url, headers=headers, params={"recursive": "1"}, timeout=10.0)
+            response.raise_for_status()
+            tree = response.json().get("tree", [])
+
+            for entry in tree:
+                path = entry.get("path", "")
+                basename = path.rsplit("/", 1)[-1]
+
+                if entry.get("type") == "tree" and basename in ("tests", "test"):
+                    return True
+                if basename == "pytest.ini":
+                    return True
+                if basename.startswith("test_") and basename.endswith(".py"):
+                    return True
+
+            return False
         except Exception:
             return False

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
           memory: 256M
 
   vector-db:
-    image: chromadb/chroma:0.4.22
+    image: chromadb/chroma@sha256:1e0b73a187a28757c572acba508c46f48c9e8b0acaf5c20e6d95cdedce1acdf6
     ports:
       - "8001:8000"
     volumes:
@@ -44,7 +44,7 @@ services:
     environment:
       ANONYMIZED_TELEMETRY: "false"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/api/v1/heartbeat"]
+      test: ["CMD", "curl", "-f", "http://localhost:8000/api/v2/heartbeat"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -99,7 +99,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -449,7 +448,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -473,7 +471,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1561,7 +1558,6 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1579,7 +1575,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1972,7 +1967,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3507,7 +3501,6 @@
       "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^2.0.1",
         "cssstyle": "^4.0.1",
@@ -4094,7 +4087,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4107,7 +4099,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4771,7 +4762,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/tests/unit/test_github_tool.py
+++ b/tests/unit/test_github_tool.py
@@ -1,0 +1,50 @@
+"""Tests for github_tool.py"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from agent.tools.github_tool import GitHubTool
+
+
+@pytest.mark.unit
+class TestGitHubToolHasTests:
+    """Reproduction for issue #50: repo analysis output has no has_tests signal."""
+
+    @pytest.fixture
+    def tool(self) -> GitHubTool:
+        return GitHubTool()
+
+    def test_repo_metadata_includes_has_tests_field(
+        self, tool: GitHubTool, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A repo whose file tree contains a tests/ directory should be flagged.
+
+        Issue #50 repro: GitHubTool.execute() currently has no has_tests key
+        in its output at all, so this assertion fails today with
+        AssertionError: None != True. There is no _has_tests() method on
+        GitHubTool, unlike the existing _has_readme() method it should mirror.
+        """
+        mock_repo_response = MagicMock()
+        mock_repo_response.raise_for_status.return_value = None
+        mock_repo_response.json.return_value = {
+            "name": "sample-repo",
+            "description": "A sample repo",
+            "language": "Python",
+            "stargazers_count": 5,
+            "forks_count": 1,
+            "open_issues_count": 0,
+            "pushed_at": "2026-01-01T00:00:00Z",
+            "topics": [],
+            "homepage": "",
+        }
+
+        mock_head_response = MagicMock(status_code=200)
+
+        monkeypatch.setattr("httpx.get", lambda *a, **k: mock_repo_response)
+        monkeypatch.setattr("httpx.head", lambda *a, **k: mock_head_response)
+
+        result = tool.execute({"github_username": "octocat", "repo_name": "sample-repo"})
+
+        assert result.success is True
+        assert result.data.get("has_tests") is True

--- a/tests/unit/test_github_tool.py
+++ b/tests/unit/test_github_tool.py
@@ -23,7 +23,9 @@ REPO_JSON = {
 
 
 def _make_get_mock(
-    tree_entries: list[dict] | None = None, tree_raises: bool = False
+    tree_entries: list[dict] | None = None,
+    tree_raises: bool = False,
+    truncated: bool = False,
 ) -> Callable[..., MagicMock]:
     """Fake httpx.get that returns repo metadata or a tree listing
     depending on the requested URL, matching GitHubTool's real call shape.
@@ -35,7 +37,10 @@ def _make_get_mock(
                 raise Exception("boom")
             response = MagicMock()
             response.raise_for_status.return_value = None
-            response.json.return_value = {"tree": tree_entries or []}
+            response.json.return_value = {
+                "tree": tree_entries or [],
+                "truncated": truncated,
+            }
             return response
 
         response = MagicMock()
@@ -60,8 +65,9 @@ class TestGitHubToolHasTests:
         monkeypatch: pytest.MonkeyPatch,
         tree_entries: list[dict] | None = None,
         tree_raises: bool = False,
+        truncated: bool = False,
     ) -> ToolResult:
-        monkeypatch.setattr("httpx.get", _make_get_mock(tree_entries, tree_raises))
+        monkeypatch.setattr("httpx.get", _make_get_mock(tree_entries, tree_raises, truncated))
         monkeypatch.setattr("httpx.head", lambda *a, **k: MagicMock(status_code=200))
         return tool.execute({"github_username": "octocat", "repo_name": "sample-repo"})
 
@@ -121,5 +127,27 @@ class TestGitHubToolHasTests:
     ) -> None:
         """If the tree API call fails, degrade to False rather than raising."""
         result = self._run(tool, monkeypatch, tree_raises=True)
+        assert result.success is True
+        assert result.data["has_tests"] is False
+
+    def test_has_tests_does_not_special_case_truncated_response(
+        self, tool: GitHubTool, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Known limitation, documented per code review on PR #221: GitHub
+        sets `"truncated": true` on the tree response for very large repos,
+        meaning some paths may be missing. _has_tests() does not currently
+        read that flag -- it just evaluates whatever entries it received. If
+        the actual tests/ directory happens to fall outside the truncated
+        portion, this produces a false negative rather than an error. This
+        test pins down that current behavior so a future change to it is a
+        deliberate decision, not an accidental one.
+        """
+        entries = [
+            {"path": "main.py", "type": "blob"},
+            {"path": "README.md", "type": "blob"},
+            # tests/ exists in the real repo but falls past the truncation
+            # point, so it never appears in this (truncated) tree listing.
+        ]
+        result = self._run(tool, monkeypatch, tree_entries=entries, truncated=True)
         assert result.success is True
         assert result.data["has_tests"] is False

--- a/tests/unit/test_github_tool.py
+++ b/tests/unit/test_github_tool.py
@@ -1,50 +1,125 @@
 """Tests for github_tool.py"""
 
+from collections.abc import Callable
 from unittest.mock import MagicMock
 
 import pytest
 
+from agent.tools.base import ToolResult
 from agent.tools.github_tool import GitHubTool
+
+REPO_JSON = {
+    "name": "sample-repo",
+    "description": "A sample repo",
+    "language": "Python",
+    "stargazers_count": 5,
+    "forks_count": 1,
+    "open_issues_count": 0,
+    "pushed_at": "2026-01-01T00:00:00Z",
+    "topics": [],
+    "homepage": "",
+    "default_branch": "main",
+}
+
+
+def _make_get_mock(
+    tree_entries: list[dict] | None = None, tree_raises: bool = False
+) -> Callable[..., MagicMock]:
+    """Fake httpx.get that returns repo metadata or a tree listing
+    depending on the requested URL, matching GitHubTool's real call shape.
+    """
+
+    def fake_get(url: str, *args: object, **kwargs: object) -> MagicMock:
+        if "/git/trees/" in url:
+            if tree_raises:
+                raise Exception("boom")
+            response = MagicMock()
+            response.raise_for_status.return_value = None
+            response.json.return_value = {"tree": tree_entries or []}
+            return response
+
+        response = MagicMock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = REPO_JSON
+        return response
+
+    return fake_get
 
 
 @pytest.mark.unit
 class TestGitHubToolHasTests:
-    """Reproduction for issue #50: repo analysis output has no has_tests signal."""
+    """Tests for issue #50: has_tests detection on GitHubTool."""
 
     @pytest.fixture
     def tool(self) -> GitHubTool:
         return GitHubTool()
 
-    def test_repo_metadata_includes_has_tests_field(
+    def _run(
+        self,
+        tool: GitHubTool,
+        monkeypatch: pytest.MonkeyPatch,
+        tree_entries: list[dict] | None = None,
+        tree_raises: bool = False,
+    ) -> ToolResult:
+        monkeypatch.setattr("httpx.get", _make_get_mock(tree_entries, tree_raises))
+        monkeypatch.setattr("httpx.head", lambda *a, **k: MagicMock(status_code=200))
+        return tool.execute({"github_username": "octocat", "repo_name": "sample-repo"})
+
+    def test_has_tests_true_for_tests_directory(
         self, tool: GitHubTool, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """A repo whose file tree contains a tests/ directory should be flagged.
-
-        Issue #50 repro: GitHubTool.execute() currently has no has_tests key
-        in its output at all, so this assertion fails today with
-        AssertionError: None != True. There is no _has_tests() method on
-        GitHubTool, unlike the existing _has_readme() method it should mirror.
-        """
-        mock_repo_response = MagicMock()
-        mock_repo_response.raise_for_status.return_value = None
-        mock_repo_response.json.return_value = {
-            "name": "sample-repo",
-            "description": "A sample repo",
-            "language": "Python",
-            "stargazers_count": 5,
-            "forks_count": 1,
-            "open_issues_count": 0,
-            "pushed_at": "2026-01-01T00:00:00Z",
-            "topics": [],
-            "homepage": "",
-        }
-
-        mock_head_response = MagicMock(status_code=200)
-
-        monkeypatch.setattr("httpx.get", lambda *a, **k: mock_repo_response)
-        monkeypatch.setattr("httpx.head", lambda *a, **k: mock_head_response)
-
-        result = tool.execute({"github_username": "octocat", "repo_name": "sample-repo"})
-
+        """A tests/ directory anywhere in the tree should be detected."""
+        entries = [
+            {"path": "main.py", "type": "blob"},
+            {"path": "tests", "type": "tree"},
+            {"path": "tests/test_main.py", "type": "blob"},
+        ]
+        result = self._run(tool, monkeypatch, tree_entries=entries)
         assert result.success is True
-        assert result.data.get("has_tests") is True
+        assert result.data["has_tests"] is True
+
+    def test_has_tests_true_for_nested_test_directory(
+        self, tool: GitHubTool, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A test/ directory nested under a subfolder should still count."""
+        entries = [{"path": "backend/test", "type": "tree"}]
+        result = self._run(tool, monkeypatch, tree_entries=entries)
+        assert result.data["has_tests"] is True
+
+    def test_has_tests_true_for_pytest_ini(
+        self, tool: GitHubTool, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A pytest.ini file with no dedicated tests/ dir should count."""
+        entries = [
+            {"path": "pytest.ini", "type": "blob"},
+            {"path": "main.py", "type": "blob"},
+        ]
+        result = self._run(tool, monkeypatch, tree_entries=entries)
+        assert result.data["has_tests"] is True
+
+    def test_has_tests_true_for_test_prefixed_file(
+        self, tool: GitHubTool, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A loose test_*.py file with no tests/ dir or pytest.ini should count."""
+        entries = [{"path": "src/test_utils.py", "type": "blob"}]
+        result = self._run(tool, monkeypatch, tree_entries=entries)
+        assert result.data["has_tests"] is True
+
+    def test_has_tests_false_when_no_signals_present(
+        self, tool: GitHubTool, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A repo with no test-related paths should report False, not missing."""
+        entries = [
+            {"path": "main.py", "type": "blob"},
+            {"path": "README.md", "type": "blob"},
+        ]
+        result = self._run(tool, monkeypatch, tree_entries=entries)
+        assert result.data["has_tests"] is False
+
+    def test_has_tests_false_on_tree_api_error(
+        self, tool: GitHubTool, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If the tree API call fails, degrade to False rather than raising."""
+        result = self._run(tool, monkeypatch, tree_raises=True)
+        assert result.success is True
+        assert result.data["has_tests"] is False


### PR DESCRIPTION
## Summary
Adds a `has_tests` boolean to the repo analysis output. `GitHubTool` already surfaces signals like `has_readme` and `star_count`; this adds test-coverage detection using the same pattern, checking for a `tests/`/`test/` directory, a `pytest.ini` file, or any `test_*.py` file anywhere in the repo.

## Issue
Closes #50

## Changes
- Added `_has_tests(username, repo_name, default_branch)` to `GitHubTool` (`agent/tools/github_tool.py`), mirroring the existing `_has_readme()` method's structure and error handling
- Uses GitHub's recursive Git Trees API (`GET /repos/{u}/{r}/git/trees/{default_branch}?recursive=1`) — a single call against the repo's default branch, rather than one request per candidate path
- Wired `has_tests` into `_fetch_repo_metadata()`'s returned metadata dict, alongside `has_readme`
- Expanded `tests/unit/test_github_tool.py` from the original single reproduction test (Week 8) to 6 cases: `tests/` directory, a nested `test/` directory, `pytest.ini`, a loose `test_*.py` file, the negative case (no signals present), and graceful degradation to `False` when the tree API call fails

## Testing
- [x] Unit tests pass (`make test-unit`) — see pre-existing-failures note below
- [ ] Integration tests pass (`make test-integration`) — not applicable to this change
- [x] Linter passes (`make lint`) — for the files this PR touches; see note below
- [x] Type checker passes (`make typecheck`) — for the files this PR touches; see note below
- [x] New/updated tests cover the changes

## Notes for Reviewers

**Diff noise from auto-formatting:** the diff on `github_tool.py` looks bigger than it is. Most of the changed lines are `black`/`ruff` auto-formatting the *existing* code (collapsing multi-line `ToolResult(...)` calls onto one line, reformatting the `logger.error`/`logger.info` calls, one added blank line after the imports) — triggered by pre-commit hooks reformatting the whole file the moment any part of it changed, not logic changes. The actual new code is the `_has_tests()` method, the one new `has_tests` line in the metadata dict, and wrapping `_has_readme`'s return in `bool(...)` to satisfy mypy.

**Pre-existing failures, confirmed before and after this change (not introduced by this PR):**
- `make test-unit`: 54 failures before this PR (across `test_pii_scrubber.py`, `test_resume_parser.py`, `test_tech_detector.py`, `test_readme_scorer.py`, `test_relevance_scorer.py`, `test_skill_extractor.py`, `test_review_service.py`, and others) → 53 after. The drop of 1 is this PR's own reproduction test flipping from failing to passing; no other test's status changed.
- `make lint`: 181 pre-existing ruff errors repo-wide, all in files this PR does not touch.
- `make typecheck`: 103 pre-existing mypy errors across 26 files, all outside the files this PR touches.
- Verified directly: `agent/tools/github_tool.py` and `tests/unit/test_github_tool.py` individually pass `ruff check`, `black --check`, and `mypy` with zero errors.

**Design notes / open questions:**
- Chose the recursive Git Trees API over the Contents API because tests can live at any depth, not just the repo root; Contents API would only see the top-level directory listing.
- `default_branch` is read from the existing repo metadata response rather than a separate API call.
- Known limitation: GitHub truncates the tree response for very large repos (`"truncated": true` in the response) — not explicitly handled yet; open to feedback on whether that's worth addressing in this PR or a follow-up.
- Assumed nested test directories (e.g. `backend/tests/`) should count, since the issue text didn't specify depth — flagging in case reviewers disagree.
