### PR TITLE
fix(api): report real safety event count in /health

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -65,4 +65,4 @@ The repo also has substantial pre-existing failures unrelated to #68, which I re
 
 Both in the "no new failures" sense the instructions describe — this repo has documented pre-existing failures (182 ruff, 52 black, 103 mypy, 53 unit tests). After my change: ruff 182 → 182, black 52 → 52, mypy 103 → 100, and the 53 failing tests are the same 53 test IDs with 6 additional passes. The baseline table is in the PR description.
 
-**Draft PR feedback received from:** _pending — draft opened Tue, requesting review in Slack_
+**Draft PR feedback received from:** none — peer/mentor review is optional for this cohort. I opened the PR as a draft first, self-reviewed it against `docs/CONTRIBUTING.md` (branch name, conventional commits, Google-style docstrings, tests alongside the change), then marked it ready for review.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -27,7 +27,22 @@ I added two unit tests in `tests/unit/test_health_safety_events.py`. The first d
 
 **PLAN.md link:** https://github.com/RadRebelSam/pathreview/blob/fix/68-health-check-safety-event-count/PLAN.md
 
-**Walkthrough video (recommended):** [not recorded yet]
-
 **Blockers or open questions:**
 The main open question is the "last hour" semantics: `get_event_count` ignores its `window_hours` argument and the Redis counters use a 24h TTL, so the count is cumulative rather than a true rolling hour. I need to confirm with the maintainer whether to relabel the field or implement hourly bucketed keys before Week 9.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+The fix is implemented and committed (`fix(api): report real safety event count in /health`). All of PLAN.md steps 1–4 are done: `SafetyMonitor.get_total_event_count()` sums `get_event_count()` across `VALID_EVENT_TYPES`; `/health` now builds one Redis client and reports that total in `safety_events_last_hour`; the reproduction test flipped from "always 0" to "reports the aggregated count"; and the file grew from 2 tests to 8, covering the aggregation helper, an empty counter set, unknown/legacy keys, a Redis read failure, and a full Redis outage. Step 3 (the "last hour" window question from Week 8) is resolved as a scoping decision rather than an implementation: true rolling-window counts need bucketed Redis keys, which would change `log_event`'s write path for every safety module — too large for a tier-1 issue — so I documented exactly what the number means in the docstrings and will raise the window semantics as a follow-up in the PR.
+
+One scope change from Week 8: I had planned to leave the broken `settings.redis_host`/`redis_port` lookup alone, but the endpoint could not build a Redis client at all because of it, so there was nothing to hand to `SafetyMonitor`. I switched that to `redis.from_url(settings.redis_url)` and reused the single client for both the redis dependency check and the safety count. It's a 3-line change my fix depends on, and it removes 3 pre-existing mypy errors in the file.
+
+**Next steps:**
+Open the draft PR, ask for peer review in Slack, address feedback, then mark it ready for review and fill in Check-in 2.
+
+**Blockers:**
+`make` isn't installed on my machine, so I run the Makefile targets directly out of `.venv/Scripts` (`ruff check .`, `black --check .`, `mypy api/ core/ ingestion/ rag/ agent/ safety/`, `pytest tests/unit -m unit`). Same commands, same results — noting it so the check-in matches what I actually ran.
+
+The repo also has substantial pre-existing failures unrelated to #68, which I recorded before touching anything: 182 ruff errors, 52 files black would reformat, 103 mypy errors, and 53 failing unit tests. After my change the failing-test set is byte-for-byte identical (383 passed, up from 377 — the 6 new tests), ruff reports the same 7 findings in the files I touched, the only black deviation left in `safety/monitoring.py` is the pre-existing missing trailing comma, and mypy in `api/routes/health.py` went from 11 errors to 8. So my changes introduce no new failures. I'll document this in the PR description.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -46,3 +46,23 @@ Open the draft PR, ask for peer review in Slack, address feedback, then mark it 
 `make` isn't installed on my machine, so I run the Makefile targets directly out of `.venv/Scripts` (`ruff check .`, `black --check .`, `mypy api/ core/ ingestion/ rag/ agent/ safety/`, `pytest tests/unit -m unit`). Same commands, same results — noting it so the check-in matches what I actually ran.
 
 The repo also has substantial pre-existing failures unrelated to #68, which I recorded before touching anything: 182 ruff errors, 52 files black would reformat, 103 mypy errors, and 53 failing unit tests. After my change the failing-test set is byte-for-byte identical (383 passed, up from 377 — the 6 new tests), ruff reports the same 7 findings in the files I touched, the only black deviation left in `safety/monitoring.py` is the pre-existing missing trailing comma, and mypy in `api/routes/health.py` went from 11 errors to 8. So my changes introduce no new failures. I'll document this in the PR description.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/341
+
+**Branch:** `fix/68-health-check-safety-event-count`
+
+**What you built:**
+`/health` now reports a real `safety_events_last_hour` instead of a hardcoded `0`. I added `SafetyMonitor.get_total_event_count()`, which sums the existing per-type Redis counters across `VALID_EVENT_TYPES`, and wired the endpoint to it. The count is best-effort — a Redis failure leaves the field at `0` rather than breaking the health check — and I corrected the endpoint's Redis client construction (`settings.redis_host`/`redis_port`, which don't exist on `Settings`) to `redis.from_url(settings.redis_url)`, because without it no client existed to hand to the monitor.
+
+**Tests added or updated:**
+`tests/unit/test_health_safety_events.py`, from 2 reproduction tests to 8. They cover the aggregation helper (sums across types, empty counters, unknown/legacy keys ignored, Redis read error degrades to `0`) and the endpoint (reports the real aggregate, reports `0` when nothing has been logged, survives a full Redis outage while still marking the dependency unhealthy).
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+Both in the "no new failures" sense the instructions describe — this repo has documented pre-existing failures (182 ruff, 52 black, 103 mypy, 53 unit tests). After my change: ruff 182 → 182, black 52 → 52, mypy 103 → 100, and the 53 failing tests are the same 53 test IDs with 6 additional passes. The baseline table is in the PR description.
+
+**Draft PR feedback received from:** _pending — draft opened Tue, requesting review in Slack_

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,6 +1,6 @@
 ## Week 7 — Issue selection
 
-**Issue link:** https://github.com/jamjamgobambam/pathreview/issues/68
+**Issue link:** https://github.com/ascherj/pathreview/issues/68
 
 **Issue title:** Add a safety event count to the health check endpoint
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -16,4 +16,4 @@ This fits the checklist for a first issue because it is small, isolated, and eas
 
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
-**Cohort ledger:** [ ] Issue added to cohort ledger
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -17,3 +17,17 @@ This fits the checklist for a first issue because it is small, isolated, and eas
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/RadRebelSam/pathreview/commit/2269a0a9d9eb9ef623ba88b2ced13104fc3124cd
+
+**Reproduction summary:**
+I added two unit tests in `tests/unit/test_health_safety_events.py`. The first drives `SafetyMonitor.get_event_count` (via an in-memory Redis stand-in) and confirms it returns real, non-zero counts after events are logged. The second calls the `/health` endpoint with a mocked DB and observes that `safety_events_last_hour` comes back as `0` no matter what — proving the endpoint never consults the monitor and just returns the hardcoded placeholder. While reproducing, I also noticed the endpoint's Redis health check references `settings.redis_host`, which doesn't exist (config only defines `redis_url`) — an adjacent bug I've noted in PLAN.md but scoped out of this fix.
+
+**PLAN.md link:** https://github.com/RadRebelSam/pathreview/blob/fix/68-health-check-safety-event-count/PLAN.md
+
+**Walkthrough video (recommended):** [not recorded yet]
+
+**Blockers or open questions:**
+The main open question is the "last hour" semantics: `get_event_count` ignores its `window_hours` argument and the Redis counters use a 24h TTL, so the count is cumulative rather than a true rolling hour. I need to confirm with the maintainer whether to relabel the field or implement hourly bucketed keys before Week 9.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,19 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/jamjamgobambam/pathreview/issues/68
+
+**Issue title:** Add a safety event count to the health check endpoint
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The health endpoint already advertises a `safety_events_last_hour` field, but it is currently hardcoded to zero. That means operators cannot tell whether the safety layer has been active recently, even though the app has monitoring hooks for safety events. A successful fix would make the health check report a real count instead of a placeholder so the endpoint reflects the actual safety system state.
+
+**Selection notes:**
+This fits the checklist for a first issue because it is small, isolated, and easy to verify. It stays inside the health/monitoring path rather than crossing into auth, ingestion, or the frontend, so the blast radius is low. I also avoided a stale tracker item where the current code already had the requested behavior.
+
+**Branch name:** fix/68-health-check-safety-event-count
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -66,3 +66,46 @@ The repo also has substantial pre-existing failures unrelated to #68, which I re
 Both in the "no new failures" sense the instructions describe — this repo has documented pre-existing failures (182 ruff, 52 black, 103 mypy, 53 unit tests). After my change: ruff 182 → 182, black 52 → 52, mypy 103 → 100, and the 53 failing tests are the same 53 test IDs with 6 additional passes. The baseline table is in the PR description.
 
 **Draft PR feedback received from:** none — peer/mentor review is optional for this cohort. I opened the PR as a draft first, self-reviewed it against `docs/CONTRIBUTING.md` (branch name, conventional commits, Google-style docstrings, tests alongside the change), then marked it ready for review.
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No review came in. As of the Week 10 deadline, PR #341 is open and marked ready for review with 0 reviews, 0 comments, and no CI checks configured on the branch. Per the Su26 course note, reviewer feedback isn't a feature this term.
+
+**How you responded:**
+N/A — no feedback to respond to. In place of an external review I did a second self-review pass against `docs/CONTRIBUTING.md` before marking the PR ready, and I pre-empted the two questions I'd expect a maintainer to raise by addressing them directly in the PR description: why I touched the Redis client construction (outside the literal issue scope) and why I did *not* implement true rolling-window counting.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Two things. First, telling my own breakage apart from the repo's. This codebase ships with 53 failing unit tests, 182 ruff errors, 103 mypy errors, and 52 files black would reformat. The first time I ran the checks I assumed I'd broken something. What actually worked was capturing a baseline *before* editing anything and then diffing the failing test IDs afterward — not the counts, the IDs — so I could say "the same 53 tests fail, and 6 more pass" instead of "roughly the same number." That turned an unusable signal into a usable one.
+
+Second, the issue was not the one-line change it looked like. The visible bug was `safety_events_last_hour` assigned a literal `0` with a "placeholder" comment. But when I went to wire in the real count, there was nothing to wire it to: the endpoint built its Redis client from `settings.redis_host` and `settings.redis_port`, and `Settings` in `core/config.py` only defines `redis_url`. Every call raised `AttributeError`, the `except` swallowed it, and no client object ever existed. The "one-line fix" had a dead dependency underneath it that I hadn't seen from the outside.
+
+**What did you learn about working in a large codebase?**
+That the ratio is inverted from personal projects. My actual change is about 25 lines across two files; the reading, baselining, and justifying around it took the overwhelming majority of the time. In my own code I'd have just fixed the Redis client, the unused `timedelta` imports, the `F841` unused `timestamp` variable in `safety/monitoring.py`, and the missing trailing comma black keeps flagging — they're all sitting right there in files I already had open. Here, leaving them alone was the correct call, because every unrelated line I touch is a line a reviewer has to evaluate and a chance to break something I don't understand yet.
+
+The corollary is that scope isn't binary. I *did* have to change the Redis client because my fix couldn't function without it — so the discipline isn't "never expand scope," it's "expand only where the change is load-bearing, and say so out loud." I put that rationale in the PR body with an explicit offer to split it into a separate PR if the maintainer would rather review it on its own.
+
+I also learned to treat existing patterns as constraints rather than suggestions. The endpoint calls a synchronous Redis client inside an `async def`, which blocks the event loop and is not what I'd write from scratch. I matched it anyway. Introducing async Redis would have been a better design and a much worse pull request.
+
+**How did AI tools help — and where did they fall short?**
+Most useful for orientation and mechanical throughput: mapping which files mattered, drafting the aggregation helper and the eight tests, running the baseline-vs-after comparison, and turning my notes into a PR description. Work that would have taken me a long evening took a fraction of that.
+
+Where it fell short is more interesting. It got the repository situation confidently wrong — it inspected `jamjamgobambam/pathreview` and `ascherj/pathreview`, saw an identical issue #68 in both, and concluded these were two mirrored copies of the course repo. They aren't. The repo was transferred and GitHub silently redirects the old URL, so every API call against the old path was returning the new repo's data. The tooling had no way to see the redirect, the evidence looked consistent, and the conclusion was wrong. I knew the old link just redirects, so I corrected it. That's the pattern I want to remember: AI is confident in proportion to how consistent its evidence looks, not to how correct it is, and the check on that is context it can't observe.
+
+The judgment calls were also mine to make, not the tool's. Whether the Redis client fix belonged in this PR, and whether to implement true hourly bucketing or defer it, are questions about what a maintainer will accept — a social question about a project, not a technical question about code. AI can lay out the tradeoff. It can't tell you which side of it a reviewer lives on.
+
+**What would you do differently if you started over?**
+I'd reproduce the bug against a running system, not only in unit tests. My Week 8 reproduction mocked Redis and asserted the endpoint returned `0`. That test passed and proved the bug, but it mocked away the very thing that was actually broken — the client construction — so I recorded `settings.redis_host` as an "adjacent bug, scoped out" and only found out in Week 9 that my fix depended on it. Ten minutes hitting `/health` against a live Redis would have surfaced it a week earlier and my plan would have been right the first time.
+
+I'd also push on the ambiguous requirement earlier instead of carrying it. I flagged the "last hour" problem in Week 8 — `get_event_count` ignores its `window_hours` argument and the counters carry a 24h TTL, so the number is cumulative, not a rolling hour — and then spent two weeks holding it as an open question before resolving it myself by documenting the real semantics and proposing a follow-up. That's a defensible answer, but I could have opened a comment on the issue in Week 8 and possibly had a real one.
+
+**What are you most proud of?**
+The PR description, more than the code. It states plainly that I went outside the issue's scope and why, admits the field still doesn't literally mean "last hour" and explains what a real fix would cost, shows a before/after table for four separate checks in a repo full of pre-existing failures, and leaves the `make test-integration` box unchecked because I genuinely didn't run it. The temptation with a first contribution is to make it look cleaner than it is. I think a maintainer can read that description and know exactly what they're getting, which seems more valuable than 25 tidy lines.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,102 @@
+# Solution plan
+
+**Issue:** Add a safety event count to the health check endpoint —
+https://github.com/jamjamgobambam/pathreview/issues/68
+
+### Understand
+
+**Root cause.** The `/health` endpoint in [api/routes/health.py](api/routes/health.py)
+advertises a `safety_events_last_hour` field but assigns it a literal `0`
+([health.py:25](api/routes/health.py#L25) and again at
+[health.py:78](api/routes/health.py#L78), with a comment calling it a
+"placeholder"). The endpoint never consults the component that actually tracks
+this data: `SafetyMonitor` in [safety/monitoring.py](safety/monitoring.py),
+whose `get_event_count()` reads real per-type counts from Redis.
+
+**Expected vs. actual.**
+- *Expected:* `safety_events_last_hour` reflects the real number of safety
+  events (PII detections, injection attempts, content filtering, bias
+  detections, rate limits) recorded recently.
+- *Actual:* it is always `0`, so operators cannot tell whether the safety layer
+  has been active — the field is misleading.
+
+Reproduction is captured in
+[tests/unit/test_health_safety_events.py](tests/unit/test_health_safety_events.py):
+one test proves `SafetyMonitor` returns real non-zero counts, a second proves
+the endpoint reports `0` regardless.
+
+### Map
+
+Files I expect to touch:
+
+- **[api/routes/health.py](api/routes/health.py)** — replace the hardcoded `0`
+  with a call that aggregates real safety-event counts; keep it wrapped so a
+  Redis failure never breaks the health check.
+- **[safety/monitoring.py](safety/monitoring.py)** — `SafetyMonitor` already
+  exposes `get_event_count(event_type)` and `VALID_EVENT_TYPES`. Add a small
+  aggregation helper (e.g. `get_total_event_count(window_hours=1)`) that sums
+  across all valid event types, so the endpoint has one clean call.
+- **[tests/unit/test_health_safety_events.py](tests/unit/test_health_safety_events.py)**
+  — flip the reproduction assertion from "hardcoded 0" to "reflects the
+  aggregated count," and add coverage for the aggregation helper and the
+  Redis-failure fallback.
+
+Supporting (read, likely not modified): [core/config.py](core/config.py) for the
+Redis connection string, and how a Redis client is obtained for the endpoint.
+
+### Plan
+
+1. **Add aggregation to `SafetyMonitor`** — a `get_total_event_count()` method
+   that sums `get_event_count()` over `VALID_EVENT_TYPES`, returning `0` on
+   Redis error (mirroring the existing per-type error handling).
+2. **Wire the endpoint** — in `health_check`, obtain a Redis client from
+   `settings.redis_url`, build a `SafetyMonitor`, and set
+   `safety_events_last_hour` from `get_total_event_count()`. Keep the existing
+   `try/except` so any failure falls back to `0` instead of raising.
+3. **Resolve the "last hour" semantics** — `get_event_count` currently ignores
+   its `window_hours` argument ([monitoring.py:61](safety/monitoring.py#L61))
+   and the Redis counters use a 24h TTL, so the count is cumulative, not a true
+   rolling hour. Decide scope with the maintainer: relabel to match reality, or
+   implement hourly bucketed keys. Document the decision in this file.
+4. **Update and add tests** — flip the reproduction test to assert the real
+   aggregated value; add a unit test for `get_total_event_count` and one
+   asserting a Redis error yields `0` (health check stays resilient).
+5. **Verify** — run `make check` and `make test-unit`; update PLAN.md/JOURNAL.md
+   with the final approach.
+
+### Inputs & outputs
+
+- **Input:** the Redis safety counters keyed `safety:events:{event_type}`,
+  populated by `SafetyMonitor.log_event()` across the safety layer.
+- **Output:** an integer `safety_events_last_hour` in the `/health` JSON
+  response equal to the sum of those counters. The change must be
+  non-breaking — the health endpoint must still succeed (and report `0` for
+  this field) even when Redis is unavailable.
+
+### Risks & unknowns
+
+- **Redis client wiring is currently broken.** While reproducing, the redis
+  health check raised `'Settings' object has no attribute 'redis_host'` — the
+  endpoint reads `settings.redis_host`/`redis_port`, but
+  [core/config.py:12](core/config.py#L12) only defines `redis_url`. My fix must
+  use `redis.from_url(settings.redis_url)`. Whether to *also* fix the existing
+  redis-health check is a scope question for the maintainer (I'll keep #68
+  focused on the safety count and flag the adjacent bug separately).
+- **Window semantics.** A true "last hour" needs bucketed keys; the current
+  cumulative-with-24h-TTL counter is not that. This could balloon scope — I'll
+  confirm the intended behavior before implementing buckets.
+- **Resilience.** A Redis outage must not flip `/health` to 503 on account of
+  the safety count; the count is best-effort and defaults to `0`.
+- **Sync client in an async handler.** The existing code already calls a
+  synchronous Redis client inside the async endpoint; I'll match that pattern
+  rather than introduce async Redis in this change.
+
+### Edge cases
+
+- **Redis unavailable / connection refused** → return `0`, do not raise.
+- **No events logged yet** (keys absent / expired) → `0`.
+- **Counter stored as a string** in Redis → integer conversion (already handled
+  by `get_event_count`).
+- **Multiple event types present** → summed correctly across
+  `VALID_EVENT_TYPES`.
+- **Unknown/legacy keys** in Redis → ignored; only valid event types counted.

--- a/PLAN.md
+++ b/PLAN.md
@@ -64,6 +64,23 @@ Redis connection string, and how a Redis client is obtained for the endpoint.
 5. **Verify** — run `make check` and `make test-unit`; update PLAN.md/JOURNAL.md
    with the final approach.
 
+### Decisions made during implementation (Week 9)
+
+- **Window semantics (step 3) — deferred, not implemented.** A true rolling hour
+  needs bucketed Redis keys, which would change `log_event`'s write path for
+  every safety module, well beyond a tier-1 "good first issue". I kept the
+  existing counters and documented precisely what the number means in the
+  `get_total_event_count` and `health_check` docstrings. Flagged in the PR as a
+  follow-up so the maintainer can decide between relabelling the field and
+  implementing buckets.
+- **Redis client wiring — fixed, because the change depends on it.** The
+  endpoint built its client from `settings.redis_host`/`redis_port`, which
+  `Settings` does not define, so the call raised `AttributeError` and no client
+  ever existed to hand to `SafetyMonitor`. Switched to
+  `redis.from_url(settings.redis_url)` and reused that one client for both the
+  redis dependency check and the safety count. This also removes 3 pre-existing
+  mypy errors in the file.
+
 ### Inputs & outputs
 
 - **Input:** the Redis safety counters keyed `safety:events:{event_type}`,

--- a/api/routes/health.py
+++ b/api/routes/health.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, HTTPException, status, Depends
 import structlog
 from datetime import datetime, timedelta
+from typing import Any
 
 from core.database import get_db
 
@@ -14,6 +15,11 @@ async def health_check(db=Depends(get_db)):
     """
     Check health of PostgreSQL, Redis, and Vector DB.
     Returns 200 if all healthy, 503 if any dependency is down.
+
+    The response also carries ``safety_events_last_hour``: the number of safety
+    events (PII detections, injection attempts, content filtering, bias
+    detections, rate limits) recorded by ``SafetyMonitor``. It is best-effort
+    and reports 0 when Redis is unavailable.
     """
     health_status = {
         "status": "healthy",
@@ -36,21 +42,18 @@ async def health_check(db=Depends(get_db)):
         health_status["dependencies"]["postgres"] = "unhealthy"
         health_status["status"] = "unhealthy"
 
+    redis_client: Any = None
     try:
         # Check Redis (if available)
         import redis
         from core.config import settings
 
-        r = redis.Redis(
-            host=settings.redis_host,
-            port=settings.redis_port,
-            db=0,
-            decode_responses=True,
-        )
-        r.ping()
+        redis_client = redis.from_url(settings.redis_url, decode_responses=True)
+        redis_client.ping()
         health_status["dependencies"]["redis"] = "healthy"
         log.debug("redis_health_check_passed")
     except Exception as exc:
+        redis_client = None
         log.error("redis_health_check_failed", error=str(exc))
         health_status["dependencies"]["redis"] = "unhealthy"
         health_status["status"] = "unhealthy"
@@ -72,10 +75,18 @@ async def health_check(db=Depends(get_db)):
         health_status["dependencies"]["vector_db"] = "unhealthy"
         health_status["status"] = "unhealthy"
 
-    # Count safety events in last hour (placeholder)
+    # Count safety events recorded by the safety layer. Best-effort: the count
+    # stays 0 when Redis is unreachable so it never fails the health check.
     try:
-        # This would be populated by actual safety event logging
-        health_status["safety_events_last_hour"] = 0
+        if redis_client is not None:
+            from safety.monitoring import SafetyMonitor
+
+            monitor = SafetyMonitor(redis_client)
+            health_status["safety_events_last_hour"] = monitor.get_total_event_count()
+            log.debug(
+                "safety_events_check_passed",
+                count=health_status["safety_events_last_hour"],
+            )
     except Exception as exc:
         log.error("safety_events_check_failed", error=str(exc))
 

--- a/safety/monitoring.py
+++ b/safety/monitoring.py
@@ -72,3 +72,20 @@ class SafetyMonitor:
         except Exception as e:
             logger.error("event_count_error", event_type=event_type, error=str(e))
             return 0
+
+    def get_total_event_count(self, window_hours: int = 1) -> int:
+        """Get the combined count of safety events across all event types.
+
+        Args:
+            window_hours: Time window in hours, forwarded to
+                :meth:`get_event_count` (see its note: the window is not
+                enforced, counters expire 24 hours after they are first set)
+
+        Returns:
+            Sum of the counts for every type in ``VALID_EVENT_TYPES``. Types
+            whose counter cannot be read contribute ``0``, so a Redis failure
+            degrades the total rather than raising.
+        """
+        return sum(
+            self.get_event_count(event_type, window_hours) for event_type in self.VALID_EVENT_TYPES
+        )

--- a/tests/unit/test_health_safety_events.py
+++ b/tests/unit/test_health_safety_events.py
@@ -1,28 +1,28 @@
-"""Reproduction tests for issue #68.
+"""Tests for issue #68.
 
 Add a safety event count to the health check endpoint.
 
-The `/health` endpoint advertises a ``safety_events_last_hour`` field, but it is
-hardcoded to ``0`` in ``api/routes/health.py`` (see the "placeholder" comment).
-Meanwhile ``safety/monitoring.py`` already tracks real per-type counts in Redis
-via ``SafetyMonitor.get_event_count``. These tests document that disconnect:
-the data source works, but the endpoint never consults it.
-
-In Week 9 the second test's expectation flips from "hardcoded 0" to "reflects
-the SafetyMonitor count" once the endpoint is wired up.
+The `/health` endpoint advertises a ``safety_events_last_hour`` field that used
+to be hardcoded to ``0`` in ``api/routes/health.py``, even though
+``safety/monitoring.py`` already tracked real per-type counts in Redis via
+``SafetyMonitor.get_event_count``. These tests cover the wiring that closes that
+gap: the aggregation helper ``SafetyMonitor.get_total_event_count`` and the
+endpoint now reporting its value instead of a placeholder.
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from fastapi import HTTPException
 
 import api.routes.health as health_module
 from safety.monitoring import SafetyMonitor
 
 
 class FakeRedis:
-    """Minimal in-memory stand-in for the Redis counter operations used by
-    ``SafetyMonitor`` (``incr``/``expire``/``get``)."""
+    """Minimal in-memory stand-in for the Redis operations used by
+    ``SafetyMonitor`` (``incr``/``expire``/``get``) and by the endpoint's Redis
+    health check (``ping``)."""
 
     def __init__(self) -> None:
         self.store: dict[str, int] = {}
@@ -37,13 +37,33 @@ class FakeRedis:
     def get(self, key: str):
         return self.store.get(key)
 
+    def ping(self) -> bool:
+        return True
+
+
+async def call_health_check(redis_client) -> dict:
+    """Call the health endpoint with a stubbed DB and the given Redis client.
+
+    Args:
+        redis_client: Object returned by the patched ``redis.from_url``
+
+    Returns:
+        The health payload, whether the endpoint returned it directly or raised
+        an ``HTTPException`` whose ``detail`` carries the same dict.
+    """
+    mock_db = AsyncMock()
+    mock_db.execute = AsyncMock(return_value=None)
+
+    with patch("redis.from_url", return_value=redis_client):
+        try:
+            return await health_module.health_check(db=mock_db)
+        except HTTPException as exc:
+            return exc.detail
+
 
 @pytest.mark.unit
 def test_safety_monitor_tracks_real_counts():
-    """The data source works: logged events produce a real, non-zero count.
-
-    This is the value the health endpoint *should* be surfacing.
-    """
+    """The data source works: logged events produce a real, non-zero count."""
     monitor = SafetyMonitor(FakeRedis())
 
     monitor.log_event("pii_detected", {"field": "email"})
@@ -55,31 +75,78 @@ def test_safety_monitor_tracks_real_counts():
 
 
 @pytest.mark.unit
+def test_get_total_event_count_sums_all_event_types():
+    """The aggregation helper sums counters across every valid event type."""
+    monitor = SafetyMonitor(FakeRedis())
+
+    monitor.log_event("pii_detected", {"field": "email"})
+    monitor.log_event("pii_detected", {"field": "phone"})
+    monitor.log_event("injection_attempt", {"source": "prompt"})
+    monitor.log_event("rate_limited", {"user": "u1"})
+
+    assert monitor.get_total_event_count() == 4
+
+
+@pytest.mark.unit
+def test_get_total_event_count_with_no_events():
+    """No events logged yet (counters absent or expired) totals to 0."""
+    assert SafetyMonitor(FakeRedis()).get_total_event_count() == 0
+
+
+@pytest.mark.unit
+def test_get_total_event_count_ignores_unknown_event_types():
+    """Only counters for VALID_EVENT_TYPES are summed."""
+    fake_redis = FakeRedis()
+    fake_redis.store["safety:events:legacy_event"] = 99
+
+    monitor = SafetyMonitor(fake_redis)
+    monitor.log_event("bias_detected", {"axis": "gender"})
+
+    assert monitor.get_total_event_count() == 1
+
+
+@pytest.mark.unit
+def test_get_total_event_count_returns_zero_on_redis_error():
+    """A Redis failure degrades the total to 0 instead of raising."""
+    failing_redis = MagicMock()
+    failing_redis.get.side_effect = ConnectionError("redis is down")
+
+    assert SafetyMonitor(failing_redis).get_total_event_count() == 0
+
+
+@pytest.mark.unit
 @pytest.mark.asyncio
-async def test_health_endpoint_hardcodes_zero_safety_events():
-    """Reproduction of the bug: `/health` reports 0 regardless of real activity.
+async def test_health_endpoint_reports_real_safety_event_count():
+    """Fix for #68: `/health` surfaces the aggregated SafetyMonitor count."""
+    fake_redis = FakeRedis()
+    monitor = SafetyMonitor(fake_redis)
+    monitor.log_event("pii_detected", {"field": "email"})
+    monitor.log_event("pii_detected", {"field": "phone"})
+    monitor.log_event("content_filtered", {"reason": "toxicity"})
 
-    The endpoint's ``safety_events_last_hour`` field is read whether the overall
-    status is healthy (returns a dict) or unhealthy (raises HTTPException whose
-    ``detail`` carries the same dict). Either way, even though SafetyMonitor
-    would report non-zero counts (see the test above), the value is the
-    hardcoded placeholder.
-    """
-    from unittest.mock import AsyncMock
+    result = await call_health_check(fake_redis)
 
-    from fastapi import HTTPException
+    assert result["safety_events_last_hour"] == 3
 
-    mock_db = AsyncMock()
-    mock_db.execute = AsyncMock(return_value=None)
 
-    fake_redis = MagicMock()
-    fake_redis.ping.return_value = True
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_health_endpoint_reports_zero_when_no_safety_events():
+    """A quiet safety layer still reports 0 — the field stays an integer."""
+    result = await call_health_check(FakeRedis())
 
-    with patch("redis.Redis", return_value=fake_redis):
-        try:
-            result = await health_module.health_check(db=mock_db)
-        except HTTPException as exc:
-            result = exc.detail
-
-    # BUG (#68): always 0 — the endpoint never calls SafetyMonitor.get_event_count.
     assert result["safety_events_last_hour"] == 0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_health_endpoint_survives_redis_outage():
+    """Redis being down marks the dependency unhealthy but never raises out of
+    the safety count: the field falls back to 0."""
+    failing_redis = MagicMock()
+    failing_redis.ping.side_effect = ConnectionError("connection refused")
+
+    result = await call_health_check(failing_redis)
+
+    assert result["safety_events_last_hour"] == 0
+    assert result["dependencies"]["redis"] == "unhealthy"

--- a/tests/unit/test_health_safety_events.py
+++ b/tests/unit/test_health_safety_events.py
@@ -1,0 +1,85 @@
+"""Reproduction tests for issue #68.
+
+Add a safety event count to the health check endpoint.
+
+The `/health` endpoint advertises a ``safety_events_last_hour`` field, but it is
+hardcoded to ``0`` in ``api/routes/health.py`` (see the "placeholder" comment).
+Meanwhile ``safety/monitoring.py`` already tracks real per-type counts in Redis
+via ``SafetyMonitor.get_event_count``. These tests document that disconnect:
+the data source works, but the endpoint never consults it.
+
+In Week 9 the second test's expectation flips from "hardcoded 0" to "reflects
+the SafetyMonitor count" once the endpoint is wired up.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import api.routes.health as health_module
+from safety.monitoring import SafetyMonitor
+
+
+class FakeRedis:
+    """Minimal in-memory stand-in for the Redis counter operations used by
+    ``SafetyMonitor`` (``incr``/``expire``/``get``)."""
+
+    def __init__(self) -> None:
+        self.store: dict[str, int] = {}
+
+    def incr(self, key: str) -> int:
+        self.store[key] = int(self.store.get(key, 0)) + 1
+        return self.store[key]
+
+    def expire(self, key: str, ttl: int) -> None:  # noqa: ARG002 - ttl unused in fake
+        pass
+
+    def get(self, key: str):
+        return self.store.get(key)
+
+
+@pytest.mark.unit
+def test_safety_monitor_tracks_real_counts():
+    """The data source works: logged events produce a real, non-zero count.
+
+    This is the value the health endpoint *should* be surfacing.
+    """
+    monitor = SafetyMonitor(FakeRedis())
+
+    monitor.log_event("pii_detected", {"field": "email"})
+    monitor.log_event("pii_detected", {"field": "phone"})
+    monitor.log_event("injection_attempt", {"source": "prompt"})
+
+    assert monitor.get_event_count("pii_detected") == 2
+    assert monitor.get_event_count("injection_attempt") == 1
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_health_endpoint_hardcodes_zero_safety_events():
+    """Reproduction of the bug: `/health` reports 0 regardless of real activity.
+
+    The endpoint's ``safety_events_last_hour`` field is read whether the overall
+    status is healthy (returns a dict) or unhealthy (raises HTTPException whose
+    ``detail`` carries the same dict). Either way, even though SafetyMonitor
+    would report non-zero counts (see the test above), the value is the
+    hardcoded placeholder.
+    """
+    from unittest.mock import AsyncMock
+
+    from fastapi import HTTPException
+
+    mock_db = AsyncMock()
+    mock_db.execute = AsyncMock(return_value=None)
+
+    fake_redis = MagicMock()
+    fake_redis.ping.return_value = True
+
+    with patch("redis.Redis", return_value=fake_redis):
+        try:
+            result = await health_module.health_check(db=mock_db)
+        except HTTPException as exc:
+            result = exc.detail
+
+    # BUG (#68): always 0 — the endpoint never calls SafetyMonitor.get_event_count.
+    assert result["safety_events_last_hour"] == 0


### PR DESCRIPTION
## Summary
`/health` advertised a `safety_events_last_hour` field but assigned it a literal `0` with a "placeholder" comment, so operators could not tell whether the safety layer had been active. `SafetyMonitor` already tracked per-type counts in Redis via `get_event_count()`; the endpoint simply never consulted it. This PR adds a small aggregation helper to `SafetyMonitor` and wires the endpoint to it, so the field reports the real number of safety events instead of a constant.

## Issue
Closes #68

## Changes
- **`safety/monitoring.py`** — added `SafetyMonitor.get_total_event_count(window_hours=1)`, which sums `get_event_count()` across `VALID_EVENT_TYPES`. Per-type read failures already degrade to `0`, so the total degrades rather than raising.
- **`api/routes/health.py`** — `safety_events_last_hour` is now populated from `get_total_event_count()`. The call is wrapped so a Redis problem leaves the field at `0` and never fails the health check; the endpoint docstring now documents what the field means.
- **`api/routes/health.py`** — the Redis client was built from `settings.redis_host` / `settings.redis_port`, neither of which exists on `Settings` (config only defines `redis_url`), so the call raised `AttributeError` and no client was ever constructed. Switched to `redis.from_url(settings.redis_url, decode_responses=True)` and reused that single client for both the redis dependency check and the safety count. This is in scope because the fix has no Redis client to use without it — happy to split it out if you'd rather review it separately.
- **`tests/unit/test_health_safety_events.py`** — grew from the 2 reproduction tests to 8 (see Testing).

## Testing
- [x] Unit tests pass (`make test-unit`) — new tests pass; no new failures (see baseline below)
- [ ] Integration tests pass (`make test-integration`) — not run; requires Docker services
- [x] Linter passes (`make lint`) — no new findings; the repo's 182 pre-existing errors are unchanged
- [x] Type checker passes (`make typecheck`) — no new errors; 3 pre-existing errors removed
- [x] New/updated tests cover the changes

I don't have `make` on this machine, so I ran the Makefile targets directly (`ruff check .`, `black --check .`, `mypy api/ core/ ingestion/ rag/ agent/ safety/`, `pytest tests/unit -m unit`).

**Pre-existing failures.** This repo has failures unrelated to #68. I recorded a baseline before starting and re-ran everything afterwards:

| Check | Before | After |
|---|---|---|
| `pytest tests/unit -m unit` | 53 failed, 377 passed | 53 failed, 383 passed |
| `ruff check .` | 182 errors | 182 errors |
| `black --check .` | 52 files would reformat | 52 files would reformat |
| `mypy api/ core/ ingestion/ rag/ agent/ safety/` | 103 errors | 100 errors |

The set of failing tests is identical before and after (same 53 test IDs); the 6 extra passes are the new tests. The 7 ruff findings in the files I touched are unchanged, and the only `black` deviation left in `safety/monitoring.py` is the pre-existing missing trailing comma in `VALID_EVENT_TYPES`, which I left alone to keep the diff focused. `mypy` on `api/routes/health.py` drops from 11 errors to 8 because the `redis_host` / `redis_port` fix removes three of them. **These changes introduce no new failures.**

**Test coverage added:**
- `test_safety_monitor_tracks_real_counts` — the data source works (kept from the reproduction commit)
- `test_get_total_event_count_sums_all_event_types` — the helper aggregates across types
- `test_get_total_event_count_with_no_events` — no events logged yet → `0`
- `test_get_total_event_count_ignores_unknown_event_types` — legacy/unknown keys are not counted
- `test_get_total_event_count_returns_zero_on_redis_error` — a Redis read failure degrades to `0`
- `test_health_endpoint_reports_real_safety_event_count` — the fix: `/health` reports the aggregate (flipped from the reproduction test's "always 0")
- `test_health_endpoint_reports_zero_when_no_safety_events` — quiet safety layer still returns an integer
- `test_health_endpoint_survives_redis_outage` — Redis down marks the dependency unhealthy, and the count falls back to `0` rather than raising

## Screenshots / Demo
N/A — JSON response field only. `safety_events_last_hour` goes from a constant `0` to the summed counter value.

## Notes for Reviewers
- **The "last hour" in the field name is still not literally enforced, and I did not change that here.** `get_event_count` ignores its `window_hours` argument and the counters carry a 24h TTL, so the number is cumulative over that TTL rather than a rolling hour. A true rolling window needs bucketed keys, which changes `log_event`'s write path for every safety module — well beyond this issue. I documented the actual semantics in both docstrings; happy to open a follow-up issue for the bucketing if you want the field to match its name.
- **The redis client change** is the one place I went past the literal issue scope; rationale is in the Changes list above.
- The count is deliberately best-effort: nothing about the safety counters should be able to flip `/health` to 503 on its own.
- I matched the existing pattern of a synchronous Redis client inside the async handler rather than introducing async Redis in this change.
