### PR TITLE
docs(api): add curl examples

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,19 @@
+Week 7 — Issue selection
+
+Issue link: Issue #117 — API docs don't include example curl commands
+
+Issue title: API docs don't include example curl commands
+
+Tier:  Tier 1 
+
+Problem summary:
+The PathReview API documentation identifies the available endpoints, but it does not provide command-line examples showing how to call them. This makes it difficult for new contributors to quickly test the API and confirm that their local backend is working correctly. The issue primarily affects docs/API.md rather than the application’s core frontend or backend logic. A successful fix will add clear and accurate curl commands that developers can copy and run against the local API.
+
+“Is this right for me?” checklist reasoning:
+I selected this Tier 1 issue because this is my first contribution to the PathReview codebase, and I am still becoming familiar with its architecture and development workflow. The task has a focused scope because the primary file involved is docs/API.md, rather than several interconnected source-code files. I understand the basic technologies involved, including HTTP requests, API endpoints, JSON, and command-line tools, and I can verify the examples by running the application locally. The expected result is also clear and testable: each documented curl command should match a real endpoint and produce the expected API response. Based on its limited scope, defined output, and Tier 1 label, this issue is appropriate for my current comfort level.
+
+Branch name: docs/117-add-curl-examples
+
+Setup confirmation: App runs locally at localhost:5173
+
+Cohort ledger:Issue added to cohort ledger

--- a/docs/API.md
+++ b/docs/API.md
@@ -8,22 +8,108 @@ Base URL: `http://localhost:8000`
 
 `GET /health` — Returns service status and dependency health.
 
+#### Example
+```bash
+curl http://localhost:8000/health
+```
 ### Authentication
 
 `POST /auth/register` — Create a new account.
+
+#### Example
+```bash
+curl -X POST "http://localhost:8000/auth/register" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "email": "newuser@example.com",
+    "password": "securepassword123"
+  }'
+```
+
 `POST /auth/login` — Obtain a JWT access token.
+
+#### Example
+
+```bash
+curl -X POST "http://localhost:8000/auth/login" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "username=newuser@example.com&password=securepassword123"
+```
 
 ### Profiles
 
 `POST /profiles` — Create a profile with resume and GitHub username.
+
+#### Example
+
+Create a profile with a GitHub username, portfolio URL, and PDF résumé:
+
+```bash
+curl -X POST "http://localhost:8000/profiles" \
+  -H "Accept: application/json" \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
+  -F "github_username=example-user" \
+  -F "portfolio_url=https://example.com" \
+  -F "resume_file=@/path/to/resume.pdf;type=application/pdf"
+```
+
 `GET /profiles/{profile_id}` — Retrieve a profile.
+#### Example
+```bash
+curl -X GET \
+  "http://localhost:8000/profiles/PROFILE_ID" \
+  -H "Accept: application/json" \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
+```
+
 `DELETE /profiles/{profile_id}` — Delete a profile and associated data.
+#### Example
+
+```bash
+curl -X DELETE \
+  "http://localhost:8000/profiles/PROFILE_ID" \
+  -H "Accept: */*" \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
+```
 
 ### Reviews
 
 `POST /reviews` — Request a new portfolio review for a profile.
+
+#### Example
+
+```bash
+curl -X POST \
+  "http://localhost:8000/reviews" \
+  -H "Accept: application/json" \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "profile_id": "PROFILE_ID"
+  }'
+```
+
 `GET /reviews/{review_id}` — Retrieve a completed review.
-`GET /reviews` — List reviews for the authenticated user (paginated).
+
+#### Example
+
+```bash
+curl -X GET \
+  "http://localhost:8000/reviews/REVIEW_ID" \
+  -H "Accept: application/json" \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
+```
+
+`GET /reviews` — List reviews for the authenticated user with pagination.
+
+#### Example
+
+```bash
+curl -X GET \
+  "http://localhost:8000/reviews?page=1&page_size=20" \
+  -H "Accept: application/json" \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
+```
 
 ## Interactive Docs
 


### PR DESCRIPTION
## Summary
<!-- One paragraph describing what this PR does and why -->
This PR improves the API documentation by adding curl examples for the health, authentication, profile, and review endpoints. The examples help new contributors test the local API and understand the required request formats, authorization headers, file uploads, IDs, and pagination parameters.
## Issue
Closes #117 

## Changes
<!-- Bullet list of the specific changes made -->
-Added a curl example for GET /health
-Added registration and login examples
-Added authenticated profile creation, retrieval, and deletion examples
-Added review creation, retrieval, and paginated listing examples
-Added safe placeholders for access tokens, profile IDs, review IDs, and résumé paths
-Improved the formatting and organization of docs/API.md

## Testing
<!-- How did you verify your changes? -->
- [ ] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`)
- [ ] Linter passes (`make lint`)
- [ ] Type checker passes (`make typecheck`)
- [ ] New/updated tests cover the changes

->I ran the application locally and manually verified each documented curl command in the terminal against the API at http://localhost:8000.

## Screenshots / Demo
<!-- If applicable, add screenshots or a link to a demo video -->
<img width="330" height="724" alt="image" src="https://github.com/user-attachments/assets/785107c8-1a5b-49e4-bf4d-4a868c0eab30" />

## Notes for Reviewers
<!-- Anything the reviewer should pay particular attention to -->
Please verify that the curl examples match the request formats expected by each endpoint. I replaced all real credentials, JWT tokens, resource IDs, and personal filenames with safe placeholders. Thanks
