### PR TITLE
Fix #159: configure structlog for pytest caplog capture

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -30,7 +30,7 @@ is open, unassigned, and has no linked branch or pull request.
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [be3973f](https://github.com/nancypatel12/pathreview/commit/be3973f4aa02df7a653d02e8315341ab05684c86)
+**Reproduction commit link:** [0bdd676](https://github.com/nancypatel12/pathreview/commit/0bdd67696f461d28d00f9733c637de8cda5e053d)
 
 **Reproduction summary:**
 Running `tests/unit/test_batch_processor.py::TestBatchEmbeddingProcessor::test_empty_chunks_list_returns_empty` printed the warning to stdout, but produced zero `caplog` records. The reproduction test now requires a warning `LogRecord` with the expected message, which failed before the test logging configuration was added.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,4 +1,4 @@
-## Week 7 — Issue selection
+## Week 7: Issue selection
 
 **Issue link:** https://github.com/ascherj/pathreview/issues/159
 
@@ -11,7 +11,7 @@ PathReview uses structlog for application logging, but its test configuration do
 not send those events through Python's standard logging system. As a result,
 tests that use pytest's `caplog` fixture cannot inspect log output even when the
 application correctly emits it. The affected test currently prints the expected
-warning to stderr, then fails because `caplog` is empty. A successful fix will
+warning to stdout, then fails because `caplog` is empty. A successful fix will
 configure structlog for the test environment so caplog-based assertions receive
 and can verify the emitted events.
 
@@ -28,7 +28,7 @@ is open, unassigned, and has no linked branch or pull request.
 
 **Cohort ledger:** [x] Issue added to cohort ledger
 
-## Week 8 — Reproduction & solution planning
+## Week 8: Reproduction and solution planning
 
 **Reproduction commit link:** [0bdd676](https://github.com/nancypatel12/pathreview/commit/0bdd67696f461d28d00f9733c637de8cda5e053d)
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -24,6 +24,6 @@ is open, unassigned, and has no linked branch or pull request.
 
 **Branch name:** test/159-structlog-caplog-capture
 
-**Setup confirmation:** [ ] App runs locally at localhost:5173
+**Setup confirmation:** [x] App runs locally at localhost:5173
 
-**Cohort ledger:** [ ] Issue added to cohort ledger
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -27,3 +27,17 @@ is open, unassigned, and has no linked branch or pull request.
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [be3973f](https://github.com/nancypatel12/pathreview/commit/be3973f4aa02df7a653d02e8315341ab05684c86)
+
+**Reproduction summary:**
+Running `tests/unit/test_batch_processor.py::TestBatchEmbeddingProcessor::test_empty_chunks_list_returns_empty` printed the warning to stdout, but produced zero `caplog` records. The reproduction test now requires a warning `LogRecord` with the expected message, which failed before the test logging configuration was added.
+
+**PLAN.md link:** [PLAN.md](https://github.com/nancypatel12/pathreview/blob/test/159-structlog-caplog-capture/PLAN.md)
+
+**Walkthrough video (recommended):**
+
+**Blockers or open questions:**
+The full unit suite has unrelated baseline failures, including unavailable tokenizer downloads and failures in review, parser, and detector tests. The focused batch-processor suite passes after the logging configuration change.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,29 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/159
+
+**Issue title:** structlog output is not captured by pytest caplog — log assertions fail suite-wide
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+PathReview uses structlog for application logging, but its test configuration does
+not send those events through Python's standard logging system. As a result,
+tests that use pytest's `caplog` fixture cannot inspect log output even when the
+application correctly emits it. The affected test currently prints the expected
+warning to stderr, then fails because `caplog` is empty. A successful fix will
+configure structlog for the test environment so caplog-based assertions receive
+and can verify the emitted events.
+
+**Selection notes:**
+This is a focused Tier 1 test-infrastructure bug with a clear, local
+reproduction command and a defined expected result. It is limited to the
+logging/test configuration rather than broad application behavior, so it is
+appropriate to implement and verify with targeted regression tests. The issue
+is open, unassigned, and has no linked branch or pull request.
+
+**Branch name:** test/159-structlog-caplog-capture
+
+**Setup confirmation:** [ ] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -57,7 +57,7 @@ The focused test passes, but the full unit suite still has unrelated failures ca
 
 ### Check-in 2 (end of week)
 
-**PR link:** Submitted from the `test/159-structlog-caplog-capture` branch for issue #159.
+**PR link:** [Fix #159: configure structlog for pytest caplog capture](https://github.com/ascherj/pathreview/pull/390)
 
 **Branch:** `test/159-structlog-caplog-capture`
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -41,3 +41,62 @@ Running `tests/unit/test_batch_processor.py::TestBatchEmbeddingProcessor::test_e
 
 **Blockers or open questions:**
 The full unit suite has unrelated baseline failures, including unavailable tokenizer downloads and failures in review, parser, and detector tests. The focused batch-processor suite passes after the logging configuration change.
+
+## Week 9: Solution building and PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+I completed the planned test-environment fix. The shared pytest configuration now routes structlog events through Python's standard logging system, and the batch-processor regression test verifies the warning through `caplog`. I also added the `PLAN.md` implementation details and documented the known unrelated suite failures.
+
+**Next steps:**
+I planned to run the focused test and the broader checks, review the diff for scope and style, then submit the pull request with the test results and pre-existing failures clearly identified.
+
+**Blockers:**
+The focused test passes, but the full unit suite still has unrelated failures caused by existing review, parser, detector, and tokenizer-download issues.
+
+### Check-in 2 (end of week)
+
+**PR link:** Submitted from the `test/159-structlog-caplog-capture` branch for issue #159.
+
+**Branch:** `test/159-structlog-caplog-capture`
+
+**What you built:**
+I added a session-scoped pytest fixture that configures structlog with `LoggerFactory`, `BoundLogger`, and `render_to_log_kwargs`, allowing events to become standard-library log records that pytest can capture. The fixture disables logger caching during tests and resets structlog during teardown so the test configuration does not leak into other runs.
+
+**Tests added or updated:**
+`tests/unit/test_batch_processor.py` now asserts the expected warning through `caplog`, and `tests/conftest.py` contains the shared test logging configuration. The focused batch-processor test passes after the fix. The full unit suite continues to report unrelated baseline failures, which were documented rather than treated as logging regressions.
+
+**Self-review confirmation:** [ ] `make check` passes  [ ] `make test-unit` passes, with unrelated pre-existing failures documented above
+
+**Draft PR feedback received from:** none
+
+## Week 10: Iteration and reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No, still awaiting review
+
+**Summary of feedback:**
+No reviewer or maintainer feedback came in during this module. Per the Summer 2026 course note, reviewer feedback is not provided for this assignment.
+
+**How you responded:**
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The hardest part was tracing why a warning that visibly appeared during pytest was still missing from `caplog`. The application used structlog, while the test expected Python logging records, so the output path looked correct from the terminal but was not connected to the fixture. I also had to separate the logging problem from unrelated full-suite failures, including tokenizer downloads and failures in other modules, instead of assuming every failure came from my change.
+
+**What did you learn about working in a large codebase?**
+A small issue can cross several boundaries even when the final code change is local. I had to inspect the failing test, the batch processor, shared pytest setup, and the production logging configuration before choosing the right integration point. In someone else's codebase, preserving existing application behavior matters as much as making the test pass, so I kept the production logging calls unchanged and limited the configuration change to the test environment.
+
+**How did AI tools help, and where did they fall short?**
+AI tools helped me locate the relevant logging and pytest files, explain the structlog-to-standard-logging pipeline, and organize the solution into concrete steps in `PLAN.md`. They were useful for generating possible configuration patterns and identifying edge cases such as logger caching and global configuration state. They could not replace running the tests or deciding which failures were genuinely related, and I still had to verify the suggested code against this repository's existing fixtures and behavior.
+
+**What would you do differently if you started over?**
+I would establish the baseline results for both `make check` and `make test-unit` earlier and record them before changing the reproduction test. That would make the final comparison clearer. I would also confirm the exact pull-request and branch state earlier, because two similarly named branches can make it unclear which `/tree/<branch>` URL the grader should open.
+
+**What are you most proud of from this module?**
+I am most proud of turning a confusing test symptom into a focused, maintainable regression test. The fix does not alter the application's logging calls or production behavior. It makes the test environment accurately represent the logging interface that `caplog` is designed to inspect, while also handling teardown and logger caching explicitly.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,64 @@
+## Solution plan
+
+**Issue:** [structlog output is not captured by pytest caplog — log assertions fail suite-wide](https://github.com/ascherj/pathreview/issues/159)
+
+### Understand
+
+`BatchEmbeddingProcessor.process([])` emits its warning through structlog, but
+the test process never configures structlog to use Python's standard logging
+pipeline. Structlog therefore uses its default print logger, which writes the
+event to stdout. Pytest displays that output but `caplog.records` remains empty.
+The expected behavior is for a structlog warning to create a standard-library
+`LogRecord` that `caplog` can inspect, without changing application log calls.
+
+### Map
+
+- `tests/conftest.py`: shared pytest setup and the appropriate location for a
+  session-wide structlog configuration.
+- `tests/unit/test_batch_processor.py`: the regression test that exercises the
+  empty-chunk warning and verifies the captured record.
+- `ingestion/embeddings/batch_processor.py`: emits the warning being tested;
+  no behavior change is expected in this module.
+- `core/logging.py`: production and development logging configuration. It is a
+  reference point for maintaining compatible processors, but is not required
+  for the test-only setup.
+
+### Plan
+
+1. Make the existing batch-processor assertion require one warning record,
+   rather than accepting stdout output, to demonstrate the missing capture.
+2. Add a session-scoped autouse fixture in `tests/conftest.py` that configures
+   structlog with `structlog.stdlib.LoggerFactory`, `BoundLogger`, and
+   `render_to_log_kwargs` so events reach standard logging.
+3. Disable logger caching for the test configuration and reset structlog after
+   the session so loggers created in one test run cannot retain stale settings.
+4. Run the focused batch-processor suite, then the full unit suite to identify
+   regressions separately from existing failures.
+
+### Inputs & outputs
+
+The fixture receives structlog event dictionaries, including the event message,
+log level, and any contextual fields supplied by application code. It produces
+standard-library log records. Tests using `caplog` should be able to assert the
+record level and message while contextual fields remain available as logging
+extras.
+
+### Risks & unknowns
+
+- Structlog configuration is global. A session fixture must restore defaults so
+  it does not leak into another pytest invocation in the same interpreter.
+- Logger caching can preserve a logger created before the test fixture runs;
+  test configuration must avoid that cache.
+- The full unit suite currently has unrelated failures, including unavailable
+  tokenizer downloads and assertions in other modules. Those failures must not
+  be mistaken for a logging regression.
+
+### Edge cases
+
+- Warnings emitted before an individual test calls `caplog.set_level` should
+  still follow the standard logging path.
+- Events with structured fields, exceptions, and non-string values must not
+  prevent record creation.
+- Loggers imported before fixture execution must use the configured factory
+  when first invoked.
+- The fixture teardown must leave structlog in its default state.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,33 @@
 """Shared test fixtures for PathReview."""
 
+from collections.abc import Iterator
+
 import pytest
+import structlog
+
+
+@pytest.fixture(scope="session", autouse=True)
+def configure_structlog_for_tests() -> Iterator[None]:
+    """Route structlog events through stdlib logging for pytest capture."""
+    structlog.configure(
+        processors=[
+            structlog.stdlib.filter_by_level,
+            structlog.stdlib.add_logger_name,
+            structlog.stdlib.add_log_level,
+            structlog.stdlib.PositionalArgumentsFormatter(),
+            structlog.processors.TimeStamper(fmt="iso"),
+            structlog.processors.StackInfoRenderer(),
+            structlog.processors.format_exc_info,
+            structlog.processors.UnicodeDecoder(),
+            structlog.stdlib.render_to_log_kwargs,
+        ],
+        context_class=dict,
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        wrapper_class=structlog.stdlib.BoundLogger,
+        cache_logger_on_first_use=False,
+    )
+    yield
+    structlog.reset_defaults()
 
 
 @pytest.fixture

--- a/tests/unit/test_batch_processor.py
+++ b/tests/unit/test_batch_processor.py
@@ -1,7 +1,9 @@
-"""Tests for batch_processor.py"""
+"""Tests for batch_processor.py."""
+
+import logging
+from unittest.mock import Mock, patch
 
 import pytest
-from unittest.mock import Mock, MagicMock, patch
 
 from ingestion.chunking.base import Chunk
 from ingestion.embeddings.batch_processor import BatchEmbeddingProcessor
@@ -15,11 +17,13 @@ class TestBatchEmbeddingProcessor:
     def mock_embedding_provider(self):
         """Create a mock embedding provider."""
         provider = Mock()
-        provider.embed = Mock(return_value=[
-            [0.1] * 1536,
-            [0.2] * 1536,
-            [0.3] * 1536,
-        ])
+        provider.embed = Mock(
+            return_value=[
+                [0.1] * 1536,
+                [0.2] * 1536,
+                [0.3] * 1536,
+            ]
+        )
         return provider
 
     @pytest.fixture
@@ -34,13 +38,16 @@ class TestBatchEmbeddingProcessor:
         return BatchEmbeddingProcessor(mock_embedding_provider, mock_vector_db)
 
     def test_empty_chunks_list_returns_empty(self, processor, caplog):
-        """Test that empty chunks list logs warning and returns empty list."""
+        """Log the empty-input warning through the standard logging pipeline."""
+        caplog.set_level(logging.WARNING)
+
         result = processor.process([])
 
         assert result == []
-        # Should log a warning
-        assert "Empty chunks list" in caplog.text or any(
-            "empty" in record.message.lower() for record in caplog.records
+        assert len(caplog.records) == 1
+        assert caplog.records[0].levelno == logging.WARNING
+        assert caplog.records[0].getMessage() == (
+            "Empty chunks list provided to BatchEmbeddingProcessor"
         )
 
     def test_normal_chunks_list_processes(self, processor, mock_embedding_provider):
@@ -63,14 +70,11 @@ class TestBatchEmbeddingProcessor:
     def test_batches_chunks_correctly(self, processor):
         """Test that chunks are batched correctly."""
         # Create more chunks than the batch size
-        chunks = [
-            Chunk(text=f"Chunk {i}", metadata={"id": i})
-            for i in range(250)
-        ]
+        chunks = [Chunk(text=f"Chunk {i}", metadata={"id": i}) for i in range(250)]
 
         processor._store_embedding = Mock(side_effect=[f"id{i}" for i in range(250)])
 
-        with patch.object(processor.embedding_provider, 'embed') as mock_embed:
+        with patch.object(processor.embedding_provider, "embed") as mock_embed:
             mock_embed.return_value = [[0.1] * 1536 for _ in range(len(chunks))]
 
             result = processor.process(chunks)
@@ -136,7 +140,7 @@ class TestBatchEmbeddingProcessor:
 
         processor._store_embedding = Mock(side_effect=[f"id{i}" for i in range(chunk_count)])
 
-        with patch.object(processor.embedding_provider, 'embed') as mock_embed:
+        with patch.object(processor.embedding_provider, "embed") as mock_embed:
             mock_embed.return_value = [[0.1] * 1536 for _ in range(chunk_count)]
 
             processor.process(chunks)
@@ -153,7 +157,7 @@ class TestBatchEmbeddingProcessor:
 
         processor._store_embedding = Mock(side_effect=[f"id{i}" for i in range(500)])
 
-        with patch.object(processor.embedding_provider, 'embed') as mock_embed:
+        with patch.object(processor.embedding_provider, "embed") as mock_embed:
             mock_embed.return_value = [[0.1] * 1536 for _ in range(500)]
 
             result = processor.process(chunks)
@@ -173,14 +177,11 @@ class TestBatchEmbeddingProcessor:
 
     def test_store_embedding_called_for_each_chunk(self, processor):
         """Test that _store_embedding is called for each chunk."""
-        chunks = [
-            Chunk(text=f"Chunk {i}", metadata={})
-            for i in range(5)
-        ]
+        chunks = [Chunk(text=f"Chunk {i}", metadata={}) for i in range(5)]
 
         processor._store_embedding = Mock(side_effect=[f"id{i}" for i in range(5)])
 
-        with patch.object(processor.embedding_provider, 'embed') as mock_embed:
+        with patch.object(processor.embedding_provider, "embed") as mock_embed:
             mock_embed.return_value = [[0.1] * 1536 for _ in range(5)]
 
             processor.process(chunks)
@@ -197,7 +198,7 @@ class TestBatchEmbeddingProcessor:
 
         processor._store_embedding = Mock(side_effect=["id1", "id2"])
 
-        with patch.object(processor.embedding_provider, 'embed') as mock_embed:
+        with patch.object(processor.embedding_provider, "embed") as mock_embed:
             mock_embed.return_value = [[0.1] * 1536, [0.2] * 1536]
 
             processor.process(chunks)

--- a/tests/unit/test_batch_processor.py
+++ b/tests/unit/test_batch_processor.py
@@ -109,7 +109,7 @@ class TestBatchEmbeddingProcessor:
 
         processor._store_embedding = Mock(side_effect=["id1", "id2"])
 
-        result = processor.process(chunks)
+        processor.process(chunks)
 
         # Check that embed was called with the texts
         mock_embedding_provider.embed.assert_called()


### PR DESCRIPTION
## Summary

Structlog was not wired into Python's standard logging system during tests. Because of this, `caplog` never saw the events the app actually logged. The warning was still emitted, but it went to stdout through structlog's default print logger instead of through a `LogRecord` that `caplog` can inspect.

This PR configures structlog for the test environment so `caplog` based assertions work as expected.

## Changes

- Added a session scoped, autouse fixture in `tests/conftest.py` that configures structlog to route through `structlog.stdlib`. Logger caching is disabled during tests, and structlog defaults are restored after the session ends.
- Updated `test_empty_chunks_list_returns_empty` to assert on the actual `LogRecord` (level and message) instead of checking printed text.
- Cleaned up a few small style issues in the same test file, such as quote style and an unused import, to match the rest of the codebase.

## Test plan

- `pytest tests/unit/test_batch_processor.py -v`: all 11 tests pass, including the previously failing caplog assertion.
- Confirmed the full unit suite has the same unrelated baseline failures as before this change (missing tokenizer downloads, and some review, parser, and detector tests). None of those are related to this fix.

Closes #159
