### PR TITLE
fix(api): add X-RateLimit headers to responses

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -53,3 +53,33 @@ Added `tests/unit/test_request_id_middleware.py`, which verifies that both 2xx r
 **Self-review confirmation:** [x] make check passes  [x] make test-unit passes
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No 
+
+**Summary of feedback:**
+No reviewer feedback assigned for this cohort.
+
+**How you responded:**
+N/A
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The hardest part was just understanding Github commands and how they are tracked from the original fork, and managing branches. Other than that, tracing how the issue flowed across multiple layers of the project was an interesting challenge. On the issue, I had to understand the rate limiter, middleware wiring, request/response behavior, and test structure before I could make a change confidently. The biggest surprise was that a small user-facing feature could touch several files and still require careful coordination to avoid breaking existing behavior.
+
+**What did you learn about working in a large codebase?**
+I learned that large codebases require patience and discipline more than speed. It helped to read existing patterns, inspect related files before editing, and keep the scope of each change small. I also learned that working in someone else’s production-style code means respecting existing architecture, tests, and conventions instead of immediately changing the code to match my first instinct.
+
+**How did AI tools help — and where did they fall short?**
+AI tools were most useful for helping me navigate unfamiliar files, summarize what each module was doing, and suggest a starting point for the implementation and tests. They were less helpful when I needed to make the final call on code structure, resolve Git conflicts, or match the project’s exact conventions. In those moments I still had to inspect the code directly and verify every change myself.
+
+**What would you do differently if you started over?**
+I would start by reading the issue more carefully and mapping the affected files before making any code changes. I would also keep the journal and plan entries updated earlier so I didn’t have to backfill them during rebases and branch updates. Finally, I would verify the PR workflow sooner so I could spend less time on Git mechanics at the end.
+
+**What are you most proud of from this module?**

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,6 +1,6 @@
 ## Week 7 — Issue understanding
 
-**Issue link:** https://github.com/ascherj/pathreview/issues/86
+**Issue link:** [https://github.com/ascherj/pathreview/issues/86](https://github.com/ascherj/pathreview/issues/86)
 
 **Issue summary:**
 The issue is that the API is enforcing rate limits but not exposing rate-limit information to clients until they actually get blocked. Currently, responses do not include headers telling the client what the configured limit is or how many requests remain in the current window, so clients can only discover the limit by hitting a 429. A successful fix will wire the existing `RateLimiter.check_rate_limit()` logic into middleware that runs on every request, then attach `X-RateLimit-Limit` and `X-RateLimit-Remaining` to both successful responses and 429 responses. This will let clients proactively manage their usage and avoid unintentionally crossing the rate limit, while keeping the server-side logic and Redis-based rolling-window behavior unchanged.
@@ -11,10 +11,9 @@ Successful responses do not expose rate-limit headers, so clients have no visibi
 **Successful fix outcome:**
 Normal responses and 429 responses both include `X-RateLimit-Limit` and `X-RateLimit-Remaining`, with values consistent with the existing limiter behavior.
 
+## Week 8 — Reproducing the issue and planning the fix
 
-## Week 8 - Reproducing the issue and planning the fix
-
-**Reproduction commit link:** <https://github.com/DhaivatN/pathreview/commits/fix/86-api-rate-limit-headers/e4c2799f28d09afe0d8c58bfa5ed1901685a2e4b>
+**Reproduction commit link:** <https://github.com/DhaivatN/pathreview/commit/e4c2799f28d09afe0d8c58bfa5ed1901685a2e4b>
 
 **Reproduction summary:**
 I inspected the rate-limiting flow across `safety/rate_limiter.py` and `api/middleware/request_id.py`. The existing `RateLimiter.check_rate_limit()` logic already calculates whether a request is allowed and how many requests remain, so the server-side rate-limit state was already available. The gap was in the middleware/response layer: clients were not receiving `X-RateLimit-Limit` and `X-RateLimit-Remaining` on responses. In the current implementation, successful responses now include those headers, but the 429 early-return path still exits before adding them, which confirms the exact issue and shows the remaining work needed to fully satisfy issue #86.
@@ -23,3 +22,34 @@ I inspected the rate-limiting flow across `safety/rate_limiter.py` and `api/midd
 
 **Blockers or open questions:**
 The main unknown is how the remaining quota should be represented on blocked requests (e.g., `0` vs another value), and whether existing tests already cover the middleware header behavior or if new tests are needed.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the request middleware changes so rate-limit headers are attached to both successful responses and 429 responses. Added unit tests in `tests/unit/test_request_id_middleware.py` to verify the headers on allowed and blocked requests.
+
+**Next steps:**
+Finalize the PR description, confirm the branch is pushed, and complete the Week 9 submission details in `JOURNAL.md`.
+
+**Blockers:**
+None.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [https://github.com/ascherj/pathreview/pull/233](https://github.com/ascherj/pathreview/pull/233)
+
+**Branch:** `fix/86-api-rate-limit-headers`
+
+**What you built:**
+I updated the request middleware so API responses consistently expose `X-RateLimit-Limit` and `X-RateLimit-Remaining` on both successful and blocked requests. The middleware uses the existing `RateLimiter` logic and attaches those headers alongside `X-Request-ID`.
+
+**Tests added or updated:**
+Added `tests/unit/test_request_id_middleware.py`, which verifies that both 2xx responses and 429 responses include the request ID and rate-limit headers.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -14,5 +14,12 @@ Normal responses and 429 responses both include `X-RateLimit-Limit` and `X-RateL
 
 ## Week 8 - Reproducing the issue and planning the fix
 
+**Reproduction commit link:** <https://github.com/DhaivatN/pathreview/commits/fix/86-api-rate-limit-headers/e4c2799f28d09afe0d8c58bfa5ed1901685a2e4b>
+
 **Reproduction summary:**
 I inspected the rate-limiting flow across `safety/rate_limiter.py` and `api/middleware/request_id.py`. The existing `RateLimiter.check_rate_limit()` logic already calculates whether a request is allowed and how many requests remain, so the server-side rate-limit state was already available. The gap was in the middleware/response layer: clients were not receiving `X-RateLimit-Limit` and `X-RateLimit-Remaining` on responses. In the current implementation, successful responses now include those headers, but the 429 early-return path still exits before adding them, which confirms the exact issue and shows the remaining work needed to fully satisfy issue #86.
+
+**PLAN.md link:** <https://github.com/DhaivatN/pathreview/blob/fix/86-api-rate-limit-headers/PLAN.md>
+
+**Blockers or open questions:**
+The main unknown is how the remaining quota should be represented on blocked requests (e.g., `0` vs another value), and whether existing tests already cover the middleware header behavior or if new tests are needed.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,18 @@
+## Week 7 — Issue understanding
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/86
+
+**Issue summary:**
+The issue is that the API is enforcing rate limits but not exposing rate-limit information to clients until they actually get blocked. Currently, responses do not include headers telling the client what the configured limit is or how many requests remain in the current window, so clients can only discover the limit by hitting a 429. A successful fix will wire the existing `RateLimiter.check_rate_limit()` logic into middleware that runs on every request, then attach `X-RateLimit-Limit` and `X-RateLimit-Remaining` to both successful responses and 429 responses. This will let clients proactively manage their usage and avoid unintentionally crossing the rate limit, while keeping the server-side logic and Redis-based rolling-window behavior unchanged.
+
+**Current broken behavior:**
+Successful responses do not expose rate-limit headers, so clients have no visibility into remaining quota until the server rejects a request with 429.
+
+**Successful fix outcome:**
+Normal responses and 429 responses both include `X-RateLimit-Limit` and `X-RateLimit-Remaining`, with values consistent with the existing limiter behavior.
+
+
+## Week 8 - Reproducing the issue and planning the fix
+
+**Reproduction summary:**
+I inspected the rate-limiting flow across `safety/rate_limiter.py` and `api/middleware/request_id.py`. The existing `RateLimiter.check_rate_limit()` logic already calculates whether a request is allowed and how many requests remain, so the server-side rate-limit state was already available. The gap was in the middleware/response layer: clients were not receiving `X-RateLimit-Limit` and `X-RateLimit-Remaining` on responses. In the current implementation, successful responses now include those headers, but the 429 early-return path still exits before adding them, which confirms the exact issue and shows the remaining work needed to fully satisfy issue #86.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,44 @@
+## Solution plan
+
+**Issue:** #86 — Add rate-limit headers to API responses  
+https://github.com/ascherj/pathreview/issues/86
+
+### Understand
+The backend already enforces rate limits and calculates remaining quota, but clients do not consistently receive that information through HTTP response headers. Successful responses now include `X-RateLimit-Limit` and `X-RateLimit-Remaining`, but the 429 early-return path still does not attach those headers, so the implementation is incomplete.
+
+### Map
+The likely files and modules involved are:
+- `api/middleware/request_id.py` — current middleware that checks the limiter and attaches response headers
+- `safety/rate_limiter.py` — existing Redis-backed rolling-window logic that returns whether a request is allowed and how many requests remain
+- Middleware registration path (for example `main.py`) — to confirm the middleware is wired into every API request
+- Relevant test files under `tests/` — to verify both successful and 429 responses include the required headers
+
+### Plan
+1. Inspect the 429 early-return path in `api/middleware/request_id.py` and refactor it so blocked responses also receive `X-Request-ID`, `X-RateLimit-Limit`, and `X-RateLimit-Remaining`.
+2. Keep `safety/rate_limiter.py` unchanged unless needed, since it already returns the limiter state required by middleware.
+3. Verify that both successful responses and 429 responses expose consistent header values.
+4. Review or add tests under `tests/` to cover both the allowed-request path and rate-limit-exceeded path.
+5. Run `make check` and `make test-unit` before final PR submission.
+
+### Inputs & outputs
+**Inputs:**
+- Incoming HTTP request
+- Client identifier (currently IP address)
+- Existing `RateLimiter.check_rate_limit()` result: `(allowed, remaining_requests)`
+
+**Outputs:**
+- Successful responses with `X-RateLimit-Limit` and `X-RateLimit-Remaining`
+- 429 responses with the same rate-limit headers
+- Existing request ID header behavior preserved
+- No change to Redis rolling-window enforcement logic
+
+### Risks & unknowns
+- `api/middleware/request_id.py` currently returns a `JSONResponse` early for blocked requests, so header logic must be carefully applied to avoid skipping required headers.
+- The remaining value on blocked requests may need confirmation to ensure it matches the intended contract (`0` vs another derived value).
+- I still need to confirm whether existing tests already cover middleware headers or whether I need to add new ones.
+
+### Edge cases
+- The final allowed request in the window should return a normal response with `X-RateLimit-Remaining: 0`.
+- A blocked request should return 429 and still include both rate-limit headers.
+- Repeated rapid requests from the same client should show remaining counts decreasing consistently.
+- Missing client connection information should not break the middleware and should fall back safely.

--- a/PLAN.md
+++ b/PLAN.md
@@ -4,41 +4,56 @@
 https://github.com/ascherj/pathreview/issues/86
 
 ### Understand
-The backend already enforces rate limits and calculates remaining quota, but clients do not consistently receive that information through HTTP response headers. Successful responses now include `X-RateLimit-Limit` and `X-RateLimit-Remaining`, but the 429 early-return path still does not attach those headers, so the implementation is incomplete.
+The backend already enforces rate limits and tracks how many requests remain using `RateLimiter.check_rate_limit()` in `safety/rate_limiter.py`. However, clients do not consistently receive this information through HTTP response headers. Successful responses now include `X-RateLimit-Limit` and `X-RateLimit-Remaining`, but the 429 early-return path in `api/middleware/request_id.py` still does not attach these headers. The goal is for both successful and rate-limited responses to expose the same rate-limit metadata so clients can monitor usage proactively and understand why a request was blocked.
 
 ### Map
-The likely files and modules involved are:
-- `api/middleware/request_id.py` — current middleware that checks the limiter and attaches response headers
-- `safety/rate_limiter.py` — existing Redis-backed rolling-window logic that returns whether a request is allowed and how many requests remain
-- Middleware registration path (for example `main.py`) — to confirm the middleware is wired into every API request
-- Relevant test files under `tests/` — to verify both successful and 429 responses include the required headers
+The key files and modules involved are:
+
+- `api/middleware/request_id.py`  
+  Current middleware that generates request IDs, calls the `RateLimiter`, and attaches response headers.
+- `safety/rate_limiter.py`  
+  Redis-backed rolling-window rate limiter that returns `(allowed, remaining_requests)`.
+- Middleware registration / app setup (e.g., `main.py` or equivalent)  
+  Ensures this middleware runs for all relevant API routes.
+- `tests/` (middleware / API tests)  
+  Existing or new tests to verify that both 2xx and 429 responses include rate-limit headers.
 
 ### Plan
-1. Inspect the 429 early-return path in `api/middleware/request_id.py` and refactor it so blocked responses also receive `X-Request-ID`, `X-RateLimit-Limit`, and `X-RateLimit-Remaining`.
-2. Keep `safety/rate_limiter.py` unchanged unless needed, since it already returns the limiter state required by middleware.
-3. Verify that both successful responses and 429 responses expose consistent header values.
-4. Review or add tests under `tests/` to cover both the allowed-request path and rate-limit-exceeded path.
-5. Run `make check` and `make test-unit` before final PR submission.
+1. Refactor `RequestIDMiddleware` in `api/middleware/request_id.py` so the 429 response path also includes `X-Request-ID`, `X-RateLimit-Limit`, and `X-RateLimit-Remaining` headers instead of returning a bare `JSONResponse`.
+2. Keep `safety/rate_limiter.py` unchanged unless necessary, since `check_rate_limit()` already returns both the allow/deny decision and remaining quota that middleware needs.
+3. Verify that both successful responses (2xx) and blocked responses (429) consistently expose `X-RateLimit-Limit` and `X-RateLimit-Remaining` with correct values.
+4. Add or update tests under `tests/` to cover:
+   - An allowed request returning 2xx with the rate-limit headers.
+   - A blocked request returning 429 with the same headers.
+5. Run `make check` and `make test-unit` and address any linting, typing, or test failures before opening or updating the pull request.
 
 ### Inputs & outputs
 **Inputs:**
-- Incoming HTTP request
-- Client identifier (currently IP address)
-- Existing `RateLimiter.check_rate_limit()` result: `(allowed, remaining_requests)`
+
+- Incoming HTTP request object.
+- Client identifier (currently the IP from `request.client.host`, or `"unknown"` as a fallback).
+- Result of `RateLimiter.check_rate_limit(identifier, limit, window_seconds)` returning `(allowed, remaining_requests)`.
 
 **Outputs:**
-- Successful responses with `X-RateLimit-Limit` and `X-RateLimit-Remaining`
-- 429 responses with the same rate-limit headers
-- Existing request ID header behavior preserved
-- No change to Redis rolling-window enforcement logic
+
+- For allowed requests:
+  - Normal 2xx response from the downstream handler.
+  - Headers:
+    - `X-Request-ID` (unique ID for the request).
+    - `X-RateLimit-Limit` (configured limit for the window).
+    - `X-RateLimit-Remaining` (remaining quota after the current request).
+- For blocked requests:
+  - 429 response with `"detail": "Rate limit exceeded. Try again later."` in the body.
+  - The same three headers (`X-Request-ID`, `X-RateLimit-Limit`, `X-RateLimit-Remaining`) attached to the response.
+- No changes to the underlying Redis rolling-window logic or rate-limit configuration.
 
 ### Risks & unknowns
-- `api/middleware/request_id.py` currently returns a `JSONResponse` early for blocked requests, so header logic must be carefully applied to avoid skipping required headers.
-- The remaining value on blocked requests may need confirmation to ensure it matches the intended contract (`0` vs another derived value).
-- I still need to confirm whether existing tests already cover middleware headers or whether I need to add new ones.
+- The current 429 path in `RequestIDMiddleware` returns a `JSONResponse` early, so the refactor must be careful not to drop `X-Request-ID` or other headers when returning 429.
+- The exact expected value of `X-RateLimit-Remaining` on blocked requests (e.g., `0` vs a value derived before the block) should be confirmed against the issue description or examples to avoid off-by-one confusion.
+- Existing tests may not assert presence of rate-limit headers on 429 responses; adding new tests must follow the project’s testing patterns and may require fixtures or helpers.
 
 ### Edge cases
-- The final allowed request in the window should return a normal response with `X-RateLimit-Remaining: 0`.
-- A blocked request should return 429 and still include both rate-limit headers.
-- Repeated rapid requests from the same client should show remaining counts decreasing consistently.
-- Missing client connection information should not break the middleware and should fall back safely.
+- A request that is the final allowed request in the current window should return 2xx with `X-RateLimit-Remaining: 0`.
+- A request that exceeds the limit should return 429 and still include `X-RateLimit-Limit` and `X-RateLimit-Remaining` headers, with values consistent with what the limiter reports.
+- Multiple rapid requests from the same client should show `X-RateLimit-Remaining` decreasing in a predictable way until it reaches 0 and then produces 429s.
+- Requests where `request.client` is `None` or has no `host` should still be handled gracefully (e.g., using `"unknown"`), without raising exceptions or skipping headers.

--- a/api/main.py
+++ b/api/main.py
@@ -2,13 +2,18 @@ from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from fastapi.openapi.utils import get_openapi
+import redis
 import structlog
 
 from api.middleware.request_id import RequestIDMiddleware
 from api.routes import auth, profiles, reviews, health
 from core.database import init_db
+from safety.rate_limiter import RateLimiter
 
 log = structlog.get_logger()
+
+redis_client = redis.Redis(host="localhost", port=6379, db=0, decode_responses=True)
+rate_limiter = RateLimiter(redis_client)
 
 # Create FastAPI application
 app = FastAPI(
@@ -51,7 +56,7 @@ app.add_middleware(
 )
 
 # Add request ID middleware
-app.add_middleware(RequestIDMiddleware)
+app.add_middleware(RequestIDMiddleware, rate_limiter=rate_limiter)
 
 
 # Exception handler for unhandled exceptions

--- a/api/middleware/request_id.py
+++ b/api/middleware/request_id.py
@@ -1,8 +1,12 @@
-from fastapi import Request
+# from fastapi import Request
+from fastapi import Request, status
 from starlette.middleware.base import BaseHTTPMiddleware
-from starlette.responses import Response
+# from starlette.responses import Response
+from starlette.responses import Response, JSONResponse
 import uuid
 import structlog
+
+from safety.rate_limiter import RateLimiter
 
 log = structlog.get_logger()
 
@@ -13,6 +17,11 @@ class RequestIDMiddleware(BaseHTTPMiddleware):
     attaches it to the request state, and adds it to response headers.
     Also binds the request_id to structlog context for the duration of the request.
     """
+    def __init__(self, app, rate_limiter: RateLimiter):
+        super().__init__(app)
+        self.limiter = rate_limiter
+        self.limit = 60
+        self.window_seconds = 60
 
     async def dispatch(self, request: Request, call_next) -> Response:
         # Generate unique request ID
@@ -25,10 +34,28 @@ class RequestIDMiddleware(BaseHTTPMiddleware):
         structlog.contextvars.clear_contextvars()
         structlog.contextvars.bind_contextvars(request_id=request_id)
 
-        # Process request
-        response = await call_next(request)
+        client_ip = request.client.host if request.client else "unknown"
+
+        allowed, remaining = self.limiter.check_rate_limit(
+            identifier=client_ip,
+            limit=self.limit,
+            window_seconds=self.window_seconds
+        )
+
+        if not allowed:
+            log.warning("rate_limit_blocked", client_ip=client_ip, limit=self.limit)
+            return JSONResponse(
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                content={"detail": "Rate limit exceeded. Try again later."}
+            )
+        else:
+
+            # Process request
+            response = await call_next(request)
 
         # Add request ID to response header
         response.headers["X-Request-ID"] = request_id
+        response.headers["X-RateLimit-Limit"] = str(self.limit)
+        response.headers["X-RateLimit-Remaining"] = str(remaining)
 
         return response

--- a/api/middleware/request_id.py
+++ b/api/middleware/request_id.py
@@ -1,7 +1,5 @@
-# from fastapi import Request
 from fastapi import Request, status
 from starlette.middleware.base import BaseHTTPMiddleware
-# from starlette.responses import Response
 from starlette.responses import Response, JSONResponse
 import uuid
 import structlog
@@ -17,20 +15,17 @@ class RequestIDMiddleware(BaseHTTPMiddleware):
     attaches it to the request state, and adds it to response headers.
     Also binds the request_id to structlog context for the duration of the request.
     """
-    def __init__(self, app, rate_limiter: RateLimiter):
+
+    def __init__(self, app, rate_limiter: RateLimiter, limit: int = 60, window_seconds: int = 60):
         super().__init__(app)
         self.limiter = rate_limiter
-        self.limit = 60
-        self.window_seconds = 60
+        self.limit = limit
+        self.window_seconds = window_seconds
 
     async def dispatch(self, request: Request, call_next) -> Response:
-        # Generate unique request ID
         request_id = str(uuid.uuid4())
-
-        # Attach to request state
         request.state.request_id = request_id
 
-        # Bind to structlog context
         structlog.contextvars.clear_contextvars()
         structlog.contextvars.bind_contextvars(request_id=request_id)
 
@@ -39,21 +34,18 @@ class RequestIDMiddleware(BaseHTTPMiddleware):
         allowed, remaining = self.limiter.check_rate_limit(
             identifier=client_ip,
             limit=self.limit,
-            window_seconds=self.window_seconds
+            window_seconds=self.window_seconds,
         )
 
         if not allowed:
             log.warning("rate_limit_blocked", client_ip=client_ip, limit=self.limit)
-            return JSONResponse(
+            response = JSONResponse(
                 status_code=status.HTTP_429_TOO_MANY_REQUESTS,
-                content={"detail": "Rate limit exceeded. Try again later."}
+                content={"detail": "Rate limit exceeded. Try again later."},
             )
         else:
-
-            # Process request
             response = await call_next(request)
 
-        # Add request ID to response header
         response.headers["X-Request-ID"] = request_id
         response.headers["X-RateLimit-Limit"] = str(self.limit)
         response.headers["X-RateLimit-Remaining"] = str(remaining)

--- a/tests/unit/test_request_id_middleware.py
+++ b/tests/unit/test_request_id_middleware.py
@@ -1,0 +1,53 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.middleware.request_id import RequestIDMiddleware
+
+
+class StubRateLimiter:
+    def __init__(self, responses):
+        self.responses = responses
+        self.calls = 0
+
+    def check_rate_limit(self, identifier: str, limit: int, window_seconds: int = 60):
+        response = self.responses[self.calls]
+        self.calls += 1
+        return response
+
+
+def create_app(rate_limiter):
+    app = FastAPI()
+    app.add_middleware(RequestIDMiddleware, rate_limiter=rate_limiter)
+
+    @app.get("/ping")
+    def ping():
+        return {"ok": True}
+
+    return app
+
+
+def test_allowed_response_includes_rate_limit_headers():
+    limiter = StubRateLimiter([(True, 59)])
+    app = create_app(limiter)
+    client = TestClient(app)
+
+    response = client.get("/ping")
+
+    assert response.status_code == 200
+    assert response.headers["X-Request-ID"]
+    assert response.headers["X-RateLimit-Limit"] == "60"
+    assert response.headers["X-RateLimit-Remaining"] == "59"
+
+
+def test_blocked_response_includes_rate_limit_headers():
+    limiter = StubRateLimiter([(False, 0)])
+    app = create_app(limiter)
+    client = TestClient(app)
+
+    response = client.get("/ping")
+
+    assert response.status_code == 429
+    assert response.json() == {"detail": "Rate limit exceeded. Try again later."}
+    assert response.headers["X-Request-ID"]
+    assert response.headers["X-RateLimit-Limit"] == "60"
+    assert response.headers["X-RateLimit-Remaining"] == "0"


### PR DESCRIPTION
## Summary
Added rate limit response headers so API clients can see how many requests they have left before hitting the limit

## Issue
Closes # 86

## Changes
- Wire 'RateLimiter.check_rate_limit' into API middleware
- Add 'X-RateLimit-Limit' and also "X-RateLimit-Remaining' to all responses
- Ensure 429 responses also include rate limit headers

## Testing
- [x ] Unit tests pass (`make test-unit`)
- [x ] Integration tests pass (`make test-integration`)
- [ ] Linter passes (`make lint`)
- [ x] Type checker passes (`make typecheck`)
- [ ] New/updated tests cover the changes

## Screenshots / Demo
N/A

## Notes for Reviewers
- Please confirm header names and values match the course spec
- See that implementation of middleware handling both allowed and blocked requests is correct
