### PR TITLE
Fix/106 restore fixture

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -55,8 +55,20 @@ https://github.com/ascherj/pathreview/blob/d1fe6edf5d114cd80406a0602831f9b530b74
 - Implemented unit test suite `tests/unit/test_fixtures.py` to assert the file's presence, valid JSON structure, and schema key completeness.
 
 **Next steps:**
-- Run local unit tests (`pytest tests/unit/test_fixtures.py`) and static quality checks (`ruff`, `black`) to ensure compliance with codebase standards.
-- Prepare and submit the Pull Request against the upstream repository.
+- Prepare and submit the Pull Request for Check-in 2
 
-**Blockers:**
-None.
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/396
+
+**Branch:** `fix/106-restore-fixture`
+
+**What you built:**
+Restored the missing shared test fixture `tests/fixtures/sample_profiles/basic_profile.json` containing a realistic user profile portfolio. Added a dedicated unit test `tests/unit/test_fixtures.py` that validates the existence, JSON parsing, and schema fields of the fixture.
+
+**Tests added or updated:**
+Added `tests/unit/test_fixtures.py`, which covers fixture file existence, JSON syntax validation, required profile keys (`github_username`, `resume`, `repositories`), and repository item attributes (`name`, `description`, `language`, `readme_content`, `file_structure`).
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -27,6 +27,7 @@ Currently, several integration tests in the test suite are failing or being skip
 **Cohort ledger:** [x] Issue added to cohort ledger
 
 **Reproduction commit link:** 
+https://github.com/ascherj/pathreview/commit/c6837e3aad379d65b79cc48293c7a47e8422837a
 
 **Reproduction summary:**
 I verified the issue by implementing a dedicated unit test at `tests/unit/test_fixtures.py` that asserts the existence and verifies the schema structure of `tests/fixtures/sample_profiles/basic_profile.json`.
@@ -41,5 +42,6 @@ I verified the issue by implementing a dedicated unit test at `tests/unit/test_f
    ```
 
 **PLAN.md link:** 
+https://github.com/ascherj/pathreview/blob/d1fe6edf5d114cd80406a0602831f9b530b74903/PLAN.md
 
 **Blockers or open questions:**

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,27 @@
+# PathReview Development Journal
+
+This journal tracks progress and reflections weekly throughout Module 3.
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/106
+
+**Issue title:** Shared test fixture for a sample user profile is missing from tests/fixtures/
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+Currently, several integration tests in the test suite are failing or being skipped because a critical JSON test fixture (`tests/fixtures/sample_profiles/basic_profile.json`) was deleted. This issue affects the testing environment, specifically the `tests/fixtures/` directory. A successful fix will restore a realistic sample user profile containing a GitHub username, a resume, and two repositories, thereby stabilizing the integration tests and ensuring they run reliably during CI/CD.
+
+### "Is this right for me?" checklist & reasoning
+- [x] **Clear Scope:** The issue clearly outlines the missing test fixture `tests/fixtures/sample_profiles/basic_profile.json` that needs to be recreated.
+- [x] **Testable:** Verify the fix by running the integration tests that depend on this fixture.
+- [x] **Manageable Size:** A JSON file containing a realistic user profile (GitHub username, resume, and two repos) is a concise task that doesn't involve complex logic, making it manageable.
+- [x] **No Core Blockers:** It is isolated to `tests/fixtures/` and does not require modifying critical business logic or third-party APIs.
+- **Scope Reasoning:** This Tier 1 issue is ideal for me to learn the repository's structure and contribution workflow. Restoring the deleted test fixture is high-value for project health since it fixes broken/skipped integration tests, yet it remains low-risk and well-defined.
+
+**Branch name:** chore/106-setup-env
+
+**Setup confirmation:** [x] App runs locally.
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -25,3 +25,9 @@ Currently, several integration tests in the test suite are failing or being skip
 **Setup confirmation:** [x] App runs locally.
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+**Reproduction summary:**
+I verified the issue by implementing a dedicated unit test at `tests/unit/test_fixtures.py` that asserts the existence and verifies the schema structure of `tests/fixtures/sample_profiles/basic_profile.json`.
+
+**Bug Reproduction:**
+   When the fixture is missing, running the test with `.venv/Scripts/pytest tests/unit/test_fixtures.py` reliably reproduces failure.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -45,3 +45,18 @@ I verified the issue by implementing a dedicated unit test at `tests/unit/test_f
 https://github.com/ascherj/pathreview/blob/d1fe6edf5d114cd80406a0602831f9b530b74903/PLAN.md
 
 **Blockers or open questions:**
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+- Re-created the missing shared test fixture file at `tests/fixtures/sample_profiles/basic_profile.json` with a realistic user portfolio (GitHub username `janedoe`, structured Markdown resume, and two repository metadata blocks with file structures and READMEs).
+- Implemented unit test suite `tests/unit/test_fixtures.py` to assert the file's presence, valid JSON structure, and schema key completeness.
+
+**Next steps:**
+- Run local unit tests (`pytest tests/unit/test_fixtures.py`) and static quality checks (`ruff`, `black`) to ensure compliance with codebase standards.
+- Prepare and submit the Pull Request against the upstream repository.
+
+**Blockers:**
+None.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -26,8 +26,20 @@ Currently, several integration tests in the test suite are failing or being skip
 
 **Cohort ledger:** [x] Issue added to cohort ledger
 
+**Reproduction commit link:** 
+
 **Reproduction summary:**
 I verified the issue by implementing a dedicated unit test at `tests/unit/test_fixtures.py` that asserts the existence and verifies the schema structure of `tests/fixtures/sample_profiles/basic_profile.json`.
 
-**Bug Reproduction:**
+1. **Bug Reproduction:**
    When the fixture is missing, running the test with `.venv/Scripts/pytest tests/unit/test_fixtures.py` reliably reproduces failure.
+2. **Resolution Verification:**
+   When the `basic_profile.json` fixture is created and properly structured with `github_username`, `resume`, and `repositories`, the verification test succeeds:
+   ```
+   tests\unit\test_fixtures.py .                                            [100%]
+   ============================== 1 passed in 0.29s ==============================
+   ```
+
+**PLAN.md link:** 
+
+**Blockers or open questions:**

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -72,3 +72,34 @@ Added `tests/unit/test_fixtures.py`, which covers fixture file existence, JSON s
 **Self-review confirmation:** [x] make check passes  [x] make test-unit passes
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+None — still awaiting review.
+
+**How you responded:**
+
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The first few assignments were harder than expected and took a lot more time than I initially thought. Setting up the environments, navigating the tooling dependencies, and figuring out my own system required significant initial effort.
+
+**What did you learn about working in a large codebase?**
+When working in a large codebase, I should spend time thoroughly learning about the architecture and existing patterns. Being careful with planning what I am specifically working on, and making sure my solution and commits are as detailed as possible.
+
+**How did AI tools help — and where did they fall short?**
+AI really helped with developing the plan, organizing the work and my thoughts, and explaining goals as I worked through the projects. However, it fell short when context limits required me to actively steer the AI back in the right direction.
+
+**What would you do differently if you started over?**
+I would start looking at the grading rubric earlier in the project lifecycle rather than later, and account for the initial setup and early tasks taking more time than anticipated.
+
+**What are you most proud of from this module?**
+I am most proud of the writing spec before coding aspect. That is becoming increasingly more important to provide the agent with the correct context and understanding the vision that I am creating. Overall, happy with successfully completing the projects to the standard of Codepath as I learn more about AI.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,34 @@
+## Solution plan
+
+**Issue:** [Shared test fixture for a sample user profile is missing from `tests/fixtures/`](https://github.com/ascherj/pathreview/issues/106)
+
+### Understand
+* **Root cause:** The test fixture file `tests/fixtures/sample_profiles/basic_profile.json` is not in the repository, which blocks/skips multiple integration tests and RAG pipeline evaluations that depend on a realistic user profile structure.
+* **Expected behavior:** A JSON file should exist at the expected path with a realistic sample portfolio structure that can be successfully ingested and parsed by the RAG pipeline.
+* **Actual behavior:** The file was missing, causing a `FileNotFoundError` when evaluation scripts or test runners attempted to access it.
+
+### Map
+* **Files involved:**
+  * `tests/fixtures/sample_profiles/basic_profile.json` (The missing shared test fixture)
+  * `tests/unit/test_fixtures.py` (Unit test verifying the existence and structure of the fixture)
+
+### Plan
+1. **Identify Schema Requirements:** Inspect schema definitions in `api/schemas/profile.py`, model fields in `core/models/profile.py` and `core/models/ingested_source.py`, and parser code in `ingestion/parsers/` to determine the fields and structure expected from a user profile.
+2. **Recreate the JSON Fixture:** Define a valid JSON profile with:
+   * `github_username`: A mock username (e.g. `janedoe`).
+   * `resume`: Realistic Markdown-formatted resume text containing standard sections (Experience, Education, Skills, Projects).
+   * `repositories`: A list of at least two repos, each containing `name`, `description`, `language`, `readme_content`, `file_structure`, and `pushed_at`.
+3. **Verify via Tests:** Unit test in `tests/unit/test_fixtures.py` to assert the file's existence and validate its structure.
+4. **Integration Testing:** Run the test suite (`pytest`) to confirm that the fixture resolves any loading issues and does not break existing test cases.
+
+### Inputs & outputs
+* **Input:** None (a static text/JSON fixture file is generated).
+* **Output:** A valid `basic_profile.json` fixture that can be parsed and used by ingestion tests and RAG scripts, and a test suite verifying its validity.
+
+### Risks & unknowns
+* **Data Schema Updates:** If the underlying parser structures (e.g., `resume_parser.py` or `repo_analyzer.py`) expect additional nested keys in the future, the static fixture might need updates to remain valid.
+* **Git Line Endings:** Text formatting differences (LF vs CRLF) on Windows systems during git commits could cause checksum or parse changes. Explicitly specifying `encoding="utf-8"` prevents character set issues.
+
+### Edge cases
+* **Missing repositories or empty values:** The RAG pipeline and parsers must handle profiles with zero/empty repositories or resumes gracefully (though this fixture specifically tests the populated, happy path).
+* **Empty Markdown structures:** The mock resume text should contain clear section headers (e.g., `Experience:`, `Education:`) to ensure parser regexes match successfully.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -99,7 +99,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -449,7 +448,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -473,7 +471,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1561,7 +1558,6 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1579,7 +1575,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1972,7 +1967,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3507,7 +3501,6 @@
       "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^2.0.1",
         "cssstyle": "^4.0.1",
@@ -4094,7 +4087,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4107,7 +4099,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4771,7 +4762,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/tests/fixtures/sample_profiles/basic_profile.json
+++ b/tests/fixtures/sample_profiles/basic_profile.json
@@ -1,0 +1,28 @@
+{
+  "github_username": "janedoe",
+  "resume": "# Jane Doe\nSoftware Engineer\njane.doe@example.com | github.com/janedoe\n\nExperience:\n- Senior Software Engineer at TechCorp (2022-2024)\n  Built REST APIs using Python, FastAPI, and PostgreSQL. Reduced latency by 20%.\n- Software Engineer at StartUpInc (2020-2022)\n  Developed frontend web applications using React, TypeScript, and Tailwind CSS.\n\nEducation:\n- B.S. Computer Science, State University (2020)\n\nSkills:\nPython, JavaScript, TypeScript, FastAPI, React, PostgreSQL, Docker, Redis, Git\n\nProjects:\n- Weather App: A weather app built with React.\n- Portfolio API: A backend API built with FastAPI.",
+  "repositories": [
+    {
+      "name": "weather-app",
+      "description": "A weather forecasting application built with React and TypeScript.",
+      "language": "TypeScript",
+      "stargazers_count": 5,
+      "forks_count": 1,
+      "open_issues_count": 0,
+      "readme_content": "# Weather App\n\nA weather forecasting application built with React and TypeScript.\n\n## Features\n- Current weather display\n- 5-day forecast\n- Location search\n\n## Tech Stack\n- React 18\n- TypeScript\n- Tailwind CSS\n- OpenWeatherMap API",
+      "file_structure": "package.json\ntsconfig.json\nsrc/App.tsx\nsrc/main.tsx\nsrc/components/WeatherDisplay.tsx\nsrc/components/__tests__/WeatherDisplay.test.tsx",
+      "pushed_at": "2026-07-01T12:00:00Z"
+    },
+    {
+      "name": "portfolio-api",
+      "description": "Backend API for my portfolio built with FastAPI and PostgreSQL.",
+      "language": "Python",
+      "stargazers_count": 12,
+      "forks_count": 3,
+      "open_issues_count": 2,
+      "readme_content": "# Portfolio API\n\nBackend API for my portfolio built with FastAPI and PostgreSQL.\n\n## Features\n- Profile management\n- Review tracking\n- User authentication\n\n## Tech Stack\n- Python 3.11\n- FastAPI\n- SQLAlchemy\n- PostgreSQL\n- Docker Compose",
+      "file_structure": "main.py\ncore/config.py\ncore/database.py\ncore/models/profile.py\nrequirements.txt\ndocker-compose.yml\ntests/test_main.py\n.github/workflows/ci.yml",
+      "pushed_at": "2026-07-05T14:30:00Z"
+    }
+  ]
+}

--- a/tests/unit/test_fixtures.py
+++ b/tests/unit/test_fixtures.py
@@ -1,0 +1,35 @@
+"""Tests for testing fixtures presence and structure."""
+
+import json
+import os
+
+import pytest
+
+
+@pytest.mark.unit
+def test_basic_profile_fixture_exists_and_is_valid() -> None:
+    """Verify that basic_profile.json exists and is valid JSON with expected keys."""
+    fixture_path = os.path.join("tests", "fixtures", "sample_profiles", "basic_profile.json")
+
+    # 1. Verify existence
+    assert os.path.exists(fixture_path), f"Fixture not found at {fixture_path}"
+
+    # 2. Verify validity and keys
+    with open(fixture_path, encoding="utf-8") as f:
+        data = json.load(f)
+
+    assert "github_username" in data, "Missing github_username"
+    assert "resume" in data, "Missing resume"
+    assert "repositories" in data, "Missing repositories"
+
+    # 3. Verify repositories structure
+    repos = data["repositories"]
+    assert isinstance(repos, list), "repositories must be a list"
+    assert len(repos) >= 2, "repositories must contain at least two entries"
+
+    for repo in repos:
+        assert "name" in repo, "Missing repo name"
+        assert "description" in repo, "Missing repo description"
+        assert "language" in repo, "Missing repo language"
+        assert "readme_content" in repo, "Missing repo readme_content"
+        assert "file_structure" in repo, "Missing repo file_structure"


### PR DESCRIPTION
**Blockers:**
None.
## Summary
This pull request restores the missing shared test fixture `tests/fixtures/sample_profiles/basic_profile.json` containing a realistic sample user profile (GitHub username, Markdown resume, and two repository metadata objects with file structures and READMEs). It also introduces a dedicated unit test suite in `tests/unit/test_fixtures.py` to validate fixture presence and schema completeness.

## Issue
Closes #106

## Changes
- **Restored Fixture:** Created `tests/fixtures/sample_profiles/basic_profile.json` with realistic mock portfolio data (`janedoe`, Markdown resume with standard section headers like `Experience:`, `Education:`, `Skills:`, and 2 repository objects with READMEs and file structures).
- **Added Unit Test Suite:** Created `tests/unit/test_fixtures.py` using `@pytest.mark.unit` to assert file existence, valid JSON parsing, required profile top-level keys (`github_username`, `resume`, `repositories`), and repository item attributes (`name`, `description`, `language`, `readme_content`, `file_structure`).
- **Updated Project Documentation:** Documented reproduction steps, `PLAN.md` solution roadmap

## Testing
- [x] Unit tests pass (`make test-unit` / `pytest tests/unit/test_fixtures.py`)
- [ ] Integration tests pass (`make test-integration`)
- [x] Linter passes (`make lint` / `ruff check tests/unit/test_fixtures.py`)
- [x] Type checker passes (`make typecheck` / `black --check tests/unit/test_fixtures.py`)
- [x] New/updated tests cover the changes

## Screenshots / Demo
N/A

## Notes for Reviewers
N/A