### PR TITLE
fix(ingestion): detect JavaScript, TypeScript, and Docker in skill extractor

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,7 @@ repos:
       - id: mypy
         additional_dependencies: [types-redis]
         args: [--ignore-missing-imports]
+        # Match the scope of `make typecheck`, which checks application packages
+        # only. Test modules are not annotated, so checking them here blocked
+        # every commit that touched a file under tests/.
+        exclude: ^tests/

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -170,7 +170,8 @@ JavaScript, and adds a word boundary to the Python type-annotation pattern so Ty
 `: string` is no longer counted as Python's `: str`.
 
 **Tests added or updated:**
-`tests/unit/test_skill_extractor.py` — six new tests. Three cover the new detection paths:
+`tests/unit/test_skill_extractor.py` — seven new tests, taking the file from 18 tests to 25. Three
+cover the new detection paths:
 TypeScript detected from prose with no filename argument, JavaScript detected from ES6
 `import ... from` / `export default` syntax, and Docker detected from a Dockerfile whose text never
 contains the word "docker". Three are regression guards against false positives: `import psycopg2`
@@ -297,7 +298,7 @@ extractor on plain Python code and saw `import psycopg2` come back as
 `['Python', 'JavaScript']` — a false positive that no test covered and the issue never mentioned,
 caused by the same regex the issue was complaining about. Fixing it changed my whole approach: it
 is why I used `JS_TS_KEYWORDS` as supporting evidence instead of as the primary signal, and why
-three of my six new tests are regression guards for inputs that must *not* be detected rather than
+three of my seven new tests are regression guards for inputs that must *not* be detected rather than
 inputs that must be. I am more proud of that than of the four tests I was asked to fix, because it
 came from actually understanding the code instead of satisfying the test names in the issue.
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -53,7 +53,8 @@ matching the reported behavior exactly.
 
 **PLAN.md link:** https://github.com/AdithNG/pathreview/blob/fix/148-skill-extractor-js-ts-detection/PLAN.md
 
-**Walkthrough video (recommended):** _(not recorded yet — optional and not graded)_
+**Walkthrough video (recommended):** None — this deliverable is recommended but not graded, so I
+put the time into the written reproduction and plan instead.
 
 **Blockers or open questions:**
 - `test_database_technology_detection` also fails, but it is **not** one of the four tests
@@ -193,5 +194,7 @@ named in issue #148. Both files I changed pass ruff, black, and mypy individuall
 49 failures and 177 ruff errors are pre-existing in other modules, and I documented them in the PR
 description.
 
-**Draft PR feedback received from:** _(pending — to be requested in Slack)_
+**Draft PR feedback received from:** None. I opened the PR ready for review rather than as a draft,
+and have asked for a peer look in Slack. Any feedback that arrives will be recorded with my
+response in the Week 10 section.
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -41,7 +41,7 @@ Verified working: frontend at localhost:5173 (HTTP 200), API docs at localhost:8
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** _(this commit — link added below once pushed)_
+**Reproduction commit link:** https://github.com/AdithNG/pathreview/commit/c050e23727f4ac8d3a56fc1e6919d08758048e40
 
 **Reproduction summary:**
 I reproduced the issue two ways in my local environment: by running
@@ -51,9 +51,9 @@ on the samples from the issue body. JavaScript text returns an empty list, TypeS
 returns only `['React']`, and Dockerfile/compose text returns no Docker detection at all —
 matching the reported behavior exactly.
 
-**PLAN.md link:** _(added below once pushed)_
+**PLAN.md link:** https://github.com/AdithNG/pathreview/blob/fix/148-skill-extractor-js-ts-detection/PLAN.md
 
-**Walkthrough video (recommended):** _(not yet recorded)_
+**Walkthrough video (recommended):** _(not recorded yet — optional and not graded)_
 
 **Blockers or open questions:**
 - `test_database_technology_detection` also fails, but it is **not** one of the four tests

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -15,7 +15,7 @@ The ingestion pipeline's skill extractor (`ingestion/parsers/skill_extractor.py`
 
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
-**Cohort ledger:** [ ] Issue added to cohort ledger
+**Cohort ledger:** [x] Issue added to cohort ledger
 
 ### Issue-fit checklist notes (scope reasoning)
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -154,7 +154,7 @@ commit so it can be split out if the maintainer prefers.
 
 ### Check-in 2 (end of week)
 
-**PR link:** _(added when the PR is opened — see below)_
+**PR link:** https://github.com/ascherj/pathreview/pull/330
 
 **Branch:** `fix/148-skill-extractor-js-ts-detection`
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -36,3 +36,80 @@ Setup on Windows hit four stacked issues before `make setup` succeeded, all wort
 4. `scripts/seed_db.py` prints ✓/✗ characters that crash on the default Windows cp1252 console, masking real errors — running with `PYTHONUTF8=1 make setup` fixes it.
 
 Verified working: frontend at localhost:5173 (HTTP 200), API docs at localhost:8000/docs, and a successful login with a seeded test account returning a JWT.
+
+---
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** _(this commit — link added below once pushed)_
+
+**Reproduction summary:**
+I reproduced the issue two ways in my local environment: by running
+`pytest tests/unit/test_skill_extractor.py`, which fails 5 of 18 tests (the 4 named in the
+issue plus one unrelated pre-existing test bug), and by calling `extract_skills()` directly
+on the samples from the issue body. JavaScript text returns an empty list, TypeScript text
+returns only `['React']`, and Dockerfile/compose text returns no Docker detection at all —
+matching the reported behavior exactly.
+
+**PLAN.md link:** _(added below once pushed)_
+
+**Walkthrough video (recommended):** _(not yet recorded)_
+
+**Blockers or open questions:**
+- `test_database_technology_detection` also fails, but it is **not** one of the four tests
+  named in issue #148. It fails first on its own bug (`skill_names = [s.name for s in skill_names]`
+  at line 138 — a `NameError`), and I confirmed that even after fixing that line the assertion
+  still fails, because `psycopg2` is not in the `DATABASES` map (only `postgresql` is). That
+  means it needs an implementation change of its own. I plan to leave it out of my PR and
+  mention it in the PR description rather than expand scope, but I may ask the maintainer
+  whether they'd prefer it included.
+- I need to decide how strict the new JavaScript keyword matching should be. Detection that is
+  too loose creates false positives (see the `import psycopg2` finding below); too strict and
+  the issue's own sample text won't be detected.
+
+### Reproduction steps and observed output
+
+```
+$ PYTHONUTF8=1 .venv/Scripts/python -m pytest tests/unit/test_skill_extractor.py -v
+FAILED tests/unit/test_skill_extractor.py::TestSkillExtractor::test_text_with_typescript_files
+FAILED tests/unit/test_skill_extractor.py::TestSkillExtractor::test_database_technology_detection
+FAILED tests/unit/test_skill_extractor.py::TestSkillExtractor::test_devops_tool_detection
+FAILED tests/unit/test_skill_extractor.py::TestSkillExtractor::test_javascript_detection
+FAILED tests/unit/test_skill_extractor.py::TestSkillExtractor::test_docker_compose_detection
+5 failed, 13 passed in 1.30s
+```
+
+Calling the extractor directly (`SkillExtractor().extract_skills(text)`):
+
+| Input | Expected | Observed |
+|---|---|---|
+| `Wrote index.js using const arrow functions and async/await callbacks` | JavaScript | `[]` |
+| `Built app.tsx and types.ts with strict TypeScript interfaces` | TypeScript | `['React']` |
+| `const fs = require('fs'); ... console.log(data)` | JavaScript | `[]` |
+| `export interface User { id: string; }` (TS) | TypeScript | `['Python']` |
+| `FROM python:3.9 / RUN pip install / EXPOSE 8000` (Dockerfile) | Docker | `['Python']` |
+| `version: '3.8' / services: / build: .` (compose) | Docker | `[]` |
+
+### Root causes confirmed during reproduction
+
+All five located in `ingestion/parsers/skill_extractor.py`:
+
+1. **`JS_TS_KEYWORDS` is dead code** (lines 30–41). I grepped the whole repo: the set is
+   defined and never referenced. `PYTHON_KEYWORDS` is unused in the same way, but Python
+   still gets detected through other signals, which is why only JS/TS visibly breaks.
+2. **`require(` never matches.** `_detect_languages` uses `re.search(r"\b(import|require)\s+", text)`,
+   which demands whitespace after the keyword, so `require('fs')` fails to match.
+3. **TypeScript vs JavaScript is decided only by filename** (line 186:
+   `lang = "TypeScript" if ".ts" in str(filename or "").lower() else "JavaScript"`). For free
+   text with no filename — the normal case for resume/portfolio content — TypeScript can never
+   be detected, even when the text says "TypeScript" and names `.ts` files.
+4. **Docker is matched as a literal word only.** `_detect_tools` does `if tool in text_lower`,
+   so a real Dockerfile (`FROM`/`RUN`/`EXPOSE`) or a compose file (`services:`/`build:`) is
+   never recognized as Docker.
+5. **False positive found while reproducing:** plain Python `import psycopg2` is currently
+   reported as **JavaScript**, because the shared `\b(import|require)\s+` regex matches Python
+   import statements too. So the current behavior is both missing real JS and inventing fake JS.
+
+A sixth, related quirk: the Python type-annotation regex `:\s*(int|str|float|bool|list|dict)`
+matches TypeScript's `: string` (because `str` is a prefix of `string`), which is why the
+TypeScript sample above is misreported as Python.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -198,3 +198,107 @@ description.
 and have asked for a peer look in Slack. Any feedback that arrives will be recorded with my
 response in the Week 10 section.
 
+---
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No review has arrived. As of the end of Week 10, PR #330 has zero reviews, zero inline comments,
+and zero conversation comments. I checked the PR's review and comment endpoints directly rather
+than relying on GitHub notifications, so I am confident nothing was missed. This matches the
+course note that reviewer feedback is not part of the Summer 2026 term, and it is also normal for
+open source generally — the repository has over 150 open PRs against a single maintainer.
+
+**How you responded:**
+No response was required, but I did not treat the absence of review as the end of the work. In the
+PR description I left two open questions under "Notes for Reviewers" that I would want a maintainer
+to weigh in on: whether `JS_TS_KEYWORDS` was intended as the primary detection signal (I
+deliberately demoted it to supporting evidence, which is a visible departure from how the issue
+describes the root cause), and whether reporting both JavaScript and TypeScript for the same text
+is desirable or whether TypeScript should suppress JavaScript the way the original code did. I also
+flagged two things that belong in separate issues rather than in my PR: the `psycopg2` driver is not
+mapped to PostgreSQL in the `DATABASES` dict, which is why
+`test_database_technology_detection` still fails, and the pre-commit `mypy` hook blocks every
+commit that touches a test file. If a reviewer disagrees with any of my judgement calls, the
+implementation is isolated in `_detect_js_ts()` and `_detect_docker()` and would be
+straightforward to change.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Getting the environment running was by far the hardest part, and none of the difficulty was in the
+project's own code. My `make setup` failed with
+`asyncpg.exceptions.InvalidPasswordError: password authentication failed for user "pathreview"`,
+and I hit that same error message twice for two completely different reasons: first because I had
+never copied `.env.example` to `.env`, so the app used its built-in default of port 5432 where a
+native Windows `postgres.exe` service was listening, and then again because a leftover container
+from an unrelated project of mine was already bound to port 5433 — the exact port PathReview remaps
+to in order to avoid conflicts. On top of that, `scripts/seed_db.py` prints ✓ and ✗ characters that
+crash on the default Windows cp1252 console, so a `UnicodeEncodeError` was burying the real error
+and making even successful runs exit non-zero until I ran everything with `PYTHONUTF8=1`. I had
+budgeted my time for the fix and almost none for setup, and the ratio ended up being closer to the
+reverse.
+
+**What did you learn about working in a large codebase?**
+The most useful thing I did all module was record a baseline before touching anything. The repo had
+53 failing unit tests and 182 ruff errors before my first edit, so "does the suite pass" was
+a meaningless question — I had to save the sorted failure list and diff against it afterwards to
+prove I had fixed exactly four tests and broken nothing. Without that, my final run showing 49
+failures would have looked like I had broken things. I also learned to check who calls the code
+before changing it: grep showed the parser `SkillExtractor` is imported only by its own test file,
+which told me the change was isolated and that its tests were the real contract. Relatedly, there
+are two different classes named `SkillExtractor` in this repo — one in `ingestion/parsers/` and one
+in `agent/tools/` — and reading the issue's file list carefully was the only thing that kept me in
+the right one. Finally, matching local convention beat applying general best practice: when the
+pre-commit `mypy` hook demanded type annotations on my new tests, I checked and found that 0 of 21
+test files in the repo annotate anything, so annotating mine would have made my file the odd one
+out.
+
+**How did AI tools help — and where did they fall short?**
+AI was most useful for orientation and for the mechanical parts of verification. It let me map six
+subsystems in one session instead of a week, and it caught things I would not have thought to look
+for — that the entire review pipeline in `core/services/review_service.py` is hardcoded
+placeholders, that the safety layer is never actually wired into the request flow, and that
+`GET /health` returns 503 unconditionally because it passes a raw SQL string to `db.execute()`.
+Knowing all of that up front kept me away from issues that looked small but depended on a pipeline
+that does not run end to end. Where it fell short was judgement about intent. The issue frames the
+root cause as "`JS_TS_KEYWORDS` is defined but never used," and the obvious move — and the one an
+AI will happily implement, because it explains what code *does* rather than what it *should* do —
+is to wire that constant up as the primary detection signal. Doing that literally reintroduces a
+bug, because four of its ten entries (`import`, `async`, `await`, `class`) are Python keywords, so
+`import psycopg2` gets reported as JavaScript. I only found that by actually running the extractor
+on Python input and reading the output, not by reasoning about the code. The other thing AI could
+not tell me was the repo's social reality: that a neighbouring test in the file I had to edit was
+broken in a way that made ruff reject every commit, and that the fix for it was out of my issue's
+scope.
+
+**What would you do differently if you started over?**
+Three things. First, I would set up and verify the environment before selecting an issue instead of
+after — I chose #148 while my `make setup` was still failing, and if setup had turned out to be
+genuinely broken I would have burned selection time twice. Second, I would check for port conflicts
+from my own other Docker projects at the very start, since that one habit would have saved most of
+a night. Third, and most importantly for the process, I would open the draft PR early in the week
+instead of opening a finished PR at the deadline. I got no peer feedback at all, which is entirely
+my own sequencing, and I had two genuine design questions that a second pair of eyes would have
+settled faster than my own reasoning did. I would also probably pick a less crowded issue: five
+other students had claimed #148 by the time I finished, and a less contested one would likely have
+meant more useful discussion.
+
+**What are you most proud of from this module?**
+The bug nobody asked me to find. The issue listed four failing tests, and the fastest path to a
+green suite was to make those four pass and stop. But while reproducing the problem I ran the
+extractor on plain Python code and saw `import psycopg2` come back as
+`['Python', 'JavaScript']` — a false positive that no test covered and the issue never mentioned,
+caused by the same regex the issue was complaining about. Fixing it changed my whole approach: it
+is why I used `JS_TS_KEYWORDS` as supporting evidence instead of as the primary signal, and why
+three of my six new tests are regression guards for inputs that must *not* be detected rather than
+inputs that must be. I am more proud of that than of the four tests I was asked to fix, because it
+came from actually understanding the code instead of satisfying the test names in the issue.
+
+

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -113,3 +113,85 @@ All five located in `ingestion/parsers/skill_extractor.py`:
 A sixth, related quirk: the Python type-annotation regex `:\s*(int|str|float|bool|list|dict)`
 matches TypeScript's `: string` (because `str` is a prefix of `string`), which is why the
 TypeScript sample above is misreported as Python.
+
+---
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Sub-tasks 1–5 of the seven in PLAN.md are done. I recorded the baseline first (step 1) and found
+the repo has substantial pre-existing breakage — 53 failing unit tests and 182 ruff errors before I
+touched anything — so I saved the sorted failure list to diff against later. For step 2 I added a
+`JS_SYNTAX_PATTERNS` constant holding syntax Python does not share (`require(`, arrow functions,
+`console.log(`, `import ... from '...'`, `export default`, and `const`/`let`/`var` declarations
+with an assignment), and wired up `JS_TS_KEYWORDS` as supporting evidence rather than as the
+primary signal. That decision came out of step 3: four of its ten entries (`import`, `async`,
+`await`, `class`) are also Python keywords, so using it as the primary signal is exactly what makes
+`import psycopg2` report JavaScript. Step 4 added text-based TypeScript detection in a new
+`_detect_js_ts()` helper plus the missing `\b` on the Python annotation regex, and step 5 added
+`_detect_docker()` for Dockerfile instructions and Compose service definitions.
+
+All four tests named in the issue now pass, and I verified the fix against the exact reproduction
+cases from the issue body plus three false-positive cases of my own.
+
+**Next steps:**
+Steps 6 and 7 — write the regression tests I specified in PLAN.md (especially the
+`import psycopg2` guard, since that false positive is the main risk in my approach), then run the
+full verification and diff the failure list against my baseline before opening the PR.
+
+**Blockers:**
+One, now resolved. The pre-commit `mypy` hook has no file filter, so it type-checks staged files
+under `tests/`. No test module in this repo is annotated and `make typecheck` only covers
+`api/ core/ ingestion/ rag/ agent/ safety/`, so the hook rejected *any* commit touching *any* test
+file — 27 errors, 21 of them in test methods I did not write. Rather than annotate 24 methods
+against the project's own convention (0 of 21 test files use annotations), I added
+`exclude: ^tests/` to the hook so it matches the Makefile's documented scope. It is in its own
+commit so it can be split out if the maintainer prefers.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** _(added when the PR is opened — see below)_
+
+**Branch:** `fix/148-skill-extractor-js-ts-detection`
+
+**What you built:**
+The skill extractor now detects JavaScript and TypeScript from the text itself instead of relying
+on a `filename` argument that is absent for free-form resume content: JavaScript is established
+from syntax Python does not share, and TypeScript from type-level syntax, `.ts`/`.tsx` references,
+or the language name. Docker is detected from Dockerfile instructions and Compose service
+definitions rather than only from the literal word "docker". The fix also removes a false positive
+I found while reproducing the issue, where plain Python `import` statements were reported as
+JavaScript, and adds a word boundary to the Python type-annotation pattern so TypeScript's
+`: string` is no longer counted as Python's `: str`.
+
+**Tests added or updated:**
+`tests/unit/test_skill_extractor.py` — six new tests. Three cover the new detection paths:
+TypeScript detected from prose with no filename argument, JavaScript detected from ES6
+`import ... from` / `export default` syntax, and Docker detected from a Dockerfile whose text never
+contains the word "docker". Three are regression guards against false positives: `import psycopg2`
+must not yield JavaScript, English prose using "let"/"run"/"function"/"class" must not yield
+JavaScript, and a single capitalised word in prose must not be read as a Dockerfile. A seventh test
+asserts that TypeScript's `: string` is no longer reported as Python.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+Both are true in the sense the contribution guidance defines for a repo with documented
+pre-existing failures — my changes introduce no new failures:
+
+| Check | Before | After |
+|---|---|---|
+| `pytest tests/unit -m unit` | 53 failed, 375 passed | 49 failed, 386 passed |
+| `ruff check .` | 182 errors | 177 errors |
+| `mypy` on the `make typecheck` paths | 5 errors in 4 files | 5 errors in 4 files (identical) |
+
+Diffing the sorted failure lists shows zero new failures and exactly four tests fixed — the four
+named in issue #148. Both files I changed pass ruff, black, and mypy individually. The remaining
+49 failures and 177 ruff errors are pre-existing in other modules, and I documented them in the PR
+description.
+
+**Draft PR feedback received from:** _(pending — to be requested in Slack)_
+

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,38 @@
+# Contribution Journal — Module 3
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/148
+
+**Issue title:** Skill extractor fails to detect JavaScript and TypeScript
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The ingestion pipeline's skill extractor (`ingestion/parsers/skill_extractor.py`) is supposed to detect technologies from resume and portfolio text, but the JavaScript/TypeScript family is essentially invisible to it. The class defines a `JS_TS_KEYWORDS` constant that is never actually used — JS/TS detection relies only on the optional `filename` argument (which is `None` for free text) and an import regex that requires whitespace after the keyword, so real-world code like `require('fs')` never matches. The same class of bug affects Docker detection: `_detect_tools` only looks for the literal word "docker", so a Dockerfile (`FROM`/`RUN`/`EXPOSE`) or a docker-compose YAML is never recognized. A successful fix makes the four failing tests in `tests/unit/test_skill_extractor.py` pass by detecting JS/TS from language keywords and syntax in the text itself, and Docker from Dockerfile/compose structure — without changing the Python, database, or framework detection that already works. This matters because skill detection feeds the RAG feedback pipeline, so a portfolio full of JavaScript work currently gets reviewed as if those skills don't exist.
+
+**Branch name:** `fix/148-skill-extractor-js-ts-detection`
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger
+
+### Issue-fit checklist notes (scope reasoning)
+
+- **Understanding:** I can reproduce the bug directly — `SkillExtractor().extract_skills('Wrote index.js using const arrow functions')` returns `[]`. I traced each of the four failing tests to a specific root cause (unused `JS_TS_KEYWORDS` set, filename-only detection, `\b(import|require)\s+` regex missing `require(`, and literal-word-only Docker matching).
+- **Tier fit:** Tier 1 and my first contribution to a large codebase — the change lives in one implementation file plus its test file.
+- **Codebase readiness:** I read the full implementation and test file. The parser `SkillExtractor` is imported only by its own tests (verified by grep), so the change is isolated and the tests define the acceptance contract. Note: there is a separate `SkillExtractor` agent tool in `agent/tools/` that this issue does *not* touch.
+- **Scope and time:** Estimated 3–6 hours (keyword/regex logic plus tests) — realistic for the Week 8–9 window. Three other students have claimed the issue, which is on the low end for tier-1 issues in this cohort; claims are non-exclusive.
+- **Blockers:** None. I verified that no open PR modifies `ingestion/parsers/skill_extractor.py` (PR #162 touches the tech detector, chunker, faithfulness checker, and PII scrubber — different files).
+- **Extra finding while reading:** `tests/unit/test_skill_extractor.py:138` has a pre-existing bug of its own (`skill_names = [s.name for s in skill_names]` — a `NameError` from referencing the variable being defined). It's out of scope for #148 but worth flagging.
+
+### Environment setup notes
+
+Setup on Windows hit four stacked issues before `make setup` succeeded, all worth documenting:
+
+1. Missing `.env` — the app's built-in default `DATABASE_URL` points at port 5432; copying `.env.example` to `.env` (which uses 5433) is required.
+2. Port conflicts from other projects: a native Windows PostgreSQL service on 5432, plus leftover Docker containers from another project squatting 5433 and 6379 (they auto-start with Docker Desktop and had to be stopped).
+3. The pathreview db container was first created while its port was taken, so it needed `docker compose up -d --force-recreate db` to bind correctly.
+4. `scripts/seed_db.py` prints ✓/✗ characters that crash on the default Windows cp1252 console, masking real errors — running with `PYTHONUTF8=1 make setup` fixes it.
+
+Verified working: frontend at localhost:5173 (HTTP 200), API docs at localhost:8000/docs, and a successful login with a seeded test account returning a JWT.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,197 @@
+# Solution plan
+
+**Issue:** [#148 — Skill extractor fails to detect JavaScript and TypeScript](https://github.com/ascherj/pathreview/issues/148)
+
+## Understand
+
+The bug is in the ingestion pipeline's skill extractor — the component that reads resume and
+portfolio text and reports which technologies a candidate has used. It detects Python,
+frameworks, and databases, but the JavaScript/TypeScript family is effectively invisible to it,
+and Docker is only found when the literal word "docker" appears.
+
+**Expected vs. actual** (confirmed locally — see JOURNAL.md Week 8 for the full output):
+
+| Input | Expected | Actual |
+|---|---|---|
+| `Wrote index.js using const arrow functions and async/await callbacks` | JavaScript | `[]` |
+| `Built app.tsx and types.ts with strict TypeScript interfaces` | TypeScript | `['React']` |
+| `const fs = require('fs')` | JavaScript | `[]` |
+| `export interface User { id: string; }` | TypeScript | `['Python']` |
+| Dockerfile (`FROM`/`RUN`/`EXPOSE`) | Docker | `['Python']` |
+| compose YAML (`services:`/`build:`) | Docker | `[]` |
+
+**Root cause** — five defects, all in `ingestion/parsers/skill_extractor.py`:
+
+1. **`JS_TS_KEYWORDS` (lines 30–41) is dead code.** It is defined and never referenced anywhere
+   in the repo (verified by grep). The set of signals it was meant to provide — `const`, `let`,
+   `function`, `export`, `require` — is exactly what the failing tests supply, so JS detection
+   has no working keyword path at all.
+2. **The import regex cannot match `require(`.** `_detect_languages` (line 179) uses
+   `re.search(r"\b(import|require)\s+", text)`, which requires whitespace after the keyword.
+   `require('fs')` has a parenthesis, so it never matches.
+3. **TypeScript is decided purely by filename** (line 186:
+   `lang = "TypeScript" if ".ts" in str(filename or "").lower() else "JavaScript"`). For free text
+   with no `filename` argument — the normal case for resume content — TypeScript can never be
+   detected, even when the text literally says "TypeScript" and names `.ts` files.
+4. **Docker is matched as a literal substring only.** `_detect_tools` (line 268) does
+   `if tool in text_lower`, so real Dockerfile instructions or compose keys are never recognized.
+5. **A false positive in the opposite direction:** because the same `\b(import|require)\s+` regex
+   matches Python's `import` statements, plain Python code like `import psycopg2` is currently
+   reported as **JavaScript**. Any fix must remove this, not just add detections.
+
+A related quirk causes the TypeScript sample to be misreported as Python: the annotation regex
+`:\s*(int|str|float|bool|list|dict)` (line 160) matches TypeScript's `: string`, because `str` is
+a prefix of `string` and the pattern has no trailing word boundary.
+
+**A successful fix** detects JavaScript and TypeScript from signals in the text itself (keywords
+and syntax, not just filenames), detects Docker from Dockerfile and compose structure, stops
+reporting Python imports as JavaScript, and leaves the Python, framework, React, and database
+detection that already works untouched.
+
+## Map
+
+Files I expect to touch:
+
+- **`ingestion/parsers/skill_extractor.py`** — the whole fix lives here:
+  - `_detect_languages()` (lines 143–214): wire up `JS_TS_KEYWORDS`, replace the import regex,
+    add text-based TypeScript signals, and add `\b` to the Python annotation pattern.
+  - `_detect_tools()` (lines 263–276): add structural Docker detection alongside the existing
+    keyword loop.
+  - Possibly a new module-level constant for Dockerfile instructions and compose keys, following
+    the existing `PYTHON_KEYWORDS` / `TOOLS` class-constant style.
+- **`tests/unit/test_skill_extractor.py`** — add regression tests (see *Inputs & outputs*). The
+  four tests named in the issue already exist and must go green; I'll add tests for the false
+  positive and the TypeScript-from-prose case, which nothing currently covers.
+
+Files I have checked and expect **not** to touch:
+
+- `agent/tools/skill_extractor.py` — a different class with the same name (an agent `BaseTool`).
+  Out of scope for this issue; I need to avoid editing it by mistake.
+- Nothing else imports the parser `SkillExtractor` except its own test file (verified by grep),
+  so the change has no production callers to break.
+
+## Plan
+
+1. **Establish the baseline.** Run `PYTHONUTF8=1 make test-unit` and record which tests fail
+   before any change, so I can prove my change fixes the 4 target tests and breaks nothing else.
+   (`PYTHONUTF8=1` is needed on Windows — see JOURNAL.md setup notes.)
+2. **Fix JavaScript detection using the existing constant.** In `_detect_languages`, count how
+   many distinct `JS_TS_KEYWORDS` appear as whole words in the text and treat that as evidence.
+   Replace `\b(import|require)\s+` with patterns that match JS-flavored syntax specifically —
+   `require(`, `import ... from`, `export` — so that `const fs = require('fs')` is detected.
+3. **Remove the Python-import false positive.** Ensure the JS evidence path no longer fires on a
+   bare Python `import x`. Verify with `import psycopg2`, which must report Python and not
+   JavaScript.
+4. **Add text-based TypeScript detection.** Detect TypeScript from signals in the text rather than
+   only the filename: the word "typescript", `.ts`/`.tsx` references, `interface X {`,
+   `Promise<...>`, and typed parameters like `(id: string)`. Keep the existing filename path
+   working. Also add the missing `\b` to the Python annotation regex so `: string` stops counting
+   as Python.
+5. **Add structural Docker detection.** In `_detect_tools`, recognize Dockerfile instructions
+   (`FROM`, `RUN`, `EXPOSE`, `COPY`, `WORKDIR`, `CMD`, `ENTRYPOINT`) and compose keys
+   (`services:` with `build:`/`image:`/`ports:`), in addition to the current literal `docker`
+   match, preserving the existing confidence value of 0.95.
+6. **Write the regression tests** described in *Inputs & outputs*, following the existing file's
+   patterns (`@pytest.mark.unit` on the class, the `extractor` fixture, and
+   `skill_names = [s.name for s in result]` assertions).
+7. **Verify.** Run `PYTHONUTF8=1 make test-unit` (all 4 target tests green, no new failures versus
+   the step-1 baseline) and `make check` for ruff, black, and mypy, which the PR gate requires.
+
+## Inputs & outputs
+
+**Function being changed:** `SkillExtractor.extract_skills(text: str, filename: Optional[str] = None) -> list[SkillDetection]`
+
+The public signature does **not** change. What changes is which `SkillDetection` objects come back
+for a given input. Each detection carries `name`, `category`, `confidence` (0.0–1.0), and an
+`evidence` list of human-readable strings, and the existing helpers mutate a shared `skills_dict`
+in place — I'll keep both conventions.
+
+| Input | Current output | Output after fix |
+|---|---|---|
+| `const fs = require('fs')` | `[]` | includes `JavaScript` (category `Language`) |
+| `export interface User { id: string; }` | `['Python']` | includes `TypeScript`, no longer `Python` |
+| `Built app.tsx and types.ts with strict TypeScript interfaces` | `['React']` | includes `TypeScript` (React may remain) |
+| Dockerfile text | `['Python']` | includes `Docker` (category `Tool`, confidence 0.95) |
+| compose YAML | `[]` | includes `Docker` |
+| `import psycopg2` | `['Python', 'JavaScript']` | `Python` only — no JavaScript |
+| `import os` / `def f():` (Python) | `['Python']` | unchanged |
+
+New evidence strings will follow the existing wording style (e.g. `"JavaScript keywords found"`,
+`"Dockerfile instructions found"`), since `evidence` is user-facing text in the review output.
+
+**Tests I'll write** (in `tests/unit/test_skill_extractor.py`, matching its existing style):
+
+```python
+def test_python_imports_not_reported_as_javascript(self, extractor):
+    """Plain Python imports should not trigger JavaScript detection."""
+    result = extractor.extract_skills("import psycopg2\nimport os")
+    skill_names = [s.name for s in result]
+    assert "JavaScript" not in skill_names
+    assert any("python" in s.lower() for s in skill_names)
+
+def test_typescript_detected_from_prose_without_filename(self, extractor):
+    """TypeScript should be detected from text alone, with no filename argument."""
+    result = extractor.extract_skills("Built app.tsx and types.ts with strict TypeScript interfaces")
+    skill_names = [s.name for s in result]
+    assert any("typescript" in s.lower() for s in skill_names)
+
+def test_dockerfile_without_the_word_docker(self, extractor):
+    """A Dockerfile should be detected as Docker even without the literal word."""
+    result = extractor.extract_skills("FROM node:20\nWORKDIR /app\nCOPY . .\nCMD [\"npm\", \"start\"]")
+    skill_names = [s.name for s in result]
+    assert any("docker" in s.lower() for s in skill_names)
+```
+
+## Risks & unknowns
+
+1. **Loosening JS keyword matching could create new false positives.** `JS_TS_KEYWORDS` contains
+   `import`, `async`, `await`, and `class`, which are all also Python keywords — so a naive
+   "any keyword matches" rule would report every Python file as JavaScript, which is precisely
+   the bug in root cause 5. My mitigation is to require either a JS-exclusive token
+   (`const`, `let`, `var`, `function`, `export`, `require(`) or several keywords together, and to
+   test `import psycopg2` explicitly. **This is the main design risk in the fix and I expect to
+   iterate on the threshold.**
+2. **Adding `\b` to the Python annotation regex at line 160 could regress Python detection.**
+   `test_text_with_python_type_annotations` relies on that pattern. Reading the fixture, its text
+   contains `url: str)` and `def`, both of which still match with a trailing `\b`, so I expect it
+   to stay green — but this is an assumption I'll verify by running that specific test rather than
+   assuming.
+3. **TypeScript vs. JavaScript could double-count.** Line 187 writes to `skills_dict[lang]` with a
+   single key, so it currently reports one or the other. If text contains both (a JS project with
+   some TS files), I need to decide whether to emit both or prefer TypeScript. I lean toward
+   emitting both, since `test_mixed_language_text` asserts more than one skill, but I'll confirm no
+   existing test asserts an exact list length before deciding.
+4. **The `.ts` filename check is a naive substring match** (`".ts" in filename.lower()`), so
+   `data.tsv` or `notes.txt.ts.bak` would match. It's pre-existing and not in the issue; I'll
+   likely tighten it to an extension check with `str.endswith`, but only if it doesn't grow the
+   diff beyond the issue's scope.
+5. **Out-of-scope failing test.** `test_database_technology_detection` also fails, but it isn't one
+   of the four in the issue. It fails first on its own bug (line 138,
+   `skill_names = [s.name for s in skill_names]` raises `NameError`), and I verified that even
+   after fixing that line the assertion still fails because `psycopg2` isn't in the `DATABASES`
+   map — only `postgresql` is. **Open question:** leave it alone and note it in the PR
+   description, or fix it too? My current plan is to leave it out to keep the PR focused on #148.
+6. **Confidence-score arithmetic.** Confidence is computed as
+   `min(0.95, 0.6 + len(evidence) * 0.1)`, so adding evidence strings silently raises scores.
+   `test_confidence_scores_are_floats` only checks the 0.0–1.0 range, so I'm not likely to break a
+   test, but I should keep JS/TS confidence comparable to Python's rather than accidentally making
+   every JS detection 0.95.
+
+## Edge cases
+
+The fix should handle each of these gracefully:
+
+- **Plain Python with imports** (`import psycopg2`) — must report Python and **not** JavaScript.
+  This is the regression risk I care most about.
+- **TypeScript prose with no filename** (`"Built app.tsx and types.ts with strict TypeScript
+  interfaces"`) — must report TypeScript; `filename` is `None`, which the code must not assume.
+- **Dockerfile with no occurrence of the word "docker"** (`FROM node:20` / `WORKDIR /app`) — must
+  report Docker.
+- **docker-compose YAML** (`services:` / `build:` / `ports:`) — must report Docker without
+  mistaking the YAML for a programming language.
+- **Mixed JS + Python + TS in one document** (the existing `test_mixed_language_text` fixture) —
+  must return more than one skill and must not crash on the overlapping keywords.
+- **Empty string and plain English prose** — must return a list (possibly empty) and never raise;
+  `test_empty_text` and `test_unrecognized_language` already assert this.
+- **Ambiguous filenames** (`data.tsv`, `README.md` describing JavaScript) — a `.tsv` file should
+  not be reported as TypeScript purely because `.ts` appears as a substring.

--- a/ingestion/parsers/skill_extractor.py
+++ b/ingestion/parsers/skill_extractor.py
@@ -1,11 +1,11 @@
 import re
 from dataclasses import dataclass
-from typing import Optional
 
 
 @dataclass
 class SkillDetection:
     """Result of detecting a skill."""
+
     name: str
     category: str
     confidence: float
@@ -39,6 +39,60 @@ class SkillExtractor:
         "await",
         "class",
     }
+
+    # Syntax that only appears in JavaScript or TypeScript. Any one of these is
+    # enough to conclude the text belongs to the JS/TS family. Bare keywords are
+    # deliberately not used on their own: JS_TS_KEYWORDS shares "import", "async",
+    # "await", and "class" with Python, and words like "let" and "function" occur
+    # in ordinary prose, so matching them alone reports JavaScript for Python code.
+    JS_SYNTAX_PATTERNS = (
+        r"require\s*\(",
+        r"\bmodule\.exports\b",
+        r"console\.(log|error|warn|info)\s*\(",
+        r"=>",
+        r"\bfrom\s+['\"]",
+        r"\bfunction\s*\w*\s*\(",
+        r"\b(const|let|var)\s+[\w${[][^\n]*=",
+        r"\bexport\s+(default|const|function|class|interface|type|enum)\b",
+    )
+
+    # Signals that JS/TS text is specifically TypeScript. These are checked against
+    # the text itself so TypeScript is detected even when no filename is supplied.
+    TS_SYNTAX_PATTERNS = (
+        r"\binterface\s+\w+\s*\{",
+        r"\btype\s+\w+\s*=",
+        r"\benum\s+\w+\s*\{",
+        r":\s*(string|number|boolean|any|void|unknown|never)\b",
+        r"\bPromise\s*<",
+    )
+
+    # Dockerfile instructions, matched case-sensitively at the start of a line so
+    # ordinary prose ("graduated from", "run a script") is not mistaken for one.
+    DOCKERFILE_INSTRUCTIONS = (
+        "ADD",
+        "ARG",
+        "CMD",
+        "COPY",
+        "ENTRYPOINT",
+        "ENV",
+        "EXPOSE",
+        "FROM",
+        "HEALTHCHECK",
+        "LABEL",
+        "RUN",
+        "VOLUME",
+        "WORKDIR",
+    )
+
+    # Keys that identify a Docker Compose file when paired with "services:".
+    COMPOSE_KEYS = (
+        "image:",
+        "build:",
+        "ports:",
+        "volumes:",
+        "depends_on:",
+        "environment:",
+    )
 
     REACT_INDICATORS = {
         "import React",
@@ -105,7 +159,7 @@ class SkillExtractor:
         "ansible": 0.85,
     }
 
-    def extract_skills(self, text: str, filename: Optional[str] = None) -> list[SkillDetection]:
+    def extract_skills(self, text: str, filename: str | None = None) -> list[SkillDetection]:
         """
         Extract skills from source code or documentation text.
 
@@ -116,7 +170,7 @@ class SkillExtractor:
         Returns:
             List of detected skills with confidence scores
         """
-        detected_skills = {}
+        detected_skills: dict[str, SkillDetection] = {}
 
         # Detect languages first
         self._detect_languages(text, filename, detected_skills)
@@ -133,6 +187,9 @@ class SkillExtractor:
         # Detect tools
         self._detect_tools(text, detected_skills)
 
+        # Detect Docker from Dockerfile or Compose structure
+        self._detect_docker(text, detected_skills)
+
         # Sort by confidence
         return sorted(
             detected_skills.values(),
@@ -143,8 +200,8 @@ class SkillExtractor:
     def _detect_languages(
         self,
         text: str,
-        filename: Optional[str],
-        skills_dict: dict,
+        filename: str | None,
+        skills_dict: dict[str, SkillDetection],
     ) -> None:
         """Detect programming languages."""
         text_lower = text.lower()
@@ -157,7 +214,7 @@ class SkillExtractor:
             python_evidence.append("Python import statements")
         if re.search(r"\bdef\s+\w+\s*\(", text):
             python_evidence.append("Python function definitions")
-        if re.search(r":\s*(int|str|float|bool|list|dict)", text):
+        if re.search(r":\s*(int|str|float|bool|list|dict)\b", text):
             python_evidence.append("Python type annotations")
         if "requirements.txt" in text_lower:
             python_evidence.append("requirements.txt found")
@@ -171,25 +228,7 @@ class SkillExtractor:
             )
 
         # JavaScript/TypeScript detection
-        js_evidence = []
-        if ".js" in str(filename or "").lower():
-            js_evidence.append("JavaScript file extension (.js)")
-        if ".ts" in str(filename or "").lower():
-            js_evidence.append("TypeScript file extension (.ts)")
-        if re.search(r"\b(import|require)\s+", text):
-            js_evidence.append("CommonJS or ES6 imports")
-        if "package.json" in text_lower:
-            js_evidence.append("package.json found")
-
-        if js_evidence:
-            confidence = min(0.95, 0.6 + len(js_evidence) * 0.1)
-            lang = "TypeScript" if ".ts" in str(filename or "").lower() else "JavaScript"
-            skills_dict[lang] = SkillDetection(
-                name=lang,
-                category="Language",
-                confidence=confidence,
-                evidence=js_evidence,
-            )
+        self._detect_js_ts(text, filename, skills_dict)
 
         # Other languages by extension
         extension_langs = {
@@ -212,6 +251,82 @@ class SkillExtractor:
                     confidence=confidence,
                     evidence=[f"{lang} file extension"],
                 )
+
+    def _detect_js_ts(
+        self,
+        text: str,
+        filename: str | None,
+        skills_dict: dict[str, SkillDetection],
+    ) -> None:
+        """
+        Detect JavaScript and TypeScript from the text content itself.
+
+        JavaScript is reported when the text contains syntax that Python does not
+        share (for example ``require('fs')`` or an arrow function). TypeScript is
+        reported when the text shows type-level syntax, references a ``.ts``/``.tsx``
+        file, or names the language, so TypeScript is detected even when no filename
+        is supplied. Both may be reported for the same text, since TypeScript
+        projects normally contain JavaScript too.
+
+        Args:
+            text: The source text to analyze
+            filename: Optional filename used as an additional extension signal
+            skills_dict: Accumulated detections, mutated in place
+        """
+        filename_lower = str(filename or "").lower()
+        text_lower = text.lower()
+
+        js_evidence = []
+        ts_evidence = []
+
+        if filename_lower.endswith((".js", ".jsx", ".mjs", ".cjs")):
+            js_evidence.append("JavaScript file extension")
+        if re.search(r"\b[\w-]+\.(js|jsx|mjs|cjs)\b", text_lower):
+            js_evidence.append("JavaScript file reference in content")
+        if "package.json" in text_lower:
+            js_evidence.append("package.json found")
+
+        for pattern in self.JS_SYNTAX_PATTERNS:
+            if re.search(pattern, text):
+                js_evidence.append("JavaScript or TypeScript syntax found")
+                break
+
+        # JS_TS_KEYWORDS enriches the evidence list once the family is established,
+        # but never decides detection on its own (see the note on the constant).
+        if js_evidence:
+            keywords_found = sorted(
+                keyword for keyword in self.JS_TS_KEYWORDS if re.search(rf"\b{keyword}\b", text)
+            )
+            if keywords_found:
+                js_evidence.append(f"Keywords found: {', '.join(keywords_found)}")
+
+        if filename_lower.endswith((".ts", ".tsx")):
+            ts_evidence.append("TypeScript file extension")
+        if re.search(r"\b[\w-]+\.(ts|tsx)\b", text_lower):
+            ts_evidence.append("TypeScript file reference in content")
+        if "typescript" in text_lower:
+            ts_evidence.append("TypeScript named in content")
+
+        for pattern in self.TS_SYNTAX_PATTERNS:
+            if re.search(pattern, text):
+                ts_evidence.append("TypeScript type syntax found")
+                break
+
+        if js_evidence:
+            skills_dict["JavaScript"] = SkillDetection(
+                name="JavaScript",
+                category="Language",
+                confidence=min(0.95, 0.6 + len(js_evidence) * 0.1),
+                evidence=js_evidence,
+            )
+
+        if ts_evidence:
+            skills_dict["TypeScript"] = SkillDetection(
+                name="TypeScript",
+                category="Language",
+                confidence=min(0.95, 0.6 + len(ts_evidence) * 0.1),
+                evidence=ts_evidence,
+            )
 
     def _detect_frameworks(self, text: str, skills_dict: dict) -> None:
         """Detect frameworks and libraries."""
@@ -259,6 +374,46 @@ class SkillExtractor:
                         confidence=confidence,
                         evidence=[f"Found '{db}' reference in content"],
                     )
+
+    def _detect_docker(self, text: str, skills_dict: dict[str, SkillDetection]) -> None:
+        """
+        Detect Docker from file structure rather than the literal word "docker".
+
+        A Dockerfile or a Compose file often never mentions Docker by name, so this
+        looks for Dockerfile instructions at the start of a line and for Compose
+        service definitions. Two or more distinct instructions are required so that
+        an isolated capitalised word in prose is not treated as a Dockerfile.
+
+        Args:
+            text: The source text to analyze
+            skills_dict: Accumulated detections, mutated in place
+        """
+        if "Docker" in skills_dict:
+            return
+
+        evidence = []
+
+        instruction_pattern = r"^\s*({})\s+\S".format("|".join(self.DOCKERFILE_INSTRUCTIONS))
+        instructions = {
+            match.group(1) for match in re.finditer(instruction_pattern, text, re.MULTILINE)
+        }
+        if len(instructions) >= 2:
+            evidence.append(f"Dockerfile instructions: {', '.join(sorted(instructions))}")
+
+        has_services = re.search(r"^\s*services\s*:", text, re.MULTILINE) is not None
+        has_service_key = any(
+            re.search(rf"^\s*{re.escape(key)}", text, re.MULTILINE) for key in self.COMPOSE_KEYS
+        )
+        if has_services and has_service_key:
+            evidence.append("Docker Compose service definitions found")
+
+        if evidence:
+            skills_dict["Docker"] = SkillDetection(
+                name="Docker",
+                category="Tool",
+                confidence=self.TOOLS["docker"],
+                evidence=evidence,
+            )
 
     def _detect_tools(self, text: str, skills_dict: dict) -> None:
         """Detect tools and DevOps technologies."""

--- a/tests/unit/test_skill_extractor.py
+++ b/tests/unit/test_skill_extractor.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from ingestion.parsers.skill_extractor import SkillExtractor, SkillDetection
+from ingestion.parsers.skill_extractor import SkillDetection, SkillExtractor
 
 
 @pytest.mark.unit
@@ -60,6 +60,29 @@ class TestSkillExtractor:
         skill_names = [s.name for s in result]
         # Should detect TypeScript
         assert any("typescript" in s.lower() for s in skill_names)
+
+    def test_typescript_detected_from_prose_without_filename(self, extractor):
+        """Test TypeScript detection from prose when no filename is supplied."""
+        text = "Built app.tsx and types.ts with strict TypeScript interfaces"
+        result = extractor.extract_skills(text)
+
+        skill_names = [s.name for s in result]
+        # TypeScript must be detected from the text alone, not just the filename
+        assert any("typescript" in s.lower() for s in skill_names), f"Got skills: {skill_names}"
+
+    def test_typescript_annotations_not_reported_as_python(self, extractor):
+        """Test that TypeScript type annotations are not mistaken for Python."""
+        text = """
+        export interface User {
+            id: string;
+            name: string;
+        }
+        """
+        result = extractor.extract_skills(text)
+
+        skill_names = [s.name for s in result]
+        # ": string" must not count as a Python type annotation
+        assert "Python" not in skill_names, f"Got skills: {skill_names}"
 
     def test_jupyter_ipynb_detection(self, extractor):
         """Test Python/Jupyter detection from .ipynb reference."""
@@ -135,7 +158,7 @@ class TestSkillExtractor:
         """
         result = extractor.extract_skills(text)
 
-        skill_names = [s.name for s in skill_names]
+        skill_names = [s.name for s in result]
         # Should detect PostgreSQL
         assert any("postgres" in s.lower() or "sql" in s.lower() for s in skill_names)
 
@@ -182,6 +205,35 @@ class TestSkillExtractor:
         skill_names = [s.name for s in result]
         assert any("javascript" in s.lower() or "js" in s.lower() for s in skill_names)
 
+    def test_javascript_detected_from_es6_imports(self, extractor):
+        """Test JavaScript detection from ES6 module syntax."""
+        text = "import express from 'express';\nexport default function app() {}"
+        result = extractor.extract_skills(text)
+
+        skill_names = [s.name for s in result]
+        assert any("javascript" in s.lower() for s in skill_names), f"Got skills: {skill_names}"
+
+    def test_python_imports_not_reported_as_javascript(self, extractor):
+        """Test that Python import statements do not trigger JavaScript detection."""
+        text = """
+        import psycopg2
+        conn = psycopg2.connect("dbname=mydb")
+        """
+        result = extractor.extract_skills(text)
+
+        skill_names = [s.name for s in result]
+        # A bare "import" is shared with Python and must not imply JavaScript
+        assert "JavaScript" not in skill_names, f"Got skills: {skill_names}"
+        assert any("python" in s.lower() for s in skill_names)
+
+    def test_prose_keywords_do_not_trigger_javascript(self, extractor):
+        """Test that English prose using JS keywords is not detected as JavaScript."""
+        text = "I let the team run a function to improve the class schedule"
+        result = extractor.extract_skills(text)
+
+        skill_names = [s.name for s in result]
+        assert "JavaScript" not in skill_names, f"Got skills: {skill_names}"
+
     def test_docker_compose_detection(self, extractor):
         """Test Docker and Docker Compose detection."""
         text = """
@@ -196,6 +248,28 @@ class TestSkillExtractor:
 
         skill_names = [s.name for s in result]
         assert any("docker" in s.lower() for s in skill_names)
+
+    def test_dockerfile_without_the_word_docker(self, extractor):
+        """Test Docker detection from Dockerfile instructions alone."""
+        text = """
+        FROM node:20
+        WORKDIR /app
+        COPY . .
+        CMD ["npm", "start"]
+        """
+        result = extractor.extract_skills(text)
+
+        skill_names = [s.name for s in result]
+        # The word "docker" never appears, but the instructions identify a Dockerfile
+        assert any("docker" in s.lower() for s in skill_names), f"Got skills: {skill_names}"
+
+    def test_single_uppercase_word_is_not_a_dockerfile(self, extractor):
+        """Test that one capitalised word in prose is not treated as a Dockerfile."""
+        text = "RUN the analysis pipeline twice before submitting results"
+        result = extractor.extract_skills(text)
+
+        skill_names = [s.name for s in result]
+        assert "Docker" not in skill_names, f"Got skills: {skill_names}"
 
     def test_aws_gcp_azure_detection(self, extractor):
         """Test cloud platform detection."""
@@ -232,10 +306,7 @@ class TestSkillExtractor:
     def test_skill_detection_dataclass(self):
         """Test SkillDetection dataclass structure."""
         skill = SkillDetection(
-            name="Python",
-            category="Language",
-            confidence=0.95,
-            evidence=["import statement"]
+            name="Python", category="Language", confidence=0.95, evidence=["import statement"]
         )
 
         assert skill.name == "Python"


### PR DESCRIPTION
## Summary

The skill extractor in `ingestion/parsers/skill_extractor.py` could not detect the
JavaScript/TypeScript family. `extract_skills()` returned no detections for text that clearly
described JavaScript work, and TypeScript samples were reported as `React` or `Python` instead of
TypeScript. Because skill detection feeds the review pipeline, a portfolio full of JavaScript work
was reviewed as though those skills did not exist. This PR makes detection read the text itself
rather than depending on a filename that is absent for free-form resume content, and it fixes the
related case where a Dockerfile or Compose file was never recognised as Docker. It also removes a
false positive found while reproducing the issue, where plain Python `import` statements were
reported as JavaScript.

## Issue

Closes #148

## Changes

**`ingestion/parsers/skill_extractor.py`**

- Added `JS_SYNTAX_PATTERNS`: syntax that Python does not share (`require(`, arrow functions,
  `console.log(`, `import ... from '...'`, `export default|const|function|class`, and
  `const|let|var` declarations with an assignment). Any one of these establishes the JS/TS family.
- Wired up `JS_TS_KEYWORDS`, which was defined but never referenced. It now enriches the evidence
  list once the family is confirmed, rather than deciding detection on its own. This is deliberate:
  the set shares `import`, `async`, `await`, and `class` with Python, and `let`/`function` occur in
  ordinary prose, so matching those words alone is what reported JavaScript for Python code.
- Added `TS_SYNTAX_PATTERNS` and text-based TypeScript signals (`interface X {`, `type X =`,
  `enum X {`, `: string|number|boolean|...`, `Promise<`, `.ts`/`.tsx` references, and the word
  "typescript"), so TypeScript is detected when no `filename` argument is supplied. Extracted this
  into a new `_detect_js_ts()` helper, following the file's existing `_detect_*` convention.
- Replaced the `".js" in filename` / `".ts" in filename` substring checks with `str.endswith()` over
  explicit extension tuples, so `data.tsv` is no longer treated as TypeScript.
- Added `_detect_docker()` plus `DOCKERFILE_INSTRUCTIONS` and `COMPOSE_KEYS`. Docker is now detected
  from Dockerfile instructions at the start of a line and from Compose service definitions, not only
  from the literal word "docker". Two or more distinct instructions are required so a single
  capitalised word in prose ("RUN the analysis twice") is not treated as a Dockerfile.
- Added a word boundary to the Python type-annotation pattern
  (`:\s*(int|str|...)` → `:\s*(int|str|...)\b`) so TypeScript's `: string` no longer matches
  Python's `: str`. This is what caused TypeScript samples to be reported as Python.
- Type-annotation hygiene in the touched file: `Optional[str]` → `str | None`, annotated the
  `detected_skills` dict, and added the blank line black wanted after the dataclass docstring. The
  file now passes ruff, black, and mypy individually.

**`tests/unit/test_skill_extractor.py`** — seven new tests, taking the file from 18 to 25 (details under Testing).

**`.pre-commit-config.yaml`** — scoped the mypy hook to application packages (see Notes for
Reviewers). Isolated in its own commit so it can be split out if you'd prefer it as a separate PR.

## Testing

- [x] Unit tests pass (`make test-unit`) — see the note on pre-existing failures below
- [x] Integration tests pass (`make test-integration`) — `tests/integration/` contains only
      `__init__.py`, so no tests are collected; this is unchanged by this PR
- [x] Linter passes (`make lint`) — both files I changed pass ruff; see note below
- [x] Type checker passes (`make typecheck`) — output is byte-identical before and after my change
- [x] New/updated tests cover the changes

**Pre-existing failures (documented as required, and unaffected by this PR).** I recorded a baseline
before starting:

| Check | Before my change | After my change |
|---|---|---|
| `pytest tests/unit -m unit` | 53 failed, 375 passed | 49 failed, 386 passed |
| `ruff check .` | 182 errors | 177 errors |
| `mypy` on the `make typecheck` paths | 5 errors in 4 files | 5 errors in 4 files (identical) |

Diffing the sorted failure lists, **my change introduces zero new failures**. The four tests it
fixes are exactly the four named in the issue:

- `test_javascript_detection`
- `test_text_with_typescript_files`
- `test_devops_tool_detection`
- `test_docker_compose_detection`

The remaining 49 unit-test failures and 177 ruff errors are pre-existing and spread across other
modules (`test_review_service.py`, `test_tech_detector.py`, `test_structural_chunker.py`, and
others). `make check` and `make lint` still fail repo-wide because of them, so "passes" here means
my changes introduce no new failures, per the contribution guidance. Both files I touched pass
ruff, black, and mypy on their own.

**New tests added** in `tests/unit/test_skill_extractor.py`, matching the file's existing style
(`@pytest.mark.unit` on the class, the `extractor` fixture, `skill_names = [s.name for s in result]`
assertions):

| Test | Covers |
|---|---|
| `test_typescript_detected_from_prose_without_filename` | TypeScript detected from text alone when `filename` is `None` |
| `test_typescript_annotations_not_reported_as_python` | `: string` is no longer counted as a Python annotation |
| `test_javascript_detected_from_es6_imports` | JavaScript detected from `import x from 'y'` / `export default` |
| `test_python_imports_not_reported_as_javascript` | Regression guard: `import psycopg2` must not yield JavaScript |
| `test_prose_keywords_do_not_trigger_javascript` | English prose using "let", "run", "function", "class" is not JavaScript |
| `test_dockerfile_without_the_word_docker` | Docker detected from `FROM`/`WORKDIR`/`COPY`/`CMD` alone |
| `test_single_uppercase_word_is_not_a_dockerfile` | One capitalised word in prose is not a Dockerfile |

### How to verify manually

```bash
# 1. The four tests named in the issue now pass (24 passed, 1 pre-existing failure)
pytest tests/unit/test_skill_extractor.py -v

# 2. The exact reproduction cases from the issue body
python -c "
from ingestion.parsers.skill_extractor import SkillExtractor
e = SkillExtractor()
print([d.name for d in e.extract_skills('Wrote index.js using const arrow functions and async/await callbacks')])
# before: []                after: ['JavaScript']
print([d.name for d in e.extract_skills('Built app.tsx and types.ts with strict TypeScript interfaces')])
# before: ['React']         after: ['TypeScript', 'React']
"

# 3. The false positive is gone, and Python detection still works
python -c "
from ingestion.parsers.skill_extractor import SkillExtractor
e = SkillExtractor()
print([d.name for d in e.extract_skills('import psycopg2')])
# before: ['Python', 'JavaScript']   after: ['Python']
"

# 4. Docker is detected without the word 'docker' appearing
python -c "
from ingestion.parsers.skill_extractor import SkillExtractor
print([d.name for d in SkillExtractor().extract_skills('FROM node:20\nWORKDIR /app\nCOPY . .')])
# before: []               after: ['Docker']
"

# 5. Confirm no regressions against the baseline
pytest tests/unit -q -m unit   # 49 failed, 386 passed (was 53 failed, 375 passed)
```

On Windows, prefix the Python commands with `PYTHONUTF8=1`.

## Screenshots / Demo

Not applicable — this is a backend parser change with no UI surface. The command-line
before/after output under "How to verify manually" serves as the demo.

## Notes for Reviewers

1. **Two judgement calls I'd like your opinion on.**
   - *Both JavaScript and TypeScript can now be reported for the same text.* The previous code
     wrote a single `skills_dict[lang]` key chosen by filename, so it reported one or the other. I
     emit both when both sets of signals are present, since TypeScript projects normally contain
     JavaScript and job descriptions ask for both. Happy to make TypeScript suppress JavaScript
     instead if you prefer the narrower behaviour.
   - *`JS_TS_KEYWORDS` is used as supporting evidence rather than as the primary signal.* Using it
     as the primary signal is what produces the `import psycopg2` → JavaScript false positive,
     since four of its ten entries are also Python keywords. If you intended it as the main
     detection path, let me know and I'll rework it.

2. **`.pre-commit-config.yaml` is a tooling fix, not part of the issue.** The mypy hook had no file
   filter, so it type-checked staged files under `tests/`. No test module in this repo is annotated
   and `make typecheck` covers only `api/ core/ ingestion/ rag/ agent/ safety/`, so the hook
   rejected **any** commit touching **any** test file. I added `exclude: ^tests/` to match the
   Makefile's scope. It's in its own commit if you'd rather I pulled it into a separate PR.

3. **One line changed in a test I am not fixing.** `test_database_technology_detection` contained
   `skill_names = [s.name for s in skill_names]`, which iterates the variable it defines. Ruff
   rejected the file on `F821`/`F841` for any commit, so I corrected the typo to
   `[s.name for s in result]`. **That test still fails**, and it is not one of the four in this
   issue: its assertion expects `import psycopg2` to yield a PostgreSQL detection, but `psycopg2`
   is a driver name and only `postgresql` is in the `DATABASES` map. Mapping drivers to their
   databases is a real feature, so I left it out of this PR — happy to open a separate issue for it
   if that's useful.

4. **Where to focus review.** `JS_SYNTAX_PATTERNS` is the security-critical part of the change in
   the sense that it decides false positives. I tested Python code, English prose, and boto3/psycopg2
   samples specifically to make sure none of them trip JavaScript detection, but more adversarial
   inputs would be welcome.
