### PR TITLE
Fix/47 persist agent state across restarts

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,9 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(docker compose *)",
-      "Bash(sudo docker compose up -d)",
-      "Bash(sudo docker compose ps)"
-    ]
-  }
-}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(docker compose *)",
+      "Bash(sudo docker compose up -d)",
+      "Bash(sudo docker compose ps)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ venv/
 # IDE
 .vscode/
 .idea/
+.claude/
 *.swp
 *.swo
 *~

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -11,6 +11,23 @@
 **Problem summary:**
 Long-running reviews that span five or more repositories currently lose all progress when the server restarts because agent session data is stored only in memory. When the API process terminates (during maintenance or deployment), all in-flight review state is lost with no way to recover. The fix requires persisting the agent's memory context to Redis before shutdown and restoring it on startup. This will ensure that users don't lose progress on long-running reviews and allow the system to handle server restarts gracefully without data loss.
 
+**Issue fit and selection reasoning:**
+
+**Scope-fit checklist:**
+- [x] Bounded fix — Not a massive refactor; adds persistence layer to `ContextManager` and `SessionStore`
+- [x] 3-4 week scope — Confirmed as Tier 3; estimate 2 weeks of work (session serialization, caching logic, tests)
+- [x] Clear acceptance criteria — Cache survives restart; tool results re-used from Redis, not re-executed
+- [x] Affects real users — Long-running reviews that span repositories lose progress on deploy
+- [x] Active maintenance — Issue shows maintainer engagement and clear reproduction steps
+- [x] Specific files identified — `Orchestrator`, `ContextManager`, `SessionStore`, Redis connection
+
+**Why this is Tier 3 for me:**
+- Requires understanding of async orchestration and memoization patterns (learning goal: multi-step system architecture)
+- Involves Redis persistence and serialization — new domain to me (learning goal: state management across system restarts)
+- Builds on existing `SessionStore` patterns — familiar enough to avoid being overwhelming
+- Clear deliverable: cache the tool results, persist to Redis, restore on restart
+- No language barriers (Python expertise) or missing infrastructure
+
 **Branch name:** fix/47-persist-agent-state-across-restarts
 
 **Setup confirmation:** [x] App runs locally at localhost:5173

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,29 @@
+# Module 3 Progress Journal
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/47
+
+**Issue title:** Agent state isn't persisted across API restarts, causing in-progress reviews to be lost
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+Long-running reviews that span five or more repositories currently lose all progress when the server restarts because agent session data is stored only in memory. When the API process terminates (during maintenance or deployment), all in-flight review state is lost with no way to recover. The fix requires persisting the agent's memory context to Redis before shutdown and restoring it on startup. This will ensure that users don't lose progress on long-running reviews and allow the system to handle server restarts gracefully without data loss.
+
+**Branch name:** fix/47-persist-agent-state-across-restarts
+
+**Setup confirmation:** [ ] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger
+
+---
+
+## Week 8 — Implementation
+(To be completed)
+
+## Week 9 — Testing & PR
+(To be completed)
+
+## Week 10 — Reflection
+(To be completed)

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -62,7 +62,7 @@ reviews on one profile ever need isolation.
 
 ### Check-in 2 (end of week)
 
-**PR link:** _pending — see PR opened against ascherj/pathreview_
+**PR link:** https://github.com/ascherj/pathreview/pull/275
 
 **Branch:** `fix/47-persist-agent-state-across-restarts`
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -37,11 +37,60 @@ Created unit tests demonstrating that `ContextManager` results are lost when the
 
 ---
 
-## Week 9 — Implementation
-(To be completed)
+## Week 9 — Solution building & PR submission
 
-## Week 9 — Testing & PR
-(To be completed)
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Working through PLAN.md. Confirmed the Week 8 open questions: tool results are
+`ToolResult` dataclasses, so they serialize cleanly with `dataclasses.asdict`.
+Sub-tasks 1–3 are done — `ContextManager` now has `to_dict`/`from_dict`,
+`SessionStore` has `get_cache`/`set_cache` under a separate `cache:` key, and the
+orchestrator restores the cache at the start of `run()`.
+
+**Next steps:**
+Add checkpointing after each tool so a mid-review restart keeps partial progress,
+then write tests covering the serialization round trip and a full restart. Run
+`make check` and `make test-unit` and open a draft PR for peer feedback.
+
+**Blockers:**
+None. Decided to key the cache on `profile_id` (matching how `SessionStore`
+already keys sessions) instead of `review_id`; noted as a follow-up if concurrent
+reviews on one profile ever need isolation.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** _pending — see PR opened against ascherj/pathreview_
+
+**Branch:** `fix/47-persist-agent-state-across-restarts`
+
+**What you built:**
+The orchestrator's memoized tool-result cache is now persisted to Redis so an API
+restart no longer wipes an in-progress review. `ContextManager` serializes its
+cache to a JSON-safe form, `SessionStore` stores it under a separate `cache:` key,
+and the orchestrator restores it on the next run and checkpoints after every tool
+so partial progress survives a mid-review restart.
+
+**Tests added or updated:**
+`tests/unit/test_agent_state_persistence.py` — 10 tests covering the serialization
+round trip (including `ToolResult` reconstruction and skipping unserializable
+entries), the `SessionStore` cache read/write, and an end-to-end restart where a
+second orchestrator reuses the persisted cache instead of re-running the tool.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+_Pre-existing failures: on this branch `make test-unit` reports 53 failing tests
+and `make check` reports pre-existing ruff/mypy errors (e.g. missing library stubs,
+`agent/tools/market_analyzer.py`) that exist on a clean checkout and are unrelated
+to this issue. My changes introduce no new failures — the count is 53 before and
+after, my 10 new tests all pass, and mypy/ruff/black are clean on every file I
+touched (enforced by the pre-commit hook)._
+
+**Draft PR feedback received from:** none yet (draft opened for peer review in Slack)
+
+---
 
 ## Week 10 — Reflection
 (To be completed)

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -6,16 +6,16 @@
 
 **Issue title:** Agent state isn't persisted across API restarts, causing in-progress reviews to be lost
 
-**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+**Tier:** [ ] Tier 1  [ ] Tier 2  [x] Tier 3
 
 **Problem summary:**
 Long-running reviews that span five or more repositories currently lose all progress when the server restarts because agent session data is stored only in memory. When the API process terminates (during maintenance or deployment), all in-flight review state is lost with no way to recover. The fix requires persisting the agent's memory context to Redis before shutdown and restoring it on startup. This will ensure that users don't lose progress on long-running reviews and allow the system to handle server restarts gracefully without data loss.
 
 **Branch name:** fix/47-persist-agent-state-across-restarts
 
-**Setup confirmation:** [ ] App runs locally at localhost:5173
+**Setup confirmation:** [x] App runs locally at localhost:5173
 
-**Cohort ledger:** [ ] Issue added to cohort ledger
+**Cohort ledger:** [x] Issue added to cohort ledger
 
 ---
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -19,7 +19,25 @@ Long-running reviews that span five or more repositories currently lose all prog
 
 ---
 
-## Week 8 — Implementation
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [9500b94](https://github.com/peter-abj/pathreview/commit/9500b94)
+
+**Reproduction summary:**
+Created unit tests demonstrating that `ContextManager` results are lost when the Orchestrator is re-initialized, simulating an API restart. Showed that while `SessionStore` can persist session state to Redis, the in-memory cache is not synchronized with Redis, causing tool re-execution on restart instead of cache hits.
+
+**PLAN.md link:** [PLAN.md](./PLAN.md)
+
+**Walkthrough video (recommended):** [Not recorded]
+
+**Blockers or open questions:**
+- Need to investigate what ToolResult objects contain to determine JSON serializability
+- Uncertain whether profile_id includes user context to prevent cache collisions
+- Should cache key use profile_id or review_id for multi-review scenarios?
+
+---
+
+## Week 9 — Implementation
 (To be completed)
 
 ## Week 9 — Testing & PR

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -105,9 +105,34 @@ to this issue. My changes introduce no new failures — the count is 53 before a
 after, my 10 new tests all pass, and mypy/ruff/black are clean on every file I
 touched (enforced by the pre-commit hook)._
 
-**Draft PR feedback received from:** none yet (draft opened for peer review in Slack)
+**Draft PR feedback received from:** none yet (draft opened for peer review )
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [•] No — still awaiting review
+
+**Summary of feedback:**
+No review came in
+
+[What changes did you make, or what did you reply? If no feedback,
+leave blank.]
 
 ---
 
-## Week 10 — Reflection
-(To be completed)
+### Reflection
+
+**What was harder than you expected?**
+The complexity of the architecture and how different pieces each play a different role. II had to study each file to understand the logic and that took some time 
+
+**What did you learn about working in a large codebase?**
+It’s so much fun working in a codebase because the organization of logic is really fascinating and collaboration itself is enjoyable
+
+**How did AI tools help — and where did they fall short?**
+I used Claude Code to deeply understand the codebase and how each piece fits into the puzzle. I also used it for debugging and understanding error messages
+
+**What would you do differently if you started over?**
+I wouldn’t change anything. The experience itself, to me, was very fruitful. 
+**What are you most proud of from this module?**
+It was my first time navigating through a monolithic codebase and so, having to contribute in a manner like I would in an industry setting was very fulfilling for me.

--- a/PLAN.md
+++ b/PLAN.md
@@ -126,3 +126,33 @@
 - Add try-except with logging around cache operations
 - Document Redis requirement for production persistence
 - Add tests for partial/stale cache scenarios
+
+---
+
+## Implementation notes (Week 9)
+
+What actually shipped, and where it differed from the plan above.
+
+**Answered from the Week 8 open questions:**
+- Tool results are `ToolResult` dataclasses (`agent/tools/base.py`) — JSON-safe
+  via `dataclasses.asdict`, so no custom encoder was needed.
+- Kept `profile_id` as the cache key rather than switching to `review_id`.
+  `SessionStore` already keys session state by `profile_id`, and the orchestrator
+  only receives `profile_id`; reusing it keeps the cache aligned with the
+  existing session and avoids a wider signature change. Noted as a follow-up if
+  concurrent reviews on one profile ever need isolation.
+
+**What changed from the plan:**
+- Added checkpointing after *every* tool, not just at the end of `run()`. The
+  issue is about reviews interrupted partway through, so persisting only on
+  completion wouldn't have saved partial progress. A small `_checkpoint` helper
+  writes session state + cache after each tool.
+- Serialization tags each entry (`__kind__`) so `from_dict` can rebuild a real
+  `ToolResult` on restore and cache hits keep the same `.data` interface.
+
+**Files touched:**
+- `agent/memory/context_manager.py` — `to_dict` / `from_dict` + helpers
+- `agent/memory/session_store.py` — `get_cache` / `set_cache`
+- `agent/orchestrator.py` — restore on start, `_checkpoint` after each tool
+- `tests/unit/test_agent_state_persistence.py` — serialization, store, and
+  end-to-end restart tests (10 tests, using an in-memory `FakeRedis`)

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,128 @@
+# Solution Plan for Issue #47
+
+## Solution plan
+
+**Issue:** [Agent state isn't persisted across API restarts, causing in-progress reviews to be lost](https://github.com/ascherj/pathreview/issues/47)
+
+### Understand
+
+**Root cause:** The `ContextManager` class stores tool execution results in memory only (`self.results` dictionary). When the Orchestrator is re-initialized after an API restart, this in-memory cache is lost, even though `SessionStore` persists some session state to Redis.
+
+**Expected behavior:** Long-running reviews (5+ repositories) should preserve cached tool results across server restarts, allowing them to resume without re-executing the same expensive operations.
+
+**Actual behavior:** On API restart, the ContextManager cache is empty, causing tool re-execution and loss of progress during long-running reviews.
+
+### Map
+
+**Files involved:**
+1. `agent/memory/context_manager.py` - Stores results in memory only
+2. `agent/memory/session_store.py` - Persists session state to Redis (not cache)
+3. `agent/orchestrator.py` - Creates and uses ContextManager, initializes new instance on each run
+4. `core/services/review_service.py` - Calls agent orchestration (placeholder currently)
+
+**Key functions:**
+- `ContextManager.__init__()` - Initializes empty results dict
+- `ContextManager.store_tool_result()` - Caches result in memory
+- `ContextManager.get_tool_result()` - Retrieves from memory cache
+- `Orchestrator.__init__()` - Creates new ContextManager instance
+- `Orchestrator.run()` - Loads session state from Redis but not cached results
+- `SessionStore.get()` / `SessionStore.set()` - Redis persistence layer
+
+### Plan
+
+**High-level approach:** Extend SessionStore to persist and restore ContextManager cache alongside session state, ensuring cached tool results survive server restarts.
+
+**Concrete sub-tasks:**
+
+1. **Extend ContextManager to serialize/deserialize cached results**
+   - Add method `to_dict()` that returns results in JSON-serializable format
+   - Add method `from_dict(data)` that restores results from dict
+   - Handle edge cases: non-serializable result objects
+
+2. **Extend SessionStore to manage context cache**
+   - Add separate Redis key prefix for context cache: `cache:<profile_id>`
+   - Implement `set_cache()` method to persist ContextManager results
+   - Implement `get_cache()` method to restore ContextManager results
+   - Use same TTL as session data (1 hour default)
+
+3. **Update Orchestrator to load and persist context cache**
+   - In `__init__()`: Add optional parameter to initialize from saved cache
+   - In `run()`: After loading session state, also load cached results into ContextManager
+   - In `run()`: After execution completes, persist context cache via SessionStore
+
+4. **Add integration test demonstrating persistence across restarts**
+   - Create test that simulates: run → restart → resume
+   - Verify cache hit rate (tool not re-executed)
+   - Ensure session integrity during restart
+
+5. **Update review_service.py to use new persistence**
+   - Pass session store to Orchestrator
+   - Verify profile_id consistency between session and cache keys
+
+### Inputs & outputs
+
+**Inputs:**
+- Profile ID (string) - used as session/cache key
+- Tool execution results (dict) - cached in memory
+- Redis client instance - for persistence
+
+**Outputs:**
+- ContextManager cache persisted to Redis with TTL
+- Restored ContextManager on Orchestrator restart
+- Cache keys follow pattern: `cache:<profile_id>`
+- Session data and cache data aligned (same profile_id)
+
+### Risks & unknowns
+
+**Risks:**
+1. **Serialization of complex results** - Tool results might contain non-JSON-serializable objects (custom classes, file handles). Need to handle gracefully with fallback or conversion.
+2. **Cache key collision** - If profile IDs aren't unique across users, cache could leak between profiles. Must verify SessionStore uses `profile_id` that includes user context.
+3. **Stale cache after deployment** - Redis keys might persist beyond expected TTL if Redis is not cleared. Could be mitigated with version prefix in cache keys.
+4. **Redis unavailability** - If Redis is down, cache persistence fails silently in SessionStore. Need to log errors and ensure graceful degradation.
+
+**Unknowns:**
+- What exactly do tool results contain? Are they JSON-serializable by default?
+- How are profile IDs constructed? Do they include user ID?
+- What's the expected maximum size of cached results for 5+ repo review?
+- Is there existing serialization pattern in the codebase (e.g., in models)?
+
+**Investigation paths:**
+- Check `agent/tools/*.py` to see what `execute()` methods return
+- Look at `agent/tools/base.py` for ToolResult schema
+- Check how profile_id is passed in review_service.py
+- Verify SessionStore key format includes user context
+
+### Edge cases
+
+**What the fix should handle gracefully:**
+
+1. **Non-serializable result objects**
+   - If tool result contains objects that can't be JSON-encoded, try to convert to dict or string representation
+   - Log warning but don't fail - graceful degradation
+
+2. **Partial cache on restart**
+   - If Redis has stale cache from previous profile, overwrite with new session
+   - If some tools succeeded but Redis persistence failed, resume with partial cache
+
+3. **Cache key collisions across users**
+   - Ensure profile_id in cache key cannot accidentally match another user's profile
+   - Consider adding user_id or session_id to cache key prefix
+
+4. **Very long-running reviews**
+   - Cache expires after TTL (1 hour default) - but review might take longer
+   - Could extend TTL for active reviews, or implement LRU eviction
+
+5. **Multiple concurrent reviews on same profile**
+   - If user starts review, restarts API, starts another review before first completes
+   - Need to distinguish cache between concurrent runs (use review_id not just profile_id)
+
+6. **Redis connection failures**
+   - If SessionStore.set_cache() fails, cache persistence fails silently
+   - Should log error but allow review to continue with in-memory cache only
+   - Document that reviews aren't truly persistent without working Redis
+
+**Edge case mitigation:**
+- Use `review_id` as cache key (more specific than profile_id)
+- Add try-except with logging around cache operations
+- Document Redis requirement for production persistence
+- Add tests for partial/stale cache scenarios

--- a/agent/error_handling.py
+++ b/agent/error_handling.py
@@ -1,14 +1,18 @@
 """Retry logic with exponential backoff."""
 
-import time
 import functools
+import time
+from collections.abc import Callable
+from typing import Any
+
 import structlog
 
 logger = structlog.get_logger()
 
 
-def retry_with_backoff(max_retries: int = 3, backoff_factor: float = 2.0,
-                       exceptions: tuple = (Exception,)):
+def retry_with_backoff(
+    max_retries: int = 3, backoff_factor: float = 2.0, exceptions: tuple = (Exception,)
+) -> Callable:
     """Decorator for retry logic with exponential backoff.
 
     Args:
@@ -19,9 +23,10 @@ def retry_with_backoff(max_retries: int = 3, backoff_factor: float = 2.0,
     Returns:
         Decorated function
     """
-    def decorator(func):
+
+    def decorator(func: Callable) -> Callable:
         @functools.wraps(func)
-        def wrapper(*args, **kwargs):
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
             attempt = 0
             last_exception = None
 
@@ -36,26 +41,37 @@ def retry_with_backoff(max_retries: int = 3, backoff_factor: float = 2.0,
 
                     if attempt < max_retries:
                         wait_time = backoff_factor ** (attempt - 1)
-                        logger.warning("retry_attempt", func=func.__name__,
-                                     attempt=attempt, max_retries=max_retries,
-                                     wait_seconds=wait_time, error=str(e))
+                        logger.warning(
+                            "retry_attempt",
+                            func=func.__name__,
+                            attempt=attempt,
+                            max_retries=max_retries,
+                            wait_seconds=wait_time,
+                            error=str(e),
+                        )
                         time.sleep(wait_time)
                     else:
-                        logger.error("retry_exhausted", func=func.__name__,
-                                   max_retries=max_retries, error=str(e))
+                        logger.error(
+                            "retry_exhausted",
+                            func=func.__name__,
+                            max_retries=max_retries,
+                            error=str(e),
+                        )
 
             if last_exception:
                 raise last_exception
 
         return wrapper
+
     return decorator
 
 
 class RetryContext:
     """Context manager for retry logic with exponential backoff."""
 
-    def __init__(self, max_retries: int = 3, backoff_factor: float = 2.0,
-                 exceptions: tuple = (Exception,)):
+    def __init__(
+        self, max_retries: int = 3, backoff_factor: float = 2.0, exceptions: tuple = (Exception,)
+    ):
         """Initialize retry context.
 
         Args:
@@ -69,11 +85,11 @@ class RetryContext:
         self.attempt = 0
         self.last_exception = None
 
-    def __enter__(self):
+    def __enter__(self) -> "RetryContext":
         """Enter context."""
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> bool:
         """Exit context and handle retries."""
         if exc_type is None:
             return False
@@ -86,12 +102,20 @@ class RetryContext:
 
         if self.attempt < self.max_retries:
             wait_time = self.backoff_factor ** (self.attempt - 1)
-            logger.warning("retry_context_attempt", attempt=self.attempt,
-                         max_retries=self.max_retries, wait_seconds=wait_time,
-                         error=str(exc_val))
+            logger.warning(
+                "retry_context_attempt",
+                attempt=self.attempt,
+                max_retries=self.max_retries,
+                wait_seconds=wait_time,
+                error=str(exc_val),
+            )
             time.sleep(wait_time)
             return True  # Suppress exception and retry
 
-        logger.error("retry_context_exhausted", attempt=self.attempt,
-                   max_retries=self.max_retries, error=str(exc_val))
+        logger.error(
+            "retry_context_exhausted",
+            attempt=self.attempt,
+            max_retries=self.max_retries,
+            error=str(exc_val),
+        )
         return False  # Re-raise exception

--- a/agent/memory/context_manager.py
+++ b/agent/memory/context_manager.py
@@ -2,6 +2,8 @@
 
 import hashlib
 import json
+from typing import Any
+
 import structlog
 
 logger = structlog.get_logger()
@@ -10,12 +12,11 @@ logger = structlog.get_logger()
 class ContextManager:
     """In-memory context manager for within-session memoization."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize context manager."""
-        self.results = {}
+        self.results: dict[str, Any] = {}
 
-    def store_tool_result(self, tool_name: str, input_hash: str,
-                         result) -> None:
+    def store_tool_result(self, tool_name: str, input_hash: str, result: dict) -> None:
         """Store tool execution result.
 
         Args:
@@ -27,7 +28,7 @@ class ContextManager:
         self.results[key] = result
         logger.info("tool_result_stored", tool=tool_name, key=key)
 
-    def get_tool_result(self, tool_name: str, input_hash: str):
+    def get_tool_result(self, tool_name: str, input_hash: str) -> Any:
         """Get cached tool result.
 
         Args:

--- a/agent/memory/context_manager.py
+++ b/agent/memory/context_manager.py
@@ -2,9 +2,12 @@
 
 import hashlib
 import json
+from dataclasses import asdict, is_dataclass
 from typing import Any
 
 import structlog
+
+from agent.tools.base import ToolResult
 
 logger = structlog.get_logger()
 
@@ -16,13 +19,13 @@ class ContextManager:
         """Initialize context manager."""
         self.results: dict[str, Any] = {}
 
-    def store_tool_result(self, tool_name: str, input_hash: str, result: dict) -> None:
+    def store_tool_result(self, tool_name: str, input_hash: str, result: Any) -> None:
         """Store tool execution result.
 
         Args:
             tool_name: Name of the tool
             input_hash: Hash of input (for memoization key)
-            result: ToolResult object
+            result: Tool result to cache (typically a ``ToolResult``)
         """
         key = f"{tool_name}:{input_hash}"
         self.results[key] = result
@@ -55,6 +58,86 @@ class ContextManager:
             Dict of all cached results
         """
         return dict(self.results)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize cached results into a JSON-safe dict for persistence.
+
+        Tool results are ``ToolResult`` dataclasses; these are converted to a
+        tagged, JSON-serializable form so they can be stored in Redis and later
+        restored via :meth:`from_dict`. Any result that cannot be serialized is
+        skipped with a warning rather than raising, so a single bad entry never
+        blocks persistence of the rest of the cache.
+
+        Returns:
+            Dict mapping cache keys to JSON-serializable payloads.
+        """
+        serialized: dict[str, Any] = {}
+        for key, result in self.results.items():
+            payload = self._serialize_result(result)
+            if payload is None:
+                logger.warning(
+                    "context_result_not_serializable",
+                    key=key,
+                    result_type=type(result).__name__,
+                )
+                continue
+            serialized[key] = payload
+        return serialized
+
+    def from_dict(self, data: dict[str, Any]) -> None:
+        """Restore cached results from a persisted dict produced by :meth:`to_dict`.
+
+        Entries are merged into the current cache. Malformed entries are skipped
+        with a warning so a partially corrupt payload cannot wipe out an
+        otherwise usable cache.
+
+        Args:
+            data: Dict of serialized cache payloads keyed by cache key.
+        """
+        if not data:
+            return
+        for key, payload in data.items():
+            try:
+                self.results[key] = self._deserialize_result(payload)
+            except Exception as exc:  # noqa: BLE001 - graceful degradation
+                logger.warning("context_result_restore_failed", key=key, error=str(exc))
+
+    @staticmethod
+    def _serialize_result(result: Any) -> dict[str, Any] | None:
+        """Convert a single cached result into a JSON-safe payload.
+
+        Returns None if the result cannot be safely serialized.
+        """
+        if is_dataclass(result) and not isinstance(result, type):
+            return {
+                "__kind__": "dataclass",
+                "__class__": type(result).__name__,
+                "value": asdict(result),
+            }
+        if isinstance(result, dict):
+            try:
+                json.dumps(result)
+            except (TypeError, ValueError):
+                return None
+            return {"__kind__": "dict", "value": result}
+        return None
+
+    @staticmethod
+    def _deserialize_result(payload: Any) -> Any:
+        """Reconstruct a cached result from its serialized payload.
+
+        Known ``ToolResult`` dataclasses are rebuilt as instances so cache hits
+        keep the same interface (e.g. ``.data``) as freshly executed tools.
+        Unknown dataclass types fall back to their raw value dict.
+        """
+        if isinstance(payload, dict) and payload.get("__kind__") == "dataclass":
+            value = payload.get("value", {})
+            if payload.get("__class__") == "ToolResult":
+                return ToolResult(**value)
+            return value
+        if isinstance(payload, dict) and payload.get("__kind__") == "dict":
+            return payload.get("value", {})
+        return payload
 
     @staticmethod
     def hash_input(input_data: dict) -> str:

--- a/agent/memory/session_store.py
+++ b/agent/memory/session_store.py
@@ -79,3 +79,59 @@ class SessionStore:
 
         except Exception as e:
             logger.error("session_delete_error", session_id=session_id, error=str(e))
+
+    def get_cache(self, session_id: str) -> dict | None:
+        """Get the persisted agent context cache for a session.
+
+        The context cache holds memoized tool results (see
+        :class:`~agent.memory.context_manager.ContextManager`). It is stored
+        under a separate ``cache:`` key so it can be restored independently of
+        the session's tool output state after an API restart.
+
+        Args:
+            session_id: Session identifier
+
+        Returns:
+            Cache dict or None if expired/not found.
+        """
+        key = f"cache:{session_id}"
+
+        try:
+            data = self.redis.get(key)
+            if not data:
+                logger.info("cache_not_found", session_id=session_id)
+                return None
+
+            parsed: dict = json.loads(data)
+            logger.info("cache_retrieved", session_id=session_id)
+            return parsed
+
+        except json.JSONDecodeError:
+            logger.error("cache_decode_error", session_id=session_id)
+            return None
+        except Exception as e:
+            logger.error("cache_get_error", session_id=session_id, error=str(e))
+            return None
+
+    def set_cache(self, session_id: str, data: dict, ttl_seconds: int = 3600) -> None:
+        """Persist the agent context cache for a session.
+
+        Serialized tool results are stored under a ``cache:`` key with a TTL so
+        that an in-progress review can resume its memoized work after the API
+        process restarts. Failures are logged but never raised, so persistence
+        problems degrade gracefully to in-memory-only behavior.
+
+        Args:
+            session_id: Session identifier
+            data: Serialized context cache (from ``ContextManager.to_dict()``)
+            ttl_seconds: Time to live in seconds (default 1 hour)
+        """
+        key = f"cache:{session_id}"
+
+        try:
+            json_data = json.dumps(data)
+            self.redis.setex(key, ttl_seconds, json_data)
+            logger.info("cache_stored", session_id=session_id, ttl_seconds=ttl_seconds)
+
+        except Exception as e:
+            logger.error("cache_set_error", session_id=session_id, error=str(e))

--- a/agent/memory/session_store.py
+++ b/agent/memory/session_store.py
@@ -1,9 +1,9 @@
 """Redis-backed session store."""
 
-import redis
 import json
+
+import redis
 import structlog
-from typing import Optional
 
 logger = structlog.get_logger()
 
@@ -19,7 +19,7 @@ class SessionStore:
         """
         self.redis = redis_client
 
-    def get(self, session_id: str) -> Optional[dict]:
+    def get(self, session_id: str) -> dict | None:
         """Get session data.
 
         Args:
@@ -36,7 +36,7 @@ class SessionStore:
                 logger.info("session_not_found", session_id=session_id)
                 return None
 
-            parsed = json.loads(data)
+            parsed: dict = json.loads(data)
             logger.info("session_retrieved", session_id=session_id)
             return parsed
 

--- a/agent/orchestrator.py
+++ b/agent/orchestrator.py
@@ -1,12 +1,13 @@
 """Plan-execute orchestrator for agent tools."""
 
 import time
-import structlog
-from typing import Optional
+from typing import Any
 
-from .memory.session_store import SessionStore
-from .memory.context_manager import ContextManager
+import structlog
+
 from .error_handling import retry_with_backoff
+from .memory.context_manager import ContextManager
+from .memory.session_store import SessionStore
 
 logger = structlog.get_logger()
 
@@ -14,8 +15,9 @@ logger = structlog.get_logger()
 class Orchestrator:
     """Orchestrate tool execution with planning and memoization."""
 
-    def __init__(self, tools: dict, session_store: Optional[SessionStore] = None,
-                 tool_timeout: float = 30.0):
+    def __init__(
+        self, tools: dict, session_store: SessionStore | None = None, tool_timeout: float = 30.0
+    ):
         """Initialize orchestrator.
 
         Args:
@@ -53,7 +55,7 @@ class Orchestrator:
         for tool_name, tool_input in plan:
             try:
                 result = self._execute_tool(tool_name, tool_input)
-                results[tool_name] = result.data if hasattr(result, 'data') else result
+                results[tool_name] = result.data if hasattr(result, "data") else result
 
                 logger.info("tool_executed", tool=tool_name, success=True)
 
@@ -66,13 +68,12 @@ class Orchestrator:
             session_state.update(results)
             self.session_store.set(profile_id, session_state)
 
-        logger.info("orchestrator_complete", profile_id=profile_id,
-                   tools_executed=len(results))
+        logger.info("orchestrator_complete", profile_id=profile_id, tools_executed=len(results))
 
         return {
             "profile_id": profile_id,
             "tool_results": results,
-            "cached_results": self.context_manager.get_all_results()
+            "cached_results": self.context_manager.get_all_results(),
         }
 
     def _build_plan(self, profile_data: dict) -> list[tuple[str, dict]]:
@@ -90,50 +91,47 @@ class Orchestrator:
         if profile_data.get("github_username"):
             for project in profile_data.get("projects", []):
                 if project.get("github_repo"):
-                    plan.append((
-                        "github_tool",
-                        {
-                            "github_username": profile_data["github_username"],
-                            "repo_name": project["github_repo"]
-                        }
-                    ))
+                    plan.append(
+                        (
+                            "github_tool",
+                            {
+                                "github_username": profile_data["github_username"],
+                                "repo_name": project["github_repo"],
+                            },
+                        )
+                    )
                     break  # Only process first repo for now
 
         # Tech detector (if files available)
         if profile_data.get("files"):
-            plan.append((
-                "tech_detector",
-                {"files": profile_data["files"]}
-            ))
+            plan.append(("tech_detector", {"files": profile_data["files"]}))
 
         # README scorer
         if profile_data.get("readme_content"):
-            plan.append((
-                "readme_scorer",
-                {"readme_content": profile_data["readme_content"]}
-            ))
+            plan.append(("readme_scorer", {"readme_content": profile_data["readme_content"]}))
 
         # Skill extractor
         if profile_data.get("resume_text"):
-            plan.append((
-                "skill_extractor",
-                {
-                    "resume_text": profile_data["resume_text"],
-                    "repo_metadata": profile_data.get("repo_metadata", {})
-                }
-            ))
+            plan.append(
+                (
+                    "skill_extractor",
+                    {
+                        "resume_text": profile_data["resume_text"],
+                        "repo_metadata": profile_data.get("repo_metadata", {}),
+                    },
+                )
+            )
 
         # Market analyzer (if skills detected)
         if plan:  # Only if other tools executed
-            plan.append((
-                "market_analyzer",
-                {"detected_skills": {}}  # Will be populated by context
-            ))
+            plan.append(
+                ("market_analyzer", {"detected_skills": {}})  # Will be populated by context
+            )
 
         logger.info("plan_built", plan_size=len(plan))
         return plan
 
-    def _execute_tool(self, tool_name: str, tool_input: dict):
+    def _execute_tool(self, tool_name: str, tool_input: dict) -> Any:
         """Execute a single tool with retry and memoization.
 
         Args:
@@ -172,7 +170,9 @@ class Orchestrator:
             logger.error("tool_execution_error", tool=tool_name, error=str(e))
             raise
 
-    def _execute_with_timeout(self, tool, tool_input: dict, timeout: Optional[float] = None):
+    def _execute_with_timeout(
+        self, tool: Any, tool_input: dict, timeout: float | None = None
+    ) -> Any:
         """Execute tool with timeout.
 
         Args:
@@ -189,7 +189,7 @@ class Orchestrator:
         timeout = timeout or self.tool_timeout
 
         @retry_with_backoff(max_retries=2, backoff_factor=1.5)
-        def _execute():
+        def _execute() -> Any:
             return tool.execute(tool_input)
 
         start = time.time()

--- a/agent/orchestrator.py
+++ b/agent/orchestrator.py
@@ -49,6 +49,9 @@ class Orchestrator:
         session_state = {}
         if self.session_store:
             session_state = self.session_store.get(profile_id) or {}
+            # Restore the memoized tool-result cache so a review that spans an
+            # API restart resumes from cached work instead of re-executing tools.
+            self.context_manager.from_dict(self.session_store.get_cache(profile_id) or {})
 
         # Execute plan
         results = {}
@@ -63,10 +66,12 @@ class Orchestrator:
                 logger.error("tool_execution_failed", tool=tool_name, error=str(e))
                 results[tool_name] = {"error": str(e), "success": False}
 
-        # Persist state
-        if self.session_store:
-            session_state.update(results)
-            self.session_store.set(profile_id, session_state)
+            # Checkpoint after every tool so an API restart mid-review keeps the
+            # progress made so far instead of discarding the whole in-flight run.
+            self._checkpoint(profile_id, session_state, results)
+
+        # Final persist (covers the empty-plan case where the loop never ran).
+        self._checkpoint(profile_id, session_state, results)
 
         logger.info("orchestrator_complete", profile_id=profile_id, tools_executed=len(results))
 
@@ -75,6 +80,24 @@ class Orchestrator:
             "tool_results": results,
             "cached_results": self.context_manager.get_all_results(),
         }
+
+    def _checkpoint(self, profile_id: str, session_state: dict, results: dict) -> None:
+        """Persist session state and the context cache to the session store.
+
+        No-op when no session store is configured. Called after each tool so a
+        restart mid-review keeps completed work; the memoized cache is stored
+        separately so it can be restored on the next run.
+
+        Args:
+            profile_id: Session/cache key.
+            session_state: Accumulated session state to persist.
+            results: Tool results gathered so far in this run.
+        """
+        if not self.session_store:
+            return
+        session_state.update(results)
+        self.session_store.set(profile_id, session_state)
+        self.session_store.set_cache(profile_id, self.context_manager.to_dict())
 
     def _build_plan(self, profile_data: dict) -> list[tuple[str, dict]]:
         """Build execution plan based on available data.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -99,7 +99,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -449,7 +448,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -473,7 +471,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1561,7 +1558,6 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1579,7 +1575,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1972,7 +1967,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3507,7 +3501,6 @@
       "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^2.0.1",
         "cssstyle": "^4.0.1",
@@ -4094,7 +4087,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4107,7 +4099,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4771,7 +4762,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/tests/unit/test_agent_state_persistence.py
+++ b/tests/unit/test_agent_state_persistence.py
@@ -1,116 +1,207 @@
-"""Test demonstrating the agent state persistence issue (Issue #47).
+"""Tests for agent state persistence across API restarts (Issue #47).
 
-This test shows that ContextManager results are lost when the Orchestrator
-is re-initialized, simulating what happens on an API restart during a
-long-running review.
+These tests cover the fix that persists the agent's memoized tool-result cache
+(``ContextManager``) to Redis via ``SessionStore`` so that a long-running review
+survives an API restart instead of losing its progress.
 """
 
-from unittest.mock import MagicMock
+from typing import cast
+
+import pytest
+import redis
 
 from agent.memory.context_manager import ContextManager
 from agent.memory.session_store import SessionStore
 from agent.orchestrator import Orchestrator
+from agent.tools.base import ToolResult
 
 
-class MockTool:
-    """Mock tool for testing."""
+class FakeRedis:
+    """Minimal in-memory stand-in for the Redis client.
+
+    Implements only the operations SessionStore uses (``get``, ``setex``,
+    ``delete``), which lets these tests exercise the full persistence round trip
+    without a live Redis server. Values are stored as JSON strings, mirroring how
+    real Redis returns bytes/strings for ``get``.
+    """
+
+    def __init__(self) -> None:
+        self.store: dict[str, str] = {}
+
+    def get(self, key: str) -> str | None:
+        return self.store.get(key)
+
+    def setex(self, key: str, ttl_seconds: int, value: str) -> None:
+        self.store[key] = value
+
+    def delete(self, key: str) -> None:
+        self.store.pop(key, None)
+
+
+def _session_store(fake: FakeRedis) -> SessionStore:
+    """Build a SessionStore backed by the in-memory FakeRedis."""
+    return SessionStore(cast(redis.Redis, fake))
+
+
+class CountingTool:
+    """Tool that records how many times it actually executed."""
 
     def __init__(self, name: str) -> None:
         self.name = name
         self.execution_count = 0
 
-    def execute(self, input_data: dict) -> dict:
-        """Execute mock tool."""
+    def execute(self, input_data: dict) -> ToolResult:
         self.execution_count += 1
-        return {
-            "result": f"Result from {self.name}",
-            "input_hash": ContextManager.hash_input(input_data),
+        return ToolResult(success=True, data={"tool": self.name, "input": input_data})
+
+
+@pytest.mark.unit
+class TestContextManagerSerialization:
+    """Serialization round trip for the memoized cache."""
+
+    def test_tool_result_survives_round_trip(self) -> None:
+        """A ToolResult is restored as a ToolResult, not a bare dict."""
+        cm = ContextManager()
+        original = ToolResult(success=True, data={"score": 0.9}, error=None)
+        cm.store_tool_result("readme_scorer", "hash1", original)
+
+        restored = ContextManager()
+        restored.from_dict(cm.to_dict())
+        result = restored.get_tool_result("readme_scorer", "hash1")
+
+        assert isinstance(result, ToolResult)
+        assert result.success is True
+        assert result.data == {"score": 0.9}
+
+    def test_plain_dict_result_survives_round_trip(self) -> None:
+        """Dict results are preserved across serialization."""
+        cm = ContextManager()
+        cm.store_tool_result("tech_detector", "hash2", {"languages": ["python"]})
+
+        restored = ContextManager()
+        restored.from_dict(cm.to_dict())
+
+        assert restored.get_tool_result("tech_detector", "hash2") == {"languages": ["python"]}
+
+    def test_unserializable_result_is_skipped_not_raised(self) -> None:
+        """A non-serializable result is dropped with a warning, not an error."""
+        cm = ContextManager()
+        cm.store_tool_result("good", "h1", ToolResult(success=True, data={"ok": True}))
+        cm.store_tool_result("bad", "h2", object())  # not a dataclass or dict
+
+        serialized = cm.to_dict()
+
+        assert "good:h1" in serialized
+        assert "bad:h2" not in serialized
+
+    def test_from_dict_ignores_empty_payload(self) -> None:
+        """Restoring from an empty/None payload leaves the cache untouched."""
+        cm = ContextManager()
+        cm.store_tool_result("keep", "h1", {"value": 1})
+        cm.from_dict({})
+
+        assert cm.get_tool_result("keep", "h1") == {"value": 1}
+
+
+@pytest.mark.unit
+class TestSessionStoreCache:
+    """SessionStore persists the context cache under its own key."""
+
+    def test_cache_set_and_get_round_trip(self) -> None:
+        store = _session_store(FakeRedis())
+        payload = {"readme_scorer:h1": {"__kind__": "dict", "value": {"score": 1}}}
+
+        store.set_cache("profile-1", payload)
+
+        assert store.get_cache("profile-1") == payload
+
+    def test_cache_uses_separate_key_from_session(self) -> None:
+        """Cache and session data must not overwrite each other."""
+        fake = FakeRedis()
+        store = _session_store(fake)
+
+        store.set("profile-1", {"github_tool": {"stars": 3}})
+        store.set_cache("profile-1", {"github_tool:h1": {"__kind__": "dict", "value": {}}})
+
+        assert "session:profile-1" in fake.store
+        assert "cache:profile-1" in fake.store
+
+    def test_get_cache_returns_none_when_absent(self) -> None:
+        store = _session_store(FakeRedis())
+        assert store.get_cache("missing") is None
+
+
+@pytest.mark.unit
+class TestOrchestratorRestart:
+    """End-to-end: cached work survives an Orchestrator restart."""
+
+    def test_cache_lost_without_session_store(self) -> None:
+        """Regression guard: with no session store, a restart still re-executes.
+
+        This documents the original bug (Issue #47): an in-memory-only cache is
+        empty after re-initialization, so the tool runs again.
+        """
+        tool = CountingTool("github_tool")
+        tools = {"github_tool": tool}
+        tool_input = {"repo": "demo"}
+
+        first = Orchestrator(tools=tools)
+        first._execute_tool("github_tool", tool_input)
+        assert tool.execution_count == 1
+
+        # Simulate restart: brand new Orchestrator, no persistence configured.
+        second = Orchestrator(tools=tools)
+        second._execute_tool("github_tool", tool_input)
+        assert tool.execution_count == 2  # ran again — the bug
+
+    def test_cache_restored_across_restart_with_session_store(self) -> None:
+        """The fix: a shared session store lets a new Orchestrator reuse cache.
+
+        A single Redis-backed store is shared between two Orchestrator instances
+        (before and after a simulated restart). The second run for the same
+        profile must hit the persisted cache and NOT re-execute the tool.
+        """
+        store = _session_store(FakeRedis())
+        tool = CountingTool("github_tool")
+        tools = {"github_tool": tool}
+
+        profile_id = "profile-42"
+        profile_data = {
+            "github_username": "octocat",
+            "projects": [{"github_repo": "hello-world"}],
         }
 
+        # First run persists the cache to Redis.
+        first = Orchestrator(tools=tools, session_store=store)
+        first.run(profile_id, profile_data)
+        assert tool.execution_count == 1
 
-def test_context_manager_memory_lost_on_restart() -> None:
-    """REPRODUCTION: Demonstrate that ContextManager results are lost on restart.
+        # Simulate an API restart: fresh Orchestrator with an empty in-memory
+        # cache, but the same backing store.
+        second = Orchestrator(tools=tools, session_store=store)
+        assert len(second.context_manager.results) == 0
 
-    This test simulates:
-    1. First orchestrator run stores cached results in memory
-    2. Orchestrator is re-initialized (simulating server restart)
-    3. New orchestrator has empty ContextManager
-    4. Same tool execution doesn't hit the cache (BUG)
-    """
-    # Setup: Create first orchestrator and execute a tool
-    mock_tool = MockTool("github_tool")
-    tools = {"github_tool": mock_tool}
+        second.run(profile_id, profile_data)
 
-    orchestrator_1 = Orchestrator(tools=tools)
-    tool_input = {"repo": "test-repo", "username": "test-user"}
-    input_hash = ContextManager.hash_input(tool_input)
+        # Tool was not re-executed: the persisted cache was restored and hit.
+        assert tool.execution_count == 1
 
-    # First execution: tool runs, result is cached in memory
-    orchestrator_1._execute_tool("github_tool", tool_input)
-    assert mock_tool.execution_count == 1
-    assert orchestrator_1.context_manager.get_tool_result("github_tool", input_hash) is not None
+    def test_progress_checkpointed_after_each_tool(self) -> None:
+        """Cache is written incrementally so a mid-review restart keeps progress."""
+        store = _session_store(FakeRedis())
+        tools = {
+            "readme_scorer": CountingTool("readme_scorer"),
+            "market_analyzer": CountingTool("market_analyzer"),
+        }
 
-    # Simulate server restart: Create new Orchestrator instance
-    # (In real scenario, this is what happens when the API process restarts)
-    orchestrator_2 = Orchestrator(tools=tools)
+        orchestrator = Orchestrator(tools=tools, session_store=store)
+        orchestrator.run(
+            "profile-7",
+            {"readme_content": "# Hello"},  # plan: readme_scorer + market_analyzer
+        )
 
-    # BUG: New orchestrator has empty ContextManager
-    assert len(orchestrator_2.context_manager.results) == 0
-
-    # Second execution: tool runs AGAIN because cache is empty
-    # Even though we have the exact same input, we don't hit the cache
-    orchestrator_2._execute_tool("github_tool", tool_input)
-    assert mock_tool.execution_count == 2  # Tool executed twice instead of once!
-
-    # In a long-running review (5+ repositories), this repeated re-execution
-    # causes:
-    # - Loss of progress if the server restarts mid-review
-    # - Wasted API calls and compute
-    # - User loses all cached results
-
-
-def test_session_store_persists_results_but_not_context_cache() -> None:
-    """REPRODUCTION: Show SessionStore persists some state but not ContextManager cache.
-
-    This demonstrates the gap: SessionStore saves tool_results to Redis,
-    but ContextManager cache is not synchronized with Redis.
-    """
-    # Setup
-    mock_redis = MagicMock()
-    mock_redis.get.return_value = None
-    mock_redis.setex.return_value = True
-
-    session_store = SessionStore(mock_redis)
-    mock_tool = MockTool("readme_scorer")
-    tools = {"readme_scorer": mock_tool}
-
-    # Create orchestrator with session store
-    orchestrator = Orchestrator(tools=tools, session_store=session_store)
-
-    profile_id = "profile-123"
-    profile_data = {
-        "readme_content": "# My Project\nGreat project!",
-        "github_username": "testuser",
-    }
-
-    # Run orchestrator (executes and caches results)
-    orchestrator.run(profile_id, profile_data)
-
-    # SessionStore saves tool_results to Redis
-    assert mock_redis.setex.called
-
-    # BUT: If we restart and re-initialize Orchestrator,
-    # the ContextManager cache is empty even though SessionStore has data
-    # The cached_results in context_manager are not persisted/restored
-
-    orchestrator_2 = Orchestrator(tools=tools, session_store=session_store)
-
-    # This new orchestrator has empty context cache
-    assert len(orchestrator_2.context_manager.results) == 0
-    # Even though SessionStore could theoretically retrieve it
-
-
-if __name__ == "__main__":
-    test_context_manager_memory_lost_on_restart()
-    test_session_store_persists_results_but_not_context_cache()
-    print("✓ Reproduction tests pass - Issue #47 confirmed")
+        cache = store.get_cache("profile-7")
+        assert cache is not None
+        # Both tools' results are present in the persisted cache.
+        assert any(key.startswith("readme_scorer:") for key in cache)
+        assert any(key.startswith("market_analyzer:") for key in cache)

--- a/tests/unit/test_agent_state_persistence.py
+++ b/tests/unit/test_agent_state_persistence.py
@@ -1,0 +1,116 @@
+"""Test demonstrating the agent state persistence issue (Issue #47).
+
+This test shows that ContextManager results are lost when the Orchestrator
+is re-initialized, simulating what happens on an API restart during a
+long-running review.
+"""
+
+from unittest.mock import MagicMock
+
+from agent.memory.context_manager import ContextManager
+from agent.memory.session_store import SessionStore
+from agent.orchestrator import Orchestrator
+
+
+class MockTool:
+    """Mock tool for testing."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.execution_count = 0
+
+    def execute(self, input_data: dict) -> dict:
+        """Execute mock tool."""
+        self.execution_count += 1
+        return {
+            "result": f"Result from {self.name}",
+            "input_hash": ContextManager.hash_input(input_data),
+        }
+
+
+def test_context_manager_memory_lost_on_restart() -> None:
+    """REPRODUCTION: Demonstrate that ContextManager results are lost on restart.
+
+    This test simulates:
+    1. First orchestrator run stores cached results in memory
+    2. Orchestrator is re-initialized (simulating server restart)
+    3. New orchestrator has empty ContextManager
+    4. Same tool execution doesn't hit the cache (BUG)
+    """
+    # Setup: Create first orchestrator and execute a tool
+    mock_tool = MockTool("github_tool")
+    tools = {"github_tool": mock_tool}
+
+    orchestrator_1 = Orchestrator(tools=tools)
+    tool_input = {"repo": "test-repo", "username": "test-user"}
+    input_hash = ContextManager.hash_input(tool_input)
+
+    # First execution: tool runs, result is cached in memory
+    orchestrator_1._execute_tool("github_tool", tool_input)
+    assert mock_tool.execution_count == 1
+    assert orchestrator_1.context_manager.get_tool_result("github_tool", input_hash) is not None
+
+    # Simulate server restart: Create new Orchestrator instance
+    # (In real scenario, this is what happens when the API process restarts)
+    orchestrator_2 = Orchestrator(tools=tools)
+
+    # BUG: New orchestrator has empty ContextManager
+    assert len(orchestrator_2.context_manager.results) == 0
+
+    # Second execution: tool runs AGAIN because cache is empty
+    # Even though we have the exact same input, we don't hit the cache
+    orchestrator_2._execute_tool("github_tool", tool_input)
+    assert mock_tool.execution_count == 2  # Tool executed twice instead of once!
+
+    # In a long-running review (5+ repositories), this repeated re-execution
+    # causes:
+    # - Loss of progress if the server restarts mid-review
+    # - Wasted API calls and compute
+    # - User loses all cached results
+
+
+def test_session_store_persists_results_but_not_context_cache() -> None:
+    """REPRODUCTION: Show SessionStore persists some state but not ContextManager cache.
+
+    This demonstrates the gap: SessionStore saves tool_results to Redis,
+    but ContextManager cache is not synchronized with Redis.
+    """
+    # Setup
+    mock_redis = MagicMock()
+    mock_redis.get.return_value = None
+    mock_redis.setex.return_value = True
+
+    session_store = SessionStore(mock_redis)
+    mock_tool = MockTool("readme_scorer")
+    tools = {"readme_scorer": mock_tool}
+
+    # Create orchestrator with session store
+    orchestrator = Orchestrator(tools=tools, session_store=session_store)
+
+    profile_id = "profile-123"
+    profile_data = {
+        "readme_content": "# My Project\nGreat project!",
+        "github_username": "testuser",
+    }
+
+    # Run orchestrator (executes and caches results)
+    orchestrator.run(profile_id, profile_data)
+
+    # SessionStore saves tool_results to Redis
+    assert mock_redis.setex.called
+
+    # BUT: If we restart and re-initialize Orchestrator,
+    # the ContextManager cache is empty even though SessionStore has data
+    # The cached_results in context_manager are not persisted/restored
+
+    orchestrator_2 = Orchestrator(tools=tools, session_store=session_store)
+
+    # This new orchestrator has empty context cache
+    assert len(orchestrator_2.context_manager.results) == 0
+    # Even though SessionStore could theoretically retrieve it
+
+
+if __name__ == "__main__":
+    test_context_manager_memory_lost_on_restart()
+    test_session_store_persists_results_but_not_context_cache()
+    print("✓ Reproduction tests pass - Issue #47 confirmed")


### PR DESCRIPTION
## Summary

Long-running reviews lose all progress when the API restarts. The orchestrator
memoizes each tool's result in `ContextManager`, but that cache lives only in a
plain in-memory dict, so restarting the process during a review throws it away and
every tool has to run again from scratch. This PR persists the cache to Redis
alongside the existing session state and restores it on the next run, so a review
that spans a restart picks up where it left off.

## Issue

Closes #47

## Changes

- `ContextManager.to_dict` / `from_dict`: serialize the memoized cache into a
  JSON-safe form and restore it. `ToolResult` dataclasses are rebuilt as real
  `ToolResult` instances so cache hits keep the same interface. Anything that
  can't be serialized is skipped with a warning instead of raising.
- `SessionStore.get_cache` / `set_cache`: store the cache under a separate
  `cache:<id>` key with the same TTL as session data, so it restores
  independently of session state and the two never overwrite each other.
- `Orchestrator`: restore the cache at the start of `run()`, and checkpoint
  session state + cache after every tool (`_checkpoint`) so a restart partway
  through a review keeps the work already done.

## Testing

- [x] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`)
- [x] Linter passes (`make lint`)
- [x] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes

New tests in `tests/unit/test_agent_state_persistence.py` (10 tests): the
serialization round trip (including `ToolResult` reconstruction and skipping
unserializable entries), the `SessionStore` cache read/write under its own key,
and an end-to-end restart where a second orchestrator reuses the persisted cache
instead of re-running the tool. They use a small in-memory `FakeRedis` so no live
Redis is needed.

## Notes for Reviewers

- This repo has pre-existing failures on a clean checkout: `make test-unit`
  reports 53 failures and `make check` reports ruff/mypy errors (missing library
  stubs, `agent/tools/market_analyzer.py`, etc.) unrelated to this issue. My
  changes add no new failures — the failing count is 53 before and after, my 10
  new tests all pass, and ruff/black/mypy are clean on every file I touched.
- I keyed the cache on `profile_id` to match how `SessionStore` already keys
  session state and because that's what the orchestrator receives. If concurrent
  reviews on the same profile ever need isolation, a more specific key
  (e.g. `review_id`) would be the follow-up.
- Checkpointing writes after each tool. For the current single-repo plan that's
  cheap; if plans grow large we may want to batch writes.