### PR TITLE
fix(health): wrap SQL probe in sqlalchemy.text() for SQLAlchemy 2.x

### DIFF
--- a/api/routes/health.py
+++ b/api/routes/health.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, HTTPException, status, Depends
 import structlog
 from datetime import datetime, timedelta
+from sqlalchemy import text
 
 from core.database import get_db
 
@@ -28,7 +29,7 @@ async def health_check(db=Depends(get_db)):
 
     try:
         # Check PostgreSQL
-        await db.execute("SELECT 1")
+        await db.execute(text("SELECT 1"))
         health_status["dependencies"]["postgres"] = "healthy"
         log.debug("postgres_health_check_passed")
     except Exception as exc:


### PR DESCRIPTION
## Summary

The database probe in `api/routes/health.py` executed the literal string `"SELECT 1"` via `db.execute()`. SQLAlchemy 2.x requires textual SQL to be wrapped in `sqlalchemy.text()`, otherwise it raises:

```
ArgumentError: Textual SQL expression 'SELECT 1' should be explicitly declared as text('SELECT 1')
```

This caused the health check to report the database as down even when it was reachable.

## Changes
- Added `from sqlalchemy import text` import
- Wrapped the probe: `await db.execute(text("SELECT 1"))`

## Testing
- Confirmed the pattern matches SQLAlchemy 2.x migration guide
- Minimal, surgical fix — no behavioral change

Fixes #154