### PR TITLE
docs(api): document POST request schemas

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -31,3 +31,17 @@ The API reference lists the profile and review creation endpoints but does not e
 - Installed Docker Desktop, WSL 2, GNU Make, Python 3.11, and project dependencies.
 - Ran `make setup` successfully, including database migrations and seed data.
 - Ran `make run`; the frontend loaded at `http://localhost:5173` and the API responded at `http://localhost:8000`.
+
+## Week 8 - Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/menukaghalan/pathreview/commit/9f245c27a52dbf4089fe976daaa859eb8c590322
+
+**Reproduction summary:**
+I reproduced the documentation gap by opening `docs/API.md` and confirming that `POST /profiles` and `POST /reviews` were listed without request body details. I then traced the expected fields through `api/routes/profiles.py`, `api/schemas/profile.py`, and `api/schemas/review.py` to confirm what the docs needed to describe.
+
+**PLAN.md link:** https://github.com/menukaghalan/pathreview/blob/docs/issue-89-request-schemas/PLAN.md
+
+**Walkthrough video (recommended):** Not recorded.
+
+**Blockers or open questions:**
+No blockers for the documentation plan. Local setup on this PC is still pending because WSL/Docker are not installed here yet; the earlier laptop setup had already confirmed the app could run locally.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,33 @@
+# PathReview Contribution Journal
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/89
+
+**Issue title:** API reference doc is missing the `POST /profiles` request body schema
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The API reference lists the profile and review creation endpoints but does not explain the data each endpoint accepts. This makes it unclear that `POST /profiles` uses multipart form data with optional profile fields and a resume upload, while `POST /reviews` expects JSON containing a required profile UUID. The change affects `docs/API.md` and uses the existing FastAPI routes and Pydantic schemas as the source of truth. A successful fix documents both request schemas with field types, requirements, constraints, descriptions, and example values.
+
+**Branch name:** `docs/issue-89-request-schemas`
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger
+
+### “Is this right for me?” checklist reasoning
+
+- The issue is labeled Tier 1 and has a focused, one-file documentation scope.
+- The expected result is clear: document both POST request formats without changing application behavior.
+- The relevant implementation is available in `api/routes/profiles.py`, `api/schemas/profile.py`, and `api/schemas/review.py`, so every documented field can be verified against code.
+- The work can be validated by reviewing the generated Markdown, checking the Git diff, and running the repository checks.
+- The main scope risk is describing `POST /profiles` as JSON even though it uses `multipart/form-data`; the draft explicitly documents the correct content type.
+
+### Setup notes
+
+- Cloned the personal fork and configured `origin` and `upstream` remotes.
+- Installed Docker Desktop, WSL 2, GNU Make, Python 3.11, and project dependencies.
+- Ran `make setup` successfully, including database migrations and seed data.
+- Ran `make run`; the frontend loaded at `http://localhost:5173` and the API responded at `http://localhost:8000`.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,82 @@
+# Week 8 - Issue Reproduction & Solution Planning
+
+## Issue
+
+**Issue:** #89 - API reference doc is missing the `POST /profiles` request body schema
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/89
+
+**Branch:** `docs/issue-89-request-schemas`
+
+## Reproduction
+
+### Expected Behavior
+
+The API reference should document the request body for endpoints that create resources.
+
+For `POST /profiles`, the docs should explain that the endpoint accepts `multipart/form-data` with fields for:
+
+- GitHub username
+- Portfolio URL
+- Resume file upload
+
+For `POST /reviews`, the docs should explain that the endpoint accepts JSON with a required `profile_id`.
+
+### Actual Behavior
+
+Before the fix, `docs/API.md` listed `POST /profiles` and `POST /reviews`, but did not document the request body fields, required/optional status, descriptions, or example values. A contributor reading only the API reference would not know what data to send to either endpoint.
+
+### Steps to Reproduce
+
+1. Open `docs/API.md`.
+2. Find the profile endpoints section.
+3. Confirm `POST /profiles` is listed.
+4. Notice the request body schema is missing.
+5. Find the review endpoints section.
+6. Confirm `POST /reviews` is listed.
+7. Notice the required `profile_id` JSON request body is missing.
+8. Compare the docs with the backend source files:
+   - `api/routes/profiles.py`
+   - `api/schemas/profile.py`
+   - `api/schemas/review.py`
+
+## Root Cause
+
+The backend already defines the expected request data, but the API reference only described the endpoints at a high level. The documentation was incomplete and did not expose the request schemas contributors need when calling the API.
+
+## Solution Plan
+
+### Files to Change
+
+- `docs/API.md`
+- `JOURNAL.md`
+
+### Implementation Steps
+
+1. Inspect `api/routes/profiles.py` to confirm the request format for `POST /profiles`.
+2. Identify which fields are form values and which field is a file upload.
+3. Inspect `api/schemas/review.py` to confirm the request format for `POST /reviews`.
+4. Update `docs/API.md` with a `POST /profiles` request body section.
+5. Document each `POST /profiles` field with type, required status, description, and example value.
+6. Update `docs/API.md` with a `POST /reviews` request body section.
+7. Document the required `profile_id` field as a UUID.
+8. Add concise example request data for both endpoints.
+9. Record issue selection, scope, branch, setup status, and planning notes in `JOURNAL.md`.
+
+## Risks and Edge Cases
+
+- `POST /profiles` must be documented as `multipart/form-data`, not JSON.
+- Optional fields should not be described as required.
+- The resume should be documented as a file upload, not a string path.
+- `profile_id` should be documented as a required UUID for `POST /reviews`.
+- The documentation should match the actual FastAPI route and Pydantic schemas, not only the issue description.
+- Because this is a docs-only change, implementation should not modify API behavior or tests.
+
+## Verification Plan
+
+- Review `docs/API.md` and confirm both request schemas are present.
+- Compare documented fields against `api/routes/profiles.py`, `api/schemas/profile.py`, and `api/schemas/review.py`.
+- Confirm the Git diff only includes documentation/planning files.
+- If the local environment is available, run the app and test suite checks.
+- If local Docker setup is unavailable, document that verification is limited to source and documentation review.
+

--- a/docs/API.md
+++ b/docs/API.md
@@ -16,12 +16,40 @@ Base URL: `http://localhost:8000`
 ### Profiles
 
 `POST /profiles` — Create a profile with resume and GitHub username.
+
+#### `POST /profiles` request body
+
+Content type: `multipart/form-data`
+
+| Field | Type | Required | Description | Example |
+| --- | --- | --- | --- | --- |
+| `github_username` | string | No | GitHub username, up to 255 characters. | `octocat` |
+| `portfolio_url` | string | No | Portfolio URL, up to 500 characters. | `https://octocat.example.com` |
+| `resume_file` | file | No | Resume in PDF, Markdown, or plain-text format. | `resume.pdf` |
+
 `GET /profiles/{profile_id}` — Retrieve a profile.
 `DELETE /profiles/{profile_id}` — Delete a profile and associated data.
 
 ### Reviews
 
 `POST /reviews` — Request a new portfolio review for a profile.
+
+#### `POST /reviews` request body
+
+Content type: `application/json`
+
+| Field | Type | Required | Description | Example |
+| --- | --- | --- | --- | --- |
+| `profile_id` | UUID | Yes | ID of the profile to review. | `550e8400-e29b-41d4-a716-446655440000` |
+
+Example:
+
+```json
+{
+  "profile_id": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
 `GET /reviews/{review_id}` — Retrieve a completed review.
 `GET /reviews` — List reviews for the authenticated user (paginated).
 


### PR DESCRIPTION
## Summary
Documents the request schemas for `POST /profiles` and `POST /reviews` so contributors can see the expected multipart form fields, JSON body fields, requirements, descriptions, and example values. Also records the Week 7 issue selection and local setup notes in `JOURNAL.md`.

## Issue
Closes #89

## Changes
- Added `POST /profiles` multipart form-data documentation for GitHub username, portfolio URL, and resume upload.
- Added `POST /reviews` JSON request documentation for the required `profile_id` field.
- Included field types, requirement status, descriptions, and example values.
- Added `JOURNAL.md` with Week 7 issue selection, tier, branch, problem summary, and setup confirmation.

## Testing
- [ ] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`)
- [ ] Linter passes (`make lint`)
- [ ] Type checker passes (`make typecheck`)
- [ ] New/updated tests cover the changes

Docs-only change. Full setup and app run were previously verified locally. The existing test suite had unrelated failures before this documentation change.

## Screenshots / Demo
N/A - documentation-only change.

## Notes for Reviewers
Please verify that the documented request fields match the FastAPI routes and Pydantic schemas for profile creation and review creation.