### PR TITLE
fix(api): verify profile ownership before review creation

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -67,3 +67,27 @@ instead of returning `None` without writing to the database.
 The current test suite has no endpoint integration-test harness, so I still need to
 decide whether Week 9 route-level coverage belongs in `tests/security/` or should use a
 smaller mocked route test alongside the service regression.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+I implemented the ownership-scoped profile lookup in `create_review()`, added the route's
+404 response for missing or unowned profiles, and prevented background processing from
+being scheduled after rejection. The focused service and route tests pass.
+
+**Next steps:**
+Open the pull request, request peer or mentor feedback, address any applicable review
+comments, and complete Check-in 2 with the final PR link and validation results.
+
+**Blockers:**
+The repository-wide suite currently has unrelated pre-existing failures, and GNU Make
+is not installed in the local PowerShell environment. I ran the underlying pytest
+command directly and confirmed the seven review-creation tests pass.
+
+---
+
+### Check-in 2 (end of week)
+
+To be completed when the pull request is finalized.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -112,3 +112,53 @@ deselected. Repository-wide checks report documented pre-existing failures
 unrelated to this change.
 
 **Draft PR feedback received from:** none
+
+### Reflection
+
+**What was harder than you expected?**
+Writing the failing test before writing the fix. The fix itself was a short,
+well-scoped change, but reproducing the bug as a test inside the repo's existing
+fixture and mocking setup took the most effort. I had to make the test fail for
+the *right* reason — because `create_review()` ignored the authenticated user and
+persisted a review it should have rejected — rather than because I had wired the
+profile lookup or the mocks incorrectly. Getting a red test that genuinely
+described the authorization flaw was harder than making it green.
+
+**What did you learn about working in a large codebase?**
+The existing code is the spec. `get_review()` and `list_reviews()` in the same
+module already did ownership scoping correctly by joining `Profile` and filtering
+on `Profile.user_id == user_id`, so my job was not to invent an approach — it was
+to make the write path match the pattern the read paths had already established.
+On my own projects I decide the convention; here the convention already existed,
+and the correct fix was the one that looked like it had always been there. That
+also made the change easier to review, because a maintainer could see it as the
+missing half of a pattern rather than as something new.
+
+**How did AI tools help — and where did they fall short?**
+AI was most useful for orientation. In an unfamiliar codebase it helped me locate
+the relevant files quickly and understand how the route, the service layer, and
+the `Profile`/`Review` models connected, which cut down the time between reading
+the issue and being able to reason about it concretely.
+
+Where it fell short was the judgment calls. Deciding that the check belonged in
+`create_review()` rather than in the route, choosing to return 404 for both
+missing and unowned profiles so the endpoint does not leak whether a profile
+exists, and framing the issue as Tier 2 because it crosses modules — AI could lay
+out the options, but it could not own those decisions or defend them in a pull
+request. Those had to be mine, because I am the one who has to justify them.
+
+**What would you do differently if you started over?**
+I would sort out the test and tooling setup first. I did not confirm that GNU Make
+was available or establish a clean baseline for the repository-wide suite until
+Week 9, so verification turned into a late blocker instead of a background detail
+— I ended up running the underlying pytest command directly and documenting
+pre-existing failures under time pressure. Ten minutes of environment checks in
+Week 7, before choosing the issue, would have removed that entirely.
+
+**What are you most proud of from this module?**
+Taking a real security bug all the way through. I found a broken object-level
+authorization flaw in production code, reproduced it with a failing test, fixed
+it at the layer where the check actually belongs, covered both the service and
+the route, and submitted the PR upstream. The change is small, but the reasoning
+behind it — why it is a vulnerability, where the enforcement goes, and what the
+client should see — is entirely mine.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -113,6 +113,31 @@ unrelated to this change.
 
 **Draft PR feedback received from:** none
 
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No review came in. PR #409 has been open on `ascherj/pathreview` since Week 9 and
+still shows zero review comments and zero issue comments, and no maintainer has
+requested changes or approved it. I checked the PR again at the end of Week 10 to
+confirm before writing this entry.
+
+**How you responded:**
+No changes were required, so nothing was revised in response to feedback. I used
+the week instead to re-read my own diff as a reviewer would and to confirm the
+branch is still in a mergeable, reviewable state: the change remains scoped to
+`create_review()` plus the route's 404 path, the seven focused review-creation
+tests still pass, and the PR description still states the vulnerability, the
+chosen enforcement layer, and the reasoning for returning 404 on both missing and
+unowned profiles. If a maintainer comments after the course deadline, the
+outstanding question I would expect — and would be ready to defend — is whether
+404 or 403 is the right status for an unowned profile.
+
+---
+
 ### Reflection
 
 **What was harder than you expected?**

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -48,3 +48,22 @@ otherwise — so the write path is scoped exactly like the read paths already ar
   belongs in `create_review()` where the existing read-path checks already live.
 - **Testing is straightforward.** The repo already has service-level tests, so I
   can add a case for the cross-user rejection alongside the existing happy path.
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [9d6a50b](https://github.com/Kienda/pathreview/commit/9d6a50b76cbbf3ce4798b3de0842ee648938475f)
+
+**Reproduction summary:**
+I configured the review service test as if an ownership-scoped profile lookup found no
+profile for the current user, then called `create_review()` with another user's profile
+ID. The test fails because the service still creates and returns a pending review
+instead of returning `None` without writing to the database.
+
+**PLAN.md link:** [PLAN.md](https://github.com/Kienda/pathreview/blob/fix/163-review-profile-ownership/PLAN.md)
+
+**Walkthrough video (recommended):** Not recorded.
+
+**Blockers or open questions:**
+The current test suite has no endpoint integration-test harness, so I still need to
+decide whether Week 9 route-level coverage belongs in `tests/security/` or should use a
+smaller mocked route test alongside the service regression.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -6,7 +6,7 @@
 
 **Issue title:** Review creation does not verify profile ownership
 
-**Tier:** [ ] Tier 1  [x] Tier 2  [ ] Tier 3
+**Tier:** [ ] Tier 1 [x] Tier 2 [ ] Tier 3
 
 **Problem summary:**
 The `POST /reviews` endpoint passes the authenticated user's ID down to
@@ -90,4 +90,25 @@ command directly and confirmed the seven review-creation tests pass.
 
 ### Check-in 2 (end of week)
 
-To be completed when the pull request is finalized.
+**PR link:** https://github.com/ascherj/pathreview/pull/409
+
+**Branch:** `fix/163-review-profile-ownership`
+
+**What you built:**
+I added an ownership-scoped profile lookup before review creation. Missing and
+unowned profiles now receive the same 404 response, no review is persisted, and
+no background processing task is scheduled.
+
+**Tests added or updated:**
+Updated `tests/unit/test_review_service.py` with owned-profile success and
+cross-user rejection coverage. Added `tests/unit/test_review_routes.py` to verify
+that the endpoint returns 404 and does not schedule a background task when
+ownership validation fails.
+
+**Self-review confirmation:** [ ] make check passes [ ] make test-unit passes
+
+The focused review-creation test suite passes with 7 tests passed and 14
+deselected. Repository-wide checks report documented pre-existing failures
+unrelated to this change.
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,50 @@
+# Module 3 Journal
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/163
+
+**Issue title:** Review creation does not verify profile ownership
+
+**Tier:** [ ] Tier 1  [x] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The `POST /reviews` endpoint passes the authenticated user's ID down to
+`create_review()` in `core/services/review_service.py`, but that function never
+actually uses it — it builds a `Review` straight from whatever `profile_id` the
+request body supplied. That makes this a broken object-level authorization bug:
+anyone who learns another user's profile UUID can create reviews attached to a
+profile they don't own, because nothing ties the submitted `profile_id` back to
+the caller. The inconsistency is easy to see in the same file, where
+`get_review()` and `list_reviews()` both join `Profile` and filter on
+`Profile.user_id == user_id` before returning anything. A successful fix makes
+`create_review()` enforce that same ownership check — looking up the profile,
+confirming it belongs to the authenticated user, and rejecting the request
+otherwise — so the write path is scoped exactly like the read paths already are.
+
+**Branch name:** `fix/163-review-profile-ownership`
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger
+
+### "Is this right for me?" — selection notes
+
+- **Scope is bounded and legible.** The issue names the exact file and function,
+  and the correct behavior already exists in the same module as a working
+  reference. I am changing one function plus its tests, not designing anything
+  new.
+- **I can state the acceptance criteria myself.** Creating a review against a
+  profile I don't own must fail with an authorization error; creating one
+  against my own profile must keep working unchanged.
+- **It is Tier 2 rather than Tier 1 because it crosses modules** — the API
+  route, the service layer, and the `Profile`/`Review` models all have to agree
+  on where the check lives and what error surfaces to the client. I chose it
+  anyway because the cross-module reach is shallow and traceable, and the
+  security framing makes it a more substantial thing to reason about and write
+  up than a one-line attribute fix.
+- **Risk I am watching:** picking the wrong layer for the check. Putting it in
+  the route would leave the service insecure for any future caller, so the fix
+  belongs in `create_review()` where the existing read-path checks already live.
+- **Testing is straightforward.** The repo already has service-level tests, so I
+  can add a case for the cross-user rejection alongside the existing happy path.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,94 @@
+## Solution plan
+
+**Issue:** [Review creation does not verify profile ownership (#163)](https://github.com/ascherj/pathreview/issues/163)
+
+### Understand
+
+`POST /reviews` authenticates the caller in `api/routes/reviews.py` and passes both
+`data.profile_id` and `current_user.id` to `create_review()`. The root cause is in
+`core/services/review_service.py`: `create_review()` ignores `user_id` and inserts a
+pending `Review` using the caller-supplied profile ID without first querying `Profile`.
+An authenticated user who knows another user's profile UUID can therefore create a
+review and start background processing for that profile.
+
+Expected behavior is that review creation succeeds only when the profile exists and
+`Profile.user_id` matches the authenticated user. A missing or unowned profile should
+produce the same 404 response so the endpoint does not reveal another user's profile.
+Actual behavior is a successful pending review for either profile.
+
+### Map
+
+- `core/services/review_service.py` — add the ownership-scoped profile lookup to
+  `create_review()` and return no review when it does not match.
+- `api/routes/reviews.py` — translate a missing/unowned result into a 404 before
+  scheduling `process_review()`.
+- `tests/unit/test_review_service.py` — keep the reproduction regression and add
+  coverage for both rejected and owned-profile creation paths.
+- `tests/security/` — investigate whether the existing test setup can support a
+  two-user endpoint-level regression; add one here if it can do so without duplicating
+  the unit test's mocks.
+
+No schema, model, migration, or frontend change is expected. `core/models/profile.py`
+and `core/models/review.py` define the ownership relationship but should remain
+unchanged.
+
+### Plan
+
+1. Query `Profile` in `create_review()` using both `Profile.id == profile_id` and
+   `Profile.user_id == user_id`, following `core/services/profile_service.py` and the
+   existing review read paths.
+2. Return `None` before constructing, adding, committing, or refreshing a `Review`
+   when the ownership-scoped query has no result; update the return annotation to
+   `Review | None`.
+3. Update `create_review_endpoint()` to return `404 Profile not found` for that result
+   and ensure no background task is scheduled on the rejected path.
+4. Update service tests so owned-profile creation still yields a pending review and
+   the cross-user reproduction proves there is no database write. Add route/security
+   coverage for the 404 and absent background task if the current fixtures support it.
+5. Run the focused review-service/security tests, then the complete test suite and
+   lint/type checks; distinguish any pre-existing failures from regressions caused by
+   the fix.
+
+### Inputs & outputs
+
+The input is an authenticated user's UUID plus the profile UUID supplied in a
+`POST /reviews` JSON body. For a profile owned by that user, the output remains a
+persisted `Review` with `status="pending"`, followed by the existing background task.
+For a nonexistent or differently owned profile, the service produces no review and
+the route returns HTTP 404 with `{"detail": "Profile not found"}`; no review row is
+inserted and no processing task is queued.
+
+### Risks & unknowns
+
+- Existing happy-path mocks in `tests/unit/test_review_service.py` do not configure
+  `db.execute()`. Adding a lookup will require those fixtures/tests to return an owned
+  profile, or unrelated creation tests may fail for mock-configuration reasons.
+- `Profile.id` and `Profile.user_id` are typed as strings in
+  `core/models/profile.py`, while the service accepts `UUID`. SQLAlchemy/PostgreSQL
+  currently handle this elsewhere, but the query should follow the proven pattern in
+  `get_profile()` rather than introduce manual conversion.
+- The route currently assumes `create_review()` always returns a `Review` and accesses
+  `review.id` immediately. The `None` check must occur before `add_task()` to prevent
+  processing an unauthorized profile.
+- The repository has no endpoint integration tests today. If adding one requires a
+  large new database/auth harness, the scoped service regression plus a mocked route
+  test may be the safer Week 9 boundary.
+- The current pre-commit hooks report unrelated lint and mypy failures in the existing
+  review service/test file. Validation must record these separately rather than
+  hiding them or expanding this security fix into a broad cleanup.
+
+### Edge cases
+
+- The profile UUID exists and belongs to the authenticated user: creation succeeds
+  exactly once and processing is scheduled.
+- The profile UUID exists but belongs to a different user: return 404, write nothing,
+  and schedule nothing.
+- The profile UUID does not exist: use the identical 404 response and side effects as
+  the cross-user case to avoid profile enumeration.
+- The request contains a malformed UUID: preserve FastAPI/Pydantic's existing 422
+  validation before the service is called.
+- The ownership query raises a database error: preserve the route's rollback and 500
+  behavior; do not convert infrastructure failures into 404 responses.
+- Ownership changes or the profile is deleted between validation and insertion: assess
+  whether the foreign key/transaction behavior is sufficient and ensure failures do
+  not leave or schedule a usable unauthorized review.

--- a/api/routes/reviews.py
+++ b/api/routes/reviews.py
@@ -39,6 +39,17 @@ async def create_review_endpoint(
             user_id=current_user.id,
         )
 
+        if not review:
+            log.warning(
+                "profile_not_found",
+                profile_id=str(data.profile_id),
+                user_id=str(current_user.id),
+            )
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Profile not found",
+            )
+
         # Add background task for processing
         background_tasks.add_task(process_review, db, review.id, data.profile_id)
 

--- a/core/services/review_service.py
+++ b/core/services/review_service.py
@@ -16,10 +16,19 @@ async def create_review(
     db,
     profile_id: UUID,
     user_id: UUID,
-) -> Review:
+) -> Review | None:
     """
-    Create a new review with status="pending".
+    Create a pending review when the user owns the target profile.
+
+    Returns None when the profile does not exist or belongs to another user.
     """
+    stmt = select(Profile).where(and_(Profile.id == profile_id, Profile.user_id == user_id))
+    result = await db.execute(stmt)
+    profile = result.scalars().first()
+
+    if not profile:
+        return None
+
     review = Review(
         profile_id=profile_id,
         status="pending",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -99,7 +99,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -449,7 +448,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -473,7 +471,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1561,7 +1558,6 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1579,7 +1575,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1972,7 +1967,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3507,7 +3501,6 @@
       "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^2.0.1",
         "cssstyle": "^4.0.1",
@@ -4094,7 +4087,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4107,7 +4099,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4771,7 +4762,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/tests/unit/test_review_routes.py
+++ b/tests/unit/test_review_routes.py
@@ -1,0 +1,34 @@
+"""Tests for review API routes."""
+
+from unittest.mock import AsyncMock, Mock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException, status
+
+from api.routes.reviews import create_review_endpoint
+from api.schemas.review import ReviewCreate
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_create_review_endpoint_rejects_unowned_profile() -> None:
+    """Return 404 and skip processing when the service rejects profile ownership."""
+    profile_id = uuid4()
+    data = ReviewCreate(profile_id=profile_id)
+    background_tasks = Mock()
+    current_user = Mock(id=uuid4())
+    db = AsyncMock()
+
+    with (
+        patch(
+            "api.routes.reviews.create_review",
+            new=AsyncMock(return_value=None),
+        ),
+        pytest.raises(HTTPException) as exc_info,
+    ):
+        await create_review_endpoint(data, background_tasks, current_user, db)
+
+    assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
+    assert exc_info.value.detail == "Profile not found"
+    background_tasks.add_task.assert_not_called()

--- a/tests/unit/test_review_service.py
+++ b/tests/unit/test_review_service.py
@@ -23,7 +23,9 @@ class TestReviewService:
         session.add = Mock()
         session.commit = AsyncMock()
         session.refresh = AsyncMock()
-        session.execute = AsyncMock()
+        result = Mock()
+        result.scalars.return_value.first.return_value = Mock()
+        session.execute = AsyncMock(return_value=result)
         return session
 
     @pytest.fixture
@@ -67,6 +69,7 @@ class TestReviewService:
             MockReview.assert_called()
             call_kwargs = MockReview.call_args[1]
             assert call_kwargs['status'] == "pending"
+            mock_db_session.execute.assert_awaited_once()
 
     @pytest.mark.security
     @pytest.mark.asyncio

--- a/tests/unit/test_review_service.py
+++ b/tests/unit/test_review_service.py
@@ -68,6 +68,30 @@ class TestReviewService:
             call_kwargs = MockReview.call_args[1]
             assert call_kwargs['status'] == "pending"
 
+    @pytest.mark.security
+    @pytest.mark.asyncio
+    async def test_create_review_rejects_profile_owned_by_another_user(
+        self, mock_db_session
+    ):
+        """Reproduce #163: callers must not create reviews for another user's profile."""
+        another_users_profile_id = uuid4()
+        current_user_id = uuid4()
+
+        # An ownership-scoped profile lookup returns no profile for the current user.
+        mock_result = Mock()
+        mock_result.scalars.return_value.first.return_value = None
+        mock_db_session.execute = AsyncMock(return_value=mock_result)
+
+        result = await create_review(
+            mock_db_session,
+            another_users_profile_id,
+            current_user_id,
+        )
+
+        assert result is None
+        mock_db_session.add.assert_not_called()
+        mock_db_session.commit.assert_not_awaited()
+
     @pytest.mark.asyncio
     async def test_get_review_returns_review_for_correct_owner(self, mock_db_session):
         """Test get_review returns review when user_id matches."""


### PR DESCRIPTION
## Summary

Prevents authenticated users from creating reviews for profiles they do not own. The review service now verifies that the requested profile belongs to the current user before creating a review, and the API returns 404 without scheduling background processing when ownership cannot be verified.

## Issue

Closes #163

## Changes

- Added an ownership-scoped `Profile` lookup to `create_review()`
- Return `None` without writing when the profile is missing or belongs to another user
- Return `404 Profile not found` from `POST /reviews` for rejected profiles
- Prevent background review processing from being scheduled after rejection
- Added service-level cross-user regression coverage
- Added route-level coverage for the 404 response and absent background task
- Added the Week 9 progress check-in to `JOURNAL.md`

## Testing

- [x] New/updated tests cover the changes
- [x] Focused unit tests pass
- [ ] Integration tests pass
- [ ] Full linter passes
- [ ] Full type checker passes

Focused command:

`.\.venv\Scripts\pytest.exe tests/unit/test_review_service.py tests/unit/test_review_routes.py -q -k create_review`

Result: 7 passed, 14 deselected.

The full repository unit command currently reports 52 failures and 31 setup errors in unrelated modules. Existing examples include bias detection, parsers, chunker fixtures, skill extraction, and pre-existing review-service mock problems. The new review-creation tests pass.

GNU Make is not installed in the local PowerShell environment, so I ran the underlying pytest, Ruff, Black, and mypy commands directly. The new route test passes Ruff and Black checks. Repository-wide linting and typing still report pre-existing issues.

## Screenshots / Demo

Not applicable; this is an API authorization fix.

## Notes for Reviewers

Please review whether returning 404 for both nonexistent and differently owned profiles is the preferred behavior. This matches the existing profile endpoints and avoids exposing whether another user’s profile exists.