### PR TITLE
Feat/53 dependency audit tool

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -19,3 +19,16 @@ PathReview currently identifies technologies used in a repository, but it does n
 ### Issue fit and selection reasoning
 
 I selected this Tier 2 issue because it requires understanding how the agent tools and orchestrator work together, but it is still limited to a clearly defined feature. I reviewed `agent/tools/base.py`, `agent/tools/tech_detector.py`, `agent/tools/readme_scorer.py`, `agent/orchestrator.py`, and the existing unit tests for `TechDetector`. My experience with Python, APIs, testing, and agent-based applications makes the scope realistic for me. The issue has no listed blockers or unresolved dependencies, and I believe it can be completed and tested within Weeks 8 and 9.
+
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [test:reproduce missing dependency audit tool](https://github.com/dinakarbl00/pathreview/commit/d972ea935c78f46f4d91f4d2ca3eee390a66f40f)
+
+**Reproduction summary:**
+I reproduced the feature gap by adding a unit test that checks whether the `agent.tools.dependency_audit_tool` module exists. The test failed because the module has not yet been implemented, confirming that PathReview currently has no agent tool for auditing outdated project dependencies.
+
+**PLAN.md link:** [PLAN.md](https://github.com/dinakarbl00/pathreview/blob/feat/53-dependency-audit-tool/PLAN.md)
+
+**Blockers or open questions:**
+The main open question is how the tool should obtain the contents of dependency manifest files. The existing GitHub tool retrieves repository metadata but does not download `requirements.txt`, `package.json`, or `pyproject.toml`, so the implementation may need to use the GitHub Contents API while keeping the work within issue #53’s Tier 2 scope.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,21 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/53
+
+**Issue title:** Implement a `DependencyAuditTool` that flags outdated major dependencies in project repos
+
+**Tier:** [ ] Tier 1  [x] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+
+PathReview currently identifies technologies used in a repository, but it does not check whether the project depends on packages that are significantly outdated. This issue requires a new agent tool that reads dependencies from `requirements.txt`, `package.json`, and `pyproject.toml`, compares their versions with current releases, and flags packages that are more than one major version behind. The tool must follow the existing `BaseTool` structure and be connected to the agent orchestrator. A successful fix will produce clear dependency audit results and include tests for the supported file types and error cases.
+
+**Branch name:** `feat/53-dependency-audit-tool`
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger
+
+### Issue fit and selection reasoning
+
+I selected this Tier 2 issue because it requires understanding how the agent tools and orchestrator work together, but it is still limited to a clearly defined feature. I reviewed `agent/tools/base.py`, `agent/tools/tech_detector.py`, `agent/tools/readme_scorer.py`, `agent/orchestrator.py`, and the existing unit tests for `TechDetector`. My experience with Python, APIs, testing, and agent-based applications makes the scope realistic for me. The issue has no listed blockers or unresolved dependencies, and I believe it can be completed and tested within Weeks 8 and 9.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -49,3 +49,25 @@ I will open a draft pull request, request peer or mentor feedback, review the im
 **Blockers:**
 
 The repository-wide checks have pre-existing failures. Before implementation, the unit suite had 53 unrelated failures and 375 passing tests when the reproduction test was excluded. After implementation, the same 53 tests fail and 381 pass, confirming that the six new tests pass without introducing new failures. Repository-wide Ruff also reports existing errors, while Ruff, Black, and Mypy pass when run against the issue-related files.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/402
+
+**Branch:** `feat/53-dependency-audit-tool`
+
+**What you built:**
+
+I added a `DependencyAuditTool` that reads dependency information from `requirements.txt`, `package.json`, and `pyproject.toml`, checks current package versions through PyPI and npm, and flags dependencies that are more than one major version behind. The tool can receive manifest contents directly or retrieve supported root-level files from GitHub, and the agent orchestrator now schedules the audit for the first submitted GitHub project.
+
+**Tests added or updated:**
+
+I updated `tests/unit/test_dependency_audit_tool.py` with six tests covering Python dependency auditing, npm dependency auditing, standard and Poetry `pyproject.toml` dependencies, empty manifests, missing input, and orchestrator plan integration. All six new tests pass.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+The repository contains documented pre-existing failures. Before implementation, the unit suite had 53 unrelated failures and 375 passing tests when the reproduction test was excluded. After implementation, the same 53 tests fail and 381 tests pass, confirming that the contribution introduced six passing tests and no new failures. Repository-wide Ruff also contains pre-existing errors, while targeted Ruff, Black, Mypy, and unit tests pass for all issue-related files.
+
+**Draft PR feedback received from:** none 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -32,3 +32,20 @@ I reproduced the feature gap by adding a unit test that checks whether the `agen
 
 **Blockers or open questions:**
 The main open question is how the tool should obtain the contents of dependency manifest files. The existing GitHub tool retrieves repository metadata but does not download `requirements.txt`, `package.json`, or `pyproject.toml`, so the implementation may need to use the GitHub Contents API while keeping the work within issue #53’s Tier 2 scope.
+
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+
+I implemented the new `DependencyAuditTool` using the existing `BaseTool` and `ToolResult` structure. The tool supports `requirements.txt`, `package.json`, and `pyproject.toml`, retrieves root-level dependency manifests from GitHub when repository details are provided, checks current versions through PyPI and npm, and flags packages that are more than one major version behind. I also updated the orchestrator to schedule the dependency audit for the first submitted GitHub project and added six unit tests covering the supported formats, version comparison behavior, missing input, empty manifests, and orchestrator integration.
+
+**Next steps:**
+
+I will open a draft pull request, request peer or mentor feedback, review the implementation and PR description against `CONTRIBUTING.md`, and address any feedback that improves the solution. Before marking the PR ready for review, I will rerun the targeted tests and quality checks, document the repository’s pre-existing full-suite failures, and complete Check-in 2 with the final PR link.
+
+**Blockers:**
+
+The repository-wide checks have pre-existing failures. Before implementation, the unit suite had 53 unrelated failures and 375 passing tests when the reproduction test was excluded. After implementation, the same 53 tests fail and 381 pass, confirming that the six new tests pass without introducing new failures. Repository-wide Ruff also reports existing errors, while Ruff, Black, and Mypy pass when run against the issue-related files.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -71,3 +71,42 @@ I updated `tests/unit/test_dependency_audit_tool.py` with six tests covering Pyt
 The repository contains documented pre-existing failures. Before implementation, the unit suite had 53 unrelated failures and 375 passing tests when the reproduction test was excluded. After implementation, the same 53 tests fail and 381 tests pass, confirming that the contribution introduced six passing tests and no new failures. Repository-wide Ruff also contains pre-existing errors, while targeted Ruff, Black, Mypy, and unit tests pass for all issue-related files.
 
 **Draft PR feedback received from:** none 
+
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+
+No reviewer or maintainer feedback was received. Reviewer feedback was not provided as part of the Summer 2026 course workflow, so I reviewed the pull request myself, confirmed that the issue-specific tests and quality checks passed, and documented the repository's unrelated pre-existing failures.
+
+**How you responded:**
+
+No code-review response or additional code change was required. I kept the pull request available for maintainers, verified that the branch contained the completed implementation and documentation, and finished the contribution reflection.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+
+The hardest part was defining the correct scope for a feature that did not already exist. Issue #53 sounded like a single new agent tool, but the tool needed actual dependency-file contents while the existing `TechDetector` only received file paths and the existing `GitHubTool` mainly returned repository metadata. I had to trace the agent flow before deciding that the new tool should support both direct manifest contents and GitHub repository input. Handling dependency formats was also more complex than expected because version declarations can contain ranges, environment markers, Git URLs, workspace references, aliases, and unpinned packages. Another challenge was separating failures caused by my work from the repository's existing failures. I recorded a baseline, compared the full unit-suite results before and after implementation, and used targeted Ruff, Black, Mypy, and pytest commands to prove that my files were clean.
+
+**What did you learn about working in a large codebase?**
+
+I learned that contributing to an existing codebase requires more restraint than building a project from scratch. In my own project, I might redesign the data flow immediately, but in PathReview I needed to follow the existing `BaseTool`, `ToolResult`, test, branch, and commit conventions and avoid expanding a Tier 2 issue into a larger review-pipeline refactor. I also learned to inspect not only the file named in an issue but its callers, inputs, tests, and integration points. A change can be locally correct and still be unsafe if it does not match the surrounding architecture. The baseline failures also showed me why contributors must distinguish their own regressions from existing technical debt instead of trying to fix unrelated problems inside the same pull request.
+
+**How did AI tools help — and where did they fall short?**
+
+AI tools were most useful for organizing the codebase investigation, explaining unfamiliar modules, drafting a structured implementation plan, proposing edge cases, and helping interpret pytest, Ruff, Black, Mypy, Git, and pre-commit output. They also helped turn the issue requirements into concrete tests for the three supported manifest formats and the orchestrator integration. However, AI suggestions still had to be checked against the actual repository. Some early assumptions about how tools were registered or how manifest contents were already available were not confirmed until I inspected the uploaded repository files. AI also could not decide the correct scope on its own; I had to compare its suggestions with the issue body, existing interfaces, test behavior, and course requirements. The most reliable workflow was to use AI for options and explanations, then validate every decision by reading the code and running the commands locally.
+
+**What would you do differently if you started over?**
+
+I would record the repository-wide test, lint, and type-check baseline at the very beginning of Week 7 instead of waiting until implementation week. That would make it easier to identify pre-existing failures and avoid uncertainty when the error counts changed. I would also define the tool's input and output contract before writing the behavior tests and ask for clarification earlier about whether nested monorepo manifests were in scope. From an implementation perspective, I would consider separating manifest parsing, registry lookup, and GitHub retrieval into smaller components earlier, even if they remained in the same file, because that would make each responsibility easier to test. I would still choose issue #53, but I would open the draft pull request as soon as the first passing vertical slice was available.
+
+**What are you most proud of from this module?**
+
+I am most proud that I completed the full open-source contribution process rather than only writing the feature code. I claimed and scoped the issue, reproduced the missing feature, created a detailed plan, implemented the tool, integrated it with the orchestrator, added six passing tests, documented pre-existing repository failures, and opened pull request #402. The full unit suite kept the same 53 unrelated failures while the passing count increased from 375 to 381, which gave me concrete evidence that my contribution added coverage without introducing new regressions.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,129 @@
+## Solution plan
+
+**Issue:** [Implement a `DependencyAuditTool` that flags outdated major dependencies in project repos](https://github.com/ascherj/pathreview/issues/53)
+
+### Understand
+
+PathReview currently detects technologies from repository file names, but it does not inspect project dependency files or report packages that are significantly outdated. The existing `GitHubTool` retrieves repository metadata only, while `TechDetector` receives file paths without their contents. There is also no `dependency_audit` tool in the agent system or corresponding entry in the orchestrator’s execution plan.
+
+The expected behavior is for PathReview to inspect supported dependency manifests, determine the declared dependency versions, compare them with current package-registry releases, and flag dependencies whose latest major version is more than one major version ahead of the project’s declared version. For example, a project using version 1.x when version 3.x is current should be flagged, while a project using version 2.x when version 3.x is current should not be flagged.
+
+### Map
+
+Files expected to be added or modified:
+
+- `agent/tools/dependency_audit_tool.py`
+  - New `DependencyAuditTool` implementation.
+  - Parsing logic for Python and npm dependency manifests.
+  - GitHub manifest retrieval and package-registry version lookup.
+  - Major-version comparison and structured result generation.
+
+- `agent/orchestrator.py`
+  - Add `dependency_audit` to the execution plan when a profile contains a GitHub project.
+  - Pass the GitHub username and repository name to the tool.
+
+- `tests/unit/test_dependency_audit_tool.py`
+  - Expand the reproduction test into unit tests for parsing, version comparison, missing files, malformed content, and mocked API responses.
+
+- Potentially `tests/fixtures/`
+  - Add mock GitHub, PyPI, or npm responses only if keeping the response data inside the test file makes the tests difficult to read.
+
+The following existing code provides the implementation patterns:
+
+- `agent/tools/base.py`
+- `agent/tools/github_tool.py`
+- `agent/tools/tech_detector.py`
+- `agent/orchestrator.py`
+- `tests/unit/test_tech_detector.py`
+
+### Plan
+
+1. Implement the `DependencyAuditTool` using the existing `BaseTool` and `ToolResult` interface. Define an input contract that accepts a GitHub username and repository name, while also allowing dependency-file contents to be supplied directly for isolated unit testing.
+
+2. Add helpers that retrieve supported root-level manifest files from GitHub and parse:
+   - `requirements.txt`
+   - `package.json`
+   - `pyproject.toml`
+
+   Use Python’s built-in `json` and `tomllib` modules where possible, and conservatively skip dependency entries that do not contain a usable numeric version.
+
+3. Add package-registry lookup helpers using `httpx`. Python dependencies will be checked against PyPI, and JavaScript dependencies will be checked against npm. Compare the declared and current major versions and flag a dependency only when the difference is greater than one.
+
+4. Update `Orchestrator._build_plan()` so that a `dependency_audit` task is added for the first submitted GitHub project, following the existing behavior of `github_tool`. Pass `github_username` and `repo_name` as the tool input.
+
+5. Add unit tests with mocked HTTP responses. Cover each supported manifest format, outdated and current dependencies, missing manifests, malformed input, registry failures, and the orchestrator plan entry. Run Ruff, Black, Mypy, and the unit test suite before submitting the implementation.
+
+### Inputs & outputs
+
+The primary tool input will contain:
+
+- `github_username`: owner of the GitHub repository
+- `repo_name`: repository to inspect
+
+For testing and future ingestion integration, the tool may also accept:
+
+- `dependency_files`: a mapping of file paths to file contents
+
+Example direct input:
+
+```python
+{
+    "dependency_files": {
+        "requirements.txt": "fastapi==0.90.0\nhttpx==0.20.0",
+        "package.json": "{\"dependencies\": {\"react\": \"^16.0.0\"}}",
+    }
+}
+```
+
+The tool should return a `ToolResult`. Its data should clearly report:
+
+- Which manifest files were found and audited
+- How many dependencies were checked
+- Which dependencies are outdated
+- Their declared and latest versions
+- How many major versions behind they are
+- Their package ecosystem and source manifest
+- Any dependencies or files that were skipped because they could not be parsed or checked
+
+An outdated dependency entry should resemble:
+
+```python
+{
+    "name": "example-package",
+    "ecosystem": "pypi",
+    "declared_version": "1.4.0",
+    "latest_version": "3.1.0",
+    "major_versions_behind": 2,
+    "source_file": "requirements.txt",
+}
+```
+
+### Risks & unknowns
+
+- The repository does not currently have a complete path for downloading manifest contents. The new tool may need to retrieve supported files through the GitHub Contents API rather than relying on `TechDetector` file paths.
+- `Orchestrator` accepts a dictionary of tool instances, but no current production construction point for that dictionary exists in the repository. The issue's orchestrator integration will therefore focus on adding the tool to the execution plan without redesigning the placeholder review pipeline.
+- Dependency version specifications can be complex. Examples include ranges, wildcards, Git URLs, local paths, extras, environment markers, npm aliases, and workspace dependencies. The first implementation should handle common numeric versions and skip unsupported specifications safely.
+- GitHub, PyPI, and npm requests may fail because of rate limits, timeouts, unavailable packages, or private repositories. External failures should not crash the entire agent run.
+- Some repositories are monorepos with manifests below the root directory. Root-level manifest support is the initial scope unless the issue owner confirms that recursive repository traversal is required.
+- Scoped npm package names must be URL encoded correctly when querying the npm registry.
+- Pre-release versions could produce misleading comparisons. Registry responses should use the normal latest release rather than treating every pre-release as current.
+
+### Edge cases
+
+The implementation should handle these cases gracefully:
+
+- No supported dependency files are present
+- The input dictionary is empty or missing repository information
+- `requirements.txt` contains blank lines, comments, recursive includes, editable installs, URLs, or environment markers
+- A Python dependency is unpinned or does not contain a numeric version
+- `package.json` contains invalid JSON
+- `package.json` has no dependency sections
+- npm dependencies use `^`, `~`, wildcards, aliases, Git URLs, or workspace references
+- `pyproject.toml` contains invalid TOML
+- Dependencies appear under standard PEP 621 or Poetry sections
+- A package does not exist in PyPI or npm
+- A registry request times out or returns an invalid response
+- The declared and latest versions have the same major version
+- The latest version is exactly one major version ahead, which should not be flagged
+- The latest version is two or more major versions ahead, which should be flagged
+- The same dependency appears in more than one manifest

--- a/agent/orchestrator.py
+++ b/agent/orchestrator.py
@@ -1,12 +1,12 @@
 """Plan-execute orchestrator for agent tools."""
 
 import time
-import structlog
-from typing import Optional
 
-from .memory.session_store import SessionStore
-from .memory.context_manager import ContextManager
+import structlog
+
 from .error_handling import retry_with_backoff
+from .memory.context_manager import ContextManager
+from .memory.session_store import SessionStore
 
 logger = structlog.get_logger()
 
@@ -14,8 +14,9 @@ logger = structlog.get_logger()
 class Orchestrator:
     """Orchestrate tool execution with planning and memoization."""
 
-    def __init__(self, tools: dict, session_store: Optional[SessionStore] = None,
-                 tool_timeout: float = 30.0):
+    def __init__(
+        self, tools: dict, session_store: SessionStore | None = None, tool_timeout: float = 30.0
+    ):
         """Initialize orchestrator.
 
         Args:
@@ -53,7 +54,7 @@ class Orchestrator:
         for tool_name, tool_input in plan:
             try:
                 result = self._execute_tool(tool_name, tool_input)
-                results[tool_name] = result.data if hasattr(result, 'data') else result
+                results[tool_name] = result.data if hasattr(result, "data") else result
 
                 logger.info("tool_executed", tool=tool_name, success=True)
 
@@ -66,13 +67,12 @@ class Orchestrator:
             session_state.update(results)
             self.session_store.set(profile_id, session_state)
 
-        logger.info("orchestrator_complete", profile_id=profile_id,
-                   tools_executed=len(results))
+        logger.info("orchestrator_complete", profile_id=profile_id, tools_executed=len(results))
 
         return {
             "profile_id": profile_id,
             "tool_results": results,
-            "cached_results": self.context_manager.get_all_results()
+            "cached_results": self.context_manager.get_all_results(),
         }
 
     def _build_plan(self, profile_data: dict) -> list[tuple[str, dict]]:
@@ -86,49 +86,44 @@ class Orchestrator:
         """
         plan = []
 
-        # Conditionally add GitHub tool
+        # Add GitHub tools when a project repository is available
         if profile_data.get("github_username"):
             for project in profile_data.get("projects", []):
                 if project.get("github_repo"):
-                    plan.append((
-                        "github_tool",
-                        {
-                            "github_username": profile_data["github_username"],
-                            "repo_name": project["github_repo"]
-                        }
-                    ))
+                    repository_input = {
+                        "github_username": profile_data["github_username"],
+                        "repo_name": project["github_repo"],
+                    }
+
+                    plan.append(("github_tool", repository_input))
+                    plan.append(("dependency_audit", repository_input.copy()))
                     break  # Only process first repo for now
 
         # Tech detector (if files available)
         if profile_data.get("files"):
-            plan.append((
-                "tech_detector",
-                {"files": profile_data["files"]}
-            ))
+            plan.append(("tech_detector", {"files": profile_data["files"]}))
 
         # README scorer
         if profile_data.get("readme_content"):
-            plan.append((
-                "readme_scorer",
-                {"readme_content": profile_data["readme_content"]}
-            ))
+            plan.append(("readme_scorer", {"readme_content": profile_data["readme_content"]}))
 
         # Skill extractor
         if profile_data.get("resume_text"):
-            plan.append((
-                "skill_extractor",
-                {
-                    "resume_text": profile_data["resume_text"],
-                    "repo_metadata": profile_data.get("repo_metadata", {})
-                }
-            ))
+            plan.append(
+                (
+                    "skill_extractor",
+                    {
+                        "resume_text": profile_data["resume_text"],
+                        "repo_metadata": profile_data.get("repo_metadata", {}),
+                    },
+                )
+            )
 
         # Market analyzer (if skills detected)
         if plan:  # Only if other tools executed
-            plan.append((
-                "market_analyzer",
-                {"detected_skills": {}}  # Will be populated by context
-            ))
+            plan.append(
+                ("market_analyzer", {"detected_skills": {}})  # Will be populated by context
+            )
 
         logger.info("plan_built", plan_size=len(plan))
         return plan
@@ -172,7 +167,7 @@ class Orchestrator:
             logger.error("tool_execution_error", tool=tool_name, error=str(e))
             raise
 
-    def _execute_with_timeout(self, tool, tool_input: dict, timeout: Optional[float] = None):
+    def _execute_with_timeout(self, tool, tool_input: dict, timeout: float | None = None):
         """Execute tool with timeout.
 
         Args:

--- a/agent/tools/dependency_audit_tool.py
+++ b/agent/tools/dependency_audit_tool.py
@@ -1,0 +1,431 @@
+"""Audit project dependencies for outdated major versions."""
+
+import base64
+import json
+import re
+import tomllib
+from urllib.parse import quote
+
+import httpx
+import structlog
+
+from .base import BaseTool, ToolResult
+
+logger = structlog.get_logger()
+
+
+class DependencyAuditTool(BaseTool):
+    """Find dependencies that are more than one major version behind."""
+
+    name = "dependency_audit"
+    description = "Audit project dependencies for outdated major versions"
+
+    SUPPORTED_FILES = ("requirements.txt", "package.json", "pyproject.toml")
+    DEPENDENCY_SECTIONS = (
+        "dependencies",
+        "devDependencies",
+        "optionalDependencies",
+        "peerDependencies",
+    )
+
+    def __init__(self, api_token: str | None = None) -> None:
+        """Initialize the dependency audit tool.
+
+        Args:
+            api_token: Optional GitHub API token.
+        """
+        self.api_token = api_token
+        self.github_base_url = "https://api.github.com"
+        self.pypi_base_url = "https://pypi.org/pypi"
+        self.npm_base_url = "https://registry.npmjs.org"
+
+    def execute(self, input_data: dict) -> ToolResult:
+        """Audit supported dependency files.
+
+        Args:
+            input_data: Either a ``dependency_files`` mapping or GitHub repository details.
+
+        Returns:
+            ToolResult containing audited manifests and outdated dependencies.
+        """
+        try:
+            dependency_files = self._resolve_dependency_files(input_data)
+            if dependency_files is None:
+                return ToolResult(
+                    success=False,
+                    data={},
+                    error=("Provide dependency_files or both github_username and repo_name"),
+                )
+
+            audit_data = self._audit_files(dependency_files)
+            return ToolResult(success=True, data=audit_data)
+        except Exception as error:
+            logger.error("dependency_audit_error", error=str(error))
+            return ToolResult(success=False, data={}, error=str(error))
+
+    def _resolve_dependency_files(self, input_data: dict) -> dict[str, str] | None:
+        """Return direct manifest contents or retrieve them from GitHub."""
+        if "dependency_files" in input_data:
+            dependency_files = input_data["dependency_files"]
+            if not isinstance(dependency_files, dict):
+                raise ValueError("dependency_files must be a mapping of file names to contents")
+
+            return {
+                str(file_name): content
+                for file_name, content in dependency_files.items()
+                if isinstance(content, str)
+            }
+
+        username = input_data.get("github_username")
+        repo_name = input_data.get("repo_name")
+        if not username or not repo_name:
+            return None
+
+        return self._fetch_dependency_files(str(username), str(repo_name))
+
+    def _fetch_dependency_files(self, username: str, repo_name: str) -> dict[str, str]:
+        """Retrieve supported root-level dependency files from GitHub."""
+        dependency_files: dict[str, str] = {}
+        headers = {"Accept": "application/vnd.github+json"}
+        if self.api_token:
+            headers["Authorization"] = f"Bearer {self.api_token}"
+
+        for file_name in self.SUPPORTED_FILES:
+            url = f"{self.github_base_url}/repos/{username}/{repo_name}/contents/" f"{file_name}"
+
+            try:
+                response = httpx.get(url, headers=headers, timeout=10.0)
+                if response.status_code == 404:
+                    continue
+
+                response.raise_for_status()
+                payload = response.json()
+                encoded_content = payload.get("content", "")
+                if not encoded_content:
+                    continue
+
+                dependency_files[file_name] = base64.b64decode(encoded_content).decode("utf-8")
+            except (httpx.HTTPError, ValueError, UnicodeDecodeError) as error:
+                logger.warning(
+                    "dependency_manifest_fetch_failed",
+                    file=file_name,
+                    username=username,
+                    repo=repo_name,
+                    error=str(error),
+                )
+
+        return dependency_files
+
+    def _audit_files(self, dependency_files: dict[str, str]) -> dict:
+        """Parse dependency files and compare declared versions with registries."""
+        manifests_found: list[str] = []
+        dependencies: list[dict[str, str]] = []
+        skipped_dependencies: list[dict[str, str]] = []
+
+        for file_path, content in dependency_files.items():
+            file_name = file_path.replace("\\", "/").rsplit("/", maxsplit=1)[-1]
+            if file_name not in self.SUPPORTED_FILES:
+                continue
+
+            manifests_found.append(file_path)
+            try:
+                dependencies.extend(self._parse_dependency_file(file_name, file_path, content))
+            except (json.JSONDecodeError, tomllib.TOMLDecodeError, ValueError) as error:
+                skipped_dependencies.append(
+                    {
+                        "name": file_path,
+                        "reason": f"Could not parse manifest: {error}",
+                    }
+                )
+
+        outdated_dependencies: list[dict[str, object]] = []
+        dependencies_checked = 0
+
+        for dependency in dependencies:
+            latest_version = self._get_latest_version(dependency["name"], dependency["ecosystem"])
+            if latest_version is None:
+                skipped_dependencies.append(
+                    {
+                        "name": dependency["name"],
+                        "reason": "Latest version could not be retrieved",
+                    }
+                )
+                continue
+
+            dependencies_checked += 1
+            declared_major = self._get_major_version(dependency["declared_version"])
+            latest_major = self._get_major_version(latest_version)
+            if declared_major is None or latest_major is None:
+                skipped_dependencies.append(
+                    {
+                        "name": dependency["name"],
+                        "reason": "Version could not be compared",
+                    }
+                )
+                continue
+
+            major_versions_behind = latest_major - declared_major
+            if major_versions_behind > 1:
+                outdated_dependencies.append(
+                    {
+                        **dependency,
+                        "latest_version": latest_version,
+                        "major_versions_behind": major_versions_behind,
+                    }
+                )
+
+        return {
+            "manifests_found": manifests_found,
+            "dependencies_checked": dependencies_checked,
+            "outdated_dependencies": outdated_dependencies,
+            "skipped_dependencies": skipped_dependencies,
+        }
+
+    def _parse_dependency_file(
+        self,
+        file_name: str,
+        source_file: str,
+        content: str,
+    ) -> list[dict[str, str]]:
+        """Parse a supported dependency file into a common structure."""
+        if file_name == "requirements.txt":
+            return self._parse_requirements(content, source_file)
+        if file_name == "package.json":
+            return self._parse_package_json(content, source_file)
+        if file_name == "pyproject.toml":
+            return self._parse_pyproject(content, source_file)
+        return []
+
+    def _parse_requirements(
+        self,
+        content: str,
+        source_file: str,
+    ) -> list[dict[str, str]]:
+        """Parse common pinned or constrained requirements.txt entries."""
+        dependencies: list[dict[str, str]] = []
+
+        for raw_line in content.splitlines():
+            line = raw_line.strip()
+            if not line or line.startswith(("#", "-", "http://", "https://", "git+")):
+                continue
+
+            line = line.split(";", maxsplit=1)[0].strip()
+            match = re.match(
+                r"^([A-Za-z0-9][A-Za-z0-9._-]*)(?:\[[^\]]+\])?"
+                r"\s*(?:===|==|~=|>=|<=|>|<)\s*([0-9][A-Za-z0-9.!+-]*)",
+                line,
+            )
+            if not match:
+                continue
+
+            dependencies.append(
+                self._dependency_entry(
+                    name=match.group(1),
+                    ecosystem="pypi",
+                    declared_version=match.group(2),
+                    source_file=source_file,
+                )
+            )
+
+        return dependencies
+
+    def _parse_package_json(
+        self,
+        content: str,
+        source_file: str,
+    ) -> list[dict[str, str]]:
+        """Parse dependency sections from package.json."""
+        payload = json.loads(content)
+        dependencies: list[dict[str, str]] = []
+
+        for section in self.DEPENDENCY_SECTIONS:
+            section_data = payload.get(section, {})
+            if not isinstance(section_data, dict):
+                continue
+
+            for name, version_spec in section_data.items():
+                if not isinstance(version_spec, str):
+                    continue
+
+                version = self._extract_version(version_spec)
+                if version is None:
+                    continue
+
+                dependencies.append(
+                    self._dependency_entry(
+                        name=str(name),
+                        ecosystem="npm",
+                        declared_version=version,
+                        source_file=source_file,
+                    )
+                )
+
+        return dependencies
+
+    def _parse_pyproject(
+        self,
+        content: str,
+        source_file: str,
+    ) -> list[dict[str, str]]:
+        """Parse PEP 621 and Poetry dependencies from pyproject.toml."""
+        payload = tomllib.loads(content)
+        dependencies: list[dict[str, str]] = []
+
+        project = payload.get("project", {})
+        if isinstance(project, dict):
+            project_dependencies = project.get("dependencies", [])
+            if isinstance(project_dependencies, list):
+                for requirement in project_dependencies:
+                    if isinstance(requirement, str):
+                        entry = self._parse_python_requirement(requirement, source_file)
+                        if entry:
+                            dependencies.append(entry)
+
+            optional_groups = project.get("optional-dependencies", {})
+            if isinstance(optional_groups, dict):
+                for group_dependencies in optional_groups.values():
+                    if not isinstance(group_dependencies, list):
+                        continue
+                    for requirement in group_dependencies:
+                        if isinstance(requirement, str):
+                            entry = self._parse_python_requirement(requirement, source_file)
+                            if entry:
+                                dependencies.append(entry)
+
+        tool_data = payload.get("tool", {})
+        poetry = tool_data.get("poetry", {}) if isinstance(tool_data, dict) else {}
+        if isinstance(poetry, dict):
+            poetry_dependencies = poetry.get("dependencies", {})
+            dependencies.extend(self._parse_poetry_dependencies(poetry_dependencies, source_file))
+
+            groups = poetry.get("group", {})
+            if isinstance(groups, dict):
+                for group_data in groups.values():
+                    if not isinstance(group_data, dict):
+                        continue
+                    dependencies.extend(
+                        self._parse_poetry_dependencies(
+                            group_data.get("dependencies", {}), source_file
+                        )
+                    )
+
+        return dependencies
+
+    def _parse_python_requirement(
+        self,
+        requirement: str,
+        source_file: str,
+    ) -> dict[str, str] | None:
+        """Parse one PEP-style dependency requirement."""
+        line = requirement.split(";", maxsplit=1)[0].strip()
+        match = re.match(
+            r"^([A-Za-z0-9][A-Za-z0-9._-]*)(?:\[[^\]]+\])?"
+            r"\s*(?:===|==|~=|>=|<=|>|<)\s*([0-9][A-Za-z0-9.!+-]*)",
+            line,
+        )
+        if not match:
+            return None
+
+        return self._dependency_entry(
+            name=match.group(1),
+            ecosystem="pypi",
+            declared_version=match.group(2),
+            source_file=source_file,
+        )
+
+    def _parse_poetry_dependencies(
+        self,
+        dependencies: object,
+        source_file: str,
+    ) -> list[dict[str, str]]:
+        """Parse a Poetry dependency mapping."""
+        if not isinstance(dependencies, dict):
+            return []
+
+        parsed: list[dict[str, str]] = []
+        for name, version_data in dependencies.items():
+            if str(name).lower() == "python":
+                continue
+
+            version_spec: str | None = None
+            if isinstance(version_data, str):
+                version_spec = version_data
+            elif isinstance(version_data, dict):
+                candidate = version_data.get("version")
+                if isinstance(candidate, str):
+                    version_spec = candidate
+
+            if version_spec is None:
+                continue
+
+            version = self._extract_version(version_spec)
+            if version is None:
+                continue
+
+            parsed.append(
+                self._dependency_entry(
+                    name=str(name),
+                    ecosystem="pypi",
+                    declared_version=version,
+                    source_file=source_file,
+                )
+            )
+
+        return parsed
+
+    def _get_latest_version(self, name: str, ecosystem: str) -> str | None:
+        """Get the latest stable version from PyPI or npm."""
+        try:
+            if ecosystem == "pypi":
+                url = f"{self.pypi_base_url}/{quote(name, safe='')}/json"
+                response = httpx.get(url, timeout=10.0)
+                response.raise_for_status()
+                version = response.json().get("info", {}).get("version")
+            elif ecosystem == "npm":
+                url = f"{self.npm_base_url}/{quote(name, safe='')}"
+                response = httpx.get(url, timeout=10.0)
+                response.raise_for_status()
+                version = response.json().get("dist-tags", {}).get("latest")
+            else:
+                return None
+
+            return str(version) if version else None
+        except (httpx.HTTPError, ValueError, TypeError) as error:
+            logger.warning(
+                "dependency_version_lookup_failed",
+                package=name,
+                ecosystem=ecosystem,
+                error=str(error),
+            )
+            return None
+
+    @staticmethod
+    def _extract_version(version_spec: str) -> str | None:
+        """Extract the first numeric version from a dependency specification."""
+        unsupported_prefixes = ("git+", "git://", "http://", "https://", "file:", "workspace:")
+        if version_spec.strip().lower().startswith(unsupported_prefixes):
+            return None
+
+        match = re.search(r"(?<![A-Za-z0-9])v?([0-9]+(?:\.[0-9A-Za-z!+-]+)*)", version_spec)
+        return match.group(1) if match else None
+
+    @staticmethod
+    def _get_major_version(version: str) -> int | None:
+        """Return the first numeric component of a version string."""
+        match = re.search(r"[0-9]+", version)
+        return int(match.group()) if match else None
+
+    @staticmethod
+    def _dependency_entry(
+        name: str,
+        ecosystem: str,
+        declared_version: str,
+        source_file: str,
+    ) -> dict[str, str]:
+        """Build a normalized dependency entry."""
+        return {
+            "name": name,
+            "ecosystem": ecosystem,
+            "declared_version": declared_version,
+            "source_file": source_file,
+        }

--- a/tests/unit/test_dependency_audit_tool.py
+++ b/tests/unit/test_dependency_audit_tool.py
@@ -1,13 +1,174 @@
-"""Reproduction test for issue #53."""
+"""Tests for dependency_audit_tool.py."""
 
-from importlib.util import find_spec
+import json
 
 import pytest
 
+from agent.orchestrator import Orchestrator
+from agent.tools.dependency_audit_tool import DependencyAuditTool
+
 
 @pytest.mark.unit
-def test_dependency_audit_tool_module_exists() -> None:
-    """Confirm the dependency audit agent tool is available."""
-    assert find_spec("agent.tools.dependency_audit_tool") is not None, (
-        "Issue #53 reproduced: " "agent.tools.dependency_audit_tool does not exist"
+class TestDependencyAuditTool:
+    """Test suite for DependencyAuditTool."""
+
+    @pytest.fixture
+    def tool(self) -> DependencyAuditTool:
+        """Create a DependencyAuditTool instance."""
+        return DependencyAuditTool()
+
+    def test_requirements_flags_only_dependencies_over_one_major_behind(
+        self,
+        tool: DependencyAuditTool,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Flag a dependency only when it is more than one major behind."""
+        latest_versions: dict[tuple[str, str], str] = {
+            ("old-package", "pypi"): "3.2.0",
+            ("near-current", "pypi"): "3.0.0",
+        }
+
+        def fake_latest_version(name: str, ecosystem: str) -> str | None:
+            return latest_versions.get((name, ecosystem))
+
+        monkeypatch.setattr(tool, "_get_latest_version", fake_latest_version)
+
+        result = tool.execute(
+            {
+                "dependency_files": {
+                    "requirements.txt": ("old-package==1.4.0\n" "near-current>=2.0.0\n")
+                }
+            }
+        )
+
+        assert result.success is True
+        assert result.data["manifests_found"] == ["requirements.txt"]
+        assert result.data["dependencies_checked"] == 2
+
+        outdated = result.data["outdated_dependencies"]
+        assert len(outdated) == 1
+        assert outdated[0] == {
+            "name": "old-package",
+            "ecosystem": "pypi",
+            "declared_version": "1.4.0",
+            "latest_version": "3.2.0",
+            "major_versions_behind": 2,
+            "source_file": "requirements.txt",
+        }
+
+    def test_package_json_dependencies_are_audited(
+        self,
+        tool: DependencyAuditTool,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Audit npm dependencies from package.json."""
+        latest_versions: dict[tuple[str, str], str] = {
+            ("react", "npm"): "19.0.0",
+            ("vite", "npm"): "6.0.0",
+        }
+
+        def fake_latest_version(name: str, ecosystem: str) -> str | None:
+            return latest_versions.get((name, ecosystem))
+
+        monkeypatch.setattr(tool, "_get_latest_version", fake_latest_version)
+
+        package_json = json.dumps(
+            {
+                "dependencies": {
+                    "react": "^16.0.0",
+                },
+                "devDependencies": {
+                    "vite": "^5.0.0",
+                },
+            }
+        )
+
+        result = tool.execute({"dependency_files": {"package.json": package_json}})
+
+        assert result.success is True
+        assert result.data["dependencies_checked"] == 2
+
+        outdated = result.data["outdated_dependencies"]
+        assert len(outdated) == 1
+        assert outdated[0]["name"] == "react"
+        assert outdated[0]["ecosystem"] == "npm"
+        assert outdated[0]["major_versions_behind"] == 3
+
+    def test_pyproject_dependencies_are_audited(
+        self,
+        tool: DependencyAuditTool,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Audit standard and Poetry dependencies from pyproject.toml."""
+        latest_versions: dict[tuple[str, str], str] = {
+            ("old-python-package", "pypi"): "3.0.0",
+            ("legacy-lib", "pypi"): "4.1.0",
+        }
+
+        def fake_latest_version(name: str, ecosystem: str) -> str | None:
+            return latest_versions.get((name, ecosystem))
+
+        monkeypatch.setattr(tool, "_get_latest_version", fake_latest_version)
+
+        pyproject = """
+[project]
+dependencies = [
+    "old-python-package>=1.2.0",
+]
+
+[tool.poetry.dependencies]
+python = "^3.11"
+"legacy-lib" = "^2.0.0"
+"""
+
+        result = tool.execute({"dependency_files": {"pyproject.toml": pyproject}})
+
+        assert result.success is True
+        assert result.data["dependencies_checked"] == 2
+
+        outdated_names = {dependency["name"] for dependency in result.data["outdated_dependencies"]}
+        assert outdated_names == {"old-python-package", "legacy-lib"}
+
+    def test_no_supported_manifests_returns_empty_audit(
+        self,
+        tool: DependencyAuditTool,
+    ) -> None:
+        """Return an empty successful audit when no manifests are provided."""
+        result = tool.execute({"dependency_files": {}})
+
+        assert result.success is True
+        assert result.data["manifests_found"] == []
+        assert result.data["dependencies_checked"] == 0
+        assert result.data["outdated_dependencies"] == []
+
+    def test_missing_input_returns_error(
+        self,
+        tool: DependencyAuditTool,
+    ) -> None:
+        """Require direct manifest contents or GitHub repository details."""
+        result = tool.execute({})
+
+        assert result.success is False
+        assert result.data == {}
+        assert result.error is not None
+
+
+@pytest.mark.unit
+def test_orchestrator_adds_dependency_audit_for_github_project() -> None:
+    """Add dependency auditing when a GitHub project is available."""
+    orchestrator = Orchestrator(tools={})
+
+    plan = orchestrator._build_plan(
+        {
+            "github_username": "octocat",
+            "projects": [{"github_repo": "hello-world"}],
+        }
     )
+
+    assert (
+        "dependency_audit",
+        {
+            "github_username": "octocat",
+            "repo_name": "hello-world",
+        },
+    ) in plan

--- a/tests/unit/test_dependency_audit_tool.py
+++ b/tests/unit/test_dependency_audit_tool.py
@@ -1,0 +1,13 @@
+"""Reproduction test for issue #53."""
+
+from importlib.util import find_spec
+
+import pytest
+
+
+@pytest.mark.unit
+def test_dependency_audit_tool_module_exists() -> None:
+    """Confirm the dependency audit agent tool is available."""
+    assert find_spec("agent.tools.dependency_audit_tool") is not None, (
+        "Issue #53 reproduced: " "agent.tools.dependency_audit_tool does not exist"
+    )


### PR DESCRIPTION
## Summary

Adds a new `DependencyAuditTool` that audits supported project dependency manifests and flags packages that are more than one major version behind their current release.

The tool supports:

- Direct manifest content for isolated testing
- Root-level `requirements.txt`
- Root-level `package.json`
- Root-level `pyproject.toml`
- GitHub manifest retrieval
- PyPI and npm version checks
- Agent orchestrator integration

## Issue

Closes #53

## Changes

- Added `agent/tools/dependency_audit_tool.py` using the existing `BaseTool` and `ToolResult` interfaces.
- Added parsing support for:
  - `requirements.txt`
  - `package.json`
  - Standard PEP 621 dependencies in `pyproject.toml`
  - Poetry dependencies in `pyproject.toml`
- Added GitHub manifest retrieval for supported root-level dependency files.
- Added PyPI and npm latest-version lookups.
- Added major-version comparison that flags a dependency only when it is more than one major version behind.
- Updated `Orchestrator._build_plan()` to schedule `dependency_audit` for the first submitted GitHub project.
- Added six unit tests covering manifest parsing, version comparison, empty input, missing input, and orchestrator integration.
- Added `PLAN.md` and updated `JOURNAL.md` for the course contribution workflow.

## Testing

### Targeted tests

- [x] Dependency audit unit tests pass
- [x] Ruff passes for issue-related files
- [x] Black passes for issue-related files
- [x] Mypy passes for issue-related files

Commands run:

```bash
python -m pytest tests/unit/test_dependency_audit_tool.py -v
ruff check agent/tools/dependency_audit_tool.py agent/orchestrator.py tests/unit/test_dependency_audit_tool.py
black --check agent/tools/dependency_audit_tool.py agent/orchestrator.py tests/unit/test_dependency_audit_tool.py
mypy agent/tools/dependency_audit_tool.py agent/orchestrator.py tests/unit/test_dependency_audit_tool.py
```

Result:

```text
6 passed
All targeted checks passed.
```

### Repository-wide checks

- [ ] `make test-unit` passes without existing repository failures
- [ ] `make check` passes without existing repository failures

The repository had pre-existing failures before this implementation:

- Before implementation, excluding the intentional reproduction test: **53 failed, 375 passed**
- After implementation: **53 failed, 381 passed**
- The same 53 unrelated failures remain.
- The six new dependency-audit tests pass.
- Repository-wide Ruff reports 183 existing errors.
- The pre-commit Mypy hook follows imports from `agent/orchestrator.py` and reports 13 existing errors in:
  - `agent/error_handling.py`
  - `agent/memory/context_manager.py`
  - `agent/memory/session_store.py`
  - Existing sections of `agent/orchestrator.py`

These failures are unrelated to issue #53, and this contribution does not introduce new full-suite failures.

## Screenshots / Demo

Not applicable. This change adds backend agent-tool behavior and does not modify the user interface.

## Notes for Reviewers

Please review the input and output contract of `DependencyAuditTool`, especially the decision to support both direct `dependency_files` input and GitHub repository input.

Direct input keeps the tool independently testable, while GitHub input allows it to work with repository details currently available to the orchestrator.

The initial scope audits supported manifests at the repository root. Complex or nonnumeric dependency specifications, including Git URLs, local paths, workspace references, and unpinned packages, are skipped instead of causing the audit to fail.
