### PR TITLE
Fix/156 readme scorer fixture

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,43 @@
+# PathReview Contribution Journal
+
+My running record of Module 3 work on PathReview. A new section is added each week.
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/156
+
+**Issue title:** Fixture too short: `test_readme_with_all_quality_signals` asserts `comprehensive` but README has ~51 words
+
+**Tier:** [x] Tier 1 [ ] Tier 2 [ ] Tier 3
+
+**Problem summary:**
+The unit test `test_readme_with_all_quality_signals` in `tests/unit/test_readme_scorer.py`
+expects a high-quality README to be scored as `comprehensive`, but the sample README embedded
+in the test only contains about 51 words. The scorer in `agent/tools/readme_scorer.py` is
+actually behaving correctly: it labels anything under 100 words as `minimal` and only calls a
+README `comprehensive` once it reaches 500+ words. So the test asserts an outcome the fixture
+data can never produce, and it fails even though the scorer logic is right the defect is in
+the test's fixture, not the production code. A successful fix expands the fixture README to a
+realistic length (500+ words) while preserving all of its quality signals (installation, usage,
+badges, a demo link, and a tech-stack section), so every assertion passes and the suite
+reflects the scorer's true behavior.
+
+**"Is this right for me?" checklist reasoning:**
+
+- **Scope is small and contained:** the change is limited to one fixture string in a single
+  test file. No production or runtime code changes, no database, no API, and no frontend,
+  so the risk of breaking unrelated behavior is very low.
+- **I understand the root cause:** I can reproduce the failure locally (`assert 51 > 100`) and
+  I've traced it to the word-count thresholds in the scorer, the fixture is simply too short
+  for the `comprehensive` category (which needs 500+ words), not a scorer bug.
+- **Effort fits Tier 1:** this is a self-contained test fix I can complete and verify with
+  `make test-unit` and `make check` well within the module window — appropriate for a first
+  contribution to a large codebase.
+- **Clear done criteria:** success is unambiguous — the previously failing test passes and the
+  rest of the `readme_scorer` suite stays green.
+
+**Branch name:** `fix/156-readme-scorer-fixture`
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -64,3 +64,54 @@ still failed at `assert 'adequate' == 'comprehensive'` because 101 words is stil
 None blocking. Open question: how far above 500 words to pad the fixture so it stays
 `comprehensive` without becoming noisy. I will confirm the exact `str.split()` count by running
 pytest rather than estimating, since code fences and markdown syntax also count as words.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the fix. All five PLAN.md sub-tasks are done. I rewrote the `readme` fixture in
+`test_readme_with_all_quality_signals` (`tests/unit/test_readme_scorer.py`) into a realistic
+README of 564 words (verified `str.split()` count by running the test) that keeps every quality
+signal the test checks: Installation and Usage sections, three image badges, a "Live Demo" /
+"try it" link, and a Tech Stack section. The test now reports `category=comprehensive`,
+`word_count=564`, `overall_score=1.0`, and passes. The full `readme_scorer` suite is green
+(23 passed), and `ruff` and `black` are clean on the changed file.
+
+**Next steps:**
+Open a draft PR early, request peer/mentor review in Slack, fill in the PR template completely,
+then mark it ready for review and record the PR link in Check-in 2.
+
+**Blockers:**
+None. Note: the repo has ~52 pre-existing unit-test failures and many pre-existing lint/format
+issues in unrelated modules (skill_extractor, tech_detector, structural_chunker). My change
+touches only the readme_scorer test fixture and does not affect them.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** PASTE_YOUR_PR_URL_HERE
+
+**Branch:** `fix/156-readme-scorer-fixture`
+
+**What you built:**
+Replaced the 51-word README fixture in `test_readme_with_all_quality_signals` with a realistic
+564-word README that contains all the quality signals the scorer looks for. This lets the test
+exercise the `comprehensive` word-count category (>= 500 words) as intended, so it passes against
+the correct scorer behavior. No production code changed; the fix is limited to test data.
+
+**Tests added or updated:**
+`tests/unit/test_readme_scorer.py`: updated the `test_readme_with_all_quality_signals` fixture.
+The assertions are unchanged; the fixture now satisfies them. Verified with `make test-unit`,
+where this test moves from failing to passing.
+
+**Pre-existing failures (documented per Week 9 guidance):**
+Baseline before my change: `53 failed, 375 passed`. After my change: `52 failed, 376 passed`.
+My change fixes exactly one test (the target) and introduces zero new failures. The remaining 52
+failures and all lint/format/type issues reported by `make check` are pre-existing and unrelated
+to this fix. "Passes" below means my changes introduce no new failures.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+**Draft PR feedback received from:** REPLACE_WITH_NAME_OR_SLACK_HANDLE_OR_none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -44,7 +44,7 @@ reflects the scorer's true behavior.
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** REPRO_COMMIT_URL_PLACEHOLDER
+**Reproduction commit link:** [REPRO_COMMIT_URL](https://github.com/sid-pandya/pathreview/commit/5e9df91223f4ddf453ff9c72e4b64bb8cee30e3d)
 
 **Reproduction summary:**
 I reproduced the bug by running the single failing test:

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -41,3 +41,26 @@ reflects the scorer's true behavior.
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** REPRO_COMMIT_URL_PLACEHOLDER
+
+**Reproduction summary:**
+I reproduced the bug by running the single failing test:
+`.venv/bin/python -m pytest tests/unit/test_readme_scorer.py::TestReadmeScorer::test_readme_with_all_quality_signals -q`.
+It fails at `assert data["word_count"] > 100` with `assert 51 > 100`, and the scorer logs
+`category=minimal word_count=51`. This confirms the fixture README is only 51 words, so it can
+never reach the `comprehensive` category (which requires >= 500 words) that the test asserts.
+The scorer is behaving correctly; the defect is in the test fixture. (I also found and reverted
+a stray uncommitted edit that had pasted notes into the fixture, pushing it to 101 words, which
+still failed at `assert 'adequate' == 'comprehensive'` because 101 words is still below 500.)
+
+**PLAN.md link:** https://github.com/sid-pandya/pathreview/blob/fix/156-readme-scorer-fixture/PLAN.md
+
+**Walkthrough video (recommended):** not recorded (optional; may record and share in Slack)
+
+**Blockers or open questions:**
+None blocking. Open question: how far above 500 words to pad the fixture so it stays
+`comprehensive` without becoming noisy. I will confirm the exact `str.split()` count by running
+pytest rather than estimating, since code fences and markdown syntax also count as words.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -91,27 +91,31 @@ touches only the readme_scorer test fixture and does not affect them.
 
 ### Check-in 2 (end of week)
 
-**PR link:** PASTE_YOUR_PR_URL_HERE
+**PR link:** https://github.com/ascherj/pathreview/pull/280
 
 **Branch:** `fix/156-readme-scorer-fixture`
 
 **What you built:**
-Replaced the 51-word README fixture in `test_readme_with_all_quality_signals` with a realistic
-564-word README that contains all the quality signals the scorer looks for. This lets the test
-exercise the `comprehensive` word-count category (>= 500 words) as intended, so it passes against
-the correct scorer behavior. No production code changed; the fix is limited to test data.
+I fixed a unit test that could never have passed. `test_readme_with_all_quality_signals` expects a
+strong README to be scored as "comprehensive," but the sample README baked into the test was only
+51 words, and the scorer only awards "comprehensive" at 500 words or more. So the test was set up
+to fail no matter how correct the scorer actually was. I rewrote that fixture into a realistic
+~560-word README that still carries every signal the test looks for (installation and usage
+sections, image badges, a live-demo link, and a tech-stack section), so it finally checks the
+behavior it was meant to. I didn't touch any production code, because the bug lived entirely in
+the test data.
 
 **Tests added or updated:**
-`tests/unit/test_readme_scorer.py`: updated the `test_readme_with_all_quality_signals` fixture.
-The assertions are unchanged; the fixture now satisfies them. Verified with `make test-unit`,
-where this test moves from failing to passing.
-
-**Pre-existing failures (documented per Week 9 guidance):**
-Baseline before my change: `53 failed, 375 passed`. After my change: `52 failed, 376 passed`.
-My change fixes exactly one test (the target) and introduces zero new failures. The remaining 52
-failures and all lint/format/type issues reported by `make check` are pre-existing and unrelated
-to this fix. "Passes" below means my changes introduce no new failures.
+Only `tests/unit/test_readme_scorer.py`. I left the assertions exactly as they were and just
+replaced the fixture README so it genuinely satisfies them. That one test goes from failing to
+passing, and the rest of the readme_scorer suite (23 tests in total) stays green.
 
 **Self-review confirmation:** [x] make check passes  [x] make test-unit passes
 
-**Draft PR feedback received from:** REPLACE_WITH_NAME_OR_SLACK_HANDLE_OR_none
+A quick note on what "passes" means here: this repo already had a lot of failing tests and lint
+warnings before I started, so I used the "no new failures" bar. The unit suite went from 53
+failing to 52 after my change, which means I fixed one test and broke nothing. Everything else
+that is red was already red and is unrelated to my fix, and I called that out in the PR
+description as well.
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -119,3 +119,71 @@ that is red was already red and is unrelated to my fix, and I called that out in
 description as well.
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No reviewer or maintainer comments came in on PR #280 during the window. (Reviewer feedback is not
+an active part of the Summer 2026 cohort, so this is expected.) The PR is open and marked ready for
+review with a complete description that documents the pre-existing failures so a future reviewer
+has the context they need.
+
+**How you responded:**
+No changes were required since no feedback arrived. If a maintainer had asked, the most likely
+requests would have been to trim the fixture README or to move the course-artifact files (JOURNAL,
+PLAN) out of the PR, and I would have addressed those before marking it ready.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The actual fix was tiny; getting a working local environment was the hard part by a wide margin.
+Before I could even reproduce the bug I had to dig out from a full disk, get Docker past a stuck
+login screen, upgrade Node from 18 to 22 because Vite 8 crashed on a missing `styleText` export,
+reinstall the frontend because a native rolldown binding was skipped by an npm optional-dependency
+bug, and get past a peer-dependency conflict. Each error only revealed the next one. The one-line
+idea ("make the fixture longer") took minutes; the plumbing around it took hours.
+
+**What did you learn about working in a large codebase?**
+The biggest shift from my own projects: I could not assume the repo was healthy. It already had 52
+failing unit tests and a lot of formatting and type drift, so "passing" had to be redefined as "my
+change introduces no new failures" (I proved it went from 53 failing to 52). That forced real
+discipline: keep the diff surgical, resist fixing unrelated things, and document the baseline so a
+reviewer can tell my change apart from the existing noise. I also learned to actually trace the
+problem instead of trusting the obvious suspect. The failing test pointed at the scorer, but the
+scorer was correct and the bug was in the test's own fixture data. Reading the real contract (the
+scorer counts words with `str.split()` and only calls a README "comprehensive" at 500+ words)
+mattered more than the code change itself.
+
+**How did AI tools help, and where did they fall short?**
+AI was most useful for moving quickly through an unfamiliar multi-module codebase and for
+diagnosing the cascade of environment failures, where it consistently read the real error and
+pointed at the next step. It also helped me structure PLAN.md and the journal, and explain what the
+scorer's regexes actually required. Where it fell short was anything that needed real verification.
+It could describe the bug, but I had to run the test to get the true numbers (51 words, and the
+fact that code fences and markdown count as words under `str.split()`), and I had to re-run after
+every change because at one point the fixture silently reverted and the image badges got deleted,
+which quietly broke the test. AI also could not make the scope call for me, like deciding not to
+commit the 54 files that `make check` reformatted. Running things and checking the result was the
+part I owned.
+
+**What would you do differently if you started over?**
+First, I would run `make test-unit` and `make check` before writing any code, so I knew exactly
+which failures were pre-existing from the start instead of discovering the baseline halfway
+through. Second, I would never run `make format` / `black .` on a repo with this much drift, since
+it rewrote 50+ files; `--check` shows the same problems without touching anything. Third, I would
+keep the fix in a single clean commit and not let the working tree drift, because the fixture got
+reverted once and cost me time re-applying and re-verifying it. The issue selection itself was
+good: small, self-contained, and genuinely Tier 1.
+
+**What are you most proud of?**
+Landing a clean, honest, minimal PR inside a messy repo. Not the fixture rewrite itself, which is
+modest, but the discipline around it: a one-file diff, a before/after number that proves the change
+fixed one test and broke nothing, and a description that clearly separates my work from the repo's
+pre-existing problems. That "make it easy for a reviewer to trust your change" habit feels like the
+most transferable thing I take out of this module.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,91 @@
+## Solution plan
+
+**Issue:** Fixture too short: `test_readme_with_all_quality_signals` asserts `comprehensive` but README has ~51 words
+(https://github.com/ascherj/pathreview/issues/156)
+
+### Understand
+
+The unit test `test_readme_with_all_quality_signals` in `tests/unit/test_readme_scorer.py`
+embeds a sample README that is only 51 words long, then asserts two things a 51-word README can
+never satisfy:
+
+- `data["word_count"] > 100`
+- `data["word_count_category"] == "comprehensive"`
+
+The scorer in `agent/tools/readme_scorer.py` categorizes word counts (lines 70-75) as:
+`< 100` = `minimal`, `100-499` = `adequate`, `>= 500` = `comprehensive`. So a README must have
+**at least 500 words** to be `comprehensive`.
+
+- **Expected:** a high-quality README fixture is scored `comprehensive` and the test passes.
+- **Actual:** the fixture is 51 words, so it scores `minimal`, and the first count assertion
+  fails with `assert 51 > 100`.
+
+The scorer logic is correct. The defect is in the test fixture data, not the production code.
+
+### Map
+
+Files involved:
+
+- `tests/unit/test_readme_scorer.py` — **the file I will change.** Specifically the `readme`
+  fixture string inside `test_readme_with_all_quality_signals` (lines ~19-50).
+- `agent/tools/readme_scorer.py` — **reference only, not changing.** It defines the word-count
+  thresholds (lines 70-75) and the signal-detection regexes (lines 79-97) that the fixture must
+  satisfy.
+
+To make the test pass, the rewritten fixture must satisfy every assertion in the test body
+(lines 54-64):
+
+- `word_count > 100` and `word_count_category == "comprehensive"` (so `>= 500` words)
+- `has_installation_section` (regex matches `install` / `setup` / `getting started`)
+- `has_usage_section` (`usage` / `how to use` / `quickstart` / `example`)
+- `has_badges` (image syntax `![...](...)`)
+- `has_demo_link` (`demo` / `live demo` / `try it` / `see it` / `live link`)
+- `has_tech_stack_section` (`tech stack` / `technologies` / `built with` / `technology` / `stack`)
+- `overall_score > 0.7`
+
+### Plan
+
+1. Rewrite the `readme` fixture in `test_readme_with_all_quality_signals` into a realistic,
+   well-structured README of **at least 500 words** (target ~550-600 for a safe margin) so the
+   category becomes `comprehensive`.
+2. Ensure the expanded fixture still contains every quality signal the test checks: an
+   Installation section, a Usage section, at least one image badge `![alt](url)`, a demo/live
+   link phrase, and a Tech Stack section.
+3. Keep the fixture as clean, plausible README prose (the stray notes/gibberish that had been
+   pasted into the fixture have already been reverted).
+4. Run `.venv/bin/python -m pytest tests/unit/test_readme_scorer.py -v` and confirm this test
+   plus the rest of the `readme_scorer` suite pass.
+5. Run `make check` (ruff, black, mypy) so the change clears the project's pre-commit gates
+   before opening the PR.
+
+### Inputs & outputs
+
+- **Input:** the multi-line `readme` string passed to `scorer.execute({"readme_content": readme})`.
+- **Output / effect:** after the change, `scorer.execute` returns `word_count >= 500`,
+  `word_count_category == "comprehensive"`, all five signal booleans `True`, and
+  `overall_score > 0.7`, so the test passes. No production code changes; no other tests change.
+
+### Risks & unknowns
+
+- **Word-count semantics:** the scorer counts with `content.split()` (readme_scorer.py:67), a
+  plain whitespace split. Code fences, badge/link syntax, and punctuation all count as "words,"
+  so I must target the `str.split()` count, not a prose word count, and verify by running the
+  test rather than estimating.
+- **Threshold margin:** land comfortably above 500 (~550+) so a small future edit does not drop
+  the fixture back under `comprehensive`.
+- **Broad regexes:** the signal patterns match substrings (e.g. `stack`, `example`, `setup`), so
+  the main risk while rewriting is accidentally *removing* a required signal, not failing to
+  match one. I will re-check all five signals after editing.
+- **Blast radius:** confirm no other test relies on the exact old fixture text. A grep shows the
+  fixture is local to this one test function, so the risk is low.
+
+### Edge cases
+
+- **Boundary counts:** 100 is not `> 100`, and 500 is the first `comprehensive` value (`>= 500`).
+  I will stay clearly above both boundaries.
+- **Badge must be an image:** keep `![alt](url)` image syntax, since a plain `[text](url)` link
+  will not match the badge regex.
+- **Demo link needs an explicit phrase:** include a "Live Demo" / "try it" phrase, because a bare
+  URL alone does not match the demo regex.
+- **Score stays above threshold:** adding more signals and words only raises `overall_score`, so
+  keeping all signals present keeps `overall_score > 0.7`.

--- a/tests/unit/test_readme_scorer.py
+++ b/tests/unit/test_readme_scorer.py
@@ -17,35 +17,98 @@ class TestReadmeScorer:
     def test_readme_with_all_quality_signals(self, scorer):
         """Test README with all quality signals returns high score."""
         readme = """
-        # Project Name
-        A comprehensive project description.
+        # PathReview Analyzer
 
-        ## Installation
-        ```bash
-        pip install package
-        ```
-
-        ## Usage
-        ```python
-        import package
-        package.run()
-        ```
-
-        ## Features
-        - Feature 1
-        - Feature 2
-        - Feature 3
-
-        ## Tech Stack
-        - Python 3.9
-        - FastAPI
-        - PostgreSQL
+        PathReview Analyzer is a command-line tool and Python library that inspects
+        the quality of open-source project documentation. It scans a repository,
+        reads the README file, and produces a structured quality report covering
+        length, required sections, badges, demo links, and the technology stack.
+        Teams run it in continuous integration to make sure every project ships with
+        clear, complete, and welcoming documentation before it is released to users.
 
         ![Build Status](https://example.com/badge.svg)
         ![Coverage](https://example.com/coverage.svg)
+        ![License](https://example.com/license.svg)
+
+        ## Overview
+
+        Good documentation is one of the strongest signals of a healthy project, yet
+        it is easy to overlook when deadlines are tight. PathReview Analyzer removes
+        the guesswork by turning documentation quality into a measurable score that
+        you can track over time. The report highlights exactly what is missing, so
+        contributors know what to improve instead of guessing. Because the tool is
+        fast and deterministic, it fits naturally into pull-request checks and
+        nightly pipelines without slowing your team down or producing noisy output.
+
+        ## Features
+
+        - Word-count analysis that classifies each README as minimal, adequate, or
+          comprehensive so you can see at a glance how much detail it contains.
+        - Section detection for installation, usage, and technology information using
+          flexible, case-insensitive matching that tolerates many common headings.
+        - Badge and demo-link detection that rewards projects for advertising build
+          status, test coverage, and a working live demonstration of the software.
+        - A single overall score between zero and one that aggregates every signal
+          into one number your team can trust and compare across many repositories.
+
+        ## Tech Stack
+
+        - Python 3.9 for the core scoring engine and the command-line interface.
+        - FastAPI for the optional web service that exposes scores over HTTP.
+        - PostgreSQL for storing historical scores and tracking trends over time.
+        - Redis for caching repeated lookups and keeping the service responsive.
+
+        ## Installation
+
+        Install the published package from PyPI using pip. We recommend creating a
+        dedicated virtual environment first, so that dependencies stay isolated from
+        the rest of your system and remain easy to upgrade or remove again later.
+
+        ```bash
+        python -m venv .venv
+        source .venv/bin/activate
+        pip install pathreview-analyzer
+        ```
+
+        ## Usage
+
+        The command-line interface accepts a path to any repository and prints a
+        readable report. You can also import the scorer directly and call it from
+        your own Python code, which is handy when you want to embed these checks
+        inside an existing test suite or a small continuous-integration script.
+
+        ```python
+        from pathreview import ReadmeScorer
+
+        scorer = ReadmeScorer()
+        report = scorer.execute({"readme_content": open("README.md").read()})
+        print(report.data["overall_score"])
+        ```
+
+        ## Configuration
+
+        Every threshold is configurable through a small YAML file. You can raise the
+        word-count boundaries, require specific sections, or disable checks that do
+        not apply to your project. Sensible defaults are provided, so most teams never
+        need to change anything at all to get useful, actionable results right away.
 
         ## Live Demo
-        [Try it here](https://demo.example.com)
+
+        Want to see it in action before installing anything? Try it here in the hosted
+        playground and paste in any README to receive an instant score and breakdown.
+
+        [Try the live demo](https://demo.example.com)
+
+        ## Contributing
+
+        Contributions are welcome and appreciated. Please read the contributing guide,
+        open an issue to discuss any significant changes, and make sure the full test
+        suite passes before you submit a pull request for review by the maintainers.
+
+        ## License
+
+        This project is released under the MIT license. See the license file in the
+        repository root for the full text and the details about permitted use.
         """
 
         result = scorer.execute({"readme_content": readme})


### PR DESCRIPTION
## Summary
The unit test `test_readme_with_all_quality_signals` was failing because its sample README
fixture was only ~51 words, while the test asserts the README scores as `comprehensive`. The
scorer correctly labels a README `comprehensive` only at >= 500 words, so the test could never
pass against correct behavior. This PR replaces the fixture with a realistic 564-word README that
contains all the quality signals the test checks, so the test now validates the intended behavior
and passes. This is a test-data fix; no production code changes.

## Issue
Closes #156

## Changes
- Rewrote the `readme` fixture in `test_readme_with_all_quality_signals`
  (`tests/unit/test_readme_scorer.py`) from ~51 words to a realistic 564-word README.
- The new fixture retains every signal the test asserts: Installation and Usage sections, image
  badges (`![...](...)`), a "Live Demo" / "try it" link, and a Tech Stack section.
- No changes to the test's assertions or to any production code.

## Testing
- [x] Unit tests pass (`make test-unit`) — my change: `53 failed` → `52 failed` (see note below)
- [ ] Integration tests pass (`make test-integration`) — not run (unrelated; requires services)
- [x] Linter passes (`make lint`) — the changed file is clean (repo has pre-existing lint errors)
- [x] New/updated tests cover the changes

## Notes for Reviewers
Per the module guidance on pre-existing failures: before this change the unit suite was
`53 failed, 375 passed`; after it is `52 failed, 376 passed`. This PR fixes exactly one test and
introduces no new failures. The remaining 52 failures (in `test_skill_extractor`,
`test_tech_detector`, `test_structural_chunker`, etc.), the 24 mypy annotation errors in this test
file, and the repo-wide lint/format issues are all pre-existing and unrelated to this fix. The
scorer counts words with `str.split()`, so the fixture is sized to 564 tokens (verified by running
the test), comfortably above the 500-word `comprehensive` threshold.
