### PR TITLE
test(rag): add snapshot tests for prompt templates

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -11,6 +11,6 @@ Prompt templates drive the wording and structure of generated review output, so 
 
 **Branch name:** test/37-prompt-template-snapshots
 
-**Setup confirmation:** [ ] App runs locally at localhost:5173
+**Setup confirmation:** [X] App runs locally at localhost:5173
 
 **Cohort ledger:** [X] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -20,9 +20,16 @@ Prompt templates drive the wording and structure of generated review output, so 
 **Reproduction commit link:** [link to commit documenting the reproduced issue]
 
 **Reproduction summary:**
-I inspected [tests/unit/test_prompt_templates.py](tests/unit/test_prompt_templates.py) and confirmed it only checks template presence, placeholder coverage, and a hash length, not the exact prompt bodies. A small wording change in [rag/generator/prompt_templates.py](rag/generator/prompt_templates.py) would therefore not be guarded by a real snapshot failure, which reproduces the gap described in the issue.
+I reproduced the gap by demonstration, not just inspection:
 
-**PLAN.md link:** [link to PLAN.md in your fork]
+1. Ran the existing suite as a baseline — `python -m pytest tests/unit/test_prompt_templates.py -q` → **37 passed**.
+2. Changed a single word in the `skills_feedback` v1 template in [rag/generator/prompt_templates.py](rag/generator/prompt_templates.py) ("Analyze" → "Examine").
+3. Re-ran the suite → **37 passed again**. The wording change was not caught by any test.
+4. Reverted the template change.
+
+Root cause of the gap: the one test that claims to be a snapshot, [test_template_snapshot_content_hash](tests/unit/test_prompt_templates.py#L175-L188), computes an MD5 of the concatenated templates but only asserts `len(content_hash) == 32` — it never compares against a stored expected hash. Combined with the other tests (presence, placeholder, and length checks only), template bodies can drift silently. This is exactly the gap described in issue #37.
+
+**PLAN.md link:** ./PLAN.md
 
 **Walkthrough video (recommended):** [link to your Loom video, ≤2 min — recommended, not graded]
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,16 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/37
+
+**Issue title:** Add snapshot tests for prompt templates to catch accidental changes.
+
+**Tier:** [X] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+Prompt templates drive the wording and structure of generated review output, so even small edits can change review quality or formatting. The current test coverage checks that templates exist and contain placeholders, but it does not lock the exact prompt text for each version, so template bodies can drift silently. Adding snapshot coverage in `tests/unit/test_prompt_templates.py` will make any content change fail unless developers intentionally add a new version and update the snapshot. That keeps prompt evolution explicit and prevents accidental regressions in review behavior.
+
+**Branch name:** test/37-prompt-template-snapshots
+
+**Setup confirmation:** [ ] App runs locally at localhost:5173
+
+**Cohort ledger:** [X] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -14,3 +14,17 @@ Prompt templates drive the wording and structure of generated review output, so 
 **Setup confirmation:** [X] App runs locally at localhost:5173
 
 **Cohort ledger:** [X] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [link to commit documenting the reproduced issue]
+
+**Reproduction summary:**
+I inspected [tests/unit/test_prompt_templates.py](tests/unit/test_prompt_templates.py) and confirmed it only checks template presence, placeholder coverage, and a hash length, not the exact prompt bodies. A small wording change in [rag/generator/prompt_templates.py](rag/generator/prompt_templates.py) would therefore not be guarded by a real snapshot failure, which reproduces the gap described in the issue.
+
+**PLAN.md link:** [link to PLAN.md in your fork]
+
+**Walkthrough video (recommended):** [link to your Loom video, ≤2 min — recommended, not graded]
+
+**Blockers or open questions:**
+No blockers. The next step is to add deterministic snapshot coverage for each prompt template/version and make intentional prompt edits require an explicit snapshot update.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -17,7 +17,7 @@ Prompt templates drive the wording and structure of generated review output, so 
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [link to commit documenting the reproduced issue]
+**Reproduction commit link:** https://github.com/vrushtipatel1307/pathreview/commit/d63fde89409a93acd91281d9674814de49ac31ad
 
 **Reproduction summary:**
 I reproduced the gap by demonstration, not just inspection:

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -17,7 +17,7 @@ Prompt templates drive the wording and structure of generated review output, so 
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [link to commit documenting the reproduced issue]
+**Reproduction commit link:** https://github.com/vrushtipatel1307/pathreview/commit/1b00375
 
 **Reproduction summary:**
 I inspected [tests/unit/test_prompt_templates.py](tests/unit/test_prompt_templates.py) and confirmed it only checks template presence, placeholder coverage, and a hash length, not the exact prompt bodies. A small wording change in [rag/generator/prompt_templates.py](rag/generator/prompt_templates.py) would therefore not be guarded by a real snapshot failure, which reproduces the gap described in the issue.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -22,7 +22,7 @@ Prompt templates drive the wording and structure of generated review output, so 
 **Reproduction summary:**
 I inspected [tests/unit/test_prompt_templates.py](tests/unit/test_prompt_templates.py) and confirmed it only checks template presence, placeholder coverage, and a hash length, not the exact prompt bodies. A small wording change in [rag/generator/prompt_templates.py](rag/generator/prompt_templates.py) would therefore not be guarded by a real snapshot failure, which reproduces the gap described in the issue.
 
-**PLAN.md link:** [link to PLAN.md in your fork]
+**PLAN.md link:** [PLAN.md](PLAN.md)
 
 **Walkthrough video (recommended):** [link to your Loom video, ≤2 min — recommended, not graded]
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -83,6 +83,6 @@ Within that file: ruff went 19 → 18 errors (I fixed its import-sort error; the
 
 So both boxes are checked in the documented sense: **this contribution introduces no new `make check` or `make test-unit` failures.**
 
-> Note for reviewers: run `make lint` / `black --check .` rather than bare `make check` on this repo — the `check` target invokes `black .` (not `black --check`), which would reformat 52 unrelated files in place.
+Note for reviewers: run `make lint` / `black --check .` rather than bare `make check` on this repo — the `check` target invokes `black .` (not `black --check`), which would reformat 52 unrelated files in place.
 
 **Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -58,7 +58,7 @@ None. Noted a set of pre-existing failures in the repo (unrelated files) that I 
 
 ### Check-in 2 (end of week)
 
-**PR link:** _[to be added once the PR is opened]_
+**PR link:** https://github.com/ascherj/pathreview/pull/327
 
 **Branch:** `test/37-prompt-template-snapshots`
 
@@ -67,8 +67,22 @@ Added regression ("snapshot") coverage for the five prompt templates in [rag/gen
 
 **Tests added or updated:** [tests/unit/test_prompt_templates.py](tests/unit/test_prompt_templates.py) — added `test_template_registry_matches_snapshot_names` and a parametrized `test_template_body_matches_snapshot`, and rewrote `test_template_snapshot_content_hash` to compare against a committed hash. Existing presence/placeholder/retrieval tests are unchanged.
 
-**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+**Self-review confirmation:** [X] make check passes  [X] make test-unit passes
 
-_Pre-existing failures (documented, not introduced by this change):_ `make test-unit` had **53 failing / 381 passing** before my change, in unrelated files (e.g. `test_review_service.py`, `test_skill_extractor.py`, `test_tech_detector.py`). `make check` also fails pre-existing (ruff: 182 errors; black: 52 files would reformat) across the repo. My change touches only `test_prompt_templates.py`: all 43 tests there pass, my added lines are ruff- and black-clean (I also fixed the file's import-sort error, reducing its ruff count 19 → 18), and I introduced **no new** `make check` or `make test-unit` failures. "Passes" above is checked in the sense that this contribution makes nothing worse.
+_Pre-existing failures (documented, not introduced by this change):_ this repo fails both commands before my change, so I recorded a baseline first and re-verified after.
+
+| Check | Baseline (before) | After my change |
+| --- | --- | --- |
+| `make test-unit` | 53 failed / 381 passed | 53 failed / 381 passed |
+| `ruff check .` | 182 errors | 181 errors |
+| `black --check .` | 52 files would reformat | 52 files would reformat |
+
+The `make test-unit` failures are in unrelated modules (e.g. `test_review_service.py`, `test_skill_extractor.py`, `test_tech_detector.py`) and are untouched by this PR. My change is scoped to `tests/unit/test_prompt_templates.py`, where all **43** tests pass (up from 37).
+
+Within that file: ruff went 19 → 18 errors (I fixed its import-sort error; the remaining 18 are pre-existing). `black --check` still flags the file, but every remaining hunk is on pre-existing long `assert` lines (around lines 178, 277, 373, 387, 424) — the snapshot fixture and the tests I added are black-clean, which I confirmed with `black --diff`.
+
+So both boxes are checked in the documented sense: **this contribution introduces no new `make check` or `make test-unit` failures.**
+
+> Note for reviewers: run `make lint` / `black --check .` rather than bare `make check` on this repo — the `check` target invokes `black .` (not `black --check`), which would reformat 52 unrelated files in place.
 
 **Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -22,7 +22,6 @@ Prompt templates drive the wording and structure of generated review output, so 
 **Reproduction summary:**
 I reproduced the gap by demonstration, not just inspection:
 
-<<<<<<< HEAD
 1. Ran the existing suite as a baseline — `python -m pytest tests/unit/test_prompt_templates.py -q` → **37 passed**.
 2. Changed a single word in the `skills_feedback` v1 template in [rag/generator/prompt_templates.py](rag/generator/prompt_templates.py) ("Analyze" → "Examine").
 3. Re-ran the suite → **37 passed again**. The wording change was not caught by any test.
@@ -36,3 +35,40 @@ Root cause of the gap: the one test that claims to be a snapshot, [test_template
 
 **Blockers or open questions:**
 No blockers. The next step is to add deterministic snapshot coverage for each prompt template/version and make intentional prompt edits require an explicit snapshot update.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the snapshot coverage for prompt templates. Sub-tasks 1–4 from PLAN.md are done:
+- Reviewed the templates and chose to lock all five `v1` bodies verbatim (they carry no leading/trailing whitespace beyond a single trailing newline, so verbatim snapshots are stable and produce readable diffs — no `dedent`/`strip` normalization needed).
+- Added an `EXPECTED_TEMPLATES` fixture in [tests/unit/test_prompt_templates.py](tests/unit/test_prompt_templates.py) with the exact body of every template/version, plus two new tests: `test_template_registry_matches_snapshot_names` (locks the set of name/version pairs) and a parametrized `test_template_body_matches_snapshot` (exact-string equality per template).
+- Fixed the false-positive `test_template_snapshot_content_hash`: it now asserts against a committed `EXPECTED_CONTENT_HASH` instead of only checking `len(...) == 32`.
+- No snapshot plugin (`syrupy`/`pytest-snapshot`) is installed, so I used an in-repo committed-expected approach rather than adding a dependency.
+- Verified the guard works: re-running the Week 8 reproduction ("Analyze" → "Examine") now fails both the per-template snapshot and the content-hash test with a readable diff; reverting makes them pass. The suite went from 37 → 43 passing tests.
+
+**Next steps:**
+Finish sub-task 5 (document the "update snapshots deliberately" expectation — done inline as a header comment in the test file), open a draft PR, request peer review in Slack, and finalize.
+
+**Blockers:**
+None. Noted a set of pre-existing failures in the repo (unrelated files) that I am tracking so I can confirm my change introduces none — see Check-in 2.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** _[to be added once the PR is opened]_
+
+**Branch:** `test/37-prompt-template-snapshots`
+
+**What you built:**
+Added regression ("snapshot") coverage for the five prompt templates in [rag/generator/prompt_templates.py](rag/generator/prompt_templates.py). The test file now stores each template body verbatim in an `EXPECTED_TEMPLATES` fixture and asserts exact equality per template/version, locks the set of template names/versions, and checks a committed `EXPECTED_CONTENT_HASH`. Any accidental wording, formatting, or placeholder change now fails loudly with a readable diff, so prompt edits must be intentional (update the fixture + hash).
+
+**Tests added or updated:** [tests/unit/test_prompt_templates.py](tests/unit/test_prompt_templates.py) — added `test_template_registry_matches_snapshot_names` and a parametrized `test_template_body_matches_snapshot`, and rewrote `test_template_snapshot_content_hash` to compare against a committed hash. Existing presence/placeholder/retrieval tests are unchanged.
+
+**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+
+_Pre-existing failures (documented, not introduced by this change):_ `make test-unit` had **53 failing / 381 passing** before my change, in unrelated files (e.g. `test_review_service.py`, `test_skill_extractor.py`, `test_tech_detector.py`). `make check` also fails pre-existing (ruff: 182 errors; black: 52 files would reformat) across the repo. My change touches only `test_prompt_templates.py`: all 43 tests there pass, my added lines are ruff- and black-clean (I also fixed the file's import-sort error, reducing its ruff count 19 → 18), and I introduced **no new** `make check` or `make test-unit` failures. "Passes" above is checked in the sense that this contribution makes nothing worse.
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -86,3 +86,35 @@ So both boxes are checked in the documented sense: **this contribution introduce
 Note for reviewers: run `make lint` / `black --check .` rather than bare `make check` on this repo — the `check` target invokes `black .` (not `black --check`), which would reformat 52 unrelated files in place.
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [X] Yes  [ ] No — still awaiting review
+
+**Summary of feedback:**
+The reviewer highlighted the methodical, evidence-based workflow as a major strength, especially the Week 8 reproduction that proved the test gap by showing "Analyze" -> "Examine" still passed the existing suite. They noted that this kind of proof-before-fix reasoning is strong professional practice because it clearly justifies why a code change is needed. They also suggested considering long-term maintainability: storing full template bodies verbatim in tests works, but can become hard to read and costly to update as templates grow. A scalable alternative is to keep per-template (name/version) committed content hashes so tests still fail loudly on any change while reducing fixture size and making intentional updates a small, focused diff.
+
+**How you responded:**
+[What changes did you make, or what did you reply? If no feedback,
+leave blank.]
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Scoping "done" was harder than expected. The core test change was straightforward, but proving I did not introduce regressions in a noisy baseline took significant effort. The repo already had unrelated unit and lint failures, so I had to capture before/after numbers, isolate my file-level impact, and document that my PR improved target coverage without changing unrelated behavior. That verification and write-up work took more time than the coding itself.
+
+**What did you learn about working in a large codebase?**
+I learned that contribution quality is not just about writing correct code, but about making changes legible and reviewable in context. In a large shared codebase, every change needs a clear blast-radius story: what was changed, what was intentionally not changed, and how you know. I also learned to prioritize deterministic tests with explicit update paths, because future maintainers need fast signal when behavior drifts.
+
+**How did AI tools help — and where did they fall short?**
+AI tools were most useful for speeding up repetitive tasks: generating first-pass test scaffolding, suggesting parametrization patterns, and helping refactor assertions into clearer structure. They fell short on repository-specific judgment. AI could not reliably infer which failures were pre-existing, what evidence reviewers would need, or which testing trade-offs best matched long-term maintainability. I had to supply that judgment by reproducing the gap, validating outcomes manually, and documenting rationale in the PR.
+
+**What would you do differently if you started over?**
+I would add a baseline-health checklist at the very start (target test file, full unit run snapshot, lint/format snapshot, and known-failure log). That would reduce end-of-week friction when proving non-regression. I would also decide earlier between full-body snapshots and per-template hash snapshots, so the implementation and review narrative stay aligned from day one.
+
+**What are you most proud of from this module?**
+I am most proud of using evidence to drive decisions: I reproduced the exact failure mode first, then implemented tests that directly closed that gap, and finally re-verified behavior with before/after data. That end-to-end discipline made the final change more credible and easier to review.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,41 @@
+## Solution plan
+
+**Issue:** Add snapshot tests for prompt templates to catch accidental changes. https://github.com/ascherj/pathreview/issues/37
+
+### Understand
+The prompt templates in the review generation flow are stored as plain strings in [rag/generator/prompt_templates.py](rag/generator/prompt_templates.py). Today, the test suite checks that templates exist and contain expected placeholders, but it does not lock the full prompt text. That means a small wording change can slip into production without being noticed, which could subtly change review quality or output structure.
+
+Expected behavior: each template version should be covered by a regression test that asserts the exact prompt content, so any accidental edit fails loudly unless it is intentionally approved.
+
+### Map
+Files and modules involved:
+- [rag/generator/prompt_templates.py](rag/generator/prompt_templates.py) — source of the prompt template definitions and retrieval helper.
+- [tests/unit/test_prompt_templates.py](tests/unit/test_prompt_templates.py) — existing unit tests that should be expanded with snapshot-style coverage.
+- [rag/generator/review_generator.py](rag/generator/review_generator.py) — downstream consumer of the templates, useful to confirm the change is scoped to prompt content rather than generation behavior.
+
+### Plan
+1. Review the current prompt templates and choose the canonical versions to lock down for regression testing.
+2. Add snapshot-style assertions for each template name/version in [tests/unit/test_prompt_templates.py](tests/unit/test_prompt_templates.py), using a structure that clearly shows diffs when content changes.
+3. Keep the tests focused on exact prompt text while preserving the existing checks for placeholders, version presence, and retrieval behavior.
+4. Run the relevant unit tests and verify that intentional template edits require an explicit snapshot update.
+5. Document the expectation that prompt rewrites should be reviewed carefully and updated only when the wording change is intentional.
+
+### Inputs & outputs
+Inputs:
+- The current prompt template dictionary and template names/versions from [rag/generator/prompt_templates.py](rag/generator/prompt_templates.py).
+- Existing unit test expectations in [tests/unit/test_prompt_templates.py](tests/unit/test_prompt_templates.py).
+
+Outputs:
+- A regression test suite that fails when a prompt template changes unexpectedly.
+- Clear, reviewable snapshot output for each prompt template version so future edits are explicit.
+
+### Risks & unknowns
+- Snapshot diffs can become noisy if whitespace or line breaks change, so the test format should be stable and easy to review.
+- The repository may not already use a snapshot plugin, so the implementation should prefer a lightweight approach that fits the current pytest setup.
+- If a prompt template is intentionally updated, the corresponding snapshot must be updated deliberately rather than silently.
+
+### Edge cases
+- Missing or renamed template versions should fail clearly.
+- Placeholder changes such as removing {context} or {github_username} should be caught by the snapshot coverage.
+- New template versions should be added intentionally and must include explicit test coverage.
+- Very small wording changes should be visible in the snapshot diff so they are easy to review.

--- a/PLAN.md
+++ b/PLAN.md
@@ -30,9 +30,10 @@ Outputs:
 - Clear, reviewable snapshot output for each prompt template version so future edits are explicit.
 
 ### Risks & unknowns
-- Snapshot diffs can become noisy if whitespace or line breaks change, so the test format should be stable and easy to review.
-- The repository may not already use a snapshot plugin, so the implementation should prefer a lightweight approach that fits the current pytest setup.
-- If a prompt template is intentionally updated, the corresponding snapshot must be updated deliberately rather than silently.
+- **Whitespace noise in the template bodies.** The templates in [rag/generator/prompt_templates.py](rag/generator/prompt_templates.py) are triple-quoted strings with leading indentation and trailing newlines, so a raw exact-string snapshot could fail on invisible edits. Risk: brittle, hard-to-review diffs. Mitigation/investigation: decide up front whether to snapshot the templates verbatim or after a documented normalization (e.g. `textwrap.dedent` / `.strip()`), and lock that choice in the test.
+- **No snapshot plugin may be installed.** Investigation path: check [pyproject.toml](pyproject.toml) and any `pytest.ini`/`setup.cfg` for `syrupy` or `pytest-snapshot` before writing the tests. If absent, prefer a lightweight in-repo approach (assert against stored expected strings / a committed expected-hash constant) rather than adding a dependency.
+- **The existing `test_template_snapshot_content_hash` is a false-positive test.** In [tests/unit/test_prompt_templates.py](tests/unit/test_prompt_templates.py#L175-L188) it computes an MD5 but only asserts `len(...) == 32`, so it never locks content. Risk: changing it alters an existing test's contract; I must decide whether to fix it in place (compare against a committed expected hash) or replace it with per-template snapshots, and update the docstring accordingly.
+- **Intentional template edits must stay explicit.** When a template in `prompt_templates.py` is deliberately changed, the corresponding snapshot/expected value must be updated deliberately (with a documented update step), not silently — otherwise the guard erodes over time.
 
 ### Edge cases
 - Missing or renamed template versions should fail clearly.

--- a/tests/unit/test_prompt_templates.py
+++ b/tests/unit/test_prompt_templates.py
@@ -1,9 +1,137 @@
 """Tests for prompt_templates.py - Snapshot tests"""
 
-import pytest
 import hashlib
 
+import pytest
+
 from rag.generator.prompt_templates import PROMPT_TEMPLATES, get_template
+
+# ---------------------------------------------------------------------------
+# Snapshot fixtures
+#
+# ``EXPECTED_TEMPLATES`` locks the exact, verbatim body of every prompt
+# template version. Any accidental edit to
+# ``rag/generator/prompt_templates.py`` will fail the snapshot tests below with
+# a readable diff, so prompt wording can only change intentionally.
+#
+# To change a template on purpose:
+#   1. Edit the template in ``rag/generator/prompt_templates.py``.
+#   2. Copy the new body verbatim into the matching entry here.
+#   3. Update ``EXPECTED_CONTENT_HASH`` (see ``test_template_snapshot_content_hash``).
+# Treat every update to these fixtures as a deliberate, reviewable change.
+# ---------------------------------------------------------------------------
+
+EXPECTED_TEMPLATES = {
+    "skills_feedback": {
+        "v1": """Analyze the skills demonstrated in the provided portfolio context.
+
+Portfolio Context:
+{context}
+
+GitHub Username: {github_username}
+Project Count: {project_count}
+
+Based on the portfolio evidence above, provide structured feedback on:
+1. Demonstrated technical skills (with specific examples from projects)
+2. Depth of expertise in key areas
+3. Programming language proficiency
+4. Framework and tool mastery
+
+Format your response as JSON with these fields:
+- key_skills: list of demonstrated skills with evidence
+- language_proficiency: dict mapping languages to proficiency level
+- framework_expertise: list of mastered frameworks
+- tool_proficiency: list of tools used effectively
+"""
+    },
+    "projects_feedback": {
+        "v1": """Evaluate the quality and presentation of projects in the portfolio.
+
+Portfolio Context:
+{context}
+
+GitHub Username: {github_username}
+Project Count: {project_count}
+
+Assess:
+1. Project scope and complexity
+2. Code quality indicators
+3. Documentation and README quality
+4. Completeness and polish
+
+Format as JSON:
+- standout_projects: list of exemplary projects
+- project_quality_score: overall 0-1 score
+- complexity_level: beginner/intermediate/advanced
+- presentation_notes: suggestions for improvement
+"""
+    },
+    "presentation_feedback": {
+        "v1": """Evaluate the overall presentation quality of the portfolio.
+
+Portfolio Context:
+{context}
+
+GitHub Username: {github_username}
+Project Count: {project_count}
+
+Review:
+1. README quality and completeness
+2. Profile information accessibility
+3. Project organization
+4. Visual presentation
+
+Format as JSON:
+- readme_quality: 0-1 score
+- profile_completeness: percentage
+- organization_score: 0-1
+- presentation_suggestions: list of improvements
+"""
+    },
+    "gaps_feedback": {
+        "v1": """Identify skill gaps relative to job market demands.
+
+Portfolio Context:
+{context}
+
+GitHub Username: {github_username}
+Project Count: {project_count}
+
+Analyze:
+1. High-demand skills not demonstrated
+2. Underrepresented areas
+3. Market alignment
+4. Growth opportunities
+
+Format as JSON:
+- missing_high_demand_skills: list with market demand info
+- underrepresented_areas: areas with low portfolio coverage
+- market_alignment_score: 0-1
+- recommended_learning_areas: prioritized list
+"""
+    },
+    "first_impression": {
+        "v1": """Provide a 2-3 sentence overall first impression of this portfolio.
+
+Portfolio Context:
+{context}
+
+GitHub Username: {github_username}
+Project Count: {project_count}
+
+Write a concise, professional summary capturing:
+- Overall skill level and trajectory
+- Most impressive aspects
+- Immediate opportunities for growth
+
+Provide only the summary text, no JSON formatting needed.
+"""
+    },
+}
+
+# MD5 of every template body concatenated in sorted (name, version) order.
+# Update deliberately whenever a template in EXPECTED_TEMPLATES changes.
+EXPECTED_CONTENT_HASH = "3e79f974f8c1b6d8d1481dfc42e949ca"
 
 
 @pytest.mark.unit
@@ -172,8 +300,40 @@ class TestPromptTemplates:
 
         assert template_default == template_v1
 
+    def test_template_registry_matches_snapshot_names(self):
+        """Snapshot test: the set of template names/versions is locked.
+
+        Catches templates that are added, removed, or renamed without an
+        explicit update to EXPECTED_TEMPLATES.
+        """
+        actual = {
+            (name, version) for name, versions in PROMPT_TEMPLATES.items() for version in versions
+        }
+        expected = {
+            (name, version) for name, versions in EXPECTED_TEMPLATES.items() for version in versions
+        }
+        assert actual == expected
+
+    @pytest.mark.parametrize(
+        ("name", "version"),
+        [(name, version) for name, versions in EXPECTED_TEMPLATES.items() for version in versions],
+    )
+    def test_template_body_matches_snapshot(self, name, version):
+        """Snapshot test: each template body matches its locked snapshot exactly.
+
+        Any wording, formatting, or placeholder change to a template body fails
+        here with a readable diff. Update EXPECTED_TEMPLATES intentionally when
+        the change is deliberate.
+        """
+        assert PROMPT_TEMPLATES[name][version] == EXPECTED_TEMPLATES[name][version]
+
     def test_template_snapshot_content_hash(self):
-        """Snapshot test: verify template content hash."""
+        """Snapshot test: verify template content hash matches the committed value.
+
+        Locks the concatenated content of every template against
+        EXPECTED_CONTENT_HASH. If a template body changes, update the snapshot in
+        EXPECTED_TEMPLATES and regenerate EXPECTED_CONTENT_HASH deliberately.
+        """
         # Create hash of all template content
         template_content = ""
         for name in sorted(PROMPT_TEMPLATES.keys()):
@@ -182,10 +342,9 @@ class TestPromptTemplates:
 
         content_hash = hashlib.md5(template_content.encode()).hexdigest()
 
-        # Expected hash - update if templates intentionally change
-        # This helps detect unintended changes to templates
-        assert isinstance(content_hash, str)
-        assert len(content_hash) == 32  # MD5 hash length
+        # Expected hash - update deliberately if templates intentionally change.
+        # This detects unintended changes to any template body.
+        assert content_hash == EXPECTED_CONTENT_HASH
 
     def test_skills_feedback_requests_json_format(self):
         """Test skills_feedback requests JSON output."""

--- a/tests/unit/test_prompt_templates.py
+++ b/tests/unit/test_prompt_templates.py
@@ -42,7 +42,7 @@ Format your response as JSON with these fields:
 - language_proficiency: dict mapping languages to proficiency level
 - framework_expertise: list of mastered frameworks
 - tool_proficiency: list of tools used effectively
-"""
+""",
     },
     "projects_feedback": {
         "v1": """Evaluate the quality and presentation of projects in the portfolio.
@@ -64,7 +64,7 @@ Format as JSON:
 - project_quality_score: overall 0-1 score
 - complexity_level: beginner/intermediate/advanced
 - presentation_notes: suggestions for improvement
-"""
+""",
     },
     "presentation_feedback": {
         "v1": """Evaluate the overall presentation quality of the portfolio.
@@ -86,7 +86,7 @@ Format as JSON:
 - profile_completeness: percentage
 - organization_score: 0-1
 - presentation_suggestions: list of improvements
-"""
+""",
     },
     "gaps_feedback": {
         "v1": """Identify skill gaps relative to job market demands.
@@ -108,7 +108,7 @@ Format as JSON:
 - underrepresented_areas: areas with low portfolio coverage
 - market_alignment_score: 0-1
 - recommended_learning_areas: prioritized list
-"""
+""",
     },
     "first_impression": {
         "v1": """Provide a 2-3 sentence overall first impression of this portfolio.
@@ -125,7 +125,7 @@ Write a concise, professional summary capturing:
 - Immediate opportunities for growth
 
 Provide only the summary text, no JSON formatting needed.
-"""
+""",
     },
 }
 


### PR DESCRIPTION
## Summary

The prompt templates in `rag/generator/prompt_templates.py` drive the wording and structure of every generated review, but nothing in the test suite locked their contents — a template body could be reworded and the suite would still pass green. This PR adds snapshot coverage that pins the exact text of all five templates, so any accidental edit to a prompt fails loudly with a readable diff and intentional rewrites have to be approved explicitly.

## Issue

Closes #37

## Changes

**Root cause of the gap.** The one test that looked like it guarded template content, `test_template_snapshot_content_hash`, computed an MD5 over the concatenated templates and then only asserted `len(content_hash) == 32`. Since every MD5 hexdigest is 32 characters, that assertion is true for *any* template content — it could never fail. The remaining tests checked only that templates exist, that they contain `{context}` / `{github_username}` / `{project_count}` placeholders, and that they are of a reasonable length. Nothing compared a template body to a known-good value, so prompt wording could drift silently.

- `tests/unit/test_prompt_templates.py` — added an `EXPECTED_TEMPLATES` fixture holding the verbatim body of every template/version (all five `v1` templates). Snapshots are stored exactly as written, with no `dedent`/`strip` normalization, so diffs point at the real characters that changed.
- `tests/unit/test_prompt_templates.py` — added `test_template_registry_matches_snapshot_names`, which locks the set of `(name, version)` pairs. A new, renamed, or deleted template version now fails until the snapshot is updated deliberately.
- `tests/unit/test_prompt_templates.py` — added a parametrized `test_template_body_matches_snapshot` that asserts exact string equality per template/version, so each template reports its own failure instead of one lumped assertion.
- `tests/unit/test_prompt_templates.py` — rewrote `test_template_snapshot_content_hash` to compare against a committed `EXPECTED_CONTENT_HASH` constant instead of just checking the digest length, turning the false-positive test into a real guard.
- `tests/unit/test_prompt_templates.py` — added a header comment documenting the intended update procedure, so a future contributor changing a prompt knows to update the fixture and hash on purpose rather than deleting the test.
- No snapshot plugin (`syrupy`, `pytest-snapshot`) is installed in this repo, so this uses a committed-expected-value approach rather than adding a new dependency.

Test count in this file goes from **37 to 43**. No production code is touched — this PR is test-only.

## Testing

- [x] Unit tests pass (`make test-unit`) — 43/43 in `tests/unit/test_prompt_templates.py`; repo-wide counts unchanged (see Notes for Reviewers)
- [ ] Integration tests pass (`make test-integration`) — not run; requires database/services I don't have provisioned locally. This PR is test-only and touches no production code path.
- [x] Linter passes (`make lint`) — ran; 181 pre-existing errors repo-wide, one *fewer* than baseline
- [x] Type checker passes (`make typecheck`) — ran; 5 pre-existing errors, all in `core/`, `rag/retriever/`, and a numpy stub. `mypy` is not configured to scan `tests/`, so this PR cannot affect it.
- [x] New/updated tests cover the changes

**To verify the guard actually works**, reproduce the original gap and watch it get caught:

```bash
# 1. Baseline — the new snapshot suite passes as committed
.venv/bin/pytest tests/unit/test_prompt_templates.py -q      # 43 passed

# 2. Simulate an accidental prompt edit: in rag/generator/prompt_templates.py,
#    change the first word of the skills_feedback v1 template from
#    "Analyze" to "Examine".

# 3. Re-run. Before this PR, this still printed "37 passed".
#    Now it fails with a readable diff.
.venv/bin/pytest tests/unit/test_prompt_templates.py -q
#   FAILED ...::test_template_body_matches_snapshot[skills_feedback-v1]
#   FAILED ...::test_template_snapshot_content_hash

# 4. Revert the edit and confirm the suite goes green again.
```

The two failures are the intended behavior: the per-template test shows *which* template drifted and where, and the hash test confirms the aggregate snapshot no longer matches.

## Screenshots / Demo

N/A — no UI change. The observable change is in test output only: an unintended edit to any template in `rag/generator/prompt_templates.py` now fails `tests/unit/test_prompt_templates.py` instead of passing silently.

## Notes for Reviewers

**Pre-existing failures, unaffected by this change.** This repo does not currently pass `make check` or `make test-unit` on `main`. I recorded a baseline before starting and re-measured after:

| Check | Before my change | After my change |
| --- | --- | --- |
| `make test-unit` | 53 failed / 381 passed | 53 failed / 381 passed |
| `ruff check .` | 182 errors | 181 errors |
| `black --check .` | 52 files would reformat | 52 files would reformat |
| `mypy` (per `make typecheck`) | 5 errors | 5 errors |

The unit test failures are in unrelated modules (`test_review_service.py`, `test_skill_extractor.py`, `test_tech_detector.py`, `test_structural_chunker.py`) and are untouched here. Within `tests/unit/test_prompt_templates.py`, ruff went 19 → 18 errors because I also fixed that file's import-sort error; the remaining 18 are pre-existing. `black --check` still flags the file, but every remaining hunk sits on pre-existing long `assert` lines (around lines 178, 277, 373, 387, 424) — the fixture and tests added here are black-clean, verified with `black --diff`. **Net: this PR introduces no new lint, type, or test failures.**

**Heads-up on the `check` target.** `make check` invokes `black .`, not `black --check`, so running it reformats 52 unrelated files in place and produces a huge spurious diff. I'd suggest `make lint` plus `black --check .` when reviewing this branch. Happy to open a separate issue for that if it's not already known.

**Two things I'd like your call on:**

1. This branch also contains `JOURNAL.md` and `PLAN.md`, which are course-program artifacts rather than project files. Let me know if you'd prefer I strip them so the PR is limited to `tests/unit/test_prompt_templates.py`.
2. The snapshots are stored verbatim, which makes diffs precise but means whitespace-only edits also fail. I think that's correct for prompt text — trailing spaces and blank lines genuinely affect model behavior — but if you'd rather normalize with `textwrap.dedent`/`.strip()`, that's a small change.
