### PR TITLE
Test/109 review service coverage

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -28,3 +28,34 @@ I reproduced the issue by running the review-service unit tests with coverage re
 
 **Blockers or open questions:**
 None at the moment; the next step is to add focused tests around the success and failure branches in the review workflow.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+I reproduced the issue by running the review-service tests and confirmed that the main workflow branches were not being exercised well. I also created a plan in [PLAN.md](PLAN.md) and started adding focused tests for the review workflow.
+
+**Next steps:**
+I’m finishing the targeted unit tests for the review-service success and failure branches and verifying them with pytest.
+
+**Blockers:**
+None at the moment.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** Not submitted yet
+
+**Branch:** `test/109-review-service-coverage`
+
+**What you built:**
+I added targeted unit tests for the review-service workflow in [tests/unit/test_review_service.py](tests/unit/test_review_service.py). The new tests cover review creation, review lookup, pagination, successful processing, safety-check failure, missing-profile failure, and missing-review early exit.
+
+**Tests added or updated:**
+Updated [tests/unit/test_review_service.py](tests/unit/test_review_service.py) to cover the main review-service execution paths.
+
+**Self-review confirmation:** [x] make check passes  [ ] make test-unit passes
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,30 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/109
+
+**Issue title:** Test coverage for `core/services/review_service.py` is below 40%
+
+**Tier:** [] Tier 1  [x] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The review service is the core workflow for creating and processing portfolio reviews, but its important execution paths are not covered by unit tests. The missing coverage leaves the success path, partial failure path, and full failure path effectively unverified, which makes regressions harder to detect. A successful fix would add focused tests around the service logic in `core/services/review_service.py` so the behavior is exercised and documented.
+
+**Branch name:** test/109-review-service-coverage
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/Oreo236/pathreview/commit/placeholder
+
+**Reproduction summary:**
+I reproduced the issue by running the review-service unit tests with coverage reporting. The current test run fails and does not provide meaningful coverage for the review workflow, confirming that the service’s main execution paths are not being exercised.
+
+**PLAN.md link:** https://github.com/Oreo236/pathreview/blob/test/109-review-service-coverage/PLAN.md
+
+**Walkthrough video (recommended):** Not recorded yet
+
+**Blockers or open questions:**
+None at the moment; the next step is to add focused tests around the success and failure branches in the review workflow.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -17,7 +17,7 @@ The review service is the core workflow for creating and processing portfolio re
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** https://github.com/Oreo236/pathreview/commit/placeholder
+**Reproduction commit link:** https://github.com/Oreo236/pathreview/commit/91a3dc7c07b5918d45a14ebe66b816d2288966a6
 
 **Reproduction summary:**
 I reproduced the issue by running the review-service unit tests with coverage reporting. The current test run fails and does not provide meaningful coverage for the review workflow, confirming that the service’s main execution paths are not being exercised.
@@ -51,7 +51,7 @@ None at the moment.
 **Branch:** `test/109-review-service-coverage`
 
 **What you built:**
-I added targeted unit tests for the review-service workflow in [tests/unit/test_review_service.py](tests/unit/test_review_service.py). The new tests cover review creation, review lookup, pagination, successful processing, safety-check failure, missing-profile failure, and missing-review early exit.
+I added targeted unit tests for the review-service workflow in [tests/unit/test_review_service.py](tests/unit/test_review_service.py). The new tests cover review creation, review lookup, safety-check failure, missing-profile failure, and missing-review early exit.
 
 **Tests added or updated:**
 Updated [tests/unit/test_review_service.py](tests/unit/test_review_service.py) to cover the main review-service execution paths.
@@ -59,3 +59,34 @@ Updated [tests/unit/test_review_service.py](tests/unit/test_review_service.py) t
 **Self-review confirmation:** [x] make check passes  [ ] make test-unit passes
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No feedback
+
+**How you responded:**
+No changes were needed in response to reviewer feedback.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The hardest part was understanding the service’s intent. It required more careful reading than I expected, especially when the code was working but the edge cases were not clearly documented.
+
+**What did you learn about working in a large codebase?**
+Working in a larger codebase taught me that contribution is about more than making a change that passes locally. It is also about reading surrounding patterns, respecting existing conventions, and making sure a change fits the expectations of the project rather than just solving the immediate problem in an isolated way.
+
+**How did AI tools help — and where did they fall short?**
+AI tools were helpful for quickly suggesting test cases, explaining unfamiliar functions, and helping me think through the service’s likely success and failure paths. They were less reliable when it came to judging whether a test reflected the intended product behavior rather than just the current implementation, so I had to verify the logic by reading the relevant code and aligning the tests with the service’s actual contract.
+
+**What would you do differently if you started over?**
+If I started over, I would map the important execution paths of the service more explicitly before writing tests, so I could focus on the highest-value branches first. I would also spend more time capturing the reasoning behind each test case in my notes and PR description so the purpose of the coverage work is easier for others to understand.
+
+**What are you most proud of from this module?**
+I am most proud of creating, understanding, fixing some of the previous test and my new test. It was a very fun journey.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,43 @@
+## Solution plan
+
+**Issue:** Test coverage for `core/services/review_service.py` is below 40% (https://github.com/ascherj/pathreview/issues/109)
+
+### Understand
+What is the root cause of this issue? What behavior is expected vs. actual?
+
+The review service contains the main workflow for creating, processing, and finalizing reviews, but the current unit tests mostly assert basic mock interactions instead of exercising the real success and failure branches. As a result, the service logic is under-tested and the coverage target is not being met.
+
+### Map
+Which files, functions, or modules are involved?
+List the specific files you expect to touch.
+
+- `core/services/review_service.py`
+- `tests/unit/test_review_service.py`
+- Possibly `core/models/review.py` 
+
+### Plan
+What are the steps to fix this issue?
+Break it into 3–5 concrete sub-tasks.
+
+1. Review the main functions in `review_service.py` and identify the key execution paths: create/list/get, successful processing, failed processing, and safety-check failure.
+2. Replace the existing superficial tests with focused unit tests that mock the service dependencies and verify the review state transitions and stored output.
+3. Add coverage for the ingestion, orchestration, RAG, and safety-check branches, including both success and failure cases.
+4. Run the targeted test suite with coverage reporting and iterate until the relevant coverage threshold is reached.
+
+### Inputs & outputs
+What does your fix take as input? What should it produce or change?
+
+The tests will take mocked database sessions, profile objects, and review objects as input. They should verify that the service updates review status, stores sections and scores, and handles exceptions or safety failures correctly.
+
+### Risks & unknowns
+What could go wrong? What are you still unsure about?
+
+The main uncertainty is how much of the workflow should be mocked versus exercised directly, so the tests need to stay focused on behavior rather than implementation details.
+
+### Edge cases
+What inputs or states should your fix handle gracefully?
+
+- Missing review or profile records
+- Safety-check failures
+- Exceptions raised during processing
+- Reviews with no ingested sources or missing section data

--- a/core/services/review_service.py
+++ b/core/services/review_service.py
@@ -1,19 +1,21 @@
-from uuid import UUID
-import structlog
 import json
 from datetime import datetime
-from sqlalchemy import select, and_
+from typing import Any, cast
+from uuid import UUID
 
-from core.models.review import Review
-from core.models.profile import Profile
-from core.models.ingested_source import IngestedSource
+import structlog
+from sqlalchemy import and_, select
+
 from api.schemas.review import FeedbackSection
+from core.models.ingested_source import IngestedSource
+from core.models.profile import Profile
+from core.models.review import Review
 
 log = structlog.get_logger()
 
 
 async def create_review(
-    db,
+    db: Any,
     profile_id: UUID,
     user_id: UUID,
 ) -> Review:
@@ -33,22 +35,22 @@ async def create_review(
 
 
 async def get_review(
-    db,
+    db: Any,
     review_id: UUID,
     user_id: UUID,
 ) -> Review | None:
     """
     Get a review by ID, checking that it belongs to the user's profile.
     """
-    stmt = select(Review).join(Profile).where(
-        and_(Review.id == review_id, Profile.user_id == user_id)
+    stmt = (
+        select(Review).join(Profile).where(and_(Review.id == review_id, Profile.user_id == user_id))
     )
     result = await db.execute(stmt)
-    return result.scalars().first()
+    return cast(Review | None, result.scalars().first())
 
 
 async def list_reviews(
-    db,
+    db: Any,
     user_id: UUID,
     page: int = 1,
     page_size: int = 20,
@@ -80,7 +82,7 @@ async def list_reviews(
 
 
 async def process_review(
-    db,
+    db: Any,
     review_id: UUID,
     profile_id: UUID,
 ) -> None:
@@ -194,12 +196,12 @@ async def process_review(
             log.error("review_status_update_failed", review_id=str(review_id), error=str(e))
 
 
-async def _run_ingestion_pipeline(db, profile: Profile) -> list[dict]:
+async def _run_ingestion_pipeline(db: Any, profile: Profile) -> list[dict[str, Any]]:
     """
     Run ingestion pipeline to extract data from profile sources.
     Returns list of ingested source data.
     """
-    sources = []
+    sources: list[dict[str, Any]] = []
 
     # Ingest from GitHub if available
     if profile.github_username:
@@ -279,7 +281,9 @@ async def _run_ingestion_pipeline(db, profile: Profile) -> list[dict]:
     return sources
 
 
-async def _run_agent_orchestration(profile: Profile, ingestion_results: list[dict]) -> dict:
+async def _run_agent_orchestration(
+    profile: Profile, ingestion_results: list[dict[str, Any]]
+) -> dict[str, Any]:
     """
     Run agent orchestration to analyze ingested data.
     Returns agent output with initial analysis.
@@ -306,9 +310,9 @@ async def _run_agent_orchestration(profile: Profile, ingestion_results: list[dic
 
 async def _run_rag_retrieval_generation(
     profile: Profile,
-    ingestion_results: list[dict],
-    agent_output: dict,
-) -> dict:
+    ingestion_results: list[dict[str, Any]],
+    agent_output: dict[str, Any],
+) -> dict[str, Any]:
     """
     Run RAG retrieval and generation to create detailed feedback.
     Returns enhanced review output.
@@ -354,7 +358,7 @@ async def _run_rag_retrieval_generation(
     }
 
 
-async def _run_safety_checks(output: dict) -> bool:
+async def _run_safety_checks(output: dict[str, Any]) -> bool:
     """
     Run safety checks on the review output.
     Returns True if all checks pass, False otherwise.

--- a/tests/unit/test_review_service.py
+++ b/tests/unit/test_review_service.py
@@ -237,6 +237,103 @@ class TestReviewService:
         mock_db_session.commit.assert_awaited()
 
     @pytest.mark.asyncio
+    async def test_process_review_marks_review_failed_after_pipeline_exception(
+        self, mock_db_session: AsyncMock, mock_review: Mock, mock_profile: Mock
+    ) -> None:
+        """Mark the review failed when a workflow dependency raises unexpectedly."""
+        mock_db_session.execute = AsyncMock(
+            side_effect=[
+                self._build_result(mock_review),
+                self._build_result(mock_profile),
+                self._build_result(mock_review),
+            ]
+        )
+
+        with patch.object(
+            review_service,
+            "_run_ingestion_pipeline",
+            AsyncMock(side_effect=RuntimeError("ingestion unavailable")),
+        ):
+            await review_service.process_review(mock_db_session, mock_review.id, mock_profile.id)
+
+        assert mock_review.status == "failed"
+        assert mock_review.updated_at is not None
+        assert mock_db_session.execute.await_count == 3
+        assert mock_db_session.commit.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_ingestion_pipeline_continues_after_one_source_fails(
+        self, mock_db_session: AsyncMock, mock_profile: Mock
+    ) -> None:
+        """Keep usable sources when storing one ingested source fails."""
+        mock_db_session.add.side_effect = [RuntimeError("GitHub storage unavailable"), None, None]
+
+        with patch.object(review_service, "IngestedSource", Mock()):
+            results = await review_service._run_ingestion_pipeline(mock_db_session, mock_profile)
+
+        assert [source["source_type"] for source in results] == ["github", "portfolio", "resume"]
+        mock_db_session.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("failed_source", ["portfolio", "resume"])
+    async def test_ingestion_pipeline_continues_when_later_source_fails(
+        self, mock_db_session: AsyncMock, mock_profile: Mock, failed_source: str
+    ) -> None:
+        """Handle a portfolio or resume ingestion failure without aborting the pipeline."""
+        failure_index = {"portfolio": 1, "resume": 2}[failed_source]
+        mock_db_session.add.side_effect = [
+            RuntimeError("source storage unavailable") if index == failure_index else None
+            for index in range(3)
+        ]
+
+        with patch.object(review_service, "IngestedSource", Mock()):
+            results = await review_service._run_ingestion_pipeline(mock_db_session, mock_profile)
+
+        assert len(results) == 3
+        mock_db_session.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_orchestration_and_rag_helpers_return_review_output(
+        self, mock_profile: Mock
+    ) -> None:
+        """Return the default analysis and generated-feedback structures."""
+        sources = [{"source_type": "github"}]
+
+        agent_output = await review_service._run_agent_orchestration(mock_profile, sources)
+        rag_output = await review_service._run_rag_retrieval_generation(
+            mock_profile, sources, agent_output
+        )
+
+        assert agent_output["sections"]
+        assert rag_output["sections"]
+        assert rag_output["overall_score"] == 0.81
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("output", "expected"),
+        [
+            ({"sections": []}, False),
+            (
+                {"sections": [{"section_name": "Skills", "content": "Good", "confidence": 0.8}]},
+                True,
+            ),
+            (
+                {"sections": [{"section_name": "", "content": "Good", "confidence": 0.8}]},
+                False,
+            ),
+            (
+                {"sections": [{"section_name": "Skills", "content": "Good", "confidence": 1.1}]},
+                False,
+            ),
+        ],
+    )
+    async def test_safety_checks_validate_review_sections(
+        self, output: dict[str, Any], expected: bool
+    ) -> None:
+        """Accept complete sections and reject incomplete or invalid output."""
+        assert await review_service._run_safety_checks(output) is expected
+
+    @pytest.mark.asyncio
     async def test_process_review_marks_review_failed_when_profile_is_missing(
         self, mock_db_session: AsyncMock, mock_review: Mock
     ) -> None:

--- a/tests/unit/test_review_service.py
+++ b/tests/unit/test_review_service.py
@@ -1,24 +1,21 @@
-"""Tests for review_service.py"""
+"""Tests for review_service.py."""
+
+from typing import Any
+from unittest.mock import AsyncMock, Mock, patch
+from uuid import uuid4
 
 import pytest
-from uuid import uuid4
-from unittest.mock import AsyncMock, Mock, patch
-import asyncio
 
-from core.services.review_service import (
-    create_review,
-    get_review,
-    list_reviews,
-)
+from core.services import review_service
 
 
 @pytest.mark.unit
 class TestReviewService:
-    """Test suite for review_service module."""
+    """Test the core review service workflow."""
 
     @pytest.fixture
-    def mock_db_session(self):
-        """Create a mock async database session."""
+    def mock_db_session(self) -> AsyncMock:
+        """Create an async database session mock."""
         session = AsyncMock()
         session.add = Mock()
         session.commit = AsyncMock()
@@ -27,314 +24,238 @@ class TestReviewService:
         return session
 
     @pytest.fixture
-    def mock_review(self):
-        """Create a mock Review object."""
+    def mock_review(self) -> Mock:
+        """Create a review-like object for workflow tests."""
         review = Mock()
         review.id = uuid4()
         review.status = "pending"
         review.sections = None
         review.overall_score = None
+        review.updated_at = None
         return review
 
     @pytest.fixture
-    def mock_profile(self):
-        """Create a mock Profile object."""
+    def mock_profile(self) -> Mock:
+        """Create a profile-like object for workflow tests."""
         profile = Mock()
         profile.id = uuid4()
         profile.user_id = uuid4()
+        profile.github_username = "octocat"
+        profile.portfolio_url = "https://example.com"
+        profile.resume_text = "resume text"
+        profile.resume_filename = "resume.md"
         return profile
 
+    def _build_result(self, value: Any) -> Mock:
+        """Build a simple DB result mock with scalars().first()/all()."""
+        result = Mock()
+        scalars_result = Mock()
+        scalars_result.first.return_value = value
+        scalars_result.all.return_value = value
+        result.scalars.return_value = scalars_result
+        return result
+
     @pytest.mark.asyncio
-    async def test_create_review_returns_review_with_pending_status(self, mock_db_session, mock_review):
-        """Test create_review returns Review with status='pending'."""
+    async def test_create_review_sets_pending_status_and_commits(
+        self, mock_db_session: AsyncMock
+    ) -> None:
+        """Create a review with pending status and persist it."""
         profile_id = uuid4()
         user_id = uuid4()
 
-        # Setup mock
-        mock_db_session.add = Mock()
-        mock_db_session.commit = AsyncMock()
-        mock_db_session.refresh = AsyncMock()
+        with patch("core.services.review_service.Review") as mock_review_cls:
+            review_obj = Mock()
+            review_obj.status = "pending"
+            review_obj.sections = None
+            review_obj.overall_score = None
+            mock_review_cls.return_value = review_obj
 
-        with patch('core.services.review_service.Review') as MockReview:
-            mock_instance = MockReview.return_value
-            mock_instance.status = "pending"
-            mock_instance.sections = None
-            mock_instance.overall_score = None
+            result = await review_service.create_review(mock_db_session, profile_id, user_id)
 
-            result = await create_review(mock_db_session, profile_id, user_id)
-
-            # Check that Review was instantiated
-            MockReview.assert_called()
-            call_kwargs = MockReview.call_args[1]
-            assert call_kwargs['status'] == "pending"
+            assert result is review_obj
+            mock_review_cls.assert_called_once_with(
+                profile_id=profile_id,
+                status="pending",
+                sections=None,
+                overall_score=None,
+            )
+            mock_db_session.add.assert_called_once_with(review_obj)
+            mock_db_session.commit.assert_awaited_once()
+            mock_db_session.refresh.assert_awaited_once_with(review_obj)
 
     @pytest.mark.asyncio
-    async def test_get_review_returns_review_for_correct_owner(self, mock_db_session):
-        """Test get_review returns review when user_id matches."""
+    async def test_get_review_returns_review_for_matching_user(
+        self, mock_db_session: AsyncMock
+    ) -> None:
+        """Return a review when it belongs to the current user."""
         review_id = uuid4()
         user_id = uuid4()
+        expected_review = Mock()
 
-        mock_review = Mock()
-        mock_review.id = review_id
+        mock_db_session.execute = AsyncMock(return_value=self._build_result(expected_review))
 
-        # Setup mock execute to return review
-        mock_result = AsyncMock()
-        mock_result.scalars.return_value.first.return_value = mock_review
-        mock_db_session.execute = AsyncMock(return_value=mock_result)
+        result = await review_service.get_review(mock_db_session, review_id, user_id)
 
-        result = await get_review(mock_db_session, review_id, user_id)
-
-        assert result == mock_review
-        mock_db_session.execute.assert_called_once()
+        assert result is expected_review
+        mock_db_session.execute.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_get_review_returns_none_for_wrong_user(self, mock_db_session):
-        """Test get_review returns None when user_id doesn't match."""
-        review_id = uuid4()
+    async def test_list_reviews_returns_paginated_results_and_total_count(
+        self, mock_db_session: AsyncMock
+    ) -> None:
+        """List reviews for a user with pagination and total count."""
         user_id = uuid4()
-        wrong_user_id = uuid4()
+        reviews = [Mock(), Mock()]
+        count_result = self._build_result(reviews)
+        page_result = self._build_result(reviews)
+        mock_db_session.execute = AsyncMock(side_effect=[count_result, page_result])
 
-        # Setup mock to return None
-        mock_result = AsyncMock()
-        mock_result.scalars.return_value.first.return_value = None
-        mock_db_session.execute = AsyncMock(return_value=mock_result)
-
-        result = await get_review(mock_db_session, review_id, wrong_user_id)
-
-        assert result is None
-
-    @pytest.mark.asyncio
-    async def test_list_reviews_returns_paginated_results(self, mock_db_session):
-        """Test list_reviews returns paginated results."""
-        user_id = uuid4()
-
-        # Create mock reviews
-        mock_reviews = [Mock() for _ in range(5)]
-
-        # Setup execute mock to return reviews
-        mock_result = AsyncMock()
-        mock_result.scalars.return_value.all.return_value = mock_reviews
-        mock_db_session.execute = AsyncMock(return_value=mock_result)
-
-        reviews, total = await list_reviews(mock_db_session, user_id, page=1, page_size=20)
-
-        assert len(reviews) > 0 or len(reviews) == 0  # May be empty
-        assert isinstance(total, int)
-        assert total >= 0
-
-    @pytest.mark.asyncio
-    async def test_list_reviews_page_2_returns_correct_offset(self, mock_db_session):
-        """Test list_reviews page 2 returns correct offset."""
-        user_id = uuid4()
-        page_size = 20
-
-        # Setup mock
-        mock_result = AsyncMock()
-        mock_result.scalars.return_value.all.return_value = []
-        mock_db_session.execute = AsyncMock(return_value=mock_result)
-
-        reviews, total = await list_reviews(
-            mock_db_session, user_id, page=2, page_size=page_size
+        result_reviews, total = await review_service.list_reviews(
+            mock_db_session, user_id, page=2, page_size=1
         )
 
-        # Second call should pass offset for page 2
-        calls = mock_db_session.execute.call_args_list
-        # Should have at least one call
-        assert len(calls) > 0
+        assert result_reviews == reviews
+        assert total == 2
+        assert mock_db_session.execute.await_count == 2
 
     @pytest.mark.asyncio
-    async def test_list_reviews_returns_tuple(self, mock_db_session):
-        """Test list_reviews returns (reviews, total) tuple."""
-        user_id = uuid4()
-
-        mock_result = AsyncMock()
-        mock_result.scalars.return_value.all.return_value = []
-        mock_db_session.execute = AsyncMock(return_value=mock_result)
-
-        result = await list_reviews(mock_db_session, user_id)
-
-        assert isinstance(result, tuple)
-        assert len(result) == 2
-        reviews, total = result
-        assert isinstance(reviews, list)
-        assert isinstance(total, int)
-
-    @pytest.mark.asyncio
-    async def test_create_review_calls_db_add(self, mock_db_session):
-        """Test create_review calls db.add()."""
-        profile_id = uuid4()
-        user_id = uuid4()
-
-        with patch('core.services.review_service.Review'):
-            await create_review(mock_db_session, profile_id, user_id)
-
-            mock_db_session.add.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_create_review_calls_db_commit(self, mock_db_session):
-        """Test create_review calls db.commit()."""
-        profile_id = uuid4()
-        user_id = uuid4()
-
-        with patch('core.services.review_service.Review'):
-            await create_review(mock_db_session, profile_id, user_id)
-
-            mock_db_session.commit.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_create_review_calls_db_refresh(self, mock_db_session):
-        """Test create_review calls db.refresh()."""
-        profile_id = uuid4()
-        user_id = uuid4()
-
-        with patch('core.services.review_service.Review'):
-            await create_review(mock_db_session, profile_id, user_id)
-
-            mock_db_session.refresh.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_get_review_uses_select_and_join(self, mock_db_session):
-        """Test get_review constructs proper SQL with join."""
-        review_id = uuid4()
-        user_id = uuid4()
-
-        mock_result = AsyncMock()
-        mock_result.scalars.return_value.first.return_value = None
-        mock_db_session.execute = AsyncMock(return_value=mock_result)
-
-        await get_review(mock_db_session, review_id, user_id)
-
-        # Should call execute with a statement
-        mock_db_session.execute.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_list_reviews_default_pagination(self, mock_db_session):
-        """Test list_reviews uses default pagination."""
-        user_id = uuid4()
-
-        mock_result = AsyncMock()
-        mock_result.scalars.return_value.all.return_value = []
-        mock_db_session.execute = AsyncMock(return_value=mock_result)
-
-        reviews, total = await list_reviews(mock_db_session, user_id)
-
-        # Should use default page=1, page_size=20
-        assert isinstance(reviews, list)
-        assert isinstance(total, int)
-
-    @pytest.mark.asyncio
-    async def test_list_reviews_custom_page_size(self, mock_db_session):
-        """Test list_reviews with custom page size."""
-        user_id = uuid4()
-        custom_page_size = 50
-
-        mock_result = AsyncMock()
-        mock_result.scalars.return_value.all.return_value = []
-        mock_db_session.execute = AsyncMock(return_value=mock_result)
-
-        reviews, total = await list_reviews(
-            mock_db_session, user_id, page=1, page_size=custom_page_size
+    async def test_process_review_completes_successfully_and_stores_sections(
+        self, mock_db_session: AsyncMock, mock_review: Mock, mock_profile: Mock
+    ) -> None:
+        """Complete the workflow when ingestion and safety checks succeed."""
+        mock_db_session.execute = AsyncMock(
+            side_effect=[self._build_result(mock_review), self._build_result(mock_profile)]
         )
 
-        assert isinstance(reviews, list)
+        with (
+            patch.object(
+                review_service,
+                "_run_ingestion_pipeline",
+                AsyncMock(return_value=[{"source_type": "github"}]),
+            ) as ingest_mock,
+            patch.object(
+                review_service,
+                "_run_agent_orchestration",
+                AsyncMock(
+                    return_value={"sections": [{"section_name": "Skills"}], "overall_score": 0.75}
+                ),
+            ) as agent_mock,
+            patch.object(
+                review_service,
+                "_run_rag_retrieval_generation",
+                AsyncMock(
+                    return_value={
+                        "sections": [
+                            {
+                                "section_name": "Skills",
+                                "content": "Great work",
+                                "confidence": 0.9,
+                                "suggestions": ["Add metrics"],
+                            }
+                        ],
+                        "overall_score": 0.81,
+                    }
+                ),
+            ) as rag_mock,
+            patch.object(
+                review_service,
+                "_run_safety_checks",
+                AsyncMock(return_value=True),
+            ) as safety_mock,
+        ):
+            await review_service.process_review(mock_db_session, mock_review.id, mock_profile.id)
+
+        assert mock_review.status == "complete"
+        assert mock_review.overall_score == 0.81
+        assert mock_review.sections[0]["section_name"] == "Skills"
+        assert mock_review.updated_at is not None
+        ingest_mock.assert_awaited_once_with(mock_db_session, mock_profile)
+        agent_mock.assert_awaited_once_with(mock_profile, [{"source_type": "github"}])
+        rag_mock.assert_awaited_once_with(
+            mock_profile,
+            [{"source_type": "github"}],
+            {"sections": [{"section_name": "Skills"}], "overall_score": 0.75},
+        )
+        safety_mock.assert_awaited_once_with(
+            {
+                "sections": [
+                    {
+                        "section_name": "Skills",
+                        "content": "Great work",
+                        "confidence": 0.9,
+                        "suggestions": ["Add metrics"],
+                    }
+                ],
+                "overall_score": 0.81,
+            }
+        )
 
     @pytest.mark.asyncio
-    async def test_create_review_with_uuid_ids(self, mock_db_session):
-        """Test create_review handles UUID objects correctly."""
-        profile_id = uuid4()
-        user_id = uuid4()
+    async def test_process_review_marks_review_failed_when_safety_checks_fail(
+        self, mock_db_session: AsyncMock, mock_review: Mock, mock_profile: Mock
+    ) -> None:
+        """Mark the review as failed when safety checks reject the output."""
+        mock_db_session.execute = AsyncMock(
+            side_effect=[self._build_result(mock_review), self._build_result(mock_profile)]
+        )
 
-        with patch('core.services.review_service.Review') as MockReview:
-            MockReview.return_value = Mock()
-            await create_review(mock_db_session, profile_id, user_id)
+        with (
+            patch.object(
+                review_service,
+                "_run_ingestion_pipeline",
+                AsyncMock(return_value=[{"source_type": "github"}]),
+            ),
+            patch.object(
+                review_service,
+                "_run_agent_orchestration",
+                AsyncMock(
+                    return_value={"sections": [{"section_name": "Skills"}], "overall_score": 0.75}
+                ),
+            ),
+            patch.object(
+                review_service,
+                "_run_rag_retrieval_generation",
+                AsyncMock(
+                    return_value={
+                        "sections": [
+                            {
+                                "section_name": "Skills",
+                                "content": "Great work",
+                                "confidence": 0.9,
+                                "suggestions": ["Add metrics"],
+                            }
+                        ],
+                        "overall_score": 0.81,
+                    }
+                ),
+            ),
+            patch.object(review_service, "_run_safety_checks", AsyncMock(return_value=False)),
+        ):
+            await review_service.process_review(mock_db_session, mock_review.id, mock_profile.id)
 
-            call_kwargs = MockReview.call_args[1]
-            assert 'profile_id' in call_kwargs
-            assert 'status' in call_kwargs
-
-    @pytest.mark.asyncio
-    async def test_get_review_verifies_ownership(self, mock_db_session):
-        """Test get_review checks Profile.user_id matches."""
-        review_id = uuid4()
-        user_id = uuid4()
-
-        mock_result = AsyncMock()
-        mock_result.scalars.return_value.first.return_value = None
-        mock_db_session.execute = AsyncMock(return_value=mock_result)
-
-        await get_review(mock_db_session, review_id, user_id)
-
-        # Should construct query with user_id filter
-        mock_db_session.execute.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_list_reviews_counts_total(self, mock_db_session):
-        """Test list_reviews calculates total count."""
-        user_id = uuid4()
-
-        mock_reviews = [Mock() for _ in range(5)]
-        mock_result = AsyncMock()
-        mock_result.scalars.return_value.all.return_value = mock_reviews
-        mock_db_session.execute = AsyncMock(return_value=mock_result)
-
-        reviews, total = await list_reviews(mock_db_session, user_id)
-
-        # Total should be counted
-        assert isinstance(total, int)
-
-    @pytest.mark.asyncio
-    async def test_list_reviews_returns_reviews_list(self, mock_db_session):
-        """Test list_reviews returns list of Review objects."""
-        user_id = uuid4()
-
-        mock_reviews = [Mock(spec=['id', 'status']) for _ in range(3)]
-        mock_result = AsyncMock()
-        mock_result.scalars.return_value.all.return_value = mock_reviews
-        mock_db_session.execute = AsyncMock(return_value=mock_result)
-
-        reviews, total = await list_reviews(mock_db_session, user_id)
-
-        assert isinstance(reviews, list)
+        assert mock_review.status == "failed"
+        mock_db_session.commit.assert_awaited()
 
     @pytest.mark.asyncio
-    async def test_review_sections_and_score_initially_none(self, mock_db_session):
-        """Test review has None for sections and overall_score initially."""
-        profile_id = uuid4()
-        user_id = uuid4()
+    async def test_process_review_marks_review_failed_when_profile_is_missing(
+        self, mock_db_session: AsyncMock, mock_review: Mock
+    ) -> None:
+        """Mark the review as failed when the profile does not exist."""
+        mock_db_session.execute = AsyncMock(
+            side_effect=[self._build_result(mock_review), self._build_result(None)]
+        )
 
-        with patch('core.services.review_service.Review') as MockReview:
-            MockReview.return_value = Mock()
-            await create_review(mock_db_session, profile_id, user_id)
+        await review_service.process_review(mock_db_session, mock_review.id, uuid4())
 
-            call_kwargs = MockReview.call_args[1]
-            assert call_kwargs['sections'] is None
-            assert call_kwargs['overall_score'] is None
-
-    @pytest.mark.asyncio
-    async def test_get_review_with_valid_uuid(self, mock_db_session):
-        """Test get_review handles valid UUID parameters."""
-        review_id = uuid4()
-        user_id = uuid4()
-
-        mock_result = AsyncMock()
-        mock_result.scalars.return_value.first.return_value = None
-        mock_db_session.execute = AsyncMock(return_value=mock_result)
-
-        # Should not raise
-        result = await get_review(mock_db_session, review_id, user_id)
-
-        assert result is None or result is not None  # Just verify no exception
+        assert mock_review.status == "failed"
 
     @pytest.mark.asyncio
-    async def test_list_reviews_ordered_by_created_at(self, mock_db_session):
-        """Test list_reviews returns results ordered by created_at desc."""
-        user_id = uuid4()
+    async def test_process_review_returns_when_review_is_not_found(
+        self, mock_db_session: AsyncMock
+    ) -> None:
+        """Exit early when no review exists for the provided ID."""
+        mock_db_session.execute = AsyncMock(return_value=self._build_result(None))
 
-        mock_result = AsyncMock()
-        mock_result.scalars.return_value.all.return_value = []
-        mock_db_session.execute = AsyncMock(return_value=mock_result)
+        await review_service.process_review(mock_db_session, uuid4(), uuid4())
 
-        reviews, total = await list_reviews(mock_db_session, user_id)
-
-        # Should order by created_at descending
-        mock_db_session.execute.assert_called_once()
+        mock_db_session.commit.assert_not_called()


### PR DESCRIPTION
## Summary
Improves test coverage for the critical review-service workflow by exercising successful processing, recoverable partial failures, and unrecoverable failures.
## Issue
Closes #109 

## Changes
<!-- Bullet list of the specific changes made -->

- Added workflow tests for review creation, retrieval, pagination, successful processing, and safety rejection.
- Added tests for missing reviews/profiles and pipeline exceptions that mark reviews as failed.
- Added ingestion tests confirming portfolio or resume failures do not stop the remaining source processing.
- Added coverage for orchestration, RAG output, and safety-validation branches.
- Added targeted type annotations in review_service.py.

## Testing
<!-- How did you verify your changes? -->
- [ ] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`)
- [ ] Linter passes (`make lint`)
- [ ] Type checker passes (`make typecheck`)
- [X] New/updated tests cover the changes

## Screenshots / Demo
<!-- If applicable, add screenshots or a link to a demo video -->

## Notes for Reviewers
<!-- Anything the reviewer should pay particular attention to -->
