### PR TITLE
feat: add real snapshot tests for prompt templates (#37)

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -42,4 +42,4 @@ it still passed, proving no protection existed.
 
 **Walkthrough video (recommended):** [skipping — will do office hours if needed]
 
-**Blockers or open questions:** None. PR is already open (#[your PR number]) and passing tests locally.
+**Blockers or open questions:** None. PR #301 is already open and passing tests locally.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -24,3 +24,22 @@ for a first contribution.
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [link to your Week 8 commit — we'll fill in after committing]
+
+**Reproduction summary:**
+Verified in the local checkout that the placeholder
+`test_template_snapshot_content_hash` in
+`tests/unit/test_prompt_templates.py` cannot detect template drift: it
+only asserts that an MD5 hex digest is 32 characters long, which is
+always true. Confirmed by editing
+`PROMPT_TEMPLATES["skills_feedback"]["v1"]` and re-running the test —
+it still passed, proving no protection existed.
+
+**PLAN.md link:** https://github.com/natanyanderson/pathreview/blob/feat/37-prompt-template-snapshots/PLAN.md
+
+**Walkthrough video (recommended):** [skipping — will do office hours if needed]
+
+**Blockers or open questions:** None. PR is already open (#[your PR number]) and passing tests locally.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -11,6 +11,16 @@ The `rag/generator/prompt_templates.py` module holds versioned prompt templates 
 
 **Branch name:** feat/37-prompt-template-snapshots
 
+**"Is this right for me?" reasoning:**
+Scope matches the Tier 1 estimate (3–5 hours) — I finished in ~4 hours.
+Skills align well: I already work with LLM prompt templates and
+evaluation in my own research, so understanding what "silent template
+drift" means and why version pinning matters was intuitive. No new
+libraries needed — the fix uses stdlib `hashlib` and existing `pytest`,
+so I didn't need to learn a snapshot testing framework from scratch.
+The blast radius is contained to one test file, which makes it low-risk
+for a first contribution.
+
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -27,7 +27,7 @@ for a first contribution.
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [link to your Week 8 commit — we'll fill in after committing]
+**Reproduction commit link:** https://github.com/natanyanderson/pathreview/commit/a7d77a8aaf2f5b83fcddb48f059f404de31dc2a0
 
 **Reproduction summary:**
 Verified in the local checkout that the placeholder

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,16 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/37
+
+**Issue title:** Add snapshot tests for prompt templates to catch accidental changes
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The `rag/generator/prompt_templates.py` module holds versioned prompt templates used by the review generator, but nothing currently enforces that changes to a template are accompanied by a version bump. A developer can silently edit the text of `v1` (or any existing version) and the app will keep running, quietly shipping different LLM behavior. The existing `tests/unit/test_prompt_templates.py` has a placeholder "snapshot" test that only checks the length of a hash string, so it does not actually catch content changes. A successful fix adds real per-template hash snapshots so that any modification to an existing version fails the test suite, forcing developers to add a new version (e.g., `v2`) instead of silently mutating `v1`.
+
+**Branch name:** feat/37-prompt-template-snapshots
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -43,3 +43,30 @@ it still passed, proving no protection existed.
 **Walkthrough video (recommended):** [skipping — will do office hours if needed]
 
 **Blockers or open questions:** None. PR #301 is already open and passing tests locally.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Fix is fully implemented. Both new tests
+(`test_template_content_matches_snapshot` and
+`test_every_template_version_has_a_snapshot`) are passing, and the
+placeholder `test_template_snapshot_content_hash` has been removed.
+All 38 tests in `tests/unit/test_prompt_templates.py` pass locally.
+The PR is open at #301 and I'm treating this week as review + polish
+rather than new implementation, since sub-tasks 1–5 in PLAN.md are
+already complete.
+
+**Next steps:**
+Run the full `make check` and `make test-unit` suites, document any
+pre-existing failures in the PR description, request peer feedback in
+Slack, and address any review comments before the deadline.
+
+**Blockers:**
+None right now. Only open question is whether reviewers will want me
+to also fix the pre-existing ruff/mypy violations in
+`test_prompt_templates.py`. I've left those alone to keep the diff
+scoped, but I'll fold them in if requested.
+
+---

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -90,3 +90,44 @@ Note on `make check`: the codebase has ~176 pre-existing ruff/mypy violations ac
 Note on `make test-unit`: 53 pre-existing test failures across the project on `main` (in files like `test_structural_chunker.py`, `test_tech_detector.py`, `test_review_service.py`). Confirmed the identical 53 failures exist on `main` before my changes via `git stash`. In `tests/unit/test_prompt_templates.py` specifically — the file I modified — all 38 tests pass, including both new snapshot tests. Per the Week 9 "doesn't make things worse" guidance, my contribution introduces 0 new test failures and 0 new lint errors.
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x0] No — still awaiting review
+
+**Summary of feedback:**
+No reviewer feedback came in during the module (per the Summer 2026 cohort note, reviewer feedback is not a course feature this term). The PR is open at ascherj/pathreview#301 and passing all tests in the file it touches.
+
+**How you responded:**
+N/A — no feedback to respond to. If a maintainer comments after the module closes, I plan to keep engaging with the PR until it either merges or the maintainers decide against it.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Setup was the biggest surprise. Getting the local environment running was a full afternoon of dependency debugging that had nothing to do with my actual issue — chromadb required an older Python because of onnxruntime, the setup script assumed Docker was already running when it wasn't, and I had a stale `.venv` from a previous failed run that kept masking the real errors. I went into Week 7 expecting to spend most of my time reading code and picking a good issue, and instead I spent most of it fighting the Python + Postgres + Docker stack before I could even run the app. In hindsight this is probably normal for any real codebase, but it was a shift from how "getting started" works on my own projects, where I control every layer.
+
+**What did you learn about working in a large codebase?**
+The biggest lesson was that "the fix" and "the scope of what to touch" are separate decisions. When I ran `make check` on my final PR, the file I edited had 13 lint errors and the whole project had 176 — but only 1 error was actually caused by my changes, and my fix removed one pre-existing error rather than adding new ones. Early in the week I assumed I had to fix everything the linter complained about; by the end I understood that a well-scoped PR fixes the thing it says it fixes and explicitly documents the pre-existing violations rather than expanding to cover them. That framing ("doesn't make things worse" vs. "fixes the whole codebase") is very different from how I work in my own projects, where I own every line.
+
+I also learned to read tests as documentation. The existing tests in `test_prompt_templates.py` were the fastest way to understand what the prompt template system was supposed to do — faster than reading `prompt_templates.py` itself. That surprised me.
+
+**How did AI tools help — and where did they fall short?**
+AI was most useful for the mechanical parts: writing the initial docstring/error-message copy for the new tests, formatting the JOURNAL and PLAN files consistently, and pattern-matching against existing test structure in the file. It was reliably fast for that kind of work.
+
+Where it fell short was scope judgment. When my commit was blocked by pre-commit hooks with ~50 lint/type errors, my first instinct (and the AI's first suggestion path) was to "just fix them all." That would have been wrong — most were pre-existing and out of scope. I had to make the call myself to compare error counts before and after my changes and prove I wasn't making things worse. AI is good at "how do I do X" and much weaker at "should I do X in this context."
+
+The other place AI fell short was on the specific mental model of "silent test that passes because the assertion is a tautology." The failing test wasn't hard to spot once I read it, but understanding *why* it was designed to fail loudly — and how to write a replacement that actually enforced the contract the docstring implied — required thinking about the intent behind the code, not just its syntax.
+
+**What would you do differently if you started over?**
+Two things.
+
+First, I'd spend less time on issue selection. I got a bit stuck comparing three candidate Tier 1 issues (async mocks, README scorer fixture, faithfulness None-handling) and worrying about who else had "claimed" them on GitHub. In retrospect, most of those claims were from months ago with no follow-up PRs, and my TF explicitly said multiple people can work on the same issue in this course. I could have started on a good issue on Day 1 instead of Day 2 or 3.
+
+Second, I'd verify my environment with `make setup && make run` before doing any of the ancillary Week 7 steps (JOURNAL, PLAN, branch naming). Getting the app running is the single most important gate, because if you can't run it, you can't verify anything else. I did steps like "create branch" and "make initial commit" in parallel with debugging setup, which meant some of my early commits were on a branch where setup wasn't actually working yet.
+
+**What are you most proud of from this module?**
+The sanity check I ran on my snapshot test. After I wrote the two new tests and they passed, it would have been easy to stop there — 38/38 green, PR opens itself. Instead I opened `prompt_templates.py`, changed one character in a template, re-ran the test, and confirmed it failed with the exact error message I'd written telling the developer to add a new version. Then I reverted and confirmed it passed again. That two-minute exercise — proving the test actually does what its name implies — is the thing I'll carry forward into future work. It's a habit I didn't really have before this module.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -95,7 +95,7 @@ Note on `make test-unit`: 53 pre-existing test failures across the project on `m
 
 ### Reviewer feedback
 
-**Feedback received:** [ ] Yes  [x0] No — still awaiting review
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
 
 **Summary of feedback:**
 No reviewer feedback came in during the module (per the Summer 2026 cohort note, reviewer feedback is not a course feature this term). The PR is open at ascherj/pathreview#301 and passing all tests in the file it touches.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -70,3 +70,23 @@ to also fix the pre-existing ruff/mypy violations in
 scoped, but I'll fold them in if requested.
 
 ---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/301
+
+**Branch:** feat/37-prompt-template-snapshots
+
+**What you built:**
+Replaced the placeholder `test_template_snapshot_content_hash` in `tests/unit/test_prompt_templates.py` with real per-template SHA-256 snapshots. Added two new pytest tests: `test_template_content_matches_snapshot` fails when a registered template's content changes without a version bump, and `test_every_template_version_has_a_snapshot` catches the reverse case of adding a new template without a registered snapshot. This gives the project actual regression protection against silent prompt drift.
+
+**Tests added or updated:**
+Modified `tests/unit/test_prompt_templates.py`. Removed 1 placeholder test, added 2 real snapshot tests plus an `EXPECTED_TEMPLATE_SNAPSHOTS` dict pinning all 5 current template versions. All 38 tests in the file pass locally. Manually verified the snapshot test catches drift by editing `PROMPT_TEMPLATES["skills_feedback"]["v1"]` character-by-character and confirming the test fails with the expected error message, then reverting to confirm it passes again.
+
+**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+
+Note on `make check`: the codebase has ~176 pre-existing ruff/mypy violations across many files. `test_prompt_templates.py` specifically had 14 errors on `main` and 13 after my changes — my contribution removed 1 error and introduced 0 new ones.
+
+Note on `make test-unit`: 53 pre-existing test failures across the project on `main` (in files like `test_structural_chunker.py`, `test_tech_detector.py`, `test_review_service.py`). Confirmed the identical 53 failures exist on `main` before my changes via `git stash`. In `tests/unit/test_prompt_templates.py` specifically — the file I modified — all 38 tests pass, including both new snapshot tests. Per the Week 9 "doesn't make things worse" guidance, my contribution introduces 0 new test failures and 0 new lint errors.
+
+**Draft PR feedback received from:** none

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,75 @@
+## Solution plan
+
+**Issue:** [Add snapshot tests for prompt templates to catch accidental changes](https://github.com/ascherj/pathreview/issues/37)
+
+### Understand
+The `rag/generator/prompt_templates.py` module stores versioned prompt
+templates (a dict of `name -> version -> template string`). The intent
+is that if a template's content changes, the version key should be
+bumped (e.g. `v1` -> `v2`) so historical behavior is preserved and
+reviewable in code. However, nothing currently enforces this contract.
+A developer can silently edit the content of `v1` and no test will fail.
+
+The existing `test_template_snapshot_content_hash` test in
+`tests/unit/test_prompt_templates.py` looks like a snapshot test but
+only asserts that an MD5 hex digest is 32 characters long — a
+tautology that holds for any string content. Expected behavior: the
+test suite should fail when a registered template version's content
+changes without a corresponding new version being added.
+
+### Map
+Files involved:
+- `tests/unit/test_prompt_templates.py` — where the fix lives. Remove
+  the placeholder `test_template_snapshot_content_hash` and add real
+  snapshot tests.
+- `rag/generator/prompt_templates.py` — no changes needed. This is
+  the module being pinned by the snapshots.
+
+### Plan
+1. Delete `test_template_snapshot_content_hash` (the placeholder).
+2. Add an `EXPECTED_TEMPLATE_SNAPSHOTS` class attribute on
+   `TestPromptTemplates` — a dict keyed by `(template_name, version)`
+   mapping to the SHA-256 hex digest of the template's content.
+3. Add `test_template_content_matches_snapshot`: iterate over
+   `EXPECTED_TEMPLATE_SNAPSHOTS`, compute the current SHA-256 of each
+   template version, and assert equality. On mismatch, raise a clear
+   error telling the developer to add a NEW version (e.g. `v2`)
+   rather than update the existing hash.
+4. Add `test_every_template_version_has_a_snapshot`: iterate over
+   `PROMPT_TEMPLATES` and assert every `(name, version)` pair has a
+   registered snapshot. This catches the reverse mistake of adding a
+   new template without pinning it.
+5. Verify: run the full file's test suite, then manually edit a
+   template and confirm the snapshot test fails with the right error.
+
+### Inputs & outputs
+- Input: current contents of `PROMPT_TEMPLATES` in
+  `rag/generator/prompt_templates.py`.
+- Output: two new pytest tests that fail on unregistered template
+  drift and pass otherwise. No runtime behavior of the app changes.
+
+### Risks & unknowns
+- **Hash collisions:** SHA-256 collisions are astronomically unlikely
+  for text of this size, so not a real risk. Chose SHA-256 over MD5
+  because MD5 is deprecated for content integrity even in
+  non-cryptographic uses.
+- **Pre-existing lint/type errors in the file:** the file has ruff
+  and mypy violations on tests that existed before this change (missing
+  return annotations, `key in dict.keys()`, unused loop vars). Fixing
+  them balloons the diff. Plan: leave them, note in the PR, offer a
+  follow-up.
+- **What if a developer legitimately wants to update `v1`?** They
+  can't silently — they must either add `v2` or, if truly deleting
+  `v1` behavior, also update `EXPECTED_TEMPLATE_SNAPSHOTS`. This is
+  intentional friction, which is the whole point of the issue.
+
+### Edge cases
+- Template added but no snapshot registered →
+  `test_every_template_version_has_a_snapshot` fails with a clear
+  "add the hash to EXPECTED_TEMPLATE_SNAPSHOTS" message.
+- Snapshot registered but the template was deleted from
+  `PROMPT_TEMPLATES` → `test_template_content_matches_snapshot` fails
+  with a "template missing but has a snapshot" message.
+- Template content change without a version bump →
+  `test_template_content_matches_snapshot` fails with expected vs.
+  actual hash and instructions to add a new version.

--- a/tests/unit/test_prompt_templates.py
+++ b/tests/unit/test_prompt_templates.py
@@ -1,7 +1,8 @@
 """Tests for prompt_templates.py - Snapshot tests"""
 
-import pytest
 import hashlib
+
+import pytest
 
 from rag.generator.prompt_templates import PROMPT_TEMPLATES, get_template
 
@@ -52,7 +53,9 @@ class TestPromptTemplates:
         """Test each template contains {context} placeholder."""
         for template_name, versions in PROMPT_TEMPLATES.items():
             for version, template_text in versions.items():
-                assert "{context}" in template_text, f"{template_name} v{version} missing {{context}}"
+                assert (
+                    "{context}" in template_text
+                ), f"{template_name} v{version} missing {{context}}"
 
     def test_each_template_contains_github_username_placeholder(self):
         """Test each template contains {github_username} placeholder."""
@@ -151,19 +154,32 @@ class TestPromptTemplates:
         """Test gaps_feedback template mentions missing/gap concepts."""
         template = PROMPT_TEMPLATES["gaps_feedback"]["v1"]
 
-        assert "gap" in template.lower() or "missing" in template.lower() or "demand" in template.lower()
+        assert (
+            "gap" in template.lower()
+            or "missing" in template.lower()
+            or "demand" in template.lower()
+        )
 
     def test_presentation_feedback_mentions_readme(self):
         """Test presentation_feedback template mentions README or presentation."""
         template = PROMPT_TEMPLATES["presentation_feedback"]["v1"]
 
-        assert "readme" in template.lower() or "presentation" in template.lower() or "organization" in template.lower()
+        assert (
+            "readme" in template.lower()
+            or "presentation" in template.lower()
+            or "organization" in template.lower()
+        )
 
     def test_first_impression_is_concise(self):
         """Test first_impression template instructs concise output."""
         template = PROMPT_TEMPLATES["first_impression"]["v1"]
 
-        assert "2" in template or "3" in template or "sentence" in template.lower() or "summary" in template.lower()
+        assert (
+            "2" in template
+            or "3" in template
+            or "sentence" in template.lower()
+            or "summary" in template.lower()
+        )
 
     def test_get_template_default_version(self):
         """Test get_template() defaults to v1 when version not specified."""
@@ -171,21 +187,6 @@ class TestPromptTemplates:
         template_v1 = get_template("skills_feedback", "v1")
 
         assert template_default == template_v1
-
-    def test_template_snapshot_content_hash(self):
-        """Snapshot test: verify template content hash."""
-        # Create hash of all template content
-        template_content = ""
-        for name in sorted(PROMPT_TEMPLATES.keys()):
-            for version in sorted(PROMPT_TEMPLATES[name].keys()):
-                template_content += PROMPT_TEMPLATES[name][version]
-
-        content_hash = hashlib.md5(template_content.encode()).hexdigest()
-
-        # Expected hash - update if templates intentionally change
-        # This helps detect unintended changes to templates
-        assert isinstance(content_hash, str)
-        assert len(content_hash) == 32  # MD5 hash length
 
     def test_skills_feedback_requests_json_format(self):
         """Test skills_feedback requests JSON output."""
@@ -216,7 +217,11 @@ class TestPromptTemplates:
         template = PROMPT_TEMPLATES["first_impression"]["v1"]
 
         # Should specify format (JSON or plain text)
-        assert "json" in template.lower() or "text" in template.lower() or "summary" in template.lower()
+        assert (
+            "json" in template.lower()
+            or "text" in template.lower()
+            or "summary" in template.lower()
+        )
 
     def test_templates_have_portfolio_context(self):
         """Test templates mention portfolio or context."""
@@ -230,7 +235,8 @@ class TestPromptTemplates:
         # Import logger to verify it's used
         with pytest.MonkeyPatch.context() as mp:
             from unittest.mock import patch
-            with patch('rag.generator.prompt_templates.logger') as mock_logger:
+
+            with patch("rag.generator.prompt_templates.logger") as mock_logger:
                 get_template("skills_feedback")
                 # Should log template retrieval
 
@@ -267,7 +273,87 @@ class TestPromptTemplates:
             for version, template_text in versions.items():
                 # All placeholders should use {name} syntax
                 import re
-                placeholders = re.findall(r'\{(\w+)\}', template_text)
+
+                placeholders = re.findall(r"\{(\w+)\}", template_text)
                 assert "context" in placeholders
                 assert "github_username" in placeholders
                 assert "project_count" in placeholders
+
+    # ------------------------------------------------------------------
+    # Snapshot tests
+    #
+    # These tests fail if a template's content changes without a version
+    # bump. If you intentionally change a template, you must:
+    #   1. Add a NEW version in prompt_templates.py (e.g. "v2")
+    #   2. Add its hash to EXPECTED_TEMPLATE_SNAPSHOTS below
+    #   3. Leave the old version's snapshot intact so historical
+    #      behavior stays pinned
+    # ------------------------------------------------------------------
+
+    EXPECTED_TEMPLATE_SNAPSHOTS = {
+        ("first_impression", "v1"): (
+            "9e7697ff3efd892c82c63ffcc8365690685fb1c29f79d45d84e057b2d0672dd0"
+        ),
+        ("gaps_feedback", "v1"): (
+            "b2673a1a1f018f2f2fdf37b2dfb6b30634404ba7bb2c241cc01b6240b9097950"
+        ),
+        ("presentation_feedback", "v1"): (
+            "87230b7045d66a1fae7d06e2509c6fae31046e0c4e8d30a3c3d6fe9ad2a7a3d7"
+        ),
+        ("projects_feedback", "v1"): (
+            "7e53575582f45389e4a3e4f93c7c137da629d3a14809e16f746732b9a06740d1"
+        ),
+        ("skills_feedback", "v1"): (
+            "a24d6d717d4f365c28a686f28b3e77f47204c325ce892fc32d68eb82259f6816"
+        ),
+    }
+
+    @staticmethod
+    def _hash_template(content: str) -> str:
+        """Return the sha256 hex digest of a template's content."""
+        return hashlib.sha256(content.encode()).hexdigest()
+
+    def test_template_content_matches_snapshot(self) -> None:
+        """Fail if a template's content changed without a version bump.
+
+        If this test fails, do NOT simply update the expected hash.
+        Instead, add a new version (e.g. v2) alongside the existing one
+        so historical prompt behavior stays pinned and reviewable.
+        """
+        for (name, version), expected_hash in self.EXPECTED_TEMPLATE_SNAPSHOTS.items():
+            assert name in PROMPT_TEMPLATES, (
+                f"Template '{name}' is missing but has a snapshot. "
+                f"If it was intentionally removed, also remove its entry "
+                f"from EXPECTED_TEMPLATE_SNAPSHOTS."
+            )
+            assert version in PROMPT_TEMPLATES[name], (
+                f"Version '{version}' is missing for template '{name}'. "
+                f"If it was intentionally removed, also remove its entry "
+                f"from EXPECTED_TEMPLATE_SNAPSHOTS."
+            )
+
+            actual_hash = self._hash_template(PROMPT_TEMPLATES[name][version])
+            assert actual_hash == expected_hash, (
+                f"Template '{name}' {version} content changed without a "
+                f"version bump.\n"
+                f"If this change is intentional, add a NEW version (e.g. "
+                f"v2) in prompt_templates.py and register its hash in "
+                f"EXPECTED_TEMPLATE_SNAPSHOTS, keeping the old snapshot "
+                f"intact.\n"
+                f"Expected hash: {expected_hash}\n"
+                f"Actual hash:   {actual_hash}"
+            )
+
+    def test_every_template_version_has_a_snapshot(self) -> None:
+        """Fail if a template version exists without a corresponding snapshot.
+
+        This catches the reverse mistake: adding a new template or version
+        in prompt_templates.py without registering a snapshot for it.
+        """
+        for name, versions in PROMPT_TEMPLATES.items():
+            for version in versions:
+                assert (name, version) in self.EXPECTED_TEMPLATE_SNAPSHOTS, (
+                    f"Template '{name}' {version} has no snapshot registered. "
+                    f"Add its hash to EXPECTED_TEMPLATE_SNAPSHOTS in this "
+                    f"test file."
+                )


### PR DESCRIPTION
## Summary

Closes #37.

The existing `test_template_snapshot_content_hash` test in
`tests/unit/test_prompt_templates.py` looked like a snapshot test but
didn't actually check template content — it only asserted that the
MD5 hash string was 32 characters long, which is always true. That
meant a developer could silently edit `v1` of any prompt and no test
would fail, even though prompt drift changes production LLM behavior.

## What changed

- Removed the placeholder `test_template_snapshot_content_hash` test.
- Added `EXPECTED_TEMPLATE_SNAPSHOTS`, a `(name, version) -> sha256` map
  covering every existing template version (`v1` of `first_impression`,
  `gaps_feedback`, `presentation_feedback`, `projects_feedback`, and
  `skills_feedback`).
- Added `test_template_content_matches_snapshot`: fails when the
  content of any registered template version changes. The error
  message explicitly tells the developer to add a new version (e.g.
  `v2`) and register a new snapshot, rather than update the hash for
  the existing version.
- Added `test_every_template_version_has_a_snapshot`: catches the
  reverse mistake of adding a new template/version without also adding
  a snapshot.

## How I verified

- `pytest tests/unit/test_prompt_templates.py -v` — 38/38 pass,
  including the two new tests.
- Manual sanity check: made a one-character edit to `skills_feedback`
  v1, re-ran the snapshot test, confirmed it fails with the
  version-bump guidance message. Reverted the edit, test passes again.

## Notes for reviewers

- Uses SHA-256 (not MD5 like the old placeholder). No new dependencies.
- The file had pre-existing ruff/mypy violations before this PR
  (missing return type annotations on existing tests, `key in dict.keys()`
  usages, unused loop variables, etc.). I left them untouched to keep
  the diff focused on issue #37. Happy to address them in a follow-up
  PR if you'd prefer.
- All existing tests in the file still pass unchanged.
