### PR TITLE
test: add coverage for review creation with no ingested documents

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,29 @@
+# JOURNAL.md
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/88
+
+**Issue title:** POST /reviews endpoint has no test for when the profile has no ingested documents
+
+**Tier:** ☑ Tier 1  ☐ Tier 2  ☐ Tier 3
+
+**Problem summary:**
+
+The review creation endpoint does not have a test covering the case where a profile exists but has no ingested documents. Without this test, changes to the endpoint could cause it to return an unexpected error or crash without being detected. A successful fix adds automated test coverage for this scenario so the endpoint consistently returns the appropriate error response.
+
+**Issue selection reasoning ("Is this right for me?"):**
+
+I chose this issue because it is a Tier 1 task with a clearly defined scope and affects a single endpoint. It allows me to become familiar with the testing structure of the project without requiring major architectural changes. The issue is small enough to complete within the module while still contributing meaningful test coverage.
+
+**Branch name:**
+
+fix/88-review-no-ingested-documents-test
+
+**Setup confirmation:**
+
+- [x] App runs locally at localhost:5173
+
+**Cohort ledger:**
+
+- [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -33,7 +33,8 @@ fix/88-review-no-ingested-documents-test
 ## Week 8 — Reproduction & solution planning
 
 **Reproduction commit link:**
-(To be filled in after creating the Week 8 reproduction commit.)
+
+9dde931ce7d1818e95fffd99f9ea33390340d722
 
 **Reproduction summary:**
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -27,3 +27,24 @@ fix/88-review-no-ingested-documents-test
 **Cohort ledger:**
 
 - [x] Issue added to cohort ledger
+
+
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:**
+(To be filled in after creating the Week 8 reproduction commit.)
+
+**Reproduction summary:**
+
+I reproduced the issue by tracing the POST `/reviews` request flow from the route into the review service and examining the existing test suite. I confirmed that there was no route test covering the scenario where a profile exists but has no ingested documents, leaving this edge case unverified.
+
+**PLAN.md link:**
+(To be filled in after creating PLAN.md.)
+
+**Walkthrough video (recommended):**
+Not recorded yet.
+
+**Blockers or open questions:**
+
+I'm still confirming whether the project expects a pure route unit test or a more integrated test that exercises the review creation flow with a profile that has no ingested documents.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -34,14 +34,14 @@ fix/88-review-no-ingested-documents-test
 
 **Reproduction commit link:**
 
-9dde931ce7d1818e95fffd99f9ea33390340d722
+https://github.com/AP2001211/pathreview/commit/9dde931ce7d1818e95fffd99f9ea33390340d722
 
 **Reproduction summary:**
 
 I reproduced the issue by tracing the POST `/reviews` request flow from the route into the review service and examining the existing test suite. I confirmed that there was no route test covering the scenario where a profile exists but has no ingested documents, leaving this edge case unverified.
 
 **PLAN.md link:**
-(To be filled in after creating PLAN.md.)
+https://github.com/AP2001211/pathreview/blob/fix/88-review-no-ingested-documents-test/PLAN.md
 
 **Walkthrough video (recommended):**
 Not recorded yet.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -107,3 +107,41 @@ The modified file passes Ruff and Black, and all three tests in `tests/unit/test
 **Draft PR feedback received from:**
 
 None
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+
+No reviewer or maintainer feedback was received during the module. Reviewer feedback is not being provided for the Summer 2026 cohort, so no additional changes were required based on review comments.
+
+**How you responded:**
+
+N/A — no reviewer feedback was received.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+
+The hardest part was determining the actual expected behavior of the issue rather than immediately writing a test based on my initial assumption. At first, I interpreted a profile with no ingested documents as an error condition and expected the endpoint to reject the request. After tracing the `POST /reviews` route into the review service and examining the existing behavior, I realized that the endpoint intentionally creates a pending review and schedules background processing. Understanding that distinction was more important than simply getting a test to pass.
+
+**What did you learn about working in a large codebase?**
+
+I learned that contributing to an existing codebase requires understanding the surrounding behavior and conventions before making changes. In my own projects, I usually know why a function was designed a certain way, but here I had to trace the route, service layer, schemas, and existing tests to understand the intended behavior. I also learned not to treat every failing project-wide check as something caused by my contribution. The repository had pre-existing test and type-checking failures, so I had to isolate my changes and verify that I was not introducing new failures.
+
+**How did AI tools help — and where did they fall short?**
+
+AI was most useful for navigating the unfamiliar codebase, explaining how the FastAPI route and service layer interacted, helping interpret test failures, and identifying appropriate pytest mocking patterns. However, AI could not determine the intended behavior of the issue just from the issue title. My initial interpretation was that a documentless profile should return an error, but examining the actual implementation and project context showed otherwise. I still needed to validate suggestions against the repository rather than assuming generated guidance was correct.
+
+**What would you do differently if you started over?**
+
+I would spend more time tracing the existing implementation and looking at related tests before writing the first reproduction test. I initially made an assumption about the expected error behavior, which led me toward the wrong test. Starting with the route and service implementation would have made the intended behavior clearer earlier and reduced rework. I would also run the repository-wide checks earlier so I could distinguish pre-existing failures from failures introduced by my work from the beginning.
+
+**What are you most proud of from this module?**
+
+I am most proud that I corrected my initial understanding instead of forcing the implementation to match my assumption. I traced the behavior, revised my plan, and ended with three focused tests that verify pending review creation, background processing, and unexpected service failure handling. The process gave me a better understanding of how to make a small, scoped contribution to an unfamiliar codebase while preserving its existing behavior.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -49,3 +49,61 @@ Not recorded yet.
 **Blockers or open questions:**
 
 I'm still confirming whether the project expects a pure route unit test or a more integrated test that exercises the review creation flow with a profile that has no ingested documents.
+
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+
+I reviewed the `POST /reviews` request flow and completed the main testing tasks from my `PLAN.md`. I added route-level unit tests confirming that a profile with no ingested documents can still receive a pending review, that background review processing is scheduled, and that unexpected service failures return an HTTP 500 response.
+
+**Next steps:**
+
+Run the full project checks, document any pre-existing failures, request feedback on the pull request, update the PR description, and complete the end-of-week check-in.
+
+**Blockers:**
+
+My main uncertainty was the intended behavior for documentless profiles. After reviewing the endpoint and related contribution examples, I confirmed that this is a test-only issue and that the endpoint should continue creating a pending review rather than rejecting the request.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:**
+
+https://github.com/ascherj/pathreview/pull/259
+
+**Branch:**
+
+`fix/88-review-no-ingested-documents-test`
+
+**What you built:**
+
+I expanded the route-level test coverage for the `POST /reviews` endpoint by adding automated tests for a profile with no ingested documents. The tests verify successful review creation, background task scheduling, and correct handling of unexpected service failures.
+
+**Tests added or updated:**
+
+Updated `tests/unit/test_review_routes.py` by adding three unit tests covering:
+- successful pending review creation for profiles with no ingested documents,
+- scheduling of background review processing,
+- HTTP 500 responses for unexpected service failures.
+
+**Self-review confirmation:**
+
+- [x] `make check` completed; it reports pre-existing project-wide linting and type-checking failures unrelated to this contribution. The modified test file passes Ruff and Black.
+- [x] `make test-unit` completed; the repository reports 53 pre-existing failures and 375 passing tests. All three tests in `tests/unit/test_review_routes.py` pass, and this contribution introduced no new failures.
+
+## Notes for reviewers
+
+The repository currently contains pre-existing project-wide validation failures unrelated to this test-only contribution:
+
+- `make check` reports existing linting and type-checking issues across unrelated files.
+- `make test-unit` reports 53 failures and 375 passing tests across the existing suite.
+
+The modified file passes Ruff and Black, and all three tests in `tests/unit/test_review_routes.py` pass. This contribution does not introduce additional failures.
+
+**Draft PR feedback received from:**
+
+None

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,62 @@
+# Solution Plan
+
+**Issue:** POST /reviews endpoint has no test for when the profile has no ingested documents
+
+Issue link: https://github.com/ascherj/pathreview/issues/88
+
+---
+
+## Understand
+
+The issue is not that the endpoint itself is known to be broken, but that an important edge case is not covered by automated tests. When a review is requested for a profile that has no ingested documents, the endpoint should return an appropriate client error instead of crashing or returning a generic server error. Without this test, future code changes could unintentionally change the endpoint's behavior without being detected.
+
+---
+
+## Map
+
+Files involved:
+
+- `api/routes/reviews.py`
+- `core/services/review_service.py`
+- `tests/unit/test_review_routes.py`
+
+---
+
+## Plan
+
+1. Understand the review creation flow from the route into the review service.
+2. Identify where the missing-documents condition should be handled.
+3. Add a focused unit test covering the missing edge case.
+4. Verify that the endpoint returns the expected error instead of a generic failure.
+5. Run the relevant unit tests and ensure the new test passes.
+
+---
+
+## Inputs & outputs
+
+**Input**
+
+- A request to create a review for a profile.
+- A profile that has no ingested documents.
+
+**Expected output**
+
+- The endpoint returns the appropriate HTTP error.
+- The new automated test verifies this behavior and prevents regressions.
+
+---
+
+## Risks & unknowns
+
+- It is not yet clear whether the project expects a pure route unit test or a more integrated test exercising the complete review creation flow.
+- The missing validation may already exist inside the service layer, requiring only additional test coverage.
+- Existing testing conventions may require a different mocking strategy than initially expected.
+
+---
+
+## Edge cases
+
+- Profile exists but has no ingested documents.
+- Profile does not exist.
+- Review creation succeeds normally.
+- Unexpected internal exceptions should still return the appropriate server error.

--- a/PLAN.md
+++ b/PLAN.md
@@ -8,7 +8,7 @@ Issue link: https://github.com/ascherj/pathreview/issues/88
 
 ## Understand
 
-The issue is not that the endpoint itself is known to be broken, but that an important edge case is not covered by automated tests. When a review is requested for a profile that has no ingested documents, the endpoint should return an appropriate client error instead of crashing or returning a generic server error. Without this test, future code changes could unintentionally change the endpoint's behavior without being detected.
+The issue is a gap in automated test coverage rather than a confirmed production bug. The `POST /reviews` endpoint currently creates a pending review and schedules background processing even when the profile has no resume, GitHub source, or portfolio content. The expected behavior is for this request to succeed without crashing, while unexpected service failures should still return an HTTP 500 response. Without tests for these cases, future changes could unintentionally alter this behavior without being detected.
 
 ---
 
@@ -24,11 +24,11 @@ Files involved:
 
 ## Plan
 
-1. Understand the review creation flow from the route into the review service.
-2. Identify where the missing-documents condition should be handled.
-3. Add a focused unit test covering the missing edge case.
-4. Verify that the endpoint returns the expected error instead of a generic failure.
-5. Run the relevant unit tests and ensure the new test passes.
+1. Trace the `POST /reviews` request flow through `api/routes/reviews.py` and `core/services/review_service.py`.
+2. Add a route-level unit test confirming that a documentless profile receives a pending review.
+3. Add a test confirming that `process_review` is scheduled as a background task.
+4. Add a test confirming that unexpected review-service failures return HTTP 500 and do not schedule background processing.
+5. Run the targeted pytest suite, Ruff, Black, `make check`, and `make test-unit`, documenting unrelated pre-existing failures.
 
 ---
 
@@ -41,22 +41,24 @@ Files involved:
 
 **Expected output**
 
-- The endpoint returns the appropriate HTTP error.
-- The new automated test verifies this behavior and prevents regressions.
-
+- The endpoint returns a pending review response for a profile with no ingested documents.
+- Background review processing is scheduled.
+- Unexpected service failures return HTTP 500.
+- Automated tests preserve these behaviors against regressions.
 ---
 
 ## Risks & unknowns
 
-- It is not yet clear whether the project expects a pure route unit test or a more integrated test exercising the complete review creation flow.
-- The missing validation may already exist inside the service layer, requiring only additional test coverage.
-- Existing testing conventions may require a different mocking strategy than initially expected.
+- Mocked route tests must still verify the correct service arguments and background-task behavior.
+- The test response object must contain all fields required by `ReviewResponse`.
+- Project-wide linting, type-checking, and unit-test failures may occur in unrelated files, so targeted checks must confirm that this contribution introduces no new failures.
 
 ---
 
 ## Edge cases
 
-- Profile exists but has no ingested documents.
-- Profile does not exist.
-- Review creation succeeds normally.
-- Unexpected internal exceptions should still return the appropriate server error.
+- A profile exists but has no resume, GitHub username, or portfolio URL.
+- A pending review is returned with `sections=None` and `overall_score=None`.
+- Exactly one background processing task is scheduled with the correct IDs.
+- An unexpected service exception returns HTTP 500.
+- No background task is scheduled when review creation fails.

--- a/tests/unit/test_review_routes.py
+++ b/tests/unit/test_review_routes.py
@@ -1,0 +1,49 @@
+"""Unit tests for review routes."""
+
+from unittest.mock import AsyncMock, Mock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import BackgroundTasks, HTTPException
+
+from api.routes.reviews import create_review_endpoint
+from api.schemas.review import ReviewCreate
+
+
+class TestCreateReviewEndpoint:
+    """Tests for POST /reviews."""
+
+    @pytest.mark.asyncio
+    async def test_returns_error_when_profile_has_no_ingested_documents(self) -> None:
+        """The endpoint should preserve the expected no-documents error."""
+        profile_id = uuid4()
+
+        data = ReviewCreate(profile_id=profile_id)
+        current_user = Mock()
+        current_user.id = uuid4()
+
+        db = AsyncMock()
+        background_tasks = BackgroundTasks()
+
+        no_documents_error = HTTPException(
+            status_code=400,
+            detail="Profile has no ingested documents",
+        )
+
+        with (
+            patch(
+                "api.routes.reviews.create_review",
+                new=AsyncMock(side_effect=no_documents_error),
+            ),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            await create_review_endpoint(
+                data=data,
+                background_tasks=background_tasks,
+                current_user=current_user,
+                db=db,
+            )
+
+        assert exc_info.value.status_code == 400
+        assert exc_info.value.detail == "Profile has no ingested documents"
+        db.rollback.assert_not_awaited()

--- a/tests/unit/test_review_routes.py
+++ b/tests/unit/test_review_routes.py
@@ -1,39 +1,137 @@
 """Unit tests for review routes."""
 
+from datetime import UTC, datetime
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, patch
 from uuid import uuid4
 
 import pytest
 from fastapi import BackgroundTasks, HTTPException
 
-from api.routes.reviews import create_review_endpoint
+from api.routes.reviews import create_review_endpoint, process_review
 from api.schemas.review import ReviewCreate
 
 
-class TestCreateReviewEndpoint:
-    """Tests for POST /reviews."""
+class TestCreateReviewEndpointNoIngestedDocuments:
+    """Tests for POST /reviews when a profile has no ingested documents."""
 
     @pytest.mark.asyncio
-    async def test_returns_error_when_profile_has_no_ingested_documents(self) -> None:
-        """The endpoint should preserve the expected no-documents error."""
+    async def test_create_review_returns_pending_for_profile_with_no_documents(
+        self,
+    ) -> None:
+        """A documentless profile should still receive a pending review."""
+        profile_id = uuid4()
+        user_id = uuid4()
+        review_id = uuid4()
+        now = datetime.now(UTC)
+
+        data = ReviewCreate(profile_id=profile_id)
+
+        current_user = Mock()
+        current_user.id = user_id
+
+        db = AsyncMock()
+        background_tasks = BackgroundTasks()
+
+        pending_review = SimpleNamespace(
+            id=review_id,
+            profile_id=profile_id,
+            status="pending",
+            sections=None,
+            overall_score=None,
+            error_message=None,
+            created_at=now,
+            updated_at=now,
+        )
+
+        with patch(
+            "api.routes.reviews.create_review",
+            new=AsyncMock(return_value=pending_review),
+        ) as mock_create_review:
+            response = await create_review_endpoint(
+                data=data,
+                background_tasks=background_tasks,
+                current_user=current_user,
+                db=db,
+            )
+
+        assert response.id == review_id
+        assert response.profile_id == profile_id
+        assert response.status == "pending"
+        assert response.sections is None
+        assert response.overall_score is None
+
+        mock_create_review.assert_awaited_once_with(
+            db=db,
+            profile_id=profile_id,
+            user_id=user_id,
+        )
+
+    @pytest.mark.asyncio
+    async def test_create_review_schedules_processing_for_profile_with_no_documents(
+        self,
+    ) -> None:
+        """A documentless profile should still schedule review processing."""
+        profile_id = uuid4()
+        user_id = uuid4()
+        review_id = uuid4()
+        now = datetime.now(UTC)
+
+        data = ReviewCreate(profile_id=profile_id)
+
+        current_user = Mock()
+        current_user.id = user_id
+
+        db = AsyncMock()
+        background_tasks = BackgroundTasks()
+
+        pending_review = SimpleNamespace(
+            id=review_id,
+            profile_id=profile_id,
+            status="pending",
+            sections=None,
+            overall_score=None,
+            error_message=None,
+            created_at=now,
+            updated_at=now,
+        )
+
+        with patch(
+            "api.routes.reviews.create_review",
+            new=AsyncMock(return_value=pending_review),
+        ):
+            await create_review_endpoint(
+                data=data,
+                background_tasks=background_tasks,
+                current_user=current_user,
+                db=db,
+            )
+
+        assert len(background_tasks.tasks) == 1
+
+        scheduled_task = background_tasks.tasks[0]
+        assert scheduled_task.func is process_review
+        assert scheduled_task.args == (db, review_id, profile_id)
+
+    @pytest.mark.asyncio
+    async def test_create_review_returns_500_when_service_fails(
+        self,
+    ) -> None:
+        """Unexpected review creation failures should return a 500 error."""
         profile_id = uuid4()
 
         data = ReviewCreate(profile_id=profile_id)
+
         current_user = Mock()
         current_user.id = uuid4()
 
         db = AsyncMock()
         background_tasks = BackgroundTasks()
 
-        no_documents_error = HTTPException(
-            status_code=400,
-            detail="Profile has no ingested documents",
-        )
-
         with (
             patch(
                 "api.routes.reviews.create_review",
-                new=AsyncMock(side_effect=no_documents_error),
+                new=AsyncMock(side_effect=RuntimeError("database unavailable")),
             ),
             pytest.raises(HTTPException) as exc_info,
         ):
@@ -44,6 +142,7 @@ class TestCreateReviewEndpoint:
                 db=db,
             )
 
-        assert exc_info.value.status_code == 400
-        assert exc_info.value.detail == "Profile has no ingested documents"
-        db.rollback.assert_not_awaited()
+        assert exc_info.value.status_code == 500
+        assert exc_info.value.detail == "Failed to create review"
+        db.rollback.assert_awaited_once()
+        assert len(background_tasks.tasks) == 0


### PR DESCRIPTION
## Summary

Adds route-level unit tests for the `POST /reviews` endpoint when a profile has no ingested documents.

The new tests verify that:
- a pending review is created successfully for a profile with no ingested documents,
- background review processing is still scheduled, and
- unexpected service failures continue to return an HTTP 500 response.

---

## Issue

Closes #88

---

## Changes

Added three unit tests in:

`tests/unit/test_review_routes.py`

Tests added:

- `test_create_review_returns_pending_for_profile_with_no_documents`
- `test_create_review_schedules_processing_for_profile_with_no_documents`
- `test_create_review_returns_500_when_service_fails`

The endpoint implementation itself did not require changes. This PR improves regression coverage by documenting the expected behavior through automated tests.

---

## Testing

```bash
.venv/bin/ruff check tests/unit/test_review_routes.py
.venv/bin/black --check tests/unit/test_review_routes.py
.venv/bin/pytest tests/unit/test_review_routes.py -v
```

Results:

- ✅ Ruff passed
- ✅ Black passed
- ✅ All 3 unit tests passed

---
## Notes for reviewers

The repository currently contains pre-existing project-wide validation failures unrelated to this test-only contribution:

- `make check` reports existing linting and type-checking issues across unrelated files.
- `make test-unit` reports 53 failures and 375 passing tests across the existing suite.

The modified file passes Ruff and Black, and all three tests in `tests/unit/test_review_routes.py` pass. This contribution does not introduce additional failures.