### PR TITLE
fix(chunker): handle documents without headings in StructuralChunker

### DIFF
--- a/ingestion/chunking/structural_chunker.py
+++ b/ingestion/chunking/structural_chunker.py
@@ -107,8 +107,11 @@ class StructuralChunker(BaseChunker):
                 current_level = heading_level
 
             else:
-                # Regular content line
-                if heading_stack or current_section_lines:  # Only collect if we have a heading
+                # Regular content line — collect if we have a heading or any content so far
+                if heading_stack or current_section_lines:
+                    current_section_lines.append(line)
+                elif line.strip():
+                    # No headings yet, but start collecting non-empty content
                     current_section_lines.append(line)
 
         # Save final section
@@ -118,5 +121,14 @@ class StructuralChunker(BaseChunker):
                 "path": [h[1] for h in heading_stack],
                 "level": heading_stack[-1][0] if heading_stack else 0,
             })
+        elif current_section_lines:
+            # Document with no headings — return as a single default section
+            content = "\n".join(current_section_lines).strip()
+            if content:
+                sections.append({
+                    "content": content,
+                    "path": ["Document"],
+                    "level": 0,
+                })
 
         return sections


### PR DESCRIPTION
## Summary

`StructuralChunker._extract_sections()` silently dropped any document that contained no markdown headings. This happened because:

1. **Lines were never collected** — the guard `if heading_stack or current_section_lines` prevented the first non-heading line from being appended (both were empty initially).
2. **Final section was never saved** — the end-of-method guard required `heading_stack` to be non-empty.

As a result, an entire document could be excluded from the RAG index without any warning.

## Changes

- **Collect non-empty lines even when no headings exist** — added an `elif line.strip()` branch to start accumulating content for headingless documents.
- **Return a default section** when the document has content but no heading hierarchy was built — uses `"Document"` as the heading path and `level: 0`.

## Behavior

```python
chunker = StructuralChunker()
# Before: []  (document silently dropped)
# After:  [Chunk(text='...', metadata={'heading_path': 'Document', 'heading_level': 0, ...})]
result = chunker.chunk('Plain text with no headings. ' * 20, {})
assert len(result) >= 1
```

This satisfies the existing `test_document_with_no_headings` test.

Fixes #149