### PR TITLE
Fix/Safety/151 - Expanding Bias Detector Patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ htmlcov/
 
 # Build artifacts
 *.pyc
+
+notes.txt

--- a/.gitignore
+++ b/.gitignore
@@ -44,5 +44,5 @@ htmlcov/
 
 # Build artifacts
 *.pyc
-
+AI-FIX.md
 notes.txt

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -13,7 +13,7 @@ would accomplish. Naming the part of the codebase it affects is helpful context.
 
 In safety/bias_detector.py we see regex patterns used here to create bias detectors. These bias detectors are too narrow and are misclassifying common phrases. A successful fix will widen regex patterns to detect common phrases instead of looking at specific phrases to detect bias. 
 
-**Branch name:** [paste branch name here]
+**Branch name:** fix/safety/151-expanding-bias-detector-patterns
 
 **Setup confirmation:** [X] App runs locally at localhost:5173
 
@@ -31,9 +31,40 @@ In safety/bias_detector.py we see regex patterns used here to create bias detect
 [1–2 sentences: How did you reproduce the issue? What did you observe?]
 I reproduced the issue by running the test suite. I observed that the bias patterns were too specific and caused the test cases to fail. 
 
-**PLAN.md link:** [link to PLAN.md in your fork]
+**PLAN.md link:** [https://github.com/snugcoder/pathreview/blob/fix/safety/151-expanding-bias-detector-patterns/PLAN.md]
 
 **Walkthrough video (recommended):** [link to your Loom video, ≤2 min — shared for early feedback]
 
 **Blockers or open questions:**
-[Anything you're still uncertain about going into Week 9, or leave blank]
+
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+[I have implemented all steps from PLAN.md]
+
+**Next steps:**
+[I am working on any additional testing that may be needed before closing this PR]
+
+**Blockers:**
+[Only my PC]
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [link to your submitted pull request]
+
+**Branch:** `fix/safety/151-expanding-bias-detector-patterns`
+
+**What you built:**
+[This fix included creating a new system for determining bias patterns. Instead of strict regex pattern matching, the bias_detector.py file now uses a series of input normalization and cleaning, before checking its phrases against a dictionary of phrases. To be determined as biased, it must match at least 6 words from the dictionary. It also takes into account dismissive phrases such as not, lack, etc, to be as accurate as possible for bias detection.]
+
+**Tests added or updated:**
+I had to update all the tests in order to pass make check and CI, but I added new test cases testing different cases in phrasing, whitespace, precise phrasing found in the dictionary, as well as words not placed into the dictionary. 
+
+**Self-review confirmation:** [X] make check passes  [X] make test-unit passes
+
+**Draft PR feedback received from:** Adejola Ogunsan

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -13,7 +13,7 @@ would accomplish. Naming the part of the codebase it affects is helpful context.
 
 In safety/bias_detector.py we see regex patterns used here to create bias detectors. These bias detectors are too narrow and are misclassifying common phrases. A successful fix will widen regex patterns to detect common phrases instead of looking at specific phrases to detect bias. 
 
-**Branch name:** [paste branch name here]
+**Branch name:** [151-expanding-bias-detector-patterns]
 
 **Setup confirmation:** [X] App runs locally at localhost:5173
 
@@ -25,13 +25,13 @@ In safety/bias_detector.py we see regex patterns used here to create bias detect
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [link to commit documenting the reproduced issue]
+**Reproduction commit link:** [[link to commit documenting the reproduced issue](https://github.com/snugcoder/pathreview/commit/54a5200621d29914b07fee43eba33661a745bfad)]
 
 **Reproduction summary:**
 [1–2 sentences: How did you reproduce the issue? What did you observe?]
 I reproduced the issue by running the test suite. I observed that the bias patterns were too specific and caused the test cases to fail. 
 
-**PLAN.md link:** [link to PLAN.md in your fork]
+**PLAN.md link:** [[link to PLAN.md in your fork](https://github.com/snugcoder/pathreview/blob/fix/safety/151-expanding-bias-detector-patterns/PLAN.md)]
 
 **Walkthrough video (recommended):** [link to your Loom video, ≤2 min — shared for early feedback]
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -13,7 +13,7 @@ would accomplish. Naming the part of the codebase it affects is helpful context.
 
 In safety/bias_detector.py we see regex patterns used here to create bias detectors. These bias detectors are too narrow and are misclassifying common phrases. A successful fix will widen regex patterns to detect common phrases instead of looking at specific phrases to detect bias. 
 
-**Branch name:** fix/safety/151-expanding-bias-detector-patterns
+**Branch name:** [paste branch name here]
 
 **Setup confirmation:** [X] App runs locally at localhost:5173
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -18,3 +18,22 @@ In safety/bias_detector.py we see regex patterns used here to create bias detect
 **Setup confirmation:** [X] App runs locally at localhost:5173
 
 **Cohort ledger:** [X] Issue added to cohort ledger
+
+<br>
+<br>
+
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [link to commit documenting the reproduced issue]
+
+**Reproduction summary:**
+[1–2 sentences: How did you reproduce the issue? What did you observe?]
+I reproduced the issue by running the test suite. I observed that the bias patterns were too specific and caused the test cases to fail. 
+
+**PLAN.md link:** [link to PLAN.md in your fork]
+
+**Walkthrough video (recommended):** [link to your Loom video, ≤2 min — shared for early feedback]
+
+**Blockers or open questions:**
+[Anything you're still uncertain about going into Week 9, or leave blank]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,20 @@
+## Week 7 — Issue selection
+
+**Issue link:** [[paste link here](https://github.com/ascherj/pathreview/issues/151)]
+
+**Issue title:** Bias detector patterns are too narrow to match common phrasings
+
+**Tier:** [X] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+[In 3–5 sentences, in your own words: what the issue is (not a copy-paste of
+the title), what is currently broken or missing, and what a successful fix
+would accomplish. Naming the part of the codebase it affects is helpful context.]
+
+In safety/bias_detector.py we see regex patterns used here to create bias detectors. These bias detectors are too narrow and are misclassifying common phrases. A successful fix will widen regex patterns to detect common phrases instead of looking at specific phrases to detect bias. 
+
+**Branch name:** [paste branch name here]
+
+**Setup confirmation:** [X] App runs locally at localhost:5173
+
+**Cohort ledger:** [X] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -37,3 +37,71 @@ I reproduced the issue by running the test suite. I observed that the bias patte
 
 **Blockers or open questions:**
 [Anything you're still uncertain about going into Week 9, or leave blank]
+<br>
+<br>
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+[I have implemented all steps from PLAN.md]
+
+**Next steps:**
+[I am working on any additional testing that may be needed before closing this PR]
+
+**Blockers:**
+[Only my PC]
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [link to your submitted pull request]
+
+**Branch:** `fix/safety/151-expanding-bias-detector-patterns`
+
+**What you built:**
+[This fix included creating a new system for determining bias patterns. Instead of strict regex pattern matching, the bias_detector.py file now uses a series of input normalization and cleaning, before checking its phrases against a dictionary of phrases. To be determined as biased, it must match at least 6 words from the dictionary. It also takes into account dismissive phrases such as not, lack, etc, to be as accurate as possible for bias detection.]
+
+**Tests added or updated:**
+I had to update all the tests in order to pass make check and CI, but I added new test cases testing different cases in phrasing, whitespace, precise phrasing found in the dictionary, as well as words not placed into the dictionary. 
+
+**Self-review confirmation:** [X] make check passes  [X] make test-unit passes
+
+**Draft PR feedback received from:** N/A
+
+<br>
+<br>
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [X] No — still awaiting review
+
+**Summary of feedback:**
+[What did reviewers comment on? Or note that no review came in.]
+
+**How you responded:**
+[What changes did you make, or what did you reply? If no feedback,
+leave blank.]
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Understanding which components were needed for bias detection. It was hard to understand how the different pieces fit in at first, but eventually it started to make sense. 
+
+**What did you learn about working in a large codebase?**
+Contributing to a large codebase requires conscious development -> continuous integration, robust testing, and pull requests to ensure that fixes and features are correct and apply to the correct changes to the right places. 
+
+**How did AI tools help — and where did they fall short?**
+AI tools helped to determine the shortcomings of REGEX (in my case) and what patterns to include in semantic bias detection for recognition within the already existing frame of development. It was bad at understanding the context of the codebase even with the knowledge of the codebase. I wou
+
+**What would you do differently if you started over?**
+I would pick another tier that connects to more parts within the codebase to learn more about the codebase. 
+
+**What are you most proud of from this module?**
+I am most proud of being able to connect all the moving parts in the project. 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,41 @@
+## Solution plan
+
+**Issue:** #151: Bias detector patterns are too narrow to match common phrasings 
+
+### Understand
+What is the root cause of this issue? What behavior is expected vs. actual?
+
+This issue is caused by the regex patterns creating a strict template to match against all phrases fed into testing. We expect the bias_detector to use common words to match against phrases to determine whether the entire statement is dismissive or 
+
+### Map
+Which files, functions, or modules are involved?
+List the specific files you expect to touch.
+
+I expect to touch the following files.
+- Files included
+   -  `safety/bias_detector.py`
+    - `tests/unit/test_bias_detector.py`
+
+### Plan
+What are the steps to fix this issue?
+Break it into 3–5 concrete sub-tasks.
+
+1. Create two categories for classification -> Subject + Dismissive. Subject denotes who/what is being judged (online course, bootcamp, immigrant, etc..) Dismissive denotes the negative judgement (can't, not, struggle, lack, etc..). 
+2. The idea is to match at least 6 words within the phrase to determine whether it is biased. Replacing regex character matching with re.fullmatch helps to create a more robust way of properly assessing negative semantic meaning
+3. Then I included a negation guard to make sure less false negatives are applied to the output. 
+
+### Inputs & outputs
+What does your fix take as input? What should it produce or change?
+
+This fix allows the same inputs, but just adjusts the parameters for bias detection
+
+### Risks & unknowns
+What could go wrong? What are you still unsure about?
+
+If a different type of phrase is entered through the bias detector that doesn't have any of the matching dismissive or subject values, it could still cause errors. 
+### Edge cases
+What inputs or states should your fix handle gracefully?
+
+I added a normalizer to make all inputs clean. This way if there is a hyphen between words like self-taught, all iterations of the spelling will be treated the same.
+
+****

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -99,7 +99,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -449,7 +448,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -473,7 +471,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1561,7 +1558,6 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1579,7 +1575,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1972,7 +1967,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3507,7 +3501,6 @@
       "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^2.0.1",
         "cssstyle": "^4.0.1",
@@ -4094,7 +4087,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4107,7 +4099,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4771,7 +4762,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/safety/bias_detector.py
+++ b/safety/bias_detector.py
@@ -1,32 +1,129 @@
 """Bias detection in generated feedback."""
 
 import re
+import unicodedata
+
 import structlog
 
 logger = structlog.get_logger()
 
 
 class BiasDetector:
-    """Detect biased language in feedback."""
+    """Detect biased language in feedback via lexicon + proximity.
 
-    # Genuinely dismissive phrases about educational background
-    DISMISSIVE_PATTERNS = [
-        r"(?:bootcamp|self-taught|online\s+course)\s+(?:education|training)\s+is\s+(?:insufficient|inadequate|lacks)",
-        r"(?:bootcamp|self-taught)\s+(?:graduates?|developers?)\s+(?:lack|missing)\s+(?:rigor|fundamentals|proper\s+training)",
-        r"(?:bootcamp|coding\s+bootcamp)\s+(?:doesn't|does\s+not)\s+prepare\s+(?:you|developers?)",
-        r"(?:self-taught|bootcamp)\s+is\s+(?:not|never)\s+(?:equal|comparable)\s+to\s+(?:university|traditional|formal)",
+    Rather than matching rigid full-sentence templates, we detect when a
+    *subject* (the person/background being judged) and a *dismissive*
+    predicate (the negative judgment) co-occur within a small word window.
+    This raises recall (catches novel phrasings) while the proximity window
+    and a negation guard keep false positives low.
+    """
+
+    # Subjects being judged, keyed by the reason reported when matched.
+    SUBJECTS = {
+        "Dismissive language about educational background": [
+            "bootcamp",
+            "coding bootcamp",
+            "self taught",
+            "online course",
+            "online class",
+            "non traditional",
+        ],
+        "Demographic assumptions detected": [
+            "young developer",
+            "young programmer",
+            "old developer",
+            "old programmer",
+            "aged developer",
+            "aged programmer",
+            "immigrant developer",
+            "international developer",
+            "foreign developer",
+            "person from poor",
+            "person from rich",
+            "working class",
+            "poor background",
+            "rich background",
+        ],
+    }
+
+    # Dismissive predicates. Innocuous single words (e.g. "fundamentals") are
+    # deliberately excluded; only the dismissive term ("lack") qualifies.
+    DISMISSIVE = [
+        "cannot",
+        "can not",
+        "cant",
+        "wont",
+        "will not",
+        "never",
+        "insufficient",
+        "inadequate",
+        "inferior",
+        "not equal",
+        "not comparable",
+        "struggle",
+        "lack",
+        "lacking",
+        "missing",
+        "not real",
+        "doesnt count",
+        "doesnt prepare",
+        "not prepared",
+        "not enough",
+        "not qualified",
+        "cant afford",
+        "cant handle",
+        "cant write",
+        "cant code",
     ]
 
-    # Demographic assumptions (about age, background, identity)
-    DEMOGRAPHIC_PATTERNS = [
-        r"(?:young|old|aged)\s+(?:person|developer|programmer)\s+(?:can't|cannot|won't|will\s+not)",
-        r"(?:person\s+from|coming\s+from)\s+(?:poor|rich|working[\s-]?class)",
-        r"(?:immigrant|international|foreign)\s+developers?.*(?:can't|cannot|won't|struggle)",
-    ]
+    # A dismissive term immediately preceded by one of these is negated
+    # ("don't lack rigor") and should not be flagged.
+    NEGATIONS = {"not", "never", "no", "isnt", "arent", "dont", "doesnt"}
+
+    # Max word-token gap between a subject and a dismissive term.
+    WINDOW = 6
+
+    @staticmethod
+    def _normalize(text: str) -> list[str]:
+        """Normalize text and return word tokens.
+
+        Handles Unicode/zero-width evasion, hyphen and apostrophe variants,
+        and collapses whitespace.
+        """
+        text = unicodedata.normalize("NFKC", text)
+        # Drop format/zero-width chars (e.g. U+200B) used to split keywords.
+        text = "".join(c for c in text if unicodedata.category(c) != "Cf")
+        text = text.lower().replace("-", " ")
+        # Delete apostrophes so "can't" -> "cant" before other punctuation is
+        # turned into whitespace (otherwise "can't" would split into "can t").
+        text = text.replace("'", "").replace("’", "")
+        text = re.sub(r"[^a-z0-9\s]", " ", text)
+        return text.split()
+
+    @staticmethod
+    def _word_match(word: str, token: str) -> bool:
+        """Match a lexicon word to a token, tolerating a plural 's' suffix."""
+        return re.fullmatch(re.escape(word) + "s?", token) is not None
+
+    @staticmethod
+    def _spans(tokens: list[str], phrases: list[str]) -> list[tuple[int, int]]:
+        """Return (start, end) token-index spans where any phrase matches."""
+        hits = []
+        for phrase in phrases:
+            words = phrase.split()
+            n = len(words)
+            for i in range(len(tokens) - n + 1):
+                if all(BiasDetector._word_match(w, tokens[i + j]) for j, w in enumerate(words)):
+                    hits.append((i, i + n - 1))
+        return hits
 
     @staticmethod
     def detect_bias(text: str) -> tuple[bool, str]:
         """Detect biased language in feedback.
+
+        Flags when a subject term and a dismissive term co-occur within
+        WINDOW words of each other and the dismissal is not itself negated
+        (i.e "bootcamp not qualified.").
 
         Args:
             text: Feedback text
@@ -34,18 +131,19 @@ class BiasDetector:
         Returns:
             Tuple of (is_biased, reason)
         """
-        # Check for dismissive language about education
-        for pattern in BiasDetector.DISMISSIVE_PATTERNS:
-            if re.search(pattern, text, re.IGNORECASE):
-                reason = "Dismissive language about educational background"
-                logger.warning("bias_detected", reason=reason)
-                return True, reason
+        tokens = BiasDetector._normalize(text)
+        pred_spans = BiasDetector._spans(tokens, BiasDetector.DISMISSIVE)
 
-        # Check for demographic assumptions
-        for pattern in BiasDetector.DEMOGRAPHIC_PATTERNS:
-            if re.search(pattern, text, re.IGNORECASE):
-                reason = "Demographic assumptions detected"
-                logger.warning("bias_detected", reason=reason)
-                return True, reason
+        for reason, subjects in BiasDetector.SUBJECTS.items():
+            for s_start, s_end in BiasDetector._spans(tokens, subjects):
+                for p_start, p_end in pred_spans:
+                    gap = max(s_start - p_end, p_start - s_end)
+                    if gap > BiasDetector.WINDOW:
+                        continue
+                    # Skip negated dismissals ("...don't lack rigor...").
+                    if p_start > 0 and tokens[p_start - 1] in BiasDetector.NEGATIONS:
+                        continue
+                    logger.warning("bias_detected", reason=reason)
+                    return True, reason
 
         return False, ""

--- a/tests/unit/test_bias_detector.py
+++ b/tests/unit/test_bias_detector.py
@@ -9,16 +9,16 @@ from safety.bias_detector import BiasDetector
 class TestBiasDetector:
     """Test suite for BiasDetector."""
 
-    def test_dismissive_bootcamp_language_detected(self):
+    def test_dismissive_bootcamp_language_detected(self) -> None:
         """Test dismissive bootcamp language is detected as biased."""
         text = "bootcamp graduates can't write production code"
 
         is_biased, reason = BiasDetector.detect_bias(text)
 
-        assert is_biased is True
-        assert reason != ""
+        assert is_biased is True  # The result is biases
+        assert reason != ""  # Return the reason passed in from bias_detector.py
 
-    def test_bootcamp_lacks_rigor_detected(self):
+    def test_bootcamp_lacks_rigor_detected(self) -> None:
         """Test 'bootcamp lacks rigor' language detected."""
         text = "bootcamp education lacks fundamentals"
 
@@ -26,7 +26,7 @@ class TestBiasDetector:
 
         assert is_biased is True
 
-    def test_bootcamp_inadequate_training_detected(self):
+    def test_bootcamp_inadequate_training_detected(self) -> None:
         """Test 'bootcamp inadequate training' language detected."""
         text = "bootcamp training is inadequate for professional development"
 
@@ -34,7 +34,7 @@ class TestBiasDetector:
 
         assert is_biased is True
 
-    def test_self_taught_comparison_detected(self):
+    def test_self_taught_comparison_detected(self) -> None:
         """Test self-taught vs traditional comparison detected."""
         text = "self-taught is never comparable to university education"
 
@@ -42,7 +42,7 @@ class TestBiasDetector:
 
         assert is_biased is True
 
-    def test_positive_bootcamp_mention_not_flagged(self):
+    def test_positive_bootcamp_mention_not_flagged(self) -> None:
         """Test positive bootcamp mention is NOT flagged as biased."""
         text = "your bootcamp background shows strong fundamentals and problem-solving skills"
 
@@ -50,7 +50,7 @@ class TestBiasDetector:
 
         assert is_biased is False
 
-    def test_neutral_bootcamp_mention_not_flagged(self):
+    def test_neutral_bootcamp_mention_not_flagged(self) -> None:
         """Test neutral bootcamp mention is NOT flagged."""
         text = "this bootcamp project demonstrates good coding practices"
 
@@ -58,7 +58,7 @@ class TestBiasDetector:
 
         assert is_biased is False
 
-    def test_educational_background_positive_not_flagged(self):
+    def test_educational_background_positive_not_flagged(self) -> None:
         """Test positive educational background mention not flagged."""
         text = "your bootcamp training has given you a solid foundation"
 
@@ -66,7 +66,7 @@ class TestBiasDetector:
 
         assert is_biased is False
 
-    def test_demographic_assumption_age_detected(self):
+    def test_demographic_assumption_age_detected(self) -> None:
         """Test demographic assumption about age detected."""
         text = "young developers can't handle complex systems"
 
@@ -75,7 +75,7 @@ class TestBiasDetector:
         assert is_biased is True
         assert "demographic" in reason.lower()
 
-    def test_demographic_assumption_old_detected(self):
+    def test_demographic_assumption_old_detected(self) -> None:
         """Test age assumption about older developers detected."""
         text = "old aged programmer won't be able to learn new technologies"
 
@@ -83,7 +83,7 @@ class TestBiasDetector:
 
         assert is_biased is True
 
-    def test_demographic_assumption_background_detected(self):
+    def test_demographic_assumption_background_detected(self) -> None:
         """Test background assumption detected."""
         text = "person from poor background can't afford proper training"
 
@@ -91,7 +91,7 @@ class TestBiasDetector:
 
         assert is_biased is True
 
-    def test_immigrant_developer_assumption_detected(self):
+    def test_immigrant_developer_assumption_detected(self) -> None:
         """Test assumption about immigrant developers detected."""
         text = "immigrant developers can't communicate effectively in code reviews"
 
@@ -99,7 +99,7 @@ class TestBiasDetector:
 
         assert is_biased is True
 
-    def test_international_developer_assumption_detected(self):
+    def test_international_developer_assumption_detected(self) -> None:
         """Test assumption about international developers detected."""
         text = "international developers struggle with American coding standards"
 
@@ -107,23 +107,28 @@ class TestBiasDetector:
 
         assert is_biased is True
 
-    def test_clean_feedback_not_flagged(self):
+    def test_clean_feedback_not_flagged(self) -> None:
         """Test clean, objective feedback is not flagged."""
-        text = "You have demonstrated strong Python skills. Your code is well-organized and follows best practices."
+        text = (
+            "You have demonstrated strong Python skills. "
+            "Your code is well-organized and follows best practices."
+        )
 
         is_biased, reason = BiasDetector.detect_bias(text)
 
         assert is_biased is False
 
-    def test_technical_feedback_not_flagged(self):
+    def test_technical_feedback_not_flagged(self) -> None:
         """Test pure technical feedback not flagged."""
-        text = "Consider adding error handling to your API endpoints and documenting the parameters."
+        text = (
+            "Consider adding error handling to your API endpoints and documenting the parameters."
+        )
 
         is_biased, reason = BiasDetector.detect_bias(text)
 
         assert is_biased is False
 
-    def test_development_suggestion_not_flagged(self):
+    def test_development_suggestion_not_flagged(self) -> None:
         """Test development suggestions not flagged."""
         text = "To improve your portfolio, try learning Kubernetes and contributing to open source."
 
@@ -131,7 +136,7 @@ class TestBiasDetector:
 
         assert is_biased is False
 
-    def test_case_insensitive_detection(self):
+    def test_case_insensitive_detection(self) -> None:
         """Test detection is case insensitive."""
         text = "BOOTCAMP GRADUATES LACK FUNDAMENTALS"
 
@@ -139,7 +144,7 @@ class TestBiasDetector:
 
         assert is_biased is True
 
-    def test_return_value_structure(self):
+    def test_return_value_structure(self) -> None:
         """Test return value has correct structure."""
         text = "some feedback"
         result = BiasDetector.detect_bias(text)
@@ -150,7 +155,7 @@ class TestBiasDetector:
         assert isinstance(is_biased, bool)
         assert isinstance(reason, str)
 
-    def test_unbiased_returns_empty_reason(self):
+    def test_unbiased_returns_empty_reason(self) -> None:
         """Test unbiased feedback returns empty reason string."""
         text = "Great coding skills"
 
@@ -159,7 +164,7 @@ class TestBiasDetector:
         if is_biased is False:
             assert reason == ""
 
-    def test_biased_returns_reason(self):
+    def test_biased_returns_reason(self) -> None:
         """Test biased feedback returns non-empty reason."""
         text = "bootcamp graduates can't code"
 
@@ -169,19 +174,19 @@ class TestBiasDetector:
             assert reason != ""
             assert len(reason) > 0
 
-    def test_empty_text(self):
+    def test_empty_text(self) -> None:
         """Test with empty text."""
         is_biased, reason = BiasDetector.detect_bias("")
 
         assert is_biased is False
 
-    def test_whitespace_only(self):
+    def test_whitespace_only(self) -> None:
         """Test with whitespace only."""
         is_biased, reason = BiasDetector.detect_bias("   \n\t  ")
 
         assert is_biased is False
 
-    def test_coding_bootcamp_variant(self):
+    def test_coding_bootcamp_variant(self) -> None:
         """Test 'coding bootcamp' variant is detected."""
         text = "coding bootcamp graduates can't write enterprise code"
 
@@ -189,7 +194,7 @@ class TestBiasDetector:
 
         assert is_biased is True
 
-    def test_online_course_bias_detected(self):
+    def test_online_course_bias_detected(self) -> None:
         """Test online course dismissal detected."""
         text = "online course education is insufficient for real work"
 
@@ -197,7 +202,7 @@ class TestBiasDetector:
 
         assert is_biased is True
 
-    def test_developer_vs_programmer_distinction(self):
+    def test_developer_vs_programmer_distinction(self) -> None:
         """Test both developer and programmer terms detected."""
         text_dev = "bootcamp developers can't handle production systems"
         text_prog = "bootcamp programmers lack proper training"
@@ -208,15 +213,17 @@ class TestBiasDetector:
         assert is_biased_dev is True
         assert is_biased_prog is True
 
-    def test_multiple_bias_indicators(self):
+    def test_multiple_bias_indicators(self) -> None:
         """Test text with multiple bias indicators."""
-        text = "young bootcamp graduates can't write code and immigrant developers lack fundamentals"
+        text = (
+            "young bootcamp graduates can't write code and immigrant developers lack fundamentals"
+        )
 
         is_biased, reason = BiasDetector.detect_bias(text)
 
         assert is_biased is True
 
-    def test_negative_educational_claim(self):
+    def test_negative_educational_claim(self) -> None:
         """Test negative claims about education detected."""
         text = "self-taught developers are not equal to university graduates"
 
@@ -224,7 +231,7 @@ class TestBiasDetector:
 
         assert is_biased is True
 
-    def test_working_class_assumption(self):
+    def test_working_class_assumption(self) -> None:
         """Test working-class assumption detected."""
         text = "person from working class background won't succeed in tech"
 
@@ -232,7 +239,7 @@ class TestBiasDetector:
 
         assert is_biased is True
 
-    def test_rich_poor_assumption(self):
+    def test_rich_poor_assumption(self) -> None:
         """Test rich/poor background assumption detected."""
         text = "developers from poor backgrounds can't afford proper tools"
 
@@ -240,7 +247,7 @@ class TestBiasDetector:
 
         assert is_biased is True
 
-    def test_foreign_developer_struggle_assumption(self):
+    def test_foreign_developer_struggle_assumption(self) -> None:
         """Test assumption about foreign developers struggling."""
         text = "foreign developers struggle with English-first codebases"
 
@@ -248,23 +255,29 @@ class TestBiasDetector:
 
         assert is_biased is True
 
-    def test_skill_assessment_not_biased(self):
+    def test_skill_assessment_not_biased(self) -> None:
         """Test skill assessment without bias language."""
-        text = "Your JavaScript skills are at an intermediate level. Practice would help advance to senior level."
+        text = (
+            "Your JavaScript skills are at an intermediate level. "
+            "Practice would help advance to senior level."
+        )
 
         is_biased, reason = BiasDetector.detect_bias(text)
 
         assert is_biased is False
 
-    def test_comparative_without_bias(self):
+    def test_comparative_without_bias(self) -> None:
         """Test comparison without biased assumptions."""
-        text = "Your bootcamp education covers practical skills. University education provides theory. Both have value."
+        text = (
+            "Your bootcamp education covers practical skills. "
+            "University education provides theory. Both have value."
+        )
 
         is_biased, reason = BiasDetector.detect_bias(text)
 
         assert is_biased is False
 
-    def test_assumption_vs_observation(self):
+    def test_assumption_vs_observation(self) -> None:
         """Test that observations are not flagged, assumptions are."""
         observation = "your resume shows bootcamp attendance"  # Factual
         assumption = "bootcamp attendance means inadequate training"  # Biased
@@ -274,3 +287,63 @@ class TestBiasDetector:
 
         assert is_biased_obs is False  # Factual
         assert is_biased_ass is True  # Biased assumption
+
+    # --- Recall / evasion resistance (missed by the old rigid templates) ---
+
+    def test_hyphen_variant_evasion(self) -> None:
+        """Test 'self taught' without a hyphen is still detected."""
+        text = "self taught developers just cant keep up"
+
+        is_biased, _ = BiasDetector.detect_bias(text)
+
+        assert is_biased is True
+
+    def test_non_template_phrasing_detected(self) -> None:
+        """Test phrasing not covered by any original template is detected."""
+        text = "bootcamp grads simply cannot handle real systems"
+
+        is_biased, _ = BiasDetector.detect_bias(text)
+
+        assert is_biased is True
+
+    def test_zero_width_char_evasion(self) -> None:
+        """Test a zero-width char splitting a keyword is still detected."""
+        text = "boot​camp graduates lack rigor"
+
+        is_biased, _ = BiasDetector.detect_bias(text)
+
+        assert is_biased is True
+
+    def test_extra_whitespace_evasion(self) -> None:
+        """Test collapsed extra whitespace is still detected."""
+        text = "bootcamp    education    is    inadequate"
+
+        is_biased, _ = BiasDetector.detect_bias(text)
+
+        assert is_biased is True
+
+    # --- Precision guards ---
+
+    def test_proximity_prevents_false_positive(self) -> None:
+        """Test subject and dismissive word far apart are not flagged."""
+        text = "Your bootcamp project is great, but the tests lack coverage."
+
+        is_biased, _ = BiasDetector.detect_bias(text)
+
+        assert is_biased is False
+
+    def test_negated_dismissal_not_flagged(self) -> None:
+        """Test a negated dismissal is not flagged."""
+        text = "bootcamp graduates don't lack rigor at all"
+
+        is_biased, _ = BiasDetector.detect_bias(text)
+
+        assert is_biased is False
+
+    def test_window_boundary_not_flagged(self) -> None:
+        """Test a dismissive term beyond the window is not flagged."""
+        text = "bootcamp is a topic and " + "word " * 10 + "the docs are inadequate"
+
+        is_biased, _ = BiasDetector.detect_bias(text)
+
+        assert is_biased is False


### PR DESCRIPTION
## Summary


## Issue
Closes #151 

## Changes
<!-- Bullet list of the specific changes made -->
- Created two dictionaries containing SUBJECTS (noun being judged) and DISMISSIVE (negative terms)
- Created a WINDOW variable as a semi-trivial number to show when to determine a phrase as biased (any lower it may be too strict, any higher it may be too loose)
- Created a normalize method to clean input for bias detection
- Created a word match method to words to the phrase passed in by span
- Created a span method to calculate the space in a phrase where any word matches the bias detector terms.
- Updated bias_detector method to feed in all the new methods, creating a new flow for bias detection, starting with first cleaning the input and creating tokens from the phrase input, creating a spans variable that uses the tokens to know which words span the phrase tokens, then counts the window distance between the tokens and accompanied phrases to capture bias. 

## Testing
<!-- How did you verify your changes? -->
- [X] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`)
- [ ] Linter passes (`make lint`)
- [ ] Type checker passes (`make typecheck`)
- [X] New/updated tests cover the changes

## Screenshots / Demo
<!-- If applicable, add screenshots or a link to a demo video -->

## Notes for Reviewers

