### PR TITLE
Fix/151 broaden bias detector patterns

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -75,3 +75,44 @@ I used and validated the existing unit tests in tests/unit/test_bias_detector.py
 **Note** `make check` and `make test-unit` still show existing unrelated failures elsewhere in the repository. This change did not introduce any new failures
 
 **Draft PR feedback received from:** N/A
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [X] No — still awaiting review
+
+**Summary of feedback:**
+[What did reviewers comment on? Or note that no review came in.]
+
+N/A - no review.
+
+**How you responded:**
+[What changes did you make, or what did you reply? If no feedback,
+leave blank.]
+
+N/a
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+
+Understanding how the existing code fit together was harder than I expected. I thought I could move faster, but the project had more moving parts than I first realized and even the setup took a long time.
+
+**What did you learn about working in a large codebase?**
+
+I learned that working in a large codebase is very different from building something from scratch. In a personal project, you already know how all the parts connect and making a mistake is not critical. In a large codebase, small changes can affect other parts of the app, so you have to be careful and thoughtful. It is also important to understand the existing patterns before making changes.
+
+**How did AI tools help — and where did they fall short?**
+
+AI helped me move faster when I was stuck or trying to understand unfamiliar code. It was useful for getting to know the codebase and getting ideas on how to solve the issue I was working on. But it still needed a lot of review. I had to check the details myself and make sure the solution actually fit the project, as well as that it doesn't break any existing structure.
+
+**What would you do differently if you started over?**
+
+To be honest, I would spend more time reading the code and understanding the flow before I started changing things. I would also break the work into smaller steps and test earlier.
+
+**What are you most proud of from this module?**
+
+I am proud that I was able to work through a confusing codebase and complete a change that fit the project.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -14,3 +14,6 @@ The review history page is showing review timestamps as if they were in UTC inst
 **Setup confirmation:** [X] App runs locally at localhost:5173
 
 **Cohort ledger:** [ ] Issue added to cohort ledger
+
+**Selection notes:** 
+I chose this issue because it has a clear title and description, which makes me fully understand what needs to be done and what files and functions were affected. It is a Tier 1 issue because it's my first open source contribution. The issue is not claimed and it's definitely realistic to complete within 2 weeks.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -36,7 +36,7 @@ When I ran the file, it returned that there is no bias (False), which is wrong.
 
 Also, I ran `pytest tests/unit/test_bias_detector.py -v` and it showed that 9 tests are failing in the bias detector.
 
-**PLAN.md link:** [link to PLAN.md in your fork]
+**PLAN.md link:** https://github.com/mariiaonokhina/pathreview/blob/fix/151-broaden-bias-detector-patterns/PLAN.md 
 
 **Walkthrough video (recommended):** [link to your Loom video, ≤2 min — shared for early feedback]
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -115,4 +115,4 @@ To be honest, I would spend more time reading the code and understanding the flo
 
 **What are you most proud of from this module?**
 
-I am proud that I was able to work through a confusing codebase and complete a change that fit the project.
+I am proud that I was able to work through a confusing codebase and complete a change that fit the project. I am also proud because this is my first open-source contribution and it opens the road for many of them to come later (because it won't feel as intimidating anymore).

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -42,3 +42,36 @@ Also, I ran `pytest tests/unit/test_bias_detector.py -v` and it showed that 9 te
 
 **Blockers or open questions:**
 [Anything you're still uncertain about going into Week 9, or leave blank]
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+I’ve reproduced the issue locally and started updating the bias detector patterns in the safety module. The first pass of the regex changes is in place for dismissive educational-background language, and I’m validating those cases against the existing bias detector tests.
+
+**Next steps:**
+I’m continuing to refine the patterns so they also catch the age and background-based assumptions from the issue without accidentally flagging neutral or positive feedback. After that, I’ll re-run the unit tests and do a final self-review.
+
+**Blockers:**
+I’m still checking the balance between broader matching and avoiding false positives, since the regexes need to be flexible enough to catch natural phrasing without over-matching "okay" descriptions.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [link to your submitted pull request]
+
+**Branch:** fix/151-broaden-bias-detector-patterns
+
+**What you built:**
+I broadened the bias detector's regex patterns so it catches dismissive language about bootcamps, self-taught backgrounds, and online courses, as well as age- and background-based assumptions, even when those ideas are phrased differently. The change keeps neutral and positive mentions from being flagged while making the detector more accurate for the biased examples in the issue.
+
+**Tests added or updated:**
+I used and validated the existing unit tests in tests/unit/test_bias_detector.py. Those tests cover dismissive educational-language cases, demographic assumptions, positive/neutral mentions, and the detector's return value behavior.
+
+**Self-review confirmation:** [X] make check passes  [X] make test-unit passes
+
+**Note** `make check` and `make test-unit` still show existing unrelated failures elsewhere in the repository. This change did not introduce any new failures
+
+**Draft PR feedback received from:** N/A

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,19 +1,33 @@
 ## Week 7 — Issue selection
 
-**Issue link:** https://github.com/jamjamgobambam/pathreview/issues/93
+**Issue link:** https://github.com/ascherj/pathreview/issues/151
 
-**Issue title:** Review history page displays dates in UTC instead of the user's local timezone
+**Issue title:** Bias detector patterns are too narrow to match common phrasings
 
 **Tier:** [X] Tier 1  [ ] Tier 2  [ ] Tier 3
 
 **Problem summary:**
-The review history page is showing review timestamps as if they were in UTC instead of converting them to the visitor’s local timezone. The broken part is the frontend date formatting logic in ReviewHistoryPage.tsx and dateFormatters.ts. A successful fix would ensure the displayed review dates are adjusted to the current user’s timezone and match the actual local time the review was created.
+The bias detector's regex patterns are too rigid and only match exact phrases, so they miss when the same bias is expressed in different ways. For example, it fails to catch natural variations like "The candidate only attended a bootcamp, so this project lacks rigor" or age-based assumptions phrased differently. The solution is to broaden the patterns to catch more variations of the same biased language.
 
-**Branch name:** fix/93-display-dates-in-user-timezone
+**Branch name:** fix/151-broaden-bias-detector-patterns
 
 **Setup confirmation:** [X] App runs locally at localhost:5173
 
-**Cohort ledger:** [ ] Issue added to cohort ledger
+**Cohort ledger:** [X] Issue added to cohort ledger
 
 **Selection notes:** 
 I chose this issue because it has a clear title and description, which makes me fully understand what needs to be done and what files and functions were affected. It is a Tier 1 issue because it's my first open source contribution. The issue is not claimed and it's definitely realistic to complete within 2 weeks.
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [link to commit documenting the reproduced issue]
+
+**Reproduction summary:**
+[1–2 sentences: How did you reproduce the issue? What did you observe?]
+
+**PLAN.md link:** [link to PLAN.md in your fork]
+
+**Walkthrough video (recommended):** [link to your Loom video, ≤2 min — shared for early feedback]
+
+**Blockers or open questions:**
+[Anything you're still uncertain about going into Week 9, or leave blank]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,16 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/jamjamgobambam/pathreview/issues/93
+
+**Issue title:** Review history page displays dates in UTC instead of the user's local timezone
+
+**Tier:** [X] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The review history page is showing review timestamps as if they were in UTC instead of converting them to the visitor’s local timezone. The broken part is the frontend date formatting logic in ReviewHistoryPage.tsx and dateFormatters.ts. A successful fix would ensure the displayed review dates are adjusted to the current user’s timezone and match the actual local time the review was created.
+
+**Branch name:** fix/93-display-dates-in-user-timezone
+
+**Setup confirmation:** [X] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -60,7 +60,7 @@ I’m still checking the balance between broader matching and avoiding false pos
 
 ### Check-in 2 (end of week)
 
-**PR link:** [link to your submitted pull request]
+**PR link:** https://github.com/ascherj/pathreview/pull/304 
 
 **Branch:** fix/151-broaden-bias-detector-patterns
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -20,10 +20,21 @@ I chose this issue because it has a clear title and description, which makes me 
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [link to commit documenting the reproduced issue]
+**Reproduction commit link:** https://github.com/mariiaonokhina/pathreview/commit/946592cf7f728cde8525c2c64ca8276c1900993b
 
 **Reproduction summary:**
 [1–2 sentences: How did you reproduce the issue? What did you observe?]
+There are 2 ways to reproduce this issue. First, I created a file called `test.py` (wasn't commited in the PR) and pasted the following code from the issue description:
+
+```python
+from safety.bias_detector import BiasDetector
+print(BiasDetector.detect_bias('The candidate only attended a bootcamp, so this project lacks the rigor of a formal CS education'))
+# observed: (False, '')  (expected: flagged as dismissive educational-background language)
+```
+
+When I ran the file, it returned that there is no bias (False), which is wrong.
+
+Also, I ran `pytest tests/unit/test_bias_detector.py -v` and it showed that 9 tests are failing in the bias detector.
 
 **PLAN.md link:** [link to PLAN.md in your fork]
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,28 @@
+## Solution plan
+
+**Issue:** #151 - Bias detector patterns are too narrow to match common phrasings (link: https://github.com/ascherj/pathreview/issues/151)
+
+### Understand
+Right now the regex patterns in `bias_detector.py` are too strict. They only catch exact phrases like "bootcamp graduates lack rigor" but miss natural variations like "The candidate only attended a bootcamp, so this project lacks the rigor of a formal CS education." The detector needs to recognize the same bias expressed in different ways. We need to make the patterns more flexible to catch these variations without creating too many false positives.
+
+### Map
+Files I expect to touch:
+- `safety/bias_detector.py`: The `DISMISSIVE_PATTERNS` and `DEMOGRAPHIC_PATTERNS` lists where the regex patterns are defined
+- `tests/unit/test_bias_detector.py`: Where the failing tests already exist that show what patterns we need to catch
+
+### Plan
+1. Look at the 9 failing tests to understand what patterns aren't being caught right now
+2. For each failing test, identify the key phrase or structure and generalize it into a more flexible regex
+3. Update the `DISMISSIVE_PATTERNS` list to catch variations like "bootcamp...lacks rigor" even if the words aren't consecutive
+4. Update the `DEMOGRAPHIC_PATTERNS` list similarly for age-based and background-based assumptions
+5. Run the tests to make sure all 9 failures pass and the 23 passing tests still pass
+6. Run `make check` to make sure linting and types are clean
+
+### Inputs & outputs
+The `detect_bias()` method takes a string of feedback text and returns a tuple of `(is_biased: bool, reason: str)`. Currently it misses variations of the same bias. After the fix, it should catch both the exact phrases AND natural variations of those phrases. The function doesn't change its signature or behavior for unbiased text, instea it just becomes more accurate at detecting biased language.
+
+### Risks & unknowns
+The main risk is making patterns too loose and creating false positives. For example, if we make the patterns too broad, we might flag neutral mentions of bootcamps. I'm also not sure exactly how much flexibility we can add to the regex without breaking the existing passing tests. We'll need to be careful with the word order and required keywords.
+
+### Edge cases
+What if someone says "bootcamp education can be rigorous", which is positive, not biased. We need to make sure our patterns don't catch positive mentions. What if the bias is expressed across multiple sentences? The patterns need to work within a single feedback text string. What if someone combines two different biases in one sentence?

--- a/safety/bias_detector.py
+++ b/safety/bias_detector.py
@@ -1,6 +1,7 @@
 """Bias detection in generated feedback."""
 
 import re
+
 import structlog
 
 logger = structlog.get_logger()
@@ -11,17 +12,17 @@ class BiasDetector:
 
     # Genuinely dismissive phrases about educational background
     DISMISSIVE_PATTERNS = [
-        r"(?:bootcamp|self-taught|online\s+course)\s+(?:education|training)\s+is\s+(?:insufficient|inadequate|lacks)",
-        r"(?:bootcamp|self-taught)\s+(?:graduates?|developers?)\s+(?:lack|missing)\s+(?:rigor|fundamentals|proper\s+training)",
-        r"(?:bootcamp|coding\s+bootcamp)\s+(?:doesn't|does\s+not)\s+prepare\s+(?:you|developers?)",
-        r"(?:self-taught|bootcamp)\s+is\s+(?:not|never)\s+(?:equal|comparable)\s+to\s+(?:university|traditional|formal)",
+        r"(?:bootcamp|coding\s+bootcamp|self-taught|online\s+course)\b.*\b(?:lacks?|lacking|insufficient|inadequate|poor|weak|not\s+up\s+to|can't|cannot|won't|doesn't|does\s+not|lack|missing|struggle|not\s+equal|not\s+comparable|never\s+comparable)\b",
+        r"(?:bootcamp|coding\s+bootcamp|self-taught)\s+(?:graduates?|developers?|programmers?)\b.*\b(?:can't|cannot|won't|lack|lacks|missing|struggle|are\s+not|are\s+never|doesn't|does\s+not)\b",
+        r"(?:bootcamp|coding\s+bootcamp)\b.*\b(?:doesn't|does\s+not|cannot|can't|won't)\s+prepare\b",
+        r"(?:self-taught|bootcamp)\b.*\b(?:is|are|being)\s+(?:not|never)\s+(?:equal|comparable)\s+to\s+(?:university|traditional|formal)\b",
     ]
 
     # Demographic assumptions (about age, background, identity)
     DEMOGRAPHIC_PATTERNS = [
-        r"(?:young|old|aged)\s+(?:person|developer|programmer)\s+(?:can't|cannot|won't|will\s+not)",
-        r"(?:person\s+from|coming\s+from)\s+(?:poor|rich|working[\s-]?class)",
-        r"(?:immigrant|international|foreign)\s+developers?.*(?:can't|cannot|won't|struggle)",
+        r"(?:young|old|aged|elderly|older|younger)\s+(?:person|developers?|programmers?|engineers?|candidates?|professionals?)\b.*\b(?:can't|cannot|won't|struggle|lack|unable|is\s+not|are\s+not)\b",
+        r"(?:person|developer|developers?|programmer|programmers?|candidate|candidates?)\s+(?:from|with)\s+(?:poor|rich|working[\s-]?class)\s+(?:background|backgrounds?)\b.*\b(?:can't|cannot|won't|struggle|lack|unable|is\s+not|are\s+not)\b",
+        r"(?:immigrant|international|foreign)\s+(?:developers?|programmers?|candidates?|people?)\b.*\b(?:can't|cannot|won't|struggle|lack|unable|are\s+not|aren't)\b",
     ]
 
     @staticmethod

--- a/tests/unit/test_bias_detector.py
+++ b/tests/unit/test_bias_detector.py
@@ -9,7 +9,7 @@ from safety.bias_detector import BiasDetector
 class TestBiasDetector:
     """Test suite for BiasDetector."""
 
-    def test_dismissive_bootcamp_language_detected(self):
+    def test_dismissive_bootcamp_language_detected(self) -> None:
         """Test dismissive bootcamp language is detected as biased."""
         text = "bootcamp graduates can't write production code"
 
@@ -18,7 +18,7 @@ class TestBiasDetector:
         assert is_biased is True
         assert reason != ""
 
-    def test_bootcamp_lacks_rigor_detected(self):
+    def test_bootcamp_lacks_rigor_detected(self) -> None:
         """Test 'bootcamp lacks rigor' language detected."""
         text = "bootcamp education lacks fundamentals"
 
@@ -26,7 +26,7 @@ class TestBiasDetector:
 
         assert is_biased is True
 
-    def test_bootcamp_inadequate_training_detected(self):
+    def test_bootcamp_inadequate_training_detected(self) -> None:
         """Test 'bootcamp inadequate training' language detected."""
         text = "bootcamp training is inadequate for professional development"
 
@@ -34,7 +34,7 @@ class TestBiasDetector:
 
         assert is_biased is True
 
-    def test_self_taught_comparison_detected(self):
+    def test_self_taught_comparison_detected(self) -> None:
         """Test self-taught vs traditional comparison detected."""
         text = "self-taught is never comparable to university education"
 
@@ -42,7 +42,7 @@ class TestBiasDetector:
 
         assert is_biased is True
 
-    def test_positive_bootcamp_mention_not_flagged(self):
+    def test_positive_bootcamp_mention_not_flagged(self) -> None:
         """Test positive bootcamp mention is NOT flagged as biased."""
         text = "your bootcamp background shows strong fundamentals and problem-solving skills"
 
@@ -50,7 +50,7 @@ class TestBiasDetector:
 
         assert is_biased is False
 
-    def test_neutral_bootcamp_mention_not_flagged(self):
+    def test_neutral_bootcamp_mention_not_flagged(self) -> None:
         """Test neutral bootcamp mention is NOT flagged."""
         text = "this bootcamp project demonstrates good coding practices"
 
@@ -58,7 +58,7 @@ class TestBiasDetector:
 
         assert is_biased is False
 
-    def test_educational_background_positive_not_flagged(self):
+    def test_educational_background_positive_not_flagged(self) -> None:
         """Test positive educational background mention not flagged."""
         text = "your bootcamp training has given you a solid foundation"
 
@@ -66,7 +66,7 @@ class TestBiasDetector:
 
         assert is_biased is False
 
-    def test_demographic_assumption_age_detected(self):
+    def test_demographic_assumption_age_detected(self) -> None:
         """Test demographic assumption about age detected."""
         text = "young developers can't handle complex systems"
 
@@ -75,7 +75,7 @@ class TestBiasDetector:
         assert is_biased is True
         assert "demographic" in reason.lower()
 
-    def test_demographic_assumption_old_detected(self):
+    def test_demographic_assumption_old_detected(self) -> None:
         """Test age assumption about older developers detected."""
         text = "old aged programmer won't be able to learn new technologies"
 
@@ -83,7 +83,7 @@ class TestBiasDetector:
 
         assert is_biased is True
 
-    def test_demographic_assumption_background_detected(self):
+    def test_demographic_assumption_background_detected(self) -> None:
         """Test background assumption detected."""
         text = "person from poor background can't afford proper training"
 
@@ -91,7 +91,7 @@ class TestBiasDetector:
 
         assert is_biased is True
 
-    def test_immigrant_developer_assumption_detected(self):
+    def test_immigrant_developer_assumption_detected(self) -> None:
         """Test assumption about immigrant developers detected."""
         text = "immigrant developers can't communicate effectively in code reviews"
 
@@ -99,7 +99,7 @@ class TestBiasDetector:
 
         assert is_biased is True
 
-    def test_international_developer_assumption_detected(self):
+    def test_international_developer_assumption_detected(self) -> None:
         """Test assumption about international developers detected."""
         text = "international developers struggle with American coding standards"
 
@@ -107,23 +107,28 @@ class TestBiasDetector:
 
         assert is_biased is True
 
-    def test_clean_feedback_not_flagged(self):
+    def test_clean_feedback_not_flagged(self) -> None:
         """Test clean, objective feedback is not flagged."""
-        text = "You have demonstrated strong Python skills. Your code is well-organized and follows best practices."
+        text = (
+            "You have demonstrated strong Python skills. Your code is well-organized "
+            "and follows best practices."
+        )
 
         is_biased, reason = BiasDetector.detect_bias(text)
 
         assert is_biased is False
 
-    def test_technical_feedback_not_flagged(self):
+    def test_technical_feedback_not_flagged(self) -> None:
         """Test pure technical feedback not flagged."""
-        text = "Consider adding error handling to your API endpoints and documenting the parameters."
+        text = (
+            "Consider adding error handling to your API endpoints and documenting the parameters."
+        )
 
         is_biased, reason = BiasDetector.detect_bias(text)
 
         assert is_biased is False
 
-    def test_development_suggestion_not_flagged(self):
+    def test_development_suggestion_not_flagged(self) -> None:
         """Test development suggestions not flagged."""
         text = "To improve your portfolio, try learning Kubernetes and contributing to open source."
 
@@ -131,7 +136,7 @@ class TestBiasDetector:
 
         assert is_biased is False
 
-    def test_case_insensitive_detection(self):
+    def test_case_insensitive_detection(self) -> None:
         """Test detection is case insensitive."""
         text = "BOOTCAMP GRADUATES LACK FUNDAMENTALS"
 
@@ -139,7 +144,7 @@ class TestBiasDetector:
 
         assert is_biased is True
 
-    def test_return_value_structure(self):
+    def test_return_value_structure(self) -> None:
         """Test return value has correct structure."""
         text = "some feedback"
         result = BiasDetector.detect_bias(text)
@@ -150,7 +155,7 @@ class TestBiasDetector:
         assert isinstance(is_biased, bool)
         assert isinstance(reason, str)
 
-    def test_unbiased_returns_empty_reason(self):
+    def test_unbiased_returns_empty_reason(self) -> None:
         """Test unbiased feedback returns empty reason string."""
         text = "Great coding skills"
 
@@ -159,7 +164,7 @@ class TestBiasDetector:
         if is_biased is False:
             assert reason == ""
 
-    def test_biased_returns_reason(self):
+    def test_biased_returns_reason(self) -> None:
         """Test biased feedback returns non-empty reason."""
         text = "bootcamp graduates can't code"
 
@@ -169,19 +174,19 @@ class TestBiasDetector:
             assert reason != ""
             assert len(reason) > 0
 
-    def test_empty_text(self):
+    def test_empty_text(self) -> None:
         """Test with empty text."""
         is_biased, reason = BiasDetector.detect_bias("")
 
         assert is_biased is False
 
-    def test_whitespace_only(self):
+    def test_whitespace_only(self) -> None:
         """Test with whitespace only."""
         is_biased, reason = BiasDetector.detect_bias("   \n\t  ")
 
         assert is_biased is False
 
-    def test_coding_bootcamp_variant(self):
+    def test_coding_bootcamp_variant(self) -> None:
         """Test 'coding bootcamp' variant is detected."""
         text = "coding bootcamp graduates can't write enterprise code"
 
@@ -189,7 +194,7 @@ class TestBiasDetector:
 
         assert is_biased is True
 
-    def test_online_course_bias_detected(self):
+    def test_online_course_bias_detected(self) -> None:
         """Test online course dismissal detected."""
         text = "online course education is insufficient for real work"
 
@@ -197,7 +202,7 @@ class TestBiasDetector:
 
         assert is_biased is True
 
-    def test_developer_vs_programmer_distinction(self):
+    def test_developer_vs_programmer_distinction(self) -> None:
         """Test both developer and programmer terms detected."""
         text_dev = "bootcamp developers can't handle production systems"
         text_prog = "bootcamp programmers lack proper training"
@@ -208,15 +213,17 @@ class TestBiasDetector:
         assert is_biased_dev is True
         assert is_biased_prog is True
 
-    def test_multiple_bias_indicators(self):
+    def test_multiple_bias_indicators(self) -> None:
         """Test text with multiple bias indicators."""
-        text = "young bootcamp graduates can't write code and immigrant developers lack fundamentals"
+        text = (
+            "young bootcamp graduates can't write code and immigrant developers lack fundamentals"
+        )
 
         is_biased, reason = BiasDetector.detect_bias(text)
 
         assert is_biased is True
 
-    def test_negative_educational_claim(self):
+    def test_negative_educational_claim(self) -> None:
         """Test negative claims about education detected."""
         text = "self-taught developers are not equal to university graduates"
 
@@ -224,7 +231,7 @@ class TestBiasDetector:
 
         assert is_biased is True
 
-    def test_working_class_assumption(self):
+    def test_working_class_assumption(self) -> None:
         """Test working-class assumption detected."""
         text = "person from working class background won't succeed in tech"
 
@@ -232,7 +239,7 @@ class TestBiasDetector:
 
         assert is_biased is True
 
-    def test_rich_poor_assumption(self):
+    def test_rich_poor_assumption(self) -> None:
         """Test rich/poor background assumption detected."""
         text = "developers from poor backgrounds can't afford proper tools"
 
@@ -240,7 +247,7 @@ class TestBiasDetector:
 
         assert is_biased is True
 
-    def test_foreign_developer_struggle_assumption(self):
+    def test_foreign_developer_struggle_assumption(self) -> None:
         """Test assumption about foreign developers struggling."""
         text = "foreign developers struggle with English-first codebases"
 
@@ -248,23 +255,29 @@ class TestBiasDetector:
 
         assert is_biased is True
 
-    def test_skill_assessment_not_biased(self):
+    def test_skill_assessment_not_biased(self) -> None:
         """Test skill assessment without bias language."""
-        text = "Your JavaScript skills are at an intermediate level. Practice would help advance to senior level."
+        text = (
+            "Your JavaScript skills are at an intermediate level. Practice would help "
+            "advance to senior level."
+        )
 
         is_biased, reason = BiasDetector.detect_bias(text)
 
         assert is_biased is False
 
-    def test_comparative_without_bias(self):
+    def test_comparative_without_bias(self) -> None:
         """Test comparison without biased assumptions."""
-        text = "Your bootcamp education covers practical skills. University education provides theory. Both have value."
+        text = (
+            "Your bootcamp education covers practical skills. University education "
+            "provides theory. Both have value."
+        )
 
         is_biased, reason = BiasDetector.detect_bias(text)
 
         assert is_biased is False
 
-    def test_assumption_vs_observation(self):
+    def test_assumption_vs_observation(self) -> None:
         """Test that observations are not flagged, assumptions are."""
         observation = "your resume shows bootcamp attendance"  # Factual
         assumption = "bootcamp attendance means inadequate training"  # Biased
@@ -274,3 +287,27 @@ class TestBiasDetector:
 
         assert is_biased_obs is False  # Factual
         assert is_biased_ass is True  # Biased assumption
+
+
+"""
+============== short test summary info ==============
+FAILED TestBiasDetector::test_dismissive_bootcamp_language_detected
+- assert False is True
+FAILED TestBiasDetector::test_bootcamp_lacks_rigor_detected
+- assert False is True
+FAILED TestBiasDetector::test_demographic_assumption_age_detected
+- assert False is True
+FAILED TestBiasDetector::test_coding_bootcamp_variant
+- assert False is True
+FAILED TestBiasDetector::test_developer_vs_programmer_distinction
+- assert False is True
+FAILED TestBiasDetector::test_multiple_bias_indicators
+- assert False is True
+FAILED TestBiasDetector::test_negative_educational_claim
+- assert False is True
+FAILED TestBiasDetector::test_rich_poor_assumption
+- assert False is True
+FAILED TestBiasDetector::test_assumption_vs_observation
+- assert False is True
+=========== 9 failed, 23 passed in 0.78s ============
+"""


### PR DESCRIPTION
## Summary
This PR improves the bias detector so it catches more common ways people express biased feedback. It now recognizes dismissive comments about bootcamps, self-taught backgrounds, and other educational paths, as well as age- and background-based assumptions.

## Issue
Closes #151 

## Changes
- Updated the bias detection patterns in `bias_detector.py` to catch more natural phrasing.
- Expanded detection for educational and demographic bias without flagging neutral or positive feedback.
- Kept the existing behavior for non-biased text the same.

## Testing
- [X] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`)
- [ ] Linter passes (`make lint`)
- [ ] Type checker passes (`make typecheck`)
- [X] New/updated tests cover the changes

## Screenshots / Demo
N/A

## Notes for Reviewers
- The targeted bias-detector tests are passing. The repo still has some unrelated existing failures outside this change.
