### PR TITLE
test(rag): fix partial overlap fixture

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -33,3 +33,27 @@ I ran the targeted `test_query_with_partial_overlap` test and reproduced the fai
 
 **Blockers or open questions:**
 No current blockers. The evidence indicates that the test fixture should change while the production relevance-scoring implementation remains unchanged.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+I completed every implementation sub-task from `PLAN.md` and opened draft PR
+[#343](https://github.com/ascherj/pathreview/pull/343). The partial-overlap
+fixture now shares exactly two of the query's four unique tokens, producing a
+deterministic score of `0.5`; the targeted test passes, and all 19 relevance
+scorer tests pass.
+
+**Next steps:**
+I will request peer or mentor feedback on the draft PR, address any actionable
+feedback, mark the PR ready for review, and complete Check-in 2 with the final
+validation results.
+
+**Blockers:**
+Peer or mentor review is pending. Repository-wide validation has 182
+pre-existing lint errors and 52 pre-existing unit-test failures after this
+fix; the contribution introduced no new failures and removed the issue #157
+failure from the baseline of 53.
+
+---

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -57,3 +57,93 @@ fix; the contribution introduced no new failures and removed the issue #157
 failure from the baseline of 53.
 
 ---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/343
+
+**Branch:** `test/157-partial-overlap-fixture`
+
+**What you built:**
+I corrected the partial-overlap test fixture so it contains exactly two of the
+query's four unique tokens and produces the intended relevance score of `0.5`.
+The production relevance-scoring code did not need to change because it was
+already calculating the overlap correctly.
+
+**Tests added or updated:**
+I updated `tests/unit/test_relevance_scorer.py`. The targeted partial-overlap
+test passes, all 19 relevance-scorer tests pass, and the repository-wide unit
+test comparison improved from 53 failures and 375 passes to 52 failures and
+376 passes without introducing any new failures.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+The repository-wide commands still report documented pre-existing failures:
+182 Ruff errors and 52 unrelated unit-test failures. Per the assignment's
+baseline rule, these boxes indicate that my contribution introduced no new
+failures.
+
+**Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No reviewer or maintainer feedback had arrived on PR #343 when I completed
+this reflection. Summer 2026 does not include formal reviewer feedback, so I
+documented the current PR status and completed my own final review.
+
+**How you responded:**
+No response or follow-up code change was needed because no feedback was
+received.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Separating a bad test fixture from a production-code defect was harder than I
+expected. The failing assertion initially made the scorer look incorrect, but
+tracing its set-intersection calculation showed that the original chunk
+contained all four query terms and therefore deserved a score of `1.0`. It
+was also challenging to distinguish my result from the repository's existing
+52 unit-test failures and 182 lint errors, which required before-and-after
+baseline comparisons instead of relying on a single green command.
+
+**What did you learn about working in a large codebase?**
+I learned that a narrow issue should lead to a narrow change, supported by
+evidence from the implementation and nearby tests. In someone else's
+codebase, changing production behavior just to satisfy one failing test can
+create regressions, so I first reproduced the failure, read the scoring logic,
+calculated the expected token overlap, and changed only the fixture. I also
+learned that contribution work includes following branch and commit
+conventions, documenting known baseline failures, and making the PR easy for
+a maintainer to evaluate.
+
+**How did AI tools help — and where did they fall short?**
+AI tools helped me navigate the repository, interpret the relevance formula,
+compare baseline and post-change test results, and draft clear journal and PR
+documentation. They were especially useful for turning test output into a
+focused investigation and checking that the final diff stayed within scope.
+However, AI could not replace my judgment about whether the test or production
+code was wrong, and it could not resolve the project's unrelated failures or
+obtain human review. I still had to verify the token math, inspect the actual
+code, run the tests, and decide which suggested changes belonged in this PR.
+
+**What would you do differently if you started over?**
+I would capture the repository-wide test and lint baseline immediately after
+setup and before beginning issue work. That would make it faster to prove that
+later failures were pre-existing. I would also ask my instructor about the
+correct Slack review channel earlier and complete both Week 9 check-ins as
+soon as each milestone was reached instead of filling in the final check-in
+later.
+
+**What are you most proud of from this module?**
+I am most proud that I resisted expanding a one-line fixture problem into an
+unnecessary production-code change. I reproduced the issue, explained the
+root cause with a concrete `2 / 4 = 0.5` expectation, made a minimal fix, and
+used focused plus repository-wide validation to show that the contribution
+removed the intended failure without making the existing baseline worse.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -90,16 +90,21 @@ green.
 
 ### Reviewer feedback
 
-**Feedback received:** [ ] Yes  [x] No — still awaiting review
+**Feedback received:** [x] Yes (automated Copilot review)  [ ] No
 
 **Summary of feedback:**
-No reviewer or maintainer feedback had arrived on PR #343 when I completed
-this reflection. Summer 2026 does not include formal reviewer feedback, so I
-documented the current PR status and completed my own final review.
+GitHub Copilot identified misleading present-tense wording in
+`REPRODUCTION.md`, a platform-specific reproduction command, and self-review
+checkboxes in `JOURNAL.md` that implied the repository-wide checks were fully
+green. This automated review does not count as the required human peer or
+mentor review, which is still pending.
 
 **How you responded:**
-No response or follow-up code change was needed because no feedback was
-received.
+I updated `REPRODUCTION.md` to identify the pre-fix upstream baseline, use a
+platform-neutral `pytest` command, and describe the old fixture behavior in
+the past tense. I also reworded the self-review confirmation to state that the
+before-and-after baselines had no new failures rather than claiming fully
+passing repository-wide checks.
 
 ---
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,21 @@
+# PathReview Contribution Journal
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/157
+
+**Issue title:** Relevance scorer “partial overlap” test fixture actually has full query overlap
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The partial-overlap unit test for the relevance scorer currently uses a query and chunk that share every query term. Because the scorer measures how many query keywords appear in the retrieved text, it correctly returns a full score of 1.0, while the test incorrectly expects a score below 0.9. The problem is confined to the fixture in `tests/unit/test_relevance_scorer.py`, rather than the scoring implementation in `rag/evaluator/relevance_scorer.py`. A successful fix will make the fixture contain only some of the query terms so the test accurately exercises partial keyword overlap.
+
+**Selection reasoning:**
+This issue is appropriate for my first contribution because it is a clearly defined Tier 1 problem limited to one test fixture. The issue supplies a direct reproduction command, and the existing scorer implementation makes the expected behavior straightforward to verify. It does not require database changes, external API access, or changes across multiple application layers. I also confirmed that the issue was open, unassigned, had no comments, and had no competing claim when I selected it.
+
+**Branch name:** test/157-partial-overlap-fixture
+
+**Setup confirmation:** [ ] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -16,6 +16,6 @@ This issue is appropriate for my first contribution because it is a clearly defi
 
 **Branch name:** test/157-partial-overlap-fixture
 
-**Setup confirmation:** [ ] App runs locally at localhost:5173
+**Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [ ] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -76,12 +76,13 @@ test passes, all 19 relevance-scorer tests pass, and the repository-wide unit
 test comparison improved from 53 failures and 375 passes to 52 failures and
 376 passes without introducing any new failures.
 
-**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+**Self-review confirmation:** [x] `make check` baseline compared: no new failures  [x] `make test-unit` baseline compared: no new failures
 
 The repository-wide commands still report documented pre-existing failures:
 182 Ruff errors and 52 unrelated unit-test failures. Per the assignment's
-baseline rule, these boxes indicate that my contribution introduced no new
-failures.
+baseline rule, these confirmations record that my contribution introduced no
+new failures; they do not claim that the repository-wide commands were fully
+green.
 
 **Draft PR feedback received from:** none
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -19,3 +19,17 @@ This issue is appropriate for my first contribution because it is a clearly defi
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/DhivyaSriLingala/pathreview/commit/66d88ee
+
+**Reproduction summary:**
+I ran the targeted `test_query_with_partial_overlap` test and reproduced the failure consistently. The relevance scorer returned `1.0` because all four query tokens occur in the fixture text, causing the test's expected middle-range assertion to fail.
+
+**PLAN.md link:** https://github.com/DhivyaSriLingala/pathreview/blob/test/157-partial-overlap-fixture/PLAN.md
+
+**Walkthrough video (recommended):** Not recorded; this optional item is not graded.
+
+**Blockers or open questions:**
+No current blockers. The evidence indicates that the test fixture should change while the production relevance-scoring implementation remains unchanged.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -18,4 +18,4 @@ This issue is appropriate for my first contribution because it is a clearly defi
 
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
-**Cohort ledger:** [ ] Issue added to cohort ledger
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,78 @@
+# Issue #157 Solution Plan
+
+## Solution plan
+
+**Issue:** [Relevance scorer “partial overlap” test fixture actually has full query overlap](https://github.com/ascherj/pathreview/issues/157)
+
+### Understand
+
+`RelevanceScorer.score()` tokenizes the query and chunk, converts both token
+lists to sets, and divides the number of shared tokens by the number of unique
+query tokens. The test query contains four tokens—`python`, `django`, `web`,
+and `framework`—and the current chunk contains all four, so the actual score
+is correctly `4 / 4 = 1.0`. The test describes this input as partial overlap
+and expects a score below `0.9`, which conflicts with the data it supplies.
+The expected behavior is for the fixture to share only some query tokens and
+produce a score strictly between `0.3` and `0.9`.
+
+### Map
+
+- `tests/unit/test_relevance_scorer.py`
+  - Update `TestRelevanceScorer.test_query_with_partial_overlap` so its fixture
+    represents genuine partial keyword overlap.
+- `rag/evaluator/relevance_scorer.py`
+  - Review `RelevanceScorer.score()` and `_tokenize()` to confirm the expected
+    score, but do not change them unless new evidence shows an implementation
+    defect.
+- `REPRODUCTION.md`
+  - Keep as the recorded baseline demonstrating the original failure.
+
+### Plan
+
+1. Choose fixture text that includes exactly two of the query's four unique
+   tokens, producing a deterministic relevance score of `0.5`.
+2. Change only the chunk text in
+   `test_query_with_partial_overlap`; retain the existing type, range, and
+   partial-overlap assertions.
+3. Run the targeted test to confirm it changes from failing at `1.0` to
+   passing with a middle-range score.
+4. Run the complete `tests/unit/test_relevance_scorer.py` file to check that
+   the fixture change does not affect the other relevance scenarios.
+5. Run the repository's relevant formatting and lint checks, then review the
+   final diff to ensure no production scoring logic changed.
+
+### Inputs & outputs
+
+The input remains the query `Python Django web framework` and one chunk of
+text. The revised chunk should contain exactly two unique query tokens, such
+as `Python` and `Django`, while omitting `web` and `framework`. The scorer
+should output `0.5`, which is within the test's required `0.3 < score < 0.9`
+range, and the test should pass without changing application behavior.
+
+### Risks & unknowns
+
+- Accidentally retaining all four query tokens in the new fixture would
+  preserve the original failure. I will calculate the token intersection
+  explicitly before running the test.
+- Using only one shared token would yield `0.25`, which would fail the lower
+  bound. The fixture therefore needs at least two, but fewer than four,
+  shared tokens.
+- Punctuation is not stripped by `_tokenize()` in
+  `rag/evaluator/relevance_scorer.py`; punctuation attached to a word could
+  unintentionally prevent a match. The revised fixture will use plain,
+  whitespace-separated words for the intended shared tokens.
+- Changing `RelevanceScorer.score()` would expand the scope and could affect
+  other tests. Current evidence indicates no production-code change is needed.
+
+### Edge cases
+
+- Zero shared query tokens should continue producing `0.0`.
+- One of four shared tokens produces `0.25` and is not suitable for this
+  test's asserted middle range.
+- Two or three of four shared tokens produce `0.5` or `0.75`, respectively,
+  and both represent valid partial overlap.
+- All four shared tokens produce `1.0` and must not be used by this fixture.
+- Repeated words should not inflate the score because the implementation uses
+  token sets.
+- Capitalization should not affect overlap because `_tokenize()` lowercases
+  both inputs.

--- a/REPRODUCTION.md
+++ b/REPRODUCTION.md
@@ -2,7 +2,7 @@
 
 ## Environment
 
-- Branch: `test/157-partial-overlap-fixture`
+- Baseline: upstream `main` before the Issue #157 fixture fix
 - Python: 3.11
 - Test file: `tests/unit/test_relevance_scorer.py`
 - Implementation: `rag/evaluator/relevance_scorer.py`
@@ -10,15 +10,16 @@
 ## Reproduction command
 
 ```bash
-.venv/Scripts/pytest tests/unit/test_relevance_scorer.py::TestRelevanceScorer::test_query_with_partial_overlap -q
+pytest tests/unit/test_relevance_scorer.py::TestRelevanceScorer::test_query_with_partial_overlap -q
 ```
 
-## Observed behavior
+## Pre-fix observed behavior
 
-The test fails at `assert 0.3 < score < 0.9` because `score` is `1.0`.
-The query is `Python Django web framework`, and the fixture text is
+Before this fix, the test failed at `assert 0.3 < score < 0.9` because `score`
+was `1.0`. The query was `Python Django web framework`, and the previous fixture
+text was
 `Django is a Python web framework for rapid development`. All four query
-tokens occur in the fixture text, so the scorer correctly calculates full
+tokens occurred in that fixture text, so the scorer correctly calculated full
 keyword coverage rather than partial overlap.
 
 ## Expected behavior

--- a/REPRODUCTION.md
+++ b/REPRODUCTION.md
@@ -1,0 +1,35 @@
+# Issue #157 Reproduction
+
+## Environment
+
+- Branch: `test/157-partial-overlap-fixture`
+- Python: 3.11
+- Test file: `tests/unit/test_relevance_scorer.py`
+- Implementation: `rag/evaluator/relevance_scorer.py`
+
+## Reproduction command
+
+```bash
+.venv/Scripts/pytest tests/unit/test_relevance_scorer.py::TestRelevanceScorer::test_query_with_partial_overlap -q
+```
+
+## Observed behavior
+
+The test fails at `assert 0.3 < score < 0.9` because `score` is `1.0`.
+The query is `Python Django web framework`, and the fixture text is
+`Django is a Python web framework for rapid development`. All four query
+tokens occur in the fixture text, so the scorer correctly calculates full
+keyword coverage rather than partial overlap.
+
+## Expected behavior
+
+The fixture should omit at least one query token while retaining enough shared
+tokens to produce a score strictly between `0.3` and `0.9`. The production
+scoring implementation should remain unchanged because its current result is
+correct for the supplied input.
+
+## Scope
+
+The defect is in the `test_query_with_partial_overlap` fixture in
+`tests/unit/test_relevance_scorer.py`. It is not a defect in
+`RelevanceScorer.score()` in `rag/evaluator/relevance_scorer.py`.

--- a/tests/unit/test_relevance_scorer.py
+++ b/tests/unit/test_relevance_scorer.py
@@ -49,7 +49,7 @@ class TestRelevanceScorer:
         query = "Python Django web framework"
         chunks = [
             {
-                "text": "Django is a Python web framework for rapid development"
+                "text": "Django and Python support rapid application development"
             },
         ]
 


### PR DESCRIPTION
## Summary

Corrects the relevance scorer's partial-overlap unit-test fixture so it
actually represents partial keyword coverage. The production scorer is
already behaving correctly; the previous fixture included every query token
and therefore correctly returned `1.0`.

## Issue

Closes #157

## Changes

- Updated `test_query_with_partial_overlap` to retain `Python` and `Django`
  while omitting the query terms `web` and `framework`.
- The revised fixture deterministically produces `2 / 4 = 0.5`, satisfying
  the existing middle-range assertion.
- Left `RelevanceScorer` production logic unchanged.

## Testing

- [ ] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`)
- [ ] Linter passes (`make lint`)
- [ ] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes

Focused validation:

- `pytest tests/unit/test_relevance_scorer.py::TestRelevanceScorer::test_query_with_partial_overlap -q` — 1 passed
- `pytest tests/unit/test_relevance_scorer.py -q` — 19 passed

Repository-wide baseline comparison:

- Before: `make test-unit` — 53 failed, 375 passed
- After: `make test-unit` — 52 failed, 376 passed
- The only removed failure is issue #157; no new failures were introduced.
- `make check` reports the same 182 pre-existing Ruff errors before and after
  this change. The existing file also has 21 pre-existing mypy annotation
  errors and repository-wide Black formatting drift.

## Screenshots / Demo

Not applicable; this is a unit-test fixture correction with no UI change.

## Notes for Reviewers

Please verify that the revised chunk intentionally overlaps exactly two of the
four unique query tokens. The one-line test-data change is intentionally
scoped; production relevance-scoring behavior is unchanged.
