### PR TITLE
test(agent): extend README scorer fixture to reach comprehensive threshold

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -76,3 +76,34 @@ pre-existing failures, then open the PR with a fully filled template.
 
 **Blockers:**
 None.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/278
+
+**Branch:** test/156-readme-scorer-fixture-length
+
+**What you built:**
+Extended the fixture README inside test_readme_with_all_quality_signals
+from 51 words to 599 words, since the scorer categorizes word_count_category
+as "comprehensive" only when word_count is 500 or higher, not just over 100
+as the issue text implied. No production code changed, only the test's
+own sample data.
+
+**Tests added or updated:**
+Modified tests/unit/test_readme_scorer.py. No new test was added since
+the bug was in the existing test's fixture data, not missing coverage.
+Verified all 23 tests in the file pass (was 22/23 before), including
+test_readme_with_all_quality_signals now correctly hitting the
+"comprehensive" code path with word_count=599.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+Note: both are true for my changed file specifically. The codebase has
+182 pre-existing lint errors and 52 pre-existing test failures unrelated
+to test_readme_scorer.py (confirmed via git stash comparison and grep
+that none reference my file), documented in the PR description.
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -107,3 +107,124 @@ to test_readme_scorer.py (confirmed via git stash comparison and grep
 that none reference my file), documented in the PR description.
 
 **Draft PR feedback received from:** none
+
+## Week 10 - Iteration & reflection
+
+
+
+### Reviewer feedback
+
+**Feedback received:** [x] Yes  [ ] No
+
+ 
+
+**Summary of feedback:**
+
+AI01010 left a comment on PR #278 on July 23, 2026. They pointed out:
+
+1. The PR title ("Test/156 readme scorer fixture length") doesn't follow the Conventional Commits style used in the actual commit messages (e.g., `test(agent): ...`), per CONTRIBUTING.md.
+
+2. The fixture word count jump from 51 to 599 words is large, and a reviewer might ask whether something closer to 550 would have worked, or whether 599 was arbitrary — worth explaining the margin choice explicitly in the PR itself (it was only in PLAN.md).
+
+3. The claim that integration tests weren't run because "this change has no integration surface" was asserted rather than confirmed — a stricter reviewer might want proof that no integration suite imports this fixture.
+
+**How you responded:**
+
+I addressed point 1 by editing the PR title to match the Conventional Commits format used elsewhere in the repo. For point 2, I explained my reasoning in a reply comment: the 599-word choice was intentional margin, not arbitrary — since the scorer's threshold is >= 500, I aimed for roughly 100 words of buffer so that minor future edits to the fixture couldn't accidentally drop it back under the threshold and reintroduce the original bug. For point 3, rather than leaving it as an unverified assumption, I actually checked it and reported back: I ran `grep -rn "test_readme_scorer|readme_scorer" tests/integration/`, which returned no matches, confirming the fixture isn't referenced outside the unit test file — and I updated the PR description to reflect that this was verified, not just assumed.
+
+ 
+
+---
+
+
+
+### Reflection
+
+**What was harder than you expected?**
+
+The environment setup took far longer than the actual code fix. I'm on
+
+Windows, so I had to install WSL, then Docker Desktop with WSL
+
+integration, then hit a Postgres port conflict, then a Node.js path
+
+issue where npm was accidentally running through Windows instead of
+
+Linux and failing on UNC paths. The actual bug fix, extending a test
+
+fixture from 51 to 599 words, took maybe 15 minutes once the
+
+environment worked. I underestimated how much of "contributing to a
+
+codebase" is actually "getting the codebase to run" in the first place.
+
+**What did you learn about working in a large codebase?**
+
+I learned that a plan can be wrong the moment you actually read the
+
+code, and that's fine as long as you catch it before writing the fix.
+
+My PLAN.md initially assumed I just needed to push the fixture past
+
+100 words per the issue text, but reading agent/tools/readme_scorer.py
+
+directly showed the "comprehensive" category actually required 500+
+
+words. If I'd trusted the issue description alone, I would have shipped
+
+a fix that still failed. Reading the actual source before touching
+
+anything, rather than working purely off the issue's summary, felt
+
+like the single most important habit this module reinforced.
+
+**How did AI tools help - and where did they fall short?**
+
+AI was most useful for the parts that are tedious but not judgment
+
+calls: writing Conventional Commits messages, drafting the PR
+
+template sections in the project's format, and debugging environment
+
+errors one at a time through the make/Docker/npm chain. Where it fell
+
+short was scope discovery. I had to be the one to actually run the
+
+test, read the failure output, and open readme_scorer.py to find the
+
+real 500-word threshold. The verification step, actually running
+
+pytest and reading the log line showing word_count and category, was
+
+something I had to do and interpret myself.
+
+**What would you do differently if you started over?**
+
+I would read the actual scorer implementation before writing PLAN.md,
+
+not after starting to reproduce the issue. I did read it, but only
+
+once I was already deep into the reproduction step, which meant
+
+redoing some of my mental model of the fix. I would also request peer
+
+review earlier in the week rather than at the very end, since Week 9's
+
+instructions specifically say to open a draft PR early for feedback,
+
+and I only opened mine once the fix was already complete.
+
+**What are you most proud of from this module?**
+
+Getting a fully broken WSL/Docker/Node environment working from
+
+scratch, on a strict deadline, without giving up on the first few
+
+failures: make not found, Postgres not reachable, npm running through
+
+the wrong OS entirely. Each failure had a real, findable cause once I
+
+looked closely rather than assumed the whole approach was wrong. That
+
+persistence mattered more here than the actual test fix itself did.
+

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -6,6 +6,17 @@
 
 **Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
 
+**Why this fits:** I chose a Tier 1 issue because this is my first time working
+in a codebase this size (multi-service Python + React with FastAPI, Postgres,
+Redis, and a vector store), and I wanted my first contribution to be scoped
+enough that I could understand the entire problem — not just patch around it.
+Issue #156 touches exactly one test file and one fixture, with no cross-module
+dependencies, an existing test that already defines the expected behavior, and
+a clear reproduction command (`pytest tests/unit/test_readme_scorer.py -q`).
+That combination meant I could verify I understood both the bug and the fix
+before writing any code, which felt like the right first step before taking on
+an issue that requires tracing logic across multiple files or modules.
+
 **Problem summary:**
 There's a unit test in the README scoring module (part of the agent/ingestion
 layer that analyzes a user's portfolio) that checks whether a README is long

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -34,3 +34,25 @@ actually exercises the "comprehensive" case it's meant to check.
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [ ] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/sidhya-ganesh/pathreview/commit/891886febe90fa19a925fef97c633f7fafe324ce
+
+**Reproduction summary:**
+Ran `.venv/bin/pytest tests/unit/test_readme_scorer.py -q` and confirmed
+`test_readme_with_all_quality_signals` fails with `assert 51 > 100`. The
+captured log line shows `word_count=51, category=minimal`, confirming
+the fixture README is far shorter than the test's own assertions require.
+
+**PLAN.md link:** https://github.com/sidhya-ganesh/pathreview/blob/test/156-readme-scorer-fixture-length/PLAN.md
+
+**Walkthrough video (recommended):** Not recorded
+
+**Blockers or open questions:**
+While reading the scorer logic, I found that "comprehensive" actually
+requires >=500 words, not just >100 as the issue text implies. This
+means my fix will need to extend the fixture much further than a quick
+read of the issue would suggest. Documented this in PLAN.md's Risks
+section — no blocker, just noting the scope is slightly larger than
+it first appeared.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,25 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/156
+
+**Issue title:** README scorer test fixture is too short for its own word-count assertion
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+There's a unit test in the README scoring module (part of the agent/ingestion
+layer that analyzes a user's portfolio) that checks whether a README is long
+enough to count as "comprehensive." The test provides a sample README fixture
+to score, but that sample only has about 51 words, while the test itself
+asserts the word count must be over 100 to earn the "comprehensive" label.
+Because the fixture data doesn't actually meet the condition it's supposed to
+satisfy, the test fails even though the scorer logic itself is working
+correctly. A successful fix means updating the fixture (or the assertion, if
+that turns out to be the better fix once I look at the code) so the test
+actually exercises the "comprehensive" case it's meant to check.
+
+**Branch name:** test/156-readme-scorer-fixture-length
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -56,3 +56,23 @@ means my fix will need to extend the fixture much further than a quick
 read of the issue would suggest. Documented this in PLAN.md's Risks
 section — no blocker, just noting the scope is slightly larger than
 it first appeared.
+
+## Week 9 - Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Completed PLAN.md steps 1-2: re-read the existing fixture to identify
+which markers had to be preserved (install/usage keywords, badges, demo
+link), then extended it from 51 to 599 words by adding realistic
+Configuration, Contributing, Testing, and License sections. Confirmed
+via `.venv/bin/pytest tests/unit/test_readme_scorer.py -q` that all 23
+tests in the file now pass (was 22/23 before).
+
+**Next steps:**
+Complete PLAN.md steps 3-5: run the full unit test suite and `make check`
+to confirm no regressions outside the fixture change, document any
+pre-existing failures, then open the PR with a fully filled template.
+
+**Blockers:**
+None.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,80 @@
+## Solution plan
+
+**Issue:** README scorer test fixture is too short for its own word-count assertion — https://github.com/ascherj/pathreview/issues/156
+
+### Understand
+The test `test_readme_with_all_quality_signals` in `tests/unit/test_readme_scorer.py`
+asserts two things about its own fixture README: `word_count > 100` and
+`word_count_category == "comprehensive"`. The fixture README currently
+contains only 51 words (confirmed by running the test and reading the
+`readme_scorer` log line: `word_count=51`). Looking at the actual scoring
+logic in `agent/tools/readme_scorer.py`, `word_count_category` is set to
+`"comprehensive"` only when `word_count >= 500` (below 100 is `"minimal"`,
+100–499 is `"adequate"`). So the fixture doesn't just need to cross 100
+words — it needs to cross 500 words to satisfy both assertions. The
+expected behavior is that a long, feature-rich README (the kind the test
+is trying to represent) scores as `"comprehensive"`; the actual behavior
+is the test fails immediately at the word-count line before that even
+gets checked, because the fixture is far too short.
+
+### Map
+- `tests/unit/test_readme_scorer.py` — contains the fixture (inline
+  triple-quoted string, lines 19–49) and the two failing/adjacent
+  assertions (lines 56–57). This is the only file that needs to change.
+- `agent/tools/readme_scorer.py` — not changed, but read to confirm the
+  500-word threshold for `"comprehensive"` (function `_score_readme`,
+  the `if/elif/else` block categorizing `word_count_category`).
+
+### Plan
+1. Re-read the existing fixture to preserve its structure (headings,
+   install/usage code blocks, badges, demo link) since those also drive
+   the `has_installation_section`, `has_usage_section`, `has_badges`,
+   and `has_demo_link` assertions elsewhere in the same test — the fix
+   must not break those.
+2. Extend the fixture content so total word count is comfortably over
+   500 (targeting ~550–650 words for margin), by adding realistic
+   prose under existing sections (e.g., a longer project description,
+   an expanded Features list, a Configuration or Contributing section)
+   rather than filler text, so the fixture still reads like a real README.
+3. Run `.venv/bin/pytest tests/unit/test_readme_scorer.py -q` locally
+   and confirm the specific test now passes and word_count prints
+   ≥500 in the captured log output.
+4. Run the full test file (`-q`, no `-k` filter) to confirm no other
+   tests in the same file were affected by the fixture change.
+5. Run `make check` to catch any formatting/lint issues introduced by
+   the edit (the fixture is inside a Python file, so black/ruff apply).
+
+### Inputs & outputs
+- Input: the fixture README string passed to `scorer.execute({"readme_content": readme})`
+  inside the test.
+- Output: the test should pass, with `result.data["word_count"] > 100`,
+  `result.data["word_count_category"] == "comprehensive"`, and all other
+  existing assertions in the same test (`has_installation_section`, etc.)
+  still `True`, since I'm only adding words, not removing existing
+  section markers.
+
+### Risks & unknowns
+- Risk: adding too many words to badge/link lines could accidentally
+  change regex matches (e.g., `has_badges`, `has_demo_link` patterns in
+  `readme_scorer.py`) if I'm not careful to keep those lines intact —
+  mitigated by only adding new prose/sections, not editing existing
+  lines.
+- Unknown: whether the maintainer intended the fixture to hit
+  "adequate" (100–499) instead of "comprehensive," which would mean the
+  *assertion* on line 57 is the actual bug, not the fixture. I'm treating
+  the fixture as the thing to fix (per the issue's suggested "extend the
+  fixture" framing), but I'll note this alternative in the PR description
+  in case a reviewer disagrees.
+- Risk: other tests in `test_readme_scorer.py` (22 currently passing)
+  could rely on a *short* fixture elsewhere — need to confirm I'm only
+  editing the one fixture inside this specific test method, not a
+  shared fixture used by other tests.
+
+### Edge cases
+- The extended fixture must still contain all the markers the other
+  assertions check for: an install-related keyword, a usage-related
+  keyword, at least one `![...](...)` badge, and a demo-link phrase —
+  none of these should be accidentally removed or reworded out of
+  matching during the extension.
+- Word count boundary: aiming well above 500 (not just barely over) so
+  the test isn't fragile to minor rewording in the future.

--- a/PLAN.md
+++ b/PLAN.md
@@ -71,10 +71,24 @@ gets checked, because the fixture is far too short.
   shared fixture used by other tests.
 
 ### Edge cases
-- The extended fixture must still contain all the markers the other
-  assertions check for: an install-related keyword, a usage-related
-  keyword, at least one `![...](...)` badge, and a demo-link phrase —
-  none of these should be accidentally removed or reworded out of
-  matching during the extension.
-- Word count boundary: aiming well above 500 (not just barely over) so
-  the test isn't fragile to minor rewording in the future.
+- **Boundary word count:** the code uses `elif word_count < 500` so a
+  count of exactly 500 already qualifies as "comprehensive" — but I'm
+  targeting 550-650 words rather than sitting right at 500, so a small
+  future edit to the fixture doesn't accidentally tip it back under the
+  threshold and reintroduce this same failure.
+- **Indentation inside the triple-quoted string:** the fixture is
+  embedded in a Python test method with leading whitespace on every
+  line. `content.split()` (used in `_score_readme`) splits on any
+  whitespace and ignores this indentation, so it shouldn't inflate the
+  word count — but I'll manually verify the printed `word_count` in the
+  test log matches what I'd expect from the added prose alone.
+- **Accidental duplicate pattern matches:** if new prose happens to
+  include a second `![...](...)`-style image link or another phrase
+  matching the demo-link regex, `has_badges`/`has_demo_link` would still
+  correctly evaluate to `True` (they're boolean, not counts), so this
+  isn't a real risk, but I confirmed it by rereading the regex checks
+  in `readme_scorer.py` rather than assuming.
+- **Other tests in the same file:** confirmed by reading the file that
+  the other 22 tests in `test_readme_scorer.py` each define their own
+  separate fixture strings, so extending this one fixture cannot affect
+  any other test's expected word count or category.

--- a/tests/unit/test_readme_scorer.py
+++ b/tests/unit/test_readme_scorer.py
@@ -18,34 +18,109 @@ class TestReadmeScorer:
         """Test README with all quality signals returns high score."""
         readme = """
         # Project Name
-        A comprehensive project description.
+
+        A comprehensive project description that explains what this application does,
+        who it is built for, and why someone might want to use it in their own workflow.
+        This project aims to solve a common problem faced by developers who need a
+        reliable, well-tested, and easy-to-integrate solution for their applications.
+        It was built with a focus on clarity, maintainability, and developer experience,
+        so that new contributors can get up to speed quickly and existing users can
+        depend on consistent, well-documented behavior across releases.
 
         ## Installation
-        ```bash
+
+        Getting started only takes a few steps. First, make sure you have a supported
+        version of the runtime installed on your machine, then install the package
+        using your preferred package manager.
+
+```bash
         pip install package
-        ```
+```
+
+        Once installed, you can verify everything is working correctly by running the
+        built-in health check command, which confirms that all required dependencies
+        are present and correctly configured on your system.
 
         ## Usage
-        ```python
+
+        Using the library is straightforward. Import the package into your project and
+        call the primary entry point function with your configuration options. Below is
+        a minimal example showing the most common usage pattern.
+
+```python
         import package
         package.run()
-        ```
+```
+
+        For more advanced use cases, refer to the full API documentation, which covers
+        configuration options, event hooks, and integration examples with popular
+        frameworks and tools used throughout the ecosystem.
 
         ## Features
-        - Feature 1
-        - Feature 2
-        - Feature 3
+
+        - Feature 1: Fast, asynchronous processing designed to handle high-throughput
+          workloads without blocking the main application thread.
+        - Feature 2: A flexible plugin architecture that allows developers to extend
+          core functionality without modifying the underlying source code.
+        - Feature 3: Comprehensive logging and observability support out of the box,
+          making it easy to debug issues in both development and production.
+        - Feature 4: Built-in support for common data formats, reducing the amount of
+          boilerplate code needed to get started with real-world data.
+        - Feature 5: Extensive test coverage and continuous integration, ensuring that
+          new changes do not introduce regressions into existing functionality.
 
         ## Tech Stack
+
         - Python 3.9
         - FastAPI
         - PostgreSQL
+        - Redis
+        - Docker
+
+        This project is built entirely on modern, well-supported open source
+        technologies, chosen specifically for their reliability, community support,
+        and long-term maintainability within production environments.
+
+        ## Configuration
+
+        Configuration is handled through environment variables, documented in the
+        accompanying `.env.example` file. Sensible defaults are provided for local
+        development, so most users will not need to change anything to get started
+        right away.
+
+        ## Contributing
+
+        Contributions are welcome. Please read the contributing guide before opening
+        a pull request, and make sure to include tests for any new functionality you
+        add. All contributions are expected to follow the existing code style and
+        pass the full test suite before being merged.
+
+        ## Testing
+
+        This project includes an extensive automated test suite covering unit tests,
+        integration tests, and end-to-end scenarios. Before submitting any change,
+        contributors are expected to run the full test suite locally to confirm that
+        existing functionality continues to work as expected, and to add new tests
+        for any new behavior they introduce.
+
+        ## License
+
+        This project is distributed under an open source license that permits both
+        personal and commercial use, modification, and redistribution, provided that
+        proper attribution is maintained and the original license text is included
+        with any distributed copies of the source code.
 
         ![Build Status](https://example.com/badge.svg)
         ![Coverage](https://example.com/coverage.svg)
 
         ## Live Demo
+
         [Try it here](https://demo.example.com)
+
+        A live, hosted version of this project is available for anyone who wants to
+        try it out before installing it locally. The demo environment mirrors the
+        production configuration as closely as possible, so you can get a realistic
+        sense of how the application behaves before committing to a full setup.
         """
 
         result = scorer.execute({"readme_content": readme})
@@ -157,9 +232,10 @@ class TestReadmeScorer:
 
         result = scorer.execute({"readme_content": readme})
         # "Getting Started" matches the pattern
-        assert result.data["has_installation_section"] is True or result.data[
-            "has_usage_section"
-        ] is True
+        assert (
+            result.data["has_installation_section"] is True
+            or result.data["has_usage_section"] is True
+        )
 
     def test_quickstart_counts_as_usage(self, scorer):
         """Test that 'quickstart' counts as usage."""
@@ -218,7 +294,8 @@ class TestReadmeScorer:
 
     def test_overall_score_calculation(self, scorer):
         """Test that overall score aggregates components."""
-        readme = """
+        readme = (
+            """
         # Good README
 
         ## Installation
@@ -233,7 +310,9 @@ class TestReadmeScorer:
         ![Build](https://example.com/build.svg)
 
         This readme has lots of content here.
-        """ * 3  # Make it comprehensive
+        """
+            * 3
+        )  # Make it comprehensive
 
         result = scorer.execute({"readme_content": readme})
 


### PR DESCRIPTION
## Summary

This PR fixes a failing unit test in the README quality scorer module. The
test `test_readme_with_all_quality_signals` was asserting that a "comprehensive"
README fixture should score as `word_count_category == "comprehensive"`, but
the fixture itself only contained 51 words - far short of what the scorer
actually requires for that category. This meant the test was failing not
because the scorer logic was broken, but because the test's own sample data
didn't meet the condition it was trying to verify. I extended the fixture
README to 599 words (well past the required threshold) while preserving
every quality-signal marker the test also checks for (installation section,
usage section, badges, tech stack, and a demo link), so the test now
correctly exercises the "comprehensive" code path it was written to test.

## Issue
Closes #156

## Changes
- Modified `tests/unit/test_readme_scorer.py`: extended the fixture README
  inside `test_readme_with_all_quality_signals` from 51 words to 599 words
  by adding realistic Configuration, Contributing, Testing, and License
  sections.
- No production code in `agent/tools/readme_scorer.py` was changed - the
  scorer's category thresholds (`< 100` = minimal, `< 500` = adequate,
  `>= 500` = comprehensive) were already correct; only the test's own
  sample data needed to change.

## Testing
- [x] Unit tests pass (`make test-unit`) - `tests/unit/test_readme_scorer.py`:
      23/23 passing (was 22/23 before this change). Full suite: 376 passing;
      52 pre-existing failures exist in unrelated files (`test_review_service.py`,
      `test_security.py`, `test_skill_extractor.py`, `test_structural_chunker.py`,
      `test_tech_detector.py`) - confirmed via grep that none reference
      `test_readme_scorer`, so this change introduces no new failures.
- [ ] Integration tests pass (`make test-integration`) - not run; this change
      only touches a unit test fixture and has no integration surface.
- [x] Linter passes (`make lint`) for the modified file - 0 errors in
      `test_readme_scorer.py`. 182 pre-existing lint errors exist elsewhere
      in the codebase, unrelated to this change.
- [x] Type checker passes (`make typecheck`) for this change specifically -
      the file has 24 pre-existing `no-untyped-def` errors (missing return
      type annotations on test methods, standard for pytest files in this
      project). Confirmed identical error count on the original file via
      `git stash` before making changes, so this PR introduces zero new
      type errors.
- [x] New/updated tests cover the changes - no new test was added since the
      existing test's own fixture was the bug; verified the existing test
      now passes and correctly exercises the "comprehensive" code path.

**Manual verification steps for reviewers:**
1. Check out this branch: `git checkout test/156-readme-scorer-fixture-length`
2. Run `.venv/bin/pytest tests/unit/test_readme_scorer.py -v`
3. Confirm all 23 tests show `PASSED`, specifically
   `test_readme_with_all_quality_signals`
4. Optionally, run with `-s` instead of `-v` and confirm the captured log
   output shows `word_count=599, category=comprehensive`

## Screenshots / Demo
Not applicable - this is a test-only fixture change with no UI or behavior
visible outside the test suite itself.

## Notes for Reviewers
I chose to extend the fixture rather than change the test's assertions,
since the issue description explicitly framed this as a fixture problem
("Extend the fixture (or correct the assertion)..."), and the scorer's
existing category thresholds appear intentional (minimal/adequate/comprehensive
tiers matching real README length conventions). If a reviewer feels the
`word_count > 100` assertion alone (separate from the category check) was
meant to test a lower threshold, happy to discuss - but extending the
fixture felt like the safer, more conservative fix since it doesn't touch
the test's intent or the scorer's production logic at all.