### PR TITLE
fix: exclude top-level vendored and build directories from language detection

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -63,3 +63,34 @@ Fixed the tech detector so vendored and build-output files are no longer counted
 *(Both exit non-zero only due to pre-existing failures unrelated to #150 — identical on base commit `fb93406` (181 ruff / 103 mypy / 51 unit). My change introduces no new failures and fixes 2 unit tests; changed files are ruff + mypy clean.)*
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No Feedback.
+
+**How you responded:**
+No Feedback.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Getting the app running was as hard as attempting to fix the issue. A Postgres port 5433 collided with the Docker container port I had on my laptop which made the setup say "password athentication failed". It took longer than expected to fix that issue before I can fix issue 150.
+
+**What did you learn about working in a large codebase?**
+Working on a large codebase can throw me off. I tend to find out you need to isolate your issue that you need to tackle and avoid going to a rabbit hole realizing the repo had uunrelated unit-test failures caused by other issues.
+
+**How did AI tools help — and where did they fall short?**
+Helping me understand the code more clearly. Reassuring that what I understand about the repo is true. It was also useful in helping me locate the bug and find out the real root of the problem. Where it fall short is sometimes it will get carried away so you have to know that AI is just focusing on one particular issue not many,
+
+**What would you do differently if you started over?**
+Planning I will do differently. I will next time make sure to reproduce the bug many times and not go straight into fixing it. Keeping the branch cleaner will be on I will do differently next time.
+
+**What are you most proud of from this module?**
+I am most proud of being able to write git command lines in terminal. Figuring out and constributing the a large repo. Being able to understand how to use AI efficiently.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -31,3 +31,18 @@ I ran pytest tests/unit/test_tech_detector.py and found test_node_modules_exclud
 
 **Blockers or open questions:**
 [Anything you're still uncertain about going into Week 9, or leave blank]
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+All four PLAN.md sub-tasks are complete. The root cause — `_should_skip_file` matching pre-slashed patterns (`/node_modules/`) so top-level vendor/build directories were never excluded — is fixed by matching whole path segments against a centralized `SKIP_DIRS` set, with backslash normalization for Windows paths (commit `05961b8`). The two originally-failing tests (`test_node_modules_excluded`, `test_build_directory_excluded`) now pass, and I added 6 regression tests covering root-level `node_modules/`/`dist/`/`vendor/`/`.venv/`, a guard that filenames merely containing a keyword (`rebuild.py`) are not skipped, and a fully-vendored repo → `Unknown` (commit `2cc33dd`). The `tech_detector` suite is 33/33 green.
+
+**Next steps:**
+Open the PR against `ascherj/pathreview` using the PR template, documenting the pre-existing repo failures and stating my change introduces none. Optionally record a short walkthrough video. Then complete the Check-in 2 self-review boxes.
+
+**Blockers:**
+None. Note: the repo has substantial pre-existing failures unrelated to #150 (181 ruff, 103 mypy, 51 unit — identical on base commit `fb93406`); my change touches only `agent/tools/tech_detector.py` and its tests and introduces no new failures (it fixes 2 unit tests and removes 1 ruff error).
+
+---

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -43,6 +43,22 @@ All four PLAN.md sub-tasks are complete. The root cause — `_should_skip_file` 
 Open the PR against `ascherj/pathreview` using the PR template, documenting the pre-existing repo failures and stating my change introduces none. Optionally record a short walkthrough video. Then complete the Check-in 2 self-review boxes.
 
 **Blockers:**
-None. Note: the repo has substantial pre-existing failures unrelated to #150 (181 ruff, 103 mypy, 51 unit — identical on base commit `fb93406`); my change touches only `agent/tools/tech_detector.py` and its tests and introduces no new failures (it fixes 2 unit tests and removes 1 ruff error).
+None. 
 
 ---
+
+### Check-in 2 (end of week)
+
+**PR link:** [link to your submitted pull request]
+
+**Branch:** [the branch name you worked on, e.g. `fix/123-short-description`]
+
+**What you built:**
+[1–3 sentences summarizing what your fix does and how it works]
+
+**Tests added or updated:**
+[Which test files did you touch? What do they cover?]
+
+**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+
+**Draft PR feedback received from:** [name or Slack handle, or "none"]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -17,12 +17,14 @@ tech_detector.py fails to filter out biuld-output files such as node_modules/ an
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [link to commit documenting the reproduced issue]
+**Reproduction commit link:** https://github.com/fuentesjm/pathreview/commit/6fcdbd656f49817b4702d99dcff1126e7f9a355e
+
 
 **Reproduction summary:**
-[1–2 sentences: How did you reproduce the issue? What did you observe?]
+I ran pytest tests/unit/test_tech_detector.py and found test_node_modules_excluded and test_build_directory_excluded already failing: a repo with a root-level node_modules/ or build/ directory reports primary_language: "JavaScript" instead of "Python". The root cause is _should_skip_file, whose skip patterns require a leading slash (/node_modules/), so top-level vendored/build directories are never excluded and their files skew language detection.
 
-**PLAN.md link:** [link to PLAN.md in your fork]
+**PLAN.md link:** https://github.com/fuentesjm/pathreview/blob/fix/150-tech-detector-skewing-language-detection/PLAN.md
+
 
 **Walkthrough video (recommended):** [link to your Loom video, ≤2 min — recommended, not graded]
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -17,7 +17,8 @@ tech_detector.py fails to filter out biuld-output files such as node_modules/ an
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** https://github.com/fuentesjm/pathreview/commit/6fcdbd656f49817b4702d99dcff1126e7f9a355e
+**Reproduction commit link:** https://github.com/fuentesjm/pathreview/commit/65e11fd9b7987b1465447a556e5d8f89093c206c
+
 
 
 **Reproduction summary:**

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -14,3 +14,17 @@ tech_detector.py fails to filter out biuld-output files such as node_modules/ an
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [link to commit documenting the reproduced issue]
+
+**Reproduction summary:**
+[1–2 sentences: How did you reproduce the issue? What did you observe?]
+
+**PLAN.md link:** [link to PLAN.md in your fork]
+
+**Walkthrough video (recommended):** [link to your Loom video, ≤2 min — recommended, not graded]
+
+**Blockers or open questions:**
+[Anything you're still uncertain about going into Week 9, or leave blank]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,16 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/150
+
+**Issue title:** Tech detector counts vendored and build-output files, skewing language detection
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+tech_detector.py fails to filter out biuld-output files such as node_modules/ and build/ directories. This causes the vendored or bundles files to be counted alongside actual source code. As a result, it is misclassified as primarily JavaScript instead of Python. There is failed tests.
+
+**Branch name:** fix/150-tech-detector-skewing-language-detection
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -49,16 +49,17 @@ None.
 
 ### Check-in 2 (end of week)
 
-**PR link:** [link to your submitted pull request]
+**PR link:** https://github.com/ascherj/pathreview/pull/366
 
-**Branch:** [the branch name you worked on, e.g. `fix/123-short-description`]
+**Branch:** `fix/150-tech-detector-skewing-language-detection`
 
 **What you built:**
-[1–3 sentences summarizing what your fix does and how it works]
+Fixed the tech detector so vendored and build-output files are no longer counted as project source. `_should_skip_file` now splits each path into segments and matches them against a `SKIP_DIRS` set (with backslash normalization), so top-level directories like `node_modules/`, `build/`, and `dist/` are excluded — not just nested ones — which stops a Python project from being misreported as primarily JavaScript.
 
 **Tests added or updated:**
-[Which test files did you touch? What do they cover?]
+`tests/unit/test_tech_detector.py` — added 6 regression tests: root-level `node_modules/`, `dist/`, `vendor/`, and `.venv/` exclusion; a guard that filenames merely containing a skip keyword (`rebuild.py`, `vendored_data.py`) are not excluded; and a fully-vendored repo resolving to `Unknown`. The two previously-failing tests (`test_node_modules_excluded`, `test_build_directory_excluded`) now pass — the suite is 33/33 green.
 
-**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+*(Both exit non-zero only due to pre-existing failures unrelated to #150 — identical on base commit `fb93406` (181 ruff / 103 mypy / 51 unit). My change introduces no new failures and fixes 2 unit tests; changed files are ruff + mypy clean.)*
 
-**Draft PR feedback received from:** [name or Slack handle, or "none"]
+**Draft PR feedback received from:** none

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,43 @@
+## Solution plan
+
+**Issue:** Tech detector counts vendored and build-output files, skewing language detection (https://github.com/ascherj/pathreview/issues/150)
+
+### Understand
+**Root cause:** `_should_skip_file` matches vendor/build dirs using patterns that require a *leading* slash — `/node_modules/`, `/build/`, `/dist/`, etc. ([tech_detector.py:153-164](agent/tools/tech_detector.py#L153-L164)). A file at the repo root like `node_modules/pkg/index.js` has no leading slash, so `/node_modules/` is not a substring and the file is **not skipped**. Only nested cases (`src/node_modules/...`) match. As a result, committed vendored/build output is counted as source, skewing the detected languages.
+
+**Expected vs. actual:**
+- Expected: files under any `node_modules/`, `vendor/`, `dist/`, `build/`, `.git/`, `__pycache__/`, `.venv/`, `venv/` directory — including at the repo root — are excluded from language detection.
+- Actual: only those dirs appearing *below* another directory are excluded; top-level ones leak through.
+
+**Reproduction (confirmed):**
+- `_should_skip_file('node_modules/pkg/index.js')` → `False` (should be `True`); same for `build/bundle.js`, `dist/app.js`.
+- `execute({'files': ['src/main.py','utils.py','node_modules/a/i.js','node_modules/b/j.js','node_modules/c/k.js']})` → `primary_language: 'JavaScript'` (should be Python).
+- Two existing tests already fail on this: `test_node_modules_excluded`, `test_build_directory_excluded`.
+
+### Map
+- [agent/tools/tech_detector.py](agent/tools/tech_detector.py) — `TechDetector._should_skip_file` (the pattern-matching logic). **Primary file to change.**
+- [tests/unit/test_tech_detector.py](tests/unit/test_tech_detector.py) — two failing tests encode the expected behavior; may add root-level cases for `dist/`, `vendor/`, `.venv/`.
+
+Files expected to touch: those two.
+
+### Plan
+1. Fix `_should_skip_file` so directory matching is anchored per path segment, not by a `/dir/` substring — e.g. split the path on `/` and check whether any segment equals a skip directory (`node_modules`, `vendor`, `dist`, `build`, `.git`, `__pycache__`, `.venv`, `venv`). This catches top-level, nested, and Windows-separator cases uniformly.
+2. Keep the skip-dir list in one place (a set of directory names) rather than pre-slashed strings.
+3. Run the suite; confirm `test_node_modules_excluded` and `test_build_directory_excluded` now pass.
+4. Add regression tests: root-level `dist/`, `vendor/`, `.venv/` files excluded; ensure a legitimate file whose *name* contains "build" (e.g. `src/buildutils.py`) is NOT skipped.
+
+### Inputs & outputs
+- **Input:** `input_data["files"]` — list of file-path strings (unchanged).
+- **Output:** same `ToolResult` shape (`primary_language`, `all_languages`, `frameworks`); the fix only removes vendored/build files from the counted set, so `primary_language`/`all_languages` reflect real source. No API change.
+
+### Risks & unknowns
+- Segment-equality matching must not over-match legitimate files whose names merely contain a keyword (`buildbot.py`, `dist_utils.py`) — match whole path segments, not substrings.
+- Backslash paths (Windows) — decide whether to normalize `\` to `/` before splitting.
+- Secondary observation (out of scope for #150): `primary_language` is `sorted(languages)[0]` (alphabetical) over a `set`, not true frequency — once vendored files are excluded these tests pass, but a genuine mixed-source repo could still mis-rank. Flag for a separate issue (cf. C-16).
+
+### Edge cases
+- Vendored/build dir at repo root vs. nested vs. deeply nested — all excluded.
+- File names containing a skip keyword as a substring (`rebuild.py`, `vendored_data.py`) — NOT excluded.
+- Empty / missing `files` → `Unknown` (already handled).
+- Mixed separators / leading `./` (`./build/x.js`) — excluded.
+- A repo that is *entirely* vendored (only `node_modules/…`) → after filtering, no files remain → `primary_language: "Unknown"`.

--- a/REPRO.md
+++ b/REPRO.md
@@ -1,0 +1,82 @@
+# Reproduction — Issue #150
+
+**Issue:** Tech detector counts vendored and build-output files, skewing language detection
+https://github.com/ascherj/pathreview/issues/150
+
+## Summary
+
+`tech_detector.py` excludes vendor/build directories via `_should_skip_file`, but the
+skip patterns require a **leading slash** (`/node_modules/`, `/build/`, …). A directory
+at the repository **root** has no leading slash, so the pattern is not a substring and the
+files are **not** skipped. Their languages are then counted as source, so a
+Python project that vendors a `node_modules/` (or commits a `build/` output) is
+misreported as primarily **JavaScript**.
+
+## Steps to reproduce
+
+### 1. Direct call — the skip filter misses top-level dirs
+
+```bash
+.venv/bin/python -c "
+from agent.tools.tech_detector import TechDetector
+d = TechDetector()
+for f in ['node_modules/pkg/index.js', 'src/node_modules/pkg/index.js', 'build/bundle.js', 'dist/app.js']:
+    print(f'{f:40} skip={d._should_skip_file(f)}')
+"
+```
+
+Observed:
+
+```
+node_modules/pkg/index.js                skip=False   <- BUG (should be True)
+src/node_modules/pkg/index.js            skip=True
+build/bundle.js                          skip=False   <- BUG (should be True)
+dist/app.js                              skip=False   <- BUG (should be True)
+```
+
+Only the *nested* case is skipped; every top-level vendored/build directory leaks through.
+
+### 2. End-to-end — language detection is skewed
+
+```bash
+.venv/bin/python -c "
+from agent.tools.tech_detector import TechDetector
+files = ['src/main.py', 'utils.py', 'node_modules/a/i.js', 'node_modules/b/j.js', 'node_modules/c/k.js']
+print(TechDetector().execute({'files': files}).data)
+"
+```
+
+Observed (a two-file Python project reported as JavaScript):
+
+```
+{'primary_language': 'JavaScript', 'all_languages': ['JavaScript', 'Python'], 'frameworks': []}
+```
+
+### 3. Existing unit tests already fail
+
+```bash
+.venv/bin/pytest tests/unit/test_tech_detector.py -v
+```
+
+Observed:
+
+```
+tests/unit/test_tech_detector.py::TestTechDetector::test_node_modules_excluded FAILED
+tests/unit/test_tech_detector.py::TestTechDetector::test_build_directory_excluded FAILED
+
+>       assert data["primary_language"] == "Python"
+E       AssertionError: assert 'JavaScript' == 'Python'
+
+2 failed, 25 passed
+```
+
+## Root cause
+
+`agent/tools/tech_detector.py`, `_should_skip_file` (lines ~153–164): skip patterns are
+pre-slashed strings matched with `in`, so they only match when the directory is nested
+under another path segment. Fix is tracked in `PLAN.md`.
+
+## Environment note
+
+Local Postgres container is remapped to host port `5434` (system Postgres already holds
+`5433`); not relevant to this bug — the detector operates on a plain file-path list.

--- a/agent/tools/tech_detector.py
+++ b/agent/tools/tech_detector.py
@@ -1,6 +1,7 @@
 """Technology stack detector tool."""
 
 import structlog
+
 from .base import BaseTool, ToolResult
 
 logger = structlog.get_logger()
@@ -56,6 +57,18 @@ class TechDetector(BaseTool):
         "cmake": ("CMake", "Build"),
     }
 
+    # Vendor / build-output directory names excluded from detection
+    SKIP_DIRS = {
+        "node_modules",
+        "vendor",
+        "dist",
+        "build",
+        ".git",
+        "__pycache__",
+        ".venv",
+        "venv",
+    }
+
     def execute(self, input_data: dict) -> ToolResult:
         """Detect tech stack from files.
 
@@ -75,7 +88,7 @@ class TechDetector(BaseTool):
                     "primary_language": "Unknown",
                     "all_languages": [],
                     "frameworks": [],
-                }
+                },
             )
 
         try:
@@ -84,11 +97,7 @@ class TechDetector(BaseTool):
 
         except Exception as e:
             logger.error("tech_detector_error", error=str(e))
-            return ToolResult(
-                success=False,
-                data={},
-                error=str(e)
-            )
+            return ToolResult(success=False, data={}, error=str(e))
 
     def _detect_tech(self, files: list[str]) -> dict:
         """Detect technologies from file list.
@@ -100,10 +109,7 @@ class TechDetector(BaseTool):
             Dict with detected languages and frameworks
         """
         # Filter out vendor/build directories
-        filtered_files = [
-            f for f in files
-            if not self._should_skip_file(f)
-        ]
+        filtered_files = [f for f in files if not self._should_skip_file(f)]
 
         languages = set()
         frameworks = set()
@@ -131,8 +137,12 @@ class TechDetector(BaseTool):
         all_languages = sorted(languages)
         all_frameworks = sorted(frameworks)
 
-        logger.info("tech_detected", primary_lang=primary,
-                   languages_count=len(all_languages), frameworks_count=len(all_frameworks))
+        logger.info(
+            "tech_detected",
+            primary_lang=primary,
+            languages_count=len(all_languages),
+            frameworks_count=len(all_frameworks),
+        )
 
         return {
             "primary_language": primary,
@@ -140,9 +150,14 @@ class TechDetector(BaseTool):
             "frameworks": all_frameworks,
         }
 
-    @staticmethod
-    def _should_skip_file(filepath: str) -> bool:
+    @classmethod
+    def _should_skip_file(cls, filepath: str) -> bool:
         """Check if file should be skipped.
+
+        Matches vendor/build directories by whole path segment so that
+        top-level directories (e.g. ``node_modules/pkg/index.js``) are
+        skipped as well as nested ones. Substring matches on file names
+        (e.g. ``src/rebuild.py``) are intentionally not skipped.
 
         Args:
             filepath: File path
@@ -150,15 +165,5 @@ class TechDetector(BaseTool):
         Returns:
             True if file should be skipped
         """
-        skip_patterns = [
-            "/node_modules/",
-            "/vendor/",
-            "/dist/",
-            "/build/",
-            "/.git/",
-            "/__pycache__/",
-            "/.venv/",
-            "/venv/",
-        ]
-
-        return any(pattern in filepath for pattern in skip_patterns)
+        segments = filepath.replace("\\", "/").split("/")
+        return any(segment in cls.SKIP_DIRS for segment in segments)

--- a/tests/unit/test_tech_detector.py
+++ b/tests/unit/test_tech_detector.py
@@ -363,3 +363,88 @@ class TestTechDetector:
 
         data = result.data
         # Should detect C++ (from .cpp files)
+
+    def test_root_level_node_modules_excluded(self, detector):
+        """Top-level node_modules/ (no leading path) is excluded (#150)."""
+        files = [
+            "main.py",
+            "utils.py",
+            "node_modules/a/index.js",
+            "node_modules/b/lib.js",
+            "node_modules/c/vendor.js",
+        ]
+
+        result = detector.execute({"files": files})
+
+        data = result.data
+        assert data["primary_language"] == "Python"
+        assert "JavaScript" not in data["all_languages"]
+
+    def test_root_level_dist_excluded(self, detector):
+        """Top-level dist/ build output is excluded (#150)."""
+        files = [
+            "src/main.py",
+            "dist/bundle.js",
+            "dist/vendor.js",
+        ]
+
+        result = detector.execute({"files": files})
+
+        data = result.data
+        assert data["primary_language"] == "Python"
+        assert "JavaScript" not in data["all_languages"]
+
+    def test_root_level_vendor_excluded(self, detector):
+        """Top-level vendor/ directory is excluded (#150)."""
+        files = [
+            "app.py",
+            "vendor/lib.go",
+            "vendor/pkg.go",
+        ]
+
+        result = detector.execute({"files": files})
+
+        data = result.data
+        assert data["primary_language"] == "Python"
+        assert "Go" not in data["all_languages"]
+
+    def test_root_level_venv_excluded(self, detector):
+        """Top-level .venv/ directory is excluded (#150)."""
+        files = [
+            "app.py",
+            ".venv/lib/python3.11/site-packages/pkg/mod.py",
+            "venv/bin/script.rb",
+        ]
+
+        result = detector.execute({"files": files})
+
+        data = result.data
+        assert data["primary_language"] == "Python"
+        assert "Ruby" not in data["all_languages"]
+
+    def test_filename_containing_skip_keyword_not_excluded(self, detector):
+        """Files whose names merely contain a keyword are NOT skipped (#150)."""
+        files = [
+            "src/rebuild.py",
+            "src/vendored_data.py",
+            "distance.py",
+        ]
+
+        result = detector.execute({"files": files})
+
+        data = result.data
+        assert data["primary_language"] == "Python"
+        assert "Python" in data["all_languages"]
+
+    def test_fully_vendored_repo_is_unknown(self, detector):
+        """A repo consisting only of vendored files resolves to Unknown (#150)."""
+        files = [
+            "node_modules/a/index.js",
+            "build/bundle.js",
+        ]
+
+        result = detector.execute({"files": files})
+
+        data = result.data
+        assert data["primary_language"] == "Unknown"
+        assert data["all_languages"] == []


### PR DESCRIPTION
## Summary
The tech-stack detector was counting vendored and build-output files (e.g. a committed `node_modules/` or `build/` directory) as project source, so a Python project could be misreported as primarily JavaScript. This PR corrects the directory-exclusion logic so vendor/build files are ignored, and adds regression tests for the cases that were slipping through.

## Issue
Closes #150

## Changes
**Root cause:** `_should_skip_file` tested each path against pre-slashed patterns like `"/node_modules/"` using a substring (`in`) check. A directory at the repository *root* (e.g. `node_modules/pkg/index.js`) has no leading slash, so `"/node_modules/"` was never a substring and the file was not skipped — only *nested* occurrences (`src/node_modules/...`) matched. Those vendored files were then counted toward language detection, skewing the result.

- `agent/tools/tech_detector.py` — `_should_skip_file`: now splits the path into segments and matches each against a `SKIP_DIRS` set, so top-level, nested, and Windows-style (`\`) paths are all handled.
- `agent/tools/tech_detector.py` — extracted the skip-directory list into a `SKIP_DIRS` class constant, matching the existing `EXT_TO_LANG` / `CONFIG_INDICATORS` pattern.
- `tests/unit/test_tech_detector.py` — added 6 regression tests (see Testing).

## Testing
- [x] Unit tests pass (`make test-unit`) — *no new failures; see Notes*
- [ ] Integration tests pass (`make test-integration`) — *not run; pure file-list logic, no external services*
- [x] Linter passes (`make lint`) — *changed files clean; see Notes*
- [x] Type checker passes (`make typecheck`) — *changed source file clean; see Notes*
- [x] New/updated tests cover the changes

**Reproduce the original bug (on `main`):**
```bash
.venv/bin/pytest tests/unit/test_tech_detector.py::TestTechDetector::test_node_modules_excluded \
                 tests/unit/test_tech_detector.py::TestTechDetector::test_build_directory_excluded -v
# Both FAIL: primary_language == "JavaScript" (expected "Python")

## Screenshots / Demo
N/A — internal tool logic. Reproduction steps and before/after output are documented in `REPRO.md`.

## Notes for Reviewers
This repo has substantial **pre-existing** failures unrelated to #150. Measured on base commit `fb93406` and again on this branch:

| Gate | Base `fb93406` | This branch |
|------|----------------|-------------|
| `make lint` (ruff)   | 182 errors | 181 errors |
| `make typecheck` (mypy) | 103 errors | 103 errors |
| `make test-unit`     | 53 failed  | 51 failed  |