### PR TITLE
fix(api): reject reviews for profiles with no ingested content

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -78,7 +78,7 @@ test file in the repo) verifying that behavior.
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [fill in once this commit is made — not committed yet, pending review]
+**Reproduction commit link:** https://github.com/OmJam/pathreview/commit/f3af37a8c45707cd3edc0617bde951a1d321b752
 
 **Reproduction summary:**
 Reproduced two ways. Live: registered a throwaway user, created a profile
@@ -94,13 +94,45 @@ pipeline functions (`_run_agent_orchestration`, `_run_rag_retrieval_generation`,
 shouldn't produce a safety-check-passing, fully-sectioned result from
 nothing — confirmed failing via `.venv/bin/pytest tests/unit/test_review_service.py -v`.
 
-**PLAN.md link:** [fill in once committed — will be https://github.com/OmJam/pathreview/blob/test/88-review-no-ingested-documents/PLAN.md]
+**PLAN.md link:** https://github.com/OmJam/pathreview/blob/test/88-review-no-ingested-documents/PLAN.md
 
-**Walkthrough video (recommended):** [not yet recorded]
+**Walkthrough video (recommended):** [not recorded]
 
 **Blockers or open questions:**
-Whether the fix belongs purely in the route layer (`api/routes/reviews.py`)
-or needs the defense-in-depth duplicate check in `process_review` too (see
-PLAN.md Risks — leaning toward both); whether to fix the `error_message`
-column not being populated on the two pre-existing failure paths as a
-drive-by while touching this code, or leave that for a separate issue.
+Resolved during Week 9 implementation — the fix ended up in both the route
+layer and `process_review` (defense-in-depth), and the `error_message` gap
+on the two pre-existing failure paths was deliberately left alone to keep
+the PR scoped to #88 (documented in PLAN.md and the PR description).
+
+## Week 9 — Solution building & PR submission
+
+### Check-in
+
+**PR link:** https://github.com/ascherj/pathreview/pull/325
+
+**Branch:** test/88-review-no-ingested-documents
+
+**What you built:**
+`POST /reviews` now loads the profile before creating a review and returns
+404 (not found/not owned) or 422 ("Profile has no ingested content to
+review") instead of silently completing with fabricated feedback.
+`process_review` runs the same check as a defense-in-depth guard, and is
+the first code path in the app to ever populate the `error_message` column
+on failure.
+
+**Tests added or updated:**
+Rewrote the Week 8 reproduction test in `tests/unit/test_review_service.py`
+to assert the fixed behavior (fails on pre-fix code, passes now — verified
+both ways via `git stash`). Added `tests/unit/test_review_routes.py` — the
+first route/HTTP-layer tests in the repo, covering 404, 422 for empty and
+whitespace-only profiles, and the happy-path regression — and
+`tests/unit/test_profile_service.py` (8 parametrized cases for the new
+`profile_has_ingested_content` helper).
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+*(documented pre-existing failures: 53 unit-test failures across 11 files
+and 103 mypy errors across 26 files predate this branch; confirmed via
+`git stash` baseline diffing that this PR introduces zero new failures in
+either — see PLAN.md "Status" and the PR's "Pre-existing issues" section)*
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -20,10 +20,55 @@ canned score. A successful fix adds an upfront validation check that rejects
 profiles with no ingested content, and a new test file (the first route-level
 test file in the repo) verifying that behavior.
 
-**Scope reasoning:** [work through your course's "Is this right for me?"
-checklist here — e.g. estimated effort vs. your available time, whether you
-understood the affected code before claiming it, whether the issue was still
-valid (verified above).]
+**Scope reasoning:**
+
+*Part 1 — Understanding the issue*
+- [x] Explained in my own words: `POST /reviews` never checks whether a profile
+  has any ingested content (GitHub username, portfolio, or resume) before
+  creating a review. Because the background processing step is currently
+  placeholder logic, a profile with nothing ingested doesn't get an error back
+  — it silently receives a fake "complete" review with fabricated content and
+  a canned score. The fix should reject that case with a clear error and add a
+  test proving it.
+- [x] Affected area confirmed: `api/routes/reviews.py` (the endpoint) and
+  `core/services/review_service.py` (`create_review`, `process_review`) — both
+  read in full. The issue's own labels (`api`, `tests`, `docs`, `devops`)
+  confirm this is an API-layer issue, not ingestion or frontend.
+- [x] Concrete before/after: **Before** — POST a profile with no ingested
+  sources, get a 200 and, eventually, a fabricated "complete" review with
+  made-up sections. **After** — the same request returns a clear 4xx error
+  immediately, with a test asserting that behavior.
+
+*Part 2 — Tier fit*
+- [x] Tier 1 — matches the issue's own `tier-1` label, and this is my first
+  open-source contribution, so I'm not reaching for Tier 2/3 yet.
+
+*Part 3 — Codebase readiness*
+- [x] Read the specific code the issue references: `api/routes/reviews.py:22-62`
+  (`create_review_endpoint`) and all of `core/services/review_service.py`,
+  including the placeholder `_run_ingestion_pipeline` /
+  `_run_agent_orchestration` / `_run_rag_retrieval_generation` steps that
+  `process_review` calls.
+- [x] Understand it well enough to sketch a fix: add a check in
+  `create_review_endpoint` (or the `create_review` service function) that
+  rejects a profile with no ingested content via a 422, before a `Review` row
+  is even created.
+- [x] Read the relevant test file end-to-end: there's no existing route-level
+  test file for this endpoint — that's the gap itself. Read
+  `tests/unit/test_review_service.py` end-to-end instead, since it's the
+  closest existing pattern: it mocks the DB session directly with
+  `AsyncMock`/`Mock` and never goes through FastAPI's `TestClient` or the HTTP
+  layer. This confirms the new test file will be the first one in the repo
+  that tests through the actual route/HTTP layer, not just the service
+  function directly.
+
+*Part 4 — Scope and time*
+- [x] Not already claimed: verified zero comments before commenting, then
+  confirmed via the GitHub API that mine is the only comment.
+- [x] Realistic for Weeks 8–9: issue estimate is 2–5 hours, Tier 1, comfortably
+  within the two-week window.
+- [x] No blockers: read the full issue body — no "blocked by" reference to any
+  other issue.
 
 **Branch name:** test/88-review-no-ingested-documents
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -75,3 +75,32 @@ test file in the repo) verifying that behavior.
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [ ] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [fill in once this commit is made — not committed yet, pending review]
+
+**Reproduction summary:**
+Reproduced two ways. Live: registered a throwaway user, created a profile
+with no github_username/portfolio_url/resume, and POSTed a review for it —
+it reached `status: "complete"` on the very first poll, with three fully
+fabricated feedback sections ("Technical Skills", "Project Experience",
+"Career Growth") and `overall_score: 0.81`, and `error_message: null`,
+despite the profile having zero real content. Code-level: added
+`test_no_ingested_content_should_not_produce_fabricated_review` to
+`tests/unit/test_review_service.py`, which calls the same placeholder
+pipeline functions (`_run_agent_orchestration`, `_run_rag_retrieval_generation`,
+`_run_safety_checks`) directly with an empty-content profile and asserts they
+shouldn't produce a safety-check-passing, fully-sectioned result from
+nothing — confirmed failing via `.venv/bin/pytest tests/unit/test_review_service.py -v`.
+
+**PLAN.md link:** [fill in once committed — will be https://github.com/OmJam/pathreview/blob/test/88-review-no-ingested-documents/PLAN.md]
+
+**Walkthrough video (recommended):** [not yet recorded]
+
+**Blockers or open questions:**
+Whether the fix belongs purely in the route layer (`api/routes/reviews.py`)
+or needs the defense-in-depth duplicate check in `process_review` too (see
+PLAN.md Risks — leaning toward both); whether to fix the `error_message`
+column not being populated on the two pre-existing failure paths as a
+drive-by while touching this code, or leave that for a separate issue.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,32 @@
+# Journal
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/jamjamgobambam/pathreview/issues/88
+
+**Issue title:** `POST /reviews` endpoint has no test for when the profile has no ingested documents
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+There is no route-level test coverage anywhere in the API — not just for this
+endpoint, but for any endpoint in the app. `POST /reviews` accepts a profile_id
+and immediately returns a pending review with no check that the profile actually
+has any ingested content (GitHub username, portfolio URL, or resume). The
+background task that's supposed to process the review is currently built from
+placeholder logic, so a profile with zero ingested sources doesn't error out —
+it silently produces a fake "complete" review with fabricated content and a
+canned score. A successful fix adds an upfront validation check that rejects
+profiles with no ingested content, and a new test file (the first route-level
+test file in the repo) verifying that behavior.
+
+**Scope reasoning:** [work through your course's "Is this right for me?"
+checklist here — e.g. estimated effort vs. your available time, whether you
+understood the affected code before claiming it, whether the issue was still
+valid (verified above).]
+
+**Branch name:** test/88-review-no-ingested-documents
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -136,3 +136,100 @@ and 103 mypy errors across 26 files predate this branch; confirmed via
 either — see PLAN.md "Status" and the PR's "Pre-existing issues" section)*
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+Checked PR #325 on 2026-08-03 via `gh pr view 325 --json
+comments,reviews,reviewRequests`: 0 comments, 0 reviews, 0 review requests
+since it opened on 2026-07-27. No maintainer or reviewer feedback arrived.
+Per this term's course note, reviewer feedback isn't provided in Su26, so
+this is the expected outcome rather than a stalled review.
+
+**How you responded:**
+*(No feedback arrived, so no response was needed — no changes made to the PR
+this week.)*
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Keeping a running mental model of the whole system was harder than I
+expected — not just the one endpoint I was fixing, but how
+`api/routes/reviews.py`, `core/services/review_service.py`, and
+`core/services/profile_service.py` all handed data to each other, and where
+the placeholder pipeline stages (`_run_agent_orchestration`,
+`_run_rag_retrieval_generation`, `_run_safety_checks`) sat in that flow.
+Every time I came back to this after a few days between Weeks 7–9, I had to
+re-derive where I'd left off and why. The harder problem underneath that was
+knowing when testing was "enough": it was easy to keep finding more cases
+(whitespace-only fields, a profile edited after creation to remove its only
+content, the two pre-existing `process_review` failure paths that still
+don't set `error_message`), and I had to consciously draw a line — cover
+what #88 actually asked for, and write the rest into `PLAN.md` as
+explicitly out of scope instead of chasing it all into one PR.
+
+**What did you learn about working in a large codebase?**
+Most of the actual time went into understanding, not writing. Before I
+changed a line, I had to read `create_review_endpoint` end-to-end and trace
+`process_review`'s four placeholder stages to see that the real bug wasn't
+"missing one validation" so much as "nothing in the pipeline ever checks its
+own input." In my own projects I'd just know that already. Here, correctness
+alone wasn't the bar, either — matching `docs/CONTRIBUTING.md`'s branch
+naming, Conventional Commits format, and the PR template mattered almost as
+much as the fix, since a maintainer reviewing many PRs is relying on that
+consistency to move fast. I also learned to verify against a baseline
+instead of a fresh run: `make test-unit` and `make typecheck` both had
+pre-existing failures (54 and 103) unrelated to my change, so "my tests
+pass" wasn't good enough — I had to `git stash` and diff before/after to
+prove I added zero new failures, a habit I didn't need in solo projects
+with no pre-existing debt to separate from.
+
+**How did AI tools help — and where did they fall short?**
+AI was most useful as a reading accelerant — pointed at the issue, it helped
+me trace `create_review_endpoint` into `process_review`'s placeholder
+stages faster than I'd have managed alone, and it was good at narrowing
+"which files actually matter for this issue" in a repo I'd never seen
+before. It fell short on codebase-specific standards: this repo has
+`docs/CONTRIBUTING.md` and a `.github/PULL_REQUEST_TEMPLATE.md` that already
+spell out the exact branch-naming scheme, commit format and scopes, and
+required PR sections, but AI didn't go find and apply those on its own — I
+had to read them myself and feed the rules back in before my branch name,
+commits, and PR body actually matched what the repo expects. It also
+couldn't tell me when a fix was "enough" — the scoping calls (leaving the
+two pre-existing `error_message` gaps alone, treating a syntactically-valid
+but fake `github_username` as out of scope) were judgment calls I had to
+make and then document myself, not something I could offload.
+
+**What would you do differently if you started over?**
+I'd read `docs/CONTRIBUTING.md` and the PR template in full on day one
+instead of picking up pieces of them mid-task — the standards were already
+written down, I just hadn't consumed them before I started, so I ended up
+correcting branch/commit/PR formatting after the fact instead of getting it
+right the first time. I'd also spend more of Week 7 mapping how
+`reviews.py`, `review_service.py`, and `profile_service.py` actually pass
+data to each other — a quick sketch of the request → endpoint → background
+task → placeholder-stage flow would have surfaced the "nothing checks its
+own input" root cause faster than reading files one at a time as I got to
+them.
+
+**What are you most proud of from this module?**
+Taking this from "reviews complete with fabricated content and nobody
+notices" (the Week 8 reproduction: a zero-field profile reaching
+`status: complete` with three made-up sections and a 0.81 score) to a
+verified fix with a paper trail — a 422/404 check in the route, a
+defense-in-depth copy in `process_review`, tests proving both the bug and
+the fix, and a baseline diff showing I didn't break anything else along the
+way. What I'm proud of isn't the diff itself, it's that I can explain every
+line of it and back it up with evidence I generated myself. That's also the
+module's biggest lesson about AI: it clearly sped up understanding an
+unfamiliar codebase and drafting the fix, but the parts that made this a
+real contribution — deciding scope, verifying against a baseline instead of
+trusting a green checkmark, catching that AI's first-pass formatting didn't
+match the repo's conventions — only happened because I treated it as a pair
+programmer to question and check, not an authority to defer to.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,130 @@
+## Solution plan
+
+**Issue:** #88 — `POST /reviews` endpoint has no test for when the profile has no ingested documents — https://github.com/jamjamgobambam/pathreview/issues/88
+
+### Understand
+`create_review_endpoint` (api/routes/reviews.py:22-62) never loads the Profile
+row and performs zero validation before creating a Review and scheduling the
+`process_review` background task. That task (core/services/review_service.py:
+82-194) runs four placeholder pipeline functions that ignore whether any real
+content was ingested and always fabricate valid-looking sections and a score.
+`_run_safety_checks` only validates the *shape* of the output (non-empty
+name/content, confidence in [0,1]), never whether it's grounded in real data.
+Net effect: a profile with no github_username, no portfolio_url, and no
+resume_text still reaches status="complete" with fabricated feedback — no
+crash, no error, anywhere in the pipeline. Confirmed live: registering a user,
+creating a profile with zero fields, and creating a review for it reached
+status="complete" with three fabricated sections and overall_score=0.81
+within one poll (see JOURNAL.md Week 8 for the full transcript).
+
+Expected vs. actual: Expected — a profile with nothing to review should be
+rejected with a clear error before a Review is even created. Actual — the API
+returns 200 immediately and the review always "succeeds" with made-up content.
+
+**Root cause:** missing upfront validation in `create_review_endpoint`
+(api/routes/reviews.py), compounded by placeholder pipeline stages in
+`core/services/review_service.py` that don't check their own input.
+
+### Map
+Files I expect to touch:
+- `api/routes/reviews.py` — `create_review_endpoint` (lines 22-62): fetch the
+  Profile via `get_profile()` (not currently imported — need to add
+  `from core.services.profile_service import get_profile`) and reject with
+  422 if it has no ingested content, before calling `create_review()`.
+- `core/services/profile_service.py` — add `profile_has_ingested_content(profile) -> bool`
+  next to the existing `get_profile()` (lines 36-48), so the check lives in one
+  place instead of being duplicated between the route and the service. Strip
+  string fields before the truthiness check so whitespace-only values (e.g.
+  `github_username=" "`) don't slip through — nothing in `api/schemas/profile.py`
+  currently prevents submitting those.
+- `core/services/review_service.py` — defense-in-depth: call the same helper
+  near the top of `process_review`, right after the existing "profile not
+  found" block (between lines 118 and 120), so a doomed review goes
+  `pending → failed` directly instead of `pending → processing → failed`. Set
+  `review.error_message` on this path (the `error_message` column already
+  exists on the model and in `ReviewResponse` but nothing populates it today
+  — decide whether the two pre-existing failure paths, lines 149-154 and
+  182-194, get the same treatment as a drive-by fix, or are explicitly left
+  for a separate issue).
+- `tests/unit/test_review_service.py` — the Week 8 reproduction test
+  (`test_no_ingested_content_should_not_produce_fabricated_review`) already
+  lives here and currently fails as expected; will need a "profile with
+  content still succeeds" regression test too once the fix lands (patch
+  `process_review` to a no-op in that test — Starlette runs `BackgroundTasks`
+  synchronously once the response is returned, so an unpatched test would
+  actually execute all four placeholder stages for real).
+- New: `tests/unit/test_review_routes.py` — first route-level test file in
+  the repo. Use plain `TestClient(app)` (**not** `with TestClient(app) as
+  client:`, which triggers `api/main.py`'s startup event and a real Postgres
+  connection attempt — verified this empirically) with
+  `app.dependency_overrides` for `get_current_user` and `get_db` (an
+  `AsyncMock` session, same mocking idiom `test_review_service.py` already
+  uses). Needs `@pytest.mark.unit` on the test class or `make test-unit`
+  (which filters with `-m unit`) will silently collect zero of these tests
+  while still exiting 0 — a real local/CI mismatch since CI's job has no
+  such filter. Clear `app.dependency_overrides` in a fixture teardown so it
+  doesn't leak into whichever test file loads next.
+
+### Plan
+1. Add `profile_has_ingested_content(profile) -> bool` to
+   `core/services/profile_service.py`, stripping string fields before the
+   truthiness check.
+2. In `create_review_endpoint`, import and call `get_profile()` (404 if
+   missing/not owned, matching the existing pattern in
+   `get_profile_endpoint`), then call the new helper and raise
+   `HTTPException(422, "Profile has no ingested content to review")` if it
+   returns False — before calling `create_review()`.
+3. Add the same helper call as a defense-in-depth guard near the top of
+   `process_review`, setting `status="failed"` and `error_message` if
+   reached with no content.
+4. Build `tests/unit/test_review_routes.py`: plain `TestClient(app)` +
+   `dependency_overrides` for `get_current_user`/`get_db`, `@pytest.mark.unit`
+   on the class, teardown that clears overrides. Write the 422-rejection
+   test and the profile-with-content regression test (with
+   `process_review` patched to a no-op in the latter).
+5. Run `make test-unit` and `make check` (lint/format/typecheck) to confirm
+   everything passes before opening a PR.
+
+### Inputs & outputs
+- Function changing: `create_review_endpoint(data: ReviewCreate, ...)`.
+- New behavior: if the `Profile` for `data.profile_id` has no
+  `github_username`, no `portfolio_url`, and no `resume_text` (after
+  stripping whitespace) → `HTTPException(422, detail="Profile has no
+  ingested content to review")`, no `Review` row created.
+- Existing happy path (profile with real content) is unchanged — verified by
+  the regression test in step 4.
+
+### Risks & unknowns
+1. Route vs. service-layer placement: doing it in the route matches the
+   existing 404 convention (`api/routes/profiles.py:122-133`) and 422
+   convention (`api/routes/profiles.py:50-53`), but the service-layer
+   defense-in-depth copy is still needed in case `create_review()` is ever
+   called from somewhere other than this one route.
+2. Building the first route/`TestClient` harness in this repo from scratch is
+   real, non-trivial work — no existing pattern to copy, and the
+   `with TestClient(...)`-triggers-real-DB gotcha above is exactly the kind of
+   thing that silently eats an hour if not already known going in.
+3. A `github_username` that's syntactically present but invalid/nonexistent
+   still passes this check — this fix only catches "literally nothing
+   provided," not "provided but ingestion would fail." Out of scope for #88
+   as written, but a real boundary worth being explicit about in the PR
+   description.
+4. The two pre-existing failure paths in `process_review` (safety-check
+   failure, generic exception handler) still don't populate `error_message`
+   today — decide explicitly whether to fix those as a drive-by or leave
+   them for a separate issue, rather than leaving it ambiguous.
+
+### Edge cases
+- `resume_text=""` — already falsy in Python, handled for free.
+- `github_username=" "` (whitespace-only) — NOT caught by a plain truthiness
+  check; needs an explicit `.strip()` before the check.
+- A profile updated after creation to remove its only content — checked the
+  actual code: `update_profile` (profile_service.py) only overwrites fields
+  `if data.X is not None`, and there's no endpoint to clear/re-upload
+  `resume_text` after creation, so this isn't reachable through the app's own
+  API today. Not a live risk, but the defense-in-depth check in
+  `process_review` future-proofs it if a clear/patch endpoint is ever added.
+- The "profile with content still succeeds" regression test must patch
+  `process_review` to a no-op, since Starlette executes queued
+  `BackgroundTasks` synchronously once the test client gets a response —
+  otherwise the test silently runs all four real placeholder pipeline stages.

--- a/PLAN.md
+++ b/PLAN.md
@@ -111,8 +111,10 @@ Files I expect to touch:
    description.
 4. The two pre-existing failure paths in `process_review` (safety-check
    failure, generic exception handler) still don't populate `error_message`
-   today — decide explicitly whether to fix those as a drive-by or leave
-   them for a separate issue, rather than leaving it ambiguous.
+   today — **decided (Week 9): left untouched.** Only the new
+   no-ingested-content path sets `error_message`, keeping this PR scoped to
+   issue #88; the gap on the two older paths is documented in the PR
+   description as a candidate follow-up issue.
 
 ### Edge cases
 - `resume_text=""` — already falsy in Python, handled for free.
@@ -128,3 +130,34 @@ Files I expect to touch:
   `process_review` to a no-op, since Starlette executes queued
   `BackgroundTasks` synchronously once the test client gets a response —
   otherwise the test silently runs all four real placeholder pipeline stages.
+
+### Status (Week 9 — implemented)
+
+All five plan steps are done. Verification against the pre-change baseline
+(the repo has documented pre-existing failures; the requirement is
+no *new* ones):
+
+| Check | Baseline (before) | After fix |
+|---|---|---|
+| `pytest tests/unit -m unit` | 54 failed / 375 passed | 53 failed / 388 passed |
+| `make typecheck` | 103 errors in 26 files | 103 errors in 26 files |
+| `ruff check .` | 174 errors | 174 errors |
+| `black --check` (my files) | — | all 4 touched/new files clean* |
+
+\* `core/services/profile_service.py` and `core/services/review_service.py`
+were already black-dirty before this change (pre-existing formatting on
+untouched lines); the added lines themselves are black-clean.
+
+The one failure that left the list is the Week 8 reproduction test, rewritten
+to assert the fixed behavior (fails on pre-fix code, passes now — verified
+both ways via `git stash`). The 53 remaining failures are byte-identical to
+the pre-existing baseline set. Also verified end-to-end against the running
+app: empty profile → 422 with a clear message, unknown profile → 404,
+profile with content → 200 pending → completes as before.
+
+One discovery worth noting for reviewers: 13 of the pre-existing failures in
+`tests/unit/test_review_service.py` stem from a broken mocking idiom
+(`AsyncMock` used for the *result* of `db.execute`, making the synchronous
+`.scalars()` call return a coroutine). The new tests use a plain `Mock` for
+result objects instead. The pre-existing tests were left untouched to keep
+this PR scoped.

--- a/api/routes/reviews.py
+++ b/api/routes/reviews.py
@@ -7,6 +7,7 @@ from api.middleware.auth import get_current_user
 from core.models.user import User
 from core.models.review import Review
 from core.database import get_db
+from core.services.profile_service import get_profile, profile_has_ingested_content
 from core.services.review_service import (
     create_review,
     get_review,
@@ -30,8 +31,40 @@ async def create_review_endpoint(
     Create a new review for a profile.
     Triggers ingestion pipeline and agent orchestration asynchronously.
     Returns review with status="pending" immediately.
+    Returns 404 if the profile is not found or not owned by current user.
+    Returns 422 if the profile has no ingested content to review.
     """
     try:
+        profile = await get_profile(
+            db=db,
+            profile_id=data.profile_id,
+            # get_profile declares user_id as UUID, but User.id is a str
+            # column and every existing caller passes it as-is.
+            user_id=current_user.id,  # type: ignore[arg-type]
+        )
+
+        if not profile:
+            log.warning(
+                "review_creation_profile_not_found",
+                profile_id=str(data.profile_id),
+                user_id=str(current_user.id),
+            )
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Profile not found",
+            )
+
+        if not profile_has_ingested_content(profile):
+            log.warning(
+                "review_creation_no_ingested_content",
+                profile_id=str(data.profile_id),
+                user_id=str(current_user.id),
+            )
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="Profile has no ingested content to review",
+            )
+
         # Create review with status="pending"
         review = await create_review(
             db=db,

--- a/core/services/profile_service.py
+++ b/core/services/profile_service.py
@@ -48,6 +48,20 @@ async def get_profile(
     return result.scalars().first()
 
 
+def profile_has_ingested_content(profile: Profile) -> bool:
+    """Check whether a profile has any content sources available to review.
+
+    Args:
+        profile: The profile to inspect.
+
+    Returns:
+        True if the profile has a non-blank github_username, portfolio_url,
+        or resume_text, False otherwise.
+    """
+    sources = (profile.github_username, profile.portfolio_url, profile.resume_text)
+    return any(source and source.strip() for source in sources)
+
+
 async def update_profile(
     db,
     profile_id: UUID,

--- a/core/services/review_service.py
+++ b/core/services/review_service.py
@@ -7,6 +7,7 @@ from sqlalchemy import select, and_
 from core.models.review import Review
 from core.models.profile import Profile
 from core.models.ingested_source import IngestedSource
+from core.services.profile_service import profile_has_ingested_content
 from api.schemas.review import FeedbackSection
 
 log = structlog.get_logger()
@@ -113,6 +114,22 @@ async def process_review(
         if not profile:
             log.error("profile_not_found_for_processing", profile_id=str(profile_id))
             review.status = "failed"
+            db.add(review)
+            await db.commit()
+            return
+
+        # Guard against reviews created outside create_review_endpoint's
+        # validation: a profile with nothing ingested must fail, not produce
+        # fabricated feedback.
+        if not profile_has_ingested_content(profile):
+            log.warning(
+                "review_processing_no_ingested_content",
+                review_id=str(review_id),
+                profile_id=str(profile_id),
+            )
+            review.status = "failed"
+            review.error_message = "Profile has no ingested content to review"
+            review.updated_at = datetime.utcnow()
             db.add(review)
             await db.commit()
             return

--- a/tests/unit/test_profile_service.py
+++ b/tests/unit/test_profile_service.py
@@ -1,0 +1,40 @@
+"""Tests for profile_service.py"""
+
+from unittest.mock import Mock
+
+import pytest
+
+from core.services.profile_service import profile_has_ingested_content
+
+
+@pytest.mark.unit
+class TestProfileHasIngestedContent:
+    """Test suite for profile_has_ingested_content."""
+
+    @pytest.mark.parametrize(
+        ("github_username", "portfolio_url", "resume_text", "expected"),
+        [
+            (None, None, None, False),
+            ("", "", "", False),
+            ("   ", None, None, False),
+            (None, " \n\t ", "", False),
+            ("octocat", None, None, True),
+            (None, "https://me.dev", None, True),
+            (None, None, "Jane Doe\nSoftware Engineer", True),
+            ("octocat", "https://me.dev", "resume text", True),
+        ],
+    )
+    def test_detects_reviewable_content(
+        self,
+        github_username: str | None,
+        portfolio_url: str | None,
+        resume_text: str | None,
+        expected: bool,
+    ) -> None:
+        """A profile counts as reviewable only with at least one non-blank source."""
+        profile = Mock()
+        profile.github_username = github_username
+        profile.portfolio_url = portfolio_url
+        profile.resume_text = resume_text
+
+        assert profile_has_ingested_content(profile) is expected

--- a/tests/unit/test_review_routes.py
+++ b/tests/unit/test_review_routes.py
@@ -1,0 +1,133 @@
+"""Route-level tests for POST /reviews (api/routes/reviews.py).
+
+These are the first tests in the repo that exercise the HTTP layer (routing,
+auth dependency, validation, response serialization) rather than calling
+service functions directly.
+
+NOTE: TestClient(app) is deliberately used WITHOUT the `with` context manager.
+Entering the context manager fires the app's startup event, which calls
+init_db() and attempts a real database connection. The plain client skips
+lifespan events entirely, so these tests run against mocked dependencies only.
+"""
+
+from collections.abc import Iterator
+from datetime import datetime
+from typing import Any
+from unittest.mock import AsyncMock, Mock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.main import app
+from api.middleware.auth import get_current_user
+from core.database import get_db
+
+
+def make_profile(
+    github_username: str | None = None,
+    portfolio_url: str | None = None,
+    resume_text: str | None = None,
+) -> Mock:
+    """Create a mock Profile with the given content fields."""
+    profile = Mock()
+    profile.id = uuid4()
+    profile.github_username = github_username
+    profile.portfolio_url = portfolio_url
+    profile.resume_text = resume_text
+    return profile
+
+
+@pytest.mark.unit
+class TestCreateReviewEndpoint:
+    """Tests for POST /reviews profile-content validation (issue #88)."""
+
+    @pytest.fixture
+    def mock_db_session(self) -> AsyncMock:
+        """Create a mock async database session."""
+        session = AsyncMock()
+        session.add = Mock()
+        return session
+
+    @pytest.fixture
+    def client(self, mock_db_session: AsyncMock) -> Iterator[TestClient]:
+        """TestClient with auth and DB dependencies overridden."""
+        user = Mock()
+        user.id = uuid4()
+        app.dependency_overrides[get_current_user] = lambda: user
+        app.dependency_overrides[get_db] = lambda: mock_db_session
+        yield TestClient(app)
+        app.dependency_overrides.clear()
+
+    @staticmethod
+    def profile_lookup_returns(session: AsyncMock, profile: Mock | None) -> None:
+        """Make the session's profile query return the given profile.
+
+        The result is a plain Mock (not AsyncMock): `await db.execute(...)`
+        returns it, then `.scalars().first()` is called synchronously.
+        """
+        result = Mock()
+        result.scalars.return_value.first.return_value = profile
+        session.execute = AsyncMock(return_value=result)
+
+    def test_profile_not_found_returns_404(
+        self, client: TestClient, mock_db_session: AsyncMock
+    ) -> None:
+        """POST /reviews returns 404 when the profile doesn't exist or isn't owned."""
+        self.profile_lookup_returns(mock_db_session, None)
+
+        response = client.post("/reviews", json={"profile_id": str(uuid4())})
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Profile not found"
+        mock_db_session.add.assert_not_called()
+
+    def test_no_ingested_content_returns_422(
+        self, client: TestClient, mock_db_session: AsyncMock
+    ) -> None:
+        """POST /reviews returns 422 and creates no Review row for an empty profile."""
+        self.profile_lookup_returns(mock_db_session, make_profile())
+
+        response = client.post("/reviews", json={"profile_id": str(uuid4())})
+
+        assert response.status_code == 422
+        assert response.json()["detail"] == "Profile has no ingested content to review"
+        mock_db_session.add.assert_not_called()
+
+    def test_whitespace_only_content_returns_422(
+        self, client: TestClient, mock_db_session: AsyncMock
+    ) -> None:
+        """Whitespace-only fields don't count as reviewable content."""
+        self.profile_lookup_returns(mock_db_session, make_profile(github_username="   "))
+
+        response = client.post("/reviews", json={"profile_id": str(uuid4())})
+
+        assert response.status_code == 422
+        mock_db_session.add.assert_not_called()
+
+    def test_profile_with_content_creates_pending_review(
+        self, client: TestClient, mock_db_session: AsyncMock
+    ) -> None:
+        """Regression: the new validation must not block profiles with real content."""
+        profile = make_profile(github_username="octocat")
+        self.profile_lookup_returns(mock_db_session, profile)
+
+        async def stamp_db_defaults(instance: Any) -> None:
+            # Mimic what db.refresh does after INSERT: populate column defaults.
+            instance.id = str(uuid4())
+            instance.created_at = datetime.utcnow()
+            instance.updated_at = datetime.utcnow()
+
+        mock_db_session.refresh = AsyncMock(side_effect=stamp_db_defaults)
+
+        # The background task would run synchronously after the response and
+        # exercise the real pipeline against the mock session -- not under test.
+        with patch("api.routes.reviews.process_review", new=AsyncMock()):
+            response = client.post("/reviews", json={"profile_id": str(uuid4())})
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["status"] == "pending"
+        assert body["sections"] is None
+        assert body["overall_score"] is None
+        mock_db_session.add.assert_called_once()

--- a/tests/unit/test_review_service.py
+++ b/tests/unit/test_review_service.py
@@ -339,44 +339,50 @@ class TestReviewService:
         mock_db_session.execute.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_no_ingested_content_should_not_produce_fabricated_review(self):
-        """Reproduces issue #88.
+    async def test_no_ingested_content_fails_instead_of_fabricating(self) -> None:
+        """Reproduces issue #88: a contentless profile must fail, not fabricate.
 
-        EXPECTED: a profile with zero ingested sources (no github_username, no
-        portfolio_url, no resume_text) should not result in a "successful"
-        review with fabricated content -- there is nothing to review.
-
-        ACTUAL (today): _run_agent_orchestration and _run_rag_retrieval_generation
-        are placeholders that ignore their ingestion_results input entirely and
-        always return the same canned sections/score, and _run_safety_checks only
-        validates the *shape* of those sections, not whether they're grounded in
-        real data -- so this currently passes safety checks and would reach
-        status="complete" via process_review with fabricated content.
-
-        This test fails today; it should pass once #88 is fixed.
+        Before the fix, process_review ran placeholder pipeline stages that
+        ignored the empty ingestion results and marked the review "complete"
+        with fabricated sections and a canned overall_score. With the fix it
+        must fail fast: status="failed", error_message set, and no fabricated
+        sections or score stored.
         """
-        from core.services.review_service import (
-            _run_agent_orchestration,
-            _run_rag_retrieval_generation,
-            _run_safety_checks,
-        )
+        from core.services.review_service import process_review
+
+        review_id = uuid4()
+        profile_id = uuid4()
+
+        review = Mock()
+        review.id = review_id
+        review.status = "pending"
+        review.sections = None
+        review.overall_score = None
+        review.error_message = None
 
         profile = Mock()
+        profile.id = profile_id
         profile.github_username = None
         profile.portfolio_url = None
         profile.resume_text = None
 
-        # Exactly what _run_ingestion_pipeline returns for a profile with no sources
-        empty_ingestion_results: list[dict] = []
+        # Plain Mock (not AsyncMock) result objects: `await db.execute(...)`
+        # returns them, then `.scalars().first()` is called synchronously.
+        review_result = Mock()
+        review_result.scalars.return_value.first.return_value = review
+        profile_result = Mock()
+        profile_result.scalars.return_value.first.return_value = profile
 
-        agent_output = await _run_agent_orchestration(profile, empty_ingestion_results)
-        rag_output = await _run_rag_retrieval_generation(
-            profile, empty_ingestion_results, agent_output
-        )
-        safety_passed = await _run_safety_checks(rag_output)
+        session = AsyncMock()
+        session.add = Mock()
+        session.execute = AsyncMock(side_effect=[review_result, profile_result])
 
-        assert not (safety_passed and len(rag_output["sections"]) > 0), (
-            "Expected a profile with no ingested content to be rejected/flagged, "
-            "but the pipeline produced a fully 'valid', safety-check-passing "
-            "review anyway -- this is issue #88."
+        await process_review(session, review_id, profile_id)
+
+        assert review.status == "failed", (
+            f"Expected a review for a profile with no ingested content to fail, "
+            f"but got status={review.status!r} with fabricated content -- issue #88."
         )
+        assert review.error_message
+        assert review.sections is None
+        assert review.overall_score is None

--- a/tests/unit/test_review_service.py
+++ b/tests/unit/test_review_service.py
@@ -1,9 +1,9 @@
 """Tests for review_service.py"""
 
-import pytest
-from uuid import uuid4
 from unittest.mock import AsyncMock, Mock, patch
-import asyncio
+from uuid import uuid4
+
+import pytest
 
 from core.services.review_service import (
     create_review,
@@ -45,7 +45,9 @@ class TestReviewService:
         return profile
 
     @pytest.mark.asyncio
-    async def test_create_review_returns_review_with_pending_status(self, mock_db_session, mock_review):
+    async def test_create_review_returns_review_with_pending_status(
+        self, mock_db_session, mock_review
+    ):
         """Test create_review returns Review with status='pending'."""
         profile_id = uuid4()
         user_id = uuid4()
@@ -55,18 +57,18 @@ class TestReviewService:
         mock_db_session.commit = AsyncMock()
         mock_db_session.refresh = AsyncMock()
 
-        with patch('core.services.review_service.Review') as MockReview:
-            mock_instance = MockReview.return_value
+        with patch("core.services.review_service.Review") as mock_review_class:
+            mock_instance = mock_review_class.return_value
             mock_instance.status = "pending"
             mock_instance.sections = None
             mock_instance.overall_score = None
 
-            result = await create_review(mock_db_session, profile_id, user_id)
+            await create_review(mock_db_session, profile_id, user_id)
 
             # Check that Review was instantiated
-            MockReview.assert_called()
-            call_kwargs = MockReview.call_args[1]
-            assert call_kwargs['status'] == "pending"
+            mock_review_class.assert_called()
+            call_kwargs = mock_review_class.call_args[1]
+            assert call_kwargs["status"] == "pending"
 
     @pytest.mark.asyncio
     async def test_get_review_returns_review_for_correct_owner(self, mock_db_session):
@@ -91,7 +93,6 @@ class TestReviewService:
     async def test_get_review_returns_none_for_wrong_user(self, mock_db_session):
         """Test get_review returns None when user_id doesn't match."""
         review_id = uuid4()
-        user_id = uuid4()
         wrong_user_id = uuid4()
 
         # Setup mock to return None
@@ -133,9 +134,7 @@ class TestReviewService:
         mock_result.scalars.return_value.all.return_value = []
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
-        reviews, total = await list_reviews(
-            mock_db_session, user_id, page=2, page_size=page_size
-        )
+        reviews, total = await list_reviews(mock_db_session, user_id, page=2, page_size=page_size)
 
         # Second call should pass offset for page 2
         calls = mock_db_session.execute.call_args_list
@@ -165,7 +164,7 @@ class TestReviewService:
         profile_id = uuid4()
         user_id = uuid4()
 
-        with patch('core.services.review_service.Review'):
+        with patch("core.services.review_service.Review"):
             await create_review(mock_db_session, profile_id, user_id)
 
             mock_db_session.add.assert_called_once()
@@ -176,7 +175,7 @@ class TestReviewService:
         profile_id = uuid4()
         user_id = uuid4()
 
-        with patch('core.services.review_service.Review'):
+        with patch("core.services.review_service.Review"):
             await create_review(mock_db_session, profile_id, user_id)
 
             mock_db_session.commit.assert_called_once()
@@ -187,7 +186,7 @@ class TestReviewService:
         profile_id = uuid4()
         user_id = uuid4()
 
-        with patch('core.services.review_service.Review'):
+        with patch("core.services.review_service.Review"):
             await create_review(mock_db_session, profile_id, user_id)
 
             mock_db_session.refresh.assert_called_once()
@@ -244,13 +243,13 @@ class TestReviewService:
         profile_id = uuid4()
         user_id = uuid4()
 
-        with patch('core.services.review_service.Review') as MockReview:
-            MockReview.return_value = Mock()
+        with patch("core.services.review_service.Review") as mock_review_class:
+            mock_review_class.return_value = Mock()
             await create_review(mock_db_session, profile_id, user_id)
 
-            call_kwargs = MockReview.call_args[1]
-            assert 'profile_id' in call_kwargs
-            assert 'status' in call_kwargs
+            call_kwargs = mock_review_class.call_args[1]
+            assert "profile_id" in call_kwargs
+            assert "status" in call_kwargs
 
     @pytest.mark.asyncio
     async def test_get_review_verifies_ownership(self, mock_db_session):
@@ -287,7 +286,7 @@ class TestReviewService:
         """Test list_reviews returns list of Review objects."""
         user_id = uuid4()
 
-        mock_reviews = [Mock(spec=['id', 'status']) for _ in range(3)]
+        mock_reviews = [Mock(spec=["id", "status"]) for _ in range(3)]
         mock_result = AsyncMock()
         mock_result.scalars.return_value.all.return_value = mock_reviews
         mock_db_session.execute = AsyncMock(return_value=mock_result)
@@ -302,13 +301,13 @@ class TestReviewService:
         profile_id = uuid4()
         user_id = uuid4()
 
-        with patch('core.services.review_service.Review') as MockReview:
-            MockReview.return_value = Mock()
+        with patch("core.services.review_service.Review") as mock_review_class:
+            mock_review_class.return_value = Mock()
             await create_review(mock_db_session, profile_id, user_id)
 
-            call_kwargs = MockReview.call_args[1]
-            assert call_kwargs['sections'] is None
-            assert call_kwargs['overall_score'] is None
+            call_kwargs = mock_review_class.call_args[1]
+            assert call_kwargs["sections"] is None
+            assert call_kwargs["overall_score"] is None
 
     @pytest.mark.asyncio
     async def test_get_review_with_valid_uuid(self, mock_db_session):
@@ -338,3 +337,46 @@ class TestReviewService:
 
         # Should order by created_at descending
         mock_db_session.execute.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_no_ingested_content_should_not_produce_fabricated_review(self):
+        """Reproduces issue #88.
+
+        EXPECTED: a profile with zero ingested sources (no github_username, no
+        portfolio_url, no resume_text) should not result in a "successful"
+        review with fabricated content -- there is nothing to review.
+
+        ACTUAL (today): _run_agent_orchestration and _run_rag_retrieval_generation
+        are placeholders that ignore their ingestion_results input entirely and
+        always return the same canned sections/score, and _run_safety_checks only
+        validates the *shape* of those sections, not whether they're grounded in
+        real data -- so this currently passes safety checks and would reach
+        status="complete" via process_review with fabricated content.
+
+        This test fails today; it should pass once #88 is fixed.
+        """
+        from core.services.review_service import (
+            _run_agent_orchestration,
+            _run_rag_retrieval_generation,
+            _run_safety_checks,
+        )
+
+        profile = Mock()
+        profile.github_username = None
+        profile.portfolio_url = None
+        profile.resume_text = None
+
+        # Exactly what _run_ingestion_pipeline returns for a profile with no sources
+        empty_ingestion_results: list[dict] = []
+
+        agent_output = await _run_agent_orchestration(profile, empty_ingestion_results)
+        rag_output = await _run_rag_retrieval_generation(
+            profile, empty_ingestion_results, agent_output
+        )
+        safety_passed = await _run_safety_checks(rag_output)
+
+        assert not (safety_passed and len(rag_output["sections"]) > 0), (
+            "Expected a profile with no ingested content to be rejected/flagged, "
+            "but the pipeline produced a fully 'valid', safety-check-passing "
+            "review anyway -- this is issue #88."
+        )


### PR DESCRIPTION
## Summary
`POST /reviews` never validated whether a profile had any ingested content before creating a review. Because the downstream processing pipeline is currently built from placeholder stages that ignore their input, a profile with zero content (no GitHub username, portfolio URL, or resume) would still reach `status="complete"` with fully fabricated feedback sections and a canned score — no error, no crash, anywhere. This PR adds an upfront validation check plus a defense-in-depth guard, backed by new tests, including one that reproduces the original bug and fails on pre-fix code.

## Issue
Closes #88

## Changes
- Added `profile_has_ingested_content()` to `core/services/profile_service.py` — a single shared check for whether a profile has any reviewable content (whitespace-only values don't count).
- `create_review_endpoint` (`api/routes/reviews.py`) now fetches the profile before creating a review: returns 404 if not found/not owned, 422 (`"Profile has no ingested content to review"`) if it has no content — before any `Review` row is created.
- `process_review` (`core/services/review_service.py`) gets the same check as a defense-in-depth guard: fails fast with `status="failed"` and `error_message` set (the first code path to ever populate that column) instead of running the placeholder pipeline.
- Rewrote the Week 8 reproduction test to assert the fixed behavior (verified it fails against pre-fix code via `git stash`, passes now).
- Added `tests/unit/test_review_routes.py` — the first route/HTTP-layer test file in this repo (plain `TestClient`, not the `with` form, which would trigger the app's startup event and a real DB connection attempt) — and `tests/unit/test_profile_service.py` for the new helper.

## Root cause
`create_review_endpoint` never loaded the `Profile` row at all — it only had `profile_id`. The background `process_review` task runs four placeholder pipeline functions (`_run_ingestion_pipeline`, `_run_agent_orchestration`, `_run_rag_retrieval_generation`, `_run_safety_checks`) that ignore whether any content was actually ingested and always fabricate valid-looking sections and a score; `_run_safety_checks` only validates the *shape* of the output, never whether it's grounded in real data. Nothing anywhere in the flow ever checked "does this profile have anything to review."

## How to test
1. `docker compose up -d && make run`
2. Register a user, then `POST /profiles` with no fields set (no `github_username`, `portfolio_url`, or resume file)
3. `POST /reviews` with that profile's id
   - **Before this fix:** 200, and the review eventually reaches `status: "complete"` with 3 fabricated sections and `overall_score: 0.81`
   - **After this fix:** 422 immediately — `{"detail": "Profile has no ingested content to review"}` — no Review row created
4. Create a profile with `github_username` set and repeat — still 200 → pending → complete, unchanged
5. `.venv/bin/pytest tests/unit/test_review_service.py tests/unit/test_review_routes.py tests/unit/test_profile_service.py -v` — all pass

## Testing
- [ ] Unit tests pass (`make test-unit`) — see **Pre-existing issues** below; all new/modified tests pass, 53 pre-existing unrelated failures remain (unchanged count from before this PR)
- [x] Integration tests pass (`make test-integration`) — 0 tests exist in `tests/integration/`, none run
- [ ] Linter passes (`make lint`) — 174 pre-existing errors repo-wide, unchanged by this PR; every file this PR touches is individually ruff-clean
- [ ] Type checker passes (`make typecheck`) — 103 pre-existing errors repo-wide, unchanged by this PR (confirmed identical count before/after)
- [x] New/updated tests cover the changes

## Screenshots / Demo
N/A (API-only change) — see "How to test" above for exact request/response pairs observed.

## Notes for Reviewers
`error_message` is only populated on the new failure path added here. The two pre-existing failure paths in `process_review` (safety-check failure, generic exception handler) still don't set it — left untouched to keep this PR scoped to #88 (see `PLAN.md` Risks/Status for the explicit reasoning). Happy to fix those as a follow-up if preferred.

## Pre-existing issues
Confirmed via baseline diffing (stashed my changes and re-ran each check), not just re-running once after:
- `make test-unit`: 54 failed / 375 passed → 53 failed / 388 passed. The only failure that left the list is this PR's own reproduction test (now passing); the remaining 53 failures are byte-identical to the pre-existing baseline set.
- `make typecheck`: 103 errors in 26 files, before and after — identical.
- `ruff check .`: 174 errors, before and after — identical.
- Worth flagging: 13 of the pre-existing `test_review_service.py` failures stem from a broken mocking idiom (`AsyncMock` used for a `db.execute` result, so SQLAlchemy's synchronous `.scalars()` ends up called on an unawaited coroutine). The new tests in this PR use plain `Mock` for result objects instead. Left the pre-existing broken tests untouched to keep this PR scoped to #88.