### PR TITLE
feat(agent): add has_tests boolean to repo analysis output

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -214,4 +214,182 @@ before starting:
 ruff errors, the 5 mypy errors, and 53 failing unit tests listed above all predate
 this branch and are unrelated to issue #50. My changes do not affect them.
 
-**Draft PR feedback received from:** [name or Slack handle, or "none"]
+**Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [*] No — still awaiting review
+
+**Summary of feedback:**
+None received. PR #299 (https://github.com/ascherj/pathreview/pull/299) was
+opened at the end of Week 9 against `ascherj/pathreview` and is still **open**
+with zero reviews, zero review comments, and no reviewers assigned as of Week 10.
+I also did not get peer feedback on the draft in Week 9, so there is no external
+input to iterate on for this entry.
+
+**How you responded:**
+With no reviewer to respond to, I spent the week reviewing my own PR as if I were
+the maintainer, and made the one change that review pass justified:
+
+- **Explanatory comments where the code is non-obvious** (commit `9c0810b`,
+  `docs(agent): explain the non-obvious parts of has_tests detection`). Reading
+  my own diff cold, three things weren't self-evident to a reviewer: *why*
+  matching happens on split path segments instead of a substring check, *why* a
+  truncated tree returns `False` instead of paginating, and *why* the tree fetch
+  swallows every exception. Those are the questions a maintainer would ask in
+  review, so I answered them in the code rather than waiting to answer them in a
+  comment thread.
+- **Re-verified the numbers still hold** after that commit, so the claims in my
+  PR description (181 ruff errors before and after, 54 → 53 failing unit tests,
+  no new failures) are still true of the branch head and not just of `616b1df`.
+- **Left the open questions in the PR description rather than resolving them
+  unilaterally**: whether truncated trees should paginate, whether the marker
+  list should grow to cover JS (`__tests__/`, `spec/`), and whether the second
+  analyzer (`ingestion/parsers/repo_analyzer.py`, which already has its own
+  `has_tests`) should eventually be consolidated with this one. Each is a scope
+  decision that belongs to a maintainer, not to a Tier 1 contributor, so I
+  flagged them and stopped.
+
+If feedback arrives after the deadline I'll address it on the same branch; the
+most likely asks are the extra GitHub API call per repo and extending the marker
+list beyond Python.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+
+The verification, not the code. The fix is about 80 lines and one dict key. What
+I did not anticipate is that on a clean checkout of this repo, **both** commands
+the self-review checkbox asks about already fail: `make check` dies at its first
+step on 181 ruff errors, and `make test-unit` reports 54 failures — all in files
+I never opened. For a while I genuinely could not honestly tick "make check
+passes," and I didn't know whether I was looking at my own damage or the repo's.
+
+What rescued it was something I did almost on instinct at the start of Week 9:
+before writing a single line, I ran both commands and saved the output. That
+baseline converted an unanswerable question ("does it pass?") into a mechanical
+one ("did my diff change the failure list?"). I could then make a claim a
+reviewer can check — 54 failed → 53 failed with **new failures: none**, and
+exactly 181 ruff errors before and after — instead of a claim they'd have to
+take on faith.
+
+The other surprise was that **reading the issue was harder than fixing it**. The
+issue and the issue manifest both named `agent/tools/repo_analyzer.py` as a
+target file. That file does not exist in the tree. Meanwhile
+`ingestion/parsers/repo_analyzer.py` *does* exist and *already* implements
+`has_tests`. So a literal reading of the issue points either at a file you can't
+edit or at a feature that's already built. Working out that the real, addressable
+gap was `GitHubTool._fetch_repo_metadata()` — and being able to defend that
+scoping in PLAN.md — took longer than implementing `_has_tests()`.
+
+**What did you learn about working in a large codebase?**
+
+On my own projects the code *is* the spec. Here the spec is scattered across the
+issue, a manifest, the existing conventions, and code that partly contradicts all
+three — and the code is the only source that can't be out of date.
+
+Concretely, four things were different:
+
+- **Existing code was a better spec than the issue.** `_has_readme()` taught me
+  more than the issue body did: it showed me the shape a helper like this is
+  supposed to have *in this repo* — the auth-header pattern, `httpx` with an
+  explicit timeout, try/except degrading to `False`, one extra call. Matching the
+  neighboring pattern is itself a form of correctness. A "better" helper that
+  didn't look like its neighbor would have been a worse contribution, because
+  the next person to read the file would have to learn two idioms instead of one.
+- **You have to check the blast radius before you think you're safe.** Adding a
+  dict key felt free, but I traced the consumer first: `agent/orchestrator.py`
+  caches `ToolResult.data` as an untyped dict with no schema, so the addition is
+  purely additive with no migration. On my own project I'd have added the key and
+  found out later.
+- **Seeing a real problem and *not* fixing it is a skill.** Two repo analyzers
+  with overlapping responsibilities is a genuine design smell, and I wanted to
+  unify them. That would have turned a reviewable Tier 1 diff into an unreviewable
+  refactor of code I don't understand the history of. Documenting it in PLAN.md
+  and leaving it was the right call.
+- **Failure modes matter more in someone else's pipeline.** The one behavior I
+  would never have written for a personal project is returning `False` on *any*
+  tree-read failure. In a portfolio-review pipeline, a GitHub rate limit must
+  degrade one boolean, not crash a user's repo analysis.
+
+**How did AI tools help — and where did they fall short?**
+
+*Where it helped.* Orientation and mechanical breadth. Locating both repo
+analyzers, finding `_has_readme` as the template, and confirming that
+`agent/tools/repo_analyzer.py` was absent took minutes instead of an afternoon of
+grepping an unfamiliar tree. It was also strong at scaling the tests once the
+pattern existed: going from my 1 reproduction test to 26 in the fixture and
+mocking style already used in `tests/unit/` was fast because the convention was
+already in the repo and could be matched. Same for drafting the verification
+write-up in Week 9 — once *I* had the numbers, turning them into precise prose
+was quick.
+
+*Where it fell short.*
+
+1. **It trusts the written record.** The manifest said
+   `agent/tools/repo_analyzer.py`, so the first plan was happily built around a
+   file that doesn't exist. AI will plan against a phantom file without blinking.
+   Checking the map against the actual tree was on me, and it was the single most
+   valuable thing I did in Week 8.
+2. **Judgment calls with no local evidence.** Whether to paginate truncated
+   trees, whether one extra API call per repo is an acceptable cost, whether to
+   touch the second analyzer — none of those are answerable from the code. They
+   depend on what a Tier 1 PR *should* be, and that's a call I had to make and
+   justify.
+3. **The design change I'm happiest with came from my own edge-case list.**
+   PLAN.md step 1 had detection and path matching in one method. Only after I
+   wrote down that `contest/` and `latest/` must not match did I see that
+   matching should be a separate pure `_path_indicates_tests()` classmethod — so
+   the false-positive traps are testable with zero HTTP mocking. That's a
+   testability instinct applied to a concrete risk, and it's the kind of thing you
+   get by writing your own edge cases before you write code.
+4. **It can't tell me whether maintainers will accept the PR.** No amount of
+   local green makes a contribution welcome. That's why I documented the
+   pre-existing failures and my scoping rationale — the parts a human reviewer
+   needs in order to trust the diff.
+
+**What would you do differently if you started over?**
+
+- **Take the baseline in Week 8, not Week 9.** It belongs next to the reproduction
+  test, because everything I can honestly claim about my changes is measured
+  against it. I got lucky that I took it before touching code; it should have been
+  a deliberate Week 8 deliverable.
+- **Read the target *function* in Week 7, not just the target file.** I confirmed
+  a file existed before claiming issue #50; I didn't confirm the function the
+  issue described existed. One read of `_fetch_repo_metadata()` in Week 7 would
+  have surfaced the whole "the named file doesn't exist and the other analyzer
+  already does this" discovery a full week earlier, which would have bought me a
+  week of review time.
+- **Open the PR as a draft mid-Week-9 and actively ask for review.** I opened it
+  at the end of Week 9 and it's still unreviewed, which is why my Week 10
+  iteration section has no external feedback in it. Review latency isn't under my
+  control, so the correct response is to expose the work as early as it's coherent
+  and ask a specific question rather than waiting until it's finished and perfect.
+- **Write the "why" comments as I go.** I added them in Week 10 (`9c0810b`) after
+  re-reading my diff as a stranger. Every one of them answers a question I had
+  already answered for myself in Week 9 — I just hadn't written it down where a
+  reviewer would see it.
+
+What I would *not* change: the reproduction-test-first order, and staying inside
+Tier 1 scope. Both made every later step easier to defend.
+
+**What are you most proud of from this module?**
+
+Not the feature — the verification paragraph in Week 9, Check-in 2. Turning "the
+checks fail and I don't know whose fault it is" into a set of specific, checkable
+claims (181 ruff errors before and exactly 181 after; 54 failing unit tests → 53;
+new failures: none; mypy and black clean on my two changed files) is the part I'd
+most want a maintainer to trust, because it's the part that lets them review my
+diff instead of the repo's pre-existing state.
+
+Runner-up: `_path_indicates_tests()` and its five false-positive traps —
+`contest/entry.py`, `latest/build.py`, `src/protest.py`, `docs/testing.md`,
+`attestation.py`. A naive `"test" in path` check flags every one of them, the
+issue's acceptance criteria didn't ask for any of them, and nobody would have
+noticed if I'd shipped without them. I found them by writing down edge cases
+before writing code, and that habit is the thing I'm actually taking out of this
+module.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,16 @@
+## Week 7 — Issue selection
+
+**Issue link:** [(https://github.com/ascherj/pathreview/issues/50)]
+
+**Issue title:** [Add a has_tests boolean to the repo analysis output #50]
+
+**Tier:** [*] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+This issue it adding detection logic to the project. This means adding logic to see if a repository has a tests/ or test/ directory, a pytest.ini, or test files matching test_*.py, and shows a boolean field in the analysis output. I am thinking for the core structural approach to either use Declarative rules or modular components and anf for the lifecycle pipeline approach using version control with git.
+
+**Branch name:** [50-dev-environment-setup]
+
+**Setup confirmation:** [*] App runs locally at localhost:5173
+
+**Cohort ledger:** [*] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -94,3 +94,17 @@ This issue it adding detection logic to the project. This means adding logic to 
 **Setup confirmation:** [*] App runs locally at localhost:5173
 
 **Cohort ledger:** [*] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/DmanDSR/pathreview/commit/ec77790306b1ba4ce36c124700b74a72c13e4b07
+
+**Reproduction summary:**
+Added a failing unit test (`tests/unit/test_github_tool.py`) that mocks the GitHub API and drives `GitHubTool._fetch_repo_metadata()` — the agent-side repo analysis tool named in issue #50. The test asserts the analysis output contains a `has_tests` boolean; it fails today because the output dict (github_tool.py:86-97) reports `has_readme` but has no `has_tests` key, confirming the gap and pinning it to that exact dict. (A separate path, `ingestion/parsers/repo_analyzer.py`, already has `has_tests` — that is out of scope; the issue targets the agent tool.)
+
+**PLAN.md link:** https://github.com/DmanDSR/pathreview/blob/chore/50-dev-environment-setup/PLAN.md
+
+**Walkthrough video (recommended):** [link to your Loom video, ≤2 min — recommended, not graded]
+
+**Blockers or open questions:**
+The manifest lists `agent/tools/repo_analyzer.py` as a target file, but it does not exist in the current tree — the agent's repo analysis lives entirely in `github_tool.py`, so that is where the fix will go. Open question for Week 9: detecting tests needs the repo file tree (an extra GitHub API call, like `_has_readme`); confirm the Git Trees API is the right approach and how to handle truncated trees on large repos.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,3 +1,83 @@
+## Part 1 — Understanding the Issue
+
+**Can I explain what this issue is asking for in my own words?**
+
+Paraphrase the issue without looking at it. If you can't, you don't understand it well enough yet. Read the full issue body, look at any linked PRs or comments, and try again.
+
+[*] I can explain the problem and the expected behavior in 2–3 sentences without reading the issue.
+
+**Do I understand which part of the app is affected?**
+
+Check the labels on the issue — they often indicate the area (api, rag, ingestion, frontend, etc.). Look at the referenced files if any are mentioned. Find those files in the repo.
+
+[*] I've located the relevant files and confirmed they exist in the codebase.
+
+**Do I understand what "done" looks like?**
+[*] Yes
+
+**Can you describe what the app should do (or not do) once the issue is fixed?** 
+
+If the issue has acceptance criteria, read them carefully. If it doesn't, try writing your own — that forces you to understand the scope.
+
+[*] I can describe a concrete before-and-after: what the user sees before the fix and what they see after.
+
+## Part 2 — Tier Fit
+Issues in the tracker are tagged with a tier level. Here's what each one means:
+
+T**ier	Description	Typical scope**
+**Tier 1**	Self-contained, localized fix. The change lives in one or two files and doesn't require understanding how the whole system fits together.	Bug fix, missing validation, broken test, documentation update
+**Tier 2**	Requires understanding how two or more modules interact. May involve a service layer, database model, or API endpoint.	Feature addition, refactor, data flow bug
+**Tier 3**	Requires understanding the full system — multiple modules, possibly infrastructure or AI pipeline changes.	Architecture change, cross-cutting behavior, RAG or agent modification
+
+**Is the tier a realistic match for where I am right now?** 
+
+[*] If this is my first open source contribution: I'm choosing Tier 1.
+
+This tier works best for me with my time constraints and skill level. This summer schedule allows me to handle a problem of this level.
+
+## Part 3 — Codebase Readiness
+
+**Can I find the relevant code?**
+
+Before claiming the issue, locate the specific function, route, or module it describes. Don't rely on grep alone — open the file, read the surrounding context, and confirm you're in the right place.
+
+[*] I've found and read the specific code the issue references (not just the file — the function or section).
+
+**Do I understand the surrounding code well enough to change it safely?**
+
+You don't need to understand the whole codebase. But you need to understand the file you're about to edit well enough to predict what a change will break. Read the function signatures, docstrings, and any callers.
+
+[*] I've read enough surrounding context that I can write a rough plan for the fix without looking anything up.
+
+**Have I read the relevant test file?**
+
+Find the test file for the module your issue touches (tests/unit/ is the right place to start). Look at how existing tests are structured — fixtures, assertions, mock patterns. You'll need to write at least one new test.
+
+[*] I've found the test file for my module and read at least one test end-to-end.
+
+## Part 4 — Scope and Time
+
+**How many others are already working on this issue?**
+
+Claims are non-exclusive — more than one student may work on the same issue, and your grade comes from your own artifacts, never from being first. Still, check the issue comments and the Claims column in the Issue Catalog tab of the cohort ledger: a less-crowded issue of the same tier can mean smoother coaching and peer review.
+
+[*] I've checked the issue comments and the ledger's Claims count, and I'm fine with how many others are on this issue.
+
+**Is the scope realistic for Weeks 8–9?**
+
+You have roughly two weeks to implement, test, and submit a PR. Tier 1 issues should take 3–6 hours of focused work. Tier 2 issues may take 8–12 hours. Tier 3 issues can take significantly longer.
+
+Think about your week — other classes, work, other commitments. Is this achievable?
+
+[*] I've estimated the time this will take and I'm confident I can complete it before the Week 9 deadline.
+
+**Are there any blockers or dependencies?**
+
+Some issues say "blocked by #X" or reference another issue that needs to be resolved first. Check the issue for any such dependencies.
+
+[*] This issue has no open blockers or dependencies on other unresolved issues.
+
+
 ## Week 7 — Issue selection
 
 **Issue link:** [(https://github.com/ascherj/pathreview/issues/50)]
@@ -7,7 +87,7 @@
 **Tier:** [*] Tier 1  [ ] Tier 2  [ ] Tier 3
 
 **Problem summary:**
-This issue it adding detection logic to the project. This means adding logic to see if a repository has a tests/ or test/ directory, a pytest.ini, or test files matching test_*.py, and shows a boolean field in the analysis output. I am thinking for the core structural approach to either use Declarative rules or modular components and anf for the lifecycle pipeline approach using version control with git.
+This issue it adding detection logic to the project. This means adding logic to see if a repository has a tests/ or test/ directory, a pytest.ini, or test files matching test_*.py, and shows a boolean field in the analysis output. I am thinking for the core structural approach to either use Declarative rules or modular components and anf for the lifecycle pipeline approach using version control with git
 
 **Branch name:** [50-dev-environment-setup]
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -108,3 +108,110 @@ Added a failing unit test (`tests/unit/test_github_tool.py`) that mocks the GitH
 
 **Blockers or open questions:**
 The manifest lists `agent/tools/repo_analyzer.py` as a target file, but it does not exist in the current tree — the agent's repo analysis lives entirely in `github_tool.py`, so that is where the fix will go. Open question for Week 9: detecting tests needs the repo file tree (an extra GitHub API call, like `_has_readme`); confirm the Git Trees API is the right approach and how to handle truncated trees on large repos.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Before writing any code I recorded a baseline of the existing failures (see the
+pre-existing failures note below), so I could prove later that my changes added
+none. PLAN.md steps 1–3 are done, in commit `616b1df`
+(`feat(agent): add has_tests detection to repo analysis output`):
+
+- **Step 1 — detection helper.** Added `GitHubTool._has_tests()`, which reads the
+  repo file tree from the GitHub Git Trees API
+  (`GET /repos/{owner}/{repo}/git/trees/{branch}?recursive=1`) and reports whether
+  any path is a test marker. It reuses the auth-header pattern from `_has_readme`.
+- **Step 2 — wired into the output.** `_fetch_repo_metadata()` now includes
+  `"has_tests"`. I pass the `default_branch` already present in the repo JSON
+  instead of re-fetching it, so the feature costs exactly one extra API call.
+- **Step 3 — graceful failure.** The tree request is wrapped in try/except and
+  defaults to `False`, the same defensive shape as `_has_readme`, so a missing
+  branch, a rate limit, or a network error can never break repo analysis.
+
+One design change from PLAN.md: I split the path matching into a separate pure
+`_path_indicates_tests(path)` classmethod. The plan's edge cases called out that
+`contest/` and `latest/` must not match, so the matcher splits a path on `/` and
+compares whole segments rather than doing a substring test. Pulling it out of the
+network code means those false-positive traps can be tested directly with no HTTP
+mocking at all.
+
+The Week 8 reproduction test now passes.
+
+**Next steps:**
+PLAN.md steps 4–5: widen `tests/unit/test_github_tool.py` past the single
+reproduction case to cover each detection marker, the false-positive traps, and
+the API-failure paths; then re-run the full checks and diff them against my
+baseline to confirm no new failures.
+
+**Blockers:**
+None. Both Week 8 open questions are resolved: the Git Trees API with
+`recursive=1` is the right call, and for truncated trees I return `False` rather
+than paginating — under-reporting is acceptable for Tier 1 and is commented in
+the code. I also confirmed the third open question from PLAN.md ("should a
+downstream consumer use `has_tests`?") is a no: `agent/orchestrator.py` caches
+`ToolResult.data` as an untyped dict with no schema, so adding a key is purely
+additive and the issue only asks to surface the field.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [link to your submitted pull request]
+
+**Branch:** `chore/50-dev-environment-setup`
+
+**What you built:**
+The agent-side repo analysis in `agent/tools/github_tool.py` reported
+`has_readme` but had no test signal. It now also reports `has_tests`: a new
+`_has_tests()` helper reads the repository file tree via the GitHub Git Trees API
+and returns `True` when any path is a test marker — a `tests/` or `test/`
+directory, a `pytest.ini`, or a `test_*.py` file. Matching happens on whole path
+segments via `_path_indicates_tests()`, so `contest/` and `latest/` are not false
+positives, and any failure reading the tree degrades to `False` so analysis never
+crashes.
+
+**Tests added or updated:**
+`tests/unit/test_github_tool.py` — grew from the 1 Week 8 reproduction test to 26
+passing tests. Through `execute()`: each marker type detected (`tests/` dir,
+scattered `test_*.py`, `pytest.ini`), a repo with no markers reporting `False`, a
+tree request error and a non-200 tree response both degrading to `False`, a
+truncated tree still reporting markers it did see, the tree being requested
+recursively from the repo's default branch, and a regression check that all ten
+pre-existing metadata fields are untouched. Directly against
+`_path_indicates_tests`: parametrized marker paths plus the false-positive traps
+(`contest/entry.py`, `latest/build.py`, `src/protest.py`, `docs/testing.md`,
+`attestation.py`) that a naive substring match would wrongly flag. The original
+reproduction test is kept as the regression guard that the field exists and is a
+bool.
+
+**Self-review confirmation:** [*] make check passes  [*] make test-unit passes
+
+Checked per the pre-existing-failures rule below — this codebase has documented
+pre-existing failures in both commands, so "passes" here means **my changes
+introduce no new failures**, verified by diffing against the baseline I took
+before starting:
+
+- `make test-unit`: **54 failed / 375 passed** before → **53 failed / 401 passed**
+  after. Diffing the two failure lists, new failures: **none**. The one that
+  flipped to passing is my own Week 8 reproduction test; the other 25 tests I
+  added all pass.
+- `make check`: fails at its first step (`lint`) both before and after, on **181
+  pre-existing ruff errors** across files I never touched — so it never reaches
+  `format` or `typecheck`. The repo-wide count is **exactly 181 before and after**,
+  so I added none. Scoped to my two changed files, `ruff`, `black --check`, and
+  `mypy` are all clean, and the repo's own pre-commit hooks (ruff, black, mypy)
+  passed on both commits.
+- `make typecheck` independently: **5 pre-existing errors** before and after —
+  missing library stubs (`PyPDF2`, `jose`, `passlib`, `rank_bm25`) plus a numpy
+  stub that needs Python 3.12+ syntax. All are in files I did not touch, and mypy
+  reports "errors prevented further checking", so it bails before reaching
+  `agent/`. That is why I ran mypy directly on `agent/tools/github_tool.py`
+  (clean) rather than relying on `make typecheck`.
+
+**Pre-existing failures observed (documented for the PR description):** the 181
+ruff errors, the 5 mypy errors, and 53 failing unit tests listed above all predate
+this branch and are unrelated to issue #50. My changes do not affect them.
+
+**Draft PR feedback received from:** [name or Slack handle, or "none"]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -158,7 +158,7 @@ additive and the issue only asks to surface the field.
 
 ### Check-in 2 (end of week)
 
-**PR link:** [link to your submitted pull request]
+**PR link:** (https://github.com/ascherj/pathreview/pull/299)
 
 **Branch:** `chore/50-dev-environment-setup`
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,101 @@
+## Solution plan
+
+**Issue:** Add a `has_tests` boolean to the repo analysis output — #50
+(https://github.com/ascherj/pathreview/issues/50) · issue-catalog id **C-10**
+· Tier 1 · labels: `agent`, `tests`, `enhancement`, `good first issue`
+
+### Understand
+
+**Root cause.** The agent-side repository analysis tool,
+`GitHubTool._fetch_repo_metadata()` in `agent/tools/github_tool.py`, builds the
+metadata dict that represents a repo's "analysis output" (lines 99-110). That
+dict already surfaces `has_readme` (via the `_has_readme` helper) but has **no
+`has_tests` field**. Test coverage is a strong portfolio signal, so the agent's
+analysis should report whether a repo ships tests.
+
+**Expected vs. actual.**
+- *Actual:* The analysis output contains `name`, `description`,
+  `primary_language`, `star_count`, `fork_count`, `open_issues_count`,
+  `last_commit_date`, `has_readme`, `topics`, `homepage`. No test signal.
+- *Expected:* The same output additionally contains `has_tests: bool`, set
+  `True` when the repo has a `tests/` or `test/` directory, a `pytest.ini`, or
+  files matching `test_*.py` — mirroring the acceptance criteria in the issue.
+
+**Note on scope (verified during reproduction).** There are two repo analyzers
+in the codebase. `ingestion/parsers/repo_analyzer.py` *already* implements
+`has_tests` (its `_detect_tests` helper) — that is a separate ingestion path
+and is out of scope. The issue names `agent/tools/github_tool.py` and
+`agent/tools/repo_analyzer.py`; the latter does **not exist** in the current
+tree, so the real, addressable gap is `GitHubTool`. This fix is scoped to the
+agent tool the issue targets and that is genuinely missing the field.
+
+### Map
+
+Files I expect to touch:
+
+- **`agent/tools/github_tool.py`** — add a `has_tests` key to the metadata dict
+  in `_fetch_repo_metadata()` (lines 99-110) and add a new `_has_tests(username,
+  repo_name)` helper modeled on the existing `_has_readme()` (lines 117-137).
+- **`tests/unit/test_github_tool.py`** — the reproduction test already added in
+  this branch; extend it with cases that assert `has_tests` is `True`/`False`
+  for repos that do / don't contain test markers (mocking the GitHub API).
+
+Reference (read, not edited):
+- `agent/tools/base.py` — `BaseTool` / `ToolResult` container.
+- `agent/tools/github_tool.py:117` — `_has_readme`, the template for `_has_tests`.
+- `ingestion/parsers/repo_analyzer.py:121` — existing `_detect_tests` logic to
+  reuse the same detection markers (`tests/`, `test/`, `pytest.ini`, `test_`).
+- `tests/unit/test_readme_scorer.py` / `test_tech_detector.py` — test patterns.
+
+### Plan
+
+1. **Add detection helper.** Implement `_has_tests(username, repo_name) -> bool`
+   in `GitHubTool`. Fetch the repo's file tree via the GitHub Git Trees API
+   (`GET /repos/{owner}/{repo}/git/trees/{default_branch}?recursive=1`) and return
+   `True` if any path matches a test marker: a `tests/` or `test/` directory, a
+   `pytest.ini`, or a file matching `test_*.py`. Reuse the auth-header pattern
+   from `_has_readme`.
+2. **Wire it into the output.** Add `"has_tests": self._has_tests(username,
+   repo_name)` to the metadata dict in `_fetch_repo_metadata()`.
+3. **Handle failure gracefully.** Wrap the tree call in try/except and default to
+   `False` on any error (missing branch, truncated tree, network/rate-limit
+   failure) so analysis never crashes — same defensive shape as `_has_readme`.
+4. **Extend tests.** Turn the reproduction test green and add cases: repo with a
+   `tests/` dir → `True`; repo with only `test_foo.py` → `True`; repo with no
+   test markers → `False`; API error → `False`.
+5. **Verify.** Run `pytest tests/unit/test_github_tool.py`, then the full
+   `make test` / lint, and confirm no regression to `has_readme` or other fields.
+
+### Inputs & outputs
+
+- **Input:** `github_username` and `repo_name` (already the tool's input), plus
+  the repo's file tree fetched from the GitHub API.
+- **Output:** the existing analysis dict gains one key, `has_tests: bool`. No
+  existing field changes; no schema/DB migration required (the output is an
+  untyped dict flowing through the agent orchestrator, not a Pydantic response
+  model).
+
+### Risks & unknowns
+
+- **Extra API call / rate limits.** Detecting tests needs the file tree, i.e. an
+  additional GitHub request per repo (like `_has_readme`). Under unauthenticated
+  rate limits this adds pressure; acceptable for Tier 1 but worth noting.
+- **Truncated trees.** The Git Trees API truncates very large repos (`truncated:
+  true`). In that case detection may under-report; I'll default to `False` and
+  leave a comment rather than paginating (out of scope for Tier 1).
+- **Default branch.** Need `default_branch` from the repo JSON; not every code
+  path guarantees it — fall back to `"main"` then `"master"` if absent.
+- **Unknown:** whether any downstream consumer (orchestrator / review prompt)
+  should also *use* `has_tests`. The issue only asks to surface it, so I'll stop
+  at the tool output unless review confirms otherwise.
+
+### Edge cases
+
+- Repo with `tests/` **or** `test/` directory → `True`.
+- Repo with `pytest.ini` at root but no test dir → `True`.
+- Repo with scattered `test_*.py` files but no `tests/` dir → `True`.
+- Repo with a `contest/` or `latest/` path (false-positive traps) → must **not**
+  match on a naive `"test" in path` substring; match on path segments/filenames.
+- Empty repo / no tree / private-or-404 / rate-limited → `False`, no exception.
+- Non-Python repos (JS `__tests__/`, `spec/`) → out of scope for the stated
+  criteria, but the marker list is easy to extend later.

--- a/agent/tools/github_tool.py
+++ b/agent/tools/github_tool.py
@@ -2,6 +2,7 @@
 
 import httpx
 import structlog
+
 from .base import BaseTool, ToolResult
 
 logger = structlog.get_logger()
@@ -35,44 +36,30 @@ class GitHubTool(BaseTool):
         repo_name = input_data.get("repo_name")
 
         if not username or not repo_name:
-            return ToolResult(
-                success=False,
-                data={},
-                error="Missing github_username or repo_name"
-            )
+            return ToolResult(success=False, data={}, error="Missing github_username or repo_name")
 
         try:
             repo_data = self._fetch_repo_metadata(username, repo_name)
             return ToolResult(success=True, data=repo_data)
 
         except httpx.HTTPStatusError as e:
-            logger.error("github_request_failed", status=e.response.status_code,
-                        username=username, repo=repo_name)
+            logger.error(
+                "github_request_failed",
+                status=e.response.status_code,
+                username=username,
+                repo=repo_name,
+            )
             if e.response.status_code == 404:
-                return ToolResult(
-                    success=False,
-                    data={},
-                    error="Repository not found"
-                )
+                return ToolResult(success=False, data={}, error="Repository not found")
             elif e.response.status_code == 403:
-                return ToolResult(
-                    success=False,
-                    data={},
-                    error="Rate limited or access denied"
-                )
+                return ToolResult(success=False, data={}, error="Rate limited or access denied")
             return ToolResult(
-                success=False,
-                data={},
-                error=f"GitHub API error: {e.response.status_code}"
+                success=False, data={}, error=f"GitHub API error: {e.response.status_code}"
             )
 
         except Exception as e:
             logger.error("github_tool_error", error=str(e))
-            return ToolResult(
-                success=False,
-                data={},
-                error=str(e)
-            )
+            return ToolResult(success=False, data={}, error=str(e))
 
     def _fetch_repo_metadata(self, username: str, repo_name: str) -> dict:
         """Fetch repository metadata from GitHub API.
@@ -109,8 +96,13 @@ class GitHubTool(BaseTool):
             "homepage": repo_json.get("homepage") or "",
         }
 
-        logger.info("github_repo_fetched", username=username, repo=repo_name,
-                   language=metadata["primary_language"], stars=metadata["star_count"])
+        logger.info(
+            "github_repo_fetched",
+            username=username,
+            repo=repo_name,
+            language=metadata["primary_language"],
+            stars=metadata["star_count"],
+        )
 
         return metadata
 
@@ -132,6 +124,6 @@ class GitHubTool(BaseTool):
 
         try:
             response = httpx.head(url, headers=headers, timeout=5.0)
-            return response.status_code == 200
+            return bool(response.status_code == 200)
         except Exception:
             return False

--- a/agent/tools/github_tool.py
+++ b/agent/tools/github_tool.py
@@ -98,6 +98,8 @@ class GitHubTool(BaseTool):
             "open_issues_count": repo_json.get("open_issues_count", 0),
             "last_commit_date": repo_json.get("pushed_at", ""),
             "has_readme": self._has_readme(username, repo_name),
+            # Pass the default branch we already have from repo_json so the tree
+            # lookup does not have to re-fetch it; fall back to "main" if absent.
             "has_tests": self._has_tests(
                 username, repo_name, repo_json.get("default_branch") or "main"
             ),
@@ -197,10 +199,13 @@ class GitHubTool(BaseTool):
             logger.debug("github_tree_fetch_failed", username=username, repo=repo_name)
             return False
 
+        # Guard the shape before iterating: an unexpected payload should report
+        # "no tests found" rather than raise from inside the loop below.
         tree = tree_json.get("tree", [])
         if not isinstance(tree, list):
             return False
 
+        # One marker anywhere in the tree is enough, so stop at the first hit.
         for entry in tree:
             if self._path_indicates_tests(entry.get("path", "")):
                 return True

--- a/agent/tools/github_tool.py
+++ b/agent/tools/github_tool.py
@@ -14,6 +14,12 @@ class GitHubTool(BaseTool):
     name = "github_tool"
     description = "Fetch repository metadata from GitHub"
 
+    # Directory and file names that indicate a repository ships tests. These are
+    # matched against whole path segments rather than raw substrings, so paths
+    # like "contest/" or "latest/" do not register as test markers.
+    TEST_DIR_NAMES = frozenset({"tests", "test"})
+    TEST_FILE_NAMES = frozenset({"pytest.ini"})
+
     def __init__(self, api_token: str | None = None):
         """Initialize GitHub tool.
 
@@ -92,6 +98,9 @@ class GitHubTool(BaseTool):
             "open_issues_count": repo_json.get("open_issues_count", 0),
             "last_commit_date": repo_json.get("pushed_at", ""),
             "has_readme": self._has_readme(username, repo_name),
+            "has_tests": self._has_tests(
+                username, repo_name, repo_json.get("default_branch") or "main"
+            ),
             "topics": repo_json.get("topics", []),
             "homepage": repo_json.get("homepage") or "",
         }
@@ -127,3 +136,78 @@ class GitHubTool(BaseTool):
             return bool(response.status_code == 200)
         except Exception:
             return False
+
+    @classmethod
+    def _path_indicates_tests(cls, path: str) -> bool:
+        """Check if a single repository path is a test marker.
+
+        A path counts as a test marker when it lives under a ``tests/`` or
+        ``test/`` directory, is a known test config file such as ``pytest.ini``,
+        or is a Python test module named ``test_*.py``.
+
+        Args:
+            path: Repository-relative path, e.g. ``tests/unit/test_foo.py``
+
+        Returns:
+            True if the path indicates the presence of tests
+        """
+        if not path:
+            return False
+
+        segments = [segment.lower() for segment in path.split("/")]
+
+        if cls.TEST_DIR_NAMES.intersection(segments):
+            return True
+
+        filename = segments[-1]
+        if filename in cls.TEST_FILE_NAMES:
+            return True
+
+        return filename.startswith("test_") and filename.endswith(".py")
+
+    def _has_tests(self, username: str, repo_name: str, default_branch: str = "main") -> bool:
+        """Check if repository contains tests.
+
+        Reads the repository file tree and looks for any test marker: a
+        ``tests/`` or ``test/`` directory, a ``pytest.ini``, or a file matching
+        ``test_*.py``.
+
+        Args:
+            username: GitHub username
+            repo_name: Repository name
+            default_branch: Branch whose file tree is inspected
+
+        Returns:
+            True if a test marker is found. False if none is found or the file
+            tree cannot be read.
+        """
+        url = f"{self.base_url}/repos/{username}/{repo_name}/git/trees/{default_branch}"
+
+        headers = {}
+        if self.api_token:
+            headers["Authorization"] = f"token {self.api_token}"
+
+        try:
+            response = httpx.get(url, headers=headers, params={"recursive": "1"}, timeout=10.0)
+            response.raise_for_status()
+            tree_json = response.json()
+        except Exception:
+            # Test detection is best-effort: a missing branch, a rate limit, or a
+            # network failure must never break repository analysis.
+            logger.debug("github_tree_fetch_failed", username=username, repo=repo_name)
+            return False
+
+        tree = tree_json.get("tree", [])
+        if not isinstance(tree, list):
+            return False
+
+        for entry in tree:
+            if self._path_indicates_tests(entry.get("path", "")):
+                return True
+
+        # The Git Trees API truncates very large repositories ("truncated": true).
+        # Detection can under-report there; paginating the tree is out of scope.
+        if tree_json.get("truncated"):
+            logger.debug("github_tree_truncated", username=username, repo=repo_name)
+
+        return False

--- a/tests/unit/test_github_tool.py
+++ b/tests/unit/test_github_tool.py
@@ -1,34 +1,77 @@
 """Tests for agent/tools/github_tool.py.
 
-REPRODUCTION for issue #50 (issue-catalog id C-10):
+Covers issue #50 (issue-catalog id C-10):
     "Add a has_tests boolean to the repo analysis output"
     https://github.com/ascherj/pathreview/issues/50
 
 `GitHubTool` is the agent-side repo analysis tool named in the issue. Its
-`_fetch_repo_metadata()` output (github_tool.py lines 99-110) currently reports
-`has_readme` but NOT `has_tests`. The test below drives that code path with a
-mocked GitHub API and asserts the analysis output exposes a `has_tests`
-boolean.
+`_fetch_repo_metadata()` output reported `has_readme` but not `has_tests`.
 
-It FAILS today (the key is absent) — that failure IS the reproduction: it
-proves the gap is real and pins it to the exact dict the fix must extend. Once
-`has_tests` detection is added to `GitHubTool`, this test will pass.
+`test_analysis_output_includes_has_tests` began as the reproduction for that gap
+(it failed because the key was absent); it now serves as the regression guard
+that the field is present and boolean. The remaining tests cover the detection
+behaviour itself: which paths count as test markers, and that any failure
+reading the repository file tree degrades to `False` rather than raising.
 """
 
 from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
 
+from agent.tools.base import ToolResult
 from agent.tools.github_tool import GitHubTool
+
+REPO_JSON = {
+    "name": "example-repo",
+    "description": "A test repository",
+    "language": "Python",
+    "stargazers_count": 42,
+    "forks_count": 7,
+    "open_issues_count": 3,
+    "pushed_at": "2024-01-01T00:00:00Z",
+    "default_branch": "main",
+    "topics": ["python"],
+    "homepage": "",
+}
+
+
+def _mock_response(json_data: dict, status_code: int = 200) -> MagicMock:
+    """Build a mock httpx response that returns ``json_data``."""
+    response = MagicMock()
+    response.status_code = status_code
+    response.json.return_value = json_data
+    response.raise_for_status.return_value = None
+    return response
+
+
+def _tree_response(paths: list[str], truncated: bool = False) -> MagicMock:
+    """Build a mock Git Trees API response listing ``paths``."""
+    return _mock_response(
+        {
+            "tree": [{"path": path, "type": "blob"} for path in paths],
+            "truncated": truncated,
+        }
+    )
 
 
 @pytest.mark.unit
 class TestGitHubToolHasTests:
-    """Reproduce the missing has_tests field in the agent repo analysis output."""
+    """The agent repo analysis output exposes a has_tests boolean."""
 
     @pytest.fixture
     def tool(self) -> GitHubTool:
         return GitHubTool()
+
+    def _execute(self, mock_httpx: MagicMock, tool: GitHubTool, tree: MagicMock) -> ToolResult:
+        """Drive ``execute()`` with a mocked repo call followed by a tree call."""
+        mock_httpx.get.side_effect = [_mock_response(REPO_JSON), tree]
+
+        head_response = MagicMock()
+        head_response.status_code = 200
+        mock_httpx.head.return_value = head_response
+
+        return tool.execute({"github_username": "octocat", "repo_name": "example-repo"})
 
     @patch("agent.tools.github_tool.httpx")
     def test_analysis_output_includes_has_tests(
@@ -63,8 +106,150 @@ class TestGitHubToolHasTests:
         assert "has_readme" in result.data
 
         # Issue #50: the analysis output MUST expose a has_tests boolean.
-        # This assertion FAILS today (key is absent) — that is the reproduction.
         assert (
             "has_tests" in result.data
         ), "has_tests missing from GitHubTool analysis output — see issue #50"
         assert isinstance(result.data["has_tests"], bool)
+
+    @patch("agent.tools.github_tool.httpx")
+    def test_tests_directory_detected(self, mock_httpx: MagicMock, tool: GitHubTool) -> None:
+        result = self._execute(mock_httpx, tool, _tree_response(["README.md", "tests/test_app.py"]))
+
+        assert result.success is True
+        assert result.data["has_tests"] is True
+
+    @patch("agent.tools.github_tool.httpx")
+    def test_scattered_test_file_detected(self, mock_httpx: MagicMock, tool: GitHubTool) -> None:
+        result = self._execute(mock_httpx, tool, _tree_response(["app.py", "test_app.py"]))
+
+        assert result.data["has_tests"] is True
+
+    @patch("agent.tools.github_tool.httpx")
+    def test_pytest_ini_detected(self, mock_httpx: MagicMock, tool: GitHubTool) -> None:
+        result = self._execute(mock_httpx, tool, _tree_response(["app.py", "pytest.ini"]))
+
+        assert result.data["has_tests"] is True
+
+    @patch("agent.tools.github_tool.httpx")
+    def test_repo_without_tests_reports_false(
+        self, mock_httpx: MagicMock, tool: GitHubTool
+    ) -> None:
+        result = self._execute(
+            mock_httpx, tool, _tree_response(["README.md", "src/app.py", "docs/guide.md"])
+        )
+
+        assert result.success is True
+        assert result.data["has_tests"] is False
+
+    @patch("agent.tools.github_tool.httpx")
+    def test_tree_request_error_reports_false(
+        self, mock_httpx: MagicMock, tool: GitHubTool
+    ) -> None:
+        """A failed tree request must degrade to False, not fail the analysis."""
+        mock_httpx.get.side_effect = [
+            _mock_response(REPO_JSON),
+            httpx.RequestError("network unavailable"),
+        ]
+        head_response = MagicMock()
+        head_response.status_code = 200
+        mock_httpx.head.return_value = head_response
+
+        result = tool.execute({"github_username": "octocat", "repo_name": "example-repo"})
+
+        assert result.success is True
+        assert result.data["has_tests"] is False
+
+    @patch("agent.tools.github_tool.httpx")
+    def test_missing_branch_reports_false(self, mock_httpx: MagicMock, tool: GitHubTool) -> None:
+        """A non-200 tree response (e.g. unknown branch) degrades to False."""
+        tree = _tree_response([])
+        tree.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "404", request=MagicMock(), response=MagicMock()
+        )
+
+        result = self._execute(mock_httpx, tool, tree)
+
+        assert result.success is True
+        assert result.data["has_tests"] is False
+
+    @patch("agent.tools.github_tool.httpx")
+    def test_truncated_tree_still_reports_found_markers(
+        self, mock_httpx: MagicMock, tool: GitHubTool
+    ) -> None:
+        """Truncation may under-report, but a marker already seen still counts."""
+        result = self._execute(
+            mock_httpx, tool, _tree_response(["tests/test_app.py"], truncated=True)
+        )
+
+        assert result.data["has_tests"] is True
+
+    @patch("agent.tools.github_tool.httpx")
+    def test_tree_fetched_recursively_from_default_branch(
+        self, mock_httpx: MagicMock, tool: GitHubTool
+    ) -> None:
+        """Nested test files are only visible when the tree is fetched recursively."""
+        repo_json = {**REPO_JSON, "default_branch": "develop"}
+        mock_httpx.get.side_effect = [_mock_response(repo_json), _tree_response([])]
+        head_response = MagicMock()
+        head_response.status_code = 200
+        mock_httpx.head.return_value = head_response
+
+        tool.execute({"github_username": "octocat", "repo_name": "example-repo"})
+
+        tree_call = mock_httpx.get.call_args_list[1]
+        assert tree_call.args[0].endswith("/repos/octocat/example-repo/git/trees/develop")
+        assert tree_call.kwargs["params"] == {"recursive": "1"}
+
+    @patch("agent.tools.github_tool.httpx")
+    def test_existing_metadata_fields_unchanged(
+        self, mock_httpx: MagicMock, tool: GitHubTool
+    ) -> None:
+        """Adding has_tests must not disturb the other analysis fields."""
+        result = self._execute(mock_httpx, tool, _tree_response(["tests/test_app.py"]))
+
+        assert result.data["name"] == "example-repo"
+        assert result.data["primary_language"] == "Python"
+        assert result.data["star_count"] == 42
+        assert result.data["fork_count"] == 7
+        assert result.data["open_issues_count"] == 3
+        assert result.data["last_commit_date"] == "2024-01-01T00:00:00Z"
+        assert result.data["has_readme"] is True
+        assert result.data["topics"] == ["python"]
+        assert result.data["homepage"] == ""
+
+
+@pytest.mark.unit
+class TestPathIndicatesTests:
+    """Path-level marker matching, including false-positive traps."""
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "tests/test_app.py",
+            "tests",
+            "test/helpers.py",
+            "backend/tests/unit/test_thing.py",
+            "pytest.ini",
+            "test_app.py",
+            "src/test_utils.py",
+            "TESTS/test_app.py",
+        ],
+    )
+    def test_marker_paths_match(self, path: str) -> None:
+        assert GitHubTool._path_indicates_tests(path) is True
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "contest/entry.py",
+            "latest/build.py",
+            "src/protest.py",
+            "docs/testing.md",
+            "attestation.py",
+            "src/app.py",
+            "README.md",
+            "",
+        ],
+    )
+    def test_non_marker_paths_do_not_match(self, path: str) -> None:
+        assert GitHubTool._path_indicates_tests(path) is False

--- a/tests/unit/test_github_tool.py
+++ b/tests/unit/test_github_tool.py
@@ -64,9 +64,17 @@ class TestGitHubToolHasTests:
         return GitHubTool()
 
     def _execute(self, mock_httpx: MagicMock, tool: GitHubTool, tree: MagicMock) -> ToolResult:
-        """Drive ``execute()`` with a mocked repo call followed by a tree call."""
+        """Drive ``execute()`` with a mocked repo call followed by a tree call.
+
+        ``_fetch_repo_metadata`` makes exactly two GET calls in a fixed order —
+        the repo metadata first, then the file tree — because the keys of a dict
+        literal are evaluated top to bottom. That is what lets side_effect hand
+        back the two responses positionally.
+        """
         mock_httpx.get.side_effect = [_mock_response(REPO_JSON), tree]
 
+        # _has_readme probes with HEAD, not GET, so it is mocked separately and
+        # does not consume one of the two GET responses above.
         head_response = MagicMock()
         head_response.status_code = 200
         mock_httpx.head.return_value = head_response

--- a/tests/unit/test_github_tool.py
+++ b/tests/unit/test_github_tool.py
@@ -1,0 +1,70 @@
+"""Tests for agent/tools/github_tool.py.
+
+REPRODUCTION for issue #50 (issue-catalog id C-10):
+    "Add a has_tests boolean to the repo analysis output"
+    https://github.com/ascherj/pathreview/issues/50
+
+`GitHubTool` is the agent-side repo analysis tool named in the issue. Its
+`_fetch_repo_metadata()` output (github_tool.py lines 99-110) currently reports
+`has_readme` but NOT `has_tests`. The test below drives that code path with a
+mocked GitHub API and asserts the analysis output exposes a `has_tests`
+boolean.
+
+It FAILS today (the key is absent) — that failure IS the reproduction: it
+proves the gap is real and pins it to the exact dict the fix must extend. Once
+`has_tests` detection is added to `GitHubTool`, this test will pass.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.tools.github_tool import GitHubTool
+
+
+@pytest.mark.unit
+class TestGitHubToolHasTests:
+    """Reproduce the missing has_tests field in the agent repo analysis output."""
+
+    @pytest.fixture
+    def tool(self) -> GitHubTool:
+        return GitHubTool()
+
+    @patch("agent.tools.github_tool.httpx")
+    def test_analysis_output_includes_has_tests(
+        self, mock_httpx: MagicMock, tool: GitHubTool
+    ) -> None:
+        # Mock the repository-metadata GET call.
+        mock_get_response = MagicMock()
+        mock_get_response.json.return_value = {
+            "name": "example-repo",
+            "description": "A test repository",
+            "language": "Python",
+            "stargazers_count": 42,
+            "forks_count": 7,
+            "open_issues_count": 3,
+            "pushed_at": "2024-01-01T00:00:00Z",
+            "topics": ["python"],
+            "homepage": "",
+        }
+        mock_get_response.raise_for_status.return_value = None
+        mock_httpx.get.return_value = mock_get_response
+
+        # Mock the README HEAD probe used by the existing _has_readme helper.
+        mock_head_response = MagicMock()
+        mock_head_response.status_code = 200
+        mock_httpx.head.return_value = mock_head_response
+
+        result = tool.execute({"github_username": "octocat", "repo_name": "example-repo"})
+
+        assert result.success is True
+
+        # Regression guard: the existing has_readme field should still be present.
+        assert "has_readme" in result.data
+
+        # Issue #50: the analysis output MUST expose a has_tests boolean.
+        # This assertion FAILS today (key is absent) — that is the reproduction.
+        assert (
+            "has_tests" in result.data
+        ), "has_tests missing from GitHubTool analysis output — see issue #50"
+        assert isinstance(result.data["has_tests"], bool)


### PR DESCRIPTION
## Summary

The agent-side repository analysis in `agent/tools/github_tool.py` reported `has_readme` but had no test signal, even though test coverage is a strong portfolio quality signal. This adds a `has_tests` boolean to the analysis output: a new `_has_tests()` helper reads the repository file tree via the GitHub Git Trees API and reports `True` when the repo ships tests — a `tests/` or `test/` directory, a `pytest.ini`, or a file matching `test_*.py`.

Detection is deliberately conservative. Path matching happens on whole path segments via a pure `_path_indicates_tests()` helper, so paths like `contest/` or `latest/` are not false positives the way a naive substring check would be. Any failure reading the tree (missing branch, rate limit, network error, unexpected payload) degrades to `False` rather than raising, so repository analysis can never be broken by test detection.

## Issue

Closes #50

## Changes

- **`agent/tools/github_tool.py`**
  - Added `_has_tests(username, repo_name, default_branch)`, which fetches `GET /repos/{owner}/{repo}/git/trees/{branch}?recursive=1` and returns whether any path is a test marker. Reuses the auth-header pattern from the existing `_has_readme`.
  - Added `_path_indicates_tests(path)`, a pure classmethod that splits a path on `/` and compares whole segments against the `TEST_DIR_NAMES` / `TEST_FILE_NAMES` markers.
  - Added `has_tests` to the metadata dict returned by `_fetch_repo_metadata()`. The `default_branch` already present in the repo JSON is threaded through, so the feature costs exactly one additional API call rather than two, and falls back to `"main"` if absent.
  - Wrapped the tree request in try/except returning `False`, matching the defensive shape of `_has_readme`, with `logger.debug` on the failure and truncation paths.
- **`tests/unit/test_github_tool.py`** — extended from 1 test to 26 (see Testing).

No existing field changed and no schema or migration is required: `agent/orchestrator.py` caches `ToolResult.data` as an untyped dict with no response model, so the new key is purely additive. The change to `github_tool.py` is +89 lines with no deletions.

Also present on the branch, and not part of the fix: `JOURNAL.md` and `PLAN.md`, which are coursework artifacts tracking my reproduction and solution planning for this issue. Happy to strip them into a separate branch if you would rather the PR contain only the `agent/` and `tests/` changes.

## Testing

- [x] Unit tests pass (`make test-unit`) — see the pre-existing failures note below
- [ ] Integration tests pass (`make test-integration`) — `tests/integration/` contains only `__init__.py`; 0 tests are collected, so there is nothing to run
- [ ] Linter passes (`make lint`) — fails on 181 pre-existing errors, unchanged by this PR; see below
- [ ] Type checker passes (`make typecheck`) — fails on 5 pre-existing errors, unchanged by this PR; see below
- [x] New/updated tests cover the changes

`tests/unit/test_github_tool.py` grew from 1 test to **26 passing tests**.

Through `execute()`, with the GitHub API mocked:
- each marker type detected independently — a `tests/` directory, a scattered `test_*.py` file, and a `pytest.ini`
- a repo with none of the markers reports `False`
- a tree request error and a non-200 tree response (e.g. unknown branch) each degrade to `False` while the overall analysis still succeeds
- a truncated tree still reports a marker it did see
- the tree is requested recursively and from the repo's default branch (asserted on the call args, since nested test files are invisible without `recursive=1`)
- a regression check that all ten pre-existing metadata fields are untouched

Directly against `_path_indicates_tests`, parametrized: the marker paths, plus false-positive traps that a substring match would wrongly flag — `contest/entry.py`, `latest/build.py`, `src/protest.py`, `docs/testing.md`, `attestation.py`.

## Notes for Reviewers

**Pre-existing failures in this codebase.** I captured a baseline before making any changes so I could show this PR introduces no new failures:

| Command | Before | After |
| --- | --- | --- |
| `make test-unit` | 54 failed / 375 passed | 53 failed / 401 passed |
| `make lint` | 181 errors | 181 errors |
| `make typecheck` | 5 errors | 5 errors |

- **`make test-unit`**: diffing the before/after failure lists, **new failures: none**. The single test that flipped to passing is the reproduction test added earlier on this branch. The other 25 tests added here all pass. The 53 remaining failures are in unrelated modules (`test_resume_parser`, `test_review_service`, `test_pii_scrubber`, and others) and predate this branch.
- **`make lint`**: `make check` fails at its first step, `lint`, both before and after — which means `make check` never reaches its `format` or `typecheck` steps. The repo-wide ruff count is **exactly 181 both before and after**, so this PR adds none. Scoped to the two files changed here, `ruff check` and `black --check` are clean.
- **`make typecheck`**: fails on 5 pre-existing errors — missing library stubs for `PyPDF2`, `jose`, `passlib`, and `rank_bm25`, plus a numpy stub requiring Python 3.12+ syntax. mypy reports "errors prevented further checking", so it exits before ever reaching `agent/`. I therefore ran mypy directly against `agent/tools/github_tool.py`, which is clean. The repo's own pre-commit hooks (ruff, black, mypy) passed on every commit in this PR.

**None of the above are affected by this change.**

Two other things worth flagging:

1. **Branch name.** This branch is `chore/50-dev-environment-setup`, created for earlier environment-setup work before the implementation began. It carries the correct issue number but the `chore` type and description do not describe this feature; `feat/50-has-tests-repo-analysis` would match `CONTRIBUTING.md` more closely. Happy to rebase onto a correctly named branch if you would prefer that.
2. **Formatting churn in the diff.** Comparing against `main`, `github_tool.py` shows 28 deleted lines. Those come from `cb761b3`, an earlier `black`-formatting commit on this branch, not from the `has_tests` work — which is purely additive.
3. **Earlier commits on the branch.** This PR was opened during environment setup, before the implementation began, which is why the first three commits and the original PR title refer to setup rather than to this feature. The `has_tests` work is commits 6–9: `feat(agent): add has_tests detection…`, `test(agent): cover has_tests detection…`, and the two docs commits.

**Known limitation (intentional).** The Git Trees API truncates very large repositories (`"truncated": true`). When that happens and no marker was found in the partial tree, detection under-reports as `False`. Paginating the tree felt out of scope here; the behaviour is commented in the code and covered by a test. Similarly, non-Python conventions (`__tests__/`, `spec/`) are outside the acceptance criteria in the issue, but `TEST_DIR_NAMES` / `TEST_FILE_NAMES` are module constants specifically so they are trivial to extend.
