### PR TITLE
Fix health check redis host

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -36,3 +36,39 @@ N/A
 
 **Blockers or open questions:**
 The repository has existing lint and type-check issues in `api/routes/health.py` that are unrelated to this issue and prevented the pre-commit hooks from passing locally.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the Redis health check fix by replacing the nonexistent settings.redis_host and settings.redis_port configuration with the existing settings.redis_url. Opened a pull request, marked it ready for review, and verified the endpoint no longer raises an AttributeError.
+
+**Next steps:**
+Run the required project checks, document any pre-existing failures, and finalize the PR.
+
+**Blockers:**
+The repository contains pre-existing unit test failures unrelated to this issue.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:**
+https://github.com/ascherj/pathreview/pull/322
+
+**Branch:**
+`fix-health-check-redis-host`
+
+**What you built:**
+Updated the health check endpoint to initialize the Redis client using the existing `settings.redis_url` configuration instead of the nonexistent `settings.redis_host` and `settings.redis_port` settings. This allows the health endpoint to complete without raising an AttributeError.
+
+**Tests added or updated:**
+No tests were modified because this change only updates the Redis client initialization to use the existing configuration value. I ran `make test-unit` and confirmed that the repository still has the same unrelated pre-existing test failures and that my change did not introduce any new failures.
+
+**Self-review confirmation:**
+- `make check`: Repository has pre-existing lint/style failures unrelated to this issue; my changes did not introduce additional failures.
+- `make test-unit`: Repository has pre-existing failing tests unrelated to this issue (53 failures); my changes did not introduce additional failures.
+
+**Draft PR feedback received from:**
+None

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,40 @@
+# Development Journal
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/155
+
+**Issue title:** Health check references `settings.redis_host`, which does not exist on Settings
+
+**Tier:** ☑ Tier 1  ☐ Tier 2  ☐ Tier 3
+
+**Problem summary:**
+
+The health check endpoint attempts to create a Redis client using `settings.redis_host` and `settings.redis_port`, but these configuration values do not exist in `core/config.py`. As a result, the endpoint raises an `AttributeError` instead of completing the health check. A successful fix updates the health check to use the existing `settings.redis_url` configuration so the endpoint can initialize the Redis client correctly.
+
+**Branch name:** `fix-health-check-redis-host`
+
+**Setup confirmation:** ☑ App runs locally at `localhost:5173`
+
+**Cohort ledger:** ☑ Issue added to cohort ledger
+
+---
+
+## Week 8 — Reproduction & solution planning
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:**
+(To be added after committing)
+
+**Reproduction summary:**
+I reproduced the issue by running the application locally and sending a request to the `/health` endpoint. The health check attempted to access `settings.redis_host` and `settings.redis_port`, which do not exist in the application's configuration, causing the endpoint to fail. I verified that the application already uses `settings.redis_url`, making it the correct configuration to use.
+
+**PLAN.md link:**
+(To be added after pushing)
+
+**Walkthrough video (recommended):**
+N/A
+
+**Blockers or open questions:**
+The repository has existing lint and type-check issues in `api/routes/health.py` that are unrelated to this issue and prevented the pre-commit hooks from passing locally.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -22,16 +22,14 @@ The health check endpoint attempts to create a Redis client using `settings.redi
 
 ## Week 8 — Reproduction & solution planning
 
-## Week 8 — Reproduction & solution planning
-
 **Reproduction commit link:**
-(To be added after committing)
+https://github.com/yoyotop/pathreview/commit/66737da
 
 **Reproduction summary:**
 I reproduced the issue by running the application locally and sending a request to the `/health` endpoint. The health check attempted to access `settings.redis_host` and `settings.redis_port`, which do not exist in the application's configuration, causing the endpoint to fail. I verified that the application already uses `settings.redis_url`, making it the correct configuration to use.
 
 **PLAN.md link:**
-(To be added after pushing)
+https://github.com/yoyotop/pathreview/blob/fix-health-check-redis-host/PLAN.md
 
 **Walkthrough video (recommended):**
 N/A

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -72,3 +72,34 @@ No tests were modified because this change only updates the Redis client initial
 
 **Draft PR feedback received from:**
 None
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No reviewer feedback was received during Summer 2026. The PR was submitted successfully, but no review comments were provided.
+
+**How you responded:**
+N/A
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Working with an unfamiliar codebase was harder than I expected, especially figuring out where the issue actually came from instead of immediately changing the code. I had to trace the health check through the configuration files and understand how Redis was being configured before making the fix. The Git and PR workflow was also something I had to become more comfortable with throughout the process.
+
+**What did you learn about working in a large codebase?**
+I learned that contributing to someone else's codebase requires more investigation and caution than working on my own projects. I had to follow the existing project structure, conventions, and configuration instead of simply implementing the solution in the way I preferred. I also learned that not every existing error in a repository is related to the issue I am working on, so it is important to distinguish pre-existing problems from problems caused by my changes.
+
+**How did AI tools help — and where did they fall short?**
+AI tools were useful for helping me navigate the codebase, understand unfamiliar files, and figure out where the health check and Redis configuration were connected. They also helped me understand Git commands and the project's workflow when I ran into issues. However, I still had to verify the suggestions myself and test the changes because AI could not always know which failures were pre-existing or how the repository was specifically configured.
+
+**What would you do differently if you started over?**
+I would start documenting my work more consistently from the beginning. I had to spend time figuring out where my JOURNAL.md had gone and reconstructing parts of my Week 7 and Week 8 work. I would also open my PR earlier and get more familiar with the review process sooner, even though no peer review was ultimately provided this session.
+
+**What are you most proud of from this module?**
+I am most proud of successfully taking an issue from selection and reproduction through planning and implementation in an unfamiliar codebase. I was able to identify the configuration problem, make the fix, document my process, and submit a PR to the original repository.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -80,7 +80,7 @@ None
 **Feedback received:** [ ] Yes  [x] No — still awaiting review
 
 **Summary of feedback:**
-No reviewer feedback was received during Summer 2026. The PR was submitted successfully, but no review comments were provided.
+No reviewer feedback was received. The PR was submitted successfully, but no review comments came in during the Summer 2026 review process.
 
 **How you responded:**
 N/A
@@ -90,16 +90,16 @@ N/A
 ### Reflection
 
 **What was harder than you expected?**
-Working with an unfamiliar codebase was harder than I expected, especially figuring out where the issue actually came from instead of immediately changing the code. I had to trace the health check through the configuration files and understand how Redis was being configured before making the fix. The Git and PR workflow was also something I had to become more comfortable with throughout the process.
+The hardest part was understanding an unfamiliar codebase well enough to make a change without breaking something else. For Issue #155, I had to trace the health check in `api/routes/health.py` and compare it with the configuration in `core/config.py` to understand why `settings.redis_host` and `settings.redis_port` were causing the problem. I also ran into some Git workflow issues during the project, including getting stuck in a rebase editor, which took some time to figure out.
 
 **What did you learn about working in a large codebase?**
-I learned that contributing to someone else's codebase requires more investigation and caution than working on my own projects. I had to follow the existing project structure, conventions, and configuration instead of simply implementing the solution in the way I preferred. I also learned that not every existing error in a repository is related to the issue I am working on, so it is important to distinguish pre-existing problems from problems caused by my changes.
+I learned that working in someone else's codebase requires more investigation before making a change than working on my own projects. With this issue, the correct solution was not to add new Redis settings, but to recognize that the project already had `settings.redis_url` and use the existing configuration. I also learned to pay attention to pre-existing test and lint failures so I could distinguish them from problems caused by my own changes.
 
 **How did AI tools help — and where did they fall short?**
-AI tools were useful for helping me navigate the codebase, understand unfamiliar files, and figure out where the health check and Redis configuration were connected. They also helped me understand Git commands and the project's workflow when I ran into issues. However, I still had to verify the suggestions myself and test the changes because AI could not always know which failures were pre-existing or how the repository was specifically configured.
+AI tools were useful for helping me understand the structure of the PathReview codebase and trace how the health check interacted with the Redis configuration. They also helped me understand Git commands and troubleshoot issues when I got confused during the branch and rebase process. However, I still needed to verify the suggested changes myself by looking at the actual files and running the project, since AI could not automatically distinguish every pre-existing repository failure from an issue caused by my changes.
 
 **What would you do differently if you started over?**
-I would start documenting my work more consistently from the beginning. I had to spend time figuring out where my JOURNAL.md had gone and reconstructing parts of my Week 7 and Week 8 work. I would also open my PR earlier and get more familiar with the review process sooner, even though no peer review was ultimately provided this session.
+I would spend more time organizing my work and documenting each week's progress as I went instead of having to figure out what happened to my `JOURNAL.md` later. I would also open my PR earlier and try to get the review process started sooner, even though no peer review was ultimately provided for Summer 2026. On the technical side, I would run and document the relevant checks earlier so I had a clearer baseline for the pre-existing failures.
 
 **What are you most proud of from this module?**
-I am most proud of successfully taking an issue from selection and reproduction through planning and implementation in an unfamiliar codebase. I was able to identify the configuration problem, make the fix, document my process, and submit a PR to the original repository.
+I am most proud of taking Issue #155 from selecting and understanding the issue all the way through reproduction, planning, implementation, and submitting a PR. I was able to identify that the health check was referencing configuration values that did not exist and change it to use the existing `redis_url` configuration. Completing that process in an unfamiliar codebase gave me a better understanding of what contributing to a real project actually looks like.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,43 @@
+# Solution plan
+
+**Issue:** Health check references `settings.redis_host`, which does not exist on Settings
+https://github.com/ascherj/pathreview/issues/155
+
+## Understand
+
+The health check creates a Redis client using `settings.redis_host` and `settings.redis_port`. These configuration fields do not exist in `core/config.py`, causing an `AttributeError` whenever the Redis health check runs. The expected behavior is to use the existing `settings.redis_url` configuration.
+
+## Map
+
+Files involved:
+
+- api/routes/health.py
+- core/config.py
+
+## Plan
+
+1. Reproduce the AttributeError by calling the `/health` endpoint.
+2. Verify that Redis is configured through `settings.redis_url`.
+3. Replace the `redis.Redis(...)` constructor with `redis.from_url(settings.redis_url)`.
+4. Verify that the `/health` endpoint returns a health response instead of crashing.
+
+## Inputs & outputs
+
+**Input**
+
+- Existing Redis URL from `settings.redis_url`
+
+**Output**
+
+- Health endpoint successfully creates a Redis client using the configured Redis URL.
+
+## Risks & unknowns
+
+- Existing health check failures may still occur if Redis or PostgreSQL are unavailable.
+- Pre-existing lint/type-check issues in `api/routes/health.py` may affect development but are unrelated to this fix.
+
+## Edge cases
+
+- Invalid Redis URL
+- Redis server unavailable
+- Other dependency health checks failing while Redis client creation succeeds

--- a/api/routes/health.py
+++ b/api/routes/health.py
@@ -1,6 +1,7 @@
-from fastapi import APIRouter, HTTPException, status, Depends
+from datetime import datetime
+
 import structlog
-from datetime import datetime, timedelta
+from fastapi import APIRouter, Depends, HTTPException, status
 
 from core.database import get_db
 
@@ -39,12 +40,11 @@ async def health_check(db=Depends(get_db)):
     try:
         # Check Redis (if available)
         import redis
+
         from core.config import settings
 
-        r = redis.Redis(
-            host=settings.redis_host,
-            port=settings.redis_port,
-            db=0,
+        r = redis.from_url(
+            settings.redis_url,
             decode_responses=True,
         )
         r.ping()

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -99,7 +99,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -449,7 +448,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -473,7 +471,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1561,7 +1558,6 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1579,7 +1575,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1972,7 +1967,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3507,7 +3501,6 @@
       "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^2.0.1",
         "cssstyle": "^4.0.1",
@@ -4094,7 +4087,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4107,7 +4099,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4771,7 +4762,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",


### PR DESCRIPTION
## Summary

This PR fixes the Redis health check by replacing references to the nonexistent `settings.redis_host` and `settings.redis_port` fields with the existing `settings.redis_url` configuration. This prevents the `/health` endpoint from raising an `AttributeError` when checking Redis.

## Issue

Closes #155

## Changes

- Replaced `redis.Redis(host=..., port=...)` with `redis.from_url(settings.redis_url)`
- Updated the Redis health check to use the existing application configuration

## Testing

- [ ] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`)
- [ ] Linter passes (`make lint`)
- [ ] Type checker passes (`make typecheck`)
- [ ] New/updated tests cover the changes

Manual verification:
- Verified that `GET /health` no longer raises an `AttributeError` and returns a health status response.

## Screenshots / Demo

N/A

## Notes for Reviewers

Local pre-commit hooks reported existing lint/type-check issues in `api/routes/health.py` that appear unrelated to this change. The functional change in this PR is limited to using `settings.redis_url` for the Redis health check.