### PR TITLE
Fix #68: Add safety event count to health endpoint

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,23 @@
+# PathReview Contribution Journal
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/68
+
+**Issue title:** Add a safety event count to the health check endpoint
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+
+The `/health` API endpoint currently reports the status of the application's services, but it does not include information about recent safety system activity. The safety monitoring module already handles safety-related events, but that information is not exposed through the health check response. This issue affects the health endpoint in `api/routes/health.py` and the monitoring logic in `safety/monitoring.py`. A successful fix will calculate the number of safety events recorded during the last hour and return that number in a new `safety_events_last_hour` response field.
+
+**Selection notes — “Is this right for me?” checklist:**
+
+I selected this issue because it is labeled Tier 1 and is estimated to take approximately two to four hours. The issue has a focused scope and identifies the two main files that are likely to require changes. I have previous experience working with Python APIs, backend routes, validation logic, and tests, so the issue matches skills I have practiced in earlier projects. The expected result is also specific and testable: the `/health` response should contain a safety event count for the previous hour.
+
+**Branch name:** `fix/68-safety-event-health-count`
+
+**Setup confirmation:** [ ] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -18,6 +18,6 @@ I selected this issue because it is labeled Tier 1 and is estimated to take appr
 
 **Branch name:** `fix/68-safety-event-health-count`
 
-**Setup confirmation:** [ ] App runs locally at localhost:5173
+**Setup confirmation:** [x] App runs locally at localhost:5173
 
-**Cohort ledger:** [ ] Issue added to cohort ledger
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -24,7 +24,7 @@ I selected this issue because it is labeled Tier 1 and is estimated to take appr
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** *(add after committing)*
+**Reproduction commit link:** https://github.com/k-hetherington/pathreview/commit/9d48bbe)
 
 **Reproduction summary:**
 
@@ -32,7 +32,7 @@ I reproduced Issue #68 by reviewing the implementation immediately before my fix
 
 While investigating, I found that `SafetyMonitor` only stored cumulative Redis counters using `INCR`. Although `get_event_count()` accepted a `window_hours` parameter, the value was never enforced because events were not stored with timestamps. As a result, the application could not accurately report the number of safety events that occurred during the previous hour.
 
-**PLAN.md link:** *(add after creating PLAN.md)*
+**PLAN.md link:** https://github.com/k-hetherington/pathreview/blob/fix/68-safety-event-health-count/PLAN.md
 
 **Walkthrough video (recommended):**
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -21,3 +21,23 @@ I selected this issue because it is labeled Tier 1 and is estimated to take appr
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** *(add after committing)*
+
+**Reproduction summary:**
+
+I reproduced Issue #68 by reviewing the implementation immediately before my fix and confirming that the `/health` endpoint always returned a placeholder value of `0` for `safety_events_last_hour`.
+
+While investigating, I found that `SafetyMonitor` only stored cumulative Redis counters using `INCR`. Although `get_event_count()` accepted a `window_hours` parameter, the value was never enforced because events were not stored with timestamps. As a result, the application could not accurately report the number of safety events that occurred during the previous hour.
+
+**PLAN.md link:** *(add after creating PLAN.md)*
+
+**Walkthrough video (recommended):**
+
+Not recorded.
+
+**Blockers or open questions:**
+
+I wanted to determine the best Redis data structure for supporting rolling time-window queries while also automatically removing expired events.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -73,7 +73,7 @@ I added real one-hour safety event reporting to the `/health` endpoint. Safety e
 
 **Tests added or updated:**
 
-Added `tests/unit/test_safety_monitoring.py`.
+Added unit tests in `tests/unit/test_safety_monitoring.py`.
 
 The tests verify:
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -88,3 +88,41 @@ The tests verify:
 The repository currently contains pre-existing linting and unit test failures unrelated to Issue #68. I verified that my new unit tests pass independently and that my changes did not introduce additional failures.
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+
+No reviewer feedback was provided during Summer 2026. My pull request remains open, so I did not have any maintainer comments or requested changes to respond to.
+
+**How you responded:**
+
+No changes were needed in response to reviewer feedback because no review was received.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+
+The hardest part was navigating an unfamiliar codebase and understanding how different parts of the application worked together. The actual implementation for Issue #68 was fairly straightforward once I understood the problem, but setting up the environment, tracing the health endpoint and safety monitoring code, and dealing with existing linting and test failures took more time than I expected. I also learned that getting code to work locally is only one part of making a contribution ready for a pull request.
+
+**What did you learn about working in a large codebase?**
+
+I learned that working in someone else's codebase requires much more investigation before making changes. For Issue #68, I had to understand how `api/routes/health.py` interacted with `safety/monitoring.py`, Redis, PostgreSQL, and the existing project structure before deciding how to implement the safety event count. I also learned the importance of limiting changes to the scope of the issue and following the project's existing formatting, typing, testing, and Git conventions.
+
+**How did AI tools help — and where did they fall short?**
+
+AI tools were especially helpful when I was navigating unfamiliar code, interpreting errors, and understanding tools such as Redis sorted sets, SQLAlchemy, pre-commit, Ruff, Black, and mypy. For example, AI helped me understand why `db.execute("SELECT 1")` needed to use SQLAlchemy's `text("SELECT 1")` and helped me work through the type-checking errors that appeared when I tried to commit my changes. However, I still needed to run the application and tests myself and compare AI suggestions against the actual PathReview codebase because suggestions that looked correct did not always match the project's existing configuration or conventions.
+
+**What would you do differently if you started over?**
+
+If I started over, I would spend more time evaluating the available issues before choosing one. Issue #68 was a good introduction to contributing to an unfamiliar open-source project, but because it was a Tier 1 issue, I realized later that I probably could have challenged myself with a more complex issue. I would also reproduce the issue and write the tests before implementing the solution instead of beginning some of the implementation work before completing the formal reproduction and planning stages.
+
+**What are you most proud of from this module?**
+
+I am most proud that I completed the full process of making an open-source contribution rather than only getting a piece of code to work. I reproduced Issue #68, created a solution plan, changed the Redis safety monitoring implementation to support time-based event counts, connected it to the `/health` endpoint, added `tests/unit/test_safety_monitoring.py`, and submitted the changes through a pull request. Going through the entire process gave me more confidence navigating an unfamiliar codebase and contributing code that someone else would have to review and maintain.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -24,7 +24,7 @@ I selected this issue because it is labeled Tier 1 and is estimated to take appr
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** https://github.com/k-hetherington/pathreview/commit/9d48bbe)
+**Reproduction commit link:** https://github.com/k-hetherington/pathreview/commit/9d48bbe
 
 **Reproduction summary:**
 
@@ -41,3 +41,50 @@ Not recorded.
 **Blockers or open questions:**
 
 I wanted to determine the best Redis data structure for supporting rolling time-window queries while also automatically removing expired events.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+
+I completed the main implementation tasks from `PLAN.md`. I updated `SafetyMonitor` to store timestamped events in Redis sorted sets, added support for counting events within a requested time window, and connected that count to the `/health` endpoint through the `safety_events_last_hour` field. I also added focused unit tests for the new aggregation behavior.
+
+**Next steps:**
+
+Finalize the pull request, complete the remaining documentation, verify my implementation against the project requirements, and submit the contribution for review.
+Run the required project checks, review and update the pull request description with clear manual verification steps, document any pre-existing failures, and complete the final Week 9 check-in.
+
+**Blockers:**
+
+The repository has pre-existing test and type-checking failures outside the files changed for Issue #68. I am verifying that my contribution does not introduce any new failures.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/258
+
+**Branch:** `fix/68-safety-event-health-count`
+
+**What you built:**
+
+I added real one-hour safety event reporting to the `/health` endpoint. Safety events are stored with timestamps in Redis sorted sets, and `SafetyMonitor.get_total_event_count()` aggregates recent events across all supported event types.
+
+**Tests added or updated:**
+
+Added `tests/unit/test_safety_monitoring.py`.
+
+The tests verify:
+
+- `test_get_total_event_count_sums_all_event_types()` correctly aggregates counts across every supported safety event type.
+- `test_get_total_event_count_returns_zero_when_no_events()` returns `0` when no safety events have been recorded.
+
+**Self-review confirmation:**
+
+- [ ] make check passes
+- [ ] make test-unit passes
+
+The repository currently contains pre-existing linting and unit test failures unrelated to Issue #68. I verified that my new unit tests pass independently and that my changes did not introduce additional failures.
+
+**Draft PR feedback received from:** none

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,129 @@
+# PathReview Issue #68 – Solution Plan
+
+## Solution plan
+
+**Issue:** Add a safety event count to the health check endpoint
+
+GitHub Issue: https://github.com/ascherj/pathreview/issues/68
+
+---
+
+## Understand
+
+The `/health` endpoint reports the status of the application's dependencies, but it does not accurately report recent safety activity.
+
+Although the endpoint includes a `safety_events_last_hour` field, it always returns a placeholder value of `0` instead of the actual number of safety events that occurred during the previous hour.
+
+While investigating the issue, I found that `SafetyMonitor` stores cumulative Redis counters using `INCR`, but it does not preserve timestamps for individual events. Because of this, the existing implementation cannot determine how many events occurred within a specific time window, even though `get_event_count()` accepts a `window_hours` parameter.
+
+The expected behavior is for the health endpoint to return the real number of safety events recorded during the previous hour.
+
+---
+
+## Map
+
+The primary files involved are:
+
+### `api/routes/health.py`
+
+Responsible for the `/health` endpoint.
+
+This file currently:
+- checks PostgreSQL health
+- checks Redis health
+- checks Vector DB health
+- returns the API health response
+
+It will need to retrieve the real safety event count instead of returning a placeholder.
+
+### `safety/monitoring.py`
+
+Contains the `SafetyMonitor` class.
+
+This file currently:
+- validates supported safety event types
+- logs safety events
+- stores Redis counters
+- retrieves event counts
+
+It will need additional functionality to support time-based event counting.
+
+Additional files that may be referenced during implementation:
+
+- `core/config.py`
+- existing unit tests for the health endpoint or safety monitoring components
+
+---
+
+## Plan
+
+1. Review how `SafetyMonitor` stores safety events and determine why the existing Redis implementation cannot support one-hour queries.
+
+2. Update the event logging logic so each safety event is stored with timestamp information that can later be queried.
+
+3. Add functionality to calculate the total number of safety events that occurred within a requested time window.
+
+4. Modify the `/health` endpoint to retrieve the calculated safety event count and populate the `safety_events_last_hour` response field.
+
+5. Verify that dependency health checks continue working correctly and confirm the endpoint returns the expected response when safety events are present or absent.
+
+---
+
+## Inputs & outputs
+
+### Inputs
+
+The solution uses:
+
+- Redis safety event data
+- Valid safety event types
+- Timestamp information for each event
+- A requested time window (one hour)
+
+### Outputs
+
+The solution should:
+
+- store safety events in a format that supports time-based queries
+- calculate the number of events that occurred during the previous hour
+- return that value in the `/health` endpoint response
+
+Example response:
+
+```json
+{
+  "status": "healthy",
+  "dependencies": {
+    "postgres": "healthy",
+    "redis": "healthy",
+    "vector_db": "healthy"
+  },
+  "safety_events_last_hour": 4
+}
+```
+
+---
+
+## Risks & unknowns
+
+Potential risks include:
+
+- The existing Redis counter implementation does not retain timestamps, so a different storage approach may be required.
+- Changes to `SafetyMonitor` could affect any other code that depends on the existing Redis key structure.
+- Redis connection failures should not cause unrelated dependency checks to fail.
+- Existing unit tests may assume the previous implementation and may require updates.
+- Event data should expire automatically so Redis does not continue growing indefinitely.
+
+---
+
+## Edge cases
+
+The solution should handle:
+
+- No safety events during the previous hour.
+- Multiple events occurring within the same second.
+- Several different safety event types occurring during the same hour.
+- Events older than one hour that should not be counted.
+- Invalid or unsupported event types.
+- Redis being temporarily unavailable.
+- Failures while calculating the safety event count without preventing the rest of the health endpoint from responding.

--- a/api/routes/health.py
+++ b/api/routes/health.py
@@ -1,8 +1,15 @@
-from fastapi import APIRouter, HTTPException, status, Depends
-import structlog
-from datetime import datetime, timedelta
+from datetime import datetime
+from typing import Annotated, Any
 
+import redis
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from core.config import settings
 from core.database import get_db
+from safety.monitoring import SafetyMonitor
 
 log = structlog.get_logger()
 
@@ -10,12 +17,14 @@ router = APIRouter(prefix="/health", tags=["health"])
 
 
 @router.get("")
-async def health_check(db=Depends(get_db)):
+async def health_check(
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> dict[str, Any]:
     """
     Check health of PostgreSQL, Redis, and Vector DB.
     Returns 200 if all healthy, 503 if any dependency is down.
     """
-    health_status = {
+    health_status: dict[str, Any] = {
         "status": "healthy",
         "dependencies": {
             "postgres": "unknown",
@@ -28,7 +37,7 @@ async def health_check(db=Depends(get_db)):
 
     try:
         # Check PostgreSQL
-        await db.execute("SELECT 1")
+        await db.execute(text("SELECT 1"))
         health_status["dependencies"]["postgres"] = "healthy"
         log.debug("postgres_health_check_passed")
     except Exception as exc:
@@ -36,18 +45,15 @@ async def health_check(db=Depends(get_db)):
         health_status["dependencies"]["postgres"] = "unhealthy"
         health_status["status"] = "unhealthy"
 
-    try:
-        # Check Redis (if available)
-        import redis
-        from core.config import settings
+    redis_client = None
 
-        r = redis.Redis(
-            host=settings.redis_host,
-            port=settings.redis_port,
-            db=0,
+    try:
+        # Check Redis
+        redis_client = redis.from_url(
+            settings.redis_url,
             decode_responses=True,
         )
-        r.ping()
+        redis_client.ping()
         health_status["dependencies"]["redis"] = "healthy"
         log.debug("redis_health_check_passed")
     except Exception as exc:
@@ -56,12 +62,7 @@ async def health_check(db=Depends(get_db)):
         health_status["status"] = "unhealthy"
 
     try:
-        # Check Vector DB (if available)
-        # This is a placeholder - actual implementation depends on vector DB choice
-        from core.config import settings
-
-        # Attempt heartbeat to vector DB
-        # For now, assume it's healthy if connection string exists
+        # Check Vector DB
         if settings.vector_db_url:
             health_status["dependencies"]["vector_db"] = "healthy"
             log.debug("vector_db_health_check_passed")
@@ -72,10 +73,18 @@ async def health_check(db=Depends(get_db)):
         health_status["dependencies"]["vector_db"] = "unhealthy"
         health_status["status"] = "unhealthy"
 
-    # Count safety events in last hour (placeholder)
     try:
-        # This would be populated by actual safety event logging
-        health_status["safety_events_last_hour"] = 0
+        # Count safety events recorded during the last hour
+        if redis_client is not None:
+            safety_monitor = SafetyMonitor(redis_client)
+            health_status["safety_events_last_hour"] = safety_monitor.get_total_event_count(
+                window_hours=1
+            )
+
+        log.debug(
+            "safety_events_check_passed",
+            count=health_status["safety_events_last_hour"],
+        )
     except Exception as exc:
         log.error("safety_events_check_failed", error=str(exc))
 

--- a/safety/monitoring.py
+++ b/safety/monitoring.py
@@ -1,8 +1,10 @@
 """Safety event monitoring."""
 
+import time
+import uuid
+
 import redis
 import structlog
-from datetime import datetime, timedelta
 
 logger = structlog.get_logger()
 
@@ -10,13 +12,12 @@ logger = structlog.get_logger()
 class SafetyMonitor:
     """Monitor and log safety events."""
 
-    # Valid event types
     VALID_EVENT_TYPES = {
         "pii_detected",
         "injection_attempt",
         "content_filtered",
         "bias_detected",
-        "rate_limited"
+        "rate_limited",
     }
 
     def __init__(self, redis_client: redis.Redis):
@@ -31,44 +32,88 @@ class SafetyMonitor:
         """Log a safety event.
 
         Args:
-            event_type: Type of event (from VALID_EVENT_TYPES)
-            details: Event details dict
+            event_type: Type of event from VALID_EVENT_TYPES
+            details: Event details dictionary
         """
         if event_type not in self.VALID_EVENT_TYPES:
             logger.warning("unknown_event_type", event_type=event_type)
             return
 
-        timestamp = datetime.utcnow().isoformat()
-
         try:
-            # Log to structlog
-            logger.warning("safety_event", event_type=event_type, **details)
+            logger.warning(
+                "safety_event",
+                event_type=event_type,
+                **details,
+            )
 
-            # Store count in Redis for monitoring
-            key = f"safety:events:{event_type}"
-            self.redis.incr(key)
-            # Set expiry to 24 hours
+            # Store each event with its timestamp in a Redis sorted set.
+            key = f"safety:events:{event_type}:timeline"
+            timestamp = time.time()
+            event_id = str(uuid.uuid4())
+
+            self.redis.zadd(key, {event_id: timestamp})
+
+            # Keep only events from the last 24 hours.
+            twenty_four_hours_ago = timestamp - (24 * 60 * 60)
+            self.redis.zremrangebyscore(key, 0, twenty_four_hours_ago)
+
+            # Remove the Redis key after 24 hours without activity.
             self.redis.expire(key, 86400)
 
-        except Exception as e:
-            logger.error("safety_monitor_error", error=str(e))
+        except Exception as exc:
+            logger.error(
+                "safety_monitor_error",
+                event_type=event_type,
+                error=str(exc),
+            )
 
     def get_event_count(self, event_type: str, window_hours: int = 1) -> int:
-        """Get count of safety events.
+        """Get the number of events within a time window.
 
         Args:
-            event_type: Type of event
-            window_hours: Time window in hours (not enforced here; for reference)
+            event_type: Type of safety event
+            window_hours: Number of previous hours to include
 
         Returns:
-            Count of events in the window
+            Number of matching events in the requested time window
         """
-        key = f"safety:events:{event_type}"
+        if event_type not in self.VALID_EVENT_TYPES:
+            logger.warning("unknown_event_type", event_type=event_type)
+            return 0
+
+        if window_hours <= 0:
+            return 0
+
+        key = f"safety:events:{event_type}:timeline"
+        current_time = time.time()
+        cutoff_time = current_time - (window_hours * 60 * 60)
 
         try:
-            count = self.redis.get(key)
-            return int(count) if count else 0
+            return int(
+                self.redis.zcount(
+                    key,
+                    cutoff_time,
+                    current_time,
+                )
+            )
 
-        except Exception as e:
-            logger.error("event_count_error", event_type=event_type, error=str(e))
+        except Exception as exc:
+            logger.error(
+                "event_count_error",
+                event_type=event_type,
+                error=str(exc),
+            )
             return 0
+
+    def get_total_event_count(self, window_hours: int = 1) -> int:
+        """Get the total number of all safety events within a time window.
+
+        Args:
+            window_hours: Number of previous hours to include
+
+        Returns:
+            Total number of safety events in the requested time window
+        """
+        return sum(
+            self.get_event_count(event_type, window_hours) for event_type in self.VALID_EVENT_TYPES
+        )

--- a/tests/unit/test_safety_monitoring.py
+++ b/tests/unit/test_safety_monitoring.py
@@ -1,0 +1,47 @@
+"""Tests for monitoring.py."""
+
+from unittest.mock import Mock
+
+import pytest
+
+from safety.monitoring import SafetyMonitor
+
+
+@pytest.mark.unit
+class TestSafetyMonitor:
+    """Test suite for SafetyMonitor."""
+
+    @pytest.fixture
+    def mock_redis(self) -> Mock:
+        """Create a mock Redis client."""
+        return Mock()
+
+    @pytest.fixture
+    def monitor(self, mock_redis: Mock) -> SafetyMonitor:
+        """Create a SafetyMonitor instance with mocked Redis."""
+        return SafetyMonitor(mock_redis)
+
+    def test_get_total_event_count_sums_all_event_types(
+        self,
+        monitor: SafetyMonitor,
+        mock_redis: Mock,
+    ) -> None:
+        """Test total event count sums all valid event types."""
+        mock_redis.zcount.side_effect = [1, 2, 0, 3, 1]
+
+        total = monitor.get_total_event_count(window_hours=1)
+
+        assert total == 7
+        assert mock_redis.zcount.call_count == len(SafetyMonitor.VALID_EVENT_TYPES)
+
+    def test_get_total_event_count_returns_zero_when_no_events(
+        self,
+        monitor: SafetyMonitor,
+        mock_redis: Mock,
+    ) -> None:
+        """Test total count is zero when no events exist."""
+        mock_redis.zcount.return_value = 0
+
+        total = monitor.get_total_event_count(window_hours=1)
+
+        assert total == 0


### PR DESCRIPTION
## Summary

This PR adds a real safety event count to the `/health` endpoint by tracking safety events in Redis and reporting the number of events recorded during the last hour.

## Issue

Closes #68

## Changes

- Store safety events in Redis sorted sets with timestamps
- Add `get_total_event_count()` to `SafetyMonitor`
- Report `safety_events_last_hour` in the `/health` endpoint
- Update PostgreSQL health check to use `text("SELECT 1")`

## Testing

- Ruff passes
- Black passes
- Mypy passes for the modified files

Manual verification:

1. Start PostgreSQL and Redis using Docker Compose.
2. Start the PathReview application.
3. Trigger one or more safety events.
4. Send a request to: curl http://localhost:8000/health
5. Verify the response contains the `safety_events_last_hour` field and that the value reflects the number of safety events recorded during the previous hour.
- [x] Ruff passes
- [x] Black passes
- [x] Mypy passes for the modified files
- [x] Verified the `/health` endpoint returns `safety_events_last_hour`

## Screenshots / Demo

N/A