### PR TITLE
fix(health): use redis_url instead of non-existent redis_host/redis_port

### DIFF
--- a/api/routes/health.py
+++ b/api/routes/health.py
@@ -41,10 +41,8 @@ async def health_check(db=Depends(get_db)):
         import redis
         from core.config import settings
 
-        r = redis.Redis(
-            host=settings.redis_host,
-            port=settings.redis_port,
-            db=0,
+        r = redis.Redis.from_url(
+            settings.redis_url,
             decode_responses=True,
         )
         r.ping()


### PR DESCRIPTION
## Summary

The health check endpoint (`GET /health`) referenced `settings.redis_host` and `settings.redis_port`, but the `Settings` model in `core/config.py` does not define those fields — it only defines `redis_url`. This caused an `AttributeError` before the Redis status could be reported, making the health check always report Redis as unhealthy.

## Changes
- Replaced `redis.Redis(host=..., port=...)` with `redis.Redis.from_url(settings.redis_url)` which:
  - Uses the existing `redis_url` config field (no new fields needed)
  - Is the recommended way to connect via URL in redis-py
  - Keeps `decode_responses=True` behavior intact

## Testing
- Verified `settings.redis_url` exists in `core/config.py` with default `redis://localhost:6379/0`
- Confirmed `redis_host` / `redis_port` are absent from Settings

Fixes #155