### PR TITLE
Fix/155 health check redis host

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -24,3 +24,50 @@ After GET /health uses settings.redis_url to verify the Redis connection and ret
 It's tier 1 issue. The bug has a clear root cause and requires a minor fix in a single file (api/routes/health.py) to swap out settings.redis_host / redis_port in favor of settings.redis_url (plus adding or updating a test file).
 I opened api/routes/health.py and core/config.py. I found that health.py references nonexistent attributes on the settings object. Looking at the test suite, there are currently no automated unit tests specifically covering the /health endpoint, so a test needs to be written to verify both healthy and degraded states.
 I'm fine with the number of claims and the fix and corresponding test should take around 4 hours.
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/devikaviju/pathreview/commit/30e4007
+
+**Reproduction summary:**
+I ran `curl http://localhost:8000/health` against a
+running stack and saw `"redis":"unhealthy"` while the Redis container was up;
+the log showed `'Settings' object has no attribute 'redis_host'`. The test file
+in the linked commit fails 2/4 against the pre-fix code.
+
+**PLAN.md link:** https://github.com/devikaviju/pathreview/blob/fix/155-health-check-redis-host/PLAN.md
+
+**Blockers or open questions:**
+[Or leave blank.]
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+[what you implemented]
+
+**Next steps:**
+[what was left]
+
+**Blockers:**
+[or blank]
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/384
+
+**Branch:** `fix/155-health-check-redis-host`
+
+**What you built:**
+[1–3 sentences]
+
+**Tests added or updated:**
+[tests/unit/test_health.py, 4 tests, what they cover]
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+(no new failures — see PR description for pre-existing failure counts)
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,26 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/155
+
+**Issue title:** Health check references `settings.redis_host`, which does not exist on Settings
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+When a request is made to GET /health, it returns a normal-looking response that reports Redis as unhealthy, even when Redis is running fine — so the endpoint gives you wrong information rather than an error.
+In api/routes/health.py, the Redis probe attempts to read settings.redis_host (and settings.redis_port), but in core/config.py, the Settings model defines the configuration using redis_url instead of separate redis_host / redis_port fields.
+The application starts up normally because core/config.py loads valid settings (including redis_url). The error is dormant until a user or system actually invokes the GET /health route, at which point Python attempts to evaluate the missing attribute dynamically. The probe is wrapped in a broad except Exception (line 53) that catches it, logs it, and sets the status to "unhealthy" — so a code bug gets disguised as Redis being down.
+Once fixed, GET /health will successfully read settings.redis_url to connect to Redis, perform the health ping, and return a 200 OK JSON response displaying the health status of both the database and Redis ({"status": "healthy", ...}).
+
+**Branch name:** fix/155-health-check-redis-host
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger
+
+**"Is this right for me?" checklist notes:**
+Before GET /health reports Redis as unhealthy even when Redis is running, because the probe reads settings.redis_host, which doesn't exist.
+After GET /health uses settings.redis_url to verify the Redis connection and returns a clean, structured JSON response showing component statuses.
+It's tier 1 issue. The bug has a clear root cause and requires a minor fix in a single file (api/routes/health.py) to swap out settings.redis_host / redis_port in favor of settings.redis_url (plus adding or updating a test file).
+I opened api/routes/health.py and core/config.py. I found that health.py references nonexistent attributes on the settings object. Looking at the test suite, there are currently no automated unit tests specifically covering the /health endpoint, so a test needs to be written to verify both healthy and degraded states.
+I'm fine with the number of claims and the fix and corresponding test should take around 4 hours.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -71,3 +71,31 @@ Added tests/unit/test_health.py with 4 unit tests using pytest and unittest.mock
 [ ] make check — fails on ~179 pre-existing ruff errors in tests/unit/ and missing mypy stubs; no errors introduced by this change (verified: `make lint` and `make typecheck` report nothing in tests/unit/test_health.py)
 
 **Draft PR feedback received from:** I didn't recieve any feedback
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [] Yes  [x] No — still awaiting review. Someone commented "is it correct". Not sure whether it is an actual reviewer.
+
+Summary of feedback:
+No feedback.
+
+How you responded:
+No response.
+
+Reflection
+What was harder than you expected?
+Debugging silent code failures wrapped in broad exception handlers. Because the health probe caught all general Exception instances and logged them as a degraded component status, the app appeared to run fine on startup, masking an underlying AttributeError until GET /health was explicitly invoked.
+
+What did you learn about working in a large codebase?
+I learned the importance of tracing configuration models across modules before making assumptions about properties. In a large codebase, existing settings models often consolidate connection details into single string representations (like redis_url), so verifying the schema in core/config.py was essential before modifying endpoint logic.
+
+How did AI tools help — and where did they fall short?
+AI tools were very helpful for quickly generating test cases using unittest.mock to simulate both healthy and failing Redis PING responses. However, they fell short in understanding how pre-existing suite failures interacted with local test runs, requiring manual investigation of existing environment issues versus new code behavior.
+
+What would you do differently if you started over?
+I would run a full suite check (make check and make test-unit) right at the beginning of reproduction to establish a clear baseline of pre-existing test failures before writing any new code or unit tests.
+
+What are you most proud of from this module?
+Writing comprehensive unit tests with mocks that cover both healthy (200 OK) and unhealthy/degraded states, ensuring high test coverage for the /health endpoint so this dormant bug won't regress.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -16,7 +16,7 @@ Once fixed, GET /health will successfully read settings.redis_url to connect to 
 
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
-**Cohort ledger:** [ ] Issue added to cohort ledger
+**Cohort ledger:** [x] Issue added to cohort ledger
 
 **"Is this right for me?" checklist notes:**
 Before GET /health reports Redis as unhealthy even when Redis is running, because the probe reads settings.redis_host, which doesn't exist.
@@ -38,20 +38,20 @@ in the linked commit fails 2/4 against the pre-fix code.
 **PLAN.md link:** https://github.com/devikaviju/pathreview/blob/fix/155-health-check-redis-host/PLAN.md
 
 **Blockers or open questions:**
-[Or leave blank.]
+None
 
 ## Week 9 — Solution building & PR submission
 
 ### Check-in 1 (mid-week)
 
 **Current progress:**
-[what you implemented]
+Fixed the dormant attribute error in api/routes/health.py by updating the Redis probe logic to use settings.redis_url instead of the non-existent settings.redis_host and settings.redis_port attributes.
 
 **Next steps:**
-[what was left]
+Write unit tests for the updated Redis health probe to verify healthy and degraded states, run local quality checks (make check, make test-unit), and submit the pull request.
 
 **Blockers:**
-[or blank]
+None
 
 ---
 
@@ -62,12 +62,12 @@ in the linked commit fails 2/4 against the pre-fix code.
 **Branch:** `fix/155-health-check-redis-host`
 
 **What you built:**
-[1–3 sentences]
+Updated the health check endpoint in api/routes/health.py to build the Redis client from settings.redis_url via redis.Redis.from_url() instead of referencing nonexistent host/port attributes. This resolves false "unhealthy" Redis status responses while preserving existing exception logging.
 
 **Tests added or updated:**
-[tests/unit/test_health.py, 4 tests, what they cover]
+Added tests/unit/test_health.py with 4 unit tests using pytest and unittest.mock. The tests verify that Settings defines redis_url rather than redis_host/redis_port, that the probe builds its client from redis_url, and that /health reports Redis as healthy on a successful ping and unhealthy when the ping fails.
 
-**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
-(no new failures — see PR description for pre-existing failure counts)
+**Self-review confirmation:** [x] make test-unit passes (53 failed/375 passed before, 53 failed/379 passed after — same 53 pre-existing failures)
+[ ] make check — fails on ~179 pre-existing ruff errors in tests/unit/ and missing mypy stubs; no errors introduced by this change (verified: `make lint` and `make typecheck` report nothing in tests/unit/test_health.py)
 
-**Draft PR feedback received from:** none
+**Draft PR feedback received from:** I didn't recieve any feedback

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,44 @@
+## Solution plan
+
+**Issue:** Health check references `settings.redis_host`, which does not exist on Settings — https://github.com/ascherj/pathreview/issues/155
+
+### Understand
+Root cause, and expected vs actual behavior. The
+probe reads attributes Settings never defines, Python raises AttributeError at
+call time rather than startup, and the broad except turns a code bug into a
+false "Redis is down" report. Expected: /health reports Redis healthy when Redis
+is reachable. Actual: always unhealthy.
+
+### Map
+
+- `api/routes/health.py` — the Redis probe inside `health_check()` builds a client from `settings.redis_host` and `settings.redis_port`. The `except Exception` closing that block swallows the resulting `AttributeError`.
+- `core/config.py` — line 12 defines `redis_url: str = Field(default="redis://localhost:6379/0")`. No `redis_host` or `redis_port` field exists.
+- `tests/unit/test_health.py` — new file. No health test existed in `tests/unit/`.
+- `tests/conftest.py` — inspected for reusable fixtures. Only sample-text fixtures exist; no client or DB fixture, so tests call `health_check()` directly with a mocked session.
+
+### Plan
+
+1. Replace the `redis.Redis(host=..., port=..., db=0, ...)` construction with `redis.Redis.from_url(settings.redis_url, decode_responses=True)`.
+2. Verify manually: `make run`, then `curl http://localhost:8000/health`, and confirm the `redis` key changes from `unhealthy` to `healthy`.
+3. Add `tests/unit/test_health.py` covering the probe, matching the class/fixture/docstring patterns in `tests/unit/test_review_service.py`.
+4. Capture `make test-unit` and `make check` baselines before changing anything, and compare after, to confirm no new failures.
+5. Open a PR against `ascherj/pathreview:main` documenting the before/after and any pre-existing failures.
+
+### Inputs & outputs
+
+[What the probe takes in (settings.redis_url) and what changes (the
+`dependencies.redis` value in the response, and the overall status/HTTP code).]
+
+### Risks & unknowns
+
+[Real candidates you actually hit: `from_url` parses the db index out of the URL
+so dropping `db=0` must not change behavior; the broad `except Exception` still
+masks future bugs and narrowing it is a scope decision; the repo has pre-existing
+`make check` and `make test-unit` failures that make "passing" ambiguous;
+postgres also reports unhealthy from an unrelated SQLAlchemy 2.0 cause.]
+
+### Edge cases
+
+[What the fix should handle: Redis genuinely down (should still report unhealthy,
+not crash); a malformed or missing redis_url; the default value when no env var
+is set.]

--- a/api/routes/health.py
+++ b/api/routes/health.py
@@ -1,6 +1,7 @@
-from fastapi import APIRouter, HTTPException, status, Depends
+from datetime import datetime
+
 import structlog
-from datetime import datetime, timedelta
+from fastapi import APIRouter, Depends, HTTPException, status
 
 from core.database import get_db
 
@@ -39,12 +40,11 @@ async def health_check(db=Depends(get_db)):
     try:
         # Check Redis (if available)
         import redis
+
         from core.config import settings
 
-        r = redis.Redis(
-            host=settings.redis_host,
-            port=settings.redis_port,
-            db=0,
+        r = redis.Redis.from_url(
+            settings.redis_url,
             decode_responses=True,
         )
         r.ping()

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -1,0 +1,64 @@
+"""Tests for health.py"""
+
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+import redis
+from fastapi import HTTPException
+
+from api.routes.health import health_check
+from core.config import settings
+
+
+@pytest.mark.unit
+class TestHealthCheckRedisProbe:
+    """Test suite for the Redis dependency probe in the health endpoint."""
+
+    @pytest.fixture
+    def mock_db_session(self):
+        """Create a mock async database session that succeeds."""
+        session = AsyncMock()
+        session.execute = AsyncMock()
+        return session
+
+    def test_settings_defines_redis_url_not_host_or_port(self):
+        """Test Settings exposes redis_url and not redis_host or redis_port."""
+        assert hasattr(settings, "redis_url")
+        assert not hasattr(settings, "redis_host")
+        assert not hasattr(settings, "redis_port")
+
+    @pytest.mark.asyncio
+    async def test_redis_probe_builds_client_from_redis_url(self, mock_db_session):
+        """Test the Redis probe builds its client from settings.redis_url."""
+        with patch("redis.Redis.from_url") as mock_from_url:
+            mock_from_url.return_value = Mock()
+            await health_check(db=mock_db_session)
+
+        mock_from_url.assert_called_once_with(
+            settings.redis_url,
+            decode_responses=True,
+        )
+
+    @pytest.mark.asyncio
+    async def test_redis_reported_healthy_when_ping_succeeds(self, mock_db_session):
+        """Test the Redis dependency is reported healthy when the ping succeeds."""
+        with patch("redis.Redis.from_url") as mock_from_url:
+            mock_from_url.return_value = Mock()
+            result = await health_check(db=mock_db_session)
+
+        assert result["dependencies"]["redis"] == "healthy"
+
+    @pytest.mark.asyncio
+    async def test_redis_reported_unhealthy_when_ping_fails(self, mock_db_session):
+        """Test the Redis dependency is reported unhealthy when the ping fails."""
+        failing_client = Mock()
+        failing_client.ping.side_effect = redis.RedisError("connection refused")
+
+        with (
+            patch("redis.Redis.from_url", return_value=failing_client),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            await health_check(db=mock_db_session)
+
+        assert exc_info.value.status_code == 503
+        assert exc_info.value.detail["dependencies"]["redis"] == "unhealthy"


### PR DESCRIPTION
## Summary

The Redis probe read config fields that don't exist, so /health reported Redis as down even when it was fine. This points the probe at the field Settings actually defines.

## Issue

Closes #155

## Changes

- `api/routes/health.py`: replaced `redis.Redis(host=settings.redis_host, port=settings.redis_port, db=0, ...)` with `redis.Redis.from_url(settings.redis_url, decode_responses=True)`. `Settings` defines `redis_url`, not `redis_host`/`redis_port`.
- Import ordering in the same file was applied automatically by the project's pre-commit hooks.
- `tests/unit/test_health.py`: new file, 4 unit tests for the Redis probe.

## Testing

- [x] Unit tests pass (`make test-unit`) — see note below
- [ ] Integration tests pass (`make test-integration`) — not run
- [ ] Linter passes (`make lint`) — see note below
- [ ] Type checker passes (`make typecheck`) — see note below
- [x] New/updated tests cover the changes

Verified manually against a running stack:

Before: `{"dependencies":{"postgres":"unhealthy","redis":"unhealthy","vector_db":"healthy"}}`

After: `{"dependencies":{"postgres":"unhealthy","redis":"healthy","vector_db":"healthy"}}`

The new tests fail 2/4 against the pre-fix code and pass 4/4 after.

## Notes for Reviewers

**Pre-existing failures.** `make test-unit` was 53 failed / 375 passed before my changes and 53 failed / 379 passed after — the same 53 failures, plus my 4 new passes. `make lint` reports 182 pre-existing errors, all in `tests/unit/` files I didn't touch. `make typecheck` fails on missing library stubs (PyPDF2, jose, passlib, rank_bm25) before reaching my code. My new test file passes ruff and black cleanly. None of these are affected by this change.

**Why the bug was invisible.** The probe's broad `except Exception` caught the `AttributeError` and set Redis to "unhealthy," so a config bug looked like an outage. Captured during the test run: `redis_health_check_failed error="'Settings' object has no attribute 'redis_host'"`

**Out of scope.** Postgres also reports unhealthy, from a different cause — `await db.execute("SELECT 1")` needs `text()` under SQLAlchemy 2.0. Left alone to keep this scoped to #155.