### PR TITLE
fix(ingestion): preserve documents without headings

### DIFF
--- a/JOURNAL.MD
+++ b/JOURNAL.MD
@@ -1,0 +1,23 @@
+# PathReview Contribution Journal
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/149
+
+**Issue title:** Structural chunker silently drops documents that contain no headings
+
+**Tier:** [x] Tier 1 [ ] Tier 2 [ ] Tier 3
+
+**Problem summary:**
+
+The structural chunker currently returns an empty list when a document does not contain Markdown headings. This causes valid plain-text documents to be silently excluded from the RAG index. The issue affects `StructuralChunker.chunk()` in the ingestion module. A successful fix should preserve documents without headings by creating a valid chunk or using an appropriate fallback strategy.
+
+**Selection reasoning — “Is this right for me?” checklist:**
+
+This issue is a Tier 1 bug with a clearly identified function and failing unit test. The scope appears limited to the structural chunker and its related tests, so it should not require understanding the entire application. I also have experience with document chunking, embeddings, and RAG projects, which makes the problem relevant to my background. I expect the issue to be realistic to complete within the Week 8–9 timeline.
+
+**Branch name:** `fix/149-handle-documents-without-headings`
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger

--- a/JOURNAL.MD
+++ b/JOURNAL.MD
@@ -24,7 +24,7 @@ This issue is a Tier 1 bug with a clearly identified function and failing unit t
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** Pending this commit (will be replaced with its permanent link).
+**Reproduction commit link:** [d5a98ef — document issue 149 reproduction](https://github.com/DTran228/pathreview/commit/d5a98ef985cd0a16a07cec8312df6e4fd5cfab5b)
 
 **Reproduction summary:** I reproduced issue #149 with a 1,000-character plain-text input that
 contains no Markdown headings. `StructuralChunker.chunk()` returned `0` chunks, even though the

--- a/JOURNAL.MD
+++ b/JOURNAL.MD
@@ -21,3 +21,22 @@ This issue is a Tier 1 bug with a clearly identified function and failing unit t
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [ ] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** Pending this commit (will be replaced with its permanent link).
+
+**Reproduction summary:** I reproduced issue #149 with a 1,000-character plain-text input that
+contains no Markdown headings. `StructuralChunker.chunk()` returned `0` chunks, even though the
+input is non-empty; `_extract_sections()` only collects lines after it has seen a heading, so it
+silently drops every line in this document type.
+
+**PLAN.md link:** [PLAN.md](PLAN.md)
+
+**Walkthrough video (recommended):** Not recorded.
+
+**Blockers or open questions:** The repository's `.venv` points to a Python executable that is
+no longer installed, so the standard `pytest` command cannot start yet. This is a local setup
+blocker separate from #149. The reproduction above was executed against the chunker's current
+logic with a minimal local tokenizer stub; after repairing the environment, I will run the
+existing focused unit test and the complete structural-chunker suite before implementing the fix.

--- a/JOURNAL.MD
+++ b/JOURNAL.MD
@@ -59,3 +59,30 @@ the repository's standard `make` commands cannot run locally. I verified the cha
 module in an isolated temporary Python 3.12 environment: its focused tests, Ruff, and
 Black pass. The full unit suite currently reports failures in unrelated modules outside
 this issue; none are in `tests/unit/test_structural_chunker.py`.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [#254 — preserve documents without headings](https://github.com/ascherj/pathreview/pull/254)
+
+**Branch:** `fix/149-handle-documents-without-headings`
+
+**What you built:** `StructuralChunker.chunk()` now creates a level-zero fallback
+section when non-empty input has no Markdown headings, preventing valid plain-text
+documents from being silently excluded. The fallback preserves source metadata and
+continues through the existing semantic chunker for large documents.
+
+**Tests added or updated:** Updated `tests/unit/test_structural_chunker.py` to assert
+the exact single-chunk fallback contract, including text and metadata. Added a long
+plain-text regression test that verifies multiple subchunks keep the level-zero
+metadata. The focused structural-chunker suite passes 16/16 tests.
+
+**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+
+The repository's `.venv` cannot start because its Python 3.11 executable was removed.
+In an isolated environment, Ruff and Black pass for the changed files and the focused
+suite passes. The full unit suite reported 52 failures in files outside this issue; this
+change neither modifies nor adds failures to those areas.
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.MD
+++ b/JOURNAL.MD
@@ -86,3 +86,65 @@ suite passes. The full unit suite reported 52 failures in files outside this iss
 change neither modifies nor adds failures to those areas.
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:** No reviewer or maintainer feedback arrived. The Summer 2026
+course instructions note that reviewer feedback is not available for this cohort.
+
+**How you responded:** No code changes were needed after opening the PR. I left the PR
+open and ready for review, with the implementation, focused test results, and known
+project-wide check failures documented in the PR description and Week 9 check-in.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+
+The difficult part was not the fallback itself; it was proving the exact boundary of
+the bug before changing code. The existing no-heading test showed a failure, but I had
+to trace why `_extract_sections()` returned no sections and make sure a fallback would
+not bypass the 800-token protection. The local Python environment also pointed to a
+removed Python 3.11 executable, which made the usual project commands unavailable and
+forced me to separate environment problems from the issue I was fixing.
+
+**What did you learn about working in a large codebase?**
+
+I learned to follow data through one narrow path instead of trying to understand the
+whole application at once. For this issue, the useful path was README input, structural
+section extraction, chunk metadata, and tests. Reading the caller and the semantic
+chunker before editing helped keep the change small: plain-text documents now get a
+level-zero section, while headed Markdown keeps its existing hierarchy and large inputs
+keep using semantic sub-chunking. In another person's codebase, preserving established
+behavior and documenting assumptions matters as much as making the new case work.
+
+**How did AI tools help — and where did they fall short?**
+
+AI tools helped me map the codebase quickly, compare the implementation with the
+failing test, and turn the observation into a concrete plan and regression tests. They
+were especially useful for explaining why an empty list was produced and for checking
+which metadata the fallback needed to preserve. They could not replace judgment about
+scope or verification: I still needed to read the surrounding code, choose a minimal
+fallback instead of rewriting the parser, and report the broken virtual environment and
+unrelated full-suite failures honestly.
+
+**What would you do differently if you started over?**
+
+I would verify the Python version and run the baseline checks before writing the Week 8
+plan. Doing that earlier would have surfaced the broken virtual environment immediately
+and made the Week 9 verification smoother. I would also open the draft PR as soon as
+the reproduction was committed, so the PR description and request for feedback could
+evolve alongside the implementation rather than being finalized at the end.
+
+**What are you most proud of from this module?**
+
+I am most proud of turning a small but silent data-loss bug into a precise, tested
+behavior. The final tests cover both the normal no-heading case and the long-document
+case, so the fix protects valid plain text without weakening the existing chunk-size
+behavior. More importantly, I can explain the root cause, the constraints of the fix,
+and the evidence that it works.

--- a/JOURNAL.MD
+++ b/JOURNAL.MD
@@ -39,3 +39,23 @@ silently drops every line in this document type.
 `test_document_with_no_headings` now runs and fails as expected: a non-empty
 plain-text document without Markdown headings produces `0` chunks. This confirms
 the reproduction for issue #149. No implementation blocker remains.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:** Completed the planned level-zero fallback in
+`StructuralChunker.chunk()` and strengthened `tests/unit/test_structural_chunker.py`.
+Plain-text documents without headings now produce chunks that retain source metadata,
+an empty `heading_path`, and `heading_level` 0; large plain-text documents still use
+semantic sub-chunking. The focused structural-chunker suite passes 16/16 tests.
+
+**Next steps:** Run final project checks in a Python 3.11 environment, open a draft PR,
+request peer or mentor feedback, address applicable feedback, then complete Check-in 2
+with the submitted PR link.
+
+**Blockers:** The project `.venv` still points to a removed Python 3.11 executable, so
+the repository's standard `make` commands cannot run locally. I verified the changed
+module in an isolated temporary Python 3.12 environment: its focused tests, Ruff, and
+Black pass. The full unit suite currently reports failures in unrelated modules outside
+this issue; none are in `tests/unit/test_structural_chunker.py`.

--- a/JOURNAL.MD
+++ b/JOURNAL.MD
@@ -35,8 +35,7 @@ silently drops every line in this document type.
 
 **Walkthrough video (recommended):** Not recorded.
 
-**Blockers or open questions:** The repository's `.venv` points to a Python executable that is
-no longer installed, so the standard `pytest` command cannot start yet. This is a local setup
-blocker separate from #149. The reproduction above was executed against the chunker's current
-logic with a minimal local tokenizer stub; after repairing the environment, I will run the
-existing focused unit test and the complete structural-chunker suite before implementing the fix.
+**Blockers or open questions:** The focused test
+`test_document_with_no_headings` now runs and fails as expected: a non-empty
+plain-text document without Markdown headings produces `0` chunks. This confirms
+the reproduction for issue #149. No implementation blocker remains.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,34 @@
+# Issue #149 Plan
+
+## Reproduction
+
+`StructuralChunker.chunk()` returns an empty list when given a non-empty plain-text document without Markdown headings.
+
+## Expected behavior
+
+A non-empty document without headings should still produce at least one valid chunk instead of being silently excluded from the RAG index.
+
+## Files to inspect
+
+- `ingestion/chunking/structural_chunker.py`
+- `tests/unit/test_structural_chunker.py`
+
+## Implementation plan
+
+1. Read the current `StructuralChunker.chunk()` logic.
+2. Identify why no-heading documents produce no sections.
+3. Add a fallback for non-empty documents without headings.
+4. Preserve existing behavior for documents with headings.
+5. Confirm empty or whitespace-only documents are still handled correctly.
+6. Update or add unit tests.
+
+## Risk
+
+The main risk is changing behavior for documents that already contain valid Markdown headings or creating one oversized chunk for long plain-text documents.
+
+## Test plan
+
+- Run the existing no-heading test.
+- Run all structural chunker tests.
+- Run `make check`.
+- Run `make test-unit`.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,34 +1,91 @@
-# Issue #149 Plan
+# Solution plan
 
-## Reproduction
+**Issue:** [#149 — Structural chunker silently drops documents that contain no headings](https://github.com/ascherj/pathreview/issues/149)
 
-`StructuralChunker.chunk()` returns an empty list when given a non-empty plain-text document without Markdown headings.
+## Understand
 
-## Expected behavior
+`StructuralChunker.chunk()` is supposed to turn non-empty source text into one or more
+`Chunk` objects for the RAG index. Instead, a non-empty plain-text document with no Markdown
+heading returns `[]` and is silently excluded from indexing.
 
-A non-empty document without headings should still produce at least one valid chunk instead of being silently excluded from the RAG index.
+The root cause is in `_extract_sections()` in
+`ingestion/chunking/structural_chunker.py`. Its `else` branch only appends a non-heading line
+when `heading_stack` or `current_section_lines` is already truthy. For a document whose first
+line is ordinary text, both are empty; each line is discarded. The final-save branch also
+requires `heading_stack`, so no section is returned.
 
-## Files to inspect
+**Expected:** a non-empty no-heading document produces a chunk that preserves its text and
+source metadata. **Actual:** the existing `test_document_with_no_headings` test expects at
+least one chunk, while the current implementation produces zero.
+
+## Map
 
 - `ingestion/chunking/structural_chunker.py`
+  - `StructuralChunker.chunk()` converts the extracted sections into `Chunk` objects.
+  - `StructuralChunker._extract_sections()` drops content before a heading; this is the defect
+    location and the only production function I expect to change.
+- `ingestion/chunking/semantic_chunker.py`
+  - I will inspect its token-boundary behavior only to make sure a large no-heading document
+    gets the same size protection as a large headed section. I do not expect to edit it.
 - `tests/unit/test_structural_chunker.py`
+  - `test_document_with_no_headings` already defines the failing behavior. I will make its
+    assertions specific enough to verify text and fallback metadata, then add only tests needed
+    for the selected fallback.
+- `JOURNAL.MD`
+  - Records the reproduction commit and this plan for the Week 8 submission.
 
-## Implementation plan
+## Plan
 
-1. Read the current `StructuralChunker.chunk()` logic.
-2. Identify why no-heading documents produce no sections.
-3. Add a fallback for non-empty documents without headings.
-4. Preserve existing behavior for documents with headings.
-5. Confirm empty or whitespace-only documents are still handled correctly.
-6. Update or add unit tests.
+1. Run the focused no-heading test before changing code and record its failure. Repair the local
+   Python virtual environment first if needed; that setup issue must not be treated as evidence
+   about #149.
+2. Add a no-heading fallback in `_extract_sections()` for non-empty text. The fallback will
+   create a section with the full trimmed document, an empty heading path, and heading level `0`.
+   Empty or whitespace-only input will continue to return `[]` from `chunk()`.
+3. Make the no-heading test assert the exact fallback contract: one or more non-empty chunks,
+   text preserved, source metadata preserved, `heading_path == ""`, and `heading_level == 0`.
+   Add a whitespace-only regression check only if the existing test does not already cover it.
+4. Run the focused test and all structural-chunker unit tests. Then run `make check` and
+   `make test-unit`; fix only regressions caused by this issue.
+5. Update this plan if investigation requires touching another file, then commit the fix and
+   link the implementation commit in the Week 9 journal entry.
 
-## Risk
+## Inputs & outputs
 
-The main risk is changing behavior for documents that already contain valid Markdown headings or creating one oversized chunk for long plain-text documents.
+**Function affected:** `StructuralChunker.chunk(text: str, metadata: dict) -> list[Chunk]`
 
-## Test plan
+- Input: `"Plain text with no Markdown headings"` and `{"source": "readme"}`.
+  Expected output: at least one `Chunk` containing that text, retaining `source`, with
+  `heading_path` set to `""` and `heading_level` set to `0`.
+- Input: a headed Markdown document such as `# Title\nBody`.
+  Expected output: unchanged headed chunks with the normal heading breadcrumb and level.
+- Input: `""` or whitespace only.
+  Expected output: `[]`; no empty `Chunk` should be emitted.
+- Input: a no-heading document larger than `SECTION_TOKEN_LIMIT`.
+  Expected output: non-empty subchunks that preserve the fallback metadata rather than a single
+  oversized chunk.
 
-- Run the existing no-heading test.
-- Run all structural chunker tests.
-- Run `make check`.
-- Run `make test-unit`.
+## Risks & unknowns
+
+- A fallback section with an empty heading path may affect consumers that assume every chunk has
+  a non-empty breadcrumb. I will search for `heading_path` readers before finalizing the metadata
+  contract and update the plan if a consumer needs a different sentinel.
+- Large plain text must still obey the 800-token limit. The fallback has to pass through the
+  existing semantic chunker rather than bypassing the current size check.
+- Documents with text before their first heading currently lose that preamble too. I will decide
+  during implementation whether it belongs in a separate level-0 chunk; the selected issue
+  guarantees the no-heading case, so I will avoid broadening scope unless a test demonstrates
+  the same fallback is necessary.
+- The current `.venv` points to a missing Python executable. It blocks normal test commands but
+  is not caused by issue #149; I will repair or recreate the environment before relying on the
+  full test suite.
+
+## Edge cases
+
+- A document containing only whitespace remains empty and produces no chunks.
+- A one-line plain-text document produces a real chunk, not an empty one.
+- A long plain-text document is semantically sub-chunked and each resulting chunk keeps source
+  metadata plus `heading_path == ""` and `heading_level == 0`.
+- A document with valid nested headings keeps its existing `Parent > Child` breadcrumbs.
+- A document beginning with a heading but containing an empty section still does not create an
+  empty chunk.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -99,7 +99,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -449,7 +448,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -473,7 +471,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1561,7 +1558,6 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1579,7 +1575,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1972,7 +1967,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3507,7 +3501,6 @@
       "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^2.0.1",
         "cssstyle": "^4.0.1",
@@ -4094,7 +4087,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4107,7 +4099,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4771,7 +4762,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/ingestion/chunking/structural_chunker.py
+++ b/ingestion/chunking/structural_chunker.py
@@ -37,6 +37,14 @@ class StructuralChunker(BaseChunker):
 
         # Extract sections with heading hierarchy
         sections = self._extract_sections(text)
+        if not sections:
+            sections = [
+                {
+                    "content": text.strip(),
+                    "path": [],
+                    "level": 0,
+                }
+            ]
 
         chunks = []
         for section in sections:
@@ -49,22 +57,26 @@ class StructuralChunker(BaseChunker):
             if section_tokens > self.SECTION_TOKEN_LIMIT:
                 # Sub-chunk using semantic chunker
                 section_metadata = metadata.copy()
-                section_metadata.update({
-                    "heading_path": heading_path,
-                    "heading_level": section["level"],
-                })
+                section_metadata.update(
+                    {
+                        "heading_path": heading_path,
+                        "heading_level": section["level"],
+                    }
+                )
                 sub_chunks = self.semantic_chunker.chunk(section_text, section_metadata)
                 chunks.extend(sub_chunks)
             else:
                 # Single chunk for this section
                 section_metadata = metadata.copy()
-                section_metadata.update({
-                    "heading_path": heading_path,
-                    "heading_level": section["level"],
-                    "chunk_index": len(chunks),
-                    "char_start": 0,
-                    "char_end": len(section_text),
-                })
+                section_metadata.update(
+                    {
+                        "heading_path": heading_path,
+                        "heading_level": section["level"],
+                        "chunk_index": len(chunks),
+                        "char_start": 0,
+                        "char_end": len(section_text),
+                    }
+                )
                 chunks.append(Chunk(text=section_text, metadata=section_metadata))
 
         return chunks
@@ -79,7 +91,6 @@ class StructuralChunker(BaseChunker):
         sections = []
         heading_stack = []  # Stack of (level, heading_text)
         current_section_lines = []
-        current_level = 0
 
         for line in lines:
             heading_match = re.match(r"^(#{1,6})\s+(.+)$", line)
@@ -88,11 +99,13 @@ class StructuralChunker(BaseChunker):
                 # Save previous section if exists
                 if current_section_lines:
                     if heading_stack:
-                        sections.append({
-                            "content": "\n".join(current_section_lines).strip(),
-                            "path": [h[1] for h in heading_stack],
-                            "level": heading_stack[-1][0] if heading_stack else 0,
-                        })
+                        sections.append(
+                            {
+                                "content": "\n".join(current_section_lines).strip(),
+                                "path": [h[1] for h in heading_stack],
+                                "level": heading_stack[-1][0] if heading_stack else 0,
+                            }
+                        )
                     current_section_lines = []
 
                 # Process new heading
@@ -104,8 +117,6 @@ class StructuralChunker(BaseChunker):
                     heading_stack.pop()
 
                 heading_stack.append((heading_level, heading_text))
-                current_level = heading_level
-
             else:
                 # Regular content line
                 if heading_stack or current_section_lines:  # Only collect if we have a heading
@@ -113,10 +124,12 @@ class StructuralChunker(BaseChunker):
 
         # Save final section
         if current_section_lines and heading_stack:
-            sections.append({
-                "content": "\n".join(current_section_lines).strip(),
-                "path": [h[1] for h in heading_stack],
-                "level": heading_stack[-1][0] if heading_stack else 0,
-            })
+            sections.append(
+                {
+                    "content": "\n".join(current_section_lines).strip(),
+                    "path": [h[1] for h in heading_stack],
+                    "level": heading_stack[-1][0] if heading_stack else 0,
+                }
+            )
 
         return sections

--- a/tests/unit/test_structural_chunker.py
+++ b/tests/unit/test_structural_chunker.py
@@ -2,8 +2,8 @@
 
 import pytest
 
-from ingestion.chunking.structural_chunker import StructuralChunker
 from ingestion.chunking.base import Chunk
+from ingestion.chunking.structural_chunker import StructuralChunker
 
 
 @pytest.mark.unit
@@ -26,13 +26,34 @@ class TestStructuralChunker:
         assert result == []
 
     def test_document_with_no_headings(self, chunker):
-        """Test document with no headings returns single chunk."""
+        """Test document with no headings returns a level-zero chunk."""
         text = "This is plain text without any markdown headings. " * 20
         result = chunker.chunk(text, {"source": "test"})
 
-        assert len(result) >= 1
-        assert isinstance(result[0], Chunk)
-        assert all(isinstance(c, Chunk) for c in result)
+        assert len(result) == 1
+        assert result[0] == Chunk(
+            text=text.strip(),
+            metadata={
+                "source": "test",
+                "heading_path": "",
+                "heading_level": 0,
+                "chunk_index": 0,
+                "char_start": 0,
+                "char_end": len(text.strip()),
+            },
+        )
+
+    def test_large_document_with_no_headings_preserves_fallback_metadata(self, chunker):
+        """Test large plain text is sub-chunked without losing fallback metadata."""
+        text = "A plain-text sentence without a heading. " * 500
+        result = chunker.chunk(text, {"source": "test"})
+
+        assert len(result) > 1
+        assert all(isinstance(chunk, Chunk) for chunk in result)
+        assert all(chunk.text.strip() for chunk in result)
+        assert all(chunk.metadata["source"] == "test" for chunk in result)
+        assert all(chunk.metadata["heading_path"] == "" for chunk in result)
+        assert all(chunk.metadata["heading_level"] == 0 for chunk in result)
 
     def test_document_with_nested_headings(self, chunker):
         """Test document with nested headings preserves heading_path."""
@@ -83,11 +104,16 @@ Content under grandchild.
                     found_path = True
                     assert isinstance(path, str)
 
+        assert found_path
+
     def test_large_section_sub_chunked(self, chunker):
         """Test large section (> 800 tokens) gets sub-chunked."""
         # Create a large section
-        large_section = """# Large Section
-""" + "This is a paragraph with lots of content. " * 50
+        large_section = (
+            """# Large Section
+"""
+            + "This is a paragraph with lots of content. " * 50
+        )
 
         result = chunker.chunk(large_section, {})
 
@@ -172,6 +198,8 @@ Content here.
                 # Should contain the hierarchy
                 if "Installation" in path or "Prerequisites" in path:
                     found_full_path = True
+
+        assert found_full_path
 
     def test_chunks_have_text_content(self, chunker):
         """Test that all chunks have text content."""


### PR DESCRIPTION
## Summary

Fixes #149 — Structural chunker silently drops documents that contain no headings.

## Changes

- Add a level-zero fallback when structural chunking finds no Markdown sections.
- Preserve source metadata for plain-text documents without headings.
- Keep large plain-text inputs protected by the existing semantic sub-chunking path.
- Strengthen structural-chunker regression tests.

## Testing

- [x] New/updated tests cover the changes.
- Focused command: `pytest tests/unit/test_structural_chunker.py -v -m unit` — 16 passed.
- Ruff and Black pass for the changed files.
- The full project suite has unrelated existing failures; this change does not touch those modules.

## Notes for Reviewers

The repository `.venv` points to a removed Python 3.11 executable, so the standard `make` commands cannot start locally. The fix was verified in a clean temporary environment.