### PR TITLE
fix: wrap health check SQL with text()

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,27 @@
+# PathReview Contribution Journal
+
+## Week 7 – Issue Selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/154
+
+**Issue title:** Health check DB probe passes a raw SQL string, which fails under SQLAlchemy 2.x
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+
+The database health check currently sends a raw SQL string when checking whether the database is available. SQLAlchemy 2.x no longer accepts raw SQL strings in this way, causing the health check to fail even when the database is working correctly. The fix is to wrap the SQL statement using SQLAlchemy's `text()` function so the health endpoint correctly reports the database status.
+
+**Branch name:** `fix/154-health-check-sql-text`
+
+**Setup confirmation:** [ ] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger
+
+### "Is this right for me?" checklist reasoning
+
+I selected this issue because it is labeled Tier 1 and Good First Issue, making it appropriate for a first contribution. The issue is small in scope and focuses on a single SQLAlchemy compatibility problem. The expected fix is clearly described, and I can verify the change by running the health check after updating the SQL query.
+
+### Selection notes
+
+The issue affects the health check endpoint that tests the database connection. SQLAlchemy 2.x requires textual SQL statements to be wrapped using the `text()` function instead of passing plain strings. I will make the smallest possible change, verify the health check works correctly, and ensure no other functionality is affected.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -16,7 +16,7 @@ The database health check currently sends a raw SQL string when checking whether
 
 **Setup confirmation:** [ ] App runs locally at localhost:5173
 
-**Cohort ledger:** [ ] Issue added to cohort ledger
+**Cohort ledger:** [x] Issue added to cohort ledger
 
 ### "Is this right for me?" checklist reasoning
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -25,3 +25,44 @@ I selected this issue because it is labeled Tier 1 and Good First Issue, making 
 ### Selection notes
 
 The issue affects the health check endpoint that tests the database connection. SQLAlchemy 2.x requires textual SQL statements to be wrapped using the `text()` function instead of passing plain strings. I will make the smallest possible change, verify the health check works correctly, and ensure no other functionality is affected.
+
+## Week 8 – Reproduction & Planning
+
+### Reproduction
+
+I investigated Issue #154 by locating the health check implementation in `api/routes/health.py`. I identified that the PostgreSQL health check executes a raw SQL string using:
+
+```python
+await db.execute("SELECT 1")
+```
+
+SQLAlchemy 2.x no longer allows raw SQL strings to be passed directly into `execute()`. Instead, the query must be wrapped using SQLAlchemy's `text()` helper. Although I was unable to fully run the application because I was still configuring Docker locally, I confirmed the issue by comparing the existing implementation with the SQLAlchemy 2.x requirements and the issue description.
+
+### Reproduction Commit
+
+<PASTE YOUR REPRODUCTION COMMIT LINK HERE>
+
+### Solution Plan
+
+Created `PLAN.md` describing:
+
+- Files to modify
+- Planned implementation steps
+- Risks
+- Edge cases
+- Points & Remedies
+
+### PLAN.md
+
+<PASTE YOUR PLAN.MD LINK HERE>
+
+### Status
+
+- Reproduced the issue through code investigation.
+- Created PLAN.md.
+- Implemented the compatibility fix.
+- Opened a pull request.
+
+### Walkthrough Video
+
+Not recorded.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,58 @@
+## Solution plan
+
+**Issue:** [Issue #154 — Health check DB probe passes a raw SQL string, which fails under SQLAlchemy 2.x](https://github.com/ascherj/pathreview/issues/154)
+
+### Understand
+
+The PostgreSQL health check in `api/routes/health.py` passes the raw string `"SELECT 1"` directly to SQLAlchemy’s `execute()` method.
+
+The expected behavior is for the health check to execute the query successfully and report PostgreSQL as healthy when the database connection works.
+
+The actual behavior under SQLAlchemy 2.x is that the raw string is rejected because textual SQL must be explicitly wrapped with SQLAlchemy’s `text()` function.
+
+### Map
+
+The primary file involved is:
+
+- `api/routes/health.py`
+  - `health_check()` function
+  - PostgreSQL database probe
+  - SQLAlchemy import section
+
+I do not expect other application files or modules to require changes.
+
+### Plan
+
+1. Inspect `api/routes/health.py` and confirm the exact database health-check query.
+2. Import `text` from SQLAlchemy.
+3. Replace `await db.execute("SELECT 1")` with `await db.execute(text("SELECT 1"))`.
+4. Review the resulting diff to ensure no unrelated health-check logic changed.
+5. Run available formatting, linting, type-checking, or health-check tests and document any environment limitations.
+
+### Inputs & outputs
+
+**Input:**
+
+- An active SQLAlchemy database session supplied through `Depends(get_db)`.
+- The textual SQL query `SELECT 1`.
+
+**Expected output:**
+
+- SQLAlchemy treats the query as an explicit SQL statement.
+- A working PostgreSQL connection is reported as `"healthy"`.
+- A failed database connection continues to be caught by the existing exception-handling logic.
+
+### Risks & unknowns
+
+- `api/routes/health.py` contains existing Ruff and MyPy errors that may cause repository checks to fail even if this fix is correct.
+- My local Docker environment may prevent me from running the complete application and integration tests.
+- Changing code beyond the SQL statement could unintentionally alter the behavior of the Redis, external-service, or overall health checks.
+- I need to confirm whether the repository expects a new automated test for this small compatibility change.
+
+### Edge cases
+
+- PostgreSQL is unavailable or the database session raises an exception.
+- The query executes successfully but another dependency, such as Redis, is unhealthy.
+- SQLAlchemy 2.x rejects an unwrapped raw SQL string.
+- The health endpoint must preserve its current error response when required dependencies are unhealthy.
+- The change should not modify the behavior of the Redis or external-service checks.

--- a/api/routes/health.py
+++ b/api/routes/health.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, HTTPException, status, Depends
 import structlog
-from datetime import datetime, timedelta
+from datetime import datetime
+from sqlalchemy import text
 
 from core.database import get_db
 
@@ -28,7 +29,7 @@ async def health_check(db=Depends(get_db)):
 
     try:
         # Check PostgreSQL
-        await db.execute("SELECT 1")
+        await db.execute(text("SELECT 1"))
         health_status["dependencies"]["postgres"] = "healthy"
         log.debug("postgres_health_check_passed")
     except Exception as exc:


### PR DESCRIPTION
## Summary

This PR fixes Issue #154 by updating the PostgreSQL health check query to use SQLAlchemy's `text()` function instead of passing a raw SQL string directly.

### Changes
- Added `from sqlalchemy import text`
- Updated `await db.execute("SELECT 1")` to `await db.execute(text("SELECT 1"))`
- Removed the unused `timedelta` import

### Testing
I verified that the change is limited to the health check implementation. I was not able to complete full local testing because my Docker environment was still being configured.

Closes #154
## Issue
Closes #

## Changes
- Added `from sqlalchemy import text`
- Updated the PostgreSQL health check query from `await db.execute("SELECT 1")` to `await db.execute(text("SELECT 1"))`
- Removed the unused `timedelta` import

## Testing
<!-- How did you verify your changes? -->
- [ ] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`)
- [ ] Linter passes (`make lint`)
- [ ] Type checker passes (`make typecheck`)
- [ ] New/updated tests cover the changes

Unable to run the project's full test suite locally because the development environment was still being configured. The code change is limited to replacing the raw SQL string with `text()` as required for SQLAlchemy 2.x.

## Screenshots / Demo
NA

## Notes for Reviewers
This PR is intentionally scoped to Issue #154 and only updates the PostgreSQL health check to use SQLAlchemy's `text()` wrapper for compatibility with SQLAlchemy 2.x.