### PR TITLE
fix: use redis_url instead of undefined redis_host/redis_port in health check (#155)

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,18 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/155
+**Issue title:** Health check references settings.redis_host, which does not exist on Settings
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The `/health` endpoint in `api/routes/health.py` tries to connect to Redis using `settings.redis_host` and `settings.redis_port`, but `core/config.py` only defines a single `redis_url` field — it never defines separate host/port fields. This causes an `AttributeError` every time the Redis check runs, which is caught by the endpoint's exception handling and silently reported as `"redis": "unhealthy"`, so the health check always fails on Redis even when Redis is running fine. A successful fix would update the Redis check to use the existing `redis_url` field (either by parsing it or connecting via `redis.from_url()`) so the health check accurately reflects Redis's real status.
+
+**Scope reasoning ("Is this right for me?" checklist):**
+I chose issue #155 because it's a well-scoped Tier 1 fix: the bug is isolated to a single function (`health_check` in `api/routes/health.py`), the root cause is already clear from reading the code (two undefined config fields), and the fix doesn't require touching other modules or understanding unfamiliar business logic. It's also easy to verify locally — I can call `GET /health` before and after the fix and see the Redis status change. Since this is my first time contributing to a large codebase, this level of contained, single-function scope felt like the right entry point rather than something involving multiple files or unclear requirements.
+
+**Branch name:** fix/155-health-check-redis-host
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -16,3 +16,16 @@ I chose issue #155 because it's a well-scoped Tier 1 fix: the bug is isolated to
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [add after you commit — see below]
+
+**Reproduction summary:**
+Ran the app locally and called `GET http://localhost:8000/health`. The response returned a 503 with `"redis": "unhealthy"`, and the Uvicorn logs confirmed the exact root cause: `redis_health_check_failed error="'Settings' object has no attribute 'redis_host'"` — matching the issue exactly. (Note: `postgres` also showed unhealthy in this run, but that's a separate, unrelated SQLAlchemy 2.x text() issue — not part of #155.)
+
+**PLAN.md link:** [add after you create PLAN.md — see below]
+
+**Walkthrough video (recommended):** [optional — skip or add later]
+
+**Blockers or open questions:**
+Need to confirm whether other files in the codebase also reference `settings.redis_host`/`settings.redis_port` besides `health.py`, and haven't yet located the test file for this route.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -18,12 +18,13 @@ I chose issue #155 because it's a well-scoped Tier 1 fix: the bug is isolated to
 **Cohort ledger:** [x] Issue added to cohort ledger
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [add after you commit — see below]
+**Reproduction commit link:** https://github.com/sandhya8109/pathreview/commit/53b4444a1a9e50870aa0875db85b7cc3f0955cf6
 
 **Reproduction summary:**
 Ran the app locally and called `GET http://localhost:8000/health`. The response returned a 503 with `"redis": "unhealthy"`, and the Uvicorn logs confirmed the exact root cause: `redis_health_check_failed error="'Settings' object has no attribute 'redis_host'"` — matching the issue exactly. (Note: `postgres` also showed unhealthy in this run, but that's a separate, unrelated SQLAlchemy 2.x text() issue — not part of #155.)
 
-**PLAN.md link:** [add after you create PLAN.md — see below]
+**PLAN.md link:** 
+https://github.com/sandhya8109/pathreview/blob/fix/155-health-check-redis-host/PLAN.md
 
 **Walkthrough video (recommended):** [optional — skip or add later]
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -42,3 +42,20 @@ Run `make check` and `make test-unit` against the full suite to confirm no new f
 
 **Blockers:**
 None currently. One open question I noted in `PLAN.md`: whether `redis.from_url()` handles every option the old `host`/`port` approach implicitly assumed (e.g. auth/TLS) — not an issue for this local setup, but worth a mentor's eyes on the PR in case it matters for other environments.
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/234
+
+**Branch:** fix/155-health-check-redis-host
+
+**What you built:**
+Fixed the `/health` endpoint so it correctly reports Redis status using the existing `redis_url` config field instead of the undefined `redis_host`/`redis_port` fields that were causing a silent `AttributeError` on every health check.
+
+**Tests added or updated:**
+Added `tests/unit/test_health.py` (7 tests) covering Redis healthy/unhealthy paths, a regression test confirming `redis_url` is used correctly, Postgres healthy/unhealthy paths, and overall response shape/status codes.
+
+**Self-review confirmation:** [x] make check passes (except 54 pre-existing mypy errors across 8 files unrelated to my change, documented in the PR) [x] make test-unit passes (except 53 pre-existing failures unrelated to my change, all in files I didn't touch — `test_health.py` passes 7/7)
+
+**Draft PR feedback received from:** Slack peer review — positive feedback, no blocking changes requested

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -58,4 +58,4 @@ Added `tests/unit/test_health.py` (7 tests) covering Redis healthy/unhealthy pat
 
 **Self-review confirmation:** [x] make check passes (except 54 pre-existing mypy errors across 8 files unrelated to my change, documented in the PR) [x] make test-unit passes (except 53 pre-existing failures unrelated to my change, all in files I didn't touch — `test_health.py` passes 7/7)
 
-**Draft PR feedback received from:** Slack peer review — positive feedback, no blocking changes requested
+**Draft PR feedback received from:** Slack peer review by Rabina Karki — positive feedback, no blocking changes requested

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -59,3 +59,51 @@ Added `tests/unit/test_health.py` (7 tests) covering Redis healthy/unhealthy pat
 **Self-review confirmation:** [x] make check passes (except 54 pre-existing mypy errors across 8 files unrelated to my change, documented in the PR) [x] make test-unit passes (except 53 pre-existing failures unrelated to my change, all in files I didn't touch — `test_health.py` passes 7/7)
 
 **Draft PR feedback received from:** Slack peer review by Rabina Karki — positive feedback, no blocking changes requested
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ Yes ] Yes  [ ] No — still awaiting review
+Answer:
+Yes
+**Summary of feedback:**
+[What did reviewers comment on? Or note that no review came in.]
+Answer: 
+According to her I figued the issue properly and was doign well.
+
+**How you responded:**
+[What changes did you make, or what did you reply? If no feedback,
+leave blank.]
+Answer: 
+Since the response was positive I thanked her for giving her time to review my code.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+[Be specific — what part of the process, codebase, or workflow
+surprised you?]
+Answer: 
+Before this I had no idea how we can integrate AI or the power of AI now I have build different project based on LLM and I am so happy about it. Collaborating was something new to me and I enjoyed it alot.
+
+**What did you learn about working in a large codebase?**
+[What's different about contributing to someone else's production code
+vs. building your own project?]
+Answer:
+You have to be careful about which branch you are comiiting and what exactly you are commiting.
+**How did AI tools help — and where did they fall short?**
+[Where was AI assistance most useful this module? Where did you need
+to go beyond what AI could give you?]
+Answer: 
+I have no problem because of AI tools and it helped me figure out what steps are posible. 
+**What would you do differently if you started over?**
+[Issue selection, planning, implementation, or process — anything
+you'd change?]
+Answer:
+While working I first took help me AI and i was too relying on AI so maybe figure thigns first and then ask AI foe help.
+**What are you most proud of from this module?**
+[One thing — it doesn't have to be the PR itself.]
+Answer: 
+ Being able to figure all issue and compelte the project was my biggest achievement. 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -30,3 +30,15 @@ https://github.com/sandhya8109/pathreview/blob/fix/155-health-check-redis-host/P
 
 **Blockers or open questions:**
 Need to confirm whether other files in the codebase also reference `settings.redis_host`/`settings.redis_port` besides `health.py`, and haven't yet located the test file for this route.
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the core fix for issue #155: replaced the broken `redis.Redis(host=settings.redis_host, port=settings.redis_port, ...)` call in `api/routes/health.py` with `redis.from_url(settings.redis_url, decode_responses=True)`, using the config field that actually exists. Verified locally in both directions — with Redis running, `/health` correctly reports `"redis": "healthy"`; with Redis stopped, it reports `"redis": "unhealthy"` for a genuine connection error rather than the old `AttributeError`. Also wrote a full test suite (`tests/unit/test_health.py`, 7 tests) covering the Redis healthy/unhealthy paths, a regression test confirming `redis_url` is used instead of the undefined fields, and the Postgres/vector_db checks and overall response shape. Cleaned up a pre-existing unused `timedelta` import and import ordering in `health.py` while I was in the file. This covers sub-tasks 1–4 of my `PLAN.md` (grep for other references, locate test file, implement the fix, verify both healthy/unhealthy cases) plus sub-task 5 (write tests).
+
+**Next steps:**
+Run `make check` and `make test-unit` against the full suite to confirm no new failures (done — confirmed 53 pre-existing failures unrelated to my change, `test_health.py` passes 7/7 clean). Open a draft PR on `pathreview` for early feedback, fill in the PR template, and get peer/mentor review before finalizing.
+
+**Blockers:**
+None currently. One open question I noted in `PLAN.md`: whether `redis.from_url()` handles every option the old `host`/`port` approach implicitly assumed (e.g. auth/TLS) — not an issue for this local setup, but worth a mentor's eyes on the PR in case it matters for other environments.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,31 @@
+## Solution plan
+
+**Issue:** Health check references settings.redis_host, which does not exist on Settings — https://github.com/ascherj/pathreview/issues/155
+
+### Understand
+The root cause is confirmed: `api/routes/health.py` builds a `redis.Redis()` client using `settings.redis_host` and `settings.redis_port`, but `core/config.py`'s `Settings` model only defines `redis_url` (a full connection string like `redis://localhost:6379/0`) — it never defines separate host/port fields. Expected behavior: the health check connects to Redis using existing config and accurately reports its real status. Actual behavior (confirmed via local reproduction): every call to `GET /health` raises `AttributeError: 'Settings' object has no attribute 'redis_host'`, which is caught by the endpoint's `try/except` and silently reported as `"redis": "unhealthy"` — even when Redis itself is running and healthy, as confirmed by `docker compose ps`.
+
+### Map
+- `api/routes/health.py` — the `health_check` function, specifically the Redis check block (`r = redis.Redis(host=settings.redis_host, port=settings.redis_port, ...)`).
+- `core/config.py` — the `Settings` model, which defines `redis_url` but not `redis_host`/`redis_port`.
+- Test file for this route — still need to locate (likely `tests/unit/test_health.py` or similar); not yet confirmed. This is an open item for early Week 9.
+
+### Plan
+1. Grep the whole repo (not just `health.py`) for any other references to `settings.redis_host` or `settings.redis_port`, to make sure I catch every place this bug shows up, not just the one in the issue.
+2. Locate and read the existing test file for `/health` to understand the mocking conventions used for Postgres/Redis/vector_db checks before writing new tests.
+3. Replace the `redis.Redis(host=..., port=...)` construction with `redis.from_url(settings.redis_url)`, which parses the existing connection string directly instead of relying on fields that don't exist.
+4. Manually re-verify locally: hit `/health` with Redis running (expect `"redis": "healthy"`), then stop the Redis container and hit `/health` again (expect a genuine `"unhealthy"`, not an AttributeError) — confirming the fix distinguishes real failures from config bugs.
+5. Write or update a unit test that mocks `redis.from_url` to cover both the healthy and unhealthy paths.
+
+### Inputs & outputs
+Input: the existing `settings.redis_url` config value. Output: an accurate `"redis"` status field in the `/health` JSON response — `"healthy"` when Redis is genuinely reachable, `"unhealthy"` when it genuinely isn't (not due to a missing config attribute).
+
+### Risks & unknowns
+- `redis.from_url()` may not support every option the old `host`/`port` approach implicitly assumed (e.g. TLS, auth) — need to check the `redis-py` docs before finalizing.
+- Haven't yet located the test file for `/health` — if none exists, I'll need to create one from scratch rather than extend an existing pattern, which adds scope.
+- The unrelated Postgres failure I saw during reproduction (`Textual SQL expression should be explicitly declared as text('SELECT 1')`) is a separate SQLAlchemy 2.x issue in the same function — I need to make sure my diff doesn't accidentally touch that code path while editing nearby lines.
+
+### Edge cases
+- `redis_url` is empty or malformed — `from_url()` should raise a clear, catchable exception, not crash the whole endpoint.
+- Redis is reachable but slow/times out — should report `"unhealthy"` rather than hang the health check indefinitely.
+- `redis_url` includes an embedded password (e.g. `redis://:password@host:port/0`) — confirm `from_url()` correctly parses credentials rather than silently dropping them.

--- a/api/routes/health.py
+++ b/api/routes/health.py
@@ -1,6 +1,7 @@
-from fastapi import APIRouter, HTTPException, status, Depends
+from datetime import datetime
+
 import structlog
-from datetime import datetime, timedelta
+from fastapi import APIRouter, Depends, HTTPException, status
 
 from core.database import get_db
 
@@ -39,14 +40,10 @@ async def health_check(db=Depends(get_db)):
     try:
         # Check Redis (if available)
         import redis
+
         from core.config import settings
 
-        r = redis.Redis(
-            host=settings.redis_host,
-            port=settings.redis_port,
-            db=0,
-            decode_responses=True,
-        )
+        r = redis.from_url(settings.redis_url, decode_responses=True)
         r.ping()
         health_status["dependencies"]["redis"] = "healthy"
         log.debug("redis_health_check_passed")

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -99,7 +99,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -449,7 +448,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -473,7 +471,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1561,7 +1558,6 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1579,7 +1575,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1972,7 +1967,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3507,7 +3501,6 @@
       "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^2.0.1",
         "cssstyle": "^4.0.1",
@@ -4094,7 +4087,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4107,7 +4099,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4771,7 +4762,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -1,0 +1,113 @@
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.main import app
+from core.database import get_db
+
+
+@pytest.mark.unit
+class TestHealthCheck:
+    """Test suite for the /health endpoint."""
+
+    @pytest.fixture
+    def mock_db(self):
+        """Create a mock async DB session that succeeds by default."""
+        db = AsyncMock()
+        db.execute = AsyncMock(return_value=None)
+        return db
+
+    @pytest.fixture
+    def client(self, mock_db):
+        """TestClient with the get_db dependency overridden."""
+
+        async def _override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = _override_get_db
+        yield TestClient(app)
+        app.dependency_overrides.clear()
+
+    def test_redis_healthy_when_reachable(self, client) -> None:
+        """Redis check should report healthy when redis.from_url + ping succeed."""
+        mock_redis_client = Mock()
+        mock_redis_client.ping = Mock(return_value=True)
+
+        with patch("redis.from_url", return_value=mock_redis_client) as mock_from_url:
+            response = client.get("/health")
+
+        body = response.json()
+        payload = body.get("detail", body)
+
+        assert payload["dependencies"]["redis"] == "healthy"
+        mock_from_url.assert_called_once()
+
+    def test_redis_unhealthy_when_connection_fails(self, client) -> None:
+        """Redis check should report unhealthy (not crash) when the connection fails."""
+        with patch("redis.from_url", side_effect=Exception("Connection refused")):
+            response = client.get("/health")
+
+        assert response.status_code == 503
+        body = response.json()["detail"]
+        assert body["dependencies"]["redis"] == "unhealthy"
+        assert body["status"] == "unhealthy"
+
+    def test_redis_check_uses_redis_url_not_undefined_fields(self, client) -> None:
+        """
+        Regression test for #155: the health check must use settings.redis_url,
+        not settings.redis_host / settings.redis_port, which don't exist on Settings.
+        """
+        mock_redis_client = Mock()
+        mock_redis_client.ping = Mock(return_value=True)
+
+        with patch("redis.from_url", return_value=mock_redis_client) as mock_from_url:
+            response = client.get("/health")
+
+        args, kwargs = mock_from_url.call_args
+        assert len(args) >= 1
+        assert "host" not in kwargs
+        assert "port" not in kwargs
+
+        body = response.json().get("detail", response.json())
+        assert body["dependencies"]["redis"] == "healthy"
+
+    def test_postgres_healthy_when_db_succeeds(self, client, mock_db) -> None:
+        """Postgres check should report healthy when the DB query succeeds."""
+        with patch("redis.from_url") as mock_from_url:
+            mock_from_url.return_value.ping = Mock(return_value=True)
+            response = client.get("/health")
+
+        body = response.json().get("detail", response.json())
+        assert body["dependencies"]["postgres"] == "healthy"
+
+    def test_postgres_unhealthy_when_db_fails(self, client, mock_db) -> None:
+        """Postgres check should report unhealthy when the DB query raises."""
+        mock_db.execute = AsyncMock(side_effect=Exception("DB connection failed"))
+
+        with patch("redis.from_url") as mock_from_url:
+            mock_from_url.return_value.ping = Mock(return_value=True)
+            response = client.get("/health")
+
+        assert response.status_code == 503
+        body = response.json()["detail"]
+        assert body["dependencies"]["postgres"] == "unhealthy"
+
+    def test_response_includes_all_dependency_keys(self, client) -> None:
+        """Response should always report postgres, redis, and vector_db keys."""
+        with patch("redis.from_url") as mock_from_url:
+            mock_from_url.return_value.ping = Mock(return_value=True)
+            response = client.get("/health")
+
+        body = response.json().get("detail", response.json())
+        assert set(body["dependencies"].keys()) == {"postgres", "redis", "vector_db"}
+
+    def test_all_healthy_returns_200(self, client):
+        """When every dependency is healthy, the endpoint should return 200."""
+        with patch("redis.from_url") as mock_from_url:
+            mock_from_url.return_value.ping = Mock(return_value=True)
+            response = client.get("/health")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["status"] == "healthy"


### PR DESCRIPTION
## Summary
Fixes the `/health` endpoint, which was reporting Redis as unhealthy on every request due to a config bug, not an actual Redis outage.

## Issue
Closes #155

`api/routes/health.py` calls `redis.Redis(host=settings.redis_host, port=settings.redis_port, ...)`, but `Settings` (in `core/config.py`) only defines `redis_url` — it never defines `redis_host` or `redis_port`. This causes an `AttributeError` on every health check, silently caught and reported as `"redis": "unhealthy"` — even when Redis is running fine.

## Changes
- Replaced the broken `redis.Redis(host=..., port=...)` construction with `redis.from_url(settings.redis_url, decode_responses=True)`, using the config field that actually exists.
- Removed an unused `timedelta` import and fixed import ordering in `health.py` (pre-existing, adjacent to my change).
- Added `tests/unit/test_health.py` (7 tests) covering:
  - Redis healthy/unhealthy paths
  - A regression test confirming `redis_url` is used (not the undefined fields)
  - Postgres healthy/unhealthy paths
  - Overall response shape and status code behavior

## Verification
Reproduced locally by hitting `GET /health` before the fix — confirmed `redis_health_check_failed error="'Settings' object has no attribute 'redis_host'"` in logs. After the fix:
- With Redis running: `"redis": "healthy"`
- With Redis stopped: `"redis": "unhealthy"` for a genuine connection error, not an AttributeError

## Pre-existing issues (unrelated to this change)
- `make test-unit`: 53 pre-existing failures across the suite, all in files I didn't modify. `test_health.py` passes 7/7.
- `make check` (mypy): 54 pre-existing type errors across 8 files I didn't create or meaningfully modify. Committed with `--no-verify` due to the scope of pre-existing type debt — documented here per Week 9 guidance rather than fixing the whole codebase's type coverage.

None of the above are introduced or affected by this change.