### PR TITLE
Fix/153 faithfulness checker crashes error

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -37,3 +37,20 @@ The exception occurs at `rag/evaluator/faithfulness_checker.py:34`, where
 `" ".join(...)` receives the `None` returned by `chunk.get("text", "")`.
 This confirms that the default handles a missing `text` key but not a key
 whose value is explicitly `None`.
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/qingtaozhou/pathreview/commit/724ba44
+
+**Reproduction summary:**
+I ran the focused `test_none_context_chunk_text` pytest case with a context
+chunk containing `"text": None`. It consistently raised `TypeError` in
+`FaithfulnessChecker.check()` when `" ".join(...)` received the null value.
+
+**PLAN.md link:** https://github.com/qingtaozhou/pathreview/blob/fix/153-faithfulness-checker-crashes-error/PLAN.md
+
+**Walkthrough video (recommended):** Not recorded.
+
+**Blockers or open questions:**
+No current blockers. The fix should remain narrowly scoped to explicit `None`
+text values rather than silently converting every malformed value to a string.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -18,3 +18,22 @@ will normalize null chunk text safely and make the related unit test pass.
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [ ] Issue added to cohort ledger
+
+### Reproduction
+
+I reproduced the issue on the working branch with:
+
+```bash
+.venv/bin/pytest tests/unit/test_faithfulness_checker.py::TestFaithfulnessChecker::test_none_context_chunk_text -vv
+```
+
+The test fails consistently with:
+
+```text
+TypeError: sequence item 0: expected str instance, NoneType found
+```
+
+The exception occurs at `rag/evaluator/faithfulness_checker.py:34`, where
+`" ".join(...)` receives the `None` returned by `chunk.get("text", "")`.
+This confirms that the default handles a missing `text` key but not a key
+whose value is explicitly `None`.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -54,3 +54,49 @@ chunk containing `"text": None`. It consistently raised `TypeError` in
 **Blockers or open questions:**
 No current blockers. The fix should remain narrowly scoped to explicit `None`
 text values rather than silently converting every malformed value to a string.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the issue #153 fix in `FaithfulnessChecker.check()` so a context
+chunk with `text: None` contributes an empty string instead of crashing during
+context concatenation. Tightened the null-text regression test and added a
+mixed null/valid-context test, completing the implementation and test tasks
+from `PLAN.md`.
+
+**Next steps:**
+Run the required repository checks, review the complete PR diff, open a draft
+PR, and request feedback from a classmate or mentor in the instructor-specified
+Slack channel. Address agreed-upon feedback before marking the PR ready.
+
+**Blockers:**
+No implementation blocker. The repository-wide `make check` and
+`make test-unit` commands currently report failures outside the issue #153
+change, which must be resolved or confirmed with the instructor before final
+submission.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** Pending — create and submit the pull request after required checks
+and review are complete.
+
+**Branch:** `fix/153-faithfulness-checker-crashes-error`
+
+**What you built:**
+Updated the faithfulness checker to treat an explicitly null context `text`
+value as empty text, preventing the `TypeError` raised by `" ".join(...)`.
+Valid text in other context chunks is preserved and still participates in
+faithfulness scoring.
+
+**Tests added or updated:**
+Updated `tests/unit/test_faithfulness_checker.py` to assert a safe `0.0` score
+for a null-only context and added a mixed null/valid-context regression test
+that confirms valid context still produces the expected supported score.
+
+**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,20 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/153
+
+**Issue title:** Faithfulness checker crashes when a context chunk has `text: None`
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The faithfulness checker assumes every context chunk's `text` value is a
+string. When the key exists but its value is `None`, the default supplied to
+`dict.get()` is not used, so the null value reaches `" ".join(...)` and raises
+a `TypeError`. A successful fix in `rag/evaluator/faithfulness_checker.py`
+will normalize null chunk text safely and make the related unit test pass.
+
+**Branch name:** fix/153-faithfulness-checker-crashes-error
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -81,8 +81,7 @@ submission.
 
 ### Check-in 2 (end of week)
 
-**PR link:** Pending — create and submit the pull request after required checks
-and review are complete.
+**PR link:** https://github.com/ascherj/pathreview/pull/292
 
 **Branch:** `fix/153-faithfulness-checker-crashes-error`
 
@@ -100,3 +99,70 @@ that confirms valid context still produces the expected supported score.
 **Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No reviewer or maintainer feedback was provided. This is expected for the
+Summer 2026 course cycle, in which reviewer feedback is not available.
+
+**How you responded:**
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The hardest part was separating a very small bug from the surrounding noise in
+the repository. The failure came from one subtle Python behavior:
+`chunk.get("text", "")` uses the default only when the key is missing, not when
+the key exists with a value of `None`. Reproducing that exact path was simpler
+than deciding how broad the fix should be. I had to avoid hiding unrelated bad
+input by converting every value to a string, while still making null text safe.
+It was also harder than expected to interpret repository-wide check failures
+that were outside my change and distinguish them from the focused regression
+tests that exercised issue #153.
+
+**What did you learn about working in a large codebase?**
+I learned that a correct change is not just code that stops the immediate
+exception. In someone else's production code, I first needed to trace the
+input shape into `FaithfulnessChecker.check()`, understand the existing scoring
+behavior, and preserve that behavior for valid chunks. I kept the production
+change to `chunk.get("text") or ""` and added both a null-only test and a mixed
+null/valid test. The second test mattered because it showed that handling one
+bad chunk did not discard useful context from the rest of the list. I also
+learned to keep the issue, reproduction commit, plan, implementation, tests,
+and PR connected so another contributor can follow why the change exists.
+
+**How did AI tools help — and where did they fall short?**
+AI tools were most useful for navigating unfamiliar files, explaining the
+`dict.get()` edge case, suggesting focused test cases, and helping format the
+code and journal consistently. They accelerated the mechanical work, but they
+could not decide the project's intended boundary for malformed inputs or tell
+me whether unrelated full-suite failures were acceptable. I still had to read
+the implementation and existing tests, reproduce the exception locally,
+compare the proposed behavior with the issue, and judge that `None` should be
+treated as empty text without broadly coercing every unexpected type.
+
+**What would you do differently if you started over?**
+I would run the focused failing test and the repository-wide checks immediately
+after setup, before making any changes. That would create a clearer baseline
+for which failures already existed and reduce uncertainty when `make check`
+and `make test-unit` later reported failures outside my patch. I would also
+write down the acceptance cases earlier—missing `text`, `text: None`, and a
+mixture of null and valid chunks—so the implementation boundary was explicit
+before coding. Finally, I would keep the PR link and check results updated in
+the journal as each step happened instead of returning to documentation at the
+end.
+
+**What are you most proud of from this module?**
+I am most proud of turning a one-line-looking crash into a precise regression
+story. I reproduced the exact `TypeError`, explained why the existing default
+did not work, made a narrow fix, and added a mixed-context test that protects
+valid scoring behavior as well as preventing the crash. That gives a future
+maintainer more confidence than a change that only makes the original test
+stop failing.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,65 @@
+## Solution plan
+
+**Issue:** [Faithfulness checker crashes when a context chunk has `text: None`](https://github.com/ascherj/pathreview/issues/153)
+
+### Understand
+
+`FaithfulnessChecker.check()` builds one context string with
+`chunk.get("text", "")` for each retrieved chunk. That default works when the
+key is absent, but a present key whose value is `None` returns `None`; passing
+it to `" ".join(...)` raises `TypeError`. The actual behavior is a crash,
+whereas the expected behavior is a valid faithfulness score between `0.0` and
+`1.0`, with a null text chunk treated as having no usable text.
+
+### Map
+
+- `rag/evaluator/faithfulness_checker.py`
+  - `FaithfulnessChecker.check()` contains the failing context concatenation.
+- `tests/unit/test_faithfulness_checker.py`
+  - `test_none_context_chunk_text` reproduces the crash.
+  - `test_missing_text_key_in_chunk` covers the related missing-key case.
+  - A mixed valid/null context case should verify that usable text is retained.
+- `JOURNAL.md`
+  - Records the reproduction and implementation-planning work.
+
+### Plan
+
+1. Update `FaithfulnessChecker.check()` to normalize an explicitly null chunk
+   text to an empty string before joining, without changing valid strings.
+2. Tighten the existing null-text regression test to assert the expected safe
+   score rather than only checking its type and range.
+3. Add a mixed-context test containing both `None` and valid text to prove the
+   valid context still participates in scoring.
+4. Run the focused regression test, the complete faithfulness-checker test
+   module, and Ruff on the touched Python files.
+5. Run the full unit-test suite, review the issue-scoped diff, and commit the
+   implementation and tests to the working branch.
+
+### Inputs & outputs
+
+The changed method takes a feedback string and a list of context dictionaries.
+Inputs may include a dictionary with a valid string `text`, a missing `text`
+key, or `"text": None`. It should return a float from `0.0` to `1.0`; null
+text should contribute no tokens, valid text should remain available for
+support scoring, and no `TypeError` should be raised.
+
+### Risks & unknowns
+
+- Converting every value with `str()` could hide malformed upstream data, so
+  the fix should target `None` instead of accepting arbitrary types silently.
+- A null chunk in a mixed list must not cause valid context to be discarded.
+- `rag/evaluator/relevance_scorer.py` has a similar access pattern, but changing
+  it would expand the scope beyond issue #153 and should be separate follow-up
+  work.
+- The scoring algorithm's behavior for empty context text should remain
+  unchanged; this issue concerns crash prevention, not scoring redesign.
+
+### Edge cases
+
+- A single context chunk with `"text": None`.
+- Multiple chunks containing both null and valid text.
+- A chunk with no `text` key.
+- Multiple null or missing-text chunks.
+- Empty feedback or an empty context list, which should keep their existing
+  early-return behavior.
+- Valid empty strings, which should remain safe and contribute no tokens.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   db:
     image: postgres:16-alpine
@@ -37,6 +35,14 @@ services:
 
   vector-db:
     image: chromadb/chroma:0.4.22
+    entrypoint:
+      - /bin/bash
+      - -c
+      - >-
+        pip install --force-reinstall --no-cache-dir "numpy<2" chroma-hnswlib &&
+        export IS_PERSISTENT=1 CHROMA_SERVER_NOFILE=65535 &&
+        exec uvicorn chromadb.app:app --workers 1 --host 0.0.0.0 --port 8000
+        --proxy-headers --log-config chromadb/log_config.yml --timeout-keep-alive 30
     ports:
       - "8001:8000"
     volumes:
@@ -44,7 +50,11 @@ services:
     environment:
       ANONYMIZED_TELEMETRY: "false"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/api/v1/heartbeat"]
+      test:
+        - CMD
+        - python
+        - -c
+        - import urllib.request; urllib.request.urlopen("http://localhost:8000/api/v1/heartbeat")
       interval: 10s
       timeout: 5s
       retries: 5

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Thank you for contributing to PathReview! This guide explains our development wo
 Create a branch from `main` using this format:
 
 ```
-<type>/<issue-number>-<short-description>
+-`fix/153-faithfulness-checker-crashes-error`
 ```
 
 Where `<issue-number>` is the GitHub issue number (the number shown under the issue title in the tracker — e.g., `#124`).

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -99,7 +99,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -449,7 +448,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -473,7 +471,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1561,7 +1558,6 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1579,7 +1575,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1972,7 +1967,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3507,7 +3501,6 @@
       "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^2.0.1",
         "cssstyle": "^4.0.1",
@@ -4094,7 +4087,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4107,7 +4099,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4771,7 +4762,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/rag/evaluator/faithfulness_checker.py
+++ b/rag/evaluator/faithfulness_checker.py
@@ -1,6 +1,7 @@
 """Check if generated feedback is supported by retrieved context."""
 
 import re
+
 import structlog
 
 logger = structlog.get_logger()
@@ -20,8 +21,11 @@ class FaithfulnessChecker:
             Faithfulness score 0.0-1.0 (ratio of supported claims)
         """
         if not feedback or not context_chunks:
-            logger.info("faithfulness_empty_input", has_feedback=bool(feedback),
-                       has_chunks=bool(context_chunks))
+            logger.info(
+                "faithfulness_empty_input",
+                has_feedback=bool(feedback),
+                has_chunks=bool(context_chunks),
+            )
             return 0.0
 
         # Extract key claims from feedback (sentences)
@@ -31,9 +35,7 @@ class FaithfulnessChecker:
             return 0.5  # Default to neutral if no extractable claims
 
         # Concatenate context text
-        context_text = " ".join([
-            chunk.get("text", "") for chunk in context_chunks
-        ])
+        context_text = " ".join([chunk.get("text") or "" for chunk in context_chunks])
 
         # Check each claim for support
         supported = 0
@@ -43,8 +45,9 @@ class FaithfulnessChecker:
 
         score = supported / len(claims) if claims else 0.0
 
-        logger.info("faithfulness_checked", claims_count=len(claims),
-                   supported_count=supported, score=score)
+        logger.info(
+            "faithfulness_checked", claims_count=len(claims), supported_count=supported, score=score
+        )
 
         return score
 
@@ -59,7 +62,7 @@ class FaithfulnessChecker:
             List of claims (sentences)
         """
         # Split by sentence (simple regex)
-        sentences = re.split(r'[.!?]+', text)
+        sentences = re.split(r"[.!?]+", text)
         claims = [s.strip() for s in sentences if s.strip() and len(s.strip()) > 10]
         return claims[:10]  # Limit to 10 claims for scoring
 
@@ -81,8 +84,25 @@ class FaithfulnessChecker:
         # Require at least some meaningful overlap
         overlap = claim_tokens & context_tokens
         # Filter out common stop words
-        stop_words = {'a', 'an', 'the', 'is', 'are', 'was', 'were', 'be', 'been',
-                     'and', 'or', 'but', 'in', 'of', 'to', 'for', 'that'}
+        stop_words = {
+            "a",
+            "an",
+            "the",
+            "is",
+            "are",
+            "was",
+            "were",
+            "be",
+            "been",
+            "and",
+            "or",
+            "but",
+            "in",
+            "of",
+            "to",
+            "for",
+            "that",
+        }
         meaningful_overlap = overlap - stop_words
 
         return len(meaningful_overlap) >= 2

--- a/tests/unit/test_faithfulness_checker.py
+++ b/tests/unit/test_faithfulness_checker.py
@@ -10,17 +10,15 @@ class TestFaithfulnessChecker:
     """Test suite for FaithfulnessChecker."""
 
     @pytest.fixture
-    def checker(self):
+    def checker(self) -> FaithfulnessChecker:
         """Create a FaithfulnessChecker instance."""
         return FaithfulnessChecker()
 
-    def test_feedback_fully_supported_by_context(self, checker):
+    def test_feedback_fully_supported_by_context(self, checker: FaithfulnessChecker) -> None:
         """Test feedback fully supported by context returns score close to 1.0."""
         feedback = "The developer has strong Python skills and experience with Django."
         context_chunks = [
-            {
-                "text": "The portfolio shows Python expertise and Django framework experience."
-            },
+            {"text": "The portfolio shows Python expertise and Django framework experience."},
         ]
 
         score = checker.check(feedback, context_chunks)
@@ -30,13 +28,11 @@ class TestFaithfulnessChecker:
         # Should be high score due to support
         assert score > 0.5
 
-    def test_feedback_with_no_support_in_context(self, checker):
+    def test_feedback_with_no_support_in_context(self, checker: FaithfulnessChecker) -> None:
         """Test feedback with no support in context returns score close to 0.0."""
         feedback = "This developer is an expert in Rust systems programming."
         context_chunks = [
-            {
-                "text": "The developer has Python and JavaScript experience."
-            },
+            {"text": "The developer has Python and JavaScript experience."},
         ]
 
         score = checker.check(feedback, context_chunks)
@@ -44,13 +40,11 @@ class TestFaithfulnessChecker:
         assert isinstance(score, float)
         assert score < 0.5  # Should be low score
 
-    def test_partial_support_returns_middle_score(self, checker):
+    def test_partial_support_returns_middle_score(self, checker: FaithfulnessChecker) -> None:
         """Test partial support returns score between 0 and 1."""
         feedback = "The developer shows Python expertise and Kubernetes knowledge."
         context_chunks = [
-            {
-                "text": "Strong Python programming skills demonstrated in projects."
-            },
+            {"text": "Strong Python programming skills demonstrated in projects."},
         ]
 
         score = checker.check(feedback, context_chunks)
@@ -60,36 +54,34 @@ class TestFaithfulnessChecker:
         # Partial support should be middle range
         assert 0.2 < score < 0.8
 
-    def test_empty_feedback_returns_zero(self, checker):
+    def test_empty_feedback_returns_zero(self, checker: FaithfulnessChecker) -> None:
         """Test empty feedback returns 0.0."""
         feedback = ""
-        context_chunks = [
-            {"text": "Some context"}
-        ]
+        context_chunks = [{"text": "Some context"}]
 
         score = checker.check(feedback, context_chunks)
 
         assert score == 0.0
 
-    def test_empty_context_chunks_returns_zero(self, checker):
+    def test_empty_context_chunks_returns_zero(self, checker: FaithfulnessChecker) -> None:
         """Test empty context chunks returns 0.0."""
         feedback = "Some feedback"
-        context_chunks = []
+        context_chunks: list[dict] = []
 
         score = checker.check(feedback, context_chunks)
 
         assert score == 0.0
 
-    def test_both_empty_returns_zero(self, checker):
+    def test_both_empty_returns_zero(self, checker: FaithfulnessChecker) -> None:
         """Test both empty returns 0.0."""
         feedback = ""
-        context_chunks = []
+        context_chunks: list[dict] = []
 
         score = checker.check(feedback, context_chunks)
 
         assert score == 0.0
 
-    def test_multiple_context_chunks(self, checker):
+    def test_multiple_context_chunks(self, checker: FaithfulnessChecker) -> None:
         """Test multiple context chunks contribute to score."""
         feedback = "The developer has Python, JavaScript, and Docker experience."
         context_chunks = [
@@ -105,7 +97,7 @@ class TestFaithfulnessChecker:
         # All three claims supported
         assert score > 0.5
 
-    def test_extract_claims(self, checker):
+    def test_extract_claims(self, checker: FaithfulnessChecker) -> None:
         """Test claim extraction from feedback."""
         feedback = "The developer is skilled. They have experience. They work well."
         claims = checker._extract_claims(feedback)
@@ -114,7 +106,7 @@ class TestFaithfulnessChecker:
         assert len(claims) > 0
         assert all(isinstance(c, str) for c in claims)
 
-    def test_extract_claims_with_punctuation(self, checker):
+    def test_extract_claims_with_punctuation(self, checker: FaithfulnessChecker) -> None:
         """Test claim extraction handles various punctuation."""
         feedback = "First claim! Second claim? Third claim. Fourth claim"
         claims = checker._extract_claims(feedback)
@@ -122,7 +114,7 @@ class TestFaithfulnessChecker:
         assert isinstance(claims, list)
         # Should extract at least some claims
 
-    def test_is_supported_with_keyword_overlap(self, checker):
+    def test_is_supported_with_keyword_overlap(self, checker: FaithfulnessChecker) -> None:
         """Test that claim is marked as supported with keyword overlap."""
         claim = "The developer has Python skills"
         context = "Python programming skills demonstrated throughout portfolio"
@@ -132,7 +124,7 @@ class TestFaithfulnessChecker:
         assert isinstance(supported, bool)
         assert supported is True
 
-    def test_is_supported_without_keywords(self, checker):
+    def test_is_supported_without_keywords(self, checker: FaithfulnessChecker) -> None:
         """Test that claim is unsupported without keyword overlap."""
         claim = "Expert in Rust systems programming"
         context = "Strong background in Python web development"
@@ -142,7 +134,7 @@ class TestFaithfulnessChecker:
         assert isinstance(supported, bool)
         assert supported is False
 
-    def test_case_insensitive_support_check(self, checker):
+    def test_case_insensitive_support_check(self, checker: FaithfulnessChecker) -> None:
         """Test that support check is case insensitive."""
         claim = "PYTHON PROGRAMMING SKILLS"
         context = "python programming skills are demonstrated"
@@ -151,31 +143,25 @@ class TestFaithfulnessChecker:
 
         assert supported is True
 
-    def test_score_never_returns_hardcoded_value(self, checker):
+    def test_score_never_returns_hardcoded_value(self, checker: FaithfulnessChecker) -> None:
         """Test that score varies with input, never hardcoded 1.0 or 0.0."""
         # First test: fully supported
         score1 = checker.check(
-            "Python and JavaScript skills",
-            [{"text": "Expert in Python and JavaScript"}]
+            "Python and JavaScript skills", [{"text": "Expert in Python and JavaScript"}]
         )
 
         # Second test: no support
-        score2 = checker.check(
-            "Rust expertise",
-            [{"text": "Java programming background"}]
-        )
+        score2 = checker.check("Rust expertise", [{"text": "Java programming background"}])
 
         # Scores should be different
         assert score1 != score2
         # First should be higher
         assert score1 > score2
 
-    def test_multiple_claims_varying_support(self, checker):
+    def test_multiple_claims_varying_support(self, checker: FaithfulnessChecker) -> None:
         """Test scoring with multiple claims of varying support."""
         feedback = "Python expert. Knows Rust. Skilled with Docker."
-        context_chunks = [
-            {"text": "Python and Docker expertise shown in projects."}
-        ]
+        context_chunks = [{"text": "Python and Docker expertise shown in projects."}]
 
         score = checker.check(feedback, context_chunks)
 
@@ -183,31 +169,27 @@ class TestFaithfulnessChecker:
         assert isinstance(score, float)
         assert 0.2 < score < 0.8
 
-    def test_very_long_feedback(self, checker):
+    def test_very_long_feedback(self, checker: FaithfulnessChecker) -> None:
         """Test handling of very long feedback text."""
         feedback = "The developer. " * 100
-        context_chunks = [
-            {"text": "Developer portfolio content"}
-        ]
+        context_chunks = [{"text": "Developer portfolio content"}]
 
         score = checker.check(feedback, context_chunks)
 
         assert isinstance(score, float)
         assert 0.0 <= score <= 1.0
 
-    def test_very_long_context(self, checker):
+    def test_very_long_context(self, checker: FaithfulnessChecker) -> None:
         """Test handling of very long context."""
         feedback = "The developer has Python skills."
-        context_chunks = [
-            {"text": "Python " * 1000}
-        ]
+        context_chunks = [{"text": "Python " * 1000}]
 
         score = checker.check(feedback, context_chunks)
 
         assert isinstance(score, float)
         assert 0.0 <= score <= 1.0
 
-    def test_common_words_filtered_in_overlap(self, checker):
+    def test_common_words_filtered_in_overlap(self, checker: FaithfulnessChecker) -> None:
         """Test that common stop words are filtered in overlap calculation."""
         # This test verifies that "the", "is", "and" etc. don't count as meaningful overlap
         claim = "The project is well documented"
@@ -215,10 +197,11 @@ class TestFaithfulnessChecker:
 
         supported = checker._is_supported(claim, context)
 
+        assert isinstance(supported, bool)
         # Despite word overlap, should look for meaningful overlap (not stop words)
         # This depends on implementation
 
-    def test_minimum_overlap_required(self, checker):
+    def test_minimum_overlap_required(self, checker: FaithfulnessChecker) -> None:
         """Test that minimum meaningful overlap is required for support."""
         claim = "Python expertise"
         context = "Python"  # Only one word match
@@ -228,25 +211,31 @@ class TestFaithfulnessChecker:
         assert isinstance(supported, bool)
         # Need at least 2 meaningful tokens for support
 
-    def test_none_context_chunk_text(self, checker):
+    def test_none_context_chunk_text(self, checker: FaithfulnessChecker) -> None:
         """Test handling of None in context chunk text."""
         feedback = "Has Python skills"
-        context_chunks = [
-            {"text": None}
+        context_chunks = [{"text": None}]
+
+        score = checker.check(feedback, context_chunks)
+
+        assert score == 0.0
+
+    def test_none_context_chunk_text_with_valid_context(self, checker: FaithfulnessChecker) -> None:
+        """Test that None text does not discard valid context."""
+        feedback = "Has Python skills"
+        context_chunks: list[dict] = [
+            {"text": None},
+            {"text": "Python skills"},
         ]
 
         score = checker.check(feedback, context_chunks)
 
-        # Should handle gracefully
-        assert isinstance(score, float)
-        assert 0.0 <= score <= 1.0
+        assert score == 1.0
 
-    def test_missing_text_key_in_chunk(self, checker):
+    def test_missing_text_key_in_chunk(self, checker: FaithfulnessChecker) -> None:
         """Test handling of missing 'text' key in context chunk."""
         feedback = "Has Python skills"
-        context_chunks = [
-            {"content": "Python skills"}  # Wrong key
-        ]
+        context_chunks = [{"content": "Python skills"}]  # Wrong key
 
         score = checker.check(feedback, context_chunks)
 
@@ -254,7 +243,7 @@ class TestFaithfulnessChecker:
         assert isinstance(score, float)
         assert 0.0 <= score <= 1.0
 
-    def test_score_consistency(self, checker):
+    def test_score_consistency(self, checker: FaithfulnessChecker) -> None:
         """Test that same input produces same score."""
         feedback = "The developer has strong Python skills."
         context_chunks = [{"text": "Expert Python programmer"}]
@@ -264,7 +253,7 @@ class TestFaithfulnessChecker:
 
         assert score1 == score2
 
-    def test_specialized_technical_terms(self, checker):
+    def test_specialized_technical_terms(self, checker: FaithfulnessChecker) -> None:
         """Test support check with specialized technical terms."""
         claim = "Experienced with PostgreSQL and ORM frameworks"
         context = "Database design with PostgreSQL, SQLAlchemy ORM"


### PR DESCRIPTION
## Summary
This PR fixes the faithfulness checker crash that occurs when a retrieved
context chunk contains `text: None`. Null text is normalized to an empty string
before context chunks are joined, allowing the checker to return a valid score
while preserving valid context.


## Issue
Closes #153

## Changes
- Normalize `None` context text to an empty string in
  `FaithfulnessChecker.check()`.
- Strengthen the null-context regression test to assert the expected score.
- Add a test covering mixed null and valid context chunks.
- Add type annotations required by the configured mypy pre-commit hook.
- Add `PLAN.md` and Week 7/Week 8 progress entries in `JOURNAL.md`.
- Add an Apple Silicon ChromaDB/NumPy local-development compatibility fix.

## Testing

- [ ] Unit tests pass (`make test-unit`)
  - The repository has documented pre-existing failures: 347 passed, 51 failed,
    31 errors, and 1 warning before and after this change.
- [ ] Integration tests pass (`make test-integration`)
  - Not run; integration testing is outside this issue’s scope.
- [ ] Linter passes (`make lint`)
  - The repository has 180 pre-existing Ruff errors. The touched issue files pass.
- [ ] Type checker passes (`make typecheck`)
  - The repository-wide command has pre-existing errors. The touched issue files
    pass the configured mypy pre-commit hook.
- [x] New/updated tests cover the changes
  - `test_none_context_chunk_text`
  - `test_none_context_chunk_text_with_valid_context`
  - `test_missing_text_key_in_chunk

Focused verification:

```bash
.venv/bin/pytest \
  tests/unit/test_faithfulness_checker.py::TestFaithfulnessChecker::test_none_context_chunk_text \
  tests/unit/test_faithfulness_checker.py::TestFaithfulnessChecker::test_none_context_chunk_text_with_valid_context \
  tests/unit/test_faithfulness_checker.py::TestFaithfulnessChecker::test_missing_text_key_in_chunk \
  -vv
Result: 3 passed.

## Screenshots / Demo
<!-- If applicable, add screenshots or a link to a demo video -->

## Notes for Reviewers
Please pay particular attention to whether treating None as empty text is the
appropriate narrowly scoped behavior and whether the mixed-context regression
test adequately proves that valid neighboring context remains available for
scoring.
The repository-wide check and unit-test failures listed above existed before
this change and remain unchanged afterward.
