### PR TITLE
docs(api): add curl examples for each endpoint

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,16 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/117
+
+**Issue title:** API docs don't include example `curl` commands
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+`docs/API.md` lists every endpoint in the PathReview API (health check, auth, profiles, reviews) but only gives a one-line description of each — there's no runnable example showing how to actually call them. That means a new contributor who just finished `make setup` has no fast way to confirm the backend is working end-to-end; they'd have to reverse-engineer request bodies and auth headers from the source code or trial-and-error in Swagger UI. The fix adds a `curl` example under each endpoint (including the auth flow of logging in with one of the seeded test accounts and exporting the resulting JWT for reuse), so a developer can copy-paste their way through health check → login → create profile → request review → fetch review and see the whole system working within a few minutes of finishing setup. I picked this one because it's tightly scoped to a single file (`docs/API.md`), doesn't require touching application code or the database schema, and is a low-risk way to get comfortable with the repo's branch/commit conventions before taking on a Tier 2/3 issue in later weeks.
+
+**Branch name:** docs/117-add-curl-examples
+
+**Setup confirmation:** [ ] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger

--- a/docs/API.md
+++ b/docs/API.md
@@ -8,25 +8,96 @@ Base URL: `http://localhost:8000`
 
 `GET /health` — Returns service status and dependency health.
 
+```bash
+curl http://localhost:8000/health
+```
+
 ### Authentication
 
 `POST /auth/register` — Create a new account.
+
+```bash
+curl -X POST http://localhost:8000/auth/register \
+  -H "Content-Type: application/json" \
+  -d '{"email": "user1@example.com", "password": "password1"}'
+```
+
 `POST /auth/login` — Obtain a JWT access token.
+
+```bash
+curl -X POST http://localhost:8000/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"email": "user1@example.com", "password": "password1"}'
+```
+
+The response includes an `access_token`. Export it for use in the examples below:
+
+```bash
+export TOKEN=$(curl -s -X POST http://localhost:8000/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"email": "user1@example.com", "password": "password1"}' \
+  | python3 -c "import sys, json; print(json.load(sys.stdin)['access_token'])")
+```
 
 ### Profiles
 
 `POST /profiles` — Create a profile with resume and GitHub username.
+
+```bash
+curl -X POST http://localhost:8000/profiles \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"github_username": "octocat", "resume_text": "Software engineer with 5 years of experience..."}'
+```
+
 `GET /profiles/{profile_id}` — Retrieve a profile.
+
+```bash
+curl -X GET http://localhost:8000/profiles/1 \
+  -H "Authorization: Bearer $TOKEN"
+```
+
 `DELETE /profiles/{profile_id}` — Delete a profile and associated data.
+
+```bash
+curl -X DELETE http://localhost:8000/profiles/1 \
+  -H "Authorization: Bearer $TOKEN"
+```
 
 ### Reviews
 
 `POST /reviews` — Request a new portfolio review for a profile.
+
+```bash
+curl -X POST http://localhost:8000/reviews \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"profile_id": 1}'
+```
+
 `GET /reviews/{review_id}` — Retrieve a completed review.
+
+```bash
+curl -X GET http://localhost:8000/reviews/1 \
+  -H "Authorization: Bearer $TOKEN"
+```
+
 `GET /reviews` — List reviews for the authenticated user (paginated).
+
+```bash
+curl -X GET "http://localhost:8000/reviews?page=1&page_size=10" \
+  -H "Authorization: Bearer $TOKEN"
+```
 
 ## Interactive Docs
 
 When the API is running, visit:
 - **Swagger UI:** http://localhost:8000/docs
 - **ReDoc:** http://localhost:8000/redoc
+
+## Try It Yourself
+
+After running `make setup` (see [SETUP.md](./SETUP.md)), the database is seeded with three test
+accounts (`user1@example.com` / `password1`, and similarly for `user2`/`user3`). Use the login
+example above to get a token, then walk through the profile and review examples in order —
+create a profile, request a review, then fetch it.


### PR DESCRIPTION
## Summary
Adds runnable curl invocations for health, auth, profiles, and reviews endpoints in docs/API.md so new contributors can verify the API works after setup.

Fixes #117