### PR TITLE
fix: 150-tech-detector-fails-to-detect-config-files-and-mislabels-repo

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -96,8 +96,8 @@ None.
 [1–3 sentences summarizing what your fix does and how it works]
 
 **Tests added or updated:**
-[Which test files did you touch? What do they cover?]
+No test needed to be updated. All existing test passed. Test referenced in `tech_detector_test.py`.
 
-**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
 
-**Draft PR feedback received from:** [name or Slack handle, or "none"]
+**Draft PR feedback received from:** slack handle: ssangela cui

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -47,7 +47,7 @@ Currently, there is a bug in `tech_detector.py` where it fails to exclude `node_
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** 
+**Reproduction commit link:** https://github.com/Dennis-1am/pathreview/commit/9fbd1d6f7839231abf799de89b46d1f3c0a2108b
 
 **Reproduction summary:**
 I reproduced the issue by running the test case for it and observing that the test fails because it mislabeled the test repository. The specific test that I observe the failure in is in this:

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -44,3 +44,29 @@ Currently, there is a bug in `tech_detector.py` where it fails to exclude `node_
     - [x] I've checked the issue comments and the ledger's Claims count, and I'm fine with how many others are on this issue.
     - [x] I've estimated the time this will take and I'm confident I can complete it before the Week 9 deadline.
     - [x] This issue has no open blockers or dependencies on other unresolved issues.
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** 
+
+**Reproduction summary:**
+I reproduced the issue by running the test case for it and observing that the test fails because it mislabeled the test repository. The specific test that I observe the failure in is in this:
+
+```
+def test_node_modules_excluded(self, detector):
+    """Test node_modules/ directory is excluded from counts."""
+    files = [
+        "src/main.py",
+        "node_modules/package1/index.js",
+        "node_modules/package2/lib.js",
+        "utils.py",
+    ]
+
+    result = detector.execute({"files": files})
+
+    data = result.data
+    assert data["primary_language"] == "Python"
+    # node_modules shouldn't dominate
+```
+
+**PLAN.md link:** http://github.com/Dennis-1am/pathreview/blob/tree/fix/150-tech-detector-fails-to-detect-config-files-and-mislabels-repo/PLAN.md

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -88,12 +88,12 @@ None.
 
 ### Check-in 2 (end of week)
 
-**PR link:** [link to your submitted pull request]
+**PR link:** https://github.com/ascherj/pathreview/pull/417
 
-**Branch:** [the branch name you worked on, e.g. `fix/123-short-description`]
+**Branch:** tree/fix/150-tech-detector-fails-to-detect-config-files-and-mislabels-repo
 
 **What you built:**
-[1–3 sentences summarizing what your fix does and how it works]
+The fix adds the missing node_modules/ & build/ from the should skip filter.
 
 **Tests added or updated:**
 No test needed to be updated. All existing test passed. Test referenced in `tech_detector_test.py`.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,46 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/150
+
+**Issue title:** Tech detector counts vendored and build-output files, skewing language detection
+
+**Tier:** [x] Tier 1 [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+
+Currently, there is a bug in `tech_detector.py` where it fails to exclude `node_modules/` and `build/`. This impacts the evaluation logic: when these directories are included, the high volume of build and configuration files causes `tech_detector.py` to mislabel the repository, rather than ignoring them and labeling it based on the actual source files. The root cause is likely in `tech_detector._should_skip_file`, where the `node_modules/` and `build/` paths are missing from the filter list. Once a successful fix is merged the failing unit test for `tech_detector` should pass and the app should correctly label repos where there is a higher volume of build / configuration files compared to source files.
+
+**Branch name:** fix/150-tech-detector-fails-to-detect-config-files-and-mislabels-repo
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger
+
+`tech_detector.py` does not exclude `node_modules/` or `build/` paths. A repo with 2 Python source files and 6 vendored/bundled JS files is reported as primarily JavaScript.
+
+**Is this right for me:** 
+
+**Selection Note:** 
+
+- Part 1: Understanding the Issue
+
+    - [x] I can explain the problem and the expected behavior.
+    - [x] I've located the relevant files and confirmed they exist in the codebase.
+    - [x] I can describe a concrete before-and-after: what the user sees before the fix and what they see after.
+
+- Part 2: Tier Fit
+
+    - Is the tier a realistic match for where I am right now?
+    - yes, this is my first open source commit so I am choosing tier 1.
+
+- Part 3: Codebase Readiness
+
+    - [x] I've found and read the specific code the issue references
+    - [x] I've read enough surrounding context that I can write a rough plan for the fix without looking anything up.
+    - [x] I've found the test file for my module and read at least one test end-to-end.
+
+- Part 4: Scope and Time
+
+    - [x] I've checked the issue comments and the ledger's Claims count, and I'm fine with how many others are on this issue.
+    - [x] I've estimated the time this will take and I'm confident I can complete it before the Week 9 deadline.
+    - [x] This issue has no open blockers or dependencies on other unresolved issues.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -96,7 +96,7 @@ None.
 The fix adds the missing node_modules/ & build/ from the should skip filter.
 
 **Tests added or updated:**
-No test needed to be updated. All existing test passed. Test referenced in `tech_detector_test.py`.
+No test needed to be updated. Test referenced in `tech_detector_test.py`. Previously, failing test now pass as well.
 
 **Self-review confirmation:** [x] make check passes  [x] make test-unit passes
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -70,3 +70,34 @@ def test_node_modules_excluded(self, detector):
 ```
 
 **PLAN.md link:** http://github.com/Dennis-1am/pathreview/blob/tree/fix/150-tech-detector-fails-to-detect-config-files-and-mislabels-repo/PLAN.md
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+I have implemented the fix for this issue using claude to help identify and put up a initial fix then iterate on it.
+
+**Next steps:**
+Document the fix and open the PR up for this and confirm that existing test still pass and failing test now passes.
+
+**Blockers:**
+None.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [link to your submitted pull request]
+
+**Branch:** [the branch name you worked on, e.g. `fix/123-short-description`]
+
+**What you built:**
+[1–3 sentences summarizing what your fix does and how it works]
+
+**Tests added or updated:**
+[Which test files did you touch? What do they cover?]
+
+**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+
+**Draft PR feedback received from:** [name or Slack handle, or "none"]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -101,3 +101,45 @@ No test needed to be updated. Test referenced in `tech_detector_test.py`. Previo
 **Self-review confirmation:** [x] make check passes  [x] make test-unit passes
 
 **Draft PR feedback received from:** slack handle: ssangela cui
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [x] Yes  [ ] No — still awaiting review
+
+**Summary of feedback:**
+No comments but a approval.
+
+**How you responded:**
+Just thanks them.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+
+The first few weeks of the course was harder than I expected. Specifically the part where
+had to train a RAG model to be production ready. I had to figure out what parameters to tune
+and learn the hard way that accuracy doesn't mean the model is good. I thought it would be more 
+straightforward when I first started the lab for the RAG model project, but I spent multiple hours
+trying to understand everything that was going on.
+
+**What did you learn about working in a large codebase?**
+
+Contributing to someone elses production code means you have to read their community guidelines. 
+Its working with more than one person so you have to be more careful. For example some repos may have contribution guidelines that state your PR titles and or commit must follow a specific format e.g. 
+"feat: .... abc" or "BUG-676767: fix .... abc "
+
+**How did AI tools help — and where did they fall short?**
+
+AI tools help with understanding and generating code they may fall short in learning the entire context of the code that is where the user must step in to provide context and ensure the AI is outputting something useful and not buggy. In the lab rag project I had to find human feedback in order to determine that the model was being fine tuned incorrectly and that accuracy + other measurements combines is the better benchmark for performance.
+
+**What would you do differently if you started over?**
+
+If I were to start over I would start by reading the problem / issue more clearly and doing my own trace before asking the AI for help. I kinda just one shotted the issue by asking claude where I was suspicious about and it fixed it for me.
+
+**What are you most proud of from this module?**
+
+I am most proud of sticking to the class despite having a busier schedule. Excited to see AI 301!!!!

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,32 @@
+## Solution plan
+
+**Issue:** [Tech detector counts vendored and build-output files, skewing language detection](https://github.com/ascherj/pathreview/issues/150)
+
+### Understand
+
+The expected fix isolates primary language identification by actively filtering `node_modules/` and `build/` directories, preventing bundled assets (e.g., vendored JavaScript) from eclipsing actual source code (e.g., Python). Initial logic and parameters surrounding the exclusion patterns in `tech_detector.py` (lines 153–161) are validated.
+
+### Map
+
+Target architecture and testing surface are validated.
+
+1. `tech_detector.py` (`tech_detector._should_skip_file`)
+2. `test_tech_detector.py`
+
+### Plan
+
+1. Integrate exact path-matching exclusions for `node_modules/` and `build/` within the target configuration.
+2. Execute standard processing and validate regressions via `test_tech_detector.py`.
+
+### Inputs & outputs
+
+**Input:** A file path (string).
+**Output:** A boolean indicating whether the file should be skipped, successfully rejecting paths containing vendored or build directories.
+
+### Risks & unknowns
+
+Applying broad static exclusion lists risks false negatives, potentially skipping legitimate source repositories that happen to utilize non-standard naming conventions overlapping with build artifacts. Relying solely on static directory names is a blunt instrument; a more robust future iteration might contextually evaluate project architecture or utilize `.gitignore` propagation.
+
+### Edge cases
+
+The system must gracefully handle empty path inputs, malformed strings, and accurately differentiate between root-level versus nested `node_modules/` and `build/` directories without throwing exceptions.

--- a/agent/tools/tech_detector.py
+++ b/agent/tools/tech_detector.py
@@ -1,6 +1,7 @@
 """Technology stack detector tool."""
 
 import structlog
+
 from .base import BaseTool, ToolResult
 
 logger = structlog.get_logger()
@@ -75,7 +76,7 @@ class TechDetector(BaseTool):
                     "primary_language": "Unknown",
                     "all_languages": [],
                     "frameworks": [],
-                }
+                },
             )
 
         try:
@@ -84,11 +85,7 @@ class TechDetector(BaseTool):
 
         except Exception as e:
             logger.error("tech_detector_error", error=str(e))
-            return ToolResult(
-                success=False,
-                data={},
-                error=str(e)
-            )
+            return ToolResult(success=False, data={}, error=str(e))
 
     def _detect_tech(self, files: list[str]) -> dict:
         """Detect technologies from file list.
@@ -100,10 +97,7 @@ class TechDetector(BaseTool):
             Dict with detected languages and frameworks
         """
         # Filter out vendor/build directories
-        filtered_files = [
-            f for f in files
-            if not self._should_skip_file(f)
-        ]
+        filtered_files = [f for f in files if not self._should_skip_file(f)]
 
         languages = set()
         frameworks = set()
@@ -131,8 +125,12 @@ class TechDetector(BaseTool):
         all_languages = sorted(languages)
         all_frameworks = sorted(frameworks)
 
-        logger.info("tech_detected", primary_lang=primary,
-                   languages_count=len(all_languages), frameworks_count=len(all_frameworks))
+        logger.info(
+            "tech_detected",
+            primary_lang=primary,
+            languages_count=len(all_languages),
+            frameworks_count=len(all_frameworks),
+        )
 
         return {
             "primary_language": primary,
@@ -151,9 +149,11 @@ class TechDetector(BaseTool):
             True if file should be skipped
         """
         skip_patterns = [
+            "node_modules/",
             "/node_modules/",
             "/vendor/",
             "/dist/",
+            "build/",
             "/build/",
             "/.git/",
             "/__pycache__/",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -99,7 +99,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -449,7 +448,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -473,7 +471,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1561,7 +1558,6 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1579,7 +1575,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1972,7 +1967,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3507,7 +3501,6 @@
       "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^2.0.1",
         "cssstyle": "^4.0.1",
@@ -4094,7 +4087,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4107,7 +4099,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4771,7 +4762,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",


### PR DESCRIPTION
## Summary
This pull request updates `agent/tools/tech_detector.py` to fix issue #150 by preventing build artifacts and vendored files from skewing language detection results. Specifically, it updates `_should_skip_file()` to include relative path patterns for `"node_modules/"` and `"build/"` alongside leading-slash variants in `skip_patterns`, ensuring root-level and nested vendored or build directories are properly excluded. Additionally, it refactors `execute()` to streamline the error response payload into a single inline `ToolResult` construction and reformats logging calls within `_detect_tech()` for improved readability.

## Issue
Closes #150 

## Changes
* Added relative path patterns (`"node_modules/"` and `"build/"`) to `skip_patterns` in `_should_skip_file()` within `agent/tools/tech_detector.py` to properly exclude root-level vendored and build directories.
* Refactored `execute()` in `agent/tools/tech_detector.py` to simplify the error handling block into a single inline `ToolResult` construction.
* Cleaned up formatting and logging parameters inside `_detect_tech()` for improved readability.

## Testing
<!-- How did you verify your changes? -->
- [x] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`)
- [x] Linter passes (`make lint`)
- [ ] Type checker passes (`make typecheck`)
- [ ] New/updated tests cover the changes

## Screenshots / Demo
N/A

## Notes for Reviewers
None. Low Risk.
