### PR TITLE
test(api): fix async mocks in review service tests

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -73,3 +73,40 @@ Updated `tests/unit/test_review_service.py` to correctly mock single-result, emp
 Full verification was completed. `make check` reported 174 pre-existing repository-wide Ruff errors unrelated to this PR. `make test-unit` produced 388 passed tests and 40 unrelated failures. None of those failures involved `tests/unit/test_review_service.py`, whose targeted suite passed all 19 tests. Ruff and Black also passed for the changed test file. Under the course instructions, the boxes are checked because this contribution introduced no new failures.
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+
+No reviewer or maintainer feedback was received during the module. I requested a review and left the pull request open and ready for review, but no comments were submitted before the deadline.
+
+**How you responded:**
+
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+
+The hardest part was understanding exactly where asynchronous behavior ended in the SQLAlchemy workflow. The database session's `execute()` method must be awaited, but the result object's `scalars()`, `first()`, and `all()` methods are synchronous. Using `AsyncMock` too broadly caused coroutine objects to appear where the service expected normal values. Debugging was also complicated by repository-wide linting, typing, and test failures that were unrelated to issue #158. I had to separate those baseline problems from failures caused by my own changes instead of assuming every failing command meant my fix was incorrect.
+
+**What did you learn about working in a large codebase?**
+
+I learned that contributing to an existing codebase requires more discipline than building a project alone. It was important to reproduce the original failure, understand the existing test patterns, follow the repository's branch and commit conventions, and keep the fix limited to the issue's scope. I also learned that a repository may already contain failing checks, so contributors need to record the baseline and prove that their changes do not introduce additional failures. A technically working fix is not enough by itself; the tests, documentation, commit history, and pull-request description all form part of the contribution.
+
+**How did AI tools help — and where did they fall short?**
+
+AI tools were most useful for explaining the difference between an asynchronous database call and a synchronous SQLAlchemy result object, identifying why `AsyncMock` caused the coroutine errors, and helping me interpret test and pre-commit output. AI also helped organize my reproduction notes, implementation plan, journal entries, and pull-request description. However, AI-generated changes still needed manual verification. Some intermediate edits introduced simple problems such as undefined variables, and a passing test did not always mean that its assertions were meaningful. I needed to inspect the actual service behavior, compare the mocks with SQLAlchemy's interface, run the tests myself, and confirm that each suggestion matched the repository's conventions.
+
+**What would you do differently if you started over?**
+
+I would run and save the full baseline results from `make check` and `make test-unit` before editing anything. That would make it easier to distinguish existing failures from regressions caused by my work. I would also inspect `CONTRIBUTING.md` and the service implementation earlier, then change one mock pattern at a time and rerun the targeted test file after every small edit. Finally, I would open the draft pull request and request peer feedback earlier so reviewers had more time to respond before the submission deadline.
+
+**What are you most proud of from this module?**
+
+I am most proud that I traced the failures to an inaccurate test double rather than changing working production code to satisfy broken tests. The review-service suite improved from 13 failures and 6 passes to all 19 tests passing, while the final change remained focused on `tests/unit/test_review_service.py`. I also documented the unrelated repository-wide failures honestly instead of claiming that every project check passed cleanly.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -4,21 +4,21 @@
 
 **Issue title:** review_service unit tests misconfigure async mocks — 13 of 19 tests fail
 
-**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+**Tier:** [x] Tier 1 [ ] Tier 2 [ ] Tier 3
 
 **Problem summary:**
 
-The unit tests for `core/services/review_service.py` incorrectly use asynchronous mocks for SQLAlchemy result objects. Although the database session's `execute()` method is asynchronous, result methods such as `scalars()`, `first()`, and `all()` are synchronous. This mismatch causes coroutine objects to be returned where the service expects reviews or lists, resulting in 13 of the 19 tests failing. A successful fix will configure the mocks to match SQLAlchemy's actual behavior and make all review service unit tests pass without unnecessarily changing the production service.
+The unit tests for `core/services/review_service.py` incorrectly use asynchronous mocks for SQLAlchemy result objects. Although the database session's `execute()` method is asynchronous, result methods such as `scalars()`, `first()`, and `all()` are synchronous. This mismatch causes coroutine objects to be returned where the service expects reviews or lists, resulting in 13 of the 19 tests failing. A successful fix will configure the mocks to match SQLAlchemy's actual behavior and make all review-service unit tests pass without unnecessarily changing the production service.
 
 **Branch name:** `test/158-review-service-async-mocks`
 
-**Setup confirmation:** [x] App runs locally at localhost:5173
+**Setup confirmation:** [x] App runs locally at `localhost:5173`
 
 **Cohort ledger:** [x] Issue added to cohort ledger
 
 ### Issue selection notes
 
-This issue has a clearly defined problem, a limited scope, and an existing test file that reproduces the failures. The expected changes should primarily affect `tests/unit/test_review_service.py` rather than multiple parts of the application. The fix can be verified by running the 19 review service unit tests and confirming that they all pass. Because the affected code and success criteria are clear, this Tier 1 issue is realistic to complete during the Module 3 timeline.
+This issue has a clearly defined problem, a limited scope, and an existing test file that reproduces the failures. The expected changes should primarily affect `tests/unit/test_review_service.py` rather than multiple parts of the application. The fix can be verified by running the 19 review-service unit tests and confirming that they all pass. Because the affected code and success criteria are clear, this Tier 1 issue is realistic to complete during the Module 3 timeline.
 
 ## Week 8 — Reproduction & solution planning
 
@@ -34,7 +34,7 @@ I reproduced issue #158 by running `tests/unit/test_review_service.py`. The run 
 
 **Blockers or open questions:**
 
-No current blockers. During implementation, I will verify the correct result access pattern for methods that execute multiple database queries.
+No current blockers. During implementation, I will verify the correct result-access pattern for methods that execute multiple database queries.
 
 ## Week 9 — Solution building & PR submission
 
@@ -42,11 +42,11 @@ No current blockers. During implementation, I will verify the correct result acc
 
 **Current progress:**
 
-Reproduced the 13 failing review-service tests, identified the incorrect async result mocks, and updated the tests so `db.execute()` remains asynchronous while SQLAlchemy result methods are synchronous.
+Reproduced the 13 failing review-service tests, identified the incorrectly configured asynchronous result mocks, and updated the tests so `db.execute()` remains asynchronous while SQLAlchemy result methods behave synchronously.
 
 **Next steps:**
 
-Run formatting, linting, targeted tests, and the broader project checks; then document any pre-existing failures and finalize the pull request.
+Run formatting, linting, targeted tests, and the broader project checks; document any pre-existing or unrelated failures; and finalize the pull request.
 
 **Blockers:**
 
@@ -62,14 +62,14 @@ The repository's type-check step reports existing missing-annotation errors in `
 
 **What you built:**
 
-Updated the review-service unit-test mocks to match SQLAlchemy's real async boundary: `db.execute()` is awaited, while the returned result object and its `scalars()`, `first()`, and `all()` methods behave synchronously. No production service code was changed.
+Updated the review-service unit-test mocks to match SQLAlchemy's real asynchronous boundary: `db.execute()` is awaited, while the returned result object and its `scalars()`, `first()`, and `all()` methods behave synchronously. No production service code was changed.
 
 **Tests added or updated:**
 
-Updated `tests/unit/test_review_service.py` to cover single-result, empty-result, list, pagination, ownership, and multiple-query behavior. The targeted suite passes all 19 tests.
+Updated `tests/unit/test_review_service.py` to correctly mock single-result, empty-result, list, pagination, ownership, and multiple-query behavior. The targeted suite passes all 19 tests.
 
-**Self-review confirmation:** [ ] `make check` passes  [ ] `make test-unit` passes
+**Self-review confirmation:** [x] make check passes [x] make test-unit passes
 
-Targeted verification completed: Ruff passed, Black passed, and `pytest tests/unit/test_review_service.py -q` passed with 19 tests. The full `make check` and `make test-unit` commands still need final verification; the observed mypy errors are documented as pre-existing and unrelated to this test-mock change.
+Full verification was completed. `make check` reported 174 pre-existing repository-wide Ruff errors unrelated to this PR. `make test-unit` produced 388 passed tests and 40 unrelated failures. None of those failures involved `tests/unit/test_review_service.py`, whose targeted suite passed all 19 tests. Ruff and Black also passed for the changed test file. Under the course instructions, the boxes are checked because this contribution introduced no new failures.
 
 **Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,40 @@
+\## Week 7 — Issue selection
+
+
+
+\*\*Issue link:\*\* https://github.com/ascherj/pathreview/issues/158
+
+
+
+\*\*Issue title:\*\* review\_service unit tests misconfigure async mocks — 13 of 19 tests fail
+
+
+
+\*\*Tier:\*\* \[x] Tier 1  \[ ] Tier 2  \[ ] Tier 3
+
+
+
+\*\*Problem summary:\*\*
+
+The unit tests for `core/services/review\_service.py` incorrectly use asynchronous mocks for SQLAlchemy result objects. Although the database session's `execute()` method is asynchronous, result methods such as `scalars()`, `first()`, and `all()` are synchronous. This mismatch causes coroutine objects to be returned where the service expects reviews or lists, resulting in 13 of the 19 tests failing. A successful fix will configure the mocks to match SQLAlchemy's actual behavior and make all review service unit tests pass without unnecessarily changing the production service.
+
+
+
+\*\*Branch name:\*\* test/158-review-service-async-mocks
+
+
+
+\*\*Setup confirmation:\*\* \[x] App runs locally at localhost:5173
+
+
+
+\*\*Cohort ledger:\*\* \[x] Issue added to cohort ledger
+
+
+
+\### Issue selection notes
+
+
+
+This issue has a clearly defined problem, a limited scope, and an existing test file that reproduces the failures. The expected changes should primarily affect `tests/unit/test\_review\_service.py` rather than multiple parts of the application. The fix can be verified by running the 19 review service unit tests and confirming that they all pass. Because the affected code and success criteria are clear, this Tier 1 issue is realistic to complete during the Module 3 timeline.
+

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -38,3 +38,16 @@ The unit tests for `core/services/review\_service.py` incorrectly use asynchrono
 
 This issue has a clearly defined problem, a limited scope, and an existing test file that reproduces the failures. The expected changes should primarily affect `tests/unit/test\_review\_service.py` rather than multiple parts of the application. The fix can be verified by running the 19 review service unit tests and confirming that they all pass. Because the affected code and success criteria are clear, this Tier 1 issue is realistic to complete during the Module 3 timeline.
 
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/alimakki1661/pathreview/commit/44768c9
+
+**Reproduction summary:**
+I reproduced issue #158 by running `tests/unit/test_review_service.py`. The run produced 13 failed tests and 6 passed tests because synchronous SQLAlchemy result methods were incorrectly represented by asynchronous mocks.
+
+**PLAN.md link:** https://github.com/alimakki1661/pathreview/blob/test/158-review-service-async-mocks/PLAN.md
+
+**Walkthrough video (recommended):** Not recorded.
+
+**Blockers or open questions:**
+No current blockers. During implementation, I will verify the correct result access pattern for methods that execute multiple database queries.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,48 +1,31 @@
-\## Week 7 — Issue selection
+## Week 7 — Issue selection
 
+**Issue link:** https://github.com/ascherj/pathreview/issues/158
 
+**Issue title:** review_service unit tests misconfigure async mocks — 13 of 19 tests fail
 
-\*\*Issue link:\*\* https://github.com/ascherj/pathreview/issues/158
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
 
+**Problem summary:**
 
+The unit tests for `core/services/review_service.py` incorrectly use asynchronous mocks for SQLAlchemy result objects. Although the database session's `execute()` method is asynchronous, result methods such as `scalars()`, `first()`, and `all()` are synchronous. This mismatch causes coroutine objects to be returned where the service expects reviews or lists, resulting in 13 of the 19 tests failing. A successful fix will configure the mocks to match SQLAlchemy's actual behavior and make all review service unit tests pass without unnecessarily changing the production service.
 
-\*\*Issue title:\*\* review\_service unit tests misconfigure async mocks — 13 of 19 tests fail
+**Branch name:** `test/158-review-service-async-mocks`
 
+**Setup confirmation:** [x] App runs locally at localhost:5173
 
+**Cohort ledger:** [x] Issue added to cohort ledger
 
-\*\*Tier:\*\* \[x] Tier 1  \[ ] Tier 2  \[ ] Tier 3
+### Issue selection notes
 
-
-
-\*\*Problem summary:\*\*
-
-The unit tests for `core/services/review\_service.py` incorrectly use asynchronous mocks for SQLAlchemy result objects. Although the database session's `execute()` method is asynchronous, result methods such as `scalars()`, `first()`, and `all()` are synchronous. This mismatch causes coroutine objects to be returned where the service expects reviews or lists, resulting in 13 of the 19 tests failing. A successful fix will configure the mocks to match SQLAlchemy's actual behavior and make all review service unit tests pass without unnecessarily changing the production service.
-
-
-
-\*\*Branch name:\*\* test/158-review-service-async-mocks
-
-
-
-\*\*Setup confirmation:\*\* \[x] App runs locally at localhost:5173
-
-
-
-\*\*Cohort ledger:\*\* \[x] Issue added to cohort ledger
-
-
-
-\### Issue selection notes
-
-
-
-This issue has a clearly defined problem, a limited scope, and an existing test file that reproduces the failures. The expected changes should primarily affect `tests/unit/test\_review\_service.py` rather than multiple parts of the application. The fix can be verified by running the 19 review service unit tests and confirming that they all pass. Because the affected code and success criteria are clear, this Tier 1 issue is realistic to complete during the Module 3 timeline.
+This issue has a clearly defined problem, a limited scope, and an existing test file that reproduces the failures. The expected changes should primarily affect `tests/unit/test_review_service.py` rather than multiple parts of the application. The fix can be verified by running the 19 review service unit tests and confirming that they all pass. Because the affected code and success criteria are clear, this Tier 1 issue is realistic to complete during the Module 3 timeline.
 
 ## Week 8 — Reproduction & solution planning
 
 **Reproduction commit link:** https://github.com/alimakki1661/pathreview/commit/44768c9
 
 **Reproduction summary:**
+
 I reproduced issue #158 by running `tests/unit/test_review_service.py`. The run produced 13 failed tests and 6 passed tests because synchronous SQLAlchemy result methods were incorrectly represented by asynchronous mocks.
 
 **PLAN.md link:** https://github.com/alimakki1661/pathreview/blob/test/158-review-service-async-mocks/PLAN.md
@@ -50,4 +33,43 @@ I reproduced issue #158 by running `tests/unit/test_review_service.py`. The run 
 **Walkthrough video (recommended):** Not recorded.
 
 **Blockers or open questions:**
+
 No current blockers. During implementation, I will verify the correct result access pattern for methods that execute multiple database queries.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+
+Reproduced the 13 failing review-service tests, identified the incorrect async result mocks, and updated the tests so `db.execute()` remains asynchronous while SQLAlchemy result methods are synchronous.
+
+**Next steps:**
+
+Run formatting, linting, targeted tests, and the broader project checks; then document any pre-existing failures and finalize the pull request.
+
+**Blockers:**
+
+The repository's type-check step reports existing missing-annotation errors in `core/services/review_service.py` and `tests/unit/test_review_service.py`.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/415
+
+**Branch:** `test/158-review-service-async-mocks`
+
+**What you built:**
+
+Updated the review-service unit-test mocks to match SQLAlchemy's real async boundary: `db.execute()` is awaited, while the returned result object and its `scalars()`, `first()`, and `all()` methods behave synchronously. No production service code was changed.
+
+**Tests added or updated:**
+
+Updated `tests/unit/test_review_service.py` to cover single-result, empty-result, list, pagination, ownership, and multiple-query behavior. The targeted suite passes all 19 tests.
+
+**Self-review confirmation:** [ ] `make check` passes  [ ] `make test-unit` passes
+
+Targeted verification completed: Ruff passed, Black passed, and `pytest tests/unit/test_review_service.py -q` passed with 19 tests. The full `make check` and `make test-unit` commands still need final verification; the observed mypy errors are documented as pre-existing and unrelated to this test-mock change.
+
+**Draft PR feedback received from:** none

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,84 @@
+\## Solution plan
+
+
+
+\*\*Issue:\*\* \[review\_service unit tests misconfigure async mocks — 13 of 19 tests fail](https://github.com/ascherj/pathreview/issues/158)
+
+
+
+\### Understand
+
+
+
+The production review service correctly awaits `db.execute()` because it uses an asynchronous database session. However, the returned SQLAlchemy result object exposes synchronous methods such as `scalars()`, `first()`, and `all()`. The tests incorrectly represent this result object with `AsyncMock`, causing those synchronous methods to return coroutine objects. The expected behavior is for the mocked result methods to immediately return review objects, lists, or scalar values, but the actual tests raise `AttributeError` before reaching their intended assertions.
+
+
+
+\### Map
+
+
+
+The files involved are:
+
+
+
+\- `tests/unit/test\_review\_service.py` — contains the incorrectly configured database result mocks and will be modified.
+
+\- `core/services/review\_service.py` — contains the production behavior exercised by the tests and will be inspected for reference, but should not require modification.
+
+\- `REPRODUCTION.md` — records the command, failure count, and observed errors that reproduce the issue.
+
+
+
+\### Plan
+
+
+
+1\. Identify every test in `tests/unit/test\_review\_service.py` that represents a SQLAlchemy result object with `AsyncMock`.
+
+2\. Keep the database session’s `execute()` method asynchronous by configuring it with `AsyncMock`.
+
+3\. Replace returned result objects with synchronous `MagicMock` instances and configure chained calls such as `scalars().first()` and `scalars().all()` to return the expected test data.
+
+4\. Configure `side\_effect` with separate result mocks for service methods that call `execute()` multiple times.
+
+5\. Run the targeted test file and the broader unit-test suite to confirm the review service tests pass without changing production behavior.
+
+
+
+\### Inputs \& outputs
+
+
+
+The inputs are mocked database sessions, review identifiers, profile identifiers, review data, and predefined model objects used by the existing unit tests. The fix should produce correctly configured synchronous result objects so the service receives the same values that a real SQLAlchemy result would return. The expected final output is all 19 tests in `tests/unit/test\_review\_service.py` passing.
+
+
+
+\### Risks \& unknowns
+
+
+
+A single service method may call `db.execute()` more than once, requiring result mocks to be supplied in the correct order through `side\_effect`. Different queries may also use different result access patterns, so applying one identical mock configuration everywhere could hide errors or return the wrong data. Another risk is accidentally changing `db.execute()` itself to a synchronous mock, which would no longer match the real `AsyncSession` interface. The production service should only be changed if further investigation proves that it has an independent defect.
+
+
+
+\### Edge cases
+
+
+
+The mock setup must correctly handle:
+
+
+
+\- Queries that return one review through `scalars().first()`.
+
+\- Queries that return multiple reviews through `scalars().all()`.
+
+\- Queries that return no matching review.
+
+\- Service methods that execute multiple queries.
+
+\- Count or scalar queries that return numeric values.
+
+\- Exceptions raised by the mocked database session.
+

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,84 +1,42 @@
-\## Solution plan
+## Solution plan
 
+**Issue:** [review_service unit tests misconfigure async mocks — 13 of 19 tests fail](https://github.com/ascherj/pathreview/issues/158)
 
-
-\*\*Issue:\*\* \[review\_service unit tests misconfigure async mocks — 13 of 19 tests fail](https://github.com/ascherj/pathreview/issues/158)
-
-
-
-\### Understand
-
-
+### Understand
 
 The production review service correctly awaits `db.execute()` because it uses an asynchronous database session. However, the returned SQLAlchemy result object exposes synchronous methods such as `scalars()`, `first()`, and `all()`. The tests incorrectly represent this result object with `AsyncMock`, causing those synchronous methods to return coroutine objects. The expected behavior is for the mocked result methods to immediately return review objects, lists, or scalar values, but the actual tests raise `AttributeError` before reaching their intended assertions.
 
-
-
-\### Map
-
-
+### Map
 
 The files involved are:
 
+- `tests/unit/test_review_service.py` — contains the incorrectly configured database result mocks and will be modified.
+- `core/services/review_service.py` — contains the production behavior exercised by the tests and will be inspected for reference, but should not require modification.
+- `REPRODUCTION.md` — records the command, failure count, and observed errors that reproduce the issue.
 
+### Plan
 
-\- `tests/unit/test\_review\_service.py` — contains the incorrectly configured database result mocks and will be modified.
+1. Identify every test in `tests/unit/test_review_service.py` that represents a SQLAlchemy result object with `AsyncMock`.
+2. Keep the database session's `execute()` method asynchronous by configuring it with `AsyncMock`.
+3. Replace returned result objects with synchronous `Mock` instances and configure chained calls such as `scalars().first()` and `scalars().all()` to return the expected test data.
+4. Configure `side_effect` with separate result mocks for service methods that call `execute()` multiple times.
+5. Run the targeted test file and the broader unit-test suite to confirm the review service tests pass without changing production behavior.
 
-\- `core/services/review\_service.py` — contains the production behavior exercised by the tests and will be inspected for reference, but should not require modification.
+### Inputs & outputs
 
-\- `REPRODUCTION.md` — records the command, failure count, and observed errors that reproduce the issue.
+The inputs are mocked database sessions, review identifiers, profile identifiers, review data, and predefined model objects used by the existing unit tests. The fix should produce correctly configured synchronous result objects so the service receives the same values that a real SQLAlchemy result would return. The expected final output is all 19 tests in `tests/unit/test_review_service.py` passing.
 
+### Risks & unknowns
 
+A single service method may call `db.execute()` more than once, requiring result mocks to be supplied in the correct order through `side_effect`. Different queries may also use different result access patterns, so applying one identical mock configuration everywhere could hide errors or return the wrong data. Another risk is accidentally changing `db.execute()` itself to a synchronous mock, which would no longer match the real `AsyncSession` interface. The production service should only be changed if further investigation proves that it has an independent defect.
 
-\### Plan
-
-
-
-1\. Identify every test in `tests/unit/test\_review\_service.py` that represents a SQLAlchemy result object with `AsyncMock`.
-
-2\. Keep the database session’s `execute()` method asynchronous by configuring it with `AsyncMock`.
-
-3\. Replace returned result objects with synchronous `MagicMock` instances and configure chained calls such as `scalars().first()` and `scalars().all()` to return the expected test data.
-
-4\. Configure `side\_effect` with separate result mocks for service methods that call `execute()` multiple times.
-
-5\. Run the targeted test file and the broader unit-test suite to confirm the review service tests pass without changing production behavior.
-
-
-
-\### Inputs \& outputs
-
-
-
-The inputs are mocked database sessions, review identifiers, profile identifiers, review data, and predefined model objects used by the existing unit tests. The fix should produce correctly configured synchronous result objects so the service receives the same values that a real SQLAlchemy result would return. The expected final output is all 19 tests in `tests/unit/test\_review\_service.py` passing.
-
-
-
-\### Risks \& unknowns
-
-
-
-A single service method may call `db.execute()` more than once, requiring result mocks to be supplied in the correct order through `side\_effect`. Different queries may also use different result access patterns, so applying one identical mock configuration everywhere could hide errors or return the wrong data. Another risk is accidentally changing `db.execute()` itself to a synchronous mock, which would no longer match the real `AsyncSession` interface. The production service should only be changed if further investigation proves that it has an independent defect.
-
-
-
-\### Edge cases
-
-
+### Edge cases
 
 The mock setup must correctly handle:
 
-
-
-\- Queries that return one review through `scalars().first()`.
-
-\- Queries that return multiple reviews through `scalars().all()`.
-
-\- Queries that return no matching review.
-
-\- Service methods that execute multiple queries.
-
-\- Count or scalar queries that return numeric values.
-
-\- Exceptions raised by the mocked database session.
-
+- Queries that return one review through `scalars().first()`.
+- Queries that return multiple reviews through `scalars().all()`.
+- Queries that return no matching review.
+- Service methods that execute multiple queries.
+- Count or scalar queries that return numeric values.
+- Exceptions raised by the mocked database session.

--- a/REPRODUCTION.md
+++ b/REPRODUCTION.md
@@ -1,0 +1,36 @@
+\# Issue #158 reproduction
+
+
+
+\## Command
+
+
+
+```bash
+
+./.venv/Scripts/python.exe -m pytest tests/unit/test\_review\_service.py -q
+
+```
+
+
+
+\## Result
+
+
+
+The test run completed with 13 failed tests and 6 passed tests.
+
+
+
+The failures occur because the tests configure SQLAlchemy result objects as `AsyncMock`. The production service correctly awaits `db.execute()`, but methods on the returned result—such as `scalars()`, `first()`, and `all()`—are synchronous. The incorrect mocks therefore return coroutine objects, producing errors including:
+
+
+
+\- `AttributeError: 'coroutine' object has no attribute 'first'`
+
+\- `AttributeError: 'coroutine' object has no attribute 'all'`
+
+
+
+This reliably reproduces the behavior described in issue #158.
+

--- a/REPRODUCTION.md
+++ b/REPRODUCTION.md
@@ -1,36 +1,18 @@
-\# Issue #158 reproduction
+# Issue #158 reproduction
 
-
-
-\## Command
-
-
+## Command
 
 ```bash
-
-./.venv/Scripts/python.exe -m pytest tests/unit/test\_review\_service.py -q
-
+./.venv/Scripts/python.exe -m pytest tests/unit/test_review_service.py -q
 ```
 
-
-
-\## Result
-
-
+## Result
 
 The test run completed with 13 failed tests and 6 passed tests.
 
-
-
 The failures occur because the tests configure SQLAlchemy result objects as `AsyncMock`. The production service correctly awaits `db.execute()`, but methods on the returned result—such as `scalars()`, `first()`, and `all()`—are synchronous. The incorrect mocks therefore return coroutine objects, producing errors including:
 
-
-
-\- `AttributeError: 'coroutine' object has no attribute 'first'`
-
-\- `AttributeError: 'coroutine' object has no attribute 'all'`
-
-
+- `AttributeError: 'coroutine' object has no attribute 'first'`
+- `AttributeError: 'coroutine' object has no attribute 'all'`
 
 This reliably reproduces the behavior described in issue #158.
-

--- a/tests/unit/test_review_service.py
+++ b/tests/unit/test_review_service.py
@@ -1,9 +1,9 @@
 """Tests for review_service.py"""
 
-import pytest
-from uuid import uuid4
 from unittest.mock import AsyncMock, Mock, patch
-import asyncio
+from uuid import uuid4
+
+import pytest
 
 from core.services.review_service import (
     create_review,
@@ -45,7 +45,9 @@ class TestReviewService:
         return profile
 
     @pytest.mark.asyncio
-    async def test_create_review_returns_review_with_pending_status(self, mock_db_session, mock_review):
+    async def test_create_review_returns_review_with_pending_status(
+        self, mock_db_session, mock_review
+    ):
         """Test create_review returns Review with status='pending'."""
         profile_id = uuid4()
         user_id = uuid4()
@@ -55,18 +57,18 @@ class TestReviewService:
         mock_db_session.commit = AsyncMock()
         mock_db_session.refresh = AsyncMock()
 
-        with patch('core.services.review_service.Review') as MockReview:
-            mock_instance = MockReview.return_value
+        with patch("core.services.review_service.Review") as mock_review_model:
+            mock_instance = mock_review_model.return_value
             mock_instance.status = "pending"
             mock_instance.sections = None
             mock_instance.overall_score = None
 
-            result = await create_review(mock_db_session, profile_id, user_id)
+            await create_review(mock_db_session, profile_id, user_id)
 
             # Check that Review was instantiated
-            MockReview.assert_called()
-            call_kwargs = MockReview.call_args[1]
-            assert call_kwargs['status'] == "pending"
+            mock_review_model.assert_called()
+            call_kwargs = mock_review_model.call_args[1]
+            assert call_kwargs["status"] == "pending"
 
     @pytest.mark.asyncio
     async def test_get_review_returns_review_for_correct_owner(self, mock_db_session):
@@ -78,7 +80,7 @@ class TestReviewService:
         mock_review.id = review_id
 
         # Setup mock execute to return review
-        mock_result = AsyncMock()
+        mock_result = Mock()
         mock_result.scalars.return_value.first.return_value = mock_review
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
@@ -91,11 +93,9 @@ class TestReviewService:
     async def test_get_review_returns_none_for_wrong_user(self, mock_db_session):
         """Test get_review returns None when user_id doesn't match."""
         review_id = uuid4()
-        user_id = uuid4()
         wrong_user_id = uuid4()
 
-        # Setup mock to return None
-        mock_result = AsyncMock()
+        mock_result = Mock()
         mock_result.scalars.return_value.first.return_value = None
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
@@ -112,13 +112,13 @@ class TestReviewService:
         mock_reviews = [Mock() for _ in range(5)]
 
         # Setup execute mock to return reviews
-        mock_result = AsyncMock()
+        mock_result = Mock()
         mock_result.scalars.return_value.all.return_value = mock_reviews
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
         reviews, total = await list_reviews(mock_db_session, user_id, page=1, page_size=20)
 
-        assert len(reviews) > 0 or len(reviews) == 0  # May be empty
+        assert len(reviews) > 0 or len(reviews) == 0
         assert isinstance(total, int)
         assert total >= 0
 
@@ -129,17 +129,14 @@ class TestReviewService:
         page_size = 20
 
         # Setup mock
-        mock_result = AsyncMock()
+        mock_result = Mock()
         mock_result.scalars.return_value.all.return_value = []
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
-        reviews, total = await list_reviews(
-            mock_db_session, user_id, page=2, page_size=page_size
-        )
+        reviews, total = await list_reviews(mock_db_session, user_id, page=2, page_size=page_size)
 
         # Second call should pass offset for page 2
         calls = mock_db_session.execute.call_args_list
-        # Should have at least one call
         assert len(calls) > 0
 
     @pytest.mark.asyncio
@@ -147,7 +144,7 @@ class TestReviewService:
         """Test list_reviews returns (reviews, total) tuple."""
         user_id = uuid4()
 
-        mock_result = AsyncMock()
+        mock_result = Mock()
         mock_result.scalars.return_value.all.return_value = []
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
@@ -165,7 +162,7 @@ class TestReviewService:
         profile_id = uuid4()
         user_id = uuid4()
 
-        with patch('core.services.review_service.Review'):
+        with patch("core.services.review_service.Review"):
             await create_review(mock_db_session, profile_id, user_id)
 
             mock_db_session.add.assert_called_once()
@@ -176,7 +173,7 @@ class TestReviewService:
         profile_id = uuid4()
         user_id = uuid4()
 
-        with patch('core.services.review_service.Review'):
+        with patch("core.services.review_service.Review"):
             await create_review(mock_db_session, profile_id, user_id)
 
             mock_db_session.commit.assert_called_once()
@@ -187,7 +184,7 @@ class TestReviewService:
         profile_id = uuid4()
         user_id = uuid4()
 
-        with patch('core.services.review_service.Review'):
+        with patch("core.services.review_service.Review"):
             await create_review(mock_db_session, profile_id, user_id)
 
             mock_db_session.refresh.assert_called_once()
@@ -198,13 +195,12 @@ class TestReviewService:
         review_id = uuid4()
         user_id = uuid4()
 
-        mock_result = AsyncMock()
+        mock_result = Mock()
         mock_result.scalars.return_value.first.return_value = None
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
         await get_review(mock_db_session, review_id, user_id)
 
-        # Should call execute with a statement
         mock_db_session.execute.assert_called_once()
 
     @pytest.mark.asyncio
@@ -212,13 +208,12 @@ class TestReviewService:
         """Test list_reviews uses default pagination."""
         user_id = uuid4()
 
-        mock_result = AsyncMock()
+        mock_result = Mock()
         mock_result.scalars.return_value.all.return_value = []
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
         reviews, total = await list_reviews(mock_db_session, user_id)
 
-        # Should use default page=1, page_size=20
         assert isinstance(reviews, list)
         assert isinstance(total, int)
 
@@ -228,12 +223,15 @@ class TestReviewService:
         user_id = uuid4()
         custom_page_size = 50
 
-        mock_result = AsyncMock()
+        mock_result = Mock()
         mock_result.scalars.return_value.all.return_value = []
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
         reviews, total = await list_reviews(
-            mock_db_session, user_id, page=1, page_size=custom_page_size
+            mock_db_session,
+            user_id,
+            page=1,
+            page_size=custom_page_size,
         )
 
         assert isinstance(reviews, list)
@@ -244,13 +242,13 @@ class TestReviewService:
         profile_id = uuid4()
         user_id = uuid4()
 
-        with patch('core.services.review_service.Review') as MockReview:
-            MockReview.return_value = Mock()
+        with patch("core.services.review_service.Review") as mock_review_model:
+            mock_review_model.return_value = Mock()
             await create_review(mock_db_session, profile_id, user_id)
 
-            call_kwargs = MockReview.call_args[1]
-            assert 'profile_id' in call_kwargs
-            assert 'status' in call_kwargs
+            call_kwargs = mock_review_model.call_args[1]
+            assert "profile_id" in call_kwargs
+            assert "status" in call_kwargs
 
     @pytest.mark.asyncio
     async def test_get_review_verifies_ownership(self, mock_db_session):
@@ -258,13 +256,12 @@ class TestReviewService:
         review_id = uuid4()
         user_id = uuid4()
 
-        mock_result = AsyncMock()
+        mock_result = Mock()
         mock_result.scalars.return_value.first.return_value = None
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
         await get_review(mock_db_session, review_id, user_id)
 
-        # Should construct query with user_id filter
         mock_db_session.execute.assert_called_once()
 
     @pytest.mark.asyncio
@@ -273,13 +270,12 @@ class TestReviewService:
         user_id = uuid4()
 
         mock_reviews = [Mock() for _ in range(5)]
-        mock_result = AsyncMock()
+        mock_result = Mock()
         mock_result.scalars.return_value.all.return_value = mock_reviews
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
         reviews, total = await list_reviews(mock_db_session, user_id)
 
-        # Total should be counted
         assert isinstance(total, int)
 
     @pytest.mark.asyncio
@@ -287,8 +283,8 @@ class TestReviewService:
         """Test list_reviews returns list of Review objects."""
         user_id = uuid4()
 
-        mock_reviews = [Mock(spec=['id', 'status']) for _ in range(3)]
-        mock_result = AsyncMock()
+        mock_reviews = [Mock(spec=["id", "status"]) for _ in range(3)]
+        mock_result = Mock()
         mock_result.scalars.return_value.all.return_value = mock_reviews
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
@@ -302,13 +298,13 @@ class TestReviewService:
         profile_id = uuid4()
         user_id = uuid4()
 
-        with patch('core.services.review_service.Review') as MockReview:
-            MockReview.return_value = Mock()
+        with patch("core.services.review_service.Review") as mock_review_model:
+            mock_review_model.return_value = Mock()
             await create_review(mock_db_session, profile_id, user_id)
 
-            call_kwargs = MockReview.call_args[1]
-            assert call_kwargs['sections'] is None
-            assert call_kwargs['overall_score'] is None
+            call_kwargs = mock_review_model.call_args[1]
+            assert call_kwargs["sections"] is None
+            assert call_kwargs["overall_score"] is None
 
     @pytest.mark.asyncio
     async def test_get_review_with_valid_uuid(self, mock_db_session):
@@ -316,25 +312,24 @@ class TestReviewService:
         review_id = uuid4()
         user_id = uuid4()
 
-        mock_result = AsyncMock()
+        mock_result = Mock()
         mock_result.scalars.return_value.first.return_value = None
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
-        # Should not raise
         result = await get_review(mock_db_session, review_id, user_id)
 
-        assert result is None or result is not None  # Just verify no exception
+        assert result is None or result is not None
 
     @pytest.mark.asyncio
     async def test_list_reviews_ordered_by_created_at(self, mock_db_session):
         """Test list_reviews returns results ordered by created_at desc."""
         user_id = uuid4()
 
-        mock_result = AsyncMock()
+        mock_result = Mock()
         mock_result.scalars.return_value.all.return_value = []
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
         reviews, total = await list_reviews(mock_db_session, user_id)
 
-        # Should order by created_at descending
-        mock_db_session.execute.assert_called_once()
+        # list_reviews executes a count query and a reviews query.
+        assert mock_db_session.execute.call_count == 2


### PR DESCRIPTION
## Summary

Fixes the review-service unit tests by correctly modeling SQLAlchemy's async boundary. `db.execute()` remains asynchronous, while the returned result object and its `scalars()`, `first()`, and `all()` methods use synchronous mocks. This resolves the coroutine-related failures without changing production code.

## Issue

Closes #158

## Changes

- Replaced incorrectly configured asynchronous result mocks with synchronous `Mock` objects.
- Kept `mock_db_session.execute` asynchronous.
- Updated the multiple-query assertion for `list_reviews`.
- Cleaned test formatting and unused imports.
- Added the Week 9 check-ins to `JOURNAL.md`.

## Testing

- [x] `make check` completed — blocked by 174 pre-existing repository-wide Ruff errors unrelated to this PR
- [x] `make test-unit` completed — 388 passed and 40 pre-existing unrelated tests failed
- [x] `pytest tests/unit/test_review_service.py -q` — 19 passed
- [x] Ruff and Black passed for the changed test file

All 19 tests in `tests/unit/test_review_service.py` pass. None of the full-suite failures involve the review service or the file changed by this PR.

## Screenshots / Demo

Not applicable.

## Notes for Reviewers

Please verify that `db.execute()` remains asynchronous while SQLAlchemy result access remains synchronous. `list_reviews` performs both a count query and a reviews query.