### PR TITLE
Fix/154 health check raw sql string

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -29,3 +29,61 @@ Wrote an integration test hitting GET /health with a real Postgres instance (via
 
 **Blockers or open questions:**
 Noticed a separate, unrelated bug in the Redis check (settings.redis_host/redis_port don't exist on Settings — only redis_url does), which independently forces the endpoint to 503. Scoped my test assertion to just the postgres dependency so it isn't coupled to that separate issue.
+
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the fix in api/routes/health.py (wrapped the raw "SELECT 1"
+string in sqlalchemy.text()). Added a unit test in tests/unit/test_health.py
+that mocks the DB session and verifies db.execute() receives a TextClause
+instead of a raw string, plus tests for both the healthy and failing-probe
+cases. Integration test from Week 8 passes against a real DB. Ran ruff/black
+scoped to the two files I touched — both pass clean.
+
+**Next steps:**
+Open a draft PR, get peer/mentor feedback in Slack, then finalize and mark
+ready for review.
+
+**Blockers:**
+None so far. Noted a separate pre-existing bug in the Redis check
+(settings.redis_host/redis_port don't exist on Settings) out of scope
+for #154, documented it in the PR notes rather than fixing it here.
+
+---
+
+Good — that's your PR description, well done. Now Check-in 2 in JOURNAL.md is a separate, shorter thing: a summary of the PR for your journal, not a repeat of the PR itself. Here's a version tailored to what you've actually done, using real content instead of placeholders:
+
+markdown
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/hoanggddo/pathreview/pull/[379]
+
+**Branch:** fix/154-health-check-raw-sql-string
+
+**What you built:**
+Fixed the health check's Postgres probe, which was passing a raw
+"SELECT 1" string to db.execute() — SQLAlchemy 2.x no longer implicitly
+coerces strings into executable SQL, so this raised ArgumentError and
+caused the health check to falsely report the database as down. Wrapped
+the query in sqlalchemy.text() to resolve it.
+
+**Tests added or updated:**
+- tests/unit/test_health.py (new): mocks the DB session and verifies
+  db.execute() receives a proper TextClause instead of a raw string,
+  plus covers both the healthy-probe and failing-probe cases
+- tests/integration/test_health.py (new): hits GET /health against a
+  real Postgres instance via the existing CI service container
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+(Ran scoped equivalents on Windows without make: `pytest tests/unit -v -m unit`,
+`ruff check` + `black --check` on the two changed files. Documented
+53 pre-existing, unrelated test failures and 5 pre-existing mypy errors
+in the PR notes — confirmed present on main before this change and not
+introduced by it.)
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,16 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/154
+
+**Issue title:** Health check DB probe passes a raw SQL string, which fails under SQLAlchemy 2.x
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The app's health check endpoint verifies the database is reachable by running a small probe query, but it passes that query to SQLAlchemy as a plain Python string instead of wrapping it in SQLAlchemy's `text()` construct. SQLAlchemy 2.x removed the automatic coercion that used to let raw strings work as executable SQL, so the probe now throws an error instead of returning a healthy status. This means the health check endpoint — which other services or monitoring tools may rely on to confirm the API is up — can report false failures even when the database is actually fine. A successful fix updates the DB probe to use the correct SQLAlchemy 2.x-compatible syntax so the health check accurately reflects database connectivity again. This affects the API layer, specifically the health check route and its database session handling.
+
+**Branch name:** fix/154-health-check-raw-sql-string
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -14,3 +14,18 @@ The app's health check endpoint verifies the database is reachable by running a 
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** (https://github.com/hoanggddo/pathreview/blob/fix/154-health-check-raw-sql-string/tests/integration/test_health.py)
+
+**Reproduction summary:**
+Wrote an integration test hitting GET /health with a real Postgres instance (via the existing CI docker service). The test fails because db.execute("SELECT 1") raises ArgumentError under SQLAlchemy 2.x — the health check catches this and reports postgres as "unhealthy" even though the database is reachable
+
+**PLAN.md link:** https://github.com/hoanggddo/pathreview/blob/fix/154-health-check-raw-sql-string/PLAN.md
+
+**Walkthrough video (recommended):** [link to your Loom video, ≤2 min — optional]
+
+**Blockers or open questions:**
+Noticed a separate, unrelated bug in the Redis check (settings.redis_host/redis_port don't exist on Settings — only redis_url does), which independently forces the endpoint to 503. Scoped my test assertion to just the postgres dependency so it isn't coupled to that separate issue.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -29,3 +29,25 @@ Wrote an integration test hitting GET /health with a real Postgres instance (via
 
 **Blockers or open questions:**
 Noticed a separate, unrelated bug in the Redis check (settings.redis_host/redis_port don't exist on Settings — only redis_url does), which independently forces the endpoint to 503. Scoped my test assertion to just the postgres dependency so it isn't coupled to that separate issue.
+
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the fix in api/routes/health.py (wrapped the raw "SELECT 1"
+string in sqlalchemy.text()). Added a unit test in tests/unit/test_health.py
+that mocks the DB session and verifies db.execute() receives a TextClause
+instead of a raw string, plus tests for both the healthy and failing-probe
+cases. Integration test from Week 8 passes against a real DB. Ran ruff/black
+scoped to the two files I touched — both pass clean.
+
+**Next steps:**
+Open a draft PR, get peer/mentor feedback in Slack, then finalize and mark
+ready for review.
+
+**Blockers:**
+None so far. Noted a separate pre-existing bug in the Redis check
+(settings.redis_host/redis_port don't exist on Settings) out of scope
+for #154, documented it in the PR notes rather than fixing it here.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -82,3 +82,36 @@ introduced by it.)
 
 **Draft PR feedback received from:** none
 
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No reviewer feedback came in. Reviewer feedback isn't a feature this term
+
+**How you responded:**
+N/A 
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The tooling friction was the biggest surprise, not the actual bug fix. The fix itself was a two-line change once I understood SQLAlchemy 2.x's argument validation. What took real time was getting a working local environment on Windows `make` isn't available without WSL/Git Bash, so I had to translate every Makefile target into its underlying command by hand. I also created a virtual environment in the wrong directory at one point (`api\routes` instead of the repo root) and didn't catch it until `pip install -e ".[dev]"` failed with a confusing "not a Python project" error. Reading the actual error message carefully, rather than assuming the tool was broken, was the fix.
+
+**What did you learn about working in a large codebase?**
+The biggest lesson was that a codebase this size already has its own failures baked in running the full unit suite surfaced 53 pre-existing failures completely unrelated to my issue (bias detection, PII scrubbing, resume parsing, tech detection, etc.). Early on I assumed a clean test run was the bar to clear; it wasn't. The actual bar was proving my two changed files didn't add to that number. I also learned that fixing one bug can surface adjacent ones while scoping my test assertions, I found that the health check's Redis probe references `settings.redis_host`/`redis_port`, which don't exist on the `Settings` class at all. That's a second, independent bug that made the endpoint always return 503 regardless of my fix. Deciding not to fix it (documenting it instead, and scoping my tests around it) was its own judgment call about staying inside the boundary of the issue I was actually assigned.
+
+**How did AI tools help — and where did they fall short?**
+AI was most useful for reading unfamiliar parts of the codebase quickly  tracing `get_db`, checking whether `asyncio_mode` was set in `pyproject.toml`, finding the CI workflow's Postgres service container, and matching existing test patterns (e.g., how `tests/unit/test_review_service.py` mocks an `AsyncSession` with `AsyncMock`) rather than guessing at conventions from scratch. It also caught a real correctness issue I wouldn't have thought to check for on my own: that a mocked `AsyncMock` won't enforce SQLAlchemy's real argument-type validation, so a naive "does execute() get called" test would have passed even on the buggy code and the test had to check the actual type of the argument passed.
+
+Where it fell short: it couldn't run anything in my actual environment. It doesn't have live access to my filesystem, so every fix had to be manually copied over, and mismatches (wrong file paths, forgetting to rename a file, git conflicts from editing JOURNAL.md in two places) were something only I could catch by actually running things myself. I also had to be the one to verify that claims about tool behavior (like how AsyncMock handles arguments) actually held against the specific versions installed in my environment.
+
+**What would you do differently if you started over?**
+I would set up my environment correctly (venv at repo root, confirm `pyproject.toml` is right there) before running any commands, rather than discovering the mistake through a failed install. I'd also run the full unrelated test suite and `mypy`/`ruff`/`black` checks earlier establishing the pre-existing-failure baseline in Week 8 rather than Week 9 would have saved me from wondering whether my own changes caused any of that noise.
+
+**What are you most proud of from this module?**
+Catching the separate Redis bug and making the deliberate choice not to fix it. It would have been easy to either ignore it (and have a permanently-failing integration test that looked like my fix didn't work) or scope-creep into fixing it too. Documenting it clearly, scoping my tests around it, and explaining the reasoning in the PR notes felt like the most "real engineering" moment of the whole module more than the actual one-line fix.
+

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,51 @@
+## Solution plan
+
+**Issue:** Database health probe fails with `ArgumentError` because raw SQL string isn't wrapped in `text()` — (https://github.com/ascherj/pathreview/issues/154)
+
+### Understand
+
+**Root cause:** `api/routes/health.py` executes a literal Python string, `"SELECT 1"`, directly against the SQLAlchemy session/connection (e.g. `session.execute("SELECT 1")`). SQLAlchemy 1.x implicitly coerced bare strings into textual SQL clauses, so this worked. SQLAlchemy 2.x removed that implicit coercion — `execute()` now only accepts executable constructs (`select()`, `text()`, ORM statements, etc.), not plain strings. Passing a raw string raises:
+
+```
+sqlalchemy.exc.ArgumentError: Textual SQL expression 'SELECT 1' should be
+explicitly declared as text('SELECT 1')
+```
+
+**Expected behavior:** `GET /health` should report `"database": "up"` (or equivalent) whenever the database is reachable.
+
+**Actual behavior:** The probe raises `ArgumentError` on every call. That exception is caught by a broad `try/except` in the health check (intended to catch real connectivity failures) and reported as `"database": "down"` — even when the database is completely healthy. It's a false negative caused by an API mismatch, not an actual outage, and it's currently indistinguishable from a real DB failure because the exception is swallowed rather than logged.
+
+### Map
+
+Files/functions expected to be touched:
+- `api/routes/health.py` — the route handler and/or helper function (e.g. `check_database()`) containing the raw `"SELECT 1"` call. This needs the `text()` import and wrapper.
+- `api/tests/` (or wherever the test suite lives) — add/extend a test that calls the health route against a live/test DB session and asserts the DB check reports healthy.
+- Possibly other modules with the same pattern — need to grep the codebase for `.execute("` to check whether this bug exists in more than one place (e.g. a shared DB utility module, other probes, migrations scripts run at startup).
+
+### Plan
+
+1. **Reproduce and document**: confirm the `ArgumentError` locally by calling `GET /health` (or invoking the route/helper directly in a test) with a live DB session, and capture the traceback.
+2. **Grep the codebase** for other bare-string `.execute()` calls (`grep -rn '\.execute("' api/`) to scope whether this is a single-line fix or needs to be applied in multiple places.
+3. **Apply the fix**: import `text` from `sqlalchemy` in `api/routes/health.py` and wrap the literal query as `session.execute(text("SELECT 1"))` (and in any async equivalent, keep the `await`).
+4. **Tighten error handling**: make sure the `except` block around the probe logs the exception (rather than silently swallowing it) so a similar regression is visible in logs next time, instead of just flipping a status flag with no trace.
+5. **Add a regression test** that runs the health route against a test DB session and asserts the database check reports "up", so this can't silently reappear.
+
+### Inputs & outputs
+
+- **Input:** an HTTP `GET /health` request (or a direct unit-test call into the route handler) with a live/test SQLAlchemy session.
+- **Output before fix:** health response reporting `"database": "down"` due to a swallowed `ArgumentError`, and a hidden traceback in logs (or nothing, if the exception is silently caught).
+- **Output after fix:** health response reporting `"database": "up"` when the DB is reachable, and a real `"down"` status (with logged exception) only for genuine connectivity failures.
+
+### Risks & unknowns
+
+- Unsure whether `api/routes/health.py` uses a sync `Session` or an `AsyncSession` — the fix is the same (`text()`), but the surrounding `await`/session-management code needs to be read carefully before editing.
+- The same bare-string `.execute()` pattern might exist in other files (other health/readiness probes, startup scripts, migration helpers) — need to grep broadly rather than assuming this is the only occurrence.
+- The current broad `except Exception` around the probe may be masking other, unrelated errors beyond this one — tightening it could surface issues that were previously hidden, so I'll want to check CI/logs after the fix, not just locally.
+- Need to confirm which SQLAlchemy version is pinned in `requirements.txt`/`pyproject.toml` to make sure this is in fact a 1.x→2.x behavior change and not something else version-specific.
+
+### Edge cases
+
+- Database temporarily unreachable (real outage) — health check should still correctly report "down" and not be masked by this fix.
+- Async vs sync session usage — the wrapped `text()` call must still be awaited correctly if the session is async.
+- Other raw-SQL call sites elsewhere in the codebase using the same unwrapped-string pattern — should be caught by the grep step, not left for a future bug report.
+- Health check timeout behavior — confirm that fixing the false failure doesn't change timeout/latency handling around the probe.

--- a/api/routes/health.py
+++ b/api/routes/health.py
@@ -1,6 +1,8 @@
-from fastapi import APIRouter, HTTPException, status, Depends
+from datetime import datetime
+
 import structlog
-from datetime import datetime, timedelta
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import text
 
 from core.database import get_db
 
@@ -28,7 +30,7 @@ async def health_check(db=Depends(get_db)):
 
     try:
         # Check PostgreSQL
-        await db.execute("SELECT 1")
+        await db.execute(text("SELECT 1"))
         health_status["dependencies"]["postgres"] = "healthy"
         log.debug("postgres_health_check_passed")
     except Exception as exc:
@@ -39,6 +41,7 @@ async def health_check(db=Depends(get_db)):
     try:
         # Check Redis (if available)
         import redis
+
         from core.config import settings
 
         r = redis.Redis(

--- a/tests/integration/test_health.py
+++ b/tests/integration/test_health.py
@@ -1,0 +1,67 @@
+"""Reproduction test for issue #154.
+
+The Postgres probe in api/routes/health.py runs:
+
+    await db.execute("SELECT 1")
+
+SQLAlchemy 2.x no longer implicitly coerces a raw Python string into an
+executable SQL construct. Passing a bare string raises:
+
+    sqlalchemy.exc.ArgumentError: Textual SQL expression 'SELECT 1' should be
+    explicitly declared as text('SELECT 1')
+
+That ArgumentError is caught by the broad `except Exception` in
+health_check(), so instead of GET /health returning 200 with
+dependencies.postgres == "healthy", it returns 503 with
+dependencies.postgres == "unhealthy" -- a false negative, since the
+database itself is reachable and functioning.
+
+This test runs against a real Postgres instance (see the `postgres`
+service container in .github/workflows/ci.yml, and `docker-compose.yml`
+for local dev), matching how the rest of tests/integration is exercised
+in CI. It currently FAILS on main / before the fix. After wrapping the
+literal query in sqlalchemy.text(), it should pass.
+"""
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from api.main import app
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_health_check_reports_postgres_healthy():
+    """
+    With a real, reachable database, GET /health should report
+    dependencies.postgres == "healthy" and an overall 200 status.
+
+    Before the fix: fails because db.execute("SELECT 1") raises
+    ArgumentError under SQLAlchemy 2.x, which is caught and reported as
+    "unhealthy", causing the endpoint to return 503 instead of 200.
+    """
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/health")
+
+    body = response.json()
+    # health_check() raises HTTPException(503, detail=health_status) if ANY
+    # dependency is unhealthy, so the payload we want lives under "detail"
+    # in that case.
+    payload = body["detail"] if response.status_code == 503 else body
+
+    # NOTE: this assertion is scoped to postgres only, on purpose.
+    # settings.redis_host / settings.redis_port referenced in the redis
+    # check below don't actually exist on Settings (only redis_url does),
+    # so the redis check independently raises AttributeError and reports
+    # "unhealthy" regardless of this fix. That's a separate bug from #154,
+    # so we don't want it to make this reproduction test look unresolved
+    # once the postgres fix lands. Overall response.status_code is
+    # deliberately NOT asserted here for the same reason.
+    assert payload["dependencies"]["postgres"] == "healthy", (
+        f"Expected postgres to report healthy, got: "
+        f"{payload['dependencies']['postgres']}. This reproduces issue #154: "
+        "the raw 'SELECT 1' string passed to db.execute() is not wrapped in "
+        "sqlalchemy.text(), so SQLAlchemy 2.x raises ArgumentError and the "
+        "health check reports a false failure."
+    )

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -1,0 +1,82 @@
+"""Tests for the health check route (api/routes/health.py)."""
+
+from contextlib import suppress
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import TextClause
+
+from api.routes.health import health_check
+
+
+@pytest.mark.unit
+class TestHealthCheckPostgresProbe:
+    """Test suite for the postgres dependency check in health_check().
+
+    Regression coverage for #154: db.execute() was being called with a
+    raw Python string ("SELECT 1") instead of a sqlalchemy.text() clause.
+    SQLAlchemy 2.x raises ArgumentError for bare strings, which was being
+    silently caught by health_check()'s broad except block and reported
+    as "unhealthy" even when the database was reachable.
+
+    NOTE: health_check() also checks Redis, which independently raises
+    AttributeError today because Settings only defines `redis_url`, not
+    `redis_host`/`redis_port` (a separate, pre-existing bug unrelated to
+    #154). That means health_check() currently always raises
+    HTTPException(503) regardless of the postgres fix. These tests catch
+    that HTTPException and inspect its `.detail` payload so the postgres
+    assertions aren't coupled to the unrelated redis bug.
+    """
+
+    @pytest.fixture
+    def mock_db_session(self):
+        """Create a mock async database session."""
+        session = AsyncMock()
+        session.execute = AsyncMock()
+        return session
+
+    @pytest.mark.asyncio
+    async def test_postgres_probe_uses_text_clause_not_raw_string(self, mock_db_session):
+        """db.execute() must be called with sqlalchemy.text(...), not a bare string.
+
+        A raw string would pass silently against an AsyncMock (mocks don't
+        enforce SQLAlchemy's argument validation), so this test checks the
+        actual type of the argument passed rather than relying on execute()
+        to raise.
+        """
+        with suppress(HTTPException):
+            await health_check(db=mock_db_session)
+        # (HTTPException expected today, due to the unrelated redis bug — see class docstring)
+
+        mock_db_session.execute.assert_awaited_once()
+        executed_statement = mock_db_session.execute.call_args[0][0]
+
+        assert isinstance(executed_statement, TextClause), (
+            "db.execute() must be called with sqlalchemy.text('SELECT 1'), "
+            f"not a raw string. Got: {type(executed_statement)!r}"
+        )
+        assert str(executed_statement) == "SELECT 1"
+
+    @pytest.mark.asyncio
+    async def test_reports_postgres_healthy_when_probe_succeeds(self, mock_db_session):
+        """When the DB probe succeeds, dependencies.postgres should be 'healthy'."""
+        try:
+            result = await health_check(db=mock_db_session)
+        except HTTPException as exc:
+            result = exc.detail
+
+        assert result["dependencies"]["postgres"] == "healthy"
+
+    @pytest.mark.asyncio
+    async def test_reports_postgres_unhealthy_when_probe_raises(self, mock_db_session):
+        """When the DB probe genuinely fails, postgres should still be reported unhealthy."""
+        mock_db_session.execute.side_effect = ConnectionError("could not connect to server")
+
+        try:
+            result = await health_check(db=mock_db_session)
+        except HTTPException as exc:
+            result = exc.detail
+
+        assert result["dependencies"]["postgres"] == "unhealthy"
+        assert result["status"] == "unhealthy"


### PR DESCRIPTION
## Summary
The database probe in `api/routes/health.py` executed the literal string `"SELECT 1"` directly against the async SQLAlchemy session. SQLAlchemy 2.x removed the implicit coercion that let raw Python strings work as executable SQL, so the probe raised `ArgumentError: Textual SQL expression 'SELECT 1' should be explicitly declared as text('SELECT 1')`. That exception was silently caught by the health check's broad `except` block and reported as `postgres: unhealthy`, producing a false negative even when the database was fully reachable. This PR wraps the literal query in `sqlalchemy.text()` so the probe executes correctly under SQLAlchemy 2.x.

## Issue
Closes #154

## Changes
- Wrapped the raw `"SELECT 1"` string in `sqlalchemy.text()` in `health_check()`'s postgres probe (`api/routes/health.py`)
- Added `from sqlalchemy import text` import; removed unused `timedelta` import while touching this file
- Added `tests/unit/test_health.py` with three tests: verifies `db.execute()` receives a `TextClause` (not a raw string), verifies `postgres` reports `healthy` when the probe succeeds, and verifies it still reports `unhealthy` when the probe genuinely fails
- Added `tests/integration/test_health.py` (from the reproduction step) which hits `GET /health` against a real Postgres instance via the existing CI service container

## Testing
- [x] Unit tests pass (`pytest tests/unit -v -m unit`)
- [x] Integration tests pass (`pytest tests/integration/test_health.py -v -m integration`, against real Postgres)
- [x] Linter passes (`ruff check api/routes/health.py tests/unit/test_health.py`)
- [x] Type checker — see note below
- [x] New/updated tests cover the changes

## Screenshots / Demo
N/A

## Notes for Reviewers
- **Pre-existing, unrelated failures** (confirmed present on `main` before this change, not introduced by it): 53 unit test failures across `test_bias_detector`, `test_pii_scrubber`, `test_resume_parser`, `test_tech_detector`, `test_review_service`, `test_skill_extractor`, `test_readme_parser`, `test_readme_scorer`, `test_relevance_scorer`, `test_faithfulness_checker`, `test_keyword_search`, `test_output_parser`, `test_batch_processor`, `test_security`, `test_prompt_defense`. Also 5 pre-existing `mypy` errors (missing type stubs for `PyPDF2`/`jose`/`passlib`/`rank_bm25`, plus a numpy syntax error) and 53 files `black` would reformat repo-wide — all outside the files this PR touches.
- **Separate bug found, intentionally not fixed here**: the Redis check in `health_check()` references `settings.redis_host` / `settings.redis_port`, but `Settings` only defines `redis_url`. This independently raises `AttributeError` and forces the endpoint to `503` regardless of this fix. Scoped my tests to assert on `dependencies.postgres` specifically so they aren't coupled to that unrelated bug. Happy to file a follow-up issue for it if useful.
- This PR's two touched files (`api/routes/health.py`, `tests/unit/test_health.py`) pass `ruff check` and `black --check` cleanly.