### PR TITLE
docs(rag): document hybrid retrieval scoring formula

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -18,6 +18,6 @@ PathReview's RAG system uses hybrid retrieval (vector similarity plus BM25 keywo
 
 **Branch name:** docs/36-hybrid-retrieval-scoring
 
-**Setup confirmation:** [ ] App runs locally at localhost:5173
+**Setup confirmation:** [x] App runs locally at localhost:5173
 
-**Cohort ledger:** [ ] Issue added to cohort ledger
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,23 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/36
+
+**Issue title:** Architecture doc doesn't explain the hybrid retrieval scoring formula
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+PathReview's RAG system uses hybrid retrieval (vector similarity plus BM25 keyword search), but `docs/ARCHITECTURE.md` only mentions that at a high level. It does not explain how the two scores are normalized, what the default weights are, or how a final blended score is computed. That makes it hard for contributors to understand why certain chunks rank higher than others or how to tune retrieval. A successful fix would document the scoring logic from `rag/retriever/hybrid.py` in `ARCHITECTURE.md`, including default weights (`vector_weight=0.7`, `keyword_weight=0.3`), the `min_score` threshold, and a short worked example.
+
+**"Is this right for me?" checklist reasoning:**
+- Scope is Tier 1 / docs-only: mainly `docs/ARCHITECTURE.md`, with reading `rag/retriever/hybrid.py` for accuracy.
+- I can explain the gap in my own words (missing formula + weights, not a runtime crash).
+- Success is clear: architecture docs include formula, defaults, and an example.
+- Fits my current skill level for a first contribution to a multi-service AI codebase; low risk of scope creep into agent/frontend work.
+- I claimed the issue on GitHub and can finish a PR within the Module 3 timeline.
+
+**Branch name:** docs/36-hybrid-retrieval-scoring
+
+**Setup confirmation:** [ ] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -35,3 +35,35 @@ I confirmed the documentation gap locally: `docs/ARCHITECTURE.md` only mentions 
 
 **Blockers or open questions:**
 In `HybridRetriever.retrieve`, `_get_all_chunks` is fetched but I don’t yet see an `index(...)` call before `keyword_searcher.search` — out of scope for this docs issue, but I may ask in office hours whether the keyword channel is empty in practice so the architecture prose stays accurate.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented PLAN.md sub-tasks 1–3: drafted the Hybrid retrieval scoring subsection in `docs/ARCHITECTURE.md` (max-normalization, default weights `0.7` / `0.3`, blend formula, `min_score`, worked example, code pointers). Confirmed the Week 8 acceptance tests in `tests/unit/test_architecture_hybrid_docs.py` now pass (3/3).
+
+**Next steps:**
+Self-review against CONTRIBUTING.md, open/finalize the PR to `ascherj/pathreview`, fill the PR template (including pre-existing `make check` / `make test-unit` failures note), and complete Check-in 2.
+
+**Blockers:**
+None.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/295
+
+**Branch:** `docs/36-hybrid-retrieval-scoring`
+
+**What you built:**
+Documented PathReview’s hybrid retrieval scoring in `docs/ARCHITECTURE.md`: how vector and BM25 scores are max-normalized, blended with default weights `vector_weight=0.7` / `keyword_weight=0.3`, filtered by `min_score=0.3`, sorted, and truncated — with a worked numeric example and pointers to `rag/retriever/hybrid.py`.
+
+**Tests added or updated:**
+- `tests/unit/test_architecture_hybrid_docs.py` (added in Week 8 as failing reproduction; now passing) — asserts ARCHITECTURE.md documents weights, normalization/blend formula, and `min_score`.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes  
+*(Full-repo `make check` / `make test-unit` still show pre-existing failures unrelated to #36; my changes introduce no new failures. Targeted: `pytest tests/unit/test_architecture_hybrid_docs.py` → 3 passed; ruff/black clean on that file. Documented in the PR.)*
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -21,3 +21,17 @@ PathReview's RAG system uses hybrid retrieval (vector similarity plus BM25 keywo
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/qhowery/pathreview/commit/294b35fd7bcdd717ecde3dd492bebc539411bd9a
+
+**Reproduction summary:**
+I confirmed the documentation gap locally: `docs/ARCHITECTURE.md` only mentions hybrid retrieval at a high level, while `rag/retriever/hybrid.py` implements max-normalization, default weights `0.7` / `0.3`, blending, and `min_score=0.3`. I captured steps in `docs/issue-36-reproduction.md` and added three failing unit tests that assert the missing doc content — they fail today and should pass after the Week 9 doc fix.
+
+**PLAN.md link:** https://github.com/qhowery/pathreview/blob/docs/36-hybrid-retrieval-scoring/PLAN.md
+
+**Walkthrough video (recommended):** _(optional — add Loom link if recorded)_
+
+**Blockers or open questions:**
+In `HybridRetriever.retrieve`, `_get_all_chunks` is fetched but I don’t yet see an `index(...)` call before `keyword_searcher.search` — out of scope for this docs issue, but I may ask in office hours whether the keyword channel is empty in practice so the architecture prose stays accurate.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,77 @@
+## Solution plan
+
+**Issue:** [Architecture doc doesn't explain the hybrid retrieval scoring formula](https://github.com/ascherj/pathreview/issues/36)
+
+### Understand
+
+**Root cause:** The hybrid ranking logic is implemented in code (`rag/retriever/hybrid.py`) but never documented in the architecture overview. `docs/ARCHITECTURE.md` only says the RAG system uses “vector similarity + BM25 keyword,” so contributors cannot tell *how* those scores become a final rank or what knobs exist.
+
+**Expected vs actual:**
+- **Expected:** ARCHITECTURE.md explains (1) per-channel max-normalization, (2) default weights `vector_weight=0.7` / `keyword_weight=0.3`, (3) the blended-score formula, (4) `min_score` filtering (default `0.3`), and (5) a short worked numeric example.
+- **Actual:** RAG section is two high-level sentences; formula/defaults/example are missing. Automated reproduction tests in `tests/unit/test_architecture_hybrid_docs.py` fail for this reason (see `docs/issue-36-reproduction.md`).
+
+**Formula as implemented today:**
+
+```text
+vector_norm  = raw_vector_score  / max(raw_vector_scores_in_candidate_set)
+keyword_norm = raw_bm25_score    / max(raw_bm25_scores_in_candidate_set)
+blended      = 0.7 * vector_norm + 0.3 * keyword_norm   # defaults
+keep if blended >= 0.3                                   # default min_score
+sort by blended desc; return top max_chunks
+```
+
+### Map
+
+| File | Role |
+|---|---|
+| `docs/ARCHITECTURE.md` | **Primary edit** — add Hybrid Retrieval Scoring subsection under RAG System |
+| `rag/retriever/hybrid.py` | Source of truth for formula, defaults, return fields (`score`, `vector_score`, `keyword_score`) |
+| `rag/retriever/keyword_search.py` | BM25 channel (`bm25_score`); linked from docs for context |
+| `rag/retriever/vector_store.py` | Vector channel (`score`); linked from docs for context |
+| `tests/unit/test_architecture_hybrid_docs.py` | Reproduction / acceptance tests — should pass after docs land |
+| `docs/issue-36-reproduction.md` | Week 8 reproduction notes (keep or fold into JOURNAL later) |
+
+**Out of scope for this issue:** changing retrieval behavior, agent/frontend code, or adding new config knobs — docs-only Tier 1 fix.
+
+### Plan
+
+1. **Draft the scoring subsection** in `docs/ARCHITECTURE.md` under `### RAG System (`rag/`)`: purpose of hybrid search, formula, defaults, `min_score`, sort/truncate behavior.
+2. **Add a worked example** with concrete numbers (e.g. vector raw/max → norm; BM25 raw/max → norm; blended; keep/drop vs `0.3`).
+3. **Cross-link to code** — point readers to `HybridRetriever` in `rag/retriever/hybrid.py` (and briefly keyword/vector modules) so docs stay traceable.
+4. **Verify acceptance** — re-run `pytest tests/unit/test_architecture_hybrid_docs.py -v` until all three tests pass; skim RAG section for clarity.
+5. **Open PR** against upstream with issue #36 linked; update JOURNAL Week 9 when implementing.
+
+### Inputs & outputs
+
+**Inputs:**
+- Existing implementation in `HybridRetriever.retrieve` / `__init__`
+- Issue acceptance criteria (formula + defaults + example)
+- Failing doc tests as the “definition of done” checklist
+
+**Outputs / changes:**
+- New prose (+ formula + example) in `docs/ARCHITECTURE.md` only (primary)
+- Passing `tests/unit/test_architecture_hybrid_docs.py`
+- No runtime behavior change
+
+### Risks & unknowns
+
+| Risk / unknown | Mitigation |
+|---|---|
+| Docs drift from code if weights change later | Cite `hybrid.py` defaults explicitly; keep example tied to current constructor signatures |
+| Over-documenting internal helpers (`_get_all_chunks`) | Stick to scoring/ranking surface; don’t expand into full retrieval pipeline redesign |
+| Possible keyword-path quirk: `retrieve()` calls `_get_all_chunks` but does not obviously call `keyword_searcher.index(...)` before `search` | Investigate only if needed for accurate wording; **do not expand #36 into a behavior bugfix** unless issue scope changes — note for office hours if keyword channel is empty in practice |
+| Example numbers confuse readers if they assume absolute BM25 scale | Emphasize that normalization is relative to the **current candidate set’s max**, not a global constant |
+
+### Edge cases
+
+Document (or at least acknowledge in the example / caveats) that the implementation handles:
+
+- **Missing from one channel:** chunk only in vector or only in keyword → other channel score treated as `0.0` before blending.
+- **Empty candidate set / max = 0:** code uses `default=1.0` for max and guards `max > 0` when dividing — avoid divide-by-zero; blended may be `0` and drop under `min_score`.
+- **Equal weights vs defaults:** constructor allows other weights; docs should label `0.7` / `0.3` as **defaults**, not hard-coded forever.
+- **Threshold boundary:** `blended == 0.3` is kept (`>= min_score`); below is filtered out.
+- **Tie / ordering:** results sorted by blended score descending; document that top-`max_chunks` are returned after filter.
+
+---
+
+*Living document — update in Week 9 if the doc section’s final shape differs.*

--- a/PLAN.md
+++ b/PLAN.md
@@ -74,4 +74,4 @@ Document (or at least acknowledge in the example / caveats) that the implementat
 
 ---
 
-*Living document — update in Week 9 if the doc section’s final shape differs.*
+*Living document — Week 9: ARCHITECTURE.md hybrid scoring subsection implemented; doc acceptance tests should now pass.*

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -59,6 +59,58 @@ A plan-execute orchestrator that coordinates multiple analysis tools. Each tool 
 ### RAG System (`rag/`)
 Hybrid retrieval (vector similarity + BM25 keyword) fetches relevant context from the user's ingested documents. The generator uses prompt templates to produce structured, evidence-based feedback. The evaluator scores retrieval relevance and generation faithfulness.
 
+#### Hybrid retrieval scoring
+
+Ranking is implemented in `HybridRetriever` (`rag/retriever/hybrid.py`). Vector hits come from `rag/retriever/vector_store.py`; keyword hits come from BM25 in `rag/retriever/keyword_search.py`. For each candidate chunk id that appears in either channel, PathReview builds a **blended** score as follows.
+
+**1. Per-channel max-normalization** (relative to the current candidate set, not a global constant):
+
+```text
+vector_norm  = raw_vector_score / max(raw_vector_scores_in_candidate_set)
+keyword_norm = raw_bm25_score   / max(raw_bm25_scores_in_candidate_set)
+```
+
+If a chunk is missing from one channel, that channel’s normalized score is treated as `0.0`. Empty candidate sets use a safe default max of `1.0` so division does not blow up.
+
+**2. Weighted blend** (constructor defaults):
+
+| Parameter | Default | Meaning |
+|---|---|---|
+| `vector_weight` | **0.7** | Weight on normalized vector similarity |
+| `keyword_weight` | **0.3** | Weight on normalized BM25 keyword score |
+
+```text
+blended = vector_weight * vector_norm + keyword_weight * keyword_norm
+```
+
+With the defaults this is:
+
+```text
+blended = 0.7 * vector_norm + 0.3 * keyword_norm
+```
+
+Weights are configurable on `HybridRetriever`; the table above documents the defaults shipped in code.
+
+**3. Filter, sort, truncate**
+
+- Drop candidates with `blended < min_score` (default **`min_score=0.3`**; equality is kept via `>=`).
+- Sort remaining results by blended score descending.
+- Return the top `max_chunks` (default `10`).
+
+Each returned row includes `score` (blended), plus the normalized `vector_score` and `keyword_score` for debugging.
+
+**Worked example**
+
+Suppose the candidate set’s max raw vector score is `1.0` and max raw BM25 score is `10.0`. For one chunk with raw vector `0.9` and raw BM25 `6.0`:
+
+```text
+vector_norm  = 0.9 / 1.0 = 0.90
+keyword_norm = 6.0 / 10.0 = 0.60
+blended      = 0.7 * 0.90 + 0.3 * 0.60 = 0.63 + 0.18 = 0.81
+```
+
+`0.81 >= 0.3`, so the chunk is kept and can rank above weaker blends. A chunk with blended `0.25` would be filtered out by the default threshold.
+
 ### Safety Layer (`safety/`)
 Middleware wrapping the generation pipeline. Components run in sequence: prompt injection defense → content filter → bias detector → PII scrubber. All safety events are logged with structured metadata for monitoring.
 

--- a/docs/issue-36-reproduction.md
+++ b/docs/issue-36-reproduction.md
@@ -1,0 +1,38 @@
+# Issue #36 — Local reproduction notes
+
+**Issue:** [Architecture doc doesn't explain the hybrid retrieval scoring formula](https://github.com/ascherj/pathreview/issues/36)  
+**Branch:** `docs/36-hybrid-retrieval-scoring`  
+**Type:** Documentation gap (not a runtime crash)
+
+## How to reproduce
+
+1. Open `docs/ARCHITECTURE.md` → section **RAG System (`rag/`)**.
+2. Observe it only says hybrid retrieval uses “vector similarity + BM25 keyword” — no formula, no weights, no threshold, no example.
+3. Open `rag/retriever/hybrid.py` → `HybridRetriever.__init__` and `retrieve`.
+4. Confirm the real scoring logic lives in code only:
+   - defaults: `vector_weight=0.7`, `keyword_weight=0.3`
+   - normalize each channel by its max score in the candidate set
+   - `blended = vector_weight * vector_norm + keyword_weight * keyword_norm`
+   - keep rows with `blended >= min_score` (default `0.3`), sort desc, truncate to `max_chunks`
+
+## Observed gap (expected vs actual)
+
+| | |
+|---|---|
+| **Expected** | Contributors can learn from ARCHITECTURE.md how ranking works and how to tune weights / `min_score`. |
+| **Actual** | ARCHITECTURE.md is high-level only; scoring details exist only in `hybrid.py`. |
+
+## Automated reproduction
+
+```bash
+pytest tests/unit/test_architecture_hybrid_docs.py -v
+```
+
+These three tests **fail today** because the docs lack the required content. After the Week 9 doc fix, they should pass.
+
+## Manual quote check (optional)
+
+```bash
+rg -n -i "hybrid|bm25|vector_weight|min_score|0\\.7|blend" docs/ARCHITECTURE.md
+rg -n "vector_weight|keyword_weight|min_score|blended_score" rag/retriever/hybrid.py
+```

--- a/docs/issue-36-reproduction.md
+++ b/docs/issue-36-reproduction.md
@@ -28,7 +28,7 @@
 pytest tests/unit/test_architecture_hybrid_docs.py -v
 ```
 
-These three tests **fail today** because the docs lack the required content. After the Week 9 doc fix, they should pass.
+These three tests **failed during Week 8** while the docs gap existed. After the Week 9 `ARCHITECTURE.md` fix they should **pass**.
 
 ## Manual quote check (optional)
 

--- a/tests/unit/test_architecture_hybrid_docs.py
+++ b/tests/unit/test_architecture_hybrid_docs.py
@@ -1,0 +1,53 @@
+"""Reproduction for issue #36: ARCHITECTURE.md missing hybrid scoring docs.
+
+These tests encode the documentation gap. They fail today (Week 8) because
+docs/ARCHITECTURE.md only mentions hybrid retrieval at a high level. They
+should pass after Week 9 when the scoring formula, defaults, and an example
+are added under the RAG System section.
+"""
+
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+ARCHITECTURE = ROOT / "docs" / "ARCHITECTURE.md"
+
+
+@pytest.fixture(scope="module")
+def architecture_text() -> str:
+    assert ARCHITECTURE.exists(), f"Missing {ARCHITECTURE}"
+    return ARCHITECTURE.read_text(encoding="utf-8")
+
+
+@pytest.mark.unit
+class TestArchitectureHybridScoringDocs:
+    """Issue #36 reproduction: expected docs content is currently absent."""
+
+    def test_documents_default_vector_and_keyword_weights(self, architecture_text: str) -> None:
+        """ARCHITECTURE.md should name the default blend weights from HybridRetriever."""
+        lower = architecture_text.lower()
+        assert "0.7" in architecture_text or "vector_weight" in lower, (
+            "docs/ARCHITECTURE.md does not document vector_weight default 0.7 "
+            "(see rag/retriever/hybrid.py HybridRetriever.__init__)"
+        )
+        assert "0.3" in architecture_text and (
+            "keyword_weight" in lower or "bm25" in lower or "keyword" in lower
+        ), "docs/ARCHITECTURE.md does not document keyword_weight default 0.3"
+
+    def test_documents_score_normalization_and_blend_formula(self, architecture_text: str) -> None:
+        """ARCHITECTURE.md should explain per-channel max-normalization + weighted sum."""
+        lower = architecture_text.lower()
+        mentions_normalize = "normal" in lower or "max" in lower
+        mentions_blend = "blend" in lower or "weight" in lower or "formula" in lower
+        assert mentions_normalize and mentions_blend, (
+            "docs/ARCHITECTURE.md does not explain how vector/BM25 scores are "
+            "normalized and blended (see HybridRetriever.retrieve)"
+        )
+
+    def test_documents_min_score_threshold(self, architecture_text: str) -> None:
+        """ARCHITECTURE.md should document the default min_score filter (0.3)."""
+        lower = architecture_text.lower()
+        assert "min_score" in lower or (
+            "threshold" in lower and "0.3" in architecture_text
+        ), "docs/ARCHITECTURE.md does not document min_score=0.3 filtering"


### PR DESCRIPTION
## Summary
Documents PathReview's hybrid retrieval scoring in `docs/ARCHITECTURE.md` so contributors can see how vector and BM25 scores are normalized, weighted, filtered, and ranked — details that previously lived only in `rag/retriever/hybrid.py`.

## Issue
Closes #36

## Changes
- Added a **Hybrid retrieval scoring** subsection under RAG System in `docs/ARCHITECTURE.md` covering:
  - per-channel max-normalization
  - default weights (`vector_weight=0.7`, `keyword_weight=0.3`)
  - blended-score formula
  - `min_score` threshold (default `0.3`), sort, and `max_chunks` truncate
  - a short worked numeric example
  - pointers to `hybrid.py` / vector / keyword modules
- Kept Week 8 acceptance tests in `tests/unit/test_architecture_hybrid_docs.py` (now passing)
- Updated `PLAN.md` and `docs/issue-36-reproduction.md` to reflect the fix

## Testing
- [x] Unit tests pass for this change (`pytest tests/unit/test_architecture_hybrid_docs.py` → 3 passed)
- [ ] Integration tests pass (`make test-integration`) — N/A for docs-only change
- [x] Linter passes on touched Python test file (`ruff` / `black`)
- [x] Type checker passes on touched test file (`mypy` via pre-commit)
- [x] New/updated tests cover the changes (architecture-doc acceptance tests)

### Pre-existing failures (unrelated to this PR)
Per CONTRIBUTING / course guidance: full-repo `make check` and `make test-unit` already report many failures outside this issue (e.g. ruff F841 across unrelated tests; ~53 failing unit tests in bias/pii/resume/review modules). **This PR does not introduce or worsen those.** Targeted verification:

```bash
pytest tests/unit/test_architecture_hybrid_docs.py -v   # 3 passed
ruff check tests/unit/test_architecture_hybrid_docs.py  # clean
```

## Screenshots / Demo
Docs-only — see the new subsection in `docs/ARCHITECTURE.md` under RAG System.

## Notes for Reviewers
- Tier 1 / docs-only; no runtime behavior change.
- Formula and defaults match `HybridRetriever` in `rag/retriever/hybrid.py`.
