### PR TITLE
docs: add Week 7 journal

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,21 @@
+# PathReview Contribution Journal
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/68
+
+**Issue title:** Add a safety event count to the health check endpoint
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The health endpoint currently reports the service status but does not include information about recent safety-system activity. This makes it difficult for operators to quickly determine whether safety events have occurred without checking the monitoring dashboard. This issue affects the health route and the safety monitoring module. A successful fix will add a `safety_events_last_hour` field to the health-check response and ensure it reports the correct number of recent safety events.
+
+**Selection notes ("Is this right for me?" checklist):**
+This issue has a clearly defined scope and affects only a small part of the codebase. The issue description identifies the main files involved, making it easier to locate the relevant code. It is labeled Tier 1, which makes it appropriate for a first open-source contribution. I expect to understand how safety events are tracked, connect that information to the health endpoint, and update or add tests.
+
+**Branch name:** feat/68-safety-event-health-count
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -9,7 +9,7 @@
 **Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
 
 **Problem summary:**
-The health endpoint currently reports the service status but does not include information about recent safety-system activity. This makes it difficult for operators to quickly determine whether safety events have occurred without checking the monitoring dashboard. This issue affects the health route and the safety monitoring module. A successful fix will add a `safety_events_last_hour` field to the health-check response and ensure it reports the correct number of recent safety events.
+The health endpoint currently reports the service status but does not include information about recent safety-system activity. This makes it difficult for operaStors to quickly determine whether safety events have occurred without checking the monitoring dashboard. This issue affects the health route and the safety monitoring module. A successful fix will add a `safety_events_last_hour` field to the health-check response and ensure it reports the correct number of recent safety events.
 
 **Selection notes ("Is this right for me?" checklist):**
 This issue has a clearly defined scope and affects only a small part of the codebase. The issue description identifies the main files involved, making it easier to locate the relevant code. It is labeled Tier 1, which makes it appropriate for a first open-source contribution. I expect to understand how safety events are tracked, connect that information to the health endpoint, and update or add tests.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -19,3 +19,18 @@ This issue has a clearly defined scope and affects only a small part of the code
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [ ] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/Streakywolff/pathreview/commit/0cd9b64
+
+**Reproduction summary:**
+I reproduced the feature gap by running the application locally and requesting the `/health` endpoint. The endpoint reported the status of PostgreSQL, Redis, and the vector database, but it did not calculate the safety event count from the existing Redis counters maintained by `SafetyMonitor`.
+
+**PLAN.md link:** https://github.com/Streakywolff/pathreview/blob/feat/68-safety-event-health-count/PLAN.md
+
+**Walkthrough video (recommended):**
+Not recorded.
+
+**Blockers or open questions:**
+None.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -34,3 +34,40 @@ Not recorded.
 
 **Blockers or open questions:**
 None.
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented Issue #68 by updating the `/health` endpoint to report the total number of safety events recorded during the previous hour. The endpoint now aggregates counts from every valid `SafetyMonitor` event type and exposes the result as `safety_events_last_hour`. I also updated the PostgreSQL health check to execute `SELECT 1` using SQLAlchemy's `text()` function and initialized the Redis client using `redis.Redis.from_url(..., decode_responses=True)`. Local verification and code quality checks were completed.
+
+**Next steps:**
+Add a unit test for the new functionality, update the pull request with the completed implementation, and finish the required Week 9 documentation before submission.
+
+**Blockers:**
+None
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** 
+https://github.com/ascherj/pathreview/pull/257
+
+**Branch:** 
+`feat/68-safety-event-health-count`
+
+**What you built:**
+Implemented Issue #68 by exposing the total number of safety events recorded during the previous hour in the `/health` endpoint. The endpoint now sums the counts for every valid `SafetyMonitor` event type and returns the result as `safety_events_last_hour`. I also updated the PostgreSQL health check and Redis client initialization for compatibility.
+
+
+**Tests added or updated:**
+Added `tests/unit/test_health.py` to verify that the health endpoint aggregates safety events across all valid event types using a one-hour window and returns the combined total as `safety_events_last_hour`.
+
+
+**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+The repository currently contains pre-existing lint and unit test failures unrelated to Issue #68. My new health endpoint test passes independently, and my changes do not introduce additional failures.
+
+
+**Draft PR feedback received from:** [name or Slack handle, or "none"]
+None.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -71,3 +71,34 @@ The repository currently contains pre-existing lint and unit test failures unrel
 
 **Draft PR feedback received from:** [name or Slack handle, or "none"]
 None.
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [X] No — still awaiting review
+
+**Summary of feedback:**
+[What did reviewers comment on? Or note that no review came in.]
+No review came in, no feedback was provided for this term
+
+**How you responded:**
+
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The hardest part was getting familar with PathReview codebase and figuring out how different parts of the projects connected with each other. While working on Issue #68, I had to understand how the /health endpoint in api/routes/health.py interacted with the safety monitoring code in safety/monitoring.py. Additionally setting up and debugging the development enviornemnt was horrendous espically with getting some of the docker servies to report healthy 
+
+**What did you learn about working in a large codebase?**
+Something I learned while working in this large codebase is it takes much more effort into reading and understanding the code before making changes. Unlike working with my personal projects it was difficult to change any code because it needed to follow the projects patterns while making sure it didn't break any other componets that I did not code. I also learned the importance of making focused changes and adding tests, such as the health endpoint test I added in tests/unit/test_health.py.
+
+**How did AI tools help — and where did they fall short?**
+Ai tools helped me understand unfamilar parts of the codebase, troubleshoot an errors, and work through docker, and testing commands when I was stuck. They were especially helpful when I encountered environment issues, such as unhealthy services and problems getting the project running locally. However, Ai could not compeletely understand the state of my local enviroment on its own, so i still had to verify any changes.
+
+**What would you do differently if you started over?**
+If I could start over I would spend more time just reading and understanding the structure of the code base. I would also test the Docker services and health endpoints earlier so that the enviroment problems would not interfer with implemenations later. Having a clearer understanding of api/routes/health.py, safety/monitoring.py, and the existing tests from the beginning would have made the process more efficient
+
+**What are you most proud of from this module?**
+I am most proud that I was able to work through a real open-source codebase and take Issue #68 from understanding the problem to implementing and testing a solution. I was also able to add a unit test for the health endpoint and worked through several enviorment and debugging problems instead of stopping/giving up when things got difficult. This module helped me gain experience with a workflow that felt much more closer to contributing to a real software project than simply compeleting an isolated coding assignment.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,72 @@
+## Solution plan
+
+**Issue:** Add safety event count to health check endpoint
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/68
+
+### Understand
+
+The `/health` endpoint currently reports the health of PostgreSQL, Redis, and the vector database, but it does not report the number of safety events recorded during the last hour.
+
+The safety monitoring module already stores counts in Redis using keys such as `safety:events:<event_type>`. The missing behavior is connecting those existing counters to the health endpoint.
+
+Expected behavior:
+- The `/health` response includes a `safety_events_last_hour` field.
+- The value represents the total count across all valid safety event types.
+- If no safety events exist, the value is `0`.
+- A failure to read the safety count should not crash the entire health endpoint.
+
+Actual behavior before the fix:
+- The endpoint either omitted the field or returned a hard-coded value of `0`.
+- It did not query the safety monitoring counters stored in Redis.
+
+### Map
+
+Files and components involved:
+
+- `api/routes/health.py`
+  - Contains the `/health` endpoint.
+  - Performs dependency checks.
+  - Will retrieve and expose the safety-event count.
+
+- `safety/monitoring.py`
+  - Contains `SafetyMonitor`.
+  - Defines `VALID_EVENT_TYPES`.
+  - Provides `get_event_count()` for reading event counters from Redis.
+
+- `JOURNAL.md`
+  - Documents the reproduction steps and planning work.
+
+- `PLAN.md`
+  - Documents the intended implementation approach.
+
+### Plan
+
+1. Reproduce the missing behavior by starting the local services and requesting the `/health` endpoint.
+2. Confirm that the response does not calculate the safety-event count from Redis and identify the placeholder or missing implementation in `api/routes/health.py`.
+3. Reuse the Redis client created during the Redis health check and initialize `SafetyMonitor`.
+4. Iterate over `SafetyMonitor.VALID_EVENT_TYPES`, retrieve each event count, and sum the results.
+5. Add the total to the response under `safety_events_last_hour`, while handling Redis or monitoring errors gracefully.
+6. Run Ruff, Black, and mypy on the staged files and verify the endpoint still returns a healthy response.
+
+### Inputs & outputs
+
+Inputs:
+- The Redis connection URL from application settings.
+- Redis counters using the key format `safety:events:<event_type>`.
+- The valid event types defined by `SafetyMonitor.VALID_EVENT_TYPES`.
+
+Output:
+- The `/health` endpoint returns a JSON response containing:
+
+```json
+{
+  "status": "healthy",
+  "dependencies": {
+    "postgres": "healthy",
+    "redis": "healthy",
+    "vector_db": "healthy"
+  },
+  "safety_events_last_hour": 0,
+  "timestamp": "..."
+}

--- a/api/routes/health.py
+++ b/api/routes/health.py
@@ -1,8 +1,18 @@
-from fastapi import APIRouter, HTTPException, status, Depends
-import structlog
-from datetime import datetime, timedelta
+"""Health-check API routes."""
 
+from datetime import UTC, datetime
+from typing import Annotated, Any
+
+import redis
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, status
+from redis import Redis
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from core.config import settings
 from core.database import get_db
+from safety.monitoring import SafetyMonitor
 
 log = structlog.get_logger()
 
@@ -10,12 +20,19 @@ router = APIRouter(prefix="/health", tags=["health"])
 
 
 @router.get("")
-async def health_check(db=Depends(get_db)):
+async def health_check(
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> dict[str, Any]:
     """
-    Check health of PostgreSQL, Redis, and Vector DB.
-    Returns 200 if all healthy, 503 if any dependency is down.
+    Check the health of PostgreSQL, Redis, and the vector database.
+
+    Returns:
+        Health information for the service and its dependencies.
+
+    Raises:
+        HTTPException: If a critical dependency is unavailable.
     """
-    health_status = {
+    health_status: dict[str, Any] = {
         "status": "healthy",
         "dependencies": {
             "postgres": "unknown",
@@ -23,12 +40,14 @@ async def health_check(db=Depends(get_db)):
             "vector_db": "unknown",
         },
         "safety_events_last_hour": 0,
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": datetime.now(UTC).isoformat(),
     }
 
+    redis_client: Redis | None = None
+
+    # PostgreSQL health check
     try:
-        # Check PostgreSQL
-        await db.execute("SELECT 1")
+        await db.execute(text("SELECT 1"))
         health_status["dependencies"]["postgres"] = "healthy"
         log.debug("postgres_health_check_passed")
     except Exception as exc:
@@ -36,18 +55,14 @@ async def health_check(db=Depends(get_db)):
         health_status["dependencies"]["postgres"] = "unhealthy"
         health_status["status"] = "unhealthy"
 
+    # Redis health check
     try:
-        # Check Redis (if available)
-        import redis
-        from core.config import settings
-
-        r = redis.Redis(
-            host=settings.redis_host,
-            port=settings.redis_port,
-            db=0,
+        redis_client = redis.Redis.from_url(
+            settings.redis_url,
             decode_responses=True,
         )
-        r.ping()
+        redis_client.ping()
+
         health_status["dependencies"]["redis"] = "healthy"
         log.debug("redis_health_check_passed")
     except Exception as exc:
@@ -55,31 +70,41 @@ async def health_check(db=Depends(get_db)):
         health_status["dependencies"]["redis"] = "unhealthy"
         health_status["status"] = "unhealthy"
 
+    # Vector database health check
     try:
-        # Check Vector DB (if available)
-        # This is a placeholder - actual implementation depends on vector DB choice
-        from core.config import settings
-
-        # Attempt heartbeat to vector DB
-        # For now, assume it's healthy if connection string exists
         if settings.vector_db_url:
             health_status["dependencies"]["vector_db"] = "healthy"
             log.debug("vector_db_health_check_passed")
         else:
             health_status["dependencies"]["vector_db"] = "unavailable"
+            log.warning("vector_db_url_not_configured")
     except Exception as exc:
         log.error("vector_db_health_check_failed", error=str(exc))
         health_status["dependencies"]["vector_db"] = "unhealthy"
         health_status["status"] = "unhealthy"
 
-    # Count safety events in last hour (placeholder)
+    # Count recent safety events
     try:
-        # This would be populated by actual safety event logging
-        health_status["safety_events_last_hour"] = 0
+        if redis_client is not None:
+            safety_monitor = SafetyMonitor(redis_client)
+
+            safety_event_count = sum(
+                safety_monitor.get_event_count(
+                    event_type,
+                    window_hours=1,
+                )
+                for event_type in SafetyMonitor.VALID_EVENT_TYPES
+            )
+
+            health_status["safety_events_last_hour"] = safety_event_count
+            log.debug(
+                "safety_events_check_passed",
+                count=safety_event_count,
+            )
     except Exception as exc:
         log.error("safety_events_check_failed", error=str(exc))
+        health_status["safety_events_last_hour"] = 0
 
-    # Return 503 if any critical dependency is down
     if health_status["status"] == "unhealthy":
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -1,0 +1,48 @@
+"""Tests for the health-check endpoint."""
+
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from api.routes.health import health_check
+from safety.monitoring import SafetyMonitor
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_health_check_reports_total_safety_events() -> None:
+    """Return the total safety events recorded during the previous hour."""
+    mock_db = AsyncMock()
+    mock_redis_client = Mock()
+    mock_redis_client.ping.return_value = True
+
+    event_counts = {
+        event_type: index + 1 for index, event_type in enumerate(SafetyMonitor.VALID_EVENT_TYPES)
+    }
+
+    with (
+        patch(
+            "api.routes.health.redis.Redis.from_url",
+            return_value=mock_redis_client,
+        ),
+        patch(
+            "api.routes.health.SafetyMonitor.get_event_count",
+            side_effect=lambda event_type, window_hours: event_counts[event_type],
+        ) as mock_get_event_count,
+    ):
+        response = await health_check(mock_db)
+
+    assert response["status"] == "healthy"
+    assert response["dependencies"]["postgres"] == "healthy"
+    assert response["dependencies"]["redis"] == "healthy"
+    assert response["safety_events_last_hour"] == sum(event_counts.values())
+
+    mock_db.execute.assert_awaited_once()
+    mock_redis_client.ping.assert_called_once()
+    assert mock_get_event_count.call_count == len(SafetyMonitor.VALID_EVENT_TYPES)
+
+    for event_type in SafetyMonitor.VALID_EVENT_TYPES:
+        mock_get_event_count.assert_any_call(
+            event_type,
+            window_hours=1,
+        )


### PR DESCRIPTION
## Summary
Implements Issue #68 by exposing the total number of safety events recorded during the previous hour in the `/health` endpoint.

The endpoint now aggregates counts across all valid SafetyMonitor event types and returns the value as `safety_events_last_hour`. I also updated the PostgreSQL health check to execute `SELECT 1` using SQLAlchemy's `text()` and initialized the Redis client with `redis.Redis.from_url(..., decode_responses=True)` for compatibility.

## Issue
Closes #68

## Changes
- Added `safety_events_last_hour` to the `/health` response.
- Aggregated counts from every valid SafetyMonitor event type.
- Updated the PostgreSQL health check to use `await db.execute(text("SELECT 1"))`.
- Updated Redis initialization using `redis.Redis.from_url(..., decode_responses=True)`.
- Added `tests/unit/test_health.py` to verify safety event aggregation.

## Testing
<!-- How did you verify your changes? -->
- [ ] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`)
- [ ] Linter passes (`make lint`)
- [ x] Type checker passes (`make typecheck`)
- [ ] New/updated tests cover the changes

Added `tests/unit/test_health.py`, which verifies that the health endpoint aggregates safety events across all valid event types.

The repository currently contains pre-existing unrelated failures in `make test-unit` and `make check`. My new health endpoint test passes, and my changes do not introduce additional test or lint failures.

## Screenshots / Demo
No Screenshots or demo

## Notes for Reviewers
No notes
