### PR TITLE
Fix/147 resume section whitespace

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -21,12 +21,12 @@ I chose this issue because it has a clear reproduction case, a well-defined scop
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [Add GitHub commit link after committing your reproduction]
+**Reproduction commit link:** https://github.com/ascherj/pathreview/commit/6f3d37e7bb0677af652e40f5971b1256852571f8
 
 **Reproduction summary:**
 I reproduced the issue by using the provided resume parser example with resume text containing leading whitespace before section headers. The parser failed to detect the expected sections because _detect_sections() only matches section headers that begin at the start of a line.
 
-**PLAN.md link:** [Add GitHub link to PLAN.md after creating it]
+**PLAN.md link:** (https://github.com/yaminik03/pathreview/blob/fix/147-resume-section-whitespace/PLAN.md)
 
 **Walkthrough video (recommended):** [Optional Loom link]
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,19 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/147
+
+**Issue title:** Resume section detection fails on text with leading whitespace
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The resume parser fails to detect section headers when the resume text contains leading whitespace, which commonly occurs in text extracted from PDFs. As a result, the parser returns an empty list of detected sections instead of identifying sections like "Education" and "Skills." A successful fix should allow section detection even when section headers are indented.
+
+**Selection reasoning ("Is this right for me?"):**
+I chose this issue because it has a clear reproduction case, a well-defined scope, and focuses on improving the resume parser without requiring changes across many parts of the codebase. It also provides related tests that will help verify the fix.
+
+**Branch name:** fix/147-resume-section-whitespace
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -33,6 +33,7 @@ I reproduced the issue by using the provided resume parser example with resume t
 **Blockers or open questions:**
 None at this time.
 
+
 ## Week 9 — Solution building & PR submission
 
 ### Check-in 1 (mid-week)
@@ -64,3 +65,34 @@ Updated `tests/unit/test_resume_parser.py` — added `test_detect_sections_with_
 *(177 pre-existing lint errors and 50 pre-existing test failures exist codebase-wide, none introduced by this change and none in the two files this PR touches beyond two pre-existing, unrelated `_strip_markdown()` failures — verified via `git stash` comparison. See PR description for details.)*
 
 **Draft PR feedback received from:** ⚠️ none
+
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No reviewer feedback was provided during Summer 2026, so there were no comments from reviewers or maintainers to address.
+
+**How you responded:**
+N/A — no reviewer feedback was received.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The hardest part was understanding the existing codebase well enough to make a focused change without introducing unnecessary changes. Reproducing the issue, identifying the relevant files, understanding the surrounding implementation, and determining what needed to be changed required more investigation than I initially expected. I learned that fixing an issue is not just about writing code; it is also about understanding the project's existing structure, conventions, and expected behavior.
+
+**What did you learn about working in a large codebase?**
+I learned that contributing to someone else's codebase requires more discipline than working on my own projects. I had to follow existing patterns, understand how different files and components interacted, and make the smallest change necessary to address the issue. I also learned the importance of checking tests, formatting, typing, and repository conventions before considering a change complete.
+
+**How did AI tools help — and where did they fall short?**
+AI tools were useful for helping me understand unfamiliar code, interpret error messages, identify possible causes, and think through implementation approaches. They helped me move faster when navigating files and unfamiliar patterns. However, AI could not replace actually validating the solution in the repository. I still needed to inspect the code myself, run tests and checks, compare the proposed change against the existing implementation, and make decisions based on the project's specific conventions.
+
+**What would you do differently if you started over?**
+If I started over, I would spend more time planning the reproduction and expected behavior before making changes. I would also verify the repository's testing, typing, and formatting requirements earlier in the process instead of discovering some issues later. This would make the implementation more deliberate and reduce unnecessary iteration.
+
+**What are you most proud of from this module?**
+I am most proud of learning how to contribute to an existing codebase rather than only building projects from scratch. I gained experience navigating unfamiliar code, investigating an issue, making a targeted change, validating my work, and documenting the process. The biggest takeaway was learning that a strong contribution is not just code that works, but a change that fits the existing project and can be understood and maintained by other developers.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -50,7 +50,7 @@ None.
 
 ### Check-in 2 (end of week)
 
-**PR link:** ⚠️ [add once you open and submit the PR]
+**PR link:** (https://github.com/ascherj/pathreview/pull/285)
 
 **Branch:** `fix/147-resume-section-whitespace`
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -32,3 +32,35 @@ I reproduced the issue by using the provided resume parser example with resume t
 
 **Blockers or open questions:**
 None at this time.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the fix in `_detect_sections()` in `ingestion/parsers/resume_parser.py`, updating the four detection regex patterns to allow optional leading whitespace (`[ \t]*`) before section headers, so indented headers from PDF-extracted text are now matched. Added 5 new unit tests in `tests/unit/test_resume_parser.py` covering leading spaces, tabs, mixed indentation, no-header text, and a regression check for unindented headers.
+
+**Next steps:**
+Run `make check` and `make test-unit`, confirm no new failures against the pre-fix baseline, open a draft PR for peer/mentor review, and finalize the JOURNAL.md and PR description.
+
+**Blockers:**
+None.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** ⚠️ [add once you open and submit the PR]
+
+**Branch:** `fix/147-resume-section-whitespace`
+
+**What you built:**
+Fixed `_detect_sections()` so its regex patterns accept optional leading whitespace or tabs before section header names, resolving the bug where indented section headers (common in PDF-extracted resume text) went undetected.
+
+**Tests added or updated:**
+Updated `tests/unit/test_resume_parser.py` — added `test_detect_sections_with_leading_spaces`, `test_detect_sections_with_leading_tabs`, `test_detect_sections_mixed_indentation`, `test_detect_sections_no_headers_still_empty`, and `test_detect_sections_unindented_unaffected`, covering the indentation edge cases from PLAN.md plus a regression check.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+*(177 pre-existing lint errors and 50 pre-existing test failures exist codebase-wide, none introduced by this change and none in the two files this PR touches beyond two pre-existing, unrelated `_strip_markdown()` failures — verified via `git stash` comparison. See PR description for details.)*
+
+**Draft PR feedback received from:** ⚠️ none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -17,3 +17,18 @@ I chose this issue because it has a clear reproduction case, a well-defined scop
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [Add GitHub commit link after committing your reproduction]
+
+**Reproduction summary:**
+I reproduced the issue by using the provided resume parser example with resume text containing leading whitespace before section headers. The parser failed to detect the expected sections because _detect_sections() only matches section headers that begin at the start of a line.
+
+**PLAN.md link:** [Add GitHub link to PLAN.md after creating it]
+
+**Walkthrough video (recommended):** [Optional Loom link]
+
+**Blockers or open questions:**
+None at this time.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,56 @@
+# Solution plan
+
+**Issue:** Resume section detection fails on text with leading whitespace (#147)
+
+## Understand
+
+The `_detect_sections()` method searches for resume section headers using regular expressions anchored to the beginning of a line (`^`). When resume text extracted from PDFs contains leading spaces before section headers, those patterns do not match. As a result, the parser returns an empty or incomplete `detected_sections` list even though valid section headers are present.
+
+## Map
+
+Files involved:
+
+- `ingestion/parsers/resume_parser.py`
+- `tests/unit/test_resume_parser.py`
+
+Functions involved:
+
+- `_detect_sections()`
+- `ResumeParser.parse()`
+
+Related tests:
+
+- `test_parse_single_column_resume_text`
+- `test_parse_resume_no_work_experience`
+- `test_detect_sections`
+
+## Plan
+
+1. Review the regular expressions used in `_detect_sections()` to understand why indented section headers are ignored.
+2. Modify the section detection logic so that optional leading whitespace is accepted before section headers.
+3. Run the existing resume parser tests to verify that indented section headers are detected correctly.
+4. Confirm that resumes without indentation continue to pass existing tests.
+
+## Inputs & outputs
+
+### Input
+
+Resume text that may contain leading spaces before section headers.
+
+### Output
+
+`detected_sections` should correctly contain section names such as "Education", "Experience", and "Skills" regardless of indentation.
+
+## Risks & unknowns
+
+- Updating the regular expressions may accidentally match text that is not a section header.
+- Additional resume formats may contain tabs or inconsistent spacing that require further testing.
+- Existing parser behavior should remain unchanged for resumes that already work correctly.
+
+## Edge cases
+
+- Multiple leading spaces.
+- Tabs before section headers.
+- Empty resumes.
+- Resumes without any recognizable section headers.
+- Mixed formatting where some headers are indented and others are not.

--- a/ingestion/parsers/resume_parser.py
+++ b/ingestion/parsers/resume_parser.py
@@ -5,7 +5,6 @@ from pypdf import PdfReader
 
 from .base import BaseParser, ParseResult
 
-
 SECTION_HEADERS = {
     "experience",
     "education",
@@ -75,7 +74,7 @@ class ResumeParser(BaseParser):
                 source_type="resume",
             )
         except Exception as e:
-            raise ValueError(f"Failed to parse PDF: {str(e)}")
+            raise ValueError("Failed to parse PDF") from e
 
     def _parse_markdown(self, content: str) -> ParseResult:
         """Extract text from markdown resume, stripping markdown syntax."""
@@ -132,10 +131,10 @@ class ResumeParser(BaseParser):
         for section in SECTION_HEADERS:
             # Look for section header patterns
             patterns = [
-                rf"^{re.escape(section)}\s*$",
-                rf"^{re.escape(section)}\s*[:|-]",
-                rf"\n{re.escape(section)}\s*$",
-                rf"\n{re.escape(section)}\s*[:|-]",
+                rf"^[ \t]*{re.escape(section)}\s*$",
+                rf"^[ \t]*{re.escape(section)}\s*[:|-]",
+                rf"\n[ \t]*{re.escape(section)}\s*$",
+                rf"\n[ \t]*{re.escape(section)}\s*[:|-]",
             ]
 
             for pattern in patterns:

--- a/tests/unit/test_resume_parser.py
+++ b/tests/unit/test_resume_parser.py
@@ -1,11 +1,11 @@
 """Tests for resume_parser.py"""
 
-import pytest
-from unittest.mock import Mock, patch, MagicMock
-from io import BytesIO
+from unittest.mock import Mock, patch
 
-from ingestion.parsers.resume_parser import ResumeParser
+import pytest
+
 from ingestion.parsers.base import ParseResult
+from ingestion.parsers.resume_parser import ResumeParser
 
 
 @pytest.mark.unit
@@ -13,11 +13,13 @@ class TestResumeParser:
     """Test suite for ResumeParser."""
 
     @pytest.fixture
-    def parser(self):
+    def parser(self) -> ResumeParser:
         """Create a ResumeParser instance."""
         return ResumeParser()
 
-    def test_parse_single_column_resume_text(self, parser, sample_resume_text):
+    def test_parse_single_column_resume_text(
+        self, parser: ResumeParser, sample_resume_text: str
+    ) -> None:
         """Test parsing a standard single-column resume text."""
         result = parser.parse(sample_resume_text)
 
@@ -27,13 +29,12 @@ class TestResumeParser:
         assert result.metadata["source_type"] == "resume"
         assert result.metadata["page_count"] == 1
         assert "detected_sections" in result.metadata
-        # Should detect common sections like Experience, Skills, Education
         detected_lower = [s.lower() for s in result.metadata["detected_sections"]]
         assert any("experience" in s for s in detected_lower) or any(
             "skills" in s for s in detected_lower
         )
 
-    def test_parse_resume_no_work_experience(self, parser):
+    def test_parse_resume_no_work_experience(self, parser: ResumeParser) -> None:
         """Test parsing a resume with no work experience section - handles gracefully."""
         resume_no_work = """
         John Smith
@@ -49,16 +50,13 @@ class TestResumeParser:
 
         assert isinstance(result, ParseResult)
         assert result.text
-        # Should not crash even with missing Experience section
         assert result.metadata["page_count"] == 1
         detected_lower = [s.lower() for s in result.metadata["detected_sections"]]
         assert any("education" in s for s in detected_lower)
 
-    def test_parse_multipage_pdf(self, parser):
+    def test_parse_multipage_pdf(self, parser: ResumeParser) -> None:
         """Test parsing a multi-page PDF resume."""
-        # Create a mock PDF with multiple pages
         with patch("ingestion.parsers.resume_parser.PdfReader") as mock_pdf_reader:
-            # Setup mock PDF with 3 pages
             mock_page1 = Mock()
             mock_page1.extract_text.return_value = "Page 1 Content\nJohn Doe\nExperience:"
 
@@ -72,8 +70,7 @@ class TestResumeParser:
             mock_reader.pages = [mock_page1, mock_page2, mock_page3]
             mock_pdf_reader.return_value = mock_reader
 
-            pdf_bytes = b"fake pdf content"
-            result = parser.parse(pdf_bytes)
+            result = parser.parse(b"fake pdf content")
 
             assert isinstance(result, ParseResult)
             assert result.metadata["page_count"] == 3
@@ -81,7 +78,7 @@ class TestResumeParser:
             assert "Page 2 Content" in result.text
             assert "Page 3 Content" in result.text
 
-    def test_parse_markdown_resume(self, parser):
+    def test_parse_markdown_resume(self, parser: ResumeParser) -> None:
         """Test parsing a Markdown resume."""
         markdown_resume = """
         # Jane Doe
@@ -101,20 +98,19 @@ class TestResumeParser:
         assert isinstance(result, ParseResult)
         assert result.source_type == "resume"
         assert result.metadata["page_count"] == 1
-        # Markdown syntax should be stripped
         assert "#" not in result.text or result.text.count("#") < markdown_resume.count("#")
         assert "Jane Doe" in result.text
 
-    def test_parse_invalid_content_type(self, parser):
+    def test_parse_invalid_content_type(self, parser: ResumeParser) -> None:
         """Test that invalid content type raises ValueError with clear message."""
         with pytest.raises(ValueError) as exc_info:
-            parser.parse(12345)  # Invalid: integer
+            parser.parse(12345)
 
         assert "Content must be bytes" in str(exc_info.value) or "Content must be" in str(
             exc_info.value
         )
 
-    def test_parse_invalid_list_content(self, parser):
+    def test_parse_invalid_list_content(self, parser: ResumeParser) -> None:
         """Test that list content raises ValueError."""
         with pytest.raises(ValueError) as exc_info:
             parser.parse(["not", "valid"])
@@ -123,7 +119,7 @@ class TestResumeParser:
             exc_info.value
         )
 
-    def test_detect_sections(self, parser):
+    def test_detect_sections(self, parser: ResumeParser) -> None:
         """Test section detection in resume text."""
         text = """
         Experience:
@@ -143,7 +139,59 @@ class TestResumeParser:
         assert any("education" in s for s in sections_lower)
         assert any("skills" in s for s in sections_lower)
 
-    def test_strip_markdown_syntax(self, parser):
+    def test_detect_sections_with_leading_spaces(self, parser: ResumeParser) -> None:
+        """Section headers indented with spaces should still be detected."""
+        text = """
+            Experience:
+            Senior Developer at TechCorp
+
+            Education:
+            BS Computer Science
+
+            Skills: Python, JavaScript
+        """
+        sections = parser._detect_sections(text)
+
+        sections_lower = [s.lower() for s in sections]
+        assert any("experience" in s for s in sections_lower)
+        assert any("education" in s for s in sections_lower)
+        assert any("skills" in s for s in sections_lower)
+
+    def test_detect_sections_with_leading_tabs(self, parser: ResumeParser) -> None:
+        """Section headers indented with tabs should still be detected."""
+        text = "\tEducation:\n\tBS Computer Science\n\n\tSkills: Python"
+        sections = parser._detect_sections(text)
+
+        sections_lower = [s.lower() for s in sections]
+        assert any("education" in s for s in sections_lower)
+        assert any("skills" in s for s in sections_lower)
+
+    def test_detect_sections_mixed_indentation(self, parser: ResumeParser) -> None:
+        """Some headers indented, others not — both should be detected."""
+        text = "Experience:\nSenior Developer\n\n    Education:\nBS Computer Science"
+        sections = parser._detect_sections(text)
+
+        sections_lower = [s.lower() for s in sections]
+        assert any("experience" in s for s in sections_lower)
+        assert any("education" in s for s in sections_lower)
+
+    def test_detect_sections_no_headers_still_empty(self, parser: ResumeParser) -> None:
+        """Text with no recognizable headers should return an empty list."""
+        sections = parser._detect_sections("Just some random text with no section headers at all.")
+
+        assert sections == []
+
+    def test_detect_sections_unindented_unaffected(self, parser: ResumeParser) -> None:
+        """Regression: non-indented headers must continue to work."""
+        text = "Experience:\nDeveloper\n\nEducation:\nBS CS\n\nSkills: Python"
+        sections = parser._detect_sections(text)
+
+        sections_lower = [s.lower() for s in sections]
+        assert any("experience" in s for s in sections_lower)
+        assert any("education" in s for s in sections_lower)
+        assert any("skills" in s for s in sections_lower)
+
+    def test_strip_markdown_syntax(self, parser: ResumeParser) -> None:
         """Test markdown syntax stripping."""
         markdown_text = """
         # Header
@@ -156,14 +204,11 @@ class TestResumeParser:
         """
         stripped = parser._strip_markdown(markdown_text)
 
-        # Headers should be removed
         assert not stripped.strip().startswith("#")
-        # Code blocks should be removed
         assert "print" not in stripped or "```" not in stripped
-        # But actual text content should remain
         assert "Header" in stripped or "Bold text" in stripped
 
-    def test_pdf_parsing_error_handling(self, parser):
+    def test_pdf_parsing_error_handling(self, parser: ResumeParser) -> None:
         """Test graceful error handling for invalid PDF."""
         with patch("ingestion.parsers.resume_parser.PdfReader") as mock_pdf_reader:
             mock_pdf_reader.side_effect = Exception("Invalid PDF format")
@@ -173,7 +218,7 @@ class TestResumeParser:
 
             assert "Failed to parse PDF" in str(exc_info.value)
 
-    def test_parse_preserves_text_content(self, parser):
+    def test_parse_preserves_text_content(self, parser: ResumeParser) -> None:
         """Test that parsing preserves actual content text."""
         original_text = "John Doe\nSoftware Engineer\nPython, JavaScript, React"
         result = parser.parse(original_text)


### PR DESCRIPTION
## Summary
Resume section detection previously missed indented section headers (e.g. "   Education:") because the regex patterns in `_detect_sections()` were anchored directly to the start of a line with no whitespace allowance. This is common in text extracted from PDFs. This PR adds optional leading whitespace/tab support to the detection patterns so indented headers are correctly identified.

## Issue
Closes #147

## Changes
- Updated the four regex patterns in `_detect_sections()` (`ingestion/parsers/resume_parser.py`) to accept optional leading spaces/tabs (`[ \t]*`) before section header names, using `[ \t]*` rather than `\s*` so newlines can't be consumed and cause a false match
- Added 5 new unit tests in `tests/unit/test_resume_parser.py`:
  - `test_detect_sections_with_leading_spaces`
  - `test_detect_sections_with_leading_tabs`
  - `test_detect_sections_mixed_indentation`
  - `test_detect_sections_no_headers_still_empty`
  - `test_detect_sections_unindented_unaffected` (regression check)

## Testing
- [x] Unit tests pass (`make test-unit`) — all tests tied to this issue pass; see Notes for Reviewers re: pre-existing unrelated failures
- [x] Integration tests pass (`make test-integration`) — not applicable to this change
- [x] Linter passes (`make lint`) — clean on both files touched by this PR
- [x] Type checker passes (`make typecheck`) — clean on the fix itself; see note below on a pre-existing, unrelated mypy finding in this test file
- [x] New/updated tests cover the changes

## Screenshots / Demo
N/A — backend parsing logic, no UI change.

## Notes for Reviewers

**Pre-existing failures (unrelated to this change):**

`make check` reports 177 pre-existing lint errors across `rag/`, `safety/`, `ingestion/embeddings/`, and other unrelated files — none in `ingestion/parsers/resume_parser.py` or `tests/unit/test_resume_parser.py`.

`make test-unit` has 50 pre-existing failures codebase-wide. Two are in `tests/unit/test_resume_parser.py` — `test_parse_markdown_resume` and `test_strip_markdown_syntax` — caused by the same class of leading-whitespace bug, but in `_strip_markdown()`'s header-stripping regex, a method this PR does not touch. Verified via `git stash` that both failures reproduce identically on the pre-change code.

Separately, the local pre-commit mypy hook flags two pre-existing type errors in `test_parse_invalid_content_type` and `test_parse_invalid_list_content`, which intentionally pass wrong types (`int`, `list[str]`) to `parser.parse()` to verify it raises `ValueError` for invalid input. These are expected by design and predate this PR.

Verified via `git stash` comparison:
- **Before this fix:** 5 failing tests in `test_resume_parser.py` (`test_parse_single_column_resume_text`, `test_parse_resume_no_work_experience`, `test_parse_markdown_resume`, `test_detect_sections`, `test_strip_markdown_syntax`)
- **After this fix:** only the 2 unrelated `_strip_markdown()` failures remain

This confirms the fix resolves the tests tied to issue #147 and introduces no new failures.
