### PR TITLE
Fix #153: Handle None text in context chunks in FaithfulnessChecker

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -22,3 +22,33 @@ by falling back to an empty string in that case too. This affects the
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+**Checklist reasoning ("Is this right for me?"):**
+
+*Part 1 — Understanding the issue:* Yes. The bug is that `check()` calls
+`chunk.get("text", "")`, but `.get()` only applies its default when the key
+is missing — if a chunk has `"text": None`, `.get()` returns `None` instead
+of falling back to `""`. That `None` then gets passed into `" ".join(...)`,
+which raises a `TypeError` because `join()` requires a list of strings.
+Before the fix: passing a chunk with `text: None` crashes the checker.
+After the fix: it should handle `None` the same way it handles a missing
+key, treating it as empty text instead of raising.
+
+*Part 2 — Tier fit:* This is my first open-source contribution, and #153
+is labeled Tier 1 — a localized, single-method fix in one file. Good match
+for where I am right now.
+
+*Part 3 — Codebase readiness:* I opened
+`rag/evaluator/faithfulness_checker.py` and read the `check()` method
+directly, not just the file listing. I also opened
+`tests/unit/test_faithfulness_checker.py` and read through
+`test_none_context_chunk_text` (and at least one other test) to see how
+the test fixtures and assertions are structured, so I know the pattern
+to follow for my own test.
+
+*Part 4 — Scope and time:* I checked the issue comments and the Claims
+count in the cohort ledger's Issue Catalog tab before claiming. The fix
+itself is small (one conditional or a safer `.get()` pattern), so I'm
+confident I can implement, test, and PR it well within the Weeks 8–9
+window. There are no "blocked by" references or unresolved dependencies
+noted on the issue.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -52,3 +52,64 @@ itself is small (one conditional or a safer `.get()` pattern), so I'm
 confident I can implement, test, and PR it well within the Weeks 8–9
 window. There are no "blocked by" references or unresolved dependencies
 noted on the issue.
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/lakshanakolur/pathreview/commit/3739f91
+
+**Reproduction summary:**
+Ran `FaithfulnessChecker().check('Knows Python.', [{'text': None}])` locally and
+confirmed it raises `TypeError: sequence item 0: expected str instance, NoneType found`,
+matching the issue report. Traced it to `chunk.get("text", "")` in `check()`, which only
+falls back to `""` when the key is missing — not when the value is explicitly `None`.
+Also confirmed the existing test `test_none_context_chunk_text` in
+`tests/unit/test_faithfulness_checker.py` fails the same way, and added a docstring
+to it documenting the reproduction.
+
+**PLAN.md link:** https://github.com/lakshanakolur/pathreview/blob/fix/153-faithfulness-checker-none-text/PLAN.md
+
+**Walkthrough video (recommended):** N/A — not recorded this week
+
+**Blockers or open questions:**
+Found the same `chunk.get("text", "")` pattern in three other files
+(`rag/evaluator/relevance_scorer.py`, `rag/retriever/hybrid.py`,
+`rag/generator/review_generator.py`) — same latent bug likely exists there too,
+but it's out of scope for #153. Considering whether to flag this as a follow-up
+issue after this PR is merged.
+
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the fix for #153: changed `chunk.get("text", "")` to `chunk.get("text") or ""`
+in `rag/evaluator/faithfulness_checker.py`, so both a missing `text` key and an explicit
+`None` value fall back to an empty string. Completed sub-tasks 1–4 from PLAN.md: located
+the exact line, applied the fix, confirmed the target test (`test_none_context_chunk_text`)
+and its sibling (`test_missing_text_key_in_chunk`) now pass, and added two additional
+edge-case tests (`test_mixed_none_and_valid_context_chunks`,
+`test_whitespace_only_context_chunk_text`) to cover scenarios from PLAN.md's edge cases
+section. All 4 relevant tests pass.
+
+Ran `make test-unit` and `make check` project-wide to check for regressions. Confirmed
+my change introduces zero new test failures and zero new lint errors — the 49 unrelated
+test failures and 180 lint errors that show up are pre-existing on `main`, in modules I
+never touched (bias_detector, pii_scrubber, review_service, resume_parser, tech_detector,
+etc.). The 3 pre-existing failures within `test_faithfulness_checker.py` itself
+(`test_partial_support_returns_middle_score`, `test_multiple_context_chunks`,
+`test_multiple_claims_varying_support`) also confirmed to fail identically with or
+without my fix — unrelated to the None-handling bug.
+
+**Next steps:**
+- Run `make check` locally to confirm formatting/lint on my specific files, and clean up
+  anything within scope
+- Open a draft PR and request peer/mentor review in Slack
+- Address any review feedback
+- Write PR description documenting pre-existing failures (drafted, ready to include)
+- Finalize and submit PR by Sunday
+
+**Blockers:**
+None currently. Note: found the identical `chunk.get("text", "")` pattern in three other
+files (`relevance_scorer.py`, `hybrid.py`, `review_generator.py`) — same latent bug likely
+exists there, but staying in scope for #153 and considering a follow-up issue instead.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,1 +1,24 @@
-# PathReview Journal
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/153
+
+**Issue title:** Faithfulness checker crashes when a context chunk has `text: None`
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The `check()` method in `FaithfulnessChecker` builds its context by calling
+`chunk.get("text", "")` on each context chunk, assuming this will fall back to
+an empty string if text is missing. However, `.get()` only applies its default
+when the key itself is absent — if a chunk has `"text": None`, `.get()` returns
+`None` instead. This value then gets passed into a `" ".join(...)` call, which
+raises a `TypeError` because `join()` expects a list of strings, not `None`.
+The fix involves handling the case where `text` is present but `None`, likely
+by falling back to an empty string in that case too. This affects the
+`rag/evaluator/faithfulness_checker.py` module.
+
+**Branch name:** fix/153-faithfulness-checker-none-text
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,1 @@
+# PathReview Journal

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -137,3 +137,72 @@ and added two new tests — `test_mixed_none_and_valid_context_chunks` and
 ones — see PR description for full details)
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No feedback came in — per the Su26 course note, reviewer feedback isn't a live
+feature this term, so there was nothing to check for on PR #414 beyond what I
+already logged in Week 9 (no comments received on the draft).
+
+**How you responded:**
+N/A — no feedback to respond to. If review is enabled in a future term, my
+plan would be to treat comments the same way I treated the pre-existing test
+failures: verify them against the actual code before agreeing or pushing
+back, rather than just deferring to whatever a reviewer says.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Getting to the actual one-line fix was fast; getting to the point where I
+trusted the fix was the hard part. Because `pathreview` isn't my code, I
+couldn't just "know" that `chunk.get("text") or ""` was safe everywhere it
+mattered — I had to read through `FaithfulnessChecker` end to end, check how
+`check()` gets called elsewhere, and run the full test suite to separate my
+change from the 49 pre-existing failures and 180 pre-existing lint errors
+already on `main`. Understanding the surrounding system took far longer than
+writing the patch itself.
+
+**What did you learn about working in a large codebase?**
+In my own projects, if something breaks I usually know which file it's in
+because I wrote all of them. Here, tracing a single crash meant reading
+across `rag/evaluator/`, `rag/retriever/`, and `rag/generator/` before I was
+confident the bug was actually isolated to `faithfulness_checker.py`. That
+search also surfaced the exact same `chunk.get("text", "")` pattern in three
+other files (`relevance_scorer.py`, `hybrid.py`, `review_generator.py`) — a
+reminder that in a large, many-contributor codebase, one reported bug is
+often several copies of the same latent bug, and part of the job is deciding
+what's in scope for *this* fix versus what belongs in a follow-up issue.
+
+**How did AI tools help — and where did they fall short?**
+AI tools were most useful for summarizing — getting oriented quickly in an
+unfamiliar file or function, and drafting boilerplate like test scaffolding
+and PR description text. They were much less useful for the two things that
+actually mattered most: finding the real fault, and reflecting on the work
+afterward. Locating the actual root cause (the `.get()` default-vs-`None`
+distinction) took manual reproduction and tracing, not a suggestion from a
+tool. And writing this reflection honestly required actually having done the
+work — a summary tool can't tell me what was hard for me.
+
+**What would you do differently if you started over?**
+I'd search the codebase for the bug pattern before implementing the fix
+rather than after. I found the three other files with the identical
+`chunk.get("text", "")` issue while writing PLAN.md in Week 8, but by then
+I'd already scoped the PR to a single file. Doing that grep earlier wouldn't
+have changed my fix, but it would have let me decide on the follow-up issue
+(and mention it) from the start instead of carrying it as an open question
+through Weeks 8 and 9.
+
+**What are you most proud of from this module?**
+Understanding the problem well enough to actually trust my own fix — tracing
+the bug to its exact cause, confirming it against the existing test, and then
+writing two additional edge-case tests (`test_mixed_none_and_valid_context_chunks`,
+`test_whitespace_only_context_chunk_text`) beyond what the issue strictly
+asked for. Going from "the app crashes" to a fix I could defend with evidence
+is the part of this module I'm most proud of, more than the PR itself.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -113,3 +113,27 @@ without my fix — unrelated to the None-handling bug.
 None currently. Note: found the identical `chunk.get("text", "")` pattern in three other
 files (`relevance_scorer.py`, `hybrid.py`, `review_generator.py`) — same latent bug likely
 exists there, but staying in scope for #153 and considering a follow-up issue instead.
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/414
+
+**Branch:** fix/153-faithfulness-checker-none-text
+
+**What you built:**
+Fixed a bug in `FaithfulnessChecker.check()` where a context chunk with
+`text: None` crashed the checker with a `TypeError`. Changed
+`chunk.get("text", "")` to `chunk.get("text") or ""` so both a missing key
+and an explicit `None` value are handled gracefully.
+
+**Tests added or updated:**
+Updated `tests/unit/test_faithfulness_checker.py`: confirmed
+`test_none_context_chunk_text` and `test_missing_text_key_in_chunk` now pass,
+and added two new tests — `test_mixed_none_and_valid_context_chunks` and
+`test_whitespace_only_context_chunk_text` — for additional edge-case coverage.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+(both confirmed to introduce no new failures beyond documented pre-existing
+ones — see PR description for full details)
+
+**Draft PR feedback received from:** none

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,73 @@
+## Solution plan
+
+**Issue:** #153 — Faithfulness checker crashes when a context chunk has `text: None`
+(https://github.com/ascherj/pathreview/issues/153)
+
+### Understand
+`FaithfulnessChecker.check()` builds context by pulling `chunk.get("text", "")` from
+each context chunk and joining the results with `" ".join(...)`. `.get()` only applies
+its default when the *key* is missing. If a chunk has `"text": None` (key present,
+value `None`), `.get()` returns `None`, and `None` passed into `" ".join(...)` raises
+`TypeError: sequence item 0: expected str instance, NoneType found`.
+
+Expected behavior: a chunk with `text: None` should be treated as empty context (`""`)
+and `check()` should return a normal float score without crashing. Actual behavior:
+the checker raises an unhandled `TypeError`.
+
+Confirmed via local reproduction:
+```python
+FaithfulnessChecker().check('Knows Python.', [{'text': None}])
+# TypeError: sequence item 0: expected str instance, NoneType found
+```
+and via the existing (currently failing) test `test_none_context_chunk_text` in
+`tests/unit/test_faithfulness_checker.py`.
+
+### Map
+- `rag/evaluator/faithfulness_checker.py` — `check()` method, line ~35, where context
+  is built via `chunk.get("text", "")`
+- `tests/unit/test_faithfulness_checker.py` — contains `test_none_context_chunk_text`
+  (target test to make pass) and `test_missing_text_key_in_chunk` (already passing,
+  covers the "key missing" case); may add further edge-case tests here
+
+### Plan
+1. Locate the exact line in `check()` where `chunk.get("text", "")` builds context.
+2. Replace `chunk.get("text", "")` with `chunk.get("text") or ""` so both a missing
+   key and an explicit `None` value fall back to an empty string.
+3. Run `test_none_context_chunk_text` and `test_missing_text_key_in_chunk` and
+   confirm both pass.
+4. Add extra unit tests for adjacent edge cases: empty string `""`, whitespace-only
+   text, and a mix of `None` and valid chunks in the same list.
+5. Run the full test suite (`pytest`) to confirm no other tests relied on the old
+   (buggy) behavior, and re-run `pre-commit` to confirm lint/format still pass.
+
+### Inputs & outputs
+- **Input:** a list of context chunk dicts, where each chunk may have `"text"` missing,
+  `None`, an empty string, or a normal string.
+- **Output:** `check()` should return a normal float faithfulness score (0.0–1.0)
+  without raising, treating any missing/`None` `text` as an empty string contribution
+  to the joined context.
+
+### Risks & unknowns
+- Need to confirm `chunk.get("text") or ""` doesn't unintentionally swallow other
+  falsy-but-valid values (e.g., if `text` could legitimately be `0` or `False` —
+  unlikely given it's expected to be a string).
+- Found the identical `.get("text", "")` pattern in three other files:
+  `rag/evaluator/relevance_scorer.py:32`, `rag/retriever/hybrid.py:85`, and
+  `rag/generator/review_generator.py:157`. Each has the same latent bug (a chunk
+  with `text: None` would crash them too), but issue #153 is scoped only to
+  `faithfulness_checker.py`. Flagging this as a candidate for a follow-up issue/PR
+  rather than expanding scope here.
+- Pre-existing mypy failures (missing type annotations) affect the entire test
+  file and exist on `main` independent of this change; confirmed via
+  `pre-commit run mypy` on `main` before using `--no-verify` on the reproduction
+  commit.
+
+### Edge cases
+- `chunk = {"text": None}` — should not crash, contributes `""` to context.
+- `chunk = {}` (no `"text"` key at all) — should still work as before (already
+  covered by `test_missing_text_key_in_chunk`, using a different wrong key).
+- `chunk = {"text": ""}` — already works, confirm it still does after the fix.
+- Multiple chunks in the list, some `None`, some valid strings — should join
+  correctly, contributing `""` only for the `None` ones.
+- `chunks = []` (empty list entirely) — should not be broken by this change
+  (already covered by `test_empty_context_chunks_returns_zero`).

--- a/rag/evaluator/faithfulness_checker.py
+++ b/rag/evaluator/faithfulness_checker.py
@@ -1,6 +1,7 @@
 """Check if generated feedback is supported by retrieved context."""
 
 import re
+
 import structlog
 
 logger = structlog.get_logger()
@@ -20,8 +21,11 @@ class FaithfulnessChecker:
             Faithfulness score 0.0-1.0 (ratio of supported claims)
         """
         if not feedback or not context_chunks:
-            logger.info("faithfulness_empty_input", has_feedback=bool(feedback),
-                       has_chunks=bool(context_chunks))
+            logger.info(
+                "faithfulness_empty_input",
+                has_feedback=bool(feedback),
+                has_chunks=bool(context_chunks),
+            )
             return 0.0
 
         # Extract key claims from feedback (sentences)
@@ -31,9 +35,7 @@ class FaithfulnessChecker:
             return 0.5  # Default to neutral if no extractable claims
 
         # Concatenate context text
-        context_text = " ".join([
-            chunk.get("text", "") for chunk in context_chunks
-        ])
+        context_text = " ".join([chunk.get("text") or "" for chunk in context_chunks])
 
         # Check each claim for support
         supported = 0
@@ -43,8 +45,9 @@ class FaithfulnessChecker:
 
         score = supported / len(claims) if claims else 0.0
 
-        logger.info("faithfulness_checked", claims_count=len(claims),
-                   supported_count=supported, score=score)
+        logger.info(
+            "faithfulness_checked", claims_count=len(claims), supported_count=supported, score=score
+        )
 
         return score
 
@@ -59,7 +62,7 @@ class FaithfulnessChecker:
             List of claims (sentences)
         """
         # Split by sentence (simple regex)
-        sentences = re.split(r'[.!?]+', text)
+        sentences = re.split(r"[.!?]+", text)
         claims = [s.strip() for s in sentences if s.strip() and len(s.strip()) > 10]
         return claims[:10]  # Limit to 10 claims for scoring
 
@@ -81,8 +84,25 @@ class FaithfulnessChecker:
         # Require at least some meaningful overlap
         overlap = claim_tokens & context_tokens
         # Filter out common stop words
-        stop_words = {'a', 'an', 'the', 'is', 'are', 'was', 'were', 'be', 'been',
-                     'and', 'or', 'but', 'in', 'of', 'to', 'for', 'that'}
+        stop_words = {
+            "a",
+            "an",
+            "the",
+            "is",
+            "are",
+            "was",
+            "were",
+            "be",
+            "been",
+            "and",
+            "or",
+            "but",
+            "in",
+            "of",
+            "to",
+            "for",
+            "that",
+        }
         meaningful_overlap = overlap - stop_words
 
         return len(meaningful_overlap) >= 2

--- a/tests/unit/test_faithfulness_checker.py
+++ b/tests/unit/test_faithfulness_checker.py
@@ -237,6 +237,31 @@ class TestFaithfulnessChecker:
         assert isinstance(score, float)
         assert 0.0 <= score <= 1.0
 
+    def test_mixed_none_and_valid_context_chunks(self, checker):
+        """Test handling of a mix of None and valid text in context chunks."""
+        feedback = "Has Python skills"
+        context_chunks = [
+            {"text": None},
+            {"text": "Strong Python programming experience"},
+        ]
+
+        score = checker.check(feedback, context_chunks)
+
+        # Should handle gracefully and still use the valid chunk's text
+        assert isinstance(score, float)
+        assert 0.0 <= score <= 1.0
+
+    def test_whitespace_only_context_chunk_text(self, checker):
+        """Test handling of whitespace-only text in a context chunk."""
+        feedback = "Has Python skills"
+        context_chunks = [{"text": "   "}]
+
+        score = checker.check(feedback, context_chunks)
+
+        # Should handle gracefully, treated as effectively empty context
+        assert isinstance(score, float)
+        assert 0.0 <= score <= 1.0
+
     def test_score_consistency(self, checker):
         """Test that same input produces same score."""
         feedback = "The developer has strong Python skills."

--- a/tests/unit/test_faithfulness_checker.py
+++ b/tests/unit/test_faithfulness_checker.py
@@ -18,9 +18,7 @@ class TestFaithfulnessChecker:
         """Test feedback fully supported by context returns score close to 1.0."""
         feedback = "The developer has strong Python skills and experience with Django."
         context_chunks = [
-            {
-                "text": "The portfolio shows Python expertise and Django framework experience."
-            },
+            {"text": "The portfolio shows Python expertise and Django framework experience."},
         ]
 
         score = checker.check(feedback, context_chunks)
@@ -34,9 +32,7 @@ class TestFaithfulnessChecker:
         """Test feedback with no support in context returns score close to 0.0."""
         feedback = "This developer is an expert in Rust systems programming."
         context_chunks = [
-            {
-                "text": "The developer has Python and JavaScript experience."
-            },
+            {"text": "The developer has Python and JavaScript experience."},
         ]
 
         score = checker.check(feedback, context_chunks)
@@ -48,9 +44,7 @@ class TestFaithfulnessChecker:
         """Test partial support returns score between 0 and 1."""
         feedback = "The developer shows Python expertise and Kubernetes knowledge."
         context_chunks = [
-            {
-                "text": "Strong Python programming skills demonstrated in projects."
-            },
+            {"text": "Strong Python programming skills demonstrated in projects."},
         ]
 
         score = checker.check(feedback, context_chunks)
@@ -63,9 +57,7 @@ class TestFaithfulnessChecker:
     def test_empty_feedback_returns_zero(self, checker):
         """Test empty feedback returns 0.0."""
         feedback = ""
-        context_chunks = [
-            {"text": "Some context"}
-        ]
+        context_chunks = [{"text": "Some context"}]
 
         score = checker.check(feedback, context_chunks)
 
@@ -155,15 +147,11 @@ class TestFaithfulnessChecker:
         """Test that score varies with input, never hardcoded 1.0 or 0.0."""
         # First test: fully supported
         score1 = checker.check(
-            "Python and JavaScript skills",
-            [{"text": "Expert in Python and JavaScript"}]
+            "Python and JavaScript skills", [{"text": "Expert in Python and JavaScript"}]
         )
 
         # Second test: no support
-        score2 = checker.check(
-            "Rust expertise",
-            [{"text": "Java programming background"}]
-        )
+        score2 = checker.check("Rust expertise", [{"text": "Java programming background"}])
 
         # Scores should be different
         assert score1 != score2
@@ -173,9 +161,7 @@ class TestFaithfulnessChecker:
     def test_multiple_claims_varying_support(self, checker):
         """Test scoring with multiple claims of varying support."""
         feedback = "Python expert. Knows Rust. Skilled with Docker."
-        context_chunks = [
-            {"text": "Python and Docker expertise shown in projects."}
-        ]
+        context_chunks = [{"text": "Python and Docker expertise shown in projects."}]
 
         score = checker.check(feedback, context_chunks)
 
@@ -186,9 +172,7 @@ class TestFaithfulnessChecker:
     def test_very_long_feedback(self, checker):
         """Test handling of very long feedback text."""
         feedback = "The developer. " * 100
-        context_chunks = [
-            {"text": "Developer portfolio content"}
-        ]
+        context_chunks = [{"text": "Developer portfolio content"}]
 
         score = checker.check(feedback, context_chunks)
 
@@ -198,9 +182,7 @@ class TestFaithfulnessChecker:
     def test_very_long_context(self, checker):
         """Test handling of very long context."""
         feedback = "The developer has Python skills."
-        context_chunks = [
-            {"text": "Python " * 1000}
-        ]
+        context_chunks = [{"text": "Python " * 1000}]
 
         score = checker.check(feedback, context_chunks)
 
@@ -213,7 +195,7 @@ class TestFaithfulnessChecker:
         claim = "The project is well documented"
         context = "The project is poorly documented"  # Opposite meaning but same stop words
 
-        supported = checker._is_supported(claim, context)
+        _supported = checker._is_supported(claim, context)
 
         # Despite word overlap, should look for meaningful overlap (not stop words)
         # This depends on implementation
@@ -229,11 +211,14 @@ class TestFaithfulnessChecker:
         # Need at least 2 meaningful tokens for support
 
     def test_none_context_chunk_text(self, checker):
-        """Test handling of None in context chunk text."""
+        """Test handling of None in context chunk text.
+
+        Reproduces #153: chunk.get("text", "") only falls back to "" when
+        the key is missing, not when the value is explicitly None. A chunk
+        with {"text": None} currently raises TypeError in check().
+        """
         feedback = "Has Python skills"
-        context_chunks = [
-            {"text": None}
-        ]
+        context_chunks = [{"text": None}]
 
         score = checker.check(feedback, context_chunks)
 
@@ -244,9 +229,7 @@ class TestFaithfulnessChecker:
     def test_missing_text_key_in_chunk(self, checker):
         """Test handling of missing 'text' key in context chunk."""
         feedback = "Has Python skills"
-        context_chunks = [
-            {"content": "Python skills"}  # Wrong key
-        ]
+        context_chunks = [{"content": "Python skills"}]  # Wrong key
 
         score = checker.check(feedback, context_chunks)
 


### PR DESCRIPTION
## Summary

Fixes #153. `FaithfulnessChecker.check()` built its context using
`chunk.get("text", "")`, but `.get()` only applies its default when the key is
*missing* — not when the value is explicitly `None`. A chunk shaped like
`{"text": None}` would cause `.get()` to return `None`, which then crashed
`" ".join(...)` with:

TypeError: sequence item 0: expected str instance, NoneType found

## Fix

Changed the line in `check()` from:

```python
chunk.get("text", "")
```

to:

```python
chunk.get("text") or ""
```

This coalesces both a missing key *and* an explicit `None` value to an empty
string, so a chunk with no meaningful text is simply treated as empty context
instead of crashing.

## Tests added/updated

In `tests/unit/test_faithfulness_checker.py`:
- `test_none_context_chunk_text` — the target test for #153, now passes
  (previously failed with `TypeError`)
- `test_missing_text_key_in_chunk` — sibling test for the "key missing"
  case, confirmed still passing
- `test_mixed_none_and_valid_context_chunks` (new) — a list with both `None`
  and valid text chunks is handled gracefully
- `test_whitespace_only_context_chunk_text` (new) — whitespace-only text is
  handled gracefully (this case never triggered the original bug, since it's
  a valid string, but adds coverage per PLAN.md)

## Pre-existing failures (not caused by this change)

Ran `make test-unit` and `make check` on `main` before making changes, and
again after, to confirm no regressions:

- **49 pre-existing unit test failures** across unrelated modules
  (`bias_detector`, `pii_scrubber`, `review_service`, `resume_parser`,
  `tech_detector`, etc.) — present identically before and after this change
- **3 pre-existing failures within `test_faithfulness_checker.py` itself**
  (`test_partial_support_returns_middle_score`, `test_multiple_context_chunks`,
  `test_multiple_claims_varying_support`) — related to claim-matching/scoring
  logic, unrelated to the `None`-handling bug this PR addresses
- **180 pre-existing lint errors** (ruff) across the codebase, mostly import
  ordering and missing type annotations, in files this PR does not touch

This PR introduces **zero new test failures** and **zero new lint errors**.

## Related finding (out of scope, flagging for follow-up)

The same `chunk.get("text", "")` pattern (same latent bug) also exists in:
- `rag/evaluator/relevance_scorer.py:32`
- `rag/retriever/hybrid.py:85`
- `rag/generator/review_generator.py:157`

Issue #153 is scoped to `faithfulness_checker.py` only, so I left these
untouched, but wanted to flag them — may be worth a follow-up issue.

## How to test

```bash
pytest tests/unit/test_faithfulness_checker.py -v
```

Reproduction of the original bug (on `main`, before this fix):
```python
from rag.evaluator.faithfulness_checker import FaithfulnessChecker
FaithfulnessChecker().check('Knows Python.', [{'text': None}])
# TypeError: sequence item 0: expected str instance, NoneType found
```
