### PR TITLE
fix: allow leading whitespaces in resume section headers

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,1 @@
+# Development Journal

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -66,3 +66,36 @@ I touched the tests/unit/test_resume_parser.py and they cover the existing secti
 - `make test-unit`: 2 pre-existing failures (`test_parse_markdown_resume` and `test_strip_markdown_syntax`) outside the scope of this issue since they are related to markdown syntax stripping. All 15 resume parser tests passed cleanly.
 
 **Draft PR feedback received from:** [ru1nw](https://github.com/ascherj/pathreview/pull/398#pullrequestreview-4821888888)
+
+---
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [X] Yes  [ ] No — still awaiting review
+
+**Summary of feedback:**
+My reviewer commented that it is ready to merge. He also commented on the checklist of the PR that verfied the codebase had no errors and ran as expected, fix ran as stated and related tests with edge cases handled correctly and passed, and the formatting of docs were correct.
+
+**How you responded:**
+I did not make any changes and just completed Week 9 Check-in 2 in this JOURNAL.md.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The harder part was the formatting of the PR description. I changed the title to a strong, specific one matching the example PR format, and I had to clearly document that the 178 `make check` errors and 2 `make test-unit` failures were pre-existing and outside my scope, so reviewers wouldn't mistake them for regressions I introduced.
+
+**What did you learn about working in a large codebase?**
+I learned that contributing to someone else's production code was to read the existing codebases, and then fix the bug or handle edge cases for the live users. I learned that this one includes the pull requests and code reviews. Building your own project was to choose your own tech stack and architecture, and execute full-lifecycle product development.
+
+**How did AI tools help — and where did they fall short?**
+I used AI assistance for the codebase navigation to understand the function and the bug of this issue that the given function has. They fell short at giving the steps to reproduce the bug using the code script from the issue link. I needed to create the reproduction bug script `detect_sections_bug.py`, so that I could see the observed output without fixing any code yet.
+
+**What would you do differently if you started over?**
+If I started over, I would test my regex patterns change in isolation before editing the source file by checking a single indented header against the pattern first. I placed the whitespace token in the wrong position (after the header word instead of after the line anchor), and a quick standalone check would have caught that immediately instead of after re-running the full suite.
+
+**What are you most proud of from this module?**
+One thing I am most proud of from this module is making my first real open-source contribution to someone else's production codebase and having it approved to merge with no requested changes. I learned the steps to contribute to someone else's production codebase and the format of the PR description, along with the commit message convention.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -25,13 +25,12 @@ The issue is the failure of the parser's section detection logic in ingestion/pa
 **Reproduction commit link:** https://github.com/Syoko3/pathreview/commit/1840b5738e8615099fe5e0be56bc7415ac64db5f
 
 **Reproduction summary:**
-[1–2 sentences: How did you reproduce the issue? What did you observe?]
+I reproduced the issue by creating the detect_sections_bug.py to test the reproduction bug logic, and mark the _detect_sections() as a bug in ingestion/parser/resume_parser.py and the related failing tests in tests/unit/test_unit_parser.py. When I run the _detect_sections_bug.py, it returns an empty list, but the expected output has to return "Education" and "Skills" as the list. I also ran the unit tests for the parser again, and confirmed that section headers with leading whitespaces are not detected, so _detect_section() of resume_parser.py will return as an empty list.
 
-
-**PLAN.md link:** [link to PLAN.md in your fork]
+**PLAN.md link:** https://github.com/Syoko3/pathreview/blob/fix/147-leading-whitespace/PLAN.md
 
 **Walkthrough video (recommended):** [link to your Loom video, ≤2 min — recommended, not graded]
 
 **Blockers or open questions:**
-[Anything you're still uncertain about going into Week 9, or leave blank]
+
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -22,10 +22,11 @@ The issue is the failure of the parser's section detection logic in ingestion/pa
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [link to commit documenting the reproduced issue]
+**Reproduction commit link:** https://github.com/Syoko3/pathreview/commit/1840b5738e8615099fe5e0be56bc7415ac64db5f
 
 **Reproduction summary:**
 [1–2 sentences: How did you reproduce the issue? What did you observe?]
+
 
 **PLAN.md link:** [link to PLAN.md in your fork]
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,1 +1,19 @@
-# Development Journal
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/147
+
+**Issue title:** Resume section detection fails on text with leading whitespace
+
+**Tier:** [X] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**"Is this right for me?" checklist reasoning:**
+I selected the Tier 1 resume parser bug because it aligns well with my skill level for a first-time open-source contribution, and it has no open blockers, dependencies, or prohibitive contributor competition. I understood that the _detect_sections() function in ingestion/parsers/resume_parser.py incorrectly handles leading indentation/whitespace, causing empty sections to be detected. Fixing this will allow resume sections to be parsed accurately. I confirmed the file locations and reproduced the issue by running pytest on tests/unit/test_resume_parser.py. Three test cases, which were test_parse_single_column_resume_text, test_parse_resume_no_work_experience, and test_detect_sections, failed as expected due to this bug. Given the isolated nature of the bug and the clear test failures, I am confident I can resolve this ahead of the Week 9 deadline.
+
+**Problem summary:**
+The issue is the failure of the parser's section detection logic in ingestion/parsers/resume_parser.py. It expects the section headers to start exactly at the very beginning of the line. Because text extracted from PDFs preserves leading indentation or whitespaces, these headers are missed entirely, resulting empty sections detected. A successful fix will modify the regex patterns to allow leading whitespace before a header name, so that the parser can correctly identify and extract resume sections even when they are indented.
+
+**Branch name:** fix/147-leading-whitespace
+
+**Setup confirmation:** [X] App runs locally at localhost:5173
+
+**Cohort ledger:** [X] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -33,4 +33,34 @@ I reproduced the issue by creating the detect_sections_bug.py to test the reprod
 
 **Blockers or open questions:**
 
+---
 
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+I implemented the fix of the _detect_sections() of the ingestion/parsers/resume_parser.py by updating the regex of the section header patterns. After that, I confirmed the bug is fixed by running the unit test of the resume parser (tests/unit/test_resume_parser.py) to verify the three related failing tests are passed. I also ran the reproduction script and verified that the sections are correctly detected. I added the test cases for the leading whitespaces and the edge cases (.e.g. non-indented headers, substring words, etc.) in the test file, and verified that these tests also passed. I finished all of the sub-tasks from PLAN.md.
+
+**Next steps:**
+I have to open the draft pull request on GitHub and document pre-existing make check / make test-unit baseline failures in the PR description. I have to share the Draft PR link to the peer/mentor, and address any review feedback. I have to look the PR thread every day at least once. After addressing any review feedback, I have to update `JOURNAL.md` with Check-in 2, and mark PR as "Ready for review".
+
+**Blockers:**
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [link to your submitted pull request]
+
+**Branch:** [the branch name you worked on, e.g. `fix/123-short-description`]
+
+**What you built:**
+[1–3 sentences summarizing what your fix does and how it works]
+
+**Tests added or updated:**
+[Which test files did you touch? What do they cover?]
+
+**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+
+**Draft PR feedback received from:** [name or Slack handle, or "none"]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -17,3 +17,20 @@ The issue is the failure of the parser's section detection logic in ingestion/pa
 **Setup confirmation:** [X] App runs locally at localhost:5173
 
 **Cohort ledger:** [X] Issue added to cohort ledger
+
+---
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [link to commit documenting the reproduced issue]
+
+**Reproduction summary:**
+[1–2 sentences: How did you reproduce the issue? What did you observe?]
+
+**PLAN.md link:** [link to PLAN.md in your fork]
+
+**Walkthrough video (recommended):** [link to your Loom video, ≤2 min — recommended, not graded]
+
+**Blockers or open questions:**
+[Anything you're still uncertain about going into Week 9, or leave blank]
+

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -51,16 +51,18 @@ I have to open the draft pull request on GitHub and document pre-existing make c
 
 ### Check-in 2 (end of week)
 
-**PR link:** [link to your submitted pull request]
+**PR link:** [fix: allow leading whitespaces in resume section headers](https://github.com/ascherj/pathreview/pull/398)
 
-**Branch:** [the branch name you worked on, e.g. `fix/123-short-description`]
+**Branch:** fix/147-leading-whitespace
 
 **What you built:**
-[1–3 sentences summarizing what your fix does and how it works]
+My fix updates the line-start regex anchors in _detect_sections() of ingestion/parsers/resume_parser.py to match optional leading horizontal whitespace, which are `^[ \t]*` and `\n[ \t]*`. This allows section headers in indented resume text to be detected correctly, and it returns the list of detected sections instead of an empty list.
 
 **Tests added or updated:**
-[Which test files did you touch? What do they cover?]
+I touched the tests/unit/test_resume_parser.py and they cover the existing section detection logic tests. I added 7 edge cases covering indented headers, non-indented headers, mid-sentence keywords, substring words, first-line headers, trailing whitespace, and section header deduplication.
 
-**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+**Self-review confirmation:** [X] make check passes  [X] make test-unit passes
+- `make check`: 178 pre-existing linting/formatting errors across the codebase. 0 new errors introduced in touched files.
+- `make test-unit`: 2 pre-existing failures (`test_parse_markdown_resume` and `test_strip_markdown_syntax`) outside the scope of this issue since they are related to markdown syntax stripping. All 15 resume parser tests passed cleanly.
 
-**Draft PR feedback received from:** [name or Slack handle, or "none"]
+**Draft PR feedback received from:** [ru1nw](https://github.com/ascherj/pathreview/pull/398#pullrequestreview-4821888888)

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,23 @@
+## Solution plan
+
+**Issue:** [issue title and link]
+
+### Understand
+What is the root cause of this issue? What behavior is expected vs. actual?
+
+### Map
+Which files, functions, or modules are involved?
+List the specific files you expect to touch.
+
+### Plan
+What are the steps to fix this issue?
+Break it into 3–5 concrete sub-tasks.
+
+### Inputs & outputs
+What does your fix take as input? What should it produce or change?
+
+### Risks & unknowns
+What could go wrong? What are you still unsure about?
+
+### Edge cases
+What inputs or states should your fix handle gracefully?

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,23 +1,41 @@
 ## Solution plan
 
-**Issue:** [issue title and link]
+**Issue:** [Resume section detection fails on text with leading whitespace](https://github.com/ascherj/pathreview/issues/147)
 
 ### Understand
 What is the root cause of this issue? What behavior is expected vs. actual?
+
+The root cause of this issue is that the regex patterns in _detect_sections() of ingestion/parsers/resume_parser.py anchor the section name directly to the start of a line, leaving no room for leading whitespaces. The expected behavior is that the _detect_sections should recognize the section headers of the resume regardless of leading whitespaces. The actual behavior is that the function returns an empty list of detected sections since there is leading whitespaces before the header word in the indented input.
 
 ### Map
 Which files, functions, or modules are involved?
 List the specific files you expect to touch.
 
+- ingestion/parsers/resume_parser.py
+    - Function: _detect_sections(self, text: str)
+- Test file: tests/unit/test_resume_parser.py
+    - Failed tests that are related to this issue: test_parse_single_column_resume_text, test_parse_resume_no_work_experience, test_detect_sections
+
 ### Plan
 What are the steps to fix this issue?
 Break it into 3–5 concrete sub-tasks.
 
+1. Update the regex patterns in _detect_sections to allow optional leading whitespace between the line-start anchor and the section header word
+2. Rerun the reproduction bug logic in detect_sections_bug.py to confirm that the sections of resume are detected.
+3. Run the unit tests (tests/unit/test_resume_parser.py) for the parser to confirm that the three related tests above are passed.
+4. Verify a non-indented section header still detects correctly.
+
 ### Inputs & outputs
 What does your fix take as input? What should it produce or change?
+
+My fix takes the current regex patterns that only match the section headers that does not contain leading whitespaces, which will return an empty list. It should produce the regex patterns that also match the section headers that preceded by the whitespaces, so it can return the detected section names as the list.
 
 ### Risks & unknowns
 What could go wrong? What are you still unsure about?
 
+This could go wrong by having a section header word inside a sentence and has the word as a substring of another word. These words are not the section headers, so they should not be detected. It will also go wrong on absorbing newlines as the leading whitespaces, since whitespaces are the spaces before the word on the same line, which means it does not count any newlines.
+
 ### Edge cases
 What inputs or states should your fix handle gracefully?
+
+Non-indented headers still have to be detected. Mixed indentation will be depended on the amount or type of leading whitespaces. Header as mid-sentence word and substring words should not be detected since they are not the section headers. The first line of the whole text have to be detected. The headers that have trailing whitespaces after them still have to be detected. Duplicate headers have to be detected once.

--- a/detect_sections_bug.py
+++ b/detect_sections_bug.py
@@ -1,0 +1,5 @@
+from ingestion.parsers.resume_parser import ResumeParser
+r = ResumeParser()
+res = r.parse('\n    John Smith\n    john@example.com\n\n    Education:\n    - B.S. Computer Science\n\n    Skills: Python\n')
+print(res.metadata['detected_sections'])
+# observed: []  (expected: Education, Skills)

--- a/detect_sections_bug.py
+++ b/detect_sections_bug.py
@@ -1,5 +1,0 @@
-from ingestion.parsers.resume_parser import ResumeParser
-r = ResumeParser()
-res = r.parse('\n    John Smith\n    john@example.com\n\n    Education:\n    - B.S. Computer Science\n\n    Skills: Python\n')
-print(res.metadata['detected_sections'])
-# observed: []  (expected: Education, Skills)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -99,7 +99,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -449,7 +448,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -473,7 +471,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1561,7 +1558,6 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1579,7 +1575,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1972,7 +1967,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3507,7 +3501,6 @@
       "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^2.0.1",
         "cssstyle": "^4.0.1",
@@ -4094,7 +4087,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4107,7 +4099,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4771,7 +4762,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/ingestion/parsers/resume_parser.py
+++ b/ingestion/parsers/resume_parser.py
@@ -132,10 +132,10 @@ class ResumeParser(BaseParser):
         for section in SECTION_HEADERS:
             # Look for section header patterns
             patterns = [
-                rf"^{re.escape(section)}\s*$",
-                rf"^{re.escape(section)}\s*[:|-]",
-                rf"\n{re.escape(section)}\s*$",
-                rf"\n{re.escape(section)}\s*[:|-]",
+                rf"^[ \t]*{re.escape(section)}\s*$",
+                rf"^[ \t]*{re.escape(section)}\s*[:|-]",
+                rf"\n[ \t]*{re.escape(section)}\s*$",
+                rf"\n[ \t]*{re.escape(section)}\s*[:|-]",
             ]
 
             for pattern in patterns:

--- a/ingestion/parsers/resume_parser.py
+++ b/ingestion/parsers/resume_parser.py
@@ -5,7 +5,6 @@ from pypdf import PdfReader
 
 from .base import BaseParser, ParseResult
 
-
 SECTION_HEADERS = {
     "experience",
     "education",
@@ -124,6 +123,7 @@ class ResumeParser(BaseParser):
 
         return text.strip()
 
+    # Bug here: Leading whitespace in section headers cause the detection to fail.
     def _detect_sections(self, text: str) -> list[str]:
         """Detect common resume sections from text."""
         detected = []

--- a/ingestion/parsers/resume_parser.py
+++ b/ingestion/parsers/resume_parser.py
@@ -123,14 +123,13 @@ class ResumeParser(BaseParser):
 
         return text.strip()
 
-    # Bug here: Leading whitespace in section headers cause the detection to fail.
     def _detect_sections(self, text: str) -> list[str]:
         """Detect common resume sections from text."""
         detected = []
         text_lower = text.lower()
 
         for section in SECTION_HEADERS:
-            # Look for section header patterns
+            # Look for section header patterns, including leading whitespaces
             patterns = [
                 rf"^[ \t]*{re.escape(section)}\s*$",
                 rf"^[ \t]*{re.escape(section)}\s*[:|-]",

--- a/tests/unit/test_resume_parser.py
+++ b/tests/unit/test_resume_parser.py
@@ -1,11 +1,11 @@
 """Tests for resume_parser.py"""
 
-import pytest
-from unittest.mock import Mock, patch, MagicMock
-from io import BytesIO
+from unittest.mock import Mock, patch
 
-from ingestion.parsers.resume_parser import ResumeParser
+import pytest
+
 from ingestion.parsers.base import ParseResult
+from ingestion.parsers.resume_parser import ResumeParser
 
 
 @pytest.mark.unit
@@ -17,6 +17,7 @@ class TestResumeParser:
         """Create a ResumeParser instance."""
         return ResumeParser()
 
+    # Failed due to the leading whitespace bug in _detect_sections
     def test_parse_single_column_resume_text(self, parser, sample_resume_text):
         """Test parsing a standard single-column resume text."""
         result = parser.parse(sample_resume_text)
@@ -33,6 +34,7 @@ class TestResumeParser:
             "skills" in s for s in detected_lower
         )
 
+    # Failed due to the leading whitespace bug in _detect_sections
     def test_parse_resume_no_work_experience(self, parser):
         """Test parsing a resume with no work experience section - handles gracefully."""
         resume_no_work = """
@@ -123,6 +125,7 @@ class TestResumeParser:
             exc_info.value
         )
 
+    # Failed due to the leading whitespace bug in _detect_sections
     def test_detect_sections(self, parser):
         """Test section detection in resume text."""
         text = """

--- a/tests/unit/test_resume_parser.py
+++ b/tests/unit/test_resume_parser.py
@@ -17,7 +17,6 @@ class TestResumeParser:
         """Create a ResumeParser instance."""
         return ResumeParser()
 
-    # Failed due to the leading whitespace bug in _detect_sections
     def test_parse_single_column_resume_text(self, parser, sample_resume_text):
         """Test parsing a standard single-column resume text."""
         result = parser.parse(sample_resume_text)
@@ -34,7 +33,6 @@ class TestResumeParser:
             "skills" in s for s in detected_lower
         )
 
-    # Failed due to the leading whitespace bug in _detect_sections
     def test_parse_resume_no_work_experience(self, parser):
         """Test parsing a resume with no work experience section - handles gracefully."""
         resume_no_work = """
@@ -125,7 +123,6 @@ class TestResumeParser:
             exc_info.value
         )
 
-    # Failed due to the leading whitespace bug in _detect_sections
     def test_detect_sections(self, parser):
         """Test section detection in resume text."""
         text = """
@@ -145,6 +142,61 @@ class TestResumeParser:
         assert any("experience" in s for s in sections_lower)
         assert any("education" in s for s in sections_lower)
         assert any("skills" in s for s in sections_lower)
+
+    # Edge Case: Indented headers with leading whitespace should still be detected
+    def test_detect_sections_indented_headers(self, parser):
+        """Mixed indentation (spaces and tabs) — headers still detected."""
+        text = "\tExperience:\n    Education:\n        Skills: Python"
+        sections = [s.lower() for s in parser._detect_sections(text)]
+        assert "experience" in sections
+        assert "education" in sections
+        assert "skills" in sections
+
+    # Edge Case: Non-indented headers should still be detected
+    def test_detect_sections_non_indented_headers(self, parser):
+        """Flush-left headers keep working (no regression)."""
+        text = "Experience:\nEducation:\nSkills: Python"
+        sections = [s.lower() for s in parser._detect_sections(text)]
+        assert "experience" in sections
+        assert "education" in sections
+        assert "skills" in sections
+
+    # Edge Case: Section words inside sentences should not be detected
+    def test_detect_sections_ignores_midsentence_words(self, parser):
+        """A section word inside a sentence is not a header."""
+        text = "I gained a lot of experience and skills at my last job."
+        sections = [s.lower() for s in parser._detect_sections(text)]
+        assert "experience" not in sections
+        assert "skills" not in sections
+
+    # Edge Case: Section words as substrings of other words should not be detected
+    def test_detect_sections_ignores_substring_words(self, parser):
+        """Words that merely contain a header as a substring are not detected."""
+        text = "Experienced Engineer\nSkillset overview"
+        sections = [s.lower() for s in parser._detect_sections(text)]
+        assert "experience" not in sections
+        assert "skills" not in sections
+
+    # Edge Case: Headers on the very first line should still be detected
+    def test_detect_sections_first_line_header(self, parser):
+        """A header on the very first line (no preceding newline) is detected."""
+        text = "Skills: Python\nMore content here"
+        sections = [s.lower() for s in parser._detect_sections(text)]
+        assert "skills" in sections
+
+    # Edge Case: Headers with trailing whitespace should still be detected
+    def test_detect_sections_trailing_whitespace(self, parser):
+        """A header with trailing whitespace is still detected."""
+        text = "Education   \n- B.S. Computer Science"
+        sections = [s.lower() for s in parser._detect_sections(text)]
+        assert "education" in sections
+
+    # Edge Case: Repeated headers should be detected only once
+    def test_detect_sections_deduplicates(self, parser):
+        """A repeated header is reported only once."""
+        text = "Skills: Python\nSkills: JavaScript"
+        sections = parser._detect_sections(text)
+        assert sections.count("Skills") == 1
 
     def test_strip_markdown_syntax(self, parser):
         """Test markdown syntax stripping."""


### PR DESCRIPTION
## Summary
<!-- One paragraph describing what this PR does and why -->
Resolves an issue where section header detection failed on resume text containing leading whitespaces. Updating the line-start anchors of all regex patterns in `_detect_sections()` ensures headers are detected regardless of leading whitespaces, preventing parser metadata from returning an empty list of sections.

## Issue
Closes #147 

## Changes
<!-- Bullet list of the specific changes made -->

Root Cause: The regex patterns in `_detect_sections()` of `ingestion/parsers/resume_parser.py` anchor the section name directly to the start of a line, leaving no room for leading whitespaces. The expected behavior is that the `_detect_sections()` should recognize the section headers of the resume regardless of leading whitespaces. The actual behavior is that the function returns an empty list of detected sections since there is leading whitespaces before the header word in the indented input.
- `ingestion/parsers/resume_parser.py`: Updated the regex patterns in `_detect_sections()` to allow leading indentation after the line-start anchors (`^[ \t]*` and `\n[ \t]*`).
- `tests/unit/test_resume_parser.py`: Ran the existing unit tests to confirm that three related failing tests (`test_parse_single_column_resume_text`, `test_parse_resume_no_work_experience`, `test_detect_sections`) are passed.
- `tests/unit/test_resume_parser.py`: Added 7 new unit tests covering the key edge cases - indented headers, non-indented headers, mid-sentence words, substring words, first line header, headers with trailing whitespaces, section header deduplication.

## Testing
<!-- How did you verify your changes? -->
- [x] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`)
- [x] Linter passes (`make lint`)
- [x] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes

**Reproduction of the original bug & Verification of the fix:**

Run the following code below on the python terminal.
```python
from ingestion.parsers.resume_parser import ResumeParser
r = ResumeParser()
res = r.parse('\n    John Smith\n    john@example.com\n\n    Education:\n    - B.S. Computer Science\n\n    Skills: Python\n')
print(res.metadata['detected_sections'])
```
- Observed output before fix: [] (expected: Education, Skills)
- Observed output after fix: ['Education', 'Skills'] or ['Skills', 'Education'](order does not matter)
- Unit test suite: Verified with `pytest tests/unit/test_resume_parser.py`

## Screenshots / Demo
<!-- If applicable, add screenshots or a link to a demo video -->
Not Applicable

## Notes for Reviewers
<!-- Anything the reviewer should pay particular attention to -->
- **`make check` or `make lint`**: The codebase currently has 178 pre-existing linting/formatting errors. This PR introduces 0 new formatting errors for both `ingestion/parsers/resume_parser.py` and `tests/unit/test_resume_parser.py`.
- **`make typecheck`**: The codebase currently has 17 pre-existing errors on typecheck. This PR shows 0 new type errors for both `ingestion/parsers/resume_parser.py` and `tests/unit/test_resume_parser.py`.
- **`make test-unit`**: All 15 parser tests, including all 7 newly added edge case tests for this issue pass cleanly. There are 2 pre-existing failures in `test_parse_markdown_resume` and `test_strip_markdown_syntax` related to markdown syntax stripping that are outside the scope of this issue and unaffected by these changes.