### PR TITLE
Docs/89 post profiles schema

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -31,3 +31,16 @@ Ran the app locally and compared the auto-generated OpenAPI schema at `localhost
 
 **Blockers or open questions:**
 
+
+## Week 9 - Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+The API.md fix from Week 7 is complete - request schemas for POST /profiles and POST /reviews are documented with field tables and examples. Ran `make check` and `make test-unit` to confirm nothing broke.
+
+**Next steps:**
+Open a draft PR, get a quick peer review, then mark it ready for review.
+
+**Blockers:**
+

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -16,3 +16,18 @@
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** PENDING
+
+**Reproduction summary:**
+Ran the app locally and compared the auto-generated OpenAPI schema at `localhost:8000/docs` against the pre-fix version of `docs/API.md` (commit 888af31). Confirmed `POST /profiles` is multipart form data with an optional resume file, and `POST /reviews` is JSON with just `profile_id` — neither was documented before this fix.
+
+**PLAN.md link:** https://github.com/RithikaMathew/pathreview/blob/docs/89-post-profiles-schema/PLAN.md
+
+**Walkthrough video (recommended):**
+
+**Blockers or open questions:**
+

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,18 @@
+# JOURNAL
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/89
+
+**Issue title:** API reference doc is missing the `POST /profiles` request body schema
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [] Tier 3
+
+**Problem summary:**
+`docs/API.md` lists the response shape for every endpoint but never documents what a client actually needs to send when creating a profile or requesting a review. This is confusing in practice because `POST /profiles` isn't a plain JSON request — it's `multipart/form-data`, since it accepts an optional resume file upload alongside `github_username` and `portfolio_url` fields, and that distinction wasn't documented anywhere. `POST /reviews` is simpler (JSON with just a `profile_id`), but it also had no documented request format. A successful fix adds field-level tables and example requests for both endpoints so a new API consumer doesn't have to read `api/routes/profiles.py` and `api/schemas/review.py` just to figure out how to call them.
+
+**Branch name:** docs/89-post-profiles-schema
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,15 +1,15 @@
-# JOURNAL
+﻿# JOURNAL
 
-## Week 7 — Issue selection
+## Week 7 Issue selection
 
 **Issue link:** https://github.com/ascherj/pathreview/issues/89
 
 **Issue title:** API reference doc is missing the `POST /profiles` request body schema
 
-**Tier:** [x] Tier 1  [ ] Tier 2  [] Tier 3
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
 
 **Problem summary:**
-`docs/API.md` lists the response shape for every endpoint but never documents what a client actually needs to send when creating a profile or requesting a review. This is confusing in practice because `POST /profiles` isn't a plain JSON request — it's `multipart/form-data`, since it accepts an optional resume file upload alongside `github_username` and `portfolio_url` fields, and that distinction wasn't documented anywhere. `POST /reviews` is simpler (JSON with just a `profile_id`), but it also had no documented request format. A successful fix adds field-level tables and example requests for both endpoints so a new API consumer doesn't have to read `api/routes/profiles.py` and `api/schemas/review.py` just to figure out how to call them.
+`docs/API.md` lists the response shape for every endpoint but never documents what a client actually needs to send when creating a profile or requesting a review. This is confusing in practice because `POST /profiles` isn't a plain JSON request â€” it's `multipart/form-data`, since it accepts an optional resume file upload alongside `github_username` and `portfolio_url` fields, and that distinction wasn't documented anywhere. `POST /reviews` is simpler (JSON with just a `profile_id`), but it also had no documented request format. A successful fix adds field-level tables and example requests for both endpoints so a new API consumer doesn't have to read `api/routes/profiles.py` and `api/schemas/review.py` just to figure out how to call them.
 
 **Branch name:** docs/89-post-profiles-schema
 
@@ -18,12 +18,12 @@
 **Cohort ledger:** [x] Issue added to cohort ledger
 
 
-## Week 8 — Reproduction & solution planning
+## Week 8 Reproduction & solution planning
 
-**Reproduction commit link:** PENDING
+**Reproduction commit link:** https://github.com/RithikaMathew/pathreview/commit/60fa346
 
 **Reproduction summary:**
-Ran the app locally and compared the auto-generated OpenAPI schema at `localhost:8000/docs` against the pre-fix version of `docs/API.md` (commit 888af31). Confirmed `POST /profiles` is multipart form data with an optional resume file, and `POST /reviews` is JSON with just `profile_id` — neither was documented before this fix.
+Ran the app locally and compared the auto-generated OpenAPI schema at `localhost:8000/docs` against the pre-fix version of `docs/API.md` (commit 888af31). Confirmed `POST /profiles` is multipart form data with an optional resume file, and `POST /reviews` is JSON with just `profile_id` â€” neither was documented before this fix.
 
 **PLAN.md link:** https://github.com/RithikaMathew/pathreview/blob/docs/89-post-profiles-schema/PLAN.md
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -44,3 +44,19 @@ Open a draft PR, get a quick peer review, then mark it ready for review.
 
 **Blockers:**
 
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/347
+
+**Branch:** docs/89-post-profiles-schema
+
+**What you built:**
+Added request body schemas (field tables and example requests) for POST /profiles and POST /reviews to docs/API.md, which previously only documented response shapes for these endpoints.
+
+**Tests added or updated:**
+None - documentation-only change, no code paths affected. Verified make test-unit, make lint, and make typecheck all show only pre-existing failures unrelated to this change.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+**Draft PR feedback received from:** Aayush

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -60,3 +60,34 @@ None - documentation-only change, no code paths affected. Verified make test-uni
 **Self-review confirmation:** [x] make check passes  [x] make test-unit passes
 
 **Draft PR feedback received from:** Aayush
+
+## Week 10 - Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No - still awaiting review (reviewer feedback not enabled for Su26 per course note)
+
+**Summary of feedback:**
+No reviewer comments received. Aayush gave informal peer feedback on the draft PR before I marked it ready for review (documented in Week 9 Check-in 2).
+
+**How you responded:**
+N/A - no formal reviewer feedback to respond to this week.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The environment setup was the hardest part, not the actual documentation fix. I hit several separate issues in sequence: PowerShell not supporting bash heredoc syntax from the setup instructions, the Makefile's `run` target being written for bash and breaking under PowerShell, Docker Desktop not running, and then a port mismatch (the app expected 5432, but docker-compose actually maps Postgres to 5433). Each one looked like a new problem until I traced it back to its actual cause.
+
+**What did I learn about working in a large codebase?**
+I learned to isolate whether a failure is actually caused by my change or is a pre-existing issue in the codebase. When `make check` and `make test-unit` came back with dozens of failures, my first instinct was that I'd broken something - but none of the failing files were ones I'd touched, and the assignment's own guidance confirmed that's an acceptable, expected situation. I also learned to read actual source code (route handlers, pydantic schemas) instead of trusting what existing documentation claimed, since the docs were the very thing that was wrong.
+
+**How did AI tools help - and where did they fall short?**
+AI was most useful for reading through the codebase quickly - finding the right route and schema files, and translating cryptic errors (bcrypt warnings, mypy output, SQLAlchemy stack traces) into plain explanations of what was actually failing and why. It fell short anywhere that needed my own judgment or actual account-specific detail - like confirming who actually reviewed my draft PR, or deciding when a docker/network issue was actually resolved versus just quiet. I had to run commands myself and report back real output rather than assume AI's suggestions worked.
+
+**What would I do differently if I started over?**
+I would use Git Bash from the very start instead of PowerShell, since the project's own SETUP.md said to, and most of my early friction (heredocs, the Makefile) traced back to ignoring that. I'd also run `docker compose up -d` and confirm containers were healthy before attempting anything else, rather than discovering the DB connection issue reactively through a startup crash.
+
+**What am I most proud of from this module?**
+Getting the full local environment running end-to-end despite several unrelated blockers (shell mismatch, Docker not running, wrong port, bcrypt warning) - that took more troubleshooting than the actual doc fix itself, and I worked through each one methodically instead of giving up or reinstalling everything from scratch.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,32 @@
+﻿## Solution plan
+
+**Issue:** API reference doc is missing the `POST /profiles` request body schema — https://github.com/ascherj/pathreview/issues/89
+
+### Understand
+`docs/API.md` documents response shapes for every endpoint but omits request bodies for `POST /profiles` and `POST /reviews`. The actual behavior, visible via FastAPI's auto-generated schema at `/docs`, is that `POST /profiles` takes `multipart/form-data` (`github_username`, `portfolio_url`, optional `resume_file`), while `POST /reviews` takes plain JSON (`profile_id` only). Neither request shape was documented, so a new API consumer had no way to know how to call these endpoints without reading the source.
+
+### Map
+- `docs/API.md` — the file being fixed
+- `api/routes/profiles.py` — defines the `POST /profiles` endpoint and its `Form`/`File` parameters
+- `api/schemas/profile.py` — `ProfileCreate` pydantic model (field constraints)
+- `api/routes/reviews.py` — defines the `POST /reviews` endpoint
+- `api/schemas/review.py` — `ReviewCreate` pydantic model
+
+### Plan
+1. Trace the `POST /profiles` route and schema to confirm exact fields, types, and constraints.
+2. Trace the `POST /reviews` route and schema the same way.
+3. Add field tables and example requests to `docs/API.md` for both endpoints.
+4. Call out the multipart vs JSON distinction explicitly, since it's easy to miss.
+5. Verify examples against the running Swagger UI at `/docs`.
+
+### Inputs & outputs
+Input: the existing route/schema source files. Output: an updated `docs/API.md` with accurate, example-backed request schemas for both endpoints.
+
+### Risks & unknowns
+- Field constraints (max lengths) could drift from the doc later if the schema changes, since nothing ties them together automatically.
+- Resume file type validation happens at runtime (`file_mime` check) rather than in the pydantic schema, so it's easy to under-document allowed types if only reading `ProfileCreate`.
+
+### Edge cases
+- No resume file provided (`resume_file` is optional).
+- Unsupported file type upload (should surface as `422`, per the route code).
+- Missing `profile_id` on `POST /reviews` (schema validation, not custom code).

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,4 +1,4 @@
-# API Reference
+﻿# API Reference
 
 Base URL: `http://localhost:8000`
 
@@ -16,12 +16,46 @@ Base URL: `http://localhost:8000`
 ### Profiles
 
 `POST /profiles` — Create a profile with resume and GitHub username.
+
+**Request body:** `multipart/form-data`
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `github_username` | string | No | GitHub username to associate with the profile (max 255 chars). |
+| `portfolio_url` | string | No | URL to the user's portfolio site (max 500 chars). |
+| `resume_file` | file | No | Resume upload. Must be PDF, Markdown, or plain text. Returns `422` for other file types. |
+
+Example (`curl`):
+```bash
+curl -X POST http://localhost:8000/profiles \
+  -H "Authorization: Bearer <token>" \
+  -F "github_username=octocat" \
+  -F "portfolio_url=https://octocat.dev" \
+  -F "resume_file=@resume.pdf;type=application/pdf"
+```
+
 `GET /profiles/{profile_id}` — Retrieve a profile.
 `DELETE /profiles/{profile_id}` — Delete a profile and associated data.
 
 ### Reviews
 
 `POST /reviews` — Request a new portfolio review for a profile.
+
+**Request body:** `application/json`
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `profile_id` | UUID (string) | Yes | ID of the profile to review. Must belong to the authenticated user. |
+
+Example:
+```json
+{
+  "profile_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+}
+```
+
+Returns the review immediately with `status: "pending"`; ingestion and agent processing run asynchronously in the background.
+
 `GET /reviews/{review_id}` — Retrieve a completed review.
 `GET /reviews` — List reviews for the authenticated user (paginated).
 


### PR DESCRIPTION
## Summary
Adds request body schemas for `POST /profiles` and `POST /reviews` to `docs/API.md`, which previously documented response shapes but not what a client needs to send. This makes the docs match the actual API contract, since `POST /profiles` accepts `multipart/form-data` (not JSON) and neither endpoint's request fields were documented anywhere.

## Issue
Closes #89

## Changes
- Added a request body field table and `curl` example for `POST /profiles`, documenting `github_username`, `portfolio_url`, and the optional `resume_file` upload, and noting the endpoint uses `multipart/form-data`
- Added a request body field table and JSON example for `POST /reviews`, documenting the single required `profile_id` field
- Verified both against the running Swagger UI (`localhost:8000/docs`) and the corresponding route/schema source (`api/routes/profiles.py`, `api/schemas/profile.py`, `api/routes/reviews.py`, `api/schemas/review.py`) — these source files were read for reference only, not modified

## Testing
- [x] Unit tests pass (`make test-unit`) — 375 passed, 53 pre-existing failures unrelated to this change (all in `test_review_service.py` and `test_tech_detector.py`)
- [ ] Integration tests pass (`make test-integration`) — not run; this is a docs-only change
- [x] Linter passes (`make lint`) — 182 pre-existing lint errors in `tests/unit/`, unrelated to this change
- [x] Type checker passes (`make typecheck`) — 103 pre-existing mypy errors across 26 `.py` files, unrelated to this change (Markdown files aren't type-checked; none of the errors are new)
- [ ] New/updated tests cover the changes — not applicable; documentation-only change with no code paths affected

## Screenshots / Demo
Compared the live Swagger UI schema at `localhost:8000/docs` against the previous `docs/API.md` (commit 888af31) to confirm the request schemas were genuinely missing before this fix.

## Notes for Reviewers
This is a documentation-only change — no `.py` or `.tsx` files were modified. The test/lint/typecheck failures reported above are pre-existing on `main` and unrelated to this PR (confirmed by their file paths, none of which is `docs/API.md`). Happy to run these on a clean `main` checkout if you'd like that logged explicitly.