### PR TITLE
test(api): add auth middleware integration coverage

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -27,7 +27,7 @@ guarantees are locked in against future changes.
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** (this commit — link added in the PLAN.md commit)
+**Reproduction commit link:** https://github.com/Nikayel/pathreview/commit/75c3b7c8cfda2623a03a62dd33f02baeb2143992
 
 **Reproduction summary:**
 Confirmed the coverage gap: `pytest tests/integration -m integration` runs
@@ -69,7 +69,7 @@ work but are completely untested.
   so startup `init_db()` crashes with `DuplicateTableError` on a fresh,
   empty database. Migrations must run first.
 
-**PLAN.md link:** (added in the PLAN.md commit)
+**PLAN.md link:** https://github.com/Nikayel/pathreview/blob/test/90-auth-middleware-edge-cases/PLAN.md
 
 **Walkthrough video (recommended):** _to record_
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -2,7 +2,7 @@
 
 ## Week 7 — Issue selection
 
-**Issue link:** https://github.com/jamjamgobambam/pathreview/issues/90
+**Issue link:** https://github.com/ascherj/pathreview/issues/90
 
 **Issue title:** Add integration tests for authentication edge cases
 
@@ -24,3 +24,58 @@ guarantees are locked in against future changes.
 **Setup confirmation:** [ ] App runs locally at localhost:5173
 
 **Cohort ledger:** [ ] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** (this commit — link added in the PLAN.md commit)
+
+**Reproduction summary:**
+Confirmed the coverage gap: `pytest tests/integration -m integration` runs
+zero tests, and no test in the repo exercises `get_current_user` or sends an
+`Authorization` header. I then hit a protected endpoint on the locally
+running API with each credential the issue lists — all four rejection paths
+work but are completely untested.
+
+**Reproduction steps:**
+
+1. Environment: corrected `upstream` to `ascherj/pathreview` and rebased on
+   `upstream/main`; `docker compose up -d db` (Postgres 16, host port 5433);
+   `.env` from `.env.example`; `alembic upgrade head` (revisions 001, 002).
+2. Show the gap:
+   - `pytest tests/integration -m integration` → `no tests ran`
+   - `grep -rl "get_current_user\|Authorization" tests/` → no matches
+     (`tests/unit/test_security.py` covers the token helper functions, but
+     nothing tests the middleware's HTTP contract)
+3. Exercise the untested paths against the running API
+   (`uvicorn api.main:app`), `GET /profiles/<random-uuid>`:
+
+   | Credential | Observed response |
+   |---|---|
+   | valid token (registered user) | 404 `{"detail":"Profile not found"}` — passes middleware |
+   | no Authorization header | 401 `{"detail":"Not authenticated"}` |
+   | malformed token (`not-a-jwt`) | 401 `{"detail":"Invalid authentication credentials"}` |
+   | expired token (`expires_delta=-5min`) | 401 `{"detail":"Invalid authentication credentials"}` |
+   | token signed with a different secret | 401 `{"detail":"Invalid authentication credentials"}` |
+
+**Findings while reproducing:**
+- The expired token returns the generic message, **not** the middleware's
+  dedicated `"Token has expired"` response — `jose.jwt.decode` rejects
+  expired tokens inside `decode_access_token` before the explicit expiry
+  branch in `api/middleware/auth.py` (lines 44–49) can run. That branch is
+  effectively dead code; tests should assert the observable contract.
+- Pre-existing bug (out of scope, to file separately):
+  `core/models/profile.py` declares the `ix_profiles_user_id` index twice
+  (`index=True` on the column + explicit `Index(...)` in `__table_args__`),
+  so startup `init_db()` crashes with `DuplicateTableError` on a fresh,
+  empty database. Migrations must run first.
+
+**PLAN.md link:** (added in the PLAN.md commit)
+
+**Walkthrough video (recommended):** _to record_
+
+**Blockers or open questions:**
+- Should the dead expiry branch in `auth.py` be cleaned up in this PR or
+  filed separately? (Planning to file separately — this PR stays test-only.)
+- The pre-commit mypy hook fails on ~65 pre-existing annotation errors in
+  `api/`/`core/` (CI's typecheck job fails on main for the same reason), so
+  Python commits need `--no-verify` until that's fixed upstream.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,26 @@
+# PathReview — Module 3 Journal
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/jamjamgobambam/pathreview/issues/90
+
+**Issue title:** Add integration tests for authentication edge cases
+
+**Tier:** [ ] Tier 1  [x] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The auth middleware currently only has coverage for the happy path — a single
+request carrying a valid JWT. That leaves every failure mode untested, so a
+regression in how the API rejects bad credentials could ship unnoticed. This
+issue asks for integration tests covering the rejection paths: an expired
+token, a malformed/garbage token, a completely missing `Authorization` header,
+and a token that is well-formed but signed with the wrong secret. A successful
+fix adds these cases to `tests/integration/test_auth_middleware.py`, each
+asserting the middleware returns the correct 401 response, so the auth layer's
+guarantees are locked in against future changes.
+
+**Branch name:** test/90-auth-middleware-edge-cases
+
+**Setup confirmation:** [ ] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,89 @@
+# Solution plan
+
+**Issue:** Add integration tests for authentication edge cases —
+https://github.com/ascherj/pathreview/issues/90
+
+### Understand
+
+This is a test-coverage gap, not a behavior bug. The JWT auth middleware
+(`api/middleware/auth.py::get_current_user`) guards every protected route,
+but the only auth-related tests in the repo (`tests/unit/test_security.py`)
+cover the token *helper functions* in isolation. Nothing tests the
+middleware's HTTP contract, and `tests/integration/` is empty.
+
+- **Expected:** each rejection path — expired token, malformed token, missing
+  `Authorization` header, token signed with a different secret — is locked in
+  by an integration test asserting the 401 response.
+- **Actual (reproduced 2026-07-19, see JOURNAL Week 8):** all four paths
+  return 401 correctly today, but zero tests exercise them, so a regression
+  would ship unnoticed.
+
+### Map
+
+Files to **create**:
+- `tests/integration/test_auth_middleware.py` — the only file the PR adds.
+
+Files to **read/exercise** (no changes):
+- `api/middleware/auth.py` — `get_current_user`, the code under test
+- `core/security.py` — `create_access_token` (negative `expires_delta`
+  forges expired tokens), `decode_access_token`
+- `api/routes/auth.py` — `POST /auth/register` to create a real user fixture
+- `api/routes/profiles.py` — `GET /profiles/{id}` as the protected route
+- `core/config.py` — `settings.secret_key` / `jwt_algorithm` for the
+  wrong-secret case (signed via `jose.jwt.encode` with a different key)
+
+### Plan
+
+1. **Fixtures:** module-scoped `TestClient(api.main.app)` against the real
+   Dockerized Postgres (context manager triggers startup/table creation), and
+   a `registered_user` fixture that registers a unique user via
+   `POST /auth/register` and returns their id + token.
+2. **Issue cases:** one test class per case — missing header, malformed
+   token (parametrized variants), expired token, wrong-secret token — each
+   asserting 401 plus the `WWW-Authenticate: Bearer` header and response detail.
+3. **Baseline:** valid-token test asserting 404 (not 401) on a random profile
+   id, proving the request passed the middleware — this cleanly separates
+   "rejected by middleware" from "route-level failure".
+4. **Adjacent edge cases** (see below) to fully lock in the contract.
+5. **Verify:** `make test-integration`, `ruff check`, `ruff format`, and
+   mypy-clean annotations on the new file (`disallow_untyped_defs` is on).
+
+### Inputs & outputs
+
+- **Inputs:** crafted JWTs (valid, expired, forged, mangled) and raw HTTP
+  requests sent to a protected endpoint on the real app with a real database.
+- **Outputs:** one new test module (~15 tests) that pins the middleware's
+  observable contract: 401 + `WWW-Authenticate: Bearer` for every bad
+  credential, and pass-through for valid ones. **No application code changes**
+  — if any test fails, that's a middleware bug to fix, not a test to adjust.
+
+### Risks & unknowns
+
+- **Fresh-DB startup crash (pre-existing):** `core/models/profile.py`
+  declares `ix_profiles_user_id` twice, so `init_db()`/`create_all` fails on
+  an empty database — migrations (`alembic upgrade head`) must run before
+  tests. Documented in JOURNAL; will file as a separate issue.
+- **Dead expiry branch:** expired tokens are rejected inside
+  `decode_access_token` (jose validates `exp`), so the middleware's explicit
+  `"Token has expired"` branch (auth.py:44–49) never runs. Tests must assert
+  the observable behavior (generic 401), not that branch. Cleaning it up is
+  out of scope for a test-only PR.
+- **Broken pre-commit mypy hook:** fails on ~65 pre-existing errors in
+  `api/`/`core/` (CI typecheck is red on main for the same reason);
+  Python commits need `--no-verify` for now.
+- **Event-loop pitfalls:** pytest-asyncio + the module-level async engine can
+  produce cross-loop connection errors; using the synchronous `TestClient`
+  with module scope (one loop for the whole module) avoids this entirely.
+
+### Edge cases
+
+Beyond the four cases in the issue, the suite should handle:
+
+- empty bearer value (`Authorization: Bearer `)
+- wrong scheme carrying a valid token (`Basic <token>`)
+- tampered payload segment (signature no longer matches)
+- stripped signature segment (unsigned token)
+- syntactically valid, correctly signed token **missing the `sub` claim**
+- correctly signed token whose `sub` is a **user that doesn't exist** in the DB
+- near-expiry but still-valid token (must NOT be rejected — guards against
+  over-eager expiry logic)

--- a/tests/integration/test_auth_middleware.py
+++ b/tests/integration/test_auth_middleware.py
@@ -1,0 +1,209 @@
+"""Integration tests for JWT authentication middleware."""
+
+from collections.abc import Iterator
+from datetime import timedelta
+from typing import TypedDict, cast
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+from httpx import Response
+from jose import jwt  # type: ignore[import-untyped]
+
+from api.main import app
+from core.config import settings
+from core.security import create_access_token
+
+pytestmark = pytest.mark.integration
+
+
+class RegisteredUser(TypedDict):
+    """Authenticated user data created for middleware tests."""
+
+    id: str
+    token: str
+
+
+@pytest.fixture(scope="module")
+def client() -> Iterator[TestClient]:
+    """Provide one app client and trigger application startup once."""
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+@pytest.fixture(scope="module")
+def registered_user(client: TestClient) -> RegisteredUser:
+    """Register a real user so valid tokens can pass middleware lookup."""
+    response = client.post(
+        "/auth/register",
+        json={
+            "email": f"auth-middleware-{uuid4()}@example.com",
+            "password": "secure-password-123",
+        },
+    )
+
+    assert response.status_code == 200
+    body = cast("dict[str, str]", response.json())
+    token = body["access_token"]
+    payload = jwt.get_unverified_claims(token)
+
+    return {"id": str(payload["sub"]), "token": token}
+
+
+def profile_url() -> str:
+    """Return a valid-but-nonexistent profile URL."""
+    return f"/profiles/{uuid4()}"
+
+
+def bearer_headers(token: str) -> dict[str, str]:
+    """Return an Authorization header for a bearer token."""
+    return {"Authorization": f"Bearer {token}"}
+
+
+def assert_unauthorized(response: Response, detail: str) -> None:
+    """Assert the public authentication rejection contract."""
+    assert response.status_code == 401
+    assert response.headers["WWW-Authenticate"] == "Bearer"
+    assert response.json() == {"detail": detail}
+
+
+class TestValidCredentials:
+    """Tests that prove valid credentials pass the middleware."""
+
+    def test_valid_token_reaches_protected_route(
+        self, client: TestClient, registered_user: RegisteredUser
+    ) -> None:
+        """A valid token reaches the route handler instead of returning 401."""
+        response = client.get(profile_url(), headers=bearer_headers(registered_user["token"]))
+
+        assert response.status_code == 404
+        assert response.json() == {"detail": "Profile not found"}
+
+
+class TestMissingAuthorization:
+    """Tests for absent or incorrectly formatted authorization headers."""
+
+    def test_missing_authorization_header_is_rejected(self, client: TestClient) -> None:
+        """Requests without credentials receive the OAuth2 authentication response."""
+        response = client.get(profile_url())
+
+        assert_unauthorized(response, "Not authenticated")
+
+    def test_empty_bearer_token_is_rejected(self, client: TestClient) -> None:
+        """An empty bearer token is rejected by token decoding."""
+        response = client.get(profile_url(), headers={"Authorization": "Bearer "})
+
+        assert_unauthorized(response, "Invalid authentication credentials")
+
+    def test_wrong_scheme_is_rejected(
+        self, client: TestClient, registered_user: RegisteredUser
+    ) -> None:
+        """A valid token cannot bypass the middleware under a non-bearer scheme."""
+        response = client.get(
+            profile_url(),
+            headers={"Authorization": f"Basic {registered_user['token']}"},
+        )
+
+        assert_unauthorized(response, "Not authenticated")
+
+
+class TestMalformedTokens:
+    """Tests for invalid JWT structures and signatures."""
+
+    @pytest.mark.parametrize("token", ["not-a-jwt", "header.payload", "a.b.c"])
+    def test_malformed_token_is_rejected(self, client: TestClient, token: str) -> None:
+        """Malformed token strings receive the middleware's generic 401 response."""
+        response = client.get(profile_url(), headers=bearer_headers(token))
+
+        assert_unauthorized(response, "Invalid authentication credentials")
+
+    def test_tampered_payload_is_rejected(
+        self, client: TestClient, registered_user: RegisteredUser
+    ) -> None:
+        """Changing a token payload invalidates its signature."""
+        header, payload, signature = registered_user["token"].split(".")
+        altered_payload = payload[:-1] + ("A" if payload[-1] != "A" else "B")
+        tampered_token = f"{header}.{altered_payload}.{signature}"
+
+        response = client.get(profile_url(), headers=bearer_headers(tampered_token))
+
+        assert_unauthorized(response, "Invalid authentication credentials")
+
+    def test_missing_signature_is_rejected(
+        self, client: TestClient, registered_user: RegisteredUser
+    ) -> None:
+        """A two-part token cannot be accepted as a signed JWT."""
+        unsigned_token = registered_user["token"].rsplit(".", maxsplit=1)[0]
+
+        response = client.get(profile_url(), headers=bearer_headers(unsigned_token))
+
+        assert_unauthorized(response, "Invalid authentication credentials")
+
+
+class TestExpiredToken:
+    """Tests for expiry handling in the observable middleware contract."""
+
+    def test_expired_token_is_rejected(
+        self, client: TestClient, registered_user: RegisteredUser
+    ) -> None:
+        """Expired credentials receive the generic invalid-token response."""
+        token = create_access_token(
+            {"sub": registered_user["id"]},
+            expires_delta=timedelta(minutes=-5),
+        )
+
+        response = client.get(profile_url(), headers=bearer_headers(token))
+
+        assert_unauthorized(response, "Invalid authentication credentials")
+
+
+class TestWrongSecretToken:
+    """Tests for JWTs signed with an untrusted secret."""
+
+    def test_token_signed_with_wrong_secret_is_rejected(
+        self, client: TestClient, registered_user: RegisteredUser
+    ) -> None:
+        """A token with the correct claims but wrong signature is rejected."""
+        token = jwt.encode(
+            {"sub": registered_user["id"]},
+            "different-test-secret",
+            algorithm=settings.jwt_algorithm,
+        )
+
+        response = client.get(profile_url(), headers=bearer_headers(token))
+
+        assert_unauthorized(response, "Invalid authentication credentials")
+
+
+class TestAdditionalClaims:
+    """Tests for validly signed tokens that cannot identify a real user."""
+
+    def test_token_without_subject_is_rejected(self, client: TestClient) -> None:
+        """A correctly signed token must include the subject claim."""
+        token = create_access_token({})
+
+        response = client.get(profile_url(), headers=bearer_headers(token))
+
+        assert_unauthorized(response, "Invalid authentication credentials")
+
+    def test_token_for_unknown_user_is_rejected(self, client: TestClient) -> None:
+        """A token subject must correspond to an existing user."""
+        token = create_access_token({"sub": str(uuid4())})
+
+        response = client.get(profile_url(), headers=bearer_headers(token))
+
+        assert_unauthorized(response, "Invalid authentication credentials")
+
+    def test_near_expiry_token_is_accepted(
+        self, client: TestClient, registered_user: RegisteredUser
+    ) -> None:
+        """A token that remains unexpired is allowed through the middleware."""
+        token = create_access_token(
+            {"sub": registered_user["id"]},
+            expires_delta=timedelta(seconds=30),
+        )
+
+        response = client.get(profile_url(), headers=bearer_headers(token))
+
+        assert response.status_code == 404
+        assert response.json() == {"detail": "Profile not found"}


### PR DESCRIPTION
## Summary

Adds HTTP-level integration coverage for the JWT authentication middleware. The suite verifies the four rejection paths requested in #90: missing credentials, malformed tokens, expired tokens, and tokens signed with another secret.

It also covers empty and wrong authorization schemes, tampered or unsigned tokens, missing or unknown subjects, and valid or near-expiry credentials reaching the protected route.

## Design decisions

The tests exercise the real FastAPI app, a registered database user, and a protected profile route. Expired tokens assert the observed generic invalid-credentials response because JWT decoding rejects expiration before the middleware explicit expiry branch is reached.

## Manual test

1. Start Postgres with docker compose up -d db.
2. Apply migrations with make migrate.
3. Run make test-integration.
4. Confirm all 14 tests in tests/integration/test_auth_middleware.py pass.

## Checks

- Passed: .venv/bin/ruff format --check tests/integration/test_auth_middleware.py
- Passed: .venv/bin/ruff check tests/integration/test_auth_middleware.py
- Blocked locally: integration tests require Postgres at localhost:5433, which is not running in this environment.
- Existing baseline failures: make test-unit has 52 failures and 31 errors; mypy reports 63 unrelated errors in api and core.