### PR TITLE
test: fix README scorer fixture too short for its comprehensive assertion (#156)

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -26,3 +26,30 @@ written to check.
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/shriyapeddakama/pathreview/commit/54efce54c0222406b4696506ca4be508e1409fac
+
+**Reproduction summary:**
+Ran the unit suite against the project venv
+(`.venv/Scripts/python.exe -m pytest tests/unit/test_readme_scorer.py -q`) and
+reproduced the failure reliably: `test_readme_with_all_quality_signals` fails
+with `assert 51 > 100` (`1 failed, 22 passed`). The scorer logs
+`category=minimal word_count=51`, confirming the scorer is correct and the
+fixture README is only ~51 words — far short of the 500 needed for the
+`"comprehensive"` category the test asserts. The bug is in the test fixture, not
+the scoring code.
+
+**PLAN.md link:** https://github.com/shriyapeddakama/pathreview/blob/test/156-readme-scorer-fixture-word-count/PLAN.md
+
+**Walkthrough video (recommended):**
+
+**Blockers or open questions:**
+The pre-commit `mypy` hook (`disallow_untyped_defs = true`, with `tests/` not
+excluded) fails on the whole test file because its functions lack type
+annotations. My Week 9 fix must edit this file, so I'll need to either annotate
+the test functions or exclude `tests/` from mypy before the fix can be committed
+with hooks active. Also want to confirm on the issue that the intended fix is to
+*extend the fixture* (make it genuinely comprehensive) rather than to weaken the
+assertions.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,28 @@
+# Module 3 Journal
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/156
+
+**Issue title:** README scorer test fixture is too short for its own word-count assertion
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The README scorer has a unit test, `test_readme_with_all_quality_signals`, that
+is meant to verify a rich, well-documented README gets scored as "comprehensive."
+The test asserts the scorer returns `word_count > 100` and a `word_count_category`
+of `"comprehensive"`, but the sample README fixture it passes in only contains
+about 51 words, so the test fails (`assert 51 > 100`) even though the scorer logic
+is behaving correctly. The bug is in the test fixture, not the scoring code, and
+lives in `tests/unit/test_readme_scorer.py`; the scoring thresholds it depends on
+are in `agent/tools/readme_scorer.py`. A successful fix extends the fixture README
+so it has enough content to legitimately cross the "comprehensive" threshold —
+which the scorer sets at 500+ words — so the test validates the behavior it was
+written to check.
+
+**Branch name:** test/156-readme-scorer-fixture-word-count
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -53,3 +53,63 @@ the test functions or exclude `tests/` from mypy before the fix can be committed
 with hooks active. Also want to confirm on the issue that the intended fix is to
 *extend the fixture* (make it genuinely comprehensive) rather than to weaken the
 assertions.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the fix from PLAN.md. Extended the README fixture in
+`test_readme_with_all_quality_signals` (`tests/unit/test_readme_scorer.py`) from
+~51 words to 606 words so the scorer legitimately reports the `comprehensive`
+category (500+ word threshold) instead of `minimal`. Kept every quality signal
+the test asserts — installation, usage, badges, demo link, tech stack — so the
+other assertions still hold. The scorer logic (`agent/tools/readme_scorer.py`)
+was **not** touched; this is a test-only fix. `test_readme_scorer.py` now passes
+23/23 (was 22/23). Also cleared the pre-commit `mypy` blocker by adding a
+`tests.*` override in `pyproject.toml` that disables `disallow_untyped_defs` for
+test modules — mirroring what `make check`'s typecheck target already does (it
+excludes `tests/`), so untyped pytest functions no longer block commits.
+
+**Next steps:**
+Open a draft PR, request peer/mentor feedback in Slack, address it, then mark the
+PR ready for review and fill in the template.
+
+**Blockers:**
+None. Resolved the Week 8 mypy blocker (chose the `tests.*` mypy override over
+annotating ~24 unrelated test functions, to keep the bugfix diff focused).
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** <!-- TODO: paste PR URL after opening -->
+
+**Branch:** `test/156-readme-scorer-fixture-word-count`
+
+**What you built:**
+A test-only fix for issue #156. The `test_readme_with_all_quality_signals` unit
+test asserted a README scored as `comprehensive` (needs 500+ words) but fed the
+scorer a ~51-word fixture, so it failed with `assert 51 > 100`. I replaced the
+fixture with a genuinely comprehensive 606-word README that still exercises every
+quality signal, so the test now validates the behavior it was written to check
+against the scorer's real, unchanged thresholds.
+
+**Tests added or updated:**
+`tests/unit/test_readme_scorer.py` — rewrote the fixture in
+`test_readme_with_all_quality_signals` and expanded its docstring to explain the
+500-word `comprehensive` threshold. No assertions were weakened; the sibling
+threshold tests (`minimal`/`adequate`/`comprehensive`) were left untouched.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+> _Note on "passes":_ this repo has **pre-existing** failures unrelated to #156.
+> Baseline before my change: `make test-unit` = 53 failed / 375 passed; `make
+> check` = ruff 182 errors, mypy 103 errors (26 files). After my change:
+> `make test-unit` = **52 failed / 376 passed** (only my test flipped fail→pass;
+> a set-diff of the failing tests confirms **zero new failures**), and `make
+> check`'s ruff/mypy counts are unchanged. Per the Week 9 guidance, "passes"
+> here means my changes introduce no new failures — confirmed.
+
+**Draft PR feedback received from:** <!-- TODO: name or Slack handle, or "none" -->
+

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -83,7 +83,7 @@ annotating ~24 unrelated test functions, to keep the bugfix diff focused).
 
 ### Check-in 2 (end of week)
 
-**PR link:** <!-- TODO: paste PR URL after opening -->
+**PR link:** https://github.com/ascherj/pathreview/pull/385
 
 **Branch:** `test/156-readme-scorer-fixture-word-count`
 
@@ -111,5 +111,7 @@ threshold tests (`minimal`/`adequate`/`comprehensive`) were left untouched.
 > check`'s ruff/mypy counts are unchanged. Per the Week 9 guidance, "passes"
 > here means my changes introduce no new failures — confirmed.
 
-**Draft PR feedback received from:** <!-- TODO: name or Slack handle, or "none" -->
+**Draft PR feedback received from:** none — opened the PR for review and posted
+it to the cohort Slack channel, but did not receive peer/mentor feedback before
+the submission deadline.
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -115,3 +115,72 @@ threshold tests (`minimal`/`adequate`/`comprehensive`) were left untouched.
 it to the cohort Slack channel, but did not receive peer/mentor feedback before
 the submission deadline.
 
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No reviewer or maintainer comments arrived on PR #385 by the end of the week.
+(Reviewer feedback is not an active feature in Summer 2026, and I did not receive
+peer feedback in Slack before the deadline either.)
+
+**How you responded:**
+I asked AI to check if there were any issues in my PR, but the respone didn't have any major red flags. Mostly stylistic choices so I filled in the real PR link (#385) and pushed update to the branch.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The hardest part wasn't the code — my actual change was one fixture string. It
+was everything *around* the code. Two things blindsided me. First, when I ran the
+full unit suite I found **53 tests already failing** and briefly assumed I'd
+broken the repo; it took a set-diff of the failing tests before/after to convince
+myself my change added zero new failures. Second, committing was a fight: the
+pre-commit `black` hook (pinned to 24.1.0) and my venv's `black` (26.5.1)
+disagreed about one unrelated line and put my commit in an infinite reformat
+loop, and the `mypy` hook rejected the whole file over 24 pre-existing untyped
+test functions. None of that was "the fix" — it was the environment, tooling
+versions, and process, which is where most of my time actually went.
+
+**What did you learn about working in a large codebase?**
+"Passing" doesn't mean a green suite — it means *do no harm*, measured against a
+documented baseline. In my own projects a failing test means I broke something;
+here, most failures pre-dated me and the real bar was "introduce no new
+failures." I also learned to keep the change surgical: I only touched the test
+fixture and left `readme_scorer.py` alone once I confirmed the thresholds were
+deliberate, because unrelated edits create review noise and regression risk in
+code other people own. And I learned that a project can hold *conflicting*
+standards at once — `make check` excludes `tests/` from strict typing while the
+pre-commit hook did not — and that resolving the inconsistency (a `tests.*` mypy
+override) is a legitimate contribution, not a hack.
+
+**How did AI tools help — and where did they fall short?**
+AI was most useful for *investigation and verification*: mapping how the scorer
+categorizes word counts, drafting a 606-word fixture and checking it cleared 500
+words before I committed, and running the before/after failing-test diff that
+proved I added no new failures. Where it fell short was the judgment calls that
+depended on context AI couldn't see — deciding whether to annotate 24 functions
+vs. add a mypy override (a trade-off about diff size and reviewer perception),
+and diagnosing that the "black won't stop reformatting" loop was a *tool-version
+mismatch* rather than a code problem. AI could explain the mechanics once I asked
+the right question, but framing the right question — and owning the decision —
+was on me.
+
+**What would you do differently if you started over?**
+Open the draft PR **early in the week**, not at the deadline. I did solid work but
+never got peer review because I opened it too late, and that's a real gap in the
+contribution cycle — the PR is the artifact teammates interact with. I'd also
+treat the JOURNAL/PR-template fields as blocking checklist items from the start. Finally, I'd run the *full* suite and record the baseline on day one,
+so the pre-existing failures don't become an issue mid-task.
+
+**What are you most proud of from this module?**
+Debugging discipline. I correctly diagnosed that the bug was in the *test*, not
+the production code — traced it through the scorer's real thresholds — and kept my
+change to the smallest thing that fixed it, then *proved* with a baseline diff that
+I hadn't made anything worse. Resisting the urge to "fix" the scorer or clean up
+unrelated failures, and instead making one well-scoped, well-evidenced change, is
+the habit I most want to carry into real contribution work.
+

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,85 @@
+# Solution plan
+
+**Issue:** [#156 — README scorer test fixture is too short for its own word-count assertion](https://github.com/ascherj/pathreview/issues/156)
+
+### Understand
+
+`test_readme_with_all_quality_signals` in `tests/unit/test_readme_scorer.py` is
+meant to prove that a rich, well-documented README is scored as
+`"comprehensive"`. It asserts `word_count > 100` and
+`word_count_category == "comprehensive"`.
+
+- **Expected:** the sample README fixture is long enough that the scorer reports
+  a high word count and the `"comprehensive"` category.
+- **Actual:** the fixture only contains ~51 words, so the scorer (correctly)
+  reports `word_count = 51` and category `"minimal"`, and the test fails with
+  `assert 51 > 100`.
+
+**Root cause:** the bug is in the *test* — the fixture is too short for the
+assertions written against it — not in the scoring logic. The scorer's
+thresholds are correct and deliberate: `< 100` → `minimal`, `100–499` →
+`adequate`, `500+` → `comprehensive` (`agent/tools/readme_scorer.py:70-75`). To
+legitimately reach `"comprehensive"` the fixture must exceed **500** words, not
+just 100.
+
+### Map
+
+| File | Role in the fix |
+|---|---|
+| `tests/unit/test_readme_scorer.py` | **Primary edit.** Fixture + assertions in `test_readme_with_all_quality_signals`. |
+| `agent/tools/readme_scorer.py` | **Reference only.** Defines the word-count thresholds and scoring; read to confirm expected behavior — not expected to change. |
+| `pyproject.toml` / `.pre-commit-config.yaml` | **Possible edit.** May need to resolve the pre-commit `mypy` blocker (see Risks). |
+
+### Plan
+
+1. **Choose the fix direction.** The test's docstring and intent ("all quality
+   signals returns high score") say the fixture *should* be comprehensive, so
+   extend the fixture rather than weaken the assertions. Extend the sample
+   README past 500 words while keeping every quality signal it already
+   exercises: installation, usage, badges, demo link, and tech-stack sections.
+2. **Rewrite the fixture** so `content.split()` yields 500+ words and the
+   category becomes `"comprehensive"`; keep the section keywords and badge/demo
+   markup so the other assertions (`has_installation_section`, `has_badges`,
+   `has_demo_link`, `has_tech_stack_section`, `overall_score > 0.7`) still hold.
+3. **Clear the pre-commit `mypy` blocker** so the change is committable with
+   hooks active (the file currently fails `disallow_untyped_defs`). Decide
+   between annotating the test functions vs. excluding `tests/` in mypy config.
+4. **Verify:** run `pytest tests/unit/test_readme_scorer.py -q` (all pass) and
+   `pre-commit run --files tests/unit/test_readme_scorer.py` (ruff/black/mypy
+   clean).
+5. **Ship:** update JOURNAL.md, push the branch, open a PR against upstream.
+
+### Inputs & outputs
+
+- **Input:** the `readme` fixture string inside
+  `test_readme_with_all_quality_signals`.
+- **Output:** a longer fixture (500+ words, all signals intact) and assertions
+  that pass against the scorer's real, unchanged behavior. **No change to
+  `readme_scorer.py`'s logic or public output** — this is a test-only fix.
+
+### Risks & unknowns
+
+- **Pre-commit `mypy` wall (biggest risk).** `disallow_untyped_defs = true` and
+  `tests/` is not excluded, so mypy checks the *entire* file and flags all ~24
+  untyped test functions on any edit. The fix commit cannot pass hooks until
+  this is resolved — either add annotations (`scorer: ReadmeScorer`, `-> None`)
+  to the functions in the file, or add `tests/` to mypy's `exclude`. Unsure
+  which the maintainer prefers; annotating is more in the project's spirit but
+  enlarges the diff.
+- **Fix direction.** Extending the fixture assumes the test intent is
+  "comprehensive." If the maintainer instead wants the assertions corrected to
+  match a shorter README, the fix flips. Worth confirming on the issue.
+- **Word-count mechanics.** The scorer counts via `content.split()`, so
+  indentation, code fences, and punctuation all count as tokens. Need to verify
+  the rewritten fixture reliably clears 500 words after Python strips the
+  triple-quoted indentation.
+
+### Edge cases
+
+- Triple-quoted-string indentation inflating/deflating the split-based word
+  count.
+- Badge regex (`!\[.*?\]\(.*?\)`) and demo/tech-stack keywords must remain
+  present after the rewrite.
+- `overall_score > 0.7` must still hold once the fixture changes.
+- Don't regress the sibling threshold tests (`minimal` / `adequate` /
+  `comprehensive`) that pin the 100/500 boundaries.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,13 @@ disallow_untyped_defs = true
 check_untyped_defs = true
 exclude = ["alembic/versions/"]
 
+# Test modules aren't required to be fully type-annotated. `make check`'s
+# typecheck target already skips tests/; this mirrors that for the pre-commit
+# mypy hook so untyped pytest functions don't block commits.
+[[tool.mypy.overrides]]
+module = "tests.*"
+disallow_untyped_defs = false
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 markers = [

--- a/tests/unit/test_readme_scorer.py
+++ b/tests/unit/test_readme_scorer.py
@@ -15,37 +15,119 @@ class TestReadmeScorer:
         return ReadmeScorer()
 
     def test_readme_with_all_quality_signals(self, scorer):
-        """Test README with all quality signals returns high score."""
+        """Test README with all quality signals returns high score.
+
+        The fixture is a genuinely comprehensive README (600+ words) so that the
+        scorer legitimately reports the ``comprehensive`` word-count category,
+        whose threshold is 500+ words. It exercises every quality signal the
+        scorer looks for: installation, usage, badges, a demo link, and a tech
+        stack section.
+        """
         readme = """
-        # Project Name
-        A comprehensive project description.
-
-        ## Installation
-        ```bash
-        pip install package
-        ```
-
-        ## Usage
-        ```python
-        import package
-        package.run()
-        ```
-
-        ## Features
-        - Feature 1
-        - Feature 2
-        - Feature 3
-
-        ## Tech Stack
-        - Python 3.9
-        - FastAPI
-        - PostgreSQL
+        # PathReview
 
         ![Build Status](https://example.com/badge.svg)
         ![Coverage](https://example.com/coverage.svg)
+        ![License](https://example.com/license.svg)
+
+        PathReview is a comprehensive, AI-powered portfolio review assistant that
+        helps software engineers turn their GitHub profiles and resumes into
+        polished, recruiter-ready portfolios. It ingests your repositories,
+        analyzes the quality of your documentation, detects the technologies you
+        work with, and produces actionable feedback you can apply immediately.
+        This project exists because most developers have strong work that is
+        poorly presented, and a good README, a clear tech stack, and a live demo
+        can make the difference between a profile that gets ignored and one that
+        gets an interview.
+
+        ## Installation
+
+        Getting started with PathReview is straightforward. First, clone the
+        repository from GitHub and change into the project directory. Then create
+        a virtual environment and install the dependencies using the provided
+        Makefile, which wires up the database, seed data, and pre-commit hooks
+        for you automatically.
+
+        ```bash
+        git clone https://github.com/ascherj/pathreview
+        cd pathreview
+        make setup
+        ```
+
+        The setup command creates a Python virtual environment, installs every
+        backend dependency, runs the database migrations, seeds sample data, and
+        installs the frontend packages with npm. Once it finishes you are ready
+        to run the application locally without any further configuration.
+
+        ## Usage
+
+        After installation, start the backend and frontend development servers
+        with a single command. The backend runs on port eight thousand and the
+        frontend runs on port five thousand one hundred and seventy three. Open
+        the frontend in your browser and sign in with the seeded test account to
+        explore the full review workflow end to end.
+
+        ```python
+        from agent.orchestrator import Orchestrator
+
+        orchestrator = Orchestrator()
+        result = orchestrator.review(github_username="octocat")
+        print(result.summary)
+        ```
+
+        For a quick example, submit any public GitHub username and PathReview
+        will fetch the associated repositories, score each README, extract the
+        detected skills, and return a ranked list of improvement suggestions.
+
+        ## Features
+
+        - Automated README quality scoring with word count analysis
+        - Skill and technology detection across many programming languages
+        - Resume parsing that understands multiple document formats
+        - Retrieval augmented generation for grounded, context aware feedback
+        - Safety filters that keep generated feedback constructive and fair
+        - A responsive React frontend for browsing your review history
+
+        ## Tech Stack
+
+        PathReview is built with a modern, well tested technology stack. The
+        backend is written in Python using FastAPI for the web layer and
+        SQLAlchemy for database access. Data is stored in PostgreSQL, background
+        caching uses Redis, and vector search is powered by ChromaDB. The
+        frontend is a single page application written in TypeScript and React.
+
+        - Python 3.11 and FastAPI
+        - SQLAlchemy and PostgreSQL
+        - Redis and ChromaDB
+        - TypeScript, React, and Vite
+
+        ## Architecture
+
+        The system is organized into clear, independent modules. The ingestion
+        pipeline fetches and parses documents, the retrieval layer indexes and
+        searches content, the agent orchestrator coordinates the scoring tools,
+        and the safety module reviews every generated response before it reaches
+        the user. Each module is covered by its own suite of fast unit tests.
 
         ## Live Demo
-        [Try it here](https://demo.example.com)
+
+        Want to see PathReview in action before installing anything? A hosted
+        instance is available online so you can explore the interface with sample
+        data. [Try it here](https://demo.example.com) and walk through a complete
+        portfolio review in just a few minutes.
+
+        ## Contributing
+
+        Contributions are welcome and appreciated. Please read the contributing
+        guide, create a branch that follows the naming convention, write tests
+        for your changes, and make sure the full check suite passes before you
+        open a pull request. We review every contribution carefully and aim to
+        respond to new pull requests within a couple of business days.
+
+        ## License
+
+        This project is released under the MIT license, so you are free to use,
+        modify, and distribute it in both personal and commercial projects.
         """
 
         result = scorer.execute({"readme_content": readme})
@@ -157,9 +239,10 @@ class TestReadmeScorer:
 
         result = scorer.execute({"readme_content": readme})
         # "Getting Started" matches the pattern
-        assert result.data["has_installation_section"] is True or result.data[
-            "has_usage_section"
-        ] is True
+        assert (
+            result.data["has_installation_section"] is True
+            or result.data["has_usage_section"] is True
+        )
 
     def test_quickstart_counts_as_usage(self, scorer):
         """Test that 'quickstart' counts as usage."""
@@ -218,7 +301,8 @@ class TestReadmeScorer:
 
     def test_overall_score_calculation(self, scorer):
         """Test that overall score aggregates components."""
-        readme = """
+        readme = (
+            """
         # Good README
 
         ## Installation
@@ -233,7 +317,9 @@ class TestReadmeScorer:
         ![Build](https://example.com/build.svg)
 
         This readme has lots of content here.
-        """ * 3  # Make it comprehensive
+        """
+            * 3
+        )  # Make it comprehensive
 
         result = scorer.execute({"readme_content": readme})
 


### PR DESCRIPTION
## Summary

The `test_readme_with_all_quality_signals` unit test was meant to prove that a
rich, well-documented README is scored as `comprehensive`, but it fed the scorer
a ~51-word fixture while asserting `word_count > 100` **and**
`word_count_category == "comprehensive"`. Since the scorer's `comprehensive`
threshold is 500+ words, the test failed with `assert 51 > 100`. This PR fixes
the **test** (not the scoring logic) by replacing the fixture with a genuinely
comprehensive 606-word README that still exercises every quality signal, so the
test validates the behavior it was written to check.

## Issue
Closes #156

## Changes
- Rewrote the `readme` fixture in `test_readme_with_all_quality_signals`
  (`tests/unit/test_readme_scorer.py`) from ~51 words to 606 words so the scorer
  legitimately reports the `comprehensive` category. All existing assertions
  (installation, usage, badges, demo link, tech stack, `overall_score > 0.7`)
  still pass — no assertions were weakened.
- Expanded the test's docstring to document the 500-word `comprehensive`
  threshold so the fixture's length is self-explanatory.
- Added a `tests.*` override to `[tool.mypy]` in `pyproject.toml` disabling
  `disallow_untyped_defs` for test modules. This mirrors what the `typecheck`
  Make target / CI job already do (they scope mypy to `api/ core/ ingestion/
  rag/ agent/ safety/`, excluding `tests/`), and unblocks the pre-commit `mypy`
  hook, which otherwise rejected the whole file over its untyped pytest
  functions.
- **No change to `agent/tools/readme_scorer.py`** — the scoring thresholds are
  correct and deliberate; this is a test-only fix.

## Testing
- [x] Unit tests pass (`make test-unit`)
- [x] Integration tests pass (`make test-integration`) — not run (require Docker services)
- [x] Linter passes (`make lint`) — no *new* findings; see note below
- [x] Type checker passes (`make typecheck`) — no *new* findings; see note below
- [x] New/updated tests cover the changes

`tests/unit/test_readme_scorer.py` now passes **23/23** (was 22/23).

## Notes for Reviewers

**Pre-existing failures (this repo is broken independent of #156).** Baseline on
`main`/before this change:
- `make test-unit`: **53 failed / 375 passed**
- `make lint` (`ruff check .`): **182 errors** (many in `tests/`)
- `make typecheck` (mypy, source scope): **103 errors in 26 files**

After this change:
- `make test-unit`: **52 failed / 376 passed** — only `test_readme_with_all_quality_signals`
  flipped fail→pass. A set-diff of the failing test IDs before vs. after confirms
  **zero new failures** introduced.
- `make lint` / `make typecheck` error counts are **unchanged** (the edited test
  file is ruff/black/mypy-clean; the `pyproject.toml` override only affects the
  `tests.*` scope, which the source-scoped typecheck job doesn't touch).

Per the module's guidance for codebases with documented pre-existing failures,
"passes" here means **this change introduces no new failures** — not that the
whole suite is green. CI (`ruff check .`, `black --check .`, full `pytest
tests/unit`) will still report red because of the pre-existing issues above; none
originate from this PR.

**Fixture word count.** The scorer counts words via `content.split()`, so the
triple-quoted indentation does not inflate the count (leading whitespace is
collapsed). The fixture yields 606 tokens — comfortably over the 500 threshold.
