### PR TITLE
feat(ingestion): add GitHub Actions workflow parser for CI/CD skills

### DIFF
--- a/ingestion/parsers/workflow_parser.py
+++ b/ingestion/parsers/workflow_parser.py
@@ -1,0 +1,159 @@
+"""Parse GitHub Actions workflow files and detect CI/CD skills."""
+
+import yaml
+
+from .base import BaseParser, ParseResult
+
+
+class WorkflowParser(BaseParser):
+    """Parse a GitHub Actions workflow file and detect CI/CD skills.
+
+    The parser reads the workflow YAML. It finds the marketplace actions and the
+    shell commands in each job. It maps them to CI/CD skills. It returns the
+    skills and the workflow metadata in a ParseResult.
+    """
+
+    # A marketplace action prefix maps to one CI/CD skill.
+    ACTION_SKILLS = {
+        "actions/checkout": "GitHub Actions",
+        "actions/upload-artifact": "GitHub Actions",
+        "actions/download-artifact": "GitHub Actions",
+        "actions/cache": "GitHub Actions",
+        "actions/setup-python": "Python CI",
+        "actions/setup-node": "Node.js CI",
+        "actions/setup-java": "Java CI",
+        "actions/setup-go": "Go CI",
+        "actions/setup-dotnet": ".NET CI",
+        "docker/build-push-action": "Docker",
+        "docker/login-action": "Docker",
+        "docker/setup-buildx-action": "Docker",
+        "aws-actions": "AWS",
+        "azure/": "Azure",
+        "google-github-actions": "GCP",
+        "hashicorp/setup-terraform": "Terraform",
+        "codecov/codecov-action": "Code Coverage",
+    }
+
+    # A shell command substring in a run step maps to one CI/CD skill.
+    RUN_SKILLS = {
+        "pytest": "Testing",
+        "npm test": "Testing",
+        "npm run test": "Testing",
+        "yarn test": "Testing",
+        "go test": "Testing",
+        "make test": "Testing",
+        "docker build": "Docker",
+        "docker push": "Docker",
+        "docker compose": "Docker",
+        "docker-compose": "Docker",
+        "kubectl": "Kubernetes",
+        "helm ": "Kubernetes",
+        "terraform ": "Terraform",
+        "ansible": "Ansible",
+        "flake8": "Linting",
+        "ruff": "Linting",
+        "black": "Linting",
+        "eslint": "Linting",
+        "mypy": "Type Checking",
+    }
+
+    def parse(self, content: str | bytes) -> ParseResult:
+        """Parse workflow content and detect CI/CD skills.
+
+        Args:
+            content: The workflow YAML text, as str or bytes.
+
+        Returns:
+            A ParseResult. The metadata holds the detected skills, the triggers,
+            the actions, and the job count.
+
+        Raises:
+            ValueError: If the content is not a valid workflow mapping.
+        """
+        if isinstance(content, bytes):
+            content = content.decode("utf-8")
+
+        try:
+            data = yaml.safe_load(content)
+        except yaml.YAMLError as exc:
+            raise ValueError(f"Invalid workflow YAML: {exc}") from exc
+
+        if not isinstance(data, dict):
+            raise ValueError("Workflow content must be a YAML mapping.")
+
+        jobs = data.get("jobs")
+        if not isinstance(jobs, dict):
+            raise ValueError("Workflow must define a 'jobs' mapping.")
+
+        skills: set[str] = {"GitHub Actions"}  # A valid workflow always uses GitHub Actions.
+        actions_used: list[str] = []
+
+        for job in jobs.values():
+            if not isinstance(job, dict):
+                continue
+            steps = job.get("steps")
+            if not isinstance(steps, list):
+                continue
+            for step in steps:
+                if not isinstance(step, dict):
+                    continue
+                self._scan_uses(step.get("uses"), skills, actions_used)
+                self._scan_run(step.get("run"), skills)
+
+        metadata = {
+            "ci_cd_skills": sorted(skills),
+            "triggers": self._extract_triggers(data),
+            "actions_used": actions_used,
+            "job_count": len(jobs),
+        }
+
+        return ParseResult(
+            text=self._summary(metadata),
+            metadata=metadata,
+            source_type="github_actions_workflow",
+        )
+
+    def _scan_uses(self, uses: object, skills: set, actions_used: list) -> None:
+        """Map a step 'uses' action to a skill."""
+        if not isinstance(uses, str):
+            return
+        action = uses.split("@", 1)[0].strip()
+        actions_used.append(action)
+        for prefix, skill in self.ACTION_SKILLS.items():
+            if action.startswith(prefix):
+                skills.add(skill)
+
+    def _scan_run(self, run: object, skills: set) -> None:
+        """Map a step 'run' command to a skill."""
+        if not isinstance(run, str):
+            return
+        run_lower = run.lower()
+        for needle, skill in self.RUN_SKILLS.items():
+            if needle in run_lower:
+                skills.add(skill)
+
+    @staticmethod
+    def _extract_triggers(data: dict) -> list[str]:
+        """Return the workflow trigger events.
+
+        YAML reads a bare 'on' key as the boolean True. The parser checks both
+        the string key and the boolean key.
+        """
+        raw = data.get("on", data.get(True))
+        if isinstance(raw, str):
+            return [raw]
+        if isinstance(raw, list):
+            return [str(item) for item in raw]
+        if isinstance(raw, dict):
+            return [str(key) for key in raw]
+        return []
+
+    @staticmethod
+    def _summary(metadata: dict) -> str:
+        """Build a short text summary of the workflow."""
+        skills = ", ".join(metadata["ci_cd_skills"]) or "none"
+        triggers = ", ".join(metadata["triggers"]) or "none"
+        return (
+            f"GitHub Actions workflow with {metadata['job_count']} job(s). "
+            f"Triggers: {triggers}. CI/CD skills: {skills}."
+        )

--- a/tests/unit/test_workflow_parser.py
+++ b/tests/unit/test_workflow_parser.py
@@ -1,0 +1,137 @@
+"""Tests for workflow_parser.py (issue #14)."""
+
+import pytest
+
+from ingestion.parsers.base import ParseResult
+from ingestion.parsers.workflow_parser import WorkflowParser
+
+PYTHON_CI = """
+name: CI
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install -e ".[dev]"
+      - run: pytest tests/ -v
+      - run: ruff check .
+"""
+
+DOCKER_DEPLOY = """
+name: Deploy
+on:
+  push:
+    branches: [main]
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/build-push-action@v5
+      - run: docker push my/image:latest
+"""
+
+
+@pytest.fixture
+def parser():
+    return WorkflowParser()
+
+
+@pytest.mark.unit
+class TestWorkflowParser:
+    """Test suite for WorkflowParser."""
+
+    def test_returns_parse_result(self, parser):
+        result = parser.parse(PYTHON_CI)
+        assert isinstance(result, ParseResult)
+        assert result.source_type == "github_actions_workflow"
+
+    def test_detects_github_actions_for_any_valid_workflow(self, parser):
+        result = parser.parse(PYTHON_CI)
+        assert "GitHub Actions" in result.metadata["ci_cd_skills"]
+
+    def test_detects_python_ci_from_setup_action(self, parser):
+        result = parser.parse(PYTHON_CI)
+        assert "Python CI" in result.metadata["ci_cd_skills"]
+
+    def test_detects_testing_and_linting_from_run_steps(self, parser):
+        result = parser.parse(PYTHON_CI)
+        skills = result.metadata["ci_cd_skills"]
+        assert "Testing" in skills
+        assert "Linting" in skills
+
+    def test_detects_docker_from_action_and_run(self, parser):
+        result = parser.parse(DOCKER_DEPLOY)
+        assert "Docker" in result.metadata["ci_cd_skills"]
+
+    def test_list_triggers_extracted(self, parser):
+        result = parser.parse(PYTHON_CI)
+        assert result.metadata["triggers"] == ["push", "pull_request"]
+
+    def test_mapping_trigger_extracted_despite_yaml_boolean_on_key(self, parser):
+        # YAML reads a bare `on:` as boolean True; the parser must still find it.
+        result = parser.parse(DOCKER_DEPLOY)
+        assert result.metadata["triggers"] == ["push"]
+
+    def test_actions_used_recorded_without_version_suffix(self, parser):
+        result = parser.parse(DOCKER_DEPLOY)
+        assert "actions/checkout" in result.metadata["actions_used"]
+        assert "docker/build-push-action" in result.metadata["actions_used"]
+
+    def test_job_count(self, parser):
+        result = parser.parse(PYTHON_CI)
+        assert result.metadata["job_count"] == 1
+
+    def test_skills_are_sorted_and_unique(self, parser):
+        result = parser.parse(PYTHON_CI)
+        skills = result.metadata["ci_cd_skills"]
+        assert skills == sorted(skills)
+        assert len(skills) == len(set(skills))
+
+    def test_accepts_bytes_input(self, parser):
+        result = parser.parse(PYTHON_CI.encode("utf-8"))
+        assert "Python CI" in result.metadata["ci_cd_skills"]
+
+    def test_summary_text_mentions_skills(self, parser):
+        result = parser.parse(PYTHON_CI)
+        assert "CI/CD skills" in result.text
+        assert "Python CI" in result.text
+
+    def test_kubectl_run_maps_to_kubernetes(self, parser):
+        workflow = """
+on: [push]
+jobs:
+  deploy:
+    steps:
+      - run: kubectl apply -f manifest.yaml
+"""
+        result = parser.parse(workflow)
+        assert "Kubernetes" in result.metadata["ci_cd_skills"]
+
+    def test_invalid_yaml_raises_value_error(self, parser):
+        with pytest.raises(ValueError):
+            parser.parse("on: [push\njobs: : :")
+
+    def test_non_mapping_content_raises_value_error(self, parser):
+        with pytest.raises(ValueError):
+            parser.parse("just a plain string")
+
+    def test_missing_jobs_raises_value_error(self, parser):
+        with pytest.raises(ValueError):
+            parser.parse("on: [push]\nname: CI")
+
+    def test_steps_without_uses_or_run_are_ignored(self, parser):
+        workflow = """
+on: [push]
+jobs:
+  noop:
+    steps:
+      - name: A step with no action or command
+"""
+        result = parser.parse(workflow)
+        # Only the baseline GitHub Actions skill is present.
+        assert result.metadata["ci_cd_skills"] == ["GitHub Actions"]


### PR DESCRIPTION
## Summary
PathReview has no parser for GitHub Actions workflow files, so it cannot detect
the CI/CD skills a portfolio shows through its automation. This adds a
`WorkflowParser` that reads a workflow YAML file and detects those skills.

## Issue
Closes #14

## Changes
- `ingestion/parsers/workflow_parser.py`: new `WorkflowParser(BaseParser)`. It maps
  marketplace actions (e.g. `actions/setup-python`, `docker/build-push-action`) and
  shell commands (e.g. `pytest`, `docker build`, `kubectl`) to CI/CD skills. It
  returns the skills, triggers, actions, and job count in the `ParseResult` metadata.
- `tests/unit/test_workflow_parser.py`: unit tests for detection, triggers, the
  YAML boolean `on:` key, byte input, and invalid input.

## Testing
- [x] Unit tests pass (`make test-unit`) — `tests/unit/test_workflow_parser.py` 17/17.
- [x] `ruff`, `black`, and `mypy` pass on the new parser.
- Manual: `WorkflowParser().parse(<workflow yaml>)` returns a `ParseResult` whose
  `metadata["ci_cd_skills"]` lists the detected skills.

## Notes for Reviewers
- The parser is standalone and fully unit-tested. Wiring it into the DB-backed
  `IngestionPipeline` needs the database, so I left that as a follow-up. Happy to
  add it here if you prefer.
