### PR TITLE
Test/88 reviews no ingested docs

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -29,3 +29,37 @@ username, portfolio URL, or resume, so no `IngestedSource` rows), which is the e
 condition the new test needs to set up. The main thing I need to confirm is the
 endpoint's intended behavior in that case so my assertion matches the design rather
 than the current implementation.
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** REPRO_COMMIT_URL_PLACEHOLDER
+
+**Reproduction summary:**
+I reproduced the empty-profile path by driving `core/services/review_service.py` directly
+against a profile with no ingested documents (`github_username=None`, `portfolio_url=None`,
+`resume_text=None`) using mocked async DB calls, mirroring the fixtures in
+`tests/unit/test_review_service.py`. Observed: `_run_ingestion_pipeline` returns `[]` (zero
+sources) as expected, but the downstream placeholder steps ignore that empty result — so
+`process_review` still marks the review `complete` with 3 fabricated sections and
+`overall_score=0.81`, and `_run_safety_checks` passes it. I confirmed no existing test covers
+this path (the review tests only touch `create_review`, `get_review`, and `list_reviews`),
+so the empty-document contract is entirely unpinned. Reproduction steps:
+
+1. `git checkout test/88-reviews-no-ingested-docs`
+2. Build a `Profile` mock with all three source fields set to `None`.
+3. Call `_run_ingestion_pipeline(db, profile)` → returns `[]`.
+4. Call `_run_agent_orchestration` / `_run_rag_retrieval_generation` / `_run_safety_checks`
+   with that empty result → 3 sections, score 0.81, safety passes.
+5. Conclusion: the empty-input path is untested and silently produces feedback from zero data.
+
+**PLAN.md link:** https://github.com/BPATHAK10/pathreview/blob/test/88-reviews-no-ingested-docs/PLAN.md
+
+**Walkthrough video (recommended):**
+
+**Blockers or open questions:**
+The main open question is the intended contract for an empty profile: should the review still
+complete, short-circuit to a distinct status, or simply not error? I want to confirm this with
+the maintainers before writing the assertion in Week 9 so I don't codify the current
+placeholder behavior if it's unintended. Secondary: 13 of 19 existing tests in
+`tests/unit/test_review_service.py` fail locally due to an `AsyncMock`/asyncio-mode setup
+issue unrelated to this issue — I'll model my new test on one of the passing tests.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -32,7 +32,7 @@ than the current implementation.
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** REPRO_COMMIT_URL_PLACEHOLDER
+**Reproduction commit link:** [commit link](https://github.com/BPATHAK10/pathreview/commit/8c6c3c81eabb95aa91dbc1921e5ecd343de6a198)
 
 **Reproduction summary:**
 I reproduced the empty-profile path by driving `core/services/review_service.py` directly
@@ -54,12 +54,8 @@ so the empty-document contract is entirely unpinned. Reproduction steps:
 
 **PLAN.md link:** https://github.com/BPATHAK10/pathreview/blob/test/88-reviews-no-ingested-docs/PLAN.md
 
-**Walkthrough video (recommended):**
-
 **Blockers or open questions:**
 The main open question is the intended contract for an empty profile: should the review still
 complete, short-circuit to a distinct status, or simply not error? I want to confirm this with
 the maintainers before writing the assertion in Week 9 so I don't codify the current
-placeholder behavior if it's unintended. Secondary: 13 of 19 existing tests in
-`tests/unit/test_review_service.py` fail locally due to an `AsyncMock`/asyncio-mode setup
-issue unrelated to this issue — I'll model my new test on one of the passing tests.
+placeholder behavior if it's unintended.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -59,3 +59,44 @@ The main open question is the intended contract for an empty profile: should the
 complete, short-circuit to a distinct status, or simply not error? I want to confirm this with
 the maintainers before writing the assertion in Week 9 so I don't codify the current
 placeholder behavior if it's unintended.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+I implemented the test-only fix for issue #88 in `tests/unit/test_review_service.py`. Working
+from PLAN.md, I added an `empty_profile` fixture (all four source fields — `github_username`,
+`portfolio_url`, `resume_text`, `resume_filename` — set to `None`) and three focused tests:
+
+1. `_run_ingestion_pipeline` returns `[]` for an empty profile and still commits with nothing staged
+2. a contrast test showing a profile with a GitHub username yields a non-empty result, so the empty assertion isn't vacuous
+3. `process_review` runs the empty-document path
+end-to-end without raising and processes the empty profile (rather than rejecting it as "not found"). 
+
+Following the plan's decision to keep assertions contract-neutral while the maintainer contract is unconfirmed, the tests deliberately do not assert the final review status and they pin only the deterministic, defensible behavior.
+
+All three new tests pass. Before my change `tests/unit/test_review_service.py` was 6 passed / 13 failed; after it is 9 passed / 13 failed — the same 13 pre-existing failures, +3 new passing tests, no new failures.
+
+**Next steps:**
+Run the full `make check` and `make test-unit` and record pre-existing vs. new failures, open a draft PR, and request peer/mentor feedback in the Slack channel before marking it ready.
+
+**Blockers:**
+No any major blockers
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** 
+
+**Branch:** `test/88-reviews-no-ingested-docs`
+
+**What you built:**
+
+
+**Tests added or updated:**
+
+**Self-review confirmation:** 
+
+**Draft PR feedback received from:** 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -52,7 +52,7 @@ so the empty-document contract is entirely unpinned. Reproduction steps:
    with that empty result → 3 sections, score 0.81, safety passes.
 5. Conclusion: the empty-input path is untested and silently produces feedback from zero data.
 
-**PLAN.md link:** https://github.com/BPATHAK10/pathreview/blob/test/88-reviews-no-ingested-docs/PLAN.md
+**PLAN.md link:** [plan.md](https://github.com/BPATHAK10/pathreview/blob/test/88-reviews-no-ingested-docs/PLAN.md)
 
 **Blockers or open questions:**
 The main open question is the intended contract for an empty profile: should the review still
@@ -88,15 +88,26 @@ No any major blockers
 
 ### Check-in 2 (end of week)
 
-**PR link:** 
+**PR link:** [draft pr](https://github.com/ascherj/pathreview/pull/364)
 
 **Branch:** `test/88-reviews-no-ingested-docs`
 
 **What you built:**
-
+Focused unit tests that pin the "no ingested documents" (empty-profile) review path for
+`POST /reviews`, closing the coverage gap in issue #88. The tests assert that ingestion yields
+zero sources for an empty profile and that `process_review` handles that empty result without
+erroring — deterministic assertions that don't codify the placeholder's fabricated-feedback
+behavior. No product code was changed (Tier 1, test-only).
 
 **Tests added or updated:**
+`tests/unit/test_review_service.py` — added an `empty_profile` fixture and three tests
+(`test_ingestion_pipeline_returns_empty_for_profile_with_no_sources`,
+`test_ingestion_pipeline_returns_sources_when_github_present`,
+`test_process_review_handles_empty_ingestion_without_error`).
 
-**Self-review confirmation:** 
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
 
-**Draft PR feedback received from:** 
+Note on "passes": this codebase has documented pre-existing failures. `make test-unit` was 53 failed / 375 passed before my change and 53 failed / 378 passed after (+3 new passing tests, no new failures). My change adds no new `make check` or `make test-unit` failures.
+
+**Draft PR feedback received from:** none
+

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,31 @@
+# PathReview — Module 3 Journal
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/88
+
+**Issue title:** POST /reviews endpoint has no test for when the profile has no ingested documents
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The `POST /reviews` endpoint (in `api/routes/reviews.py`) lets a user kick off a
+review for one of their profiles. It creates a review row with `status="pending"`,
+returns immediately, and does the heavy lifting in a background task (`process_review` in `core/services/review_service.py`). One realistic situation is a profile that has no ingested documents at all i.e. no GitHub username, portfolio URL, or uploaded resume. This makes the ingestion step produce an empty result set. Right now nothing pins down how the endpoint should behave in that case: the only review tests live in `tests/unit/test_review_service.py`, and there is no test for the empty-profile path, so a future change could silently break it. A successful fix adds a focused test that submits a review for a profile with zero ingested documents and asserts the endpoint's contract (that it still responds as designed rather than erroring on empty input), closing the coverage gap.
+
+**Branch name:** test/88-reviews-no-ingested-docs
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger
+
+**"Is this right for me?" checklist reasoning:**
+This fits my scope as a first contribution for a few reasons. It is test-only work in which I add a test rather than change product behavior, so the blast radius is small and I am unlikely to break existing features. I was able to locate the relevant code
+quickly: the handler in `api/routes/reviews.py`, the background logic in
+`core/services/review_service.py`, and the existing tests in
+`tests/unit/test_review_service.py`, which gives me a pattern to follow. I understand
+what "no ingested documents" means in the data model (a profile with no GitHub
+username, portfolio URL, or resume, so no `IngestedSource` rows), which is the exact
+condition the new test needs to set up. The main thing I need to confirm is the
+endpoint's intended behavior in that case so my assertion matches the design rather
+than the current implementation.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -111,3 +111,70 @@ Note on "passes": this codebase has documented pre-existing failures. `make test
 
 **Draft PR feedback received from:** none
 
+
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No
+
+**Summary of feedback:**
+No reviewer feedback came in.
+
+**How you responded:**
+No response was required.
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Deciding what the test should actually assert was much harder than writing it. Issue #88 sounded like a five-line addition. It was like simply "add a test for the empty-profile case" but`POST /reviews` in `api/routes/reviews.py` returns immediately with a `pending`review and hands the real work to `process_review` in `core/services/review_service.py` as a background task. That split meant the behavior which the issue cares about does not happen inside the request I was testing. I spent most of my time working
+out which layer to pin down the endpoint's synchronous contract, or the background
+service's handling of an empty source list rather than writing assertions.
+
+Setup friction also cost real time the async SQLAlchemy session needs `greenlet`
+installed, and getting the test to construct a profile with no `IngestedSource` rows
+meant understanding the data model (no `github_username`, no `portfolio_url`, no
+uploaded resume) rather than just calling a factory.
+
+**What did you learn about working in a large codebase?**
+In my own projects I know the behavior before I open the file, so the code is just a
+reminder. Here the code was the only source of truth, and it did not always agree
+with what the issue implied. Nobody had written down what `POST /reviews` should do
+for an empty profile, so "correct" was something I had to infer from the handler,
+the service, the response schema, and the existing tests together. Writing a test that just asserts whatever the code
+does today makes the suite look better while making future refactors harder, which
+is a failure mode I had never had to think about before.
+
+I also learned how much of contributing is navigation and convention rather than
+logic: matching the `@pytest.mark.unit` / `@pytest.mark.asyncio` markers, the
+fixture style, the docstring format, and the branch/commit conventions in the repo's
+own docs. The actual code change was small; fitting it into someone else's house
+style so it looks like it belongs was most of the work.
+
+**How did AI tools help — and where did they fall short?**
+AI was strongest as a search-and-orient tool. Asking where reviews are created, what
+happens after the endpoint returns, and which fixtures exist got me from a cold repo
+to the three files that mattered which are the route, the service, and the test module. 
+
+Where it fell short was exactly the part that made the issue non-trivial. Asked what
+the endpoint *should* do with a profile that has no ingested documents, AI happily
+produced a confident answer but it was describing what the code currently does, or
+what a reasonable API would do, not a decision grounded in this project's intent.
+It could not tell me whether the empty-profile case ought to be a validation error,
+a `pending` review that later fails, or a completed review with empty sections. It
+also mirrored the weak assertion style already in the test file rather than flagging
+it as a problem. Judging what to assert, and reading the existing tests critically
+instead of imitating them, was the part I had to do myself.
+
+**What would you do differently if you started over?**
+I would settle the intended behavior before writing any test code. I would read the route, the service, and the response schema end to end, write down in one sentence what the contract is, and confirm it on the issue thread. I drifted into writing assertions
+while still unsure what the answer was, which meant rewriting them more than once. Finally, on issue selection I would
+still pick a test-only Tier 1 issue, but I would check earlier whether the behavior under test is actually documented anywhere. "Small diff" and "small amount of thinking" turned out to be very different things.
+
+**What are you most proud of from this module?**
+That I did not paper over the ambiguity. The easy path was to write a test asserting
+whatever the endpoint happens to return today, get a green check, and ship it. I
+took the time to work out what the contract should be and to write an assertion that
+describes intended behavior rather than current behavior. I was honest in the PR about the assumption I was making.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,90 @@
+## Solution plan
+
+**Issue:** POST /reviews endpoint has no test for when the profile has no ingested documents — https://github.com/ascherj/pathreview/issues/88
+
+### Understand
+This is a **test-coverage gap**, not a functional bug in the usual sense. `POST /reviews`
+(`api/routes/reviews.py`) creates a review with `status="pending"`, returns immediately,
+and hands the real work to the background task `process_review`
+(`core/services/review_service.py`). One realistic input is a profile with **no ingested
+documents** — no `github_username`, no `portfolio_url`, and no `resume_text`. Nothing in
+the test suite exercises this path, so the empty-profile contract is undefined and a future
+change could silently break it.
+
+Reproducing the path locally revealed the concrete behavior it currently produces:
+
+- `_run_ingestion_pipeline(db, profile)` correctly returns `[]` (zero sources) for an empty
+  profile.
+- **However**, `_run_agent_orchestration` and `_run_rag_retrieval_generation` are placeholders
+  that ignore `ingestion_results` and return hardcoded sections. `_run_safety_checks` then
+  passes.
+- Net result: `process_review` marks the review **`complete`** with **3 fabricated sections**
+  and `overall_score=0.81`, even though there was zero real input.
+
+**Expected:** the empty-document path is pinned down by an explicit, focused test so its
+behavior is intentional and protected against regressions.
+**Actual:** no test covers it; the empty path silently produces fabricated feedback.
+
+### Map
+Files involved (read/understand):
+- `api/routes/reviews.py` — the `POST /reviews` handler (`create_review_endpoint`).
+- `core/services/review_service.py` — `create_review`, `process_review`, and
+  `_run_ingestion_pipeline` (the function whose output depends on the profile's sources).
+- `core/models/profile.py` — the `Profile` model; the three nullable fields
+  (`github_username`, `portfolio_url`, `resume_text`) that define "no ingested documents".
+- `api/schemas/review.py` — `ReviewCreate` / `ReviewResponse` contract.
+- `tests/unit/test_review_service.py` — existing tests; the `AsyncMock`/`Mock` fixture
+  pattern to follow.
+
+Files I expect to **touch**:
+- `tests/unit/test_review_service.py` — add the new focused test(s) and an empty-profile
+  fixture. (No product code changes — this is test-only work per the Tier 1 scope.)
+
+### Plan
+1. **Confirm the intended contract.** Clarify on the issue / with maintainers whether the
+   empty-profile path should (a) still complete, (b) short-circuit to a distinct status, or
+   (c) simply not error. The test's assertions must match the design, not just the current
+   placeholder behavior.
+2. **Add an empty-profile fixture** mirroring the existing `mock_profile` fixture but with
+   `github_username=None`, `portfolio_url=None`, `resume_text=None`, `resume_filename=None`.
+3. **Write the focused test** asserting the confirmed contract. The most tractable and
+   deterministic assertion is that `_run_ingestion_pipeline` returns an empty list `[]` for an
+   empty profile (the exact "no ingested documents" condition), and — if the contract calls
+   for it — that `process_review` handles the empty result without raising.
+4. **Follow the existing async mocking pattern** (`AsyncMock` session, `Mock()` for
+   `db.add`, patched `Review`) so the new test passes reliably in the current environment.
+5. **Run and lint:** `make test-unit`, then `ruff check .` / `black .`. Ensure the new test
+   passes and I have not disturbed existing tests.
+
+### Inputs & outputs
+- **Input:** a `Profile` with no ingested sources (all three source fields `None`), plus a
+  mocked async DB session.
+- **Output:** one or more new **passing tests** in `tests/unit/test_review_service.py` that
+  assert the empty-document contract. No product behavior changes; the deliverable is added
+  test coverage that closes the gap.
+
+### Risks & unknowns
+- **Contract ambiguity (primary unknown):** the current placeholder returns fabricated
+  feedback for zero input. If I assert that behavior verbatim, I would be codifying something
+  that may be unintended. I need maintainer confirmation before locking in the assertion —
+  otherwise the "fix" cements a possibly-wrong behavior.
+- **Pre-existing failing tests:** 13 of 19 tests in `tests/unit/test_review_service.py`
+  currently fail locally (`AsyncMock`/asyncio-mode setup, e.g. `scalars().all()` on an
+  awaited mock). I must not build my test on the same broken pattern; I'll model it on a
+  test that passes (e.g. `test_create_review_calls_db_add`).
+- **Testing a background task:** `process_review` is `async` and commits to the DB; asserting
+  its end state requires careful mocking of `db.execute`/`db.commit` and possibly patching
+  the placeholder helpers.
+- **Endpoint vs service level:** the issue names the endpoint, but the empty-document logic
+  lives in the service. A true endpoint test needs auth + DB dependency overrides; a
+  service-level unit test is lower-risk and targets the actual behavior. I'll decide based on
+  the confirmed contract.
+
+### Edge cases the fix should consider
+- All three source fields `None` (the core case).
+- Source fields present but empty strings (`""`) vs `None` — both should count as "no
+  documents".
+- A profile that exists but whose ingestion attempts all fail (still zero sources).
+- Partial sources (e.g. `github_username` set but no resume/portfolio) — the non-empty path,
+  used as a contrast to confirm the empty path is what's being asserted.
+- `process_review` when the profile is not found (already handled: status set to `failed`).

--- a/tests/unit/test_review_service.py
+++ b/tests/unit/test_review_service.py
@@ -1,14 +1,16 @@
 """Tests for review_service.py"""
 
-import pytest
-from uuid import uuid4
 from unittest.mock import AsyncMock, Mock, patch
-import asyncio
+from uuid import uuid4
+
+import pytest
 
 from core.services.review_service import (
+    _run_ingestion_pipeline,
     create_review,
     get_review,
     list_reviews,
+    process_review,
 )
 
 
@@ -44,8 +46,30 @@ class TestReviewService:
         profile.user_id = uuid4()
         return profile
 
+    @pytest.fixture
+    def empty_profile(self):
+        """Create a mock Profile with no ingested-document sources.
+
+        Represents the "no ingested documents" case when a profile
+        with no GitHub username, portfolio URL, or resume, so ingestion yields
+        zero sources.
+
+        Returns:
+            Mock: A Profile mock whose four source fields are all ``None``.
+        """
+        profile = Mock()
+        profile.id = uuid4()
+        profile.user_id = uuid4()
+        profile.github_username = None
+        profile.portfolio_url = None
+        profile.resume_text = None
+        profile.resume_filename = None
+        return profile
+
     @pytest.mark.asyncio
-    async def test_create_review_returns_review_with_pending_status(self, mock_db_session, mock_review):
+    async def test_create_review_returns_review_with_pending_status(
+        self, mock_db_session, mock_review
+    ):
         """Test create_review returns Review with status='pending'."""
         profile_id = uuid4()
         user_id = uuid4()
@@ -55,7 +79,7 @@ class TestReviewService:
         mock_db_session.commit = AsyncMock()
         mock_db_session.refresh = AsyncMock()
 
-        with patch('core.services.review_service.Review') as MockReview:
+        with patch("core.services.review_service.Review") as MockReview:
             mock_instance = MockReview.return_value
             mock_instance.status = "pending"
             mock_instance.sections = None
@@ -66,7 +90,7 @@ class TestReviewService:
             # Check that Review was instantiated
             MockReview.assert_called()
             call_kwargs = MockReview.call_args[1]
-            assert call_kwargs['status'] == "pending"
+            assert call_kwargs["status"] == "pending"
 
     @pytest.mark.asyncio
     async def test_get_review_returns_review_for_correct_owner(self, mock_db_session):
@@ -133,9 +157,7 @@ class TestReviewService:
         mock_result.scalars.return_value.all.return_value = []
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
-        reviews, total = await list_reviews(
-            mock_db_session, user_id, page=2, page_size=page_size
-        )
+        reviews, total = await list_reviews(mock_db_session, user_id, page=2, page_size=page_size)
 
         # Second call should pass offset for page 2
         calls = mock_db_session.execute.call_args_list
@@ -165,7 +187,7 @@ class TestReviewService:
         profile_id = uuid4()
         user_id = uuid4()
 
-        with patch('core.services.review_service.Review'):
+        with patch("core.services.review_service.Review"):
             await create_review(mock_db_session, profile_id, user_id)
 
             mock_db_session.add.assert_called_once()
@@ -176,7 +198,7 @@ class TestReviewService:
         profile_id = uuid4()
         user_id = uuid4()
 
-        with patch('core.services.review_service.Review'):
+        with patch("core.services.review_service.Review"):
             await create_review(mock_db_session, profile_id, user_id)
 
             mock_db_session.commit.assert_called_once()
@@ -187,7 +209,7 @@ class TestReviewService:
         profile_id = uuid4()
         user_id = uuid4()
 
-        with patch('core.services.review_service.Review'):
+        with patch("core.services.review_service.Review"):
             await create_review(mock_db_session, profile_id, user_id)
 
             mock_db_session.refresh.assert_called_once()
@@ -244,13 +266,13 @@ class TestReviewService:
         profile_id = uuid4()
         user_id = uuid4()
 
-        with patch('core.services.review_service.Review') as MockReview:
+        with patch("core.services.review_service.Review") as MockReview:
             MockReview.return_value = Mock()
             await create_review(mock_db_session, profile_id, user_id)
 
             call_kwargs = MockReview.call_args[1]
-            assert 'profile_id' in call_kwargs
-            assert 'status' in call_kwargs
+            assert "profile_id" in call_kwargs
+            assert "status" in call_kwargs
 
     @pytest.mark.asyncio
     async def test_get_review_verifies_ownership(self, mock_db_session):
@@ -287,7 +309,7 @@ class TestReviewService:
         """Test list_reviews returns list of Review objects."""
         user_id = uuid4()
 
-        mock_reviews = [Mock(spec=['id', 'status']) for _ in range(3)]
+        mock_reviews = [Mock(spec=["id", "status"]) for _ in range(3)]
         mock_result = AsyncMock()
         mock_result.scalars.return_value.all.return_value = mock_reviews
         mock_db_session.execute = AsyncMock(return_value=mock_result)
@@ -302,13 +324,13 @@ class TestReviewService:
         profile_id = uuid4()
         user_id = uuid4()
 
-        with patch('core.services.review_service.Review') as MockReview:
+        with patch("core.services.review_service.Review") as MockReview:
             MockReview.return_value = Mock()
             await create_review(mock_db_session, profile_id, user_id)
 
             call_kwargs = MockReview.call_args[1]
-            assert call_kwargs['sections'] is None
-            assert call_kwargs['overall_score'] is None
+            assert call_kwargs["sections"] is None
+            assert call_kwargs["overall_score"] is None
 
     @pytest.mark.asyncio
     async def test_get_review_with_valid_uuid(self, mock_db_session):
@@ -338,3 +360,76 @@ class TestReviewService:
 
         # Should order by created_at descending
         mock_db_session.execute.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_ingestion_pipeline_returns_empty_for_profile_with_no_sources(
+        self, mock_db_session, empty_profile
+    ):
+        """Ingestion yields zero sources for a profile with no documents.
+
+        This is the exact "no ingested documents" condition:
+        with ``github_username``, ``portfolio_url``, and ``resume_text`` all
+        ``None``, ``_run_ingestion_pipeline`` must return an empty list and
+        still commit (no ``IngestedSource`` rows are added).
+        """
+        result = await _run_ingestion_pipeline(mock_db_session, empty_profile)
+
+        assert result == []
+        # No sources means nothing is staged for insertion...
+        mock_db_session.add.assert_not_called()
+        # ...but the pipeline still commits the (empty) unit of work.
+        mock_db_session.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_ingestion_pipeline_returns_sources_when_github_present(
+        self, mock_db_session, empty_profile
+    ):
+        """Contrast case: a profile with a source yields a non-empty result.
+
+        Confirms the empty-profile assertion above is meaningful rather than
+        vacuous: when ``github_username`` is set, ingestion produces a
+        non-empty result whereas the empty profile produces ``[]``.
+        """
+        empty_profile.github_username = "octocat"
+
+        result = await _run_ingestion_pipeline(mock_db_session, empty_profile)
+
+        assert result != []
+        assert result[0]["source_type"] == "github"
+        mock_db_session.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_process_review_handles_empty_ingestion_without_error(
+        self, mock_db_session, mock_review, empty_profile
+    ):
+        """process_review completes the empty-profile path without raising.
+
+        The review and profile lookups are stubbed and ingestion is forced to
+        return ``[]`` so the assertion is deterministic and independent of the
+        placeholder downstream steps. We only assert the defensible contract:
+        an empty profile is processed (ingestion runs on it) rather than being
+        rejected as "not found", and no exception escapes. We deliberately do
+        NOT assert the final status, since the intended contract for the
+        empty-document path is not yet confirmed by the maintainer.
+        """
+        review_id = uuid4()
+        profile_id = uuid4()
+
+        # execute() is awaited; its result is a plain Mock so that the
+        # synchronous .scalars().first() chain works (the AsyncMock-result
+        # pattern used elsewhere in this file is the one that fails locally).
+        review_result = Mock()
+        review_result.scalars.return_value.first.return_value = mock_review
+        profile_result = Mock()
+        profile_result.scalars.return_value.first.return_value = empty_profile
+        mock_db_session.execute = AsyncMock(side_effect=[review_result, profile_result])
+
+        with patch(
+            "core.services.review_service._run_ingestion_pipeline",
+            new=AsyncMock(return_value=[]),
+        ) as mock_pipeline:
+            # Should not raise for the empty-document path.
+            await process_review(mock_db_session, review_id, profile_id)
+
+        # The empty profile was processed (not short-circuited as not-found).
+        mock_pipeline.assert_awaited_once_with(mock_db_session, empty_profile)


### PR DESCRIPTION
## Summary

Adds focused unit-test coverage for the "no ingested documents" (empty-profile) path of `POST /reviews`, closing the gap described in issue #88. When a profile has no GitHub username, portfolio URL, or resume, the background `process_review` task receives an empty ingestion result — a realistic input that was previously unexercised by any test, leaving its behavior undefined and unprotected against regressions. This is a Tier 1, test-only change: no product code is modified.

## Issue
Closes #88

## Changes
- Added an `empty_profile` fixture to `tests/unit/test_review_service.py` with all four source fields (`github_username`, `portfolio_url`, `resume_text`, `resume_filename`) set to `None`.
- Added `test_ingestion_pipeline_returns_empty_for_profile_with_no_sources` — asserts `_run_ingestion_pipeline` returns `[]` for an empty profile, stages no `IngestedSource` rows, and still commits.
- Added `test_ingestion_pipeline_returns_sources_when_github_present` — contrast case proving the empty-profile assertion is meaningful rather than vacuous.
- Added `test_process_review_handles_empty_ingestion_without_error` — asserts the empty-document path runs end-to-end without raising and that the empty profile is processed (not rejected as "not found").
- The new tests assert only deterministic, contract-neutral behavior; they intentionally do **not** assert the final review status, since the intended contract for the empty-document path is not yet confirmed (see Notes).

## Testing
- [x] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`)
- [ ] Linter passes (`make lint`)
- [ ] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes

**Pre-existing failures (documented per contribution guidelines):** this codebase has pre-existing unit-test failures and lint findings unrelated to this issue.
- `make test-unit`: **53 failed / 375 passed before**, **53 failed / 378 passed after** — the same 13 pre-existing failures in `test_review_service.py` remain, plus my 3 new passing tests. **No new failures introduced.**
- `make check`: fails at the lint step with pre-existing repo-wide `ruff` errors (182 total, e.g. in `test_tech_detector.py` and the original, never-`black`-formatted `test_review_service.py`); it never reaches `typecheck`. My added lines are `black`- and `ruff`-clean, and `make check`'s `mypy` step does not cover `tests/`. My change introduces no new `make check` failures.

## Screenshots / Demo
N/A — test-only change.

## Notes for Reviewers
- **Open contract question:** for an empty profile, the current placeholder pipeline (`_run_agent_orchestration` / `_run_rag_retrieval_generation`) ignores the empty ingestion result and returns hardcoded sections, so `process_review` marks the review `complete` with fabricated feedback and `overall_score=0.81`. Rather than codify that possibly-unintended behavior, these tests assert only the deterministic facts. Please confirm the intended contract — should the empty path (a) still complete, (b) short-circuit to a distinct status, or (c) simply not error? I'll tighten the assertions to match.
- **Out-of-scope bug found while writing the contrast test:** `_run_ingestion_pipeline` constructs `IngestedSource(profile_id=..., source_type=..., raw_data=json.dumps(...))`, but `raw_data` is not a valid column/keyword on the `IngestedSource` model. The construction raises inside the function's `try/except`, which logs `*_ingestion_failed` and swallows it — so **no `IngestedSource` row is ever persisted** for any source type. I left this untouched to keep this PR test-only and scoped to #88; happy to file a follow-up issue.
