### PR TITLE
feat(api): report real safety event count in health check

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -34,6 +34,64 @@ asserts the reported count matches. It fails with
 
 ---
 
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Established a pre-change baseline of the repo (`make test-unit`: 53 pre-existing
+unrelated failures; `ruff`: 182 errors; `black`: 53 files; `mypy`: bails early on
+stub/numpy issues). Implemented the two core sub-tasks from PLAN.md: added
+`SafetyMonitor.get_total_event_count()` (sums per-type counts across
+`VALID_EVENT_TYPES`, degrading to 0 on Redis errors) and wired `/health` to it
+via `redis.from_url(settings.redis_url)` instead of the hardcoded `0`.
+
+**Next steps:**
+Finish the test coverage (endpoint wiring + no-events + Redis-unavailable), re-run
+the suite to confirm no new failures, and open a draft PR for feedback.
+
+**Blockers:**
+Decided to keep the pre-existing `settings.redis_host` gap in `health.py` out of
+scope (it affects the Redis dependency line, not the safety count) and document
+it in the PR instead of expanding the change.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** <!-- PR_URL_PLACEHOLDER -->
+
+**Branch:** `feat/d08-health-safety-event-count`
+
+**What you built:**
+`/health` now reports the real `safety_events_last_hour` instead of a hardcoded
+`0`. A new `SafetyMonitor.get_total_event_count()` sums recorded safety events
+across all event types from Redis, and the endpoint calls it inside a guarded
+block so a Redis outage degrades the count to `0` rather than failing the health
+check.
+
+**Tests added or updated:**
+`tests/unit/test_health_safety_events.py` — converted the Week 8 reproduction
+test to assert the corrected behavior, and added coverage for
+`get_total_event_count` (sum across types; zero when empty) and the endpoint
+wiring (reports the recorded count; zero with no events; degrades to zero when
+Redis is unavailable). All 5 pass.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+*("Passes" per the documented pre-existing-failures guidance: my change
+introduces **no new** failures. Verified by diffing the failing-test set before
+and after — unit failures went 54 → 53 (my reproduction test now passes, zero
+new failures); `mypy` error count on the touched files is unchanged (14 → 14);
+`ruff`/`black` on my added code are clean, and the remaining warnings on the
+touched files — unsorted imports, unused `timedelta`/`timestamp`, `Depends`
+default, and a `black` trailing-comma on `VALID_EVENT_TYPES` — are all
+pre-existing, not introduced by this change.)*
+
+**Draft PR feedback received from:** none yet — draft opened for peer/mentor review
+
+---
+
 ### Note on issue selection
 
 I first surveyed the tier-1 bug issues in `scripts/issues_manifest.json`

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -59,7 +59,7 @@ it in the PR instead of expanding the change.
 
 ### Check-in 2 (end of week)
 
-**PR link:** <!-- PR_URL_PLACEHOLDER -->
+**PR link:** https://github.com/ascherj/pathreview/pull/315
 
 **Branch:** `feat/d08-health-safety-event-count`
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,45 @@
+# JOURNAL
+
+PathReview contribution. Issue: **D-08 — Add a safety event count to the health
+check endpoint.** Working branch: `feat/d08-health-safety-event-count`.
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/eokoned1/pathreview/commit/9fa2929
+
+**Reproduction summary:**
+Added a failing unit test,
+`tests/unit/test_health_safety_events.py::test_health_reports_recorded_safety_events`.
+It records 3 safety events through `SafetyMonitor` (proving the count data is
+available via `get_event_count`), then calls the real `/health` endpoint and
+asserts the reported count matches. It fails with
+`AssertionError: health endpoint reports 0 safety events, but 3 were recorded`
+(`assert 0 == 3`) — confirming `api/routes/health.py` hardcodes
+`safety_events_last_hour = 0` and never queries `SafetyMonitor`.
+
+**PLAN.md link:** https://github.com/eokoned1/pathreview/blob/feat/d08-health-safety-event-count/PLAN.md
+
+**Walkthrough video (recommended):** <!-- optional Loom link -->
+
+**Blockers or open questions:**
+- The Redis block in `health.py` reads `settings.redis_host` / `settings.redis_port`,
+  but `core/config.py` only defines `redis_url` — so Redis access there already
+  raises `AttributeError`. My fix needs a working Redis client (parse `redis_url`
+  or reuse a shared one) or the count will silently stay `0`. Want to confirm the
+  intended way to get a client.
+- "Last hour" is currently a misnomer: `get_event_count` doesn't enforce
+  `window_hours` and relies on a 24h key expiry. Deciding whether to implement
+  true hourly bucketing (touches `log_event` and every event producer) or
+  document the limitation and file a follow-up.
+
+---
+
+### Note on issue selection
+
+I first surveyed the tier-1 bug issues in `scripts/issues_manifest.json`
+(A-01, B-01, B-02, C-01, D-01, E-01, E-02, E-03, F-02) and found they are
+**already implemented/handled on `main`** — e.g. the resume parser has no
+`sections['experience'][0]` access, `github_tool` null-guards the description,
+`GET /reviews/{id}` already returns 404. D-08 is genuinely unfinished: the
+`safety_events_last_hour` field is present but stubbed to `0`, which makes it a
+real, reproducible gap to close.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -92,6 +92,76 @@ pre-existing, not introduced by this change.)*
 
 ---
 
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No reviewer or maintainer feedback came in. Reviewer feedback isn't a feature in
+the Summer 2026 cohort, and PR #315 (https://github.com/ascherj/pathreview/pull/315)
+had no reviews or comments as of the end of the week.
+
+**How you responded:**
+N/A — no feedback to respond to. The PR remains open with the fix, tests, and a
+"Notes for Reviewers" section flagging the two out-of-scope items I found
+(the `settings.redis_host` config gap and the approximate `window_hours`).
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Reproducing the issue, not fixing it. The fix itself was ~30 lines. The hard part
+was proving the bug in a service that won't run standalone — `/health` depends on
+Postgres and Redis, and importing the route even pulls in an async DB engine at
+import time. I ended up mocking the DB, standing up an in-memory fake Redis, and
+catching the 503 the endpoint throws because of an *unrelated* pre-existing bug
+(`health.py` reads `settings.redis_host`, which doesn't exist) just to read the
+one field I cared about. Before any of that, I lost real time discovering that the
+issue tracker didn't match the code: most tier-1 "bugs" (A-01, B-01, C-01, E-02…)
+were already fixed on `main`, so I had to verify a dozen issues that didn't
+reproduce before landing on D-08, which genuinely did.
+
+**What did you learn about working in a large codebase?**
+That most of the work is orientation and restraint, not typing. Contributing to
+someone else's production code, I spent far more effort establishing a baseline
+(53 pre-existing unit failures, 182 ruff findings) and *scoping* than writing the
+change. The discipline that mattered: not running `black .` (it would have
+reformatted 53 unrelated files into my diff), not "fixing" the `redis_host` bug I
+noticed, and being able to prove — by diffing the failure set before and after —
+that I introduced zero new failures. In my own projects I fix everything I see;
+here, blast radius and a clean, reviewable diff mattered more than thoroughness.
+
+**How did AI tools help — and where did they fall short?**
+AI was most useful for breadth and mechanics: fanning out to check which of ~12
+manifest issues actually reproduced, scaffolding tests that matched the existing
+`tests/unit/` patterns, and doing the before/after failure-set diffing to back up
+the "no new failures" claim. Where it fell short was judgment: deciding D-08 was
+the *honest* pick once the manifest didn't match reality, choosing to leave the
+`redis_host` bug out of scope rather than scope-creep, and figuring out how to
+represent "passes" truthfully against a suite with documented pre-existing
+failures. Those calls required reading the actual code and the assignment's
+intent — AI could generate options, but it couldn't decide what was defensible.
+
+**What would you do differently if you started over?**
+I'd verify that a candidate issue actually reproduces against the current branch
+*before* committing to it, instead of trusting that the tracker matched the code —
+that alone would have saved the detour through already-fixed bugs. I'd also set up
+the environment first thing: the heavy deps (chromadb) and the import-time DB
+engine meant "just run it" wasn't quick, and I only learned that mid-reproduction.
+
+**What are you most proud of?**
+The reproduction test. Turning "the field is always 0" into a runnable failing
+test that drives the *real* endpoint with mocked dependencies — and that it then
+survived the fix as regression coverage — felt like an actual engineering
+artifact rather than a checkbox. A close second: the scope discipline of
+documenting the `redis_host` bug for a follow-up instead of dragging it into this
+PR.
+
+---
+
 ### Note on issue selection
 
 I first surveyed the tier-1 bug issues in `scripts/issues_manifest.json`

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,113 @@
+# Solution plan
+
+**Issue:** D-08 — "Add a safety event count to the health check endpoint"
+(from `scripts/issues_manifest.json`; seeded into the PathReview issue tracker)
+
+### Understand
+
+**Root cause.** The `/health` endpoint already exposes a `safety_events_last_hour`
+field in its response, but [`api/routes/health.py`](api/routes/health.py) hardcodes
+it to `0`:
+
+```python
+# Count safety events in last hour (placeholder)
+try:
+    # This would be populated by actual safety event logging
+    health_status["safety_events_last_hour"] = 0
+except Exception as exc:
+    log.error("safety_events_check_failed", error=str(exc))
+```
+
+The data it should surface already exists: [`safety/monitoring.py`](safety/monitoring.py)
+has `SafetyMonitor.get_event_count(event_type, window_hours=1)`, which reads
+per-type counts from Redis (keys `safety:events:{event_type}`). The endpoint
+simply never calls it — so operators always see `0` regardless of real activity.
+
+**Expected vs. actual.**
+- *Expected:* `safety_events_last_hour` reflects the number of safety events
+  (PII detections, injection attempts, content filters, bias detections, rate
+  limits) recorded in the recent window.
+- *Actual:* it is always `0`. Reproduced by
+  `tests/unit/test_health_safety_events.py::test_health_reports_recorded_safety_events`,
+  which records 3 events through `SafetyMonitor` and asserts the endpoint
+  reports them — it reports `0`, failing with
+  `assert 0 == 3`.
+
+**Secondary correctness gap.** `get_event_count`'s `window_hours` argument is
+documented as *"not enforced here; for reference"* — it returns the cumulative
+count under a 24h key expiry, not a true rolling one-hour count. A faithful
+`safety_events_last_hour` needs real hourly windowing, so this is in scope to at
+least decide on and document.
+
+### Map
+
+Files I expect to touch:
+
+- [`api/routes/health.py`](api/routes/health.py) — replace the hardcoded `0`
+  with a real count summed across `SafetyMonitor.VALID_EVENT_TYPES`, using a
+  Redis client, degrading to `0` if Redis is unavailable.
+- [`safety/monitoring.py`](safety/monitoring.py) — add a helper for the rolling
+  one-hour total (e.g. `get_total_event_count(window_hours=1)`) and, if we do
+  true windowing, switch `log_event`/`get_event_count` to hour-bucketed keys
+  (`safety:events:{type}:{YYYYMMDDHH}`).
+- [`tests/unit/test_health_safety_events.py`](tests/unit/test_health_safety_events.py)
+  — flip the reproduction test to assert the correct count, and add cases for
+  "no events" and "Redis unavailable".
+
+Reference (context, likely not edited): [`core/config.py`](core/config.py) —
+see the Redis-settings risk below; callers of `SafetyMonitor.log_event` in
+`safety/` that establish which event types actually fire.
+
+### Plan
+
+1. **Expose a total-count helper.** Add `get_total_event_count(window_hours=1)`
+   to `SafetyMonitor` that sums `get_event_count` across `VALID_EVENT_TYPES`,
+   so the endpoint has one call to make.
+2. **Wire it into `/health`.** In the safety block of `health_check`, build a
+   `SafetyMonitor` from a Redis client and set
+   `health_status["safety_events_last_hour"] = monitor.get_total_event_count()`.
+   Keep the `try/except` so a Redis failure logs and leaves the value at `0`
+   instead of 500-ing the health check.
+3. **Make the window real (or explicitly deferred).** Decide between (a) true
+   hour-bucketed keys summed over the last `window_hours`, or (b) documenting
+   the current 24h-expiry cumulative behavior as a known limitation with a
+   follow-up issue. Reflect the decision in the docstring and the PR.
+4. **Update tests.** Turn the reproduction test green (endpoint reports the
+   recorded count) and add: zero events → `0`; Redis raising → `0` (no crash).
+5. **Verify.** `make check && make test-unit`, plus a manual `curl /health`
+   showing a non-zero count after triggering a safety event.
+
+### Inputs & outputs
+
+- **Input:** a `GET /health` request; internally, per-type safety counts stored
+  in Redis by `SafetyMonitor.log_event`.
+- **Output / change:** the `safety_events_last_hour` field in the `/health`
+  JSON now returns the summed recent safety-event count (integer ≥ 0) instead of
+  a constant `0`. No change to the endpoint's status/HTTP-code logic.
+
+### Risks & unknowns
+
+- **Redis access in `health.py` is currently broken independently of D-08.** The
+  endpoint reads `settings.redis_host` / `settings.redis_port`, but
+  `core/config.py` only defines `redis_url` — so the Redis block already raises
+  `AttributeError` and marks Redis unhealthy. My fix must obtain a working Redis
+  client (parse `settings.redis_url`, or reuse a shared client) or the count
+  will silently stay `0`. Flagging this as a real dependency, not a hypothetical.
+- **Window semantics.** If I keep `get_event_count` as-is, "last hour" is a
+  misnomer (it's really "last 24h, cumulative"). True windowing means changing
+  the key scheme in `log_event`, which touches every event producer — larger
+  blast radius. Need to decide scope with the maintainer.
+- **Constructing a client per health call** adds a Redis round-trip to a
+  hot endpoint; acceptable for `/health` but worth noting.
+- **Which event types count.** Summing all `VALID_EVENT_TYPES` assumes each is
+  equally a "safety event"; confirm `rate_limited` should be included.
+
+### Edge cases
+
+- No events recorded → `0` (and the sanity path must not error on missing keys).
+- Redis unavailable / raising → field is `0`, `/health` still responds, error
+  logged (no 500 from the safety block).
+- Keys just expired at the hour boundary → count rolls off as designed.
+- An event type in Redis that isn't in `VALID_EVENT_TYPES` → ignored (only known
+  types are summed).
+- Large counts → returned as a plain integer; no formatting assumptions.

--- a/api/routes/health.py
+++ b/api/routes/health.py
@@ -72,12 +72,19 @@ async def health_check(db=Depends(get_db)):
         health_status["dependencies"]["vector_db"] = "unhealthy"
         health_status["status"] = "unhealthy"
 
-    # Count safety events in last hour (placeholder)
+    # Count safety events in the last hour from the safety monitor.
     try:
-        # This would be populated by actual safety event logging
-        health_status["safety_events_last_hour"] = 0
+        import redis
+
+        from core.config import settings
+        from safety.monitoring import SafetyMonitor
+
+        redis_client = redis.from_url(settings.redis_url)
+        monitor = SafetyMonitor(redis_client)
+        health_status["safety_events_last_hour"] = monitor.get_total_event_count()
     except Exception as exc:
         log.error("safety_events_check_failed", error=str(exc))
+        health_status["safety_events_last_hour"] = 0
 
     # Return 503 if any critical dependency is down
     if health_status["status"] == "unhealthy":

--- a/safety/monitoring.py
+++ b/safety/monitoring.py
@@ -72,3 +72,22 @@ class SafetyMonitor:
         except Exception as e:
             logger.error("event_count_error", event_type=event_type, error=str(e))
             return 0
+
+    def get_total_event_count(self, window_hours: int = 1) -> int:
+        """Get the total count of safety events across all event types.
+
+        Sums ``get_event_count`` over every type in ``VALID_EVENT_TYPES``.
+        Individual lookups that fail degrade to 0, so a Redis outage yields a
+        total of 0 rather than raising.
+
+        Args:
+            window_hours: Time window in hours, passed through to
+                ``get_event_count`` (see its note on windowing).
+
+        Returns:
+            Total count of safety events across all known event types.
+        """
+        return sum(
+            self.get_event_count(event_type, window_hours=window_hours)
+            for event_type in self.VALID_EVENT_TYPES
+        )

--- a/tests/unit/test_health_safety_events.py
+++ b/tests/unit/test_health_safety_events.py
@@ -1,0 +1,88 @@
+"""
+Reproduction test for issue D-08:
+"Add a safety event count to the health check endpoint."
+
+The /health endpoint exposes a `safety_events_last_hour` field, but
+api/routes/health.py hardcodes it to 0 (line ~78, "This would be populated by
+actual safety event logging") and never queries SafetyMonitor. So no matter how
+many safety events are recorded, /health always reports 0.
+
+This test demonstrates the gap: it records safety events through SafetyMonitor
+(proving the count data is available via get_event_count), then calls the real
+health_check endpoint and asserts the reported count matches. It FAILS on the
+current code because the endpoint returns 0 regardless.
+
+Unit test: no external services — the DB is mocked and Redis is an in-memory fake.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException
+
+import api.routes.health as health_module
+from safety.monitoring import SafetyMonitor
+
+
+class FakeRedis:
+    """Minimal in-memory stand-in for the redis client SafetyMonitor uses."""
+
+    def __init__(self):
+        self.store = {}
+
+    def incr(self, key):
+        self.store[key] = self.store.get(key, 0) + 1
+        return self.store[key]
+
+    def expire(self, key, seconds):
+        return True
+
+    def get(self, key):
+        val = self.store.get(key)
+        return None if val is None else str(val).encode()
+
+    def ping(self):
+        return True
+
+
+def _health_payload(db):
+    """
+    Return the health payload whether the endpoint responds 200 or raises 503.
+
+    (On the current code an unrelated config gap marks Redis unhealthy and the
+    endpoint raises 503, but the full status dict — including
+    safety_events_last_hour — travels in the exception detail either way.)
+    """
+    try:
+        return asyncio.run(health_module.health_check(db=db))
+    except HTTPException as exc:
+        return exc.detail
+
+
+@pytest.mark.unit
+def test_health_reports_recorded_safety_events():
+    # Record 3 safety events through the monitor.
+    fake_redis = FakeRedis()
+    monitor = SafetyMonitor(fake_redis)
+    monitor.log_event("pii_detected", {"field": "email"})
+    monitor.log_event("pii_detected", {"field": "phone"})
+    monitor.log_event("injection_attempt", {"pattern": "ignore previous"})
+
+    # The count data IS available from the monitor.
+    recorded = sum(
+        monitor.get_event_count(event_type)
+        for event_type in SafetyMonitor.VALID_EVENT_TYPES
+    )
+    assert recorded == 3, "sanity check: SafetyMonitor should have 3 events"
+
+    # But the health endpoint ignores it and always reports 0.
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=None)
+    payload = _health_payload(db)
+
+    assert payload["safety_events_last_hour"] == recorded, (
+        "health endpoint reports "
+        f"{payload['safety_events_last_hour']} safety events, "
+        f"but {recorded} were recorded (endpoint hardcodes 0 — issue D-08)"
+    )

--- a/tests/unit/test_health_safety_events.py
+++ b/tests/unit/test_health_safety_events.py
@@ -1,22 +1,16 @@
 """
-Reproduction test for issue D-08:
-"Add a safety event count to the health check endpoint."
+Tests for issue D-08: "Add a safety event count to the health check endpoint."
 
-The /health endpoint exposes a `safety_events_last_hour` field, but
-api/routes/health.py hardcodes it to 0 (line ~78, "This would be populated by
-actual safety event logging") and never queries SafetyMonitor. So no matter how
-many safety events are recorded, /health always reports 0.
+The /health endpoint exposes a ``safety_events_last_hour`` field. It used to be
+hardcoded to 0; it now reports the real total from ``SafetyMonitor``. These tests
+cover the monitor's total-count helper and the endpoint wiring, including the
+no-events and Redis-unavailable cases.
 
-This test demonstrates the gap: it records safety events through SafetyMonitor
-(proving the count data is available via get_event_count), then calls the real
-health_check endpoint and asserts the reported count matches. It FAILS on the
-current code because the endpoint returns 0 regardless.
-
-Unit test: no external services — the DB is mocked and Redis is an in-memory fake.
+Unit tests: no external services — the DB is mocked and Redis is an in-memory fake.
 """
 
 import asyncio
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastapi import HTTPException
@@ -46,13 +40,28 @@ class FakeRedis:
         return True
 
 
+class BrokenRedis(FakeRedis):
+    """A redis client whose reads fail, simulating an outage."""
+
+    def get(self, key):
+        raise ConnectionError("redis unavailable")
+
+
+def _mock_db():
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=None)
+    return db
+
+
 def _health_payload(db):
     """
-    Return the health payload whether the endpoint responds 200 or raises 503.
+    Return the /health payload whether the endpoint responds 200 or raises 503.
 
-    (On the current code an unrelated config gap marks Redis unhealthy and the
-    endpoint raises 503, but the full status dict — including
-    safety_events_last_hour — travels in the exception detail either way.)
+    (An unrelated config gap — health.py reads ``settings.redis_host``, which is
+    not defined on Settings — marks the redis dependency unhealthy and makes the
+    endpoint raise 503. The full status dict, including safety_events_last_hour,
+    travels in the exception detail either way. That gap is out of scope for
+    D-08; see PLAN.md.)
     """
     try:
         return asyncio.run(health_module.health_check(db=db))
@@ -60,29 +69,61 @@ def _health_payload(db):
         return exc.detail
 
 
+# ── SafetyMonitor.get_total_event_count ──────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_get_total_event_count_sums_across_types():
+    monitor = SafetyMonitor(FakeRedis())
+    monitor.log_event("pii_detected", {"field": "email"})
+    monitor.log_event("pii_detected", {"field": "phone"})
+    monitor.log_event("injection_attempt", {"pattern": "ignore previous"})
+    monitor.log_event("bias_detected", {"term": "example"})
+
+    assert monitor.get_total_event_count() == 4
+
+
+@pytest.mark.unit
+def test_get_total_event_count_zero_when_no_events():
+    monitor = SafetyMonitor(FakeRedis())
+    assert monitor.get_total_event_count() == 0
+
+
+# ── /health endpoint wiring (D-08) ───────────────────────────────────────────
+
+
 @pytest.mark.unit
 def test_health_reports_recorded_safety_events():
-    # Record 3 safety events through the monitor.
-    fake_redis = FakeRedis()
-    monitor = SafetyMonitor(fake_redis)
+    """
+    The endpoint should report the safety-event total recorded in Redis.
+
+    Regression for D-08: previously this field was hardcoded to 0 regardless of
+    recorded events.
+    """
+    fake = FakeRedis()
+    monitor = SafetyMonitor(fake)
     monitor.log_event("pii_detected", {"field": "email"})
     monitor.log_event("pii_detected", {"field": "phone"})
     monitor.log_event("injection_attempt", {"pattern": "ignore previous"})
 
-    # The count data IS available from the monitor.
-    recorded = sum(
-        monitor.get_event_count(event_type)
-        for event_type in SafetyMonitor.VALID_EVENT_TYPES
-    )
-    assert recorded == 3, "sanity check: SafetyMonitor should have 3 events"
+    with patch("redis.from_url", return_value=fake):
+        payload = _health_payload(_mock_db())
 
-    # But the health endpoint ignores it and always reports 0.
-    db = AsyncMock()
-    db.execute = AsyncMock(return_value=None)
-    payload = _health_payload(db)
+    assert payload["safety_events_last_hour"] == 3
 
-    assert payload["safety_events_last_hour"] == recorded, (
-        "health endpoint reports "
-        f"{payload['safety_events_last_hour']} safety events, "
-        f"but {recorded} were recorded (endpoint hardcodes 0 — issue D-08)"
-    )
+
+@pytest.mark.unit
+def test_health_safety_events_zero_when_no_events():
+    with patch("redis.from_url", return_value=FakeRedis()):
+        payload = _health_payload(_mock_db())
+
+    assert payload["safety_events_last_hour"] == 0
+
+
+@pytest.mark.unit
+def test_health_safety_events_degrades_to_zero_when_redis_unavailable():
+    """A Redis outage must not crash /health; the count degrades to 0."""
+    with patch("redis.from_url", return_value=BrokenRedis()):
+        payload = _health_payload(_mock_db())
+
+    assert payload["safety_events_last_hour"] == 0


### PR DESCRIPTION
## Summary

The `/health` endpoint advertised a `safety_events_last_hour` field but hardcoded
it to `0` (with a `# This would be populated by actual safety event logging`
placeholder), so operators could never actually see safety activity. This PR
wires the field to the real data that `SafetyMonitor` already records in Redis.

## Issue
Closes #68

## Changes
- Add `SafetyMonitor.get_total_event_count(window_hours=1)` — sums per-type
  counts across `VALID_EVENT_TYPES`; failing lookups degrade to `0`.
- `api/routes/health.py`: build a `SafetyMonitor` from `settings.redis_url` and
  report `get_total_event_count()` instead of the hardcoded `0`, inside a guarded
  block so a Redis outage degrades the count to `0` rather than failing `/health`.
- Add `tests/unit/test_health_safety_events.py` covering the helper (sum across
  types, zero when empty) and the endpoint wiring (reports recorded count, zero
  with no events, degrades to zero when Redis is unavailable).

## Testing
- [x] Unit tests pass (`make test-unit`) — see note on pre-existing failures below
- [ ] Integration tests pass (`make test-integration`) — not run (requires Docker services)
- [x] Linter passes (`make lint`) — no new findings on touched files
- [x] Type checker passes (`make typecheck`) — no new errors on touched files
- [x] New/updated tests cover the changes

**Pre-existing failures (this change introduces none):** the repo has documented
pre-existing failures unrelated to this issue (e.g. #158 async-mock misconfig, 13
review_service tests; #159 structlog/caplog). Before/after this change, unit
failures went **54 → 53** — my Week 8 reproduction test now passes and **no new
failures** are introduced. `mypy` error count on the touched files is unchanged
(14 → 14); the remaining `ruff`/`black` findings on those files (unsorted imports,
unused `timedelta`/`timestamp`, `Depends` default, a trailing-comma on
`VALID_EVENT_TYPES`) are all pre-existing.

## Screenshots / Demo
New unit tests (all pass):
```
tests/unit/test_health_safety_events.py::test_get_total_event_count_sums_across_types PASSED
tests/unit/test_health_safety_events.py::test_get_total_event_count_zero_when_no_events PASSED
tests/unit/test_health_safety_events.py::test_health_reports_recorded_safety_events PASSED
tests/unit/test_health_safety_events.py::test_health_safety_events_zero_when_no_events PASSED
tests/unit/test_health_safety_events.py::test_health_safety_events_degrades_to_zero_when_redis_unavailable PASSED
```

## Notes for Reviewers
- **Out of scope, but noticed:** the Redis *dependency* check in `health.py` reads
  `settings.redis_host` / `settings.redis_port`, which don't exist on `Settings`
  (only `redis_url` does), so that block always marks Redis unhealthy. I kept this
  PR scoped to the safety-count field and did **not** change that block — happy to
  file a follow-up.
- **Windowing:** `get_event_count` doesn't strictly enforce `window_hours` (counts
  live under a 24h key expiry), so "last hour" is approximate. I preserved the
  existing semantics rather than re-architecting the key scheme (which would touch
  every event producer); flagging in case a true rolling window is preferred as a
  follow-up.
