### PR TITLE
Feat/14 GitHub actions parser

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,6 @@ repos:
     rev: v1.8.0
     hooks:
       - id: mypy
-        additional_dependencies: [types-redis]
+        additional_dependencies: [types-redis, types-PyYAML]
         args: [--ignore-missing-imports]
         language_version: python3.13

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,4 @@ repos:
       - id: mypy
         additional_dependencies: [types-redis]
         args: [--ignore-missing-imports]
+        language_version: python3.13

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -9,7 +9,7 @@
 **Problem summary:**
 Currently, `SkillExtractor` (`ingestion/parsers/skill_extractor.py`) infers a developer's skills only from source code, import statements, and README, so DevOps practices like CI/CD pipelines, containerization, and automated deployment go completely undetected even when a candidate's repo has a working `.github/workflows/*.yml` pipeline. There is no parser in `ingestion/parsers/` that reads GitHub Actions workflow YAML, so signals like `uses: docker/build-push-action`, `pytest` test steps, or deploy jobs never make it into the skill graph. A successful fix adds a `workflow_parser.py` that parses `.github/workflows/*.yml` into structured data (triggers, jobs, actions used, run commands) and extends `skill_extractor.py` to infer skills such as "GitHub Actions," "Docker," "pytest," and "deployment" from that structure.
 
-**Branch name:** [paste branch name here]
+**Branch name:** https://github.com/sindhunaydu/pathreview/tree/feat/14-github-actions-parser
 
 **Setup confirmation:** [X] App runs locally at localhost:5173
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,16 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/14
+
+**Issue title:** Add support for parsing GitHub Actions workflow files to detect CI/CD skills
+
+**Tier:** [ ] Tier 1  [ ] Tier 2  [X] Tier 3
+
+**Problem summary:**
+Currently, `SkillExtractor` (`ingestion/parsers/skill_extractor.py`) infers a developer's skills only from source code, import statements, and README, so DevOps practices like CI/CD pipelines, containerization, and automated deployment go completely undetected even when a candidate's repo has a working `.github/workflows/*.yml` pipeline. There is no parser in `ingestion/parsers/` that reads GitHub Actions workflow YAML, so signals like `uses: docker/build-push-action`, `pytest` test steps, or deploy jobs never make it into the skill graph. A successful fix adds a `workflow_parser.py` that parses `.github/workflows/*.yml` into structured data (triggers, jobs, actions used, run commands) and extends `skill_extractor.py` to infer skills such as "GitHub Actions," "Docker," "pytest," and "deployment" from that structure.
+
+**Branch name:** [paste branch name here]
+
+**Setup confirmation:** [X] App runs locally at localhost:5173
+
+**Cohort ledger:** [X] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -17,3 +17,17 @@ I have a particular interest in CI/CD and DevOps work, and issues involving GitH
 **Setup confirmation:** [X] App runs locally at localhost:5173
 
 **Cohort ledger:** [X] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** (added in this commit, see `tests/unit/test_workflow_parser_reproduction.py`)
+
+**Reproduction summary:**
+Added `tests/unit/test_workflow_parser_reproduction.py`, which confirms `ingestion.parsers.workflow_parser` does not exist and shows that `SkillExtractor.extract_skills` cannot detect "GitHub Actions," "Pytest," or "Deployment" from a real GitHub Actions workflow YAML — it only matches the literal word "docker" in text, with no structural parsing of jobs/steps. Both tests pass today, which is expected: they document the current (missing) behavior.
+
+**PLAN.md link:** [PLAN.md](PLAN.md)
+
+**Walkthrough video (recommended):**
+
+**Blockers or open questions:**
+Still deciding whether workflow ingestion should be its own `source_type` in `ingestion/pipeline.py` or folded into the existing "repo" source type — see Risks & unknowns in PLAN.md.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -9,6 +9,9 @@
 **Problem summary:**
 Currently, `SkillExtractor` (`ingestion/parsers/skill_extractor.py`) infers a developer's skills only from source code, import statements, and README, so DevOps practices like CI/CD pipelines, containerization, and automated deployment go completely undetected even when a candidate's repo has a working `.github/workflows/*.yml` pipeline. There is no parser in `ingestion/parsers/` that reads GitHub Actions workflow YAML, so signals like `uses: docker/build-push-action`, `pytest` test steps, or deploy jobs never make it into the skill graph. A successful fix adds a `workflow_parser.py` that parses `.github/workflows/*.yml` into structured data (triggers, jobs, actions used, run commands) and extends `skill_extractor.py` to infer skills such as "GitHub Actions," "Docker," "pytest," and "deployment" from that structure.
 
+**Reasoning:** 
+I have a particular interest in CI/CD and DevOps work, and issues involving GitHub Actions are a great fit for me. I'm an experienced software engineer comfortable taking on Tier 3 issues and I'm interested in desiging and building new parser module + integration into an existing extraction pipeline.
+
 **Branch name:** https://github.com/sindhunaydu/pathreview/tree/feat/14-github-actions-parser
 
 **Setup confirmation:** [X] App runs locally at localhost:5173

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,45 @@
+## Solution plan
+
+**Issue:** Add support for parsing GitHub Actions workflow files to detect CI/CD skills — https://github.com/ascherj/pathreview/issues/14
+
+### Understand
+`SkillExtractor` (`ingestion/parsers/skill_extractor.py`) only does keyword matching over raw text (source code/README), and `RepoAnalyzer._detect_ci` (`ingestion/parsers/repo_analyzer.py:111`) only checks whether a `.github/workflows` path string is present — it never opens or parses the YAML. Because of this:
+- No `workflow_parser.py` exists in `ingestion/parsers/` (confirmed in [tests/unit/test_workflow_parser_reproduction.py](tests/unit/test_workflow_parser_reproduction.py)).
+- CI/CD is reduced to a boolean (`has_ci`), losing structured signal like which actions are used (`docker/build-push-action`), which jobs run `pytest`, or whether a deploy job exists.
+- `SkillExtractor` can only detect "Docker" because the literal word appears in text, not because a build/push step was structurally identified — so skills like "GitHub Actions," "pytest" (as a CI-run test suite), or "Deployment" never get inferred from a real workflow file.
+
+Expected behavior: a `.github/workflows/*.yml` file should be parsed into structured data (triggers, jobs, steps, `uses:` actions, `run:` commands), and that structure should feed into skill inference so signals like "GitHub Actions," "Docker," "pytest," and "Deployment" are detected with real evidence (which job/step they came from), not just substring matches.
+
+### Map
+Files expected to be touched:
+- `ingestion/parsers/workflow_parser.py` (new) — parses workflow YAML into structured data, following the `BaseParser`/`ParseResult` contract used by `readme_parser.py` and `repo_analyzer.py`.
+- `ingestion/parsers/base.py` — reuse `BaseParser`/`ParseResult` as-is; no changes expected.
+- `ingestion/parsers/skill_extractor.py` — add a method (e.g. `extract_skills_from_workflow`) that takes the parsed workflow structure and infers skills ("GitHub Actions," specific actions, "pytest," "Deployment") with evidence tied to job/step names, instead of only ever scanning raw text.
+- `ingestion/pipeline.py` — add an `ingest_workflow` method mirroring `ingest_readme`/`ingest_repo_metadata`, wiring `WorkflowParser` into the pipeline the same way `ReadmeParser` and `RepoAnalyzer` are wired in `__init__`.
+- `tests/unit/test_workflow_parser.py` (new) — unit tests for the parser itself (triggers, jobs, actions, run commands, malformed YAML).
+- `tests/unit/test_skill_extractor.py` — extend with cases for workflow-derived skill inference.
+- `pyproject.toml` — add `pyyaml` as an explicit dependency (currently only present transitively in `.venv`; not declared as a direct project dependency).
+
+### Plan
+1. Add `pyyaml` as an explicit dependency in `pyproject.toml` and confirm `make setup`/existing lockfile picks it up.
+2. Build `WorkflowParser(BaseParser)` in `ingestion/parsers/workflow_parser.py`: parse YAML safely (`yaml.safe_load`), extract `on:` triggers, `jobs:` (names, `runs-on`, `needs`), each job's `steps:` (`uses:` actions with pinned versions, `run:` commands), and return this as `ParseResult.metadata` (mirroring the `heading_hierarchy`-style structured metadata pattern in `readme_parser.py`) plus a flattened `text` summary for embedding.
+3. Extend `SkillExtractor` with workflow-aware skill inference: map known actions (`docker/build-push-action`, `actions/setup-python`, etc.) and run-command patterns (`pytest`, `npm test`, `terraform apply`) to `SkillDetection` entries with evidence referencing the specific job/step, reusing the existing `SkillDetection` dataclass and confidence-scoring conventions already used for frameworks/tools.
+4. Wire `WorkflowParser` into `IngestionPipeline` as `ingest_workflow`, following the existing `ingest_readme` structure (source_id hashing, skip-check, chunk, embed, record).
+5. Write/replace tests: add `test_workflow_parser.py` covering parsing correctness and malformed/missing YAML handling; update `test_skill_extractor.py` for workflow-derived skills; update `test_workflow_parser_reproduction.py` (or remove it) once the gap it documents is closed, since its assertions currently pass *because* the bug exists.
+
+### Inputs & outputs
+- **Input:** raw `.github/workflows/*.yml` file content (str or bytes), matching how `ReadmeParser.parse` and `RepoAnalyzer.parse` accept content today.
+- **Output:** a `ParseResult` with structured metadata (triggers, jobs, actions used, run commands) and a text summary suitable for chunking/embedding, plus a list of `SkillDetection` objects (e.g. "GitHub Actions," "Docker," "pytest," "Deployment") with evidence pointing at the originating job/step.
+
+### Risks & unknowns
+- Real-world workflows use YAML anchors, matrix builds, reusable workflows (`uses: org/repo/.github/workflows/x.yml@main`), and composite actions — need to decide how much of this to support in v1 vs. treat as out of scope.
+- Malformed/invalid YAML must fail gracefully (raise a clear `ValueError`, consistent with `ReadmeParser`'s bytes/str validation) rather than crashing the ingestion pipeline.
+- Unclear whether workflow ingestion should be a new `source_type` in the pipeline/DB or folded into the existing "repo" source type — affects `pipeline.py` and any downstream consumers of `source_type`.
+- Mapping from actions/run-commands to skill names will need a maintained lookup table (similar to `FRAMEWORKS`/`TOOLS` in `skill_extractor.py`), which will need to grow over time as new actions become common — need to scope an initial list rather than trying to be exhaustive.
+
+### Edge cases
+- Empty or missing `.github/workflows/` directory (no workflow files at all).
+- Workflow YAML with no `jobs:` key, or jobs with no `steps:`.
+- Steps using only `run:` (no `uses:`), and steps using only `uses:` (no `run:`).
+- Multiple workflow files in one repo (e.g. `ci.yml` and `deploy.yml`) — need aggregation rather than only handling a single file.
+- Reusable/composite actions and matrix strategies that don't map cleanly to a single "job = one thing" model.

--- a/ingestion/parsers/skill_extractor.py
+++ b/ingestion/parsers/skill_extractor.py
@@ -1,11 +1,11 @@
 import re
 from dataclasses import dataclass
-from typing import Optional
 
 
 @dataclass
 class SkillDetection:
     """Result of detecting a skill."""
+
     name: str
     category: str
     confidence: float
@@ -105,7 +105,34 @@ class SkillExtractor:
         "ansible": 0.85,
     }
 
-    def extract_skills(self, text: str, filename: Optional[str] = None) -> list[SkillDetection]:
+    # Maps a `uses:` action prefix (owner/repo, ignoring @ref) to a skill.
+    WORKFLOW_ACTION_SKILLS = {
+        "docker/build-push-action": ("Docker", "Tool", 0.95),
+        "docker/login-action": ("Docker", "Tool", 0.90),
+        "docker/setup-buildx-action": ("Docker", "Tool", 0.85),
+        "actions/setup-python": ("Python", "Language", 0.80),
+        "actions/setup-node": ("JavaScript", "Language", 0.80),
+        "aws-actions/configure-aws-credentials": ("AWS", "Tool", 0.90),
+        "azure/login": ("Azure", "Tool", 0.90),
+        "google-github-actions/auth": ("GCP", "Tool", 0.90),
+        "hashicorp/setup-terraform": ("Terraform", "Tool", 0.90),
+    }
+
+    # Maps a substring found in a `run:` command to a skill.
+    WORKFLOW_RUN_SKILLS = {
+        "pytest": ("Pytest", "Tool", 0.90),
+        "npm test": ("Jest", "Tool", 0.75),
+        "npm run test": ("Jest", "Tool", 0.75),
+        "terraform": ("Terraform", "Tool", 0.85),
+        "kubectl": ("Kubernetes", "Tool", 0.85),
+        "docker build": ("Docker", "Tool", 0.90),
+        "docker push": ("Docker", "Tool", 0.90),
+    }
+
+    # Job-name keywords that indicate a deployment job.
+    DEPLOY_JOB_KEYWORDS = {"deploy", "release", "publish"}
+
+    def extract_skills(self, text: str, filename: str | None = None) -> list[SkillDetection]:
         """
         Extract skills from source code or documentation text.
 
@@ -116,7 +143,7 @@ class SkillExtractor:
         Returns:
             List of detected skills with confidence scores
         """
-        detected_skills = {}
+        detected_skills: dict[str, SkillDetection] = {}
 
         # Detect languages first
         self._detect_languages(text, filename, detected_skills)
@@ -143,7 +170,7 @@ class SkillExtractor:
     def _detect_languages(
         self,
         text: str,
-        filename: Optional[str],
+        filename: str | None,
         skills_dict: dict,
     ) -> None:
         """Detect programming languages."""
@@ -274,3 +301,98 @@ class SkillExtractor:
                         confidence=confidence,
                         evidence=[f"Found '{tool}' reference in content"],
                     )
+
+    def extract_skills_from_workflow(self, workflow_metadata: dict) -> list[SkillDetection]:
+        """
+        Infer skills from structured GitHub Actions workflow data.
+
+        Args:
+            workflow_metadata: The `metadata` dict produced by
+                `WorkflowParser.parse` (must contain a `jobs` list of
+                job dicts with `name` and `steps`).
+
+        Returns:
+            List of detected skills with confidence scores
+        """
+        skills_dict: dict[str, SkillDetection] = {}
+        jobs = workflow_metadata.get("jobs") or []
+
+        if jobs:
+            skills_dict["GitHub Actions"] = SkillDetection(
+                name="GitHub Actions",
+                category="Tool",
+                confidence=0.95,
+                evidence=[f"Workflow defines {len(jobs)} job(s)"],
+            )
+
+        for job in jobs:
+            job_name = job.get("name", "")
+
+            for step in job.get("steps", []):
+                uses = step.get("uses")
+                if uses:
+                    self._detect_workflow_action(uses, job_name, skills_dict)
+
+                run = step.get("run")
+                if run:
+                    self._detect_workflow_run_command(run, job_name, skills_dict)
+
+            if any(keyword in job_name.lower() for keyword in self.DEPLOY_JOB_KEYWORDS):
+                self._record_skill(
+                    skills_dict,
+                    name="Deployment",
+                    category="Practice",
+                    confidence=0.85,
+                    evidence=f"Job '{job_name}' matches a deployment naming pattern",
+                )
+
+        return sorted(skills_dict.values(), key=lambda x: x.confidence, reverse=True)
+
+    def _detect_workflow_action(self, uses: str, job_name: str, skills_dict: dict) -> None:
+        """Match a step's `uses:` action against known workflow actions."""
+        action_name = uses.split("@")[0]
+
+        for prefix, (skill_name, category, confidence) in self.WORKFLOW_ACTION_SKILLS.items():
+            if action_name == prefix:
+                self._record_skill(
+                    skills_dict,
+                    name=skill_name,
+                    category=category,
+                    confidence=confidence,
+                    evidence=f"Job '{job_name}' uses '{uses}'",
+                )
+
+    def _detect_workflow_run_command(self, run: str, job_name: str, skills_dict: dict) -> None:
+        """Match a step's `run:` command against known workflow run patterns."""
+        run_lower = run.lower()
+
+        for keyword, (skill_name, category, confidence) in self.WORKFLOW_RUN_SKILLS.items():
+            if keyword in run_lower:
+                self._record_skill(
+                    skills_dict,
+                    name=skill_name,
+                    category=category,
+                    confidence=confidence,
+                    evidence=f"Job '{job_name}' runs '{run.strip()}'",
+                )
+
+    def _record_skill(
+        self,
+        skills_dict: dict,
+        name: str,
+        category: str,
+        confidence: float,
+        evidence: str,
+    ) -> None:
+        """Add a skill, or merge evidence into an existing detection for it."""
+        existing = skills_dict.get(name)
+        if existing:
+            existing.evidence.append(evidence)
+            existing.confidence = max(existing.confidence, confidence)
+        else:
+            skills_dict[name] = SkillDetection(
+                name=name,
+                category=category,
+                confidence=confidence,
+                evidence=[evidence],
+            )

--- a/ingestion/parsers/workflow_parser.py
+++ b/ingestion/parsers/workflow_parser.py
@@ -1,0 +1,127 @@
+import yaml
+
+from .base import BaseParser, ParseResult
+
+
+class WorkflowParser(BaseParser):
+    """Parser for GitHub Actions workflow files (.github/workflows/*.yml)."""
+
+    def parse(self, content: str | bytes) -> ParseResult:
+        """
+        Parse a GitHub Actions workflow from YAML content.
+
+        Args:
+            content: Workflow YAML string or bytes
+
+        Returns:
+            ParseResult with structured workflow data and a text summary
+
+        Raises:
+            ValueError: If content is not a valid string/bytes, or not valid
+                workflow YAML
+        """
+        if isinstance(content, bytes):
+            content = content.decode("utf-8", errors="replace")
+        elif not isinstance(content, str):
+            raise ValueError("Content must be a string or bytes")
+
+        try:
+            workflow = yaml.safe_load(content)
+        except yaml.YAMLError as e:
+            raise ValueError(f"Invalid workflow YAML: {e}") from e
+
+        if not isinstance(workflow, dict):
+            raise ValueError("Workflow content must be a YAML mapping")
+
+        name = workflow.get("name") or "Unnamed workflow"
+        triggers = self._extract_triggers(workflow)
+        jobs = self._extract_jobs(workflow)
+        actions_used = sorted(
+            {step["uses"] for job in jobs for step in job["steps"] if step["uses"]}
+        )
+        run_commands = [step["run"] for job in jobs for step in job["steps"] if step["run"]]
+
+        metadata = {
+            "source_type": "workflow",
+            "workflow_name": name,
+            "triggers": triggers,
+            "jobs": jobs,
+            "actions_used": actions_used,
+            "run_commands": run_commands,
+            "job_count": len(jobs),
+        }
+
+        return ParseResult(
+            text=self._build_summary(name, triggers, jobs),
+            metadata=metadata,
+            source_type="workflow",
+        )
+
+    def _extract_triggers(self, workflow: dict) -> list[str]:
+        """Normalize the `on:` key into a flat list of trigger names.
+
+        PyYAML's default (1.1) resolver parses the bare `on` key as the
+        boolean `True` rather than the string "on", so both are checked here.
+        """
+        on = workflow.get("on", workflow.get(True))
+        if isinstance(on, str):
+            return [on]
+        if isinstance(on, list):
+            return [str(trigger) for trigger in on]
+        if isinstance(on, dict):
+            return list(on.keys())
+        return []
+
+    def _extract_jobs(self, workflow: dict) -> list[dict]:
+        """Extract job name, runner, dependencies, and steps for each job."""
+        jobs_data = workflow.get("jobs") or {}
+        jobs = []
+        for job_name, job_def in jobs_data.items():
+            if not isinstance(job_def, dict):
+                continue
+
+            needs = job_def.get("needs") or []
+            if isinstance(needs, str):
+                needs = [needs]
+
+            jobs.append(
+                {
+                    "name": job_name,
+                    "runs_on": job_def.get("runs-on"),
+                    "needs": needs,
+                    "steps": self._extract_steps(job_def.get("steps") or []),
+                }
+            )
+        return jobs
+
+    def _extract_steps(self, steps_data: list) -> list[dict]:
+        """Extract the `uses:` action and `run:` command from each step."""
+        steps = []
+        for step in steps_data:
+            if not isinstance(step, dict):
+                continue
+            steps.append(
+                {
+                    "name": step.get("name"),
+                    "uses": step.get("uses"),
+                    "run": step.get("run"),
+                }
+            )
+        return steps
+
+    def _build_summary(self, name: str, triggers: list[str], jobs: list[dict]) -> str:
+        """Build a flattened text summary of the workflow for embedding."""
+        lines = [
+            f"Workflow: {name}",
+            f"Triggers: {', '.join(triggers) if triggers else 'none'}",
+        ]
+        for job in jobs:
+            lines.append(f"Job: {job['name']} (runs-on: {job['runs_on'] or 'unknown'})")
+            if job["needs"]:
+                lines.append(f"  Needs: {', '.join(job['needs'])}")
+            for step in job["steps"]:
+                if step["uses"]:
+                    lines.append(f"  Uses: {step['uses']}")
+                if step["run"]:
+                    lines.append(f"  Run: {step['run']}")
+        return "\n".join(lines)

--- a/ingestion/pipeline.py
+++ b/ingestion/pipeline.py
@@ -1,6 +1,5 @@
 import hashlib
 from dataclasses import dataclass
-from typing import Optional
 
 import structlog
 
@@ -10,7 +9,7 @@ from .embeddings.provider import EmbeddingProvider
 from .parsers.readme_parser import ReadmeParser
 from .parsers.repo_analyzer import RepoAnalyzer
 from .parsers.resume_parser import ResumeParser
-
+from .parsers.workflow_parser import WorkflowParser
 
 logger = structlog.get_logger()
 
@@ -18,10 +17,11 @@ logger = structlog.get_logger()
 @dataclass
 class IngestResult:
     """Result of ingesting a source."""
+
     source_id: str
     chunk_count: int
     skipped: bool
-    skip_reason: Optional[str] = None
+    skip_reason: str | None = None
 
 
 class IngestionPipeline:
@@ -51,6 +51,7 @@ class IngestionPipeline:
         self.resume_parser = ResumeParser()
         self.readme_parser = ReadmeParser()
         self.repo_analyzer = RepoAnalyzer()
+        self.workflow_parser = WorkflowParser()
 
     def ingest_resume(
         self,
@@ -86,16 +87,21 @@ class IngestionPipeline:
         try:
             # Parse resume
             parse_result = self.resume_parser.parse(content)
-            logger.info("Resume parsed successfully", sections=parse_result.metadata.get("detected_sections"))
+            logger.info(
+                "Resume parsed successfully",
+                sections=parse_result.metadata.get("detected_sections"),
+            )
 
             # Prepare metadata
             metadata = parse_result.metadata.copy()
-            metadata.update({
-                "source_id": source_id,
-                "profile_id": profile_id,
-                "filename": filename,
-                "source_type": "resume",
-            })
+            metadata.update(
+                {
+                    "source_id": source_id,
+                    "profile_id": profile_id,
+                    "filename": filename,
+                    "source_type": "resume",
+                }
+            )
 
             # Chunk the content
             chunks = self.strategy_selector.chunk(parse_result.text, metadata)
@@ -165,12 +171,14 @@ class IngestionPipeline:
 
             # Prepare metadata
             metadata = parse_result.metadata.copy()
-            metadata.update({
-                "source_id": source_id,
-                "profile_id": profile_id,
-                "repo_name": repo_name,
-                "source_type": "readme",
-            })
+            metadata.update(
+                {
+                    "source_id": source_id,
+                    "profile_id": profile_id,
+                    "repo_name": repo_name,
+                    "source_type": "readme",
+                }
+            )
 
             # Chunk the content
             chunks = self.strategy_selector.chunk(parse_result.text, metadata)
@@ -192,6 +200,83 @@ class IngestionPipeline:
         except Exception as e:
             logger.error(
                 "README ingestion failed",
+                profile_id=profile_id,
+                repo_name=repo_name,
+                error=str(e),
+            )
+            raise
+
+    def ingest_workflow(
+        self,
+        profile_id: str,
+        repo_name: str,
+        content: str | bytes,
+    ) -> IngestResult:
+        """
+        Ingest a GitHub Actions workflow file.
+
+        Args:
+            profile_id: ID of the profile owner
+            repo_name: Name of the repository
+            content: Workflow YAML content (string or bytes)
+
+        Returns:
+            IngestResult with ingestion status
+        """
+        source_id = f"workflow_{profile_id}_{repo_name}_{self._hash_content(content)}"
+
+        logger.info(
+            "Starting workflow ingestion",
+            profile_id=profile_id,
+            repo_name=repo_name,
+            source_id=source_id,
+        )
+
+        # Check if already ingested
+        skip_result = self._check_skip(source_id, "workflow")
+        if skip_result:
+            return skip_result
+
+        try:
+            # Parse workflow
+            parse_result = self.workflow_parser.parse(content)
+            logger.info(
+                "Workflow parsed successfully",
+                workflow_name=parse_result.metadata.get("workflow_name"),
+                job_count=parse_result.metadata.get("job_count"),
+            )
+
+            # Prepare metadata
+            metadata = parse_result.metadata.copy()
+            metadata.update(
+                {
+                    "source_id": source_id,
+                    "profile_id": profile_id,
+                    "repo_name": repo_name,
+                    "source_type": "workflow",
+                }
+            )
+
+            # Chunk the content
+            chunks = self.strategy_selector.chunk(parse_result.text, metadata)
+            logger.info("Workflow chunked successfully", chunk_count=len(chunks))
+
+            # Generate embeddings and store
+            self.batch_processor.process(chunks)
+            logger.info("Workflow embeddings stored", chunk_count=len(chunks))
+
+            # Record in database
+            self._record_ingested_source(source_id, "workflow", profile_id, len(chunks))
+
+            return IngestResult(
+                source_id=source_id,
+                chunk_count=len(chunks),
+                skipped=False,
+            )
+
+        except Exception as e:
+            logger.error(
+                "Workflow ingestion failed",
                 profile_id=profile_id,
                 repo_name=repo_name,
                 error=str(e),
@@ -239,11 +324,13 @@ class IngestionPipeline:
 
             # Prepare metadata
             metadata = parse_result.metadata.copy()
-            metadata.update({
-                "source_id": source_id,
-                "profile_id": profile_id,
-                "source_type": "repo",
-            })
+            metadata.update(
+                {
+                    "source_id": source_id,
+                    "profile_id": profile_id,
+                    "source_type": "repo",
+                }
+            )
 
             # Chunk the content
             chunks = self.strategy_selector.chunk(parse_result.text, metadata)
@@ -277,7 +364,7 @@ class IngestionPipeline:
             content = content.encode()
         return hashlib.sha256(content).hexdigest()[:16]
 
-    def _check_skip(self, source_id: str, source_type: str) -> Optional[IngestResult]:
+    def _check_skip(self, source_id: str, source_type: str) -> IngestResult | None:
         """
         Check if source has already been ingested.
 
@@ -286,9 +373,11 @@ class IngestionPipeline:
         try:
             # Query database for existing source
             # This assumes a table/model named IngestedSource
-            existing = self.db_session.query(
-                "IngestedSource"  # Placeholder - actual query depends on ORM
-            ).filter_by(source_id=source_id).first()
+            existing = (
+                self.db_session.query("IngestedSource")  # Placeholder - actual query depends on ORM
+                .filter_by(source_id=source_id)
+                .first()
+            )
 
             if existing:
                 logger.info("Source already ingested, skipping", source_id=source_id)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "structlog>=24.1.0",
     "rank-bm25>=0.2.2",
     "numpy>=1.26.0",
+    "pyyaml>=6.0",
 ]
 
 [project.optional-dependencies]
@@ -50,6 +51,7 @@ dev = [
     "pre-commit>=3.6.0",
     "mutmut>=2.4.4",
     "types-redis>=4.6.0",
+    "types-PyYAML>=6.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/tests/unit/test_skill_extractor.py
+++ b/tests/unit/test_skill_extractor.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from ingestion.parsers.skill_extractor import SkillExtractor, SkillDetection
+from ingestion.parsers.skill_extractor import SkillDetection, SkillExtractor
 
 
 @pytest.mark.unit
@@ -135,7 +135,7 @@ class TestSkillExtractor:
         """
         result = extractor.extract_skills(text)
 
-        skill_names = [s.name for s in skill_names]
+        skill_names = [s.name for s in result]
         # Should detect PostgreSQL
         assert any("postgres" in s.lower() or "sql" in s.lower() for s in skill_names)
 
@@ -232,13 +232,114 @@ class TestSkillExtractor:
     def test_skill_detection_dataclass(self):
         """Test SkillDetection dataclass structure."""
         skill = SkillDetection(
-            name="Python",
-            category="Language",
-            confidence=0.95,
-            evidence=["import statement"]
+            name="Python", category="Language", confidence=0.95, evidence=["import statement"]
         )
 
         assert skill.name == "Python"
         assert skill.category == "Language"
         assert skill.confidence == 0.95
         assert len(skill.evidence) == 1
+
+
+@pytest.mark.unit
+class TestSkillExtractorWorkflow:
+    """Test suite for SkillExtractor.extract_skills_from_workflow."""
+
+    @pytest.fixture
+    def extractor(self):
+        """Create a SkillExtractor instance."""
+        return SkillExtractor()
+
+    @pytest.fixture
+    def workflow_metadata(self):
+        """Structured metadata as produced by WorkflowParser.parse."""
+        return {
+            "jobs": [
+                {
+                    "name": "test",
+                    "runs_on": "ubuntu-latest",
+                    "needs": [],
+                    "steps": [
+                        {"name": "Checkout", "uses": "actions/checkout@v4", "run": None},
+                        {"name": "Run tests", "uses": None, "run": "pytest tests/"},
+                    ],
+                },
+                {
+                    "name": "deploy",
+                    "runs_on": "ubuntu-latest",
+                    "needs": ["test"],
+                    "steps": [
+                        {
+                            "name": "Build and push",
+                            "uses": "docker/build-push-action@v5",
+                            "run": None,
+                        },
+                    ],
+                },
+            ],
+        }
+
+    def test_detects_github_actions_when_jobs_present(self, extractor, workflow_metadata):
+        """Any workflow with at least one job should be flagged as GitHub Actions."""
+        skills = extractor.extract_skills_from_workflow(workflow_metadata)
+        skill_names = {s.name for s in skills}
+
+        assert "GitHub Actions" in skill_names
+
+    def test_no_jobs_means_no_skills(self, extractor):
+        """A workflow with no jobs should produce no skill detections."""
+        skills = extractor.extract_skills_from_workflow({"jobs": []})
+
+        assert skills == []
+
+    def test_detects_docker_from_action(self, extractor, workflow_metadata):
+        """A `docker/build-push-action` step should be detected as Docker."""
+        skills = extractor.extract_skills_from_workflow(workflow_metadata)
+        docker_skill = next(s for s in skills if s.name == "Docker")
+
+        assert docker_skill.category == "Tool"
+        assert any("build-push-action" in e for e in docker_skill.evidence)
+
+    def test_detects_pytest_from_run_command(self, extractor, workflow_metadata):
+        """A `run: pytest ...` step should be detected as Pytest."""
+        skills = extractor.extract_skills_from_workflow(workflow_metadata)
+        skill_names = {s.name for s in skills}
+
+        assert "Pytest" in skill_names
+
+    def test_detects_deployment_from_job_name(self, extractor, workflow_metadata):
+        """A job named 'deploy' should be detected as a Deployment practice."""
+        skills = extractor.extract_skills_from_workflow(workflow_metadata)
+        deploy_skill = next(s for s in skills if s.name == "Deployment")
+
+        assert deploy_skill.category == "Practice"
+        assert "deploy" in deploy_skill.evidence[0]
+
+    def test_evidence_merges_for_repeated_skill(self, extractor):
+        """Multiple steps triggering the same skill merge evidence, not duplicate the skill."""
+        metadata = {
+            "jobs": [
+                {
+                    "name": "build",
+                    "runs_on": "ubuntu-latest",
+                    "needs": [],
+                    "steps": [
+                        {"name": None, "uses": "docker/build-push-action@v5", "run": None},
+                        {"name": None, "uses": None, "run": "docker build -t app ."},
+                    ],
+                },
+            ],
+        }
+        skills = extractor.extract_skills_from_workflow(metadata)
+        docker_skills = [s for s in skills if s.name == "Docker"]
+
+        assert len(docker_skills) == 1
+        assert len(docker_skills[0].evidence) == 2
+
+    def test_all_results_are_skill_detections(self, extractor, workflow_metadata):
+        """extract_skills_from_workflow should return SkillDetection instances."""
+        skills = extractor.extract_skills_from_workflow(workflow_metadata)
+
+        assert len(skills) > 0
+        for skill in skills:
+            assert isinstance(skill, SkillDetection)

--- a/tests/unit/test_workflow_parser.py
+++ b/tests/unit/test_workflow_parser.py
@@ -1,0 +1,159 @@
+"""Tests for workflow_parser.py"""
+
+import pytest
+
+from ingestion.parsers.base import ParseResult
+from ingestion.parsers.workflow_parser import WorkflowParser
+
+SAMPLE_WORKFLOW_YAML = """
+name: CI
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run tests
+        run: pytest tests/
+
+  build-and-push:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: docker/build-push-action@v5
+        with:
+          push: true
+          tags: myapp:latest
+"""
+
+
+@pytest.mark.unit
+class TestWorkflowParser:
+    """Test suite for WorkflowParser."""
+
+    @pytest.fixture
+    def parser(self):
+        """Create a WorkflowParser instance."""
+        return WorkflowParser()
+
+    def test_parse_standard_workflow(self, parser):
+        """Test parsing a standard GitHub Actions workflow."""
+        result = parser.parse(SAMPLE_WORKFLOW_YAML)
+
+        assert isinstance(result, ParseResult)
+        assert result.source_type == "workflow"
+        assert result.metadata["source_type"] == "workflow"
+        assert result.metadata["workflow_name"] == "CI"
+
+    def test_extract_triggers(self, parser):
+        """Test that triggers are extracted from the `on:` key."""
+        result = parser.parse(SAMPLE_WORKFLOW_YAML)
+
+        assert set(result.metadata["triggers"]) == {"push", "pull_request"}
+
+    def test_extract_string_trigger(self, parser):
+        """Test that a single string trigger (e.g. `on: push`) is normalized to a list."""
+        workflow = "name: CI\non: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n"
+        result = parser.parse(workflow)
+
+        assert result.metadata["triggers"] == ["push"]
+
+    def test_extract_list_trigger(self, parser):
+        """Test that a list of triggers (e.g. `on: [push, pull_request]`) is preserved."""
+        workflow = (
+            "name: CI\non: [push, pull_request]\njobs:\n  test:\n    runs-on: ubuntu-latest\n"
+        )
+        result = parser.parse(workflow)
+
+        assert result.metadata["triggers"] == ["push", "pull_request"]
+
+    def test_extract_jobs(self, parser):
+        """Test that jobs are extracted with name, runner, and dependencies."""
+        result = parser.parse(SAMPLE_WORKFLOW_YAML)
+        jobs = result.metadata["jobs"]
+
+        assert result.metadata["job_count"] == 2
+        job_names = {job["name"] for job in jobs}
+        assert job_names == {"test", "build-and-push"}
+
+        build_job = next(job for job in jobs if job["name"] == "build-and-push")
+        assert build_job["runs_on"] == "ubuntu-latest"
+        assert build_job["needs"] == ["test"]
+
+    def test_extract_actions_used(self, parser):
+        """Test that `uses:` actions are collected across all jobs."""
+        result = parser.parse(SAMPLE_WORKFLOW_YAML)
+
+        assert "actions/checkout@v4" in result.metadata["actions_used"]
+        assert "docker/build-push-action@v5" in result.metadata["actions_used"]
+
+    def test_extract_run_commands(self, parser):
+        """Test that `run:` commands are collected across all jobs."""
+        result = parser.parse(SAMPLE_WORKFLOW_YAML)
+
+        assert "pytest tests/" in result.metadata["run_commands"]
+
+    def test_parse_workflow_with_no_jobs(self, parser):
+        """Test parsing a workflow with no `jobs:` key - returns empty job list, no crash."""
+        workflow = "name: Empty\non: push\n"
+        result = parser.parse(workflow)
+
+        assert result.metadata["jobs"] == []
+        assert result.metadata["job_count"] == 0
+        assert result.metadata["actions_used"] == []
+        assert result.metadata["run_commands"] == []
+
+    def test_parse_job_with_no_steps(self, parser):
+        """Test parsing a job with no `steps:` key."""
+        workflow = "name: CI\non: push\njobs:\n  noop:\n    runs-on: ubuntu-latest\n"
+        result = parser.parse(workflow)
+
+        job = result.metadata["jobs"][0]
+        assert job["steps"] == []
+
+    def test_parse_missing_workflow_name(self, parser):
+        """Test that a workflow without a `name:` key falls back to a default."""
+        workflow = "on: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n"
+        result = parser.parse(workflow)
+
+        assert result.metadata["workflow_name"] == "Unnamed workflow"
+
+    def test_parse_bytes_input(self, parser):
+        """Test parsing workflow YAML from bytes input."""
+        result = parser.parse(SAMPLE_WORKFLOW_YAML.encode("utf-8"))
+
+        assert result.metadata["workflow_name"] == "CI"
+
+    def test_parse_invalid_content_type(self, parser):
+        """Test that invalid content type raises ValueError."""
+        with pytest.raises(ValueError) as exc_info:
+            parser.parse(12345)
+
+        assert "Content must be a string or bytes" in str(exc_info.value)
+
+    def test_parse_malformed_yaml_raises_value_error(self, parser):
+        """Test that malformed YAML raises a clear ValueError instead of crashing."""
+        malformed = "name: CI\non: [push\njobs: {broken"
+
+        with pytest.raises(ValueError) as exc_info:
+            parser.parse(malformed)
+
+        assert "Invalid workflow YAML" in str(exc_info.value)
+
+    def test_parse_non_mapping_yaml_raises_value_error(self, parser):
+        """Test that YAML that isn't a mapping (e.g. a bare list) raises ValueError."""
+        with pytest.raises(ValueError) as exc_info:
+            parser.parse("- just\n- a\n- list\n")
+
+        assert "Workflow content must be a YAML mapping" in str(exc_info.value)
+
+    def test_text_summary_includes_jobs_and_actions(self, parser):
+        """Test that the flattened text summary mentions jobs and actions used."""
+        result = parser.parse(SAMPLE_WORKFLOW_YAML)
+
+        assert "build-and-push" in result.text
+        assert "docker/build-push-action@v5" in result.text


### PR DESCRIPTION
## Summary
Adds a WorkflowParser that parses GitHub Actions workflow YAML (`.github/workflows/*.yml`) into structured data (triggers, jobs, runs-on, needs, steps' `uses:`/`run:`), and extends SkillExtractor to infer skills (GitHub Actions, Docker, pytest, Deployment, etc.) from that structure instead of relying only on substring matches. Wires the new parser into IngestionPipeline via `ingest_workflow`, mirroring the existing `ingest_readme` flow.

## Issue
Closes #14

## Changes
- Add `ingestion/parsers/workflow_parser.py`: `WorkflowParser(BaseParser)` parses workflow YAML into triggers, jobs, runs-on, needs, and each step's `uses:`/`run:`, with a flattened text summary for embedding. Handles malformed/non-mapping YAML and missing jobs/steps gracefully.
- Add `SkillExtractor.extract_skills_from_workflow` in `ingestion/parsers/skill_extractor.py`: maps known GitHub Actions (`docker/build-push-action`, `actions/setup-python`, etc.) and run-command patterns (`pytest`, `npm test`, `terraform apply`) to `SkillDetection` entries with evidence tied to the originating job; flags "GitHub Actions" whenever a workflow has jobs, and "Deployment" for deploy-style job names.
- Add `IngestionPipeline.ingest_workflow` in `ingestion/pipeline.py`, mirroring `ingest_readme` (source_id hashing, skip-check, chunk, embed, record).
- Add `pyyaml` as an explicit dependency in `pyproject.toml` (previously only transitive), plus `types-PyYAML` for mypy.
- Add `tests/unit/test_workflow_parser.py` (15 tests) and extend `tests/unit/test_skill_extractor.py` with `TestSkillExtractorWorkflow` (7 tests).
- Fix a pre-existing bug in `test_database_technology_detection` (self-referencing `skill_names` instead of using the extractor's result).

## Testing
- [x] Unit tests pass (`make test-unit`) — new/changed tests all pass; 5 pre-existing unrelated failures in `test_skill_extractor.py` (JS/TS/database/devops/docker-compose text-substring detection) are untouched by this change
- [x] Linter passes (`make lint`) — clean on this branch's files; repo-wide pre-existing debt untouched
- [x] Type checker passes (`make typecheck`) — clean on this branch's files
- [x] New/updated tests cover the changes

## Screenshots / Demo
N/A, backend parser/pipeline change, no UI surface.

## Notes for Reviewers
- The local pre-commit mypy hook's isolated environment can't currently build on this machine (pre-existing `types-redis` → `cryptography` needs a newer Rust/Cargo toolchain), unrelated to this change; commits after the first used `--no-verify` for that reason.
- 173 pre-existing ruff errors and a handful of pre-existing mypy errors elsewhere in the repo, plus 5 pre-existing `test_skill_extractor.py` failures, were left untouched — flagging for separate cleanup, not fixed here.