### PR TITLE
Feat/102 compare reviews view

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@
 #   cp .env.example .env
 
 # Database
-DATABASE_URL=postgresql+asyncpg://pathreview:pathreview@localhost:5433/pathreview_dev
+DATABASE_URL=postgresql+asyncpg://pathreview:pathreview@127.0.0.1:5433/pathreview_dev
 
 # Redis
 REDIS_URL=redis://localhost:6379/0

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -20,3 +20,15 @@
 * **Part 2 (Tier Fit):** I selected a Tier 3 issue because I have strong prior experience with React and feel confident building a new component from scratch without getting overwhelmed. 
 * **Part 3 (Codebase):** I've identified exactly where the new files (`ComparisonView.tsx` and `diffFormatter.ts`) need to be created and how they fit into the existing frontend structure. 
 * **Part 4 (Scope):** The 7–10 hour estimate is realistic for my schedule over the next two weeks, and there are no external blockers.
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [paste your commit link here]
+
+**Reproduction summary:**
+Because this is a feature gap rather than a bug, my reproduction involved navigating the local application to the user dashboard/review history view. I confirmed that there is currently no UI element, route, or utility that allows a user to select multiple reviews for comparison. I documented this missing state with a commit outlining where the entry point for the new feature should live.
+
+**PLAN.md link:** [PLAN.md]
+
+**Blockers or open questions:**
+I need to investigate the existing data flow to see if a user's full review history is already available in the frontend state, or if I will need to modify the data-fetching logic to populate the comparison dropdowns.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -32,3 +32,41 @@ Because this is a feature gap rather than a bug, my reproduction involved naviga
 
 **Blockers or open questions:**
 I need to investigate the existing data flow to see if a user's full review history is already available in the frontend state, or if I will need to modify the data-fetching logic to populate the comparison dropdowns.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+I have successfully implemented all sub-tasks from my PLAN.md. 
+1. Created `frontend/src/utils/diffFormatter.ts` to calculate score deltas and identify text changes.
+2. Built the `frontend/src/pages/ComparisonView.tsx` component to fetch the review history and display the side-by-side comparison.
+3. Updated `frontend/src/App.tsx` to register the new `/compare` protected route.
+4. Added a conditional "Compare Reviews" button to `frontend/src/pages/DashboardPage.tsx` that only appears if the user has 2 or more reviews.
+
+**Next steps:**
+Since I worked ahead and already wrote my unit tests, my next steps are to open a Draft PR, document the pre-existing test failures I found on `main`, and request a peer review before finalizing my submission.
+
+**Blockers:**
+I briefly ran into a blocker with the testing framework—the course guide referenced Python `pytest` setups, but the frontend uses `Vitest`. I successfully navigated this by matching the existing `Vitest` pattern found in the `frontend/src/components/__tests__/` directory.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [Insert link to your submitted pull request here]
+
+**Branch:** [`feat/102-comparison-view`]
+
+**What you built:**
+I built a progress-tracking feature that allows users to visualize how their portfolio reviews have changed over time. The feature introduces a new `ComparisonView` page that fetches the user's review history, lets them select an older and newer review via dropdowns, and renders a side-by-side visual difference. It calculates absolute score deltas (highlighting improvements in green and regressions in red) and highlights whether written feedback was updated.
+
+**Tests added or updated:**
+I created a new test suite at `frontend/src/components/__tests__/DiffFormatter.test.tsx` (following the existing frontend test directory structure). It covers the `calculateScoreDiff` and `calculateTextDiff` utility functions, ensuring that positive, negative, and flat score trends are accurately calculated, text changes are detected, and missing data (`undefined`) is handled gracefully without crashing the UI.
+
+**Self-review confirmation:** 
+[X] make check passes  
+[X] make test-unit passes 
+*(Note: I observed 182 linting errors and 2 test failures in `ProfileForm.test.tsx` and `ReviewSection.test.tsx` upon creating my branch. My code introduces no new failures to the baseline).*
+
+**Draft PR feedback received from:** [Insert name, Discord handle, or "none"]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -23,7 +23,7 @@
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [paste your commit link here]
+**Reproduction commit link:** [https://github.com/ColonelToad/pathreview/commit/74aa05357fcd305273fcb5b7b68a9a5dd100201c]
 
 **Reproduction summary:**
 Because this is a feature gap rather than a bug, my reproduction involved navigating the local application to the user dashboard/review history view. I confirmed that there is currently no UI element, route, or utility that allows a user to select multiple reviews for comparison. I documented this missing state with a commit outlining where the entry point for the new feature should live.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,22 @@
+## Week 7 — Issue selection
+
+**Issue link:** [https://github.com/jamjamgobambam/pathreview/issues/102]
+
+**Issue title:** [Add a before/after comparison view for users who have completed multiple reviews]
+
+**Tier:** [ ] Tier 1  [ ] Tier 2  [X] Tier 3
+
+**Problem summary:**
+[Currently, users who submit their portfolios for multiple reviews over time cannot easily compare their past and present results to track their progress. This issue requires building a brand new comparison feature on the frontend that allows users to select two distinct reviews and view a side-by-side visual difference of their scores and feedback. A successful fix will involve creating a new page component (frontend/src/pages/ComparisonView.tsx) and a utility for formatting the data differences (frontend/src/utils/diffFormatter.ts), ultimately giving users a clear picture of their improvement.]
+
+**Branch name:** [paste branch name here]
+
+**Setup confirmation:** [X] App runs locally at localhost:5173
+
+**Cohort ledger:** [X] Issue added to cohort ledger
+
+**Checklist Reasoning:** I reviewed the "Is this right for me?" checklist before claiming this issue. 
+* **Part 1 (Understanding):** I clearly understand the "done" state—a side-by-side UI showing diffs of two specific reviews. 
+* **Part 2 (Tier Fit):** I selected a Tier 3 issue because I have strong prior experience with React and feel confident building a new component from scratch without getting overwhelmed. 
+* **Part 3 (Codebase):** I've identified exactly where the new files (`ComparisonView.tsx` and `diffFormatter.ts`) need to be created and how they fit into the existing frontend structure. 
+* **Part 4 (Scope):** The 7–10 hour estimate is realistic for my schedule over the next two weeks, and there are no external blockers.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -56,7 +56,7 @@ I briefly ran into a blocker with the testing framework—the course guide refer
 
 **PR link:** [Insert link to your submitted pull request here]
 
-**Branch:** [`feat/102-comparison-view`]
+**Branch:** [`feat/102-compare-reviews-view`]
 
 **What you built:**
 I built a progress-tracking feature that allows users to visualize how their portfolio reviews have changed over time. The feature introduces a new `ComparisonView` page that fetches the user's review history, lets them select an older and newer review via dropdowns, and renders a side-by-side visual difference. It calculates absolute score deltas (highlighting improvements in green and regressions in red) and highlights whether written feedback was updated.
@@ -70,3 +70,35 @@ I created a new test suite at `frontend/src/components/__tests__/DiffFormatter.t
 *(Note: I observed 182 linting errors and 2 test failures in `ProfileForm.test.tsx` and `ReviewSection.test.tsx` upon creating my branch. My code introduces no new failures to the baseline).*
 
 **Draft PR feedback received from:** [Insert name, Discord handle, or "none"]
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [X] No — still awaiting review
+
+**Summary of feedback:**
+[What did reviewers comment on? Or note that no review came in.]
+
+**How you responded:**
+[What changes did you make, or what did you reply? If no feedback,
+leave blank.]
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+I am familiar with typescript setups and how that works but I was surprised how many files did need to modified not just the new logic for the pr but also for the test, hunting down the right test files and what package they use took a bit.
+
+**What did you learn about working in a large codebase?**
+This isn't my first time doing an open-source contribution, but I think what I relearned is each codebase maintains a different set of standard and rules, so it's very important to understand the structure, what's expected of a good pr, and conventions before diving into any code writing.
+
+**How did AI tools help — and where did they fall short?**
+AI was very helpful in generating the code. Guiding the AI to generate the right code, right tests, and just working on the stated problem probably took more time to verifying outputs at times. But this is where learning what model is right for the problem comes to play, usually using a smaller model for a well scoped task gave less issues, and a larger one for design choices.
+
+**What would you do differently if you started over?**
+One thing I would change is how AI was used, currently I did a more standard approach of ai and verify what it writes, but something I've read is a test-driven approach (TDD) is generally better at keeping the llm more grounded in it's approach. Definitely something I would try to see how different approaches to AI affect the output and flow.
+
+**What are you most proud of from this module?**
+I am genuinely proud for actually learning, none of these topics are themselves ground breaking and often written as short articles I can read many of. But slowing down and actually doing (not jsut following a well made tutorial) did force me to better understand certain decisions and concepts, like rag and decided what results to pull; doing a math based approach or just setting k to a value are both valid and deciding on one requires understand what is most important in the system being built.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,33 @@
+## Solution plan
+
+**Issue:** Add a before/after comparison view for users who have completed multiple reviews (#102)
+**Link:** https://github.com/jamjamgobambam/pathreview/issues/102
+
+### Understand
+This is a feature gap rather than a bug. Currently, users have no built-in way to visualize their progress over time because the app only displays individual reviews in isolation. The expected behavior is that a user can select two distinct historical reviews and view a side-by-side comparison that explicitly highlights the differences in their scores and feedback.
+
+### Map
+Expected files to touch:
+* `frontend/src/pages/ComparisonView.tsx` (New - Main UI component for the side-by-side layout)
+* `frontend/src/utils/diffFormatter.ts` (New - Utility function to calculate score deltas and text differences)
+* `frontend/src/App.tsx` (Existing - To register the new `/compare` route)
+* `frontend/src/pages/DashboardPage.tsx` (Existing - To add a link/button routing users to the comparison feature)
+
+### Plan
+1. **Utility Creation:** Write `diffFormatter.ts` to accept two review data objects and return formatted diffs (e.g., calculating "+2" or "-1" for numerical scores, and identifying text changes). Write basic unit tests for this utility if the testing framework is already configured.
+2. **Component Shell:** Create `ComparisonView.tsx` with a basic layout, including two dropdown selectors that allow the user to choose which past reviews they want to compare.
+3. **UI Implementation:** Build the side-by-side visual layout within the component to render the data returned from `diffFormatter.ts`, utilizing existing UI components (like cards or tables) from the codebase.
+4. **Routing & Navigation:** Add the new route to the application and place a "Compare Reviews" button on the user's main dashboard or review history list.
+
+### Inputs & outputs
+* **Inputs:** Two complete review objects (including numerical scores, written feedback, and timestamps) selected by the user.
+* **Outputs:** A rendered React page displaying a visual differential—showing absolute scores for both dates, the calculated delta (e.g., green for improvement, red for regression), and side-by-side text boxes for feedback.
+
+### Risks & unknowns
+* **Data Fetching:** I need to investigate how a user's past reviews are currently fetched. Does the global state already hold all past reviews, or do I need to write a new API call to fetch a user's complete history?
+* **Mobile Responsiveness:** A side-by-side view might become cramped and unreadable on smaller screens. I may need to stack the comparisons vertically on mobile breakpoints.
+
+### Edge cases
+* The user has only completed one review (the "Compare" button should be disabled or hidden).
+* The user selects the exact same review for both the "Before" and "After" dropdowns.
+* Older reviews might be missing data fields that newer reviews have, so `diffFormatter.ts` needs to handle `null` or `undefined` gracefully.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -99,7 +99,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -449,7 +448,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -473,7 +471,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1561,7 +1558,6 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1579,7 +1575,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1972,7 +1967,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3507,7 +3501,6 @@
       "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^2.0.1",
         "cssstyle": "^4.0.1",
@@ -4094,7 +4087,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4107,7 +4099,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4771,7 +4762,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import { DashboardPage } from './pages/DashboardPage'
 import { NewProfilePage } from './pages/NewProfilePage'
 import { ReviewPage } from './pages/ReviewPage'
 import { ReviewHistoryPage } from './pages/ReviewHistoryPage'
+import { ComparisonView } from './pages/ComparisonView'
 
 const ProtectedRoute: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const { user, isLoading } = useAuth()
@@ -81,6 +82,14 @@ function App() {
           element={
             <ProtectedRoute>
               <ReviewPage />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/compare"
+          element={
+            <ProtectedRoute>
+              <ComparisonView />
             </ProtectedRoute>
           }
         />

--- a/frontend/src/components/__tests__/DiffFormatter.test.tsx
+++ b/frontend/src/components/__tests__/DiffFormatter.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { calculateScoreDiff, calculateTextDiff } from '../../utils/diffFormatter';
+
+describe('diffFormatter utility', () => {
+  
+  describe('calculateScoreDiff', () => {
+    it('calculates a positive improvement correctly', () => {
+      const result = calculateScoreDiff(70, 85);
+      expect(result.delta).toBe(15);
+      expect(result.formattedDelta).toBe('+15');
+      expect(result.trend).toBe('up');
+    });
+
+    it('calculates a regression correctly', () => {
+      const result = calculateScoreDiff(90, 85);
+      expect(result.delta).toBe(-5);
+      expect(result.formattedDelta).toBe('-5');
+      expect(result.trend).toBe('down');
+    });
+
+    it('calculates a flat score correctly', () => {
+      const result = calculateScoreDiff(80, 80);
+      expect(result.delta).toBe(0);
+      expect(result.formattedDelta).toBe('0');
+      expect(result.trend).toBe('flat');
+    });
+
+    it('gracefully handles missing before data', () => {
+      const result = calculateScoreDiff(undefined, 85);
+      expect(result.delta).toBeNull();
+      expect(result.formattedDelta).toBe('—');
+      expect(result.trend).toBe('unknown');
+    });
+  });
+
+  describe('calculateTextDiff', () => {
+    it('detects when text has changed', () => {
+      const result = calculateTextDiff('Good job.', 'Great job!');
+      expect(result.isChanged).toBe(true);
+    });
+
+    it('detects when text is identical', () => {
+      const result = calculateTextDiff('Same feedback', 'Same feedback');
+      expect(result.isChanged).toBe(false);
+    });
+
+    it('handles undefined or missing text', () => {
+      const result = calculateTextDiff(undefined, 'New feedback');
+      expect(result.isChanged).toBe(true);
+    });
+  });
+});

--- a/frontend/src/pages/ComparisonView.tsx
+++ b/frontend/src/pages/ComparisonView.tsx
@@ -1,0 +1,192 @@
+// frontend/src/pages/ComparisonView.tsx
+
+import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { apiClient } from '../services/api';
+import { Review } from '../types';
+import { calculateScoreDiff, calculateTextDiff } from '../utils/diffFormatter';
+import { formatDate } from '../utils/dateFormatters';
+
+export const ComparisonView: React.FC = () => {
+  const navigate = useNavigate();
+  const [reviews, setReviews] = useState<Review[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState('');
+  
+  const [beforeId, setBeforeId] = useState<string>('');
+  const [afterId, setAfterId] = useState<string>('');
+
+  useEffect(() => {
+    const fetchAllReviews = async () => {
+      try {
+        // Fetching a larger page size to populate the dropdowns
+        const response = await apiClient.listReviews(1, 100);
+        const fetchedReviews = response.items ?? [];
+        
+        // Sort chronologically (oldest first) so Before/After makes intuitive sense
+        const sortedReviews = fetchedReviews.sort((a, b) => 
+          new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+        );
+        
+        setReviews(sortedReviews);
+        
+        // Auto-select the oldest and newest if there are at least two
+        if (sortedReviews.length >= 2) {
+          setBeforeId(sortedReviews[0].id);
+          setAfterId(sortedReviews[sortedReviews.length - 1].id);
+        }
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to load review history');
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchAllReviews();
+  }, []);
+
+  const beforeReview = reviews.find(r => r.id === beforeId);
+  const afterReview = reviews.find(r => r.id === afterId);
+
+  // Use our utility to calculate diffs
+  const scoreDiff = calculateScoreDiff(beforeReview?.overall_score, afterReview?.overall_score);
+  // Assuming the text field is called 'feedback'. Update this if it's 'notes', 'comments', etc.
+  const textDiff = calculateTextDiff(beforeReview?.feedback, afterReview?.feedback);
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <p className="text-gray-600">Loading comparison data...</p>
+      </div>
+    );
+  }
+
+  if (reviews.length < 2) {
+    return (
+      <div className="min-h-screen bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
+        <div className="max-w-3xl mx-auto bg-white rounded-lg shadow p-12 text-center">
+          <h2 className="text-2xl font-bold text-gray-900 mb-4">Not Enough Data</h2>
+          <p className="text-gray-600 mb-6">
+            You need at least two completed reviews to use the comparison tool. 
+            Keep learning and submit another portfolio soon!
+          </p>
+          <button
+            onClick={() => navigate('/reviews')}
+            className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
+          >
+            Back to History
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const isSameReview = beforeId === afterId;
+
+  return (
+    <div className="min-h-screen bg-gray-50 py-12">
+      <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="mb-8">
+          <h1 className="text-3xl font-bold text-gray-900">Compare Reviews</h1>
+          <p className="text-gray-600 mt-2">See how your portfolio has improved over time</p>
+        </div>
+
+        {error && (
+          <div className="mb-6 p-4 bg-red-50 border border-red-200 rounded-lg">
+            <p className="text-sm text-red-800">{error}</p>
+          </div>
+        )}
+
+        {/* Selection Controls */}
+        <div className="bg-white rounded-lg shadow p-6 mb-8 flex flex-col md:flex-row gap-6 items-end">
+          <div className="flex-1 w-full">
+            <label className="block text-sm font-medium text-gray-700 mb-2">Before (Older Review)</label>
+            <select
+              value={beforeId}
+              onChange={(e) => setBeforeId(e.target.value)}
+              className="w-full p-2 border border-gray-300 rounded-md"
+            >
+              {reviews.map(r => (
+                <option key={r.id} value={r.id}>
+                  {formatDate(r.created_at)} - {r.id.slice(0, 8)}
+                </option>
+              ))}
+            </select>
+          </div>
+          
+          <div className="flex-1 w-full">
+            <label className="block text-sm font-medium text-gray-700 mb-2">After (Newer Review)</label>
+            <select
+              value={afterId}
+              onChange={(e) => setAfterId(e.target.value)}
+              className="w-full p-2 border border-gray-300 rounded-md"
+            >
+              {reviews.map(r => (
+                <option key={r.id} value={r.id}>
+                  {formatDate(r.created_at)} - {r.id.slice(0, 8)}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        {isSameReview ? (
+          <div className="p-8 bg-yellow-50 border border-yellow-200 rounded-lg text-center">
+            <p className="text-yellow-800 font-medium">Please select two different reviews to compare.</p>
+          </div>
+        ) : (
+          <div className="space-y-8">
+            {/* Score Comparison */}
+            <div className="bg-white rounded-lg shadow overflow-hidden">
+              <div className="px-6 py-4 bg-gray-50 border-b border-gray-200 flex justify-between items-center">
+                <h3 className="text-lg font-semibold text-gray-900">Overall Score</h3>
+                {scoreDiff.trend !== 'unknown' && (
+                  <span className={`px-3 py-1 rounded-full text-sm font-medium ${
+                    scoreDiff.trend === 'up' ? 'bg-green-100 text-green-800' : 
+                    scoreDiff.trend === 'down' ? 'bg-red-100 text-red-800' : 
+                    'bg-gray-100 text-gray-800'
+                  }`}>
+                    Delta: {scoreDiff.formattedDelta}
+                  </span>
+                )}
+              </div>
+              
+              {/* Responsive Grid: Stacks on mobile, side-by-side on md screens */}
+              <div className="grid grid-cols-1 md:grid-cols-2 divide-y md:divide-y-0 md:divide-x divide-gray-200">
+                <div className="p-6 text-center">
+                  <p className="text-sm text-gray-500 mb-2">Before ({formatDate(beforeReview?.created_at || '')})</p>
+                  <p className="text-4xl font-bold text-gray-900">{scoreDiff.before ?? '—'}</p>
+                </div>
+                <div className="p-6 text-center">
+                  <p className="text-sm text-gray-500 mb-2">After ({formatDate(afterReview?.created_at || '')})</p>
+                  <p className="text-4xl font-bold text-gray-900">{scoreDiff.after ?? '—'}</p>
+                </div>
+              </div>
+            </div>
+
+            {/* Feedback Comparison */}
+            <div className="bg-white rounded-lg shadow overflow-hidden">
+              <div className="px-6 py-4 bg-gray-50 border-b border-gray-200">
+                <h3 className="text-lg font-semibold text-gray-900 flex justify-between">
+                  Feedback Notes
+                  {textDiff.isChanged && <span className="text-sm font-normal text-blue-600 bg-blue-50 px-2 py-1 rounded">Content updated</span>}
+                </h3>
+              </div>
+              
+              <div className="grid grid-cols-1 md:grid-cols-2 divide-y md:divide-y-0 md:divide-x divide-gray-200">
+                <div className="p-6">
+                  <p className="text-sm font-medium text-gray-500 mb-4">Previous Feedback</p>
+                  <p className="text-gray-700 whitespace-pre-wrap">{textDiff.before || 'No feedback provided.'}</p>
+                </div>
+                <div className="p-6">
+                  <p className="text-sm font-medium text-gray-500 mb-4">New Feedback</p>
+                  <p className="text-gray-700 whitespace-pre-wrap">{textDiff.after || 'No feedback provided.'}</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { Plus, TrendingUp, Calendar } from 'lucide-react'
+import { Plus, TrendingUp, Calendar, GitCompare } from 'lucide-react'
 import { useAuth } from '../context/AuthContext'
 import { apiClient } from '../services/api'
 import { Review } from '../types'
@@ -42,6 +42,26 @@ export const DashboardPage: React.FC = () => {
           <p className="text-gray-600">
             Get AI-powered feedback on your portfolio and career trajectory
           </p>
+        </div>
+        <div className="flex flex-wrap gap-4 mb-12">
+          <button
+            onClick={() => navigate('/profiles/new')}
+            className="inline-flex items-center gap-2 px-6 py-3 bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-lg transition-colors"
+          >
+            <Plus className="w-5 h-5" />
+            Start a New Review
+          </button>
+
+          {/* Only show the comparison button if there are 2 or more reviews */}
+          {reviews.length >= 2 && (
+            <button
+              onClick={() => navigate('/compare')}
+              className="inline-flex items-center gap-2 px-6 py-3 bg-white border border-gray-300 hover:bg-gray-50 text-gray-700 font-semibold rounded-lg transition-colors shadow-sm"
+            >
+              <GitCompare className="w-5 h-5" />
+              Compare Reviews
+            </button>
+          )}
         </div>
 
         <button

--- a/frontend/src/utils/diffFormatter.ts
+++ b/frontend/src/utils/diffFormatter.ts
@@ -1,0 +1,56 @@
+// frontend/src/utils/diffFormatter.ts
+
+export interface ScoreDiff {
+  before: number | undefined;
+  after: number | undefined;
+  delta: number | null;
+  formattedDelta: string;
+  trend: 'up' | 'down' | 'flat' | 'unknown';
+}
+
+export interface TextDiff {
+  before: string | undefined;
+  after: string | undefined;
+  isChanged: boolean;
+}
+
+/**
+ * Calculates the difference between two numerical scores.
+ * Gracefully handles undefined or null values.
+ */
+export const calculateScoreDiff = (before?: number, after?: number): ScoreDiff => {
+  // Handle edge cases where data might be missing from older reviews
+  if (before === undefined || after === undefined || before === null || after === null) {
+    return { 
+      before, 
+      after, 
+      delta: null, 
+      formattedDelta: '—', 
+      trend: 'unknown' 
+    };
+  }
+
+  const delta = after - before;
+  
+  let formattedDelta = `${delta}`;
+  if (delta > 0) formattedDelta = `+${delta}`;
+  if (delta === 0) formattedDelta = '0';
+
+  const trend = delta > 0 ? 'up' : delta < 0 ? 'down' : 'flat';
+
+  return { before, after, delta, formattedDelta, trend };
+};
+
+/**
+ * Compares two text fields to determine if feedback has changed.
+ */
+export const calculateTextDiff = (beforeText?: string, afterText?: string): TextDiff => {
+  const safeBefore = beforeText || '';
+  const safeAfter = afterText || '';
+
+  return {
+    before: beforeText,
+    after: afterText,
+    isChanged: safeBefore.trim() !== safeAfter.trim()
+  };
+};


### PR DESCRIPTION
## Summary
This PR introduces a progress-tracking feature that allows users to visualize how their portfolio reviews have changed over time. It adds a new comparison view where users can select two distinct historical reviews and see a side-by-side visual difference of their overall scores (with calculated deltas) and feedback.

## Issue
Closes #102

## Changes
- Created `frontend/src/utils/diffFormatter.ts` utility to calculate numerical and textual diffs between reviews.
- Built `frontend/src/pages/ComparisonView.tsx` component to allow users to fetch, select, and compare two historical reviews.
- Registered the `/compare` protected route in `frontend/src/App.tsx`.
- Added a conditional "Compare Reviews" entry point button to `frontend/src/pages/DashboardPage.tsx` that only appears if the user has completed at least two reviews.
- Added a comprehensive unit test suite in `frontend/src/components/__tests__/DiffFormatter.test.tsx`.

## Testing
- [x] Unit tests pass (`make test-unit`) *— See Notes for Reviewers*
- [ ] Integration tests pass (`make test-integration`)
- [x] Linter passes (`make lint`) *— See Notes for Reviewers*
- [x] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes

## Notes for Reviewers
**Important Note regarding `make check` and `make test-unit`:** 
I observed 182 pre-existing errors in the codebase when running the formatting/linting checks, as well as 2 pre-existing test failures on `main` (`ProfileForm.test.tsx` and `ReviewSection.test.tsx`) prior to starting my work. 

My newly added test suite (`DiffFormatter.test.tsx`) passes completely, and my changes do not introduce any new errors or test failures to the baseline codebase.