### PR TITLE
Fix #151: refactor regex patterns to detect more bias patterns

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -120,20 +120,32 @@ However, regex patterns are still deterministic pattern matching and more limite
 
 **Blockers:**
 
+None
+
 ---
 
 ### Check-in 2 (end of week)
 
-**PR link:** [link to your submitted pull request]
+**PR link:** 
 
-**Branch:** [the branch name you worked on, e.g. `fix/123-short-description`]
+https://github.com/ascherj/pathreview/pull/378
+
+**Branch:** 
+
+`fix/151-bias-detector-patterns`
 
 **What you built:**
-[1–3 sentences summarizing what your fix does and how it works]
+
+- Refactored the regex patterns to generalize the concept of SOURCE, PERSON, NEG_QUALITY and DESIRED_PROPERTY to capture their synoymns and plurals, and then standardize their usage across all the regex expressions so that the overall set of expressions are simplified and more easily maintainable.
+- Added a new pattern to connect those concepts within a sentence boundary, so that they don't have to be immediately next to each other to trigger a bias flag.
 
 **Tests added or updated:**
 [Which test files did you touch? What do they cover?]
 
-**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+- Added test_dismissive_bootcamp_language_rephrased_detected(self) in tests/unit/test_bias_detector.py to test that bias is detected for natural language rephrasings.
 
-**Draft PR feedback received from:** [name or Slack handle, or "none"]
+**Self-review confirmation:** [X] make check passes  [X] make test-unit passes
+
+**Draft PR feedback received from:** 
+
+none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -10,7 +10,7 @@ I picked this issue because:
 
 1. The solution looks appropriate and feasible for my skillset:
 - It is a 'Tier 1' issue, which is the guidance for someone like me who is making their first open source contribution
-- I've double-check from a global project search for that the class class and method defined in `bias_detector.py` is limited to just that file and it's unit tests `test_bias_detector.py` -- so limited complexity and blast radius for any fix
+- I've double-check from a global project search that class and method defined in `bias_detector.py` is limited to just that file and it's unit tests `test_bias_detector.py` -- so limited complexity and blast radius for any fix
 - The identified code is in Python, which I'm comfortable with 
 
 2. I've confirmed that it is a live issue by rerunning `test_bias_detector.py`. As reported, 9 unit tests are failing. 
@@ -20,7 +20,7 @@ I picked this issue because:
 
 **Problem summary:**
 
-The method checks reviews for two types of bias -- dismissive assessments (e.g., "bootcamp graduates lack rigor") or demographic steroetypes (e.g, "young developers can't handle complex systems") -- and returns `is_biased == True` if bias is detected.    
+The method checks reviews for two types of bias -- dismissive assessments (e.g., "bootcamp graduates lack rigor") or demographic stereotypes (e.g, "young developers can't handle complex systems") -- and returns `is_biased == True` if bias is detected.    
 
 However the regex patterns for `DISMISSIVE_PATTERNS` and `DEMOGRAPHIC_PATTERNS` in `bias_detector.py` are too strict and miss other common phrasings that mean the same thing (e.g, "the candidate only attended a bootcamp, so this project lacks sufficient rigor"), resulting in some biased statements being marked as `is_biased == False`. 
 
@@ -34,3 +34,41 @@ An alternative solution is to use LLM as a classifier, although the effort to im
 
 **Cohort ledger:** [X] Issue added to cohort ledger
 
+
+**Reproduction commit link:** [link to commit documenting the reproduced issue]
+
+
+
+**Reproduction summary:**
+
+I added an additional unit test `test_dismissive_bootcamp_language_rephrased_detected` to verify that the bug reporter's rephrasing ("The candidate only attended a bootcamp, so this project lacks the rigor of a formal CS education.") is incorrectly passing the bias test. 
+
+The new unit test and another 9 tests cited by bug reporter are failing as reported, i.e., incorrectly classifying biased test as `False`. See output of running of `.venv/bin/pytest tests/unit/test_bias_detector.py -v` below:
+
+```
+
+====================================================== short test summary info ======================================================
+FAILED tests/unit/test_bias_detector.py::TestBiasDetector::test_dismissive_bootcamp_language_detected - assert False is True
+FAILED tests/unit/test_bias_detector.py::TestBiasDetector::test_dismissive_bootcamp_language_rephrased_detected - assert False is True
+FAILED tests/unit/test_bias_detector.py::TestBiasDetector::test_bootcamp_lacks_rigor_detected - assert False is True
+FAILED tests/unit/test_bias_detector.py::TestBiasDetector::test_demographic_assumption_age_detected - assert False is True
+FAILED tests/unit/test_bias_detector.py::TestBiasDetector::test_coding_bootcamp_variant - assert False is True
+FAILED tests/unit/test_bias_detector.py::TestBiasDetector::test_developer_vs_programmer_distinction - assert False is True
+FAILED tests/unit/test_bias_detector.py::TestBiasDetector::test_multiple_bias_indicators - assert False is True
+FAILED tests/unit/test_bias_detector.py::TestBiasDetector::test_negative_educational_claim - assert False is True
+FAILED tests/unit/test_bias_detector.py::TestBiasDetector::test_rich_poor_assumption - assert False is True
+FAILED tests/unit/test_bias_detector.py::TestBiasDetector::test_assumption_vs_observation - assert False is True
+=================================================== 10 failed, 23 passed in 0.17s ===================================================
+```
+
+**PLAN.md link:** [link to PLAN.md in your fork]
+
+https://github.com/chungmengcheong/pathreview/blob/fix/151-bias-detector-patterns/PLAN.md
+
+
+**Walkthrough video (recommended):** [link to your Loom video, ≤2 min — shared for early feedback]
+
+
+**Blockers or open questions:**
+
+No blockers or open questions

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -148,4 +148,5 @@ https://github.com/ascherj/pathreview/pull/378
 
 **Draft PR feedback received from:** 
 
-none
+@LeslieCodePath
+

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -150,3 +150,56 @@ https://github.com/ascherj/pathreview/pull/378
 
 @LeslieCodePath
 
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [X] Yes  [ ] No — still awaiting review
+
+**Summary of feedback:**
+
+@LeslieCodePath left three inline comments on `safety/bias_detector.py`: 
+- two of the shared regex constants (`SOURCE`'s `online\s+(course)?` and `DESIRED_PROPERTY`'s `(proper\s+)?training`) used capturing groups whose output was never read, adding unnecessary overhead  
+- the 30/40-character gap in my "connector" pattern (e.g., "bootcamp... so... lacks rigor") wasn't bounded by sentence punctuation, so it could span across unrelated sentences instead of staying within one dismissive claim; 
+- a question on whether `re.DOTALL` was needed if the input could span multiple lines. They also left an encouraging general note that "regex is a bit of black magic" and that even once familiar with it, you can't judge how effective a pattern is until you test it.
+
+**How you responded:**
+
+- I fixed the two missed capturing groups to non-capturing groups. 
+- For the sentence-boundary issue, I replaced the ad hoc `[^.]` gap with a shared `GAP` constant that excludes `.`, `!`, `?`, and newlines, so the pattern can no longer bridge across a real sentence or line break 
+- For the `DOTALL` question, I checked the reasoning with Claude Code first: `DOTALL` only changes what `.` matches and wouldn't affect this pattern's boundary behavior, and enabling it to let `.*` cross newlines would have reopened the same false-positive risk the reviewer had just flagged — so I responded in the PR thread with that reasoning instead of applying the suggestion as-is.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+
+Getting the regex patterns to actually work correctly took far longer than I expected. I now know what the PR reviewer meant by "even once you're very familiar w/ regex, it'll still be unclear... until you test it," :)
+
+I was clumsy with the mechanics of doing the git workflow, and doing so correctly and professionally took nearly as much care as the code itself, specifically on making sure that:
+- every clone, branch, commit, and pull request step was free of mistakes
+- content at each step (commit messages, PR description, feedback responses) met the expected level of detail and style
+
+**What did you learn about working in a large codebase?**
+
+The biggest lesson was around "fitting in" to the existing codebase. I had to take time upfront to internalize the codebase's existing mental model, coding patterns, and style guidelines, especially when they differed from how I'd naturally approach something. 
+
+I ended up refactoring the initial regex patterns in `bias_detector.py` to pull out and generalize SOURCE, PERSON, NEG_QUALITY and DESIRED_PROPERTY because I thought that made the code more readable and maintainable in the future. However that took up considerably more time for something that I didn't have to do in order to address the reported issue and make the code pass the failing unit tests. This was a trivial situation, but it has now made me more aware that I need to make a judgment call on whether to do a 'quick patch' or a more substantive refactoring when working on future issues.  
+
+**How did AI tools help — and where did they fall short?**
+
+For learning concepts, I used ChatGPT to learn regex from scratch and to decipher the intent behind the existing patterns in `bias_detector.py`. 
+
+For the mechanics, I used Claude Code to double-check my work, decipher error and output messages from the command line, and walk me step-by-step through Docker and git CLI setup. 
+
+The AI tools were also helpful in reasoning through a reviewer's suggestion rather than applying it blindly. I asked Claude whether `re.DOTALL` was needed for multi-line input, and it explained that `DOTALL` wouldn't fix the boundary issue and would reopen a false-positive risk already raised in review, which let me respond to the reviewer with an explanation rather than a guess.
+
+**What would you do differently if you started over?**
+
+If I were optimizing purely for time, I would have picked a different bug. The solution was clear after I had identified the issue (I needed to "loosen" the regex patterns), but I found regex to be difficult to build an intuition for and getting the patterns right was finicky work. 
+
+**What are you most proud of from this module?**
+
+I spent time scanning through parts of the codebase unrelated to my bug, and I'm proud that I understood both conceptually and mechanically much more of it than I expected going in. I feel more confident that I have a working sense of the patterns behind a modern AI application.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -35,8 +35,9 @@ An alternative solution is to use LLM as a classifier, although the effort to im
 **Cohort ledger:** [X] Issue added to cohort ledger
 
 
-**Reproduction commit link:** [link to commit documenting the reproduced issue]
+**Reproduction commit link:** 
 
+https://github.com/chungmengcheong/pathreview/commit/2ac590662e70251df38bef162ed06975af6ed95b
 
 
 **Reproduction summary:**
@@ -63,11 +64,12 @@ FAILED tests/unit/test_bias_detector.py::TestBiasDetector::test_assumption_vs_ob
 
 **PLAN.md link:** [link to PLAN.md in your fork]
 
-https://github.com/chungmengcheong/pathreview/blob/fix/151-bias-detector-patterns/PLAN.md
+
 
 
 **Walkthrough video (recommended):** [link to your Loom video, ≤2 min — shared for early feedback]
 
+No video
 
 **Blockers or open questions:**
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,18 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/151
+
+**Issue title:** Bias detector patterns are too narrow to match common phrasings #151
+
+**Tier:** [X] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+[In 3–5 sentences, in your own words: what the issue is (not a copy-paste of
+the title), what is currently broken or missing, and what a successful fix
+would accomplish. Naming the part of the codebase it affects is helpful context.]
+
+**Branch name:** https://github.com/chungmengcheong/pathreview/tree/fix/151-bias-detector-patterns
+
+**Setup confirmation:** [ ] App runs locally at localhost:5173
+
+**Cohort ledger:** [X] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -6,13 +6,31 @@
 
 **Tier:** [X] Tier 1  [ ] Tier 2  [ ] Tier 3
 
+I picked this issue because: 
+
+1. The solution looks appropriate and feasible for my skillset:
+- It is a 'Tier 1' issue, which is the guidance for someone like me who is making their first open source contribution
+- I've double-check from a global project search for that the class class and method defined in `bias_detector.py` is limited to just that file and it's unit tests `test_bias_detector.py` -- so limited complexity and blast radius for any fix
+- The identified code is in Python, which I'm comfortable with 
+
+2. I've confirmed that it is a live issue by rerunning `test_bias_detector.py`. As reported, 9 unit tests are failing. 
+
+3. It does not have a PR that fixes it, so I'm not duplicating or wasting effort.
+
+
 **Problem summary:**
-[In 3–5 sentences, in your own words: what the issue is (not a copy-paste of
-the title), what is currently broken or missing, and what a successful fix
-would accomplish. Naming the part of the codebase it affects is helpful context.]
 
-**Branch name:** https://github.com/chungmengcheong/pathreview/tree/fix/151-bias-detector-patterns
+The method checks reviews for two types of bias -- dismissive assessments (e.g., "bootcamp graduates lack rigor") or demographic steroetypes (e.g, "young developers can't handle complex systems") -- and returns `is_biased == True` if bias is detected.    
 
-**Setup confirmation:** [ ] App runs locally at localhost:5173
+However the regex patterns for `DISMISSIVE_PATTERNS` and `DEMOGRAPHIC_PATTERNS` in `bias_detector.py` are too strict and miss other common phrasings that mean the same thing (e.g, "the candidate only attended a bootcamp, so this project lacks sufficient rigor"), resulting in some biased statements being marked as `is_biased == False`. 
+
+My hypothesized solution is to make the regex less restrictive to catch a broader range of similar phrasing, so that those are properly assessed as `is_biased == True`. The known unknown is that I'm not familiar with regex so I don't know how effective the fix would be or how much effort is required. 
+
+An alternative solution is to use LLM as a classifier, although the effort to implement and test this would likely elevate it to a higher issue tier. 
+
+**Branch name:** fix/151-bias-detector-patterns
+
+**Setup confirmation:** [X] App runs locally at localhost:5173
 
 **Cohort ledger:** [X] Issue added to cohort ledger
+

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -34,6 +34,7 @@ An alternative solution is to use LLM as a classifier, although the effort to im
 
 **Cohort ledger:** [X] Issue added to cohort ledger
 
+## Week 8 — Reproduction & solution planning
 
 **Reproduction commit link:** 
 
@@ -64,7 +65,7 @@ FAILED tests/unit/test_bias_detector.py::TestBiasDetector::test_assumption_vs_ob
 
 **PLAN.md link:** [link to PLAN.md in your fork]
 
-
+https://github.com/chungmengcheong/pathreview/blob/fix/151-bias-detector-patterns/PLAN.md
 
 
 **Walkthrough video (recommended):** [link to your Loom video, ≤2 min — shared for early feedback]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -75,3 +75,65 @@ No video
 **Blockers or open questions:**
 
 No blockers or open questions
+
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+
+Per the plan, I have:
+
+1. Refactored the regex patterns to generalize the concept of `SOURCE`, `PERSON`, `NEG_QUALITY` and `DESIRED_PROPERTY` to capture their synoymns and plurals, 
+
+```
+    SOURCE = r"(?:(?:coding\s+)?bootcamp|self-taught|online\s+(course)?)"
+    PERSON = r"(?:graduates?|developers?|programmers?|person|people)"
+    NEG_QUALITY = r"(?:insufficient|inadequate|lack|lacking|lacks)"
+    DESIRED_PROPERTY = r"(?:code|rigor|fundamentals|proper\s+training|preparation)"
+```
+
+and then standardize their usage across all the regex expressions so that the overall set of expressions are simplified and more easily maintainable, e.g., 
+
+```
+        rf"(?:{SOURCE})\s+(?:education|training)\s+(?:is\s+)?{NEG_QUALITY}",
+        rf"(?:{SOURCE})\s+attendance\s+means\s+({NEG_QUALITY})\s+{DESIRED_PROPERTY}",
+```
+
+2. Added a new pattern to connect those concepts within a sentence boundary, so that they don't have to be immediately next to each other to trigger a bias flag, i.e.:
+```
+        rf"(?:{SOURCE})\b"
+        r"(?:[^.]){0,40}?\b(?:so|because|since|thus|therefore|which\s+means)\b(?:[^.]){0,30}?\b"
+        rf"{NEG_QUALITY}\s+"
+        rf"(?:the\s+)?{DESIRED_PROPERTY}\b",
+```
+
+3. Added a new unit test `test_dismissive_bootcamp_language_rephrased_detected` to verify that the alternative rephrasing reported in #151 is correctly flagged as bias. 
+
+
+**Next steps:**
+
+The refactoring are passing the unit tests and have addressed the issue. 
+
+However, regex patterns are still deterministic pattern matching and more limited compared to a natural language classifier. I'll create a future enhancement request to refactor this module to an AI classifier if there is sufficient need. 
+
+**Blockers:**
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [link to your submitted pull request]
+
+**Branch:** [the branch name you worked on, e.g. `fix/123-short-description`]
+
+**What you built:**
+[1–3 sentences summarizing what your fix does and how it works]
+
+**Tests added or updated:**
+[Which test files did you touch? What do they cover?]
+
+**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+
+**Draft PR feedback received from:** [name or Slack handle, or "none"]

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,70 @@
+## Solution plan
+
+**Issue:** [issue title and link]
+
+Bias detector patterns are too narrow to match common phrasings #151
+https://github.com/ascherj/pathreview/issues/151
+
+### Understand
+What is the root cause of this issue? What behavior is expected vs. actual?
+
+`detect_bias` in `bias_detector.py` uses a set of regex patterns (`DISMISSIVE_PATTERNS`, `DEMOGRAPHIC_PATTERNS`) to detect bias in a provided text. The patterns are written such that they require near-exact phrase adjacency (fixed word order, inconsistent plural nouns, one verb per concept). 
+
+As such, natural paraphrases will not be detected by the existing patterns. For example, "bootcamp graduates lack rigor" is detected, but not "the candidate only attented a bootcamp, so this project lacks sufficient rigor". 
+
+
+### Map
+Which files, functions, or modules are involved?
+List the specific files you expect to touch.
+
+1. `bias_detector.py` - file containing the `detect_bias` method
+2. `DISMISSIVE_PATTERNS`, `DEMOGRAPHIC_PATTERNS` - regex patterns referenced by `detect_bias`. I'll modify the regex patterns here. 
+3. `test_bias_detector.py` - file containing the unit tests with different biased and non-biased texts. I'll add a unit test for the bug reporter's natural rephrasing following existing patterns. I'll also rerun the entire set of tests to make the fix passes all of them. 
+
+
+### Plan
+What are the steps to fix this issue?
+Break it into 3–5 concrete sub-tasks.
+
+1. Review the failing unit tests in `test_bias_detector.py` to identify how the existing regex patterns are failing
+
+2. Modify the patterns in `DISMISSIVE_PATTERNS` and `DEMOGRAPHIC_PATTERNS` to catch the failing patterns as well as other potential refinements. 
+
+3. Add an additional unit tests into `test_bias_detector.py` with the bug reporter's natural rephrasing 
+
+4. Rerurn the entire set of tests in `test_bias_detector.py` to make the fix makes all the test pass. Note, I'm skipping running the entire test suite as `detect_bias` is only referenced by `test_bias_detector.py`.  
+
+
+### Inputs & outputs
+What does your fix take as input? What should it produce or change?
+
+The fix preserves the existing behavior as documented in docstring for `detect_bias`, i.e., 
+- Input: text
+- Output: Tuple of `(is_biased, reason)`
+
+
+### Risks & unknowns
+What could go wrong? What are you still unsure about?
+
+I'm "loosening" the regex patterns to catch rephrasings. However this could generate more false-positives and false-negatives. For example, I could trigger a false-positive for "The bootcamp training was solid, so this project doesn't lack rigor." 
+
+On a larger note, regex patterns are deterministic pattern matching and as limited compared to a natural language classifier. For example, an approach that uses connectors (e.g., `so|because|since`) to allow triggers words to be further apart in a sentence may not be exhaustive (e.g., misses `given|given that`). 
+
+We'll have to monitor the degree of false-positives and false-negatives to keep refining the patterns, and potentially even consider implementing a different classifier approach (e.g., LLM classifier). 
+
+
+### Edge cases
+What inputs or states should your fix handle gracefully?
+
+1. **Unrelated co-occurrence.** Widening a pattern to match "bootcamp" and "lacks rigor" anywhere in the text risks matching two unrelated observations that happen to co-occur, not an actual dismissive claim. 
+
+Example: "Your resume lists a bootcamp certificate under Education. The system design write-up lacks the rigor expected for this level of role."
+
+2. **Broadening trigger words.** Adding additional trigger words (e.g., `missing`, `gap`) may make it more likely to trigger false-postives. 
+
+Example: "Your resume is missing details on international education."
+    
+
+
+
+

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -99,7 +99,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -449,7 +448,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -473,7 +471,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1561,7 +1558,6 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1579,7 +1575,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1972,7 +1967,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3507,7 +3501,6 @@
       "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^2.0.1",
         "cssstyle": "^4.0.1",
@@ -4094,7 +4087,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4107,7 +4099,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4771,7 +4762,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/safety/bias_detector.py
+++ b/safety/bias_detector.py
@@ -10,10 +10,12 @@ logger = structlog.get_logger()
 class BiasDetector:
     """Detect biased language in feedback."""
 
-    SOURCE = r"(?:(?:coding\s+)?bootcamp|self-taught|online\s+(course)?)"
+    SOURCE = r"(?:(?:coding\s+)?bootcamp|self-taught|online\s+(?:course)?)"
     PERSON = r"(?:graduates?|developers?|programmers?|person|people)"
     NEG_QUALITY = r"(?:insufficient|inadequate|lack|lacking|lacks)"
-    DESIRED_PROPERTY = r"(?:code|rigor|fundamentals|(proper\s+)?training|preparation)"
+    DESIRED_PROPERTY = r"(?:code|rigor|fundamentals|(?:proper\s+)?training|preparation)"
+    # Excludes sentence terminators and newlines so cross-topic text can't bridge a match.
+    GAP = r"(?:[^.!?\n])"
 
     DISMISSIVE_PATTERNS = [
         rf"(?:{SOURCE})\s+(?:education|training)\s+(?:is\s+)?{NEG_QUALITY}",
@@ -23,9 +25,9 @@ class BiasDetector:
         rf"(?:{SOURCE})\s+(?:doesn't|does\s+not)\s+prepare\s+(?:you|developers?)",
         rf"(?:{SOURCE})(?:\s+{PERSON})?\s+"
         rf"(?:is|are)\s+(?:not|never)\s+(?:equal|comparable)\s+to\s+(?:university|traditional|formal)",
-        rf"(?:{SOURCE})\s+attendance\s+means\s+({NEG_QUALITY})\s+{DESIRED_PROPERTY}",
+        rf"(?:{SOURCE})\s+attendance\s+means\s+{NEG_QUALITY}\s+{DESIRED_PROPERTY}",
         rf"(?:{SOURCE})\b"
-        r"(?:[^.]){0,40}?\b(?:so|because|since|thus|therefore|which\s+means)\b(?:[^.]){0,30}?\b"
+        rf"{GAP}{{0,30}}?\b(?:so|because|since|thus|therefore|which\s+means)\b{GAP}{{0,30}}?\b"
         rf"{NEG_QUALITY}\s+"
         rf"(?:the\s+)?{DESIRED_PROPERTY}\b",
     ]
@@ -34,7 +36,8 @@ class BiasDetector:
     DEMOGRAPHIC_PATTERNS = [
         rf"(?:young|old|aged)\s+(?:{PERSON})\s+(?:can't|cannot|won't|will\s+not)",
         rf"(?:{PERSON}|coming)\s+from\s+(?:poor|rich|working[\s-]?class)",
-        rf"(?:immigrant|international|foreign)\s+{PERSON}?.*(?:can't|cannot|won't|will\s+not|struggle|lacks?|missing)",
+        rf"(?:immigrant|international|foreign)\s+{PERSON}?{GAP}{{0,40}}?"
+        r"(?:can't|cannot|won't|will\s+not|struggle|lacks?|missing)",
     ]
 
     @staticmethod

--- a/safety/bias_detector.py
+++ b/safety/bias_detector.py
@@ -1,6 +1,7 @@
 """Bias detection in generated feedback."""
 
 import re
+
 import structlog
 
 logger = structlog.get_logger()
@@ -9,19 +10,31 @@ logger = structlog.get_logger()
 class BiasDetector:
     """Detect biased language in feedback."""
 
-    # Genuinely dismissive phrases about educational background
+    SOURCE = r"(?:(?:coding\s+)?bootcamp|self-taught|online\s+(course)?)"
+    PERSON = r"(?:graduates?|developers?|programmers?|person|people)"
+    NEG_QUALITY = r"(?:insufficient|inadequate|lack|lacking|lacks)"
+    DESIRED_PROPERTY = r"(?:code|rigor|fundamentals|(proper\s+)?training|preparation)"
+
     DISMISSIVE_PATTERNS = [
-        r"(?:bootcamp|self-taught|online\s+course)\s+(?:education|training)\s+is\s+(?:insufficient|inadequate|lacks)",
-        r"(?:bootcamp|self-taught)\s+(?:graduates?|developers?)\s+(?:lack|missing)\s+(?:rigor|fundamentals|proper\s+training)",
-        r"(?:bootcamp|coding\s+bootcamp)\s+(?:doesn't|does\s+not)\s+prepare\s+(?:you|developers?)",
-        r"(?:self-taught|bootcamp)\s+is\s+(?:not|never)\s+(?:equal|comparable)\s+to\s+(?:university|traditional|formal)",
+        rf"(?:{SOURCE})\s+(?:education|training)\s+(?:is\s+)?{NEG_QUALITY}",
+        rf"(?:{SOURCE})\s+{PERSON}\s+"
+        rf"(?:lacks?|missing|can't|cannot)\s+(?:write\s+|handle\s+)?"
+        rf"(?:(?:production\s+|enterprise\s+)?{DESIRED_PROPERTY}|(?:production\s+|complex\s+)?systems)",
+        rf"(?:{SOURCE})\s+(?:doesn't|does\s+not)\s+prepare\s+(?:you|developers?)",
+        rf"(?:{SOURCE})(?:\s+{PERSON})?\s+"
+        rf"(?:is|are)\s+(?:not|never)\s+(?:equal|comparable)\s+to\s+(?:university|traditional|formal)",
+        rf"(?:{SOURCE})\s+attendance\s+means\s+({NEG_QUALITY})\s+{DESIRED_PROPERTY}",
+        rf"(?:{SOURCE})\b"
+        r"(?:[^.]){0,40}?\b(?:so|because|since|thus|therefore|which\s+means)\b(?:[^.]){0,30}?\b"
+        rf"{NEG_QUALITY}\s+"
+        rf"(?:the\s+)?{DESIRED_PROPERTY}\b",
     ]
 
     # Demographic assumptions (about age, background, identity)
     DEMOGRAPHIC_PATTERNS = [
-        r"(?:young|old|aged)\s+(?:person|developer|programmer)\s+(?:can't|cannot|won't|will\s+not)",
-        r"(?:person\s+from|coming\s+from)\s+(?:poor|rich|working[\s-]?class)",
-        r"(?:immigrant|international|foreign)\s+developers?.*(?:can't|cannot|won't|struggle)",
+        rf"(?:young|old|aged)\s+(?:{PERSON})\s+(?:can't|cannot|won't|will\s+not)",
+        rf"(?:{PERSON}|coming)\s+from\s+(?:poor|rich|working[\s-]?class)",
+        rf"(?:immigrant|international|foreign)\s+{PERSON}?.*(?:can't|cannot|won't|will\s+not|struggle|lacks?|missing)",
     ]
 
     @staticmethod

--- a/tests/unit/test_bias_detector.py
+++ b/tests/unit/test_bias_detector.py
@@ -19,7 +19,7 @@ class TestBiasDetector:
         assert reason != ""
 
     def test_dismissive_bootcamp_language_rephrased_detected(self) -> None:
-        """Test alternative phrasing of dismissive bootcamp language is detected as biased."""
+        """Test alternative dismissive bootcamp language is detected as biased."""
         text = (
             "The candidate only attended a bootcamp, so this project lacks "
             "the rigor of a formal CS education."

--- a/tests/unit/test_bias_detector.py
+++ b/tests/unit/test_bias_detector.py
@@ -9,7 +9,7 @@ from safety.bias_detector import BiasDetector
 class TestBiasDetector:
     """Test suite for BiasDetector."""
 
-    def test_dismissive_bootcamp_language_detected(self):
+    def test_dismissive_bootcamp_language_detected(self) -> None:
         """Test dismissive bootcamp language is detected as biased."""
         text = "bootcamp graduates can't write production code"
 
@@ -18,7 +18,19 @@ class TestBiasDetector:
         assert is_biased is True
         assert reason != ""
 
-    def test_bootcamp_lacks_rigor_detected(self):
+    def test_dismissive_bootcamp_language_rephrased_detected(self) -> None:
+        """Test alternative phrasing of dismissive bootcamp language is detected as biased."""
+        text = (
+            "The candidate only attended a bootcamp, so this project lacks "
+            "the rigor of a formal CS education."
+        )
+
+        is_biased, reason = BiasDetector.detect_bias(text)
+
+        assert is_biased is True
+        assert reason != ""
+
+    def test_bootcamp_lacks_rigor_detected(self) -> None:
         """Test 'bootcamp lacks rigor' language detected."""
         text = "bootcamp education lacks fundamentals"
 
@@ -26,7 +38,7 @@ class TestBiasDetector:
 
         assert is_biased is True
 
-    def test_bootcamp_inadequate_training_detected(self):
+    def test_bootcamp_inadequate_training_detected(self) -> None:
         """Test 'bootcamp inadequate training' language detected."""
         text = "bootcamp training is inadequate for professional development"
 
@@ -34,7 +46,7 @@ class TestBiasDetector:
 
         assert is_biased is True
 
-    def test_self_taught_comparison_detected(self):
+    def test_self_taught_comparison_detected(self) -> None:
         """Test self-taught vs traditional comparison detected."""
         text = "self-taught is never comparable to university education"
 
@@ -42,7 +54,7 @@ class TestBiasDetector:
 
         assert is_biased is True
 
-    def test_positive_bootcamp_mention_not_flagged(self):
+    def test_positive_bootcamp_mention_not_flagged(self) -> None:
         """Test positive bootcamp mention is NOT flagged as biased."""
         text = "your bootcamp background shows strong fundamentals and problem-solving skills"
 
@@ -50,7 +62,7 @@ class TestBiasDetector:
 
         assert is_biased is False
 
-    def test_neutral_bootcamp_mention_not_flagged(self):
+    def test_neutral_bootcamp_mention_not_flagged(self) -> None:
         """Test neutral bootcamp mention is NOT flagged."""
         text = "this bootcamp project demonstrates good coding practices"
 
@@ -58,7 +70,7 @@ class TestBiasDetector:
 
         assert is_biased is False
 
-    def test_educational_background_positive_not_flagged(self):
+    def test_educational_background_positive_not_flagged(self) -> None:
         """Test positive educational background mention not flagged."""
         text = "your bootcamp training has given you a solid foundation"
 
@@ -66,7 +78,7 @@ class TestBiasDetector:
 
         assert is_biased is False
 
-    def test_demographic_assumption_age_detected(self):
+    def test_demographic_assumption_age_detected(self) -> None:
         """Test demographic assumption about age detected."""
         text = "young developers can't handle complex systems"
 
@@ -75,7 +87,7 @@ class TestBiasDetector:
         assert is_biased is True
         assert "demographic" in reason.lower()
 
-    def test_demographic_assumption_old_detected(self):
+    def test_demographic_assumption_old_detected(self) -> None:
         """Test age assumption about older developers detected."""
         text = "old aged programmer won't be able to learn new technologies"
 
@@ -83,7 +95,7 @@ class TestBiasDetector:
 
         assert is_biased is True
 
-    def test_demographic_assumption_background_detected(self):
+    def test_demographic_assumption_background_detected(self) -> None:
         """Test background assumption detected."""
         text = "person from poor background can't afford proper training"
 
@@ -91,7 +103,7 @@ class TestBiasDetector:
 
         assert is_biased is True
 
-    def test_immigrant_developer_assumption_detected(self):
+    def test_immigrant_developer_assumption_detected(self) -> None:
         """Test assumption about immigrant developers detected."""
         text = "immigrant developers can't communicate effectively in code reviews"
 
@@ -99,7 +111,7 @@ class TestBiasDetector:
 
         assert is_biased is True
 
-    def test_international_developer_assumption_detected(self):
+    def test_international_developer_assumption_detected(self) -> None:
         """Test assumption about international developers detected."""
         text = "international developers struggle with American coding standards"
 
@@ -107,23 +119,28 @@ class TestBiasDetector:
 
         assert is_biased is True
 
-    def test_clean_feedback_not_flagged(self):
+    def test_clean_feedback_not_flagged(self) -> None:
         """Test clean, objective feedback is not flagged."""
-        text = "You have demonstrated strong Python skills. Your code is well-organized and follows best practices."
+        text = (
+            "You have demonstrated strong Python skills. Your code is "
+            "well-organized and follows best practices."
+        )
 
         is_biased, reason = BiasDetector.detect_bias(text)
 
         assert is_biased is False
 
-    def test_technical_feedback_not_flagged(self):
+    def test_technical_feedback_not_flagged(self) -> None:
         """Test pure technical feedback not flagged."""
-        text = "Consider adding error handling to your API endpoints and documenting the parameters."
+        text = (
+            "Consider adding error handling to your API endpoints and documenting the parameters."
+        )
 
         is_biased, reason = BiasDetector.detect_bias(text)
 
         assert is_biased is False
 
-    def test_development_suggestion_not_flagged(self):
+    def test_development_suggestion_not_flagged(self) -> None:
         """Test development suggestions not flagged."""
         text = "To improve your portfolio, try learning Kubernetes and contributing to open source."
 
@@ -131,7 +148,7 @@ class TestBiasDetector:
 
         assert is_biased is False
 
-    def test_case_insensitive_detection(self):
+    def test_case_insensitive_detection(self) -> None:
         """Test detection is case insensitive."""
         text = "BOOTCAMP GRADUATES LACK FUNDAMENTALS"
 
@@ -139,7 +156,7 @@ class TestBiasDetector:
 
         assert is_biased is True
 
-    def test_return_value_structure(self):
+    def test_return_value_structure(self) -> None:
         """Test return value has correct structure."""
         text = "some feedback"
         result = BiasDetector.detect_bias(text)
@@ -150,7 +167,7 @@ class TestBiasDetector:
         assert isinstance(is_biased, bool)
         assert isinstance(reason, str)
 
-    def test_unbiased_returns_empty_reason(self):
+    def test_unbiased_returns_empty_reason(self) -> None:
         """Test unbiased feedback returns empty reason string."""
         text = "Great coding skills"
 
@@ -159,7 +176,7 @@ class TestBiasDetector:
         if is_biased is False:
             assert reason == ""
 
-    def test_biased_returns_reason(self):
+    def test_biased_returns_reason(self) -> None:
         """Test biased feedback returns non-empty reason."""
         text = "bootcamp graduates can't code"
 
@@ -169,19 +186,19 @@ class TestBiasDetector:
             assert reason != ""
             assert len(reason) > 0
 
-    def test_empty_text(self):
+    def test_empty_text(self) -> None:
         """Test with empty text."""
         is_biased, reason = BiasDetector.detect_bias("")
 
         assert is_biased is False
 
-    def test_whitespace_only(self):
+    def test_whitespace_only(self) -> None:
         """Test with whitespace only."""
         is_biased, reason = BiasDetector.detect_bias("   \n\t  ")
 
         assert is_biased is False
 
-    def test_coding_bootcamp_variant(self):
+    def test_coding_bootcamp_variant(self) -> None:
         """Test 'coding bootcamp' variant is detected."""
         text = "coding bootcamp graduates can't write enterprise code"
 
@@ -189,7 +206,7 @@ class TestBiasDetector:
 
         assert is_biased is True
 
-    def test_online_course_bias_detected(self):
+    def test_online_course_bias_detected(self) -> None:
         """Test online course dismissal detected."""
         text = "online course education is insufficient for real work"
 
@@ -197,7 +214,7 @@ class TestBiasDetector:
 
         assert is_biased is True
 
-    def test_developer_vs_programmer_distinction(self):
+    def test_developer_vs_programmer_distinction(self) -> None:
         """Test both developer and programmer terms detected."""
         text_dev = "bootcamp developers can't handle production systems"
         text_prog = "bootcamp programmers lack proper training"
@@ -208,15 +225,17 @@ class TestBiasDetector:
         assert is_biased_dev is True
         assert is_biased_prog is True
 
-    def test_multiple_bias_indicators(self):
+    def test_multiple_bias_indicators(self) -> None:
         """Test text with multiple bias indicators."""
-        text = "young bootcamp graduates can't write code and immigrant developers lack fundamentals"
+        text = (
+            "young bootcamp graduates can't write code and immigrant developers lack fundamentals"
+        )
 
         is_biased, reason = BiasDetector.detect_bias(text)
 
         assert is_biased is True
 
-    def test_negative_educational_claim(self):
+    def test_negative_educational_claim(self) -> None:
         """Test negative claims about education detected."""
         text = "self-taught developers are not equal to university graduates"
 
@@ -224,7 +243,7 @@ class TestBiasDetector:
 
         assert is_biased is True
 
-    def test_working_class_assumption(self):
+    def test_working_class_assumption(self) -> None:
         """Test working-class assumption detected."""
         text = "person from working class background won't succeed in tech"
 
@@ -232,7 +251,7 @@ class TestBiasDetector:
 
         assert is_biased is True
 
-    def test_rich_poor_assumption(self):
+    def test_rich_poor_assumption(self) -> None:
         """Test rich/poor background assumption detected."""
         text = "developers from poor backgrounds can't afford proper tools"
 
@@ -240,7 +259,7 @@ class TestBiasDetector:
 
         assert is_biased is True
 
-    def test_foreign_developer_struggle_assumption(self):
+    def test_foreign_developer_struggle_assumption(self) -> None:
         """Test assumption about foreign developers struggling."""
         text = "foreign developers struggle with English-first codebases"
 
@@ -248,23 +267,29 @@ class TestBiasDetector:
 
         assert is_biased is True
 
-    def test_skill_assessment_not_biased(self):
+    def test_skill_assessment_not_biased(self) -> None:
         """Test skill assessment without bias language."""
-        text = "Your JavaScript skills are at an intermediate level. Practice would help advance to senior level."
+        text = (
+            "Your JavaScript skills are at an intermediate level. Practice "
+            "would help advance to senior level."
+        )
 
         is_biased, reason = BiasDetector.detect_bias(text)
 
         assert is_biased is False
 
-    def test_comparative_without_bias(self):
+    def test_comparative_without_bias(self) -> None:
         """Test comparison without biased assumptions."""
-        text = "Your bootcamp education covers practical skills. University education provides theory. Both have value."
+        text = (
+            "Your bootcamp education covers practical skills. University "
+            "education provides theory. Both have value."
+        )
 
         is_biased, reason = BiasDetector.detect_bias(text)
 
         assert is_biased is False
 
-    def test_assumption_vs_observation(self):
+    def test_assumption_vs_observation(self) -> None:
         """Test that observations are not flagged, assumptions are."""
         observation = "your resume shows bootcamp attendance"  # Factual
         assumption = "bootcamp attendance means inadequate training"  # Biased


### PR DESCRIPTION
## Summary
The bias detection in `safety/bias_detector.py` uses regex patterns that require near-exact phrase adjacency (fixed word order, inconsistent plural nouns, one verb per concept). As such, natural paraphrases will not be detected by the existing patterns. 

Relatedly, 9 out of 32 pre-existing unit tests in `test/unit/test_bias_detector.py` specifying the intended coverage are failing.

## Issue
Closes #151 - Bias detector patterns are too narrow to match common phrasings

## Changes
- Refactored the regex patterns to generalize the concept of `SOURCE`, `PERSON`, `NEG_QUALITY` and `DESIRED_PROPERTY` to capture their synoymns and plurals, and then standardize their usage across all the regex expressions so that the overall set of expressions are simplified and more easily maintainable.
- Added a new pattern to connect those concepts within a sentence boundary, so that they don't have to be immediately next to each other to trigger a bias flag.

## Testing
- [X] Unit tests pass (`make test-unit`)

All unit tests for bias_detector.py pass. 

The remaining 44 failed tests were failing prior to my changes. 
```
============================ 44 failed, 385 passed, 1 warning in 5.46s =============================

/Users/ccm/Documents/CS/codepath/pathreview/.venv/lib/python3.13/site-packages/_pytest/unraisableexception.py:33: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited

  gc.collect()

RuntimeWarning: Enable tracemalloc to get the object allocation traceback

make: *** [test-unit] Error 1
```

- [ ] Integration tests pass (`make test-integration`)

`make test-integration` did not run; this was the behavior prior to my changes: 
```
collected 0 items                                                                
====================================== no tests ran in 0.07s =======================================
make: *** [test-integration] Error 5
```

- [ ] Linter passes (`make lint`)

`make lint` was failing prior with 177 pre-existing errors prior to my changes. The pre-commit `ruff --fix` hook fixed one error with remaining 176 failing:

```
Found 176 errors.

[*] 85 fixable with the `--fix` option (42 hidden fixes can be enabled with the `--unsafe-fixes` option).

make: *** [lint] Error 1
```


- [ ] Type checker passes (`make typecheck`)

`make typecheck` was failing prior to my changes:
```
Found 5 errors in 4 files (errors prevented further checking)
make: *** [typecheck] Error 2
```


- [X] New/updated tests cover the changes

Added `test_dismissive_bootcamp_language_rephrased_detected(self)` in `tests/unit/test_bias_detector.py` to test that bias is detected for natural language rephrasings. 

**Manual testing**:

To run a manual test, in this case using the issue reporter's phrasing: 

```
python -c "from safety.bias_detector import BiasDetector; 
  print(BiasDetector.detect_bias('The candidate only attended a bootcamp, so this project lacks the rigor of a formal CS education.'))"
```
 
Expect (True, 'Dismissive language about educational background').


## Screenshots / Demo
<!-- If applicable, add screenshots or a link to a demo video -->
None

## Notes for Reviewers
<!-- Anything the reviewer should pay particular attention to -->


The "looser" regex patterns catch more rephrasings. However this could generate more false-positives. Regex patterns are still deterministic pattern matching and more limited compared to a natural language classifier. A future enhancement request to refactor this module into an AI classifier may be necessary.