### PR TITLE
Docs/36 hybrid retrieval scoring formula

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -17,3 +17,17 @@
 
 **Issue checklist reasoning:**
 This is a Tier 1 / "good first issue" labeled purely as documentation work — no code paths to modify, no tests to write or break, and a stated estimate of 2–3 hours. Scope is tightly bounded to one file (`docs/ARCHITECTURE.md`), which limits merge-conflict risk and review back-and-forth. The main prerequisite is actually locating the hybrid scoring logic in the `rag` module's code to describe it accurately rather than guessing, which I'll do before writing the doc update.
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/oimahawong/pathreview/commit/968c806
+
+**Reproduction summary:**
+I traced the doc gap to `rag/retriever/hybrid.py` (`HybridRetriever.retrieve`) and confirmed the exact formula, default weights (`vector_weight=0.7`, `keyword_weight=0.3`), and `min_score=0.3` threshold that `docs/ARCHITECTURE.md` never mentions. I added an inline comment at the relevant line in `docs/ARCHITECTURE.md` documenting these specifics so the fix is grounded in the real implementation rather than guesswork.
+
+**PLAN.md link:** https://github.com/oimahawong/pathreview/blob/docs/36-hybrid-retrieval-scoring-formula/PLAN.md
+
+**Walkthrough video (recommended):** Not recorded this week.
+
+**Blockers or open questions:**
+I couldn't find any call site in the codebase that actually constructs `HybridRetriever(...)` outside its own file — no tests, no service-layer wiring located yet. I'm not yet certain the 0.7/0.3 defaults are the values used in production versus overridden somewhere I haven't found. I'll either track down the call site in Week 9 or document the weights explicitly as "constructor defaults" rather than confirmed production values.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,19 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/36
+
+**Issue title:** Architecture doc doesn't explain the hybrid retrieval scoring formula
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+`docs/ARCHITECTURE.md` mentions that PathReview's retrieval step uses "hybrid retrieval" — blending vector similarity search with BM25 keyword scoring — but it never explains how the two scores are combined or what weights are applied by default. This makes the RAG pipeline's retrieval behavior opaque to anyone reading the architecture doc, especially new contributors trying to understand or tune retrieval quality. A successful fix adds a clear section to `docs/ARCHITECTURE.md` that walks through the scoring formula, states the default weight values, and includes a worked example showing how a document's final relevance score is calculated from its vector and keyword scores. The affected area is documentation only (`rag` module concepts), with no code changes required.
+
+**Branch name:** docs/36-hybrid-retrieval-scoring-formula
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger
+
+**Issue checklist reasoning:**
+This is a Tier 1 / "good first issue" labeled purely as documentation work — no code paths to modify, no tests to write or break, and a stated estimate of 2–3 hours. Scope is tightly bounded to one file (`docs/ARCHITECTURE.md`), which limits merge-conflict risk and review back-and-forth. The main prerequisite is actually locating the hybrid scoring logic in the `rag` module's code to describe it accurately rather than guessing, which I'll do before writing the doc update.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -13,7 +13,7 @@
 
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
-**Cohort ledger:** [ ] Issue added to cohort ledger
+**Cohort ledger:** [x] Issue added to cohort ledger
 
 **Issue checklist reasoning:**
 This is a Tier 1 / "good first issue" labeled purely as documentation work — no code paths to modify, no tests to write or break, and a stated estimate of 2–3 hours. Scope is tightly bounded to one file (`docs/ARCHITECTURE.md`), which limits merge-conflict risk and review back-and-forth. The main prerequisite is actually locating the hybrid scoring logic in the `rag` module's code to describe it accurately rather than guessing, which I'll do before writing the doc update.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -31,3 +31,35 @@ I traced the doc gap to `rag/retriever/hybrid.py` (`HybridRetriever.retrieve`) a
 
 **Blockers or open questions:**
 I couldn't find any call site in the codebase that actually constructs `HybridRetriever(...)` outside its own file — no tests, no service-layer wiring located yet. I'm not yet certain the 0.7/0.3 defaults are the values used in production versus overridden somewhere I haven't found. I'll either track down the call site in Week 9 or document the weights explicitly as "constructor defaults" rather than confirmed production values.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the fix: added a "Hybrid Retrieval Scoring" subsection to `docs/ARCHITECTURE.md` covering the two signals, per-query normalization, the blend formula, the `min_score` cutoff, both edge cases (empty result set, single-method chunk), and a worked example (`0.7*0.8 + 0.3*0.4 = 0.68`). Re-confirmed there's no `HybridRetriever(...)` call site anywhere in the codebase, so the weights are documented explicitly as constructor defaults rather than confirmed production values, per the plan's fallback. Committed as `289069d`.
+
+**Next steps:**
+Run `make check` and `make test-unit` locally and confirm the change introduces no new failures (the codebase has pre-existing ruff/test failures unrelated to this change — docs-only edits can't touch them, and pre-commit's ruff/black/mypy hooks skipped with "no files to check" on this commit, confirming it). Then push, open a draft PR, and request peer/mentor review.
+
+**Blockers:**
+None. The Week 8 open question (whether 0.7/0.3 are confirmed production defaults) is resolved by documenting them as constructor defaults, per the plan's fallback — no call site was ever found.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [link to your submitted pull request]
+
+**Branch:** [the branch name you worked on, e.g. `fix/123-short-description`]
+
+**What you built:**
+[1–3 sentences summarizing what your fix does and how it works]
+
+**Tests added or updated:**
+[Which test files did you touch? What do they cover?]
+
+**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+
+**Draft PR feedback received from:** [name or Slack handle, or "none"]
+

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -49,17 +49,18 @@ None. The Week 8 open question (whether 0.7/0.3 are confirmed production default
 
 ### Check-in 2 (end of week)
 
-**PR link:** [link to your submitted pull request]
+**PR link:** https://github.com/ascherj/pathreview/pull/376
 
-**Branch:** [the branch name you worked on, e.g. `fix/123-short-description`]
+**Branch:** `docs/36-hybrid-retrieval-scoring-formula`
 
 **What you built:**
-[1–3 sentences summarizing what your fix does and how it works]
+Added a "Hybrid Retrieval Scoring" subsection to `docs/ARCHITECTURE.md` that explains how `HybridRetriever` (in `rag/retriever/hybrid.py`) combines vector similarity and BM25 keyword scores: each signal is normalized to 0–1 per query, blended as `vector_weight * vector_score + keyword_weight * keyword_score` (defaults 0.7/0.3), filtered by a `min_score` threshold, and illustrated with a worked numeric example. No application code changed — this is a documentation-only fix.
 
 **Tests added or updated:**
-[Which test files did you touch? What do they cover?]
+None. This issue is scoped entirely to `docs/ARCHITECTURE.md` (per PLAN.md and the issue's own scope) — no code paths were added, changed, or removed, so there is no new behavior to cover with tests. I confirmed the documented formula against the existing (untouched) logic in `rag/retriever/hybrid.py` and `rag/retriever/keyword_search.py` rather than adding tests for it.
 
-**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+(Both commands have pre-existing failures unrelated to this change — 182 pre-existing ruff errors and 19 pre-existing test failures across 7 files, confirmed via `git stash` to be identical with and without this change. Per the pre-existing-failures policy, "passes" here means this change introduces no new failures, which is confirmed since it only touches `docs/ARCHITECTURE.md`.)
 
-**Draft PR feedback received from:** [name or Slack handle, or "none"]
+**Draft PR feedback received from:** Pending — PR posted in course Slack channel, awaiting review.
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -62,5 +62,37 @@ None. This issue is scoped entirely to `docs/ARCHITECTURE.md` (per PLAN.md and t
 **Self-review confirmation:** [x] make check passes  [x] make test-unit passes
 (Both commands have pre-existing failures unrelated to this change — 182 pre-existing ruff errors and 19 pre-existing test failures across 7 files, confirmed via `git stash` to be identical with and without this change. Per the pre-existing-failures policy, "passes" here means this change introduces no new failures, which is confirmed since it only touches `docs/ARCHITECTURE.md`.)
 
-**Draft PR feedback received from:** Pending — PR posted in course Slack channel, awaiting review.
+**Draft PR feedback received from:** LeslieCodePath (course mentor, informal feedback — no formal review was required this term)
 
+---
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No formal reviewer feedback was assigned or required this term (per the Su26 course note). I posted my draft PR in the course Slack channel, and LeslieCodePath, a course mentor not officially enrolled this cohort, reviewed it on her own. She called it "good overall, but very verbose" and flagged three specific spots: an over-hedged sentence about the tunable weights, a wordier-than-needed `min_score` paragraph, and a worked example that only covered the passing case, not the case where filtering returns zero chunks.
+
+**How you responded:**
+Even though this wasn't required feedback, I applied all three suggestions to `docs/ARCHITECTURE.md`: simplified the tunable-weights sentence to state just the defaults and that they're configurable; condensed the `min_score` paragraph into two short sentences; and added a second worked example showing a chunk that falls below the cutoff and gets dropped, to make the "zero chunks is expected, not a bug" behavior concrete rather than just asserted.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Reading the codebase was the hardest part for me — I had to understand someone else's code well enough to trust it, without having written it myself.
+
+**What did you learn about working in a large codebase?**
+With someone else's production code, you have to be able to read and interpret it before you can even figure out the problem — there's no shortcut. With your own code, you already know the intent behind it, so understanding the issue and what needs to change comes much more naturally.
+
+**How did AI tools help — and where did they fall short?**
+AI was useful for helping me locate the right files for this issue and explaining what functions did. Where it fell short was keeping my writing short and simple — my first draft came out more verbose than it needed to be, which is exactly what my reviewer flagged.
+
+**What would you do differently if you started over?**
+I'd aim to write more simply and get to the point from the start, instead of needing reviewer feedback to catch it.
+
+**What are you most proud of from this module?**
+I'm most proud of figuring out how to approach an unfamiliar problem — knowing what to look for and how to track down the answer on my own.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,32 @@
+## Solution plan
+
+**Issue:** Architecture doc doesn't explain the hybrid retrieval scoring formula (#36) — https://github.com/ascherj/pathreview/issues/36
+
+### Understand
+`docs/ARCHITECTURE.md`'s RAG System section states that hybrid retrieval "blends vector and BM25 keyword scores" but stops there — it never explains how the two scores are combined, what the default weights are, or how results get filtered. Expected behavior: a reader of the architecture doc should be able to predict a chunk's final relevance score without reading source code. Actual behavior: the formula only exists in `rag/retriever/hybrid.py` (`HybridRetriever.retrieve`), where vector and BM25 scores are each normalized to 0–1 (divided by the max score in their respective result set), then blended as `vector_weight * vector_score + keyword_weight * keyword_score` with defaults `vector_weight=0.7`, `keyword_weight=0.3`, and results below `min_score=0.3` are dropped. The root cause is a documentation gap, not a code bug — the fix is entirely in the doc.
+
+### Map
+- `docs/ARCHITECTURE.md` — add a new subsection under "RAG System (`rag/`)" explaining the formula, default weights, and threshold. This is the only file that needs to change.
+- `rag/retriever/hybrid.py` (`HybridRetriever.__init__`, `HybridRetriever.retrieve`) — source of truth for the formula and defaults; read-only reference, not modified.
+- `rag/retriever/keyword_search.py` (`KeywordSearcher.search`) — source of truth for how BM25 scores are produced before blending; read-only reference.
+- `docs/adr/` — check whether an existing ADR already covers retrieval design decisions, to link from rather than duplicate.
+
+### Plan
+1. Re-read `hybrid.py` and `keyword_search.py` end to end to confirm there's no additional normalization or override path I'm missing (e.g. config-driven weights).
+2. Search the codebase for any place `HybridRetriever(...)` is actually constructed, to confirm whether the 0.7/0.3 defaults are the values actually used in production, or whether something overrides them at call time.
+3. Draft a new "Hybrid Retrieval Scoring" subsection in `docs/ARCHITECTURE.md`: describe the two signals, the normalization step, the blending formula, and the `min_score` cutoff in plain language plus a short formula line.
+4. Add one worked numeric example (e.g., a chunk with vector_score=0.8, keyword_score=0.4 → blended score 0.68) so the abstract formula is concrete.
+5. Note in the doc that the weights are constructor parameters (not hardcoded constants), so readers know they're tunable.
+
+### Inputs & outputs
+Input: the existing, unchanged logic in `rag/retriever/hybrid.py` and `rag/retriever/keyword_search.py`. Output: an updated `docs/ARCHITECTURE.md` with a new subsection covering the scoring formula, default weights, and a worked example — no application code changes.
+
+### Risks & unknowns
+- I couldn't find any call site that actually constructs `HybridRetriever(...)` outside its own file — no tests, no service wiring found yet. Before documenting 0.7/0.3 as "the" defaults, I need to confirm nothing overrides them elsewhere (step 2 above); if I can't find a call site at all, I'll document them as "constructor defaults" rather than implying they're confirmed production values.
+- There are no existing unit tests for `HybridRetriever`, so I can't cross-check the formula against test fixtures — I'm relying solely on reading the source.
+- Score normalization is per-query (divides by the max score within that query's result set), not a fixed global scale — I need to word this precisely in the doc so it isn't misread as an absolute 0-1 confidence score.
+
+### Edge cases
+- Empty result sets: `vector_scores_max`/`keyword_scores_max` default to `1.0` when no results exist, avoiding a divide-by-zero — worth a one-line mention so readers don't assume a bug if they see an empty set behave differently.
+- A chunk found by only one retrieval method (vector or keyword, not both) — the doc should show that the missing side's score defaults to 0 rather than being excluded outright.
+- `min_score` filtering out every candidate (e.g., a very short or unusual query) — worth noting that this can legitimately return zero chunks, since that's a real possible outcome of the threshold, not a bug.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -59,6 +59,16 @@ A plan-execute orchestrator that coordinates multiple analysis tools. Each tool 
 ### RAG System (`rag/`)
 Hybrid retrieval (vector similarity + BM25 keyword) fetches relevant context from the user's ingested documents. The generator uses prompt templates to produce structured, evidence-based feedback. The evaluator scores retrieval relevance and generation faithfulness.
 
+<!-- Reproduction note for issue #36: this paragraph is the entire extent of the current
+     hybrid retrieval explanation. It names the two signals but never states how they are
+     combined. The actual logic lives in rag/retriever/hybrid.py (HybridRetriever.retrieve):
+     vector and BM25 scores are each normalized to 0-1 by dividing by the max score in their
+     result set, then blended as `vector_weight * vector_score + keyword_weight * keyword_score`
+     using default weights vector_weight=0.7, keyword_weight=0.3 (set in
+     HybridRetriever.__init__). Results below min_score=0.3 are dropped before the top
+     max_chunks are returned. None of this - the formula, the default weights, or a worked
+     example - appears in this doc. That's the gap this issue asks to close. -->
+
 ### Safety Layer (`safety/`)
 Middleware wrapping the generation pipeline. Components run in sequence: prompt injection defense → content filter → bias detector → PII scrubber. All safety events are logged with structured metadata for monitoring.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -59,15 +59,28 @@ A plan-execute orchestrator that coordinates multiple analysis tools. Each tool 
 ### RAG System (`rag/`)
 Hybrid retrieval (vector similarity + BM25 keyword) fetches relevant context from the user's ingested documents. The generator uses prompt templates to produce structured, evidence-based feedback. The evaluator scores retrieval relevance and generation faithfulness.
 
-<!-- Reproduction note for issue #36: this paragraph is the entire extent of the current
-     hybrid retrieval explanation. It names the two signals but never states how they are
-     combined. The actual logic lives in rag/retriever/hybrid.py (HybridRetriever.retrieve):
-     vector and BM25 scores are each normalized to 0-1 by dividing by the max score in their
-     result set, then blended as `vector_weight * vector_score + keyword_weight * keyword_score`
-     using default weights vector_weight=0.7, keyword_weight=0.3 (set in
-     HybridRetriever.__init__). Results below min_score=0.3 are dropped before the top
-     max_chunks are returned. None of this - the formula, the default weights, or a worked
-     example - appears in this doc. That's the gap this issue asks to close. -->
+#### Hybrid Retrieval Scoring
+
+`HybridRetriever.retrieve` (`rag/retriever/hybrid.py`) combines two independent signals for each candidate chunk:
+
+- **Vector score** — cosine similarity from `VectorStore.query`.
+- **Keyword score** — BM25 relevance from `KeywordSearcher.search`.
+
+The two signals live on different scales, so each is normalized to 0–1 before blending by dividing every score in a result set by the maximum score in that same result set. This normalization is per query, not a fixed global scale — a vector score of `1.0` means "the best vector match for this query," not an absolute similarity threshold. If a result set is empty, its max defaults to `1.0` to avoid a divide-by-zero.
+
+A chunk found by only one retrieval method (say, a strong keyword match with no vector hit) is not excluded — the missing side's score defaults to `0`, so the chunk is still scored using only the signal it has.
+
+The normalized scores are blended as:
+
+```
+score = vector_weight * vector_score + keyword_weight * keyword_score
+```
+
+`vector_weight` and `keyword_weight` are constructor parameters of `HybridRetriever`, not hardcoded constants, defaulting to `vector_weight=0.7` and `keyword_weight=0.3`. No call site in this codebase currently constructs `HybridRetriever` with overrides, so these defaults are also the only values in effect today — but they remain tunable per instance.
+
+Chunks with a blended score below `min_score` (default `0.3`) are dropped before the remaining results are sorted and truncated to `max_chunks`. A short or unusual query can legitimately push every candidate below `min_score`, returning zero chunks — that's expected threshold behavior, not a bug.
+
+**Worked example:** a chunk with normalized `vector_score=0.8` and `keyword_score=0.4` blends to `0.7 * 0.8 + 0.3 * 0.4 = 0.68`, which clears the `0.3` `min_score` cutoff.
 
 ### Safety Layer (`safety/`)
 Middleware wrapping the generation pipeline. Components run in sequence: prompt injection defense → content filter → bias detector → PII scrubber. All safety events are logged with structured metadata for monitoring.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -76,11 +76,13 @@ The normalized scores are blended as:
 score = vector_weight * vector_score + keyword_weight * keyword_score
 ```
 
-`vector_weight` and `keyword_weight` are constructor parameters of `HybridRetriever`, not hardcoded constants, defaulting to `vector_weight=0.7` and `keyword_weight=0.3`. No call site in this codebase currently constructs `HybridRetriever` with overrides, so these defaults are also the only values in effect today — but they remain tunable per instance.
+`vector_weight` and `keyword_weight` default to `vector_weight=0.7` and `keyword_weight=0.3`. The defaults are tunable per instance since the constructor parameters remain configurable.
 
-Chunks with a blended score below `min_score` (default `0.3`) are dropped before the remaining results are sorted and truncated to `max_chunks`. A short or unusual query can legitimately push every candidate below `min_score`, returning zero chunks — that's expected threshold behavior, not a bug.
+Chunks with a blended score below `min_score` (default `0.3`) are dropped. Remaining results are sorted by score (descending) and truncated to the top `max_chunks` results.
 
-**Worked example:** a chunk with normalized `vector_score=0.8` and `keyword_score=0.4` blends to `0.7 * 0.8 + 0.3 * 0.4 = 0.68`, which clears the `0.3` `min_score` cutoff.
+**Worked examples:**
+- A chunk with normalized `vector_score=0.8` and `keyword_score=0.4` blends to `0.7 * 0.8 + 0.3 * 0.4 = 0.68`, which clears the `0.3` `min_score` cutoff and is returned.
+- A chunk with normalized `vector_score=0.2` and `keyword_score=0.1` blends to `0.7 * 0.2 + 0.3 * 0.1 = 0.17`, which falls below the `0.3` cutoff and is dropped. If every candidate for a query scores this low, `retrieve` legitimately returns zero chunks — that's expected threshold behavior, not a bug.
 
 ### Safety Layer (`safety/`)
 Middleware wrapping the generation pipeline. Components run in sequence: prompt injection defense → content filter → bias detector → PII scrubber. All safety events are logged with structured metadata for monitoring.


### PR DESCRIPTION
## Summary
Adds a "Hybrid Retrieval Scoring" subsection to `docs/ARCHITECTURE.md` explaining how PathReview's `HybridRetriever` combines vector similarity and BM25 keyword scores into a single relevance score. The doc previously said retrieval "blends vector and BM25 keyword scores" but never explained the formula, the default weights, or the score threshold — this closes that gap with a plain-language walkthrough and a worked numeric example. No application code changed.

## Issue
Closes #36

## Changes
- Replaced the reproduction-note comment in `docs/ARCHITECTURE.md` with a real subsection covering: the two signals (vector score, BM25 keyword score), the per-query 0–1 normalization step, the blend formula (`vector_weight * vector_score + keyword_weight * keyword_score`), the `min_score` filtering threshold, two edge cases (empty result set defaulting to a max of 1.0; a chunk found by only one method defaulting the other side to 0), and a worked example (`0.7*0.8 + 0.3*0.4 = 0.68`).
- Documented `vector_weight=0.7` / `keyword_weight=0.3` explicitly as `HybridRetriever` constructor defaults rather than confirmed production values — I searched the codebase for any place that constructs `HybridRetriever(...)` and found none outside its own file, so there's no evidence anything overrides these defaults, but also no evidence they're exercised in a real call path.

## Testing
- [x] Unit tests pass (`make test-unit`) — 409 passed, 19 pre-existing failures, 428 collected (see below; none touch this change)
- [x] Integration tests pass (`make test-integration`) — N/A, no code changed
- [x] Linter passes (`make lint`) — pre-commit's ruff hook reported "no files to check" on this docs-only commit, confirming no Python files were touched
- [x] Type checker passes (`make typecheck`) — same reason (mypy hook: "no files to check")
- [x] New/updated tests cover the changes — N/A, this is a documentation-only change; no code paths were added or modified, so no tests apply (per CONTRIBUTING.md and PLAN.md scoping)

**Pre-existing failures (unrelated to this change):**
This repo has pre-existing `make check`/`make test-unit` failures unaffected by this PR:
- `make lint`: 182 pre-existing ruff errors across the codebase (86 auto-fixable), none in `docs/ARCHITECTURE.md` — confirmed via `git stash` + re-run that the error count is identical with and without this change.
- `make test-unit`: 19 pre-existing failures out of 428 collected tests (409 passing), spread across `test_batch_processor.py` (1), `test_bias_detector.py` (9), `test_faithfulness_checker.py` (4), `test_keyword_search.py` (1), `test_output_parser.py` (1), `test_structural_chunker.py` (1), and `test_tech_detector.py` (2). None of these files were touched by this PR, and a docs-only diff cannot affect Python test execution or outcomes.

This PR does not introduce any new lint or test failures; it only adds documentation.

## Screenshots / Demo
N/A — documentation change, no UI/behavior change.

## Notes for Reviewers
- This is scoped purely to `docs/ARCHITECTURE.md`; no application code was touched.
- The 0.7/0.3 weight defaults are documented as constructor defaults (not confirmed production values) because no call site constructing `HybridRetriever` exists in the codebase today. If a reviewer knows of a call site I missed, happy to update the wording to reflect confirmed production usage.
- Pre-existing lint/test failures noted above are documented per the course's pre-existing-failures policy and are unrelated to this change.

**How to manually verify this change:**
1. Open `rag/retriever/hybrid.py` and read `HybridRetriever.__init__` and `HybridRetriever.retrieve` side by side with the new subsection in `docs/ARCHITECTURE.md`.
2. Confirm the doc's normalization description matches lines computing `vector_scores_max` / `keyword_scores_max` and the `if vector_scores_max > 0 else 0` guards.
3. Confirm the blend formula in the doc (`vector_weight * vector_score + keyword_weight * keyword_score`) matches the `blended_score` computation in `retrieve`.
4. Confirm the stated defaults (`vector_weight=0.7`, `keyword_weight=0.3`, `min_score=0.3`) match the constructor/method signatures.
5. Recompute the worked example by hand: `0.7 * 0.8 + 0.3 * 0.4` should equal `0.68`, matching the doc.
6. Optionally, run `grep -rn "HybridRetriever(" --include="*.py" .` from the repo root to confirm there's still no call site overriding the defaults, which is why the doc frames them as "constructor defaults" rather than confirmed production values.