### PR TITLE
Docs/36 hybrid retrieval scoring formula

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -61,7 +61,7 @@ comment on the issue to record my claim.
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** _REPRO_COMMIT_URL_
+**Reproduction commit link:** https://github.com/knowbibek/pathreview/commit/8562401290b8b29cc5220a28af0f6bc6a342f0bd
 
 **Reproduction summary:**
 Because this is a documentation-gap issue rather than a runtime bug, I

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -58,3 +58,32 @@ the doc section with a worked example, and verify the numbers against the
 implementation. The issue lists no "blocked by" dependencies and stands
 alone. Remaining to-do: check the Claims column in the cohort ledger and
 comment on the issue to record my claim.
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** _REPRO_COMMIT_URL_
+
+**Reproduction summary:**
+Because this is a documentation-gap issue rather than a runtime bug, I
+reproduced it by tracing the retrieval code and confirming the doc omission.
+The blend is implemented in `rag/retriever/hybrid.py` — defaults
+`vector_weight=0.7` / `keyword_weight=0.3` in the constructor
+([hybrid.py:13-14](rag/retriever/hybrid.py#L13-L14)) and the max-normalized
+weighted sum in `retrieve()`
+([hybrid.py:57-90](rag/retriever/hybrid.py#L57-L90)) — yet
+`docs/ARCHITECTURE.md` mentions the blend in exactly one sentence
+([ARCHITECTURE.md:60](docs/ARCHITECTURE.md#L60)) with no formula, weights, or
+example. I also confirmed `HybridRetriever` is never instantiated elsewhere,
+so the constructor defaults are the only source of the weights. The gap is
+real and localized to that one doc file.
+
+**PLAN.md link:** [PLAN.md](PLAN.md)
+
+**Walkthrough video (recommended):** _(not recorded)_
+
+**Blockers or open questions:**
+None blocking. Open question for Week 9: how much of the post-blend behavior
+(`min_score` threshold, `max_chunks` cutoff, BM25 tokenizer) to document
+versus keeping the section focused strictly on the formula + weights + example
+the issue asks for. Current plan leans toward mentioning the thresholds
+briefly and no further.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -24,3 +24,37 @@ contributors can reason about (and safely adjust) retrieval ranking.
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [ ] Issue added to cohort ledger
+
+### Selection notes — "Is this issue right for me?" checklist
+
+**Part 1 — Understanding the issue.** In my own words: the architecture doc
+says retrieval is "hybrid" (vector + BM25 keyword) but never says *how* the
+two scores are combined, so a reader can't predict or tune ranking. The
+affected area is the RAG docs (labels: `docs`, `rag`), and the one referenced
+file — `docs/ARCHITECTURE.md` — exists; its RAG section currently gives the
+blend exactly one sentence. "Done" looks like: before, the doc mentions
+blending with no formula; after, it has a section stating the formula
+(`score = 0.7 * normalized_vector + 0.3 * normalized_keyword`, per
+`HybridRetriever` in `rag/retriever/hybrid.py`), the default weights, the
+max-normalization step, and a worked example with sample numbers.
+
+**Part 2 — Tier fit.** Tier 1 is right for me: this is my first contribution
+to this codebase, and the change is a self-contained documentation update to
+a single file. It fits the "documentation update" scope in the tier table.
+
+**Part 3 — Codebase readiness.** I read `rag/retriever/hybrid.py`
+end-to-end, not just located it: `HybridRetriever.__init__` sets
+`vector_weight=0.7` / `keyword_weight=0.3`, and `retrieve()` normalizes each
+score set by its max, blends per chunk, filters by `min_score=0.3`, and
+returns the top `max_chunks=10`. That's everything the doc section needs, so
+I can draft the fix without further lookups. On tests: there is no
+`test_hybrid.py` today (only `test_keyword_search.py` covers the retriever
+package), but since this issue changes only documentation, no new test is
+required — the "read the test file" item doesn't gate a docs fix.
+
+**Part 4 — Scope and time.** Estimated effort on the issue is 2–3 hours,
+which fits comfortably in the Weeks 8–9 window: read the code (done), write
+the doc section with a worked example, and verify the numbers against the
+implementation. The issue lists no "blocked by" dependencies and stands
+alone. Remaining to-do: check the Claims column in the cohort ledger and
+comment on the issue to record my claim.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -87,3 +87,32 @@ None blocking. Open question for Week 9: how much of the post-blend behavior
 versus keeping the section focused strictly on the formula + weights + example
 the issue asks for. Current plan leans toward mentioning the thresholds
 briefly and no further.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the fix from PLAN.md: added a new "Hybrid Retrieval Scoring"
+subsection to `docs/ARCHITECTURE.md`, right after the existing RAG System
+paragraph. It covers the blending formula, the default weights
+(`vector_weight=0.7`, `keyword_weight=0.3`), the max-normalization step
+applied to each score set before blending, a worked two-chunk numeric
+example showing how normalization and weighting affect the final ranking,
+and a short note on the post-blend `min_score`/`max_chunks` filtering. This
+completes PLAN.md steps 2–4. Before starting, I captured a baseline of
+`make check`/`make test-unit` on `main`: 182 pre-existing lint errors, 5
+pre-existing mypy errors (all missing type stubs), and 53 failed / 375
+passed unit tests — none in `docs/` or touching `rag/retriever/hybrid.py`,
+so they're unrelated to this issue.
+
+**Next steps:**
+Finish PLAN.md step 5 — proofread the new section against
+`rag/retriever/hybrid.py` line-by-line to confirm every number and file
+reference is accurate. Re-run `make lint`/`make typecheck` after the edit to
+confirm the pre-existing counts are unchanged. Then push the branch, open
+the PR against the upstream repo as a draft, and request peer review in
+Slack before marking it ready.
+
+**Blockers:**
+None.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -79,7 +79,7 @@ real and localized to that one doc file.
 
 **PLAN.md link:** [PLAN.md](PLAN.md)
 
-**Walkthrough video (recommended):** _(not recorded)_
+**Walkthrough video (recommended):** https://youtu.be/UjrDfip7_w4
 
 **Blockers or open questions:**
 None blocking. Open question for Week 9: how much of the post-blend behavior

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,26 @@
+# Journal
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/36
+
+**Issue title:** Architecture doc doesn't explain the hybrid retrieval scoring formula
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+`docs/ARCHITECTURE.md` currently states that hybrid retrieval blends vector
+similarity and keyword scores, but it never shows the actual formula or the
+default weighting between the two signals. A reader can't tell how much a
+document's semantic match versus its keyword match contributes to its final
+rank, or how to tune that balance. This affects the RAG/retrieval
+documentation rather than the retrieval code itself. A successful fix adds a
+clear section to `docs/ARCHITECTURE.md` that spells out the scoring formula,
+states the default weights, and walks through a worked example so future
+contributors can reason about (and safely adjust) retrieval ranking.
+
+**Branch name:** docs/36-hybrid-retrieval-scoring-formula
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -116,3 +116,35 @@ Slack before marking it ready.
 
 **Blockers:**
 None.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/399
+
+**Branch:** docs/36-hybrid-retrieval-scoring-formula
+
+**What you built:**
+Added a "Hybrid Retrieval Scoring" subsection to `docs/ARCHITECTURE.md`
+explaining how `HybridRetriever` blends vector and BM25 keyword scores: the
+formula, the default weights (`vector_weight=0.7`, `keyword_weight=0.3`),
+the max-normalization step applied before blending, and a worked two-chunk
+example showing how the ranking comes out. Documentation-only change — no
+code behavior was modified.
+
+**Tests added or updated:**
+None — this is a documentation-only fix with no code behavior change, so no
+new tests apply. Baselined `make lint`/`make typecheck`/`make test-unit`
+before and after the edit: 182 pre-existing lint errors, 5 pre-existing
+mypy errors (missing type stubs), and 53 pre-existing failing unit tests,
+all identical before and after — none touch `docs/` or
+`rag/retriever/hybrid.py`, so this change introduces no new failures.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+*(both confirmed against the pre-existing baseline — no new failures introduced by this change; see Testing section of the PR description for counts)*
+
+**Draft PR feedback received from:** none — opened as a draft and posted in
+the cohort Slack channel for review, but no response came in before the
+Sunday deadline. Marked ready for review to submit on time; open to
+addressing feedback after the fact if any comes in.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -149,3 +149,63 @@ earlier in the week but forgot to actually post it in the cohort Slack
 channel for review until Sunday, close to the deadline, so no feedback came
 in before submitting. Marked ready for review to submit on time; open to
 addressing any feedback that comes in after the fact.
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No comments or reviews came in on PR #399 by the end of the module. (Per
+the Su26 course note, reviewer feedback isn't a live feature this term, so
+this was expected.)
+
+**How you responded:**
+N/A — no feedback to respond to.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The whole four-week cycle was demanding but genuinely engaging. Since #36
+turned out to be a documentation-only issue, in hindsight I think a
+code-level bug would have pushed me harder — tracing `hybrid.py` to get the
+formula right was useful, but I didn't have to touch the actual codebase
+logic or write new tests, so I came away wondering if I picked the "safe"
+issue instead of the one that would've taught me the most.
+
+**What did you learn about working in a large codebase?**
+Mostly about collaboration and structure — how a real project is
+organized, how the pieces fit together (API layer → ingestion → agent →
+RAG → safety), and what the contribution workflow looks like end to end,
+from picking an issue through opening a PR. Seeing that high-level shape
+was something I genuinely enjoyed.
+
+**How did AI tools help — and where did they fall short?**
+I used Claude and Gemini throughout — genuinely useful for automating parts
+of the process and drafting code and docs, but not infallible: sometimes
+what looked correct was actually a hallucination, so I had to verify things
+myself rather than trust the output blindly. If you don't already
+understand the syntax or the problem, the tool can give you a false sense
+of confidence. The real lesson: the tool isn't what produces a good result
+— the person driving it, verifying its output, and asking it the right
+questions is.
+
+**What would you do differently if you started over?**
+Stay ahead of deadlines instead of scrambling — I forgot to actually post
+my PR in the Slack review channel until Sunday, right before the deadline,
+which left no time for real feedback. I'd also lean on the cohort community
+more throughout the month, asking questions there while working on my own
+side projects in parallel, instead of only engaging reactively at crunch
+time.
+
+**What are you most proud of from this module?**
+Finishing the course built real discipline for me. I wasn't consistently
+working on things before this, but going through this structured
+four-week cycle gave me momentum and a habit of staying focused on the
+work. While going through it — and doing research alongside the
+coursework — I ended up finding something that mattered to me beyond just
+this class. Getting back into that rhythm and rediscovering that momentum
+is what I'm most proud of, more than the PR itself.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -144,7 +144,8 @@ all identical before and after — none touch `docs/` or
 **Self-review confirmation:** [x] make check passes  [x] make test-unit passes
 *(both confirmed against the pre-existing baseline — no new failures introduced by this change; see Testing section of the PR description for counts)*
 
-**Draft PR feedback received from:** none — opened as a draft and posted in
-the cohort Slack channel for review, but no response came in before the
-Sunday deadline. Marked ready for review to submit on time; open to
-addressing feedback after the fact if any comes in.
+**Draft PR feedback received from:** none — I opened the PR as a draft
+earlier in the week but forgot to actually post it in the cohort Slack
+channel for review until Sunday, close to the deadline, so no feedback came
+in before submitting. Marked ready for review to submit on time; open to
+addressing any feedback that comes in after the fact.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,95 @@
+## Solution plan
+
+**Issue:** [Architecture doc doesn't explain the hybrid retrieval scoring formula #36](https://github.com/ascherj/pathreview/issues/36)
+
+### Understand
+
+`docs/ARCHITECTURE.md` describes the RAG system as using "Hybrid retrieval
+(vector similarity + BM25 keyword)" in a single sentence
+([ARCHITECTURE.md:60](docs/ARCHITECTURE.md#L60)), but never explains **how**
+the two signals are combined into a single rank. There is no formula, no
+statement of the default weights, and no worked example.
+
+- **Expected:** A reader of the architecture doc can understand the scoring
+  formula, the default vector/keyword weights, the normalization step, and
+  see a concrete example of how a chunk's final score is computed — enough to
+  reason about and safely tune retrieval ranking.
+- **Actual:** The doc mentions blending but gives no formula or weights, so
+  the only source of truth is the code itself.
+
+This is a documentation gap, not a code bug — the retrieval logic is correct
+and already implemented; it is simply undocumented. **Root cause:** the
+architecture doc was written at a high level and the scoring detail was never
+back-filled after `HybridRetriever` was implemented.
+
+### Map
+
+The fix touches one documentation file, but the *source of truth* for the
+content is the retriever code:
+
+- **File to edit:** `docs/ARCHITECTURE.md` — add a "Hybrid Retrieval Scoring"
+  subsection under the RAG System section (around line 60).
+- **Reference (read-only) — where the formula actually lives:**
+  - `rag/retriever/hybrid.py` — `HybridRetriever.__init__` sets the defaults
+    `vector_weight=0.7`, `keyword_weight=0.3`
+    ([hybrid.py:13-14](rag/retriever/hybrid.py#L13-L14)); `retrieve()`
+    normalizes each score set by its max and blends per chunk
+    ([hybrid.py:57-90](rag/retriever/hybrid.py#L57-L90)), then filters by
+    `min_score=0.3` and returns the top `max_chunks=10`.
+  - `rag/retriever/keyword_search.py` — BM25 raw scores (`bm25_score`) that
+    feed the keyword side.
+  - `rag/retriever/vector_store.py` — vector similarity `score` that feeds
+    the vector side.
+
+### Plan
+
+1. Read the retriever code carefully and extract the exact formula,
+   normalization method, default weights, and post-blend filtering
+   (`min_score`, `max_chunks`). (Done during reproduction.)
+2. Draft a new "Hybrid Retrieval Scoring" subsection in `docs/ARCHITECTURE.md`
+   stating: the formula
+   `blended = vector_weight * norm(vector_score) + keyword_weight * norm(keyword_score)`,
+   the defaults `0.7 / 0.3`, and that each score set is max-normalized to
+   0–1 before blending.
+3. Add a small worked example: sample raw vector + BM25 scores for two
+   chunks, show the normalization, the weighted blend, and the resulting
+   ranking, so the numbers are concrete.
+4. Note the post-blend behavior (min_score threshold and top-k cutoff) and
+   where the defaults are configured (`HybridRetriever` constructor args), so
+   readers know how to tune them.
+5. Proofread: confirm every number and default in the doc matches the code,
+   and that internal references (file paths) are correct.
+
+### Inputs & outputs
+
+- **Input:** The current `HybridRetriever` implementation (the authoritative
+  formula and defaults) and the existing `docs/ARCHITECTURE.md` structure.
+- **Output:** An updated `docs/ARCHITECTURE.md` with a new scoring subsection
+  containing the formula, default weights, normalization explanation, and a
+  worked numeric example. No code behavior changes.
+
+### Risks & unknowns
+
+- **Doc drift:** If the weights or formula in `hybrid.py` change later, the
+  doc could go stale. Mitigation: point readers to the `HybridRetriever`
+  constructor as the source of the defaults rather than implying the doc is
+  canonical.
+- **Accuracy risk:** The worked example must match the code's actual
+  normalization (max-normalization, not softmax or min-max). I confirmed it
+  divides by the max of each score set — the example is built on that.
+- **Scope creep:** Tempting to also document `min_score`/`max_chunks` tuning
+  or the BM25 tokenizer; I'll keep it to what the issue asks (formula +
+  weights + example) and mention the thresholds only briefly.
+
+### Edge cases
+
+The doc should acknowledge the states the code already handles, so readers
+aren't surprised:
+
+- A chunk found by **only** vector search or **only** keyword search — the
+  missing side contributes 0 to the blend (code defaults the absent score to
+  `0.0`).
+- **All-zero scores** on one side — normalization guards against divide-by-zero
+  (`if max > 0 else 0`), so the blend degrades gracefully to the other signal.
+- The **min_score filter** dropping everything — the result list can legitimately
+  be shorter than `max_chunks` (or empty).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -59,6 +59,45 @@ A plan-execute orchestrator that coordinates multiple analysis tools. Each tool 
 ### RAG System (`rag/`)
 Hybrid retrieval (vector similarity + BM25 keyword) fetches relevant context from the user's ingested documents. The generator uses prompt templates to produce structured, evidence-based feedback. The evaluator scores retrieval relevance and generation faithfulness.
 
+#### Hybrid Retrieval Scoring
+
+`HybridRetriever` (`rag/retriever/hybrid.py`) blends two independent signals into a single relevance score for each candidate chunk:
+
+- **Vector score** — cosine similarity from `VectorStore.query()` (`rag/retriever/vector_store.py`).
+- **Keyword score** — a raw BM25 score from `KeywordSearcher.search()` (`rag/retriever/keyword_search.py`).
+
+Because the two scores live on different scales, each is first **normalized against the maximum score in its own result set** for the query (divide by max; guarded against divide-by-zero, defaulting to `0` when a result set is empty). The normalized scores are then combined with fixed weights:
+
+```
+blended_score = vector_weight * (vector_score / max(vector_scores))
+              + keyword_weight * (keyword_score / max(keyword_scores))
+```
+
+The default weights, set in the `HybridRetriever` constructor, favor the semantic signal:
+
+| Weight | Default | Meaning |
+|---|---|---|
+| `vector_weight` | `0.7` | Contribution of vector similarity |
+| `keyword_weight` | `0.3` | Contribution of BM25 keyword overlap |
+
+A chunk returned by only one of the two searches still gets a blended score — the missing side simply contributes `0`.
+
+**Worked example.** Suppose a query returns two candidate chunks:
+
+| Chunk | Raw vector score | Raw BM25 score |
+|---|---|---|
+| A | 0.90 (max) | 4.0 |
+| B | 0.60 | 8.0 (max) |
+
+Normalizing each column by its max gives vector scores `1.00` / `0.67` and keyword scores `0.50` / `1.00`. Applying the default `0.7` / `0.3` weights:
+
+- Chunk A: `0.7 * 1.00 + 0.3 * 0.50 = 0.85`
+- Chunk B: `0.7 * 0.67 + 0.3 * 1.00 = 0.77`
+
+Chunk A ranks first even though Chunk B's keyword match was stronger, because the default weighting favors semantic similarity.
+
+After blending, `HybridRetriever.retrieve()` drops any chunk below `min_score` (default `0.3`) and returns at most `max_chunks` (default `10`) results — so the final list can be shorter than `max_chunks`, or empty, if nothing clears the threshold. The weights are constructor arguments, not global constants, so callers can retune the vector/keyword balance per use case without touching the blending logic itself.
+
 ### Safety Layer (`safety/`)
 Middleware wrapping the generation pipeline. Components run in sequence: prompt injection defense → content filter → bias detector → PII scrubber. All safety events are logged with structured metadata for monitoring.
 


### PR DESCRIPTION
## Summary
Documents the hybrid retrieval scoring formula in `docs/ARCHITECTURE.md`. The RAG section previously said retrieval was "hybrid" but never explained how vector and keyword scores are combined — this adds the formula, default weights, normalization step, and a worked example so contributors can reason about and tune ranking without reading `hybrid.py` directly.

## Issue
Closes #36

## Changes
- Added a "Hybrid Retrieval Scoring" subsection under RAG System in `docs/ARCHITECTURE.md`
- Documented the blending formula and default weights (`vector_weight=0.7`, `keyword_weight=0.3`)
- Documented the max-normalization step applied to each score set before blending
- Added a worked two-chunk example showing normalization and the resulting ranking
- Noted the post-blend `min_score`/`max_chunks` filtering behavior

## Testing
- [ ] N/A — documentation-only change, no code behavior touched, no new tests required
- [ ] Linter passes (`make lint`) — 182 pre-existing errors, unchanged by this PR
- [ ] Type checker passes (`make typecheck`) — 5 pre-existing errors (missing type stubs), unchanged by this PR
- [x] Unit tests pass (`make test-unit`) — 53 pre-existing failures / 375 passed, unchanged by this PR (none touch `docs/` or `rag/retriever/hybrid.py`)

All counts above were verified identical before and after this change.

## Screenshots / Demo
N/A — documentation change.

## Notes for Reviewers
The formula, defaults, and worked example were verified directly against `rag/retriever/hybrid.py` (constructor defaults + `retrieve()` normalization/blending logic) line-by-line to make sure the doc matches actual behavior, not just intent.
