### PR TITLE
fix(agent): exclude vendored and build-output dirs from tech detection

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -22,7 +22,7 @@ the code the user actually wrote.
 
 **Branch name:** fix/150-exclude-vendored-build-files
 
-**Setup confirmation:** [ ] App runs locally at localhost:5173
+**Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [ ] Issue added to cohort ledger
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,44 @@
+# Module 3 Journal — PathReview
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/150
+
+**Issue title:** Tech detector counts vendored and build-output files, skewing language detection
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The `TechDetector` tool (`agent/tools/tech_detector.py`) guesses a repository's primary language by
+counting source files per language. It's supposed to ignore vendored dependencies and build output, and
+it has a `_should_skip_file()` filter for that — but the skip patterns are written with leading slashes
+(`"/node_modules/"`, `"/build/"`, `"/dist/"`, etc.), so they only match those directories when nested,
+not when they sit at the top of a path (`node_modules/lib/index.js`). As a result, top-level vendored and
+build files aren't excluded and inflate the language counts, so a repo with 2 Python files and 6 bundled
+JS files gets reported as "JavaScript." A successful fix makes the exclusion match these directories
+whether they appear at the start of a path or nested inside it, so the two failing tests
+(`test_node_modules_excluded`, `test_build_directory_excluded`) pass and the primary language reflects
+the code the user actually wrote.
+
+**Branch name:** fix/150-exclude-vendored-build-files
+
+**Setup confirmation:** [ ] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger
+
+---
+
+### "Is this right for me?" — scope notes
+- **Single file, tightly scoped:** the fix lives entirely in `agent/tools/tech_detector.py` (the
+  `_should_skip_file` path-matching logic). No cross-module changes, no schema/API changes.
+- **"Done" is objective:** two existing unit tests (`test_node_modules_excluded`,
+  `test_build_directory_excluded` in `tests/unit/test_tech_detector.py`) already define the expected
+  behavior — success = make them pass without breaking the others.
+- **No new dependencies** and no external services needed to reproduce (pure Python function with a file
+  list input).
+- **In my skill range:** it's Python string/path matching — I can reason about it fully and explain the
+  root cause, which fits a Tier 1 first contribution.
+- **Watch-out I noted:** there's a secondary quirk (`primary = sorted(languages)[0]` picks the
+  alphabetically-first language, not the most common). The reproduction is fixed by the exclusion change
+  alone; I'll keep the scope to the vendored/build exclusion the issue describes and only touch the
+  primary-language logic if the tests require it.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -50,6 +50,56 @@ None blocking. One open decision documented in PLAN.md: there's a secondary late
 common). The two target tests pass with the exclusion fix alone, so I'm keeping scope to
 the vendored/build exclusion the issue describes and leaving the tie-break logic alone.
 
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+All PLAN.md sub-tasks are done. Replaced the leading-slash substring skip patterns in
+`agent/tools/tech_detector.py` with a `SKIP_DIRECTORIES` frozenset and rewrote
+`_should_skip_file()` as a `@classmethod` that normalizes separators, splits the path
+into segments, and skips a file if any segment is a vendored/build directory. The two
+target tests (`test_node_modules_excluded`, `test_build_directory_excluded`) now pass,
+and all 27 tech_detector tests are green.
+
+**Next steps:**
+Open the PR to `ascherj/pathreview`, fill out the template, and document the
+pre-existing codebase failures so reviewers know they're unrelated to this change.
+
+**Blockers:**
+None.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/PENDING
+
+**Branch:** `fix/150-exclude-vendored-build-files`
+
+**What you built:**
+Fixed the tech detector so it no longer counts files inside vendored dependency or
+build-output directories. The old skip filter used leading-slash substring matching
+(`"/node_modules/"`), which silently missed top-level directories; the new filter
+matches each path segment against a set of directory names, so `node_modules/lib/x.js`
+and nested `packages/app/build/x.js` are both excluded.
+
+**Tests added or updated:**
+No new tests needed — the two pre-existing tests `test_node_modules_excluded` and
+`test_build_directory_excluded` in `tests/unit/test_tech_detector.py` already defined
+the correct behavior and were failing; my change makes them pass (27/27 in that file).
+
+**Self-review confirmation:** [x] make check passes*  [x] make test-unit passes*
+
+\*The codebase has documented **pre-existing** failures unrelated to this issue: on a
+clean `main`, `make test-unit` reports 51 failures (review_service, security,
+skill_extractor, structural_chunker) and `make check` reports 181 lint errors. My change
+introduces **zero** new failures — my file (`agent/tools/tech_detector.py`) passes ruff,
+black, and mypy individually, and my module's tests all pass. Per the Week 9 guidance,
+"passes" here means my changes make nothing worse.
+
+**Draft PR feedback received from:** none
+
 ---
 
 ### "Is this right for me?" — scope notes

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -28,6 +28,30 @@ the code the user actually wrote.
 
 ---
 
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/obwoj1/pathreview/commit/5cec0c3
+
+**Reproduction summary:**
+Ran the existing unit suite against the pre-fix `tech_detector.py` and got
+`2 failed, 25 passed` — `test_node_modules_excluded` and `test_build_directory_excluded`
+both failed, with the tool logging `primary_lang=JavaScript` for a repo whose only
+hand-written code is Python (the 6 bundled JS files under `node_modules/` were counted
+instead of skipped). This confirms the leading-slash skip patterns never match
+top-level vendored/build directories.
+
+**PLAN.md link:** https://github.com/obwoj1/pathreview/blob/fix/150-exclude-vendored-build-files/PLAN.md
+
+**Walkthrough video (recommended):** _(not recorded)_
+
+**Blockers or open questions:**
+None blocking. One open decision documented in PLAN.md: there's a secondary latent bug
+(`primary = sorted(languages)[0]` picks the alphabetically-first language, not the most
+common). The two target tests pass with the exclusion fix alone, so I'm keeping scope to
+the vendored/build exclusion the issue describes and leaving the tie-break logic alone.
+
+---
+
 ### "Is this right for me?" — scope notes
 - **Single file, tightly scoped:** the fix lives entirely in `agent/tools/tech_detector.py` (the
   `_should_skip_file` path-matching logic). No cross-module changes, no schema/API changes.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -73,7 +73,7 @@ None.
 
 ### Check-in 2 (end of week)
 
-**PR link:** https://github.com/ascherj/pathreview/pull/PENDING
+**PR link:** https://github.com/ascherj/pathreview/pull/418
 
 **Branch:** `fix/150-exclude-vendored-build-files`
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -24,7 +24,7 @@ the code the user actually wrote.
 
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
-**Cohort ledger:** [ ] Issue added to cohort ledger
+**Cohort ledger:** [x] Issue added to cohort ledger
 
 ---
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -100,6 +100,76 @@ black, and mypy individually, and my module's tests all pass. Per the Week 9 gui
 
 **Draft PR feedback received from:** none
 
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No reviewer or maintainer comments came in on PR #418 during the module. (Per the
+Summer 2026 course note, reviewer feedback isn't an active feature this cohort.) I
+checked the PR conversation on GitHub — reviews and comments were both empty, status
+`OPEN` / `REVIEW_REQUIRED` — so there was nothing to respond to.
+
+**How you responded:**
+Nothing to respond to yet. The PR is open and ready for review if the maintainer
+picks it up later.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Trusting that a broken codebase wasn't my fault. When I ran `make test-unit` I got
+51 failing tests and `make check` threw 181 lint errors, and my gut reaction was "I
+broke everything." The harder skill wasn't fixing my bug — it was proving those
+failures were *pre-existing* by checking out a clean `main` and running the same
+commands there, so I could confidently write in the PR "my change introduces zero new
+failures." Separating my blast radius from the codebase's existing mess took more care
+than the actual fix.
+
+**What did you learn about working in a large codebase?**
+In my own projects I know where everything is, so if something's broken it's on me.
+Here, most of what was "wrong" had nothing to do with me — other people's half-finished
+issues, unrelated modules. Contributing to someone else's production code is mostly
+*discipline about scope*: touch only the file the issue names (`tech_detector.py`),
+match their existing conventions (branch naming, commit format, docstring style, the
+pre-commit hooks), and prove you didn't make things worse rather than trying to fix the
+whole repo. I actually found a *second* bug while I was in there (the primary-language
+picker uses `sorted()[0]`, so it returns the alphabetically-first language instead of
+the most common) — and the discipline was choosing NOT to fix it, because it was out of
+scope for issue #150, and instead noting it for a follow-up.
+
+**How did AI tools help — and where did they fall short?**
+AI was strongest at *navigation and speed*: tracing the bug from the issue down to the
+exact line, explaining why leading-slash substring matching silently fails on top-level
+paths, and drafting the segment-matching rewrite plus the docstring in the project's
+style. It was also great at grunt work — running the test suite, capturing the
+before/after output, and drafting the PR description. Where it fell short: it couldn't
+make the *judgment calls* for me. Deciding the scope boundary (fix the vendored-dir bug,
+leave the `sorted()[0]` bug alone), deciding this was a real reproduction and not a fluke,
+and the accountability stuff — submitting the right branch URL, claiming the issue,
+requesting a regrade when a different project got mis-graded — all of that is on me. AI
+hands you the code; it doesn't own the contribution.
+
+**What would you do differently if you started over?**
+Be religious about *how* I submit, not just *what* I build. On an earlier project I lost
+points because a submission link pointed a grader at `main` (the starter code) instead of
+my feature branch — all my real work was one branch away and invisible. That burned in a
+lesson I carried through all four weeks here: always submit the `/tree/<branch>` URL, never
+a bare repo link. I'd also open the PR even earlier than I did — the assignment kept saying
+"don't wait for the deadline," and having it open early is the only way real feedback can
+reach you in time.
+
+**What are you most proud of from this module?**
+Not the code itself — it's a small, clean fix — but that the whole contribution is
+*honest and self-documenting*. Anyone can open PR #418 and see exactly what broke, a
+reproduction with real before/after output, an upfront note that the codebase's 51
+pre-existing failures aren't mine, and even a flagged second bug I chose to leave for a
+follow-up. That's what a real open-source contribution looks like, and it reads like I
+actually understood the code instead of just making tests go green.
+
 ---
 
 ### "Is this right for me?" — scope notes

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,78 @@
+# Solution plan
+
+**Issue:** [#150 — Tech detector counts vendored and build-output files, skewing language detection](https://github.com/ascherj/pathreview/issues/150)
+
+### Understand
+
+**Root cause.** The `TechDetector` tool guesses a repository's primary language by
+counting source files per language. It is supposed to ignore vendored dependencies
+(`node_modules`, `vendor`) and build output (`dist`, `build`), and it has a
+`_should_skip_file()` filter meant to do exactly that. But the skip patterns were
+written with **leading slashes** — `"/node_modules/"`, `"/build/"`, `"/dist/"` — and
+the check was a substring match:
+
+```python
+return any(pattern in filepath for pattern in SKIP_PATTERNS)
+```
+
+`"/node_modules/" in "node_modules/lib/index.js"` is `False`, because the path does
+not start with a slash. So the filter only catches these directories when they are
+**nested** inside another folder, and misses them when they sit at the **top** of the
+path — which is the common case.
+
+**Expected vs. actual.** For a repo with 2 hand-written Python files and 6 bundled
+JS files under `node_modules/`, the primary language *should* be reported as
+`Python`. Actual behavior: the vendored JS files are counted, inflating the JS count,
+and the tool reports `JavaScript`.
+
+### Map
+
+Files involved:
+
+- **`agent/tools/tech_detector.py`** — the only file with logic to change.
+  - `_should_skip_file()` — the broken filter (rewrite this).
+  - `_detect_tech()` — calls the filter via a list comprehension (no change needed).
+- **`tests/unit/test_tech_detector.py`** — the two failing tests that define
+  correct behavior (`test_node_modules_excluded`, `test_build_directory_excluded`).
+  Read-only reference; success = make these green without breaking the other 25.
+
+### Plan
+
+1. Replace the leading-slash substring patterns with a `SKIP_DIRECTORIES` set of bare
+   directory names (`node_modules`, `vendor`, `dist`, `build`, `.git`, `__pycache__`,
+   `.venv`, `venv`).
+2. Rewrite `_should_skip_file()` to normalize Windows separators (`\` → `/`), split
+   the path into segments, and skip the file if **any** segment is in
+   `SKIP_DIRECTORIES`. This matches the directory whether it is top-level or nested.
+3. Run the unit tests and confirm the two target tests pass and the other 25 still do.
+4. Run `make check` (ruff + black + mypy) so the change satisfies the pre-commit hooks.
+
+### Inputs & outputs
+
+- **Input:** a list of repository file paths (strings), e.g.
+  `["node_modules/lib/index.js", "main.py", "build/out.js", "app.py"]`.
+- **Output:** the same `_detect_tech()` result dict, but with vendored/build files
+  correctly excluded — so `primary_language` reflects only the code the user wrote
+  (`"Python"` in the example above), not bundled dependencies.
+
+### Risks & unknowns
+
+- **Over-matching a legitimate folder.** A real source directory literally named
+  `build/` or `dist/` would also be skipped. Acceptable — that matches the issue's
+  intent and how tools like GitHub Linguist behave — but worth noting.
+- **Path separators.** Windows paths use `\`. The rewrite normalizes them before
+  splitting; if a caller passes an already-mixed path this stays correct.
+- **Secondary latent bug (out of scope).** `primary = sorted(languages)[0]` picks the
+  **alphabetically first** language, not the most common one. The two failing tests
+  pass with the exclusion fix alone, so I am keeping scope to the vendored/build
+  exclusion the issue describes and *not* touching the primary-language tie-break
+  unless a test demands it.
+
+### Edge cases
+
+- Directory at the **top** of the path: `node_modules/lib/index.js` → skipped.
+- Directory **nested** deeper: `packages/app/build/bundle.js` → skipped.
+- **Windows** separators: `node_modules\lib\index.js` → skipped.
+- A filename that merely **contains** the word but isn't a directory:
+  `my_build_notes.py` → **not** skipped (segment match, not substring).
+- Empty file list → returns `Unknown` (existing behavior, unchanged).

--- a/agent/tools/tech_detector.py
+++ b/agent/tools/tech_detector.py
@@ -1,6 +1,7 @@
 """Technology stack detector tool."""
 
 import structlog
+
 from .base import BaseTool, ToolResult
 
 logger = structlog.get_logger()
@@ -56,6 +57,21 @@ class TechDetector(BaseTool):
         "cmake": ("CMake", "Build"),
     }
 
+    # Directory names holding vendored dependencies or build output. Files inside
+    # any of these should not count toward language detection.
+    SKIP_DIRECTORIES = frozenset(
+        {
+            "node_modules",
+            "vendor",
+            "dist",
+            "build",
+            ".git",
+            "__pycache__",
+            ".venv",
+            "venv",
+        }
+    )
+
     def execute(self, input_data: dict) -> ToolResult:
         """Detect tech stack from files.
 
@@ -75,7 +91,7 @@ class TechDetector(BaseTool):
                     "primary_language": "Unknown",
                     "all_languages": [],
                     "frameworks": [],
-                }
+                },
             )
 
         try:
@@ -84,11 +100,7 @@ class TechDetector(BaseTool):
 
         except Exception as e:
             logger.error("tech_detector_error", error=str(e))
-            return ToolResult(
-                success=False,
-                data={},
-                error=str(e)
-            )
+            return ToolResult(success=False, data={}, error=str(e))
 
     def _detect_tech(self, files: list[str]) -> dict:
         """Detect technologies from file list.
@@ -100,10 +112,7 @@ class TechDetector(BaseTool):
             Dict with detected languages and frameworks
         """
         # Filter out vendor/build directories
-        filtered_files = [
-            f for f in files
-            if not self._should_skip_file(f)
-        ]
+        filtered_files = [f for f in files if not self._should_skip_file(f)]
 
         languages = set()
         frameworks = set()
@@ -131,8 +140,12 @@ class TechDetector(BaseTool):
         all_languages = sorted(languages)
         all_frameworks = sorted(frameworks)
 
-        logger.info("tech_detected", primary_lang=primary,
-                   languages_count=len(all_languages), frameworks_count=len(all_frameworks))
+        logger.info(
+            "tech_detected",
+            primary_lang=primary,
+            languages_count=len(all_languages),
+            frameworks_count=len(all_frameworks),
+        )
 
         return {
             "primary_language": primary,
@@ -140,9 +153,14 @@ class TechDetector(BaseTool):
             "frameworks": all_frameworks,
         }
 
-    @staticmethod
-    def _should_skip_file(filepath: str) -> bool:
-        """Check if file should be skipped.
+    @classmethod
+    def _should_skip_file(cls, filepath: str) -> bool:
+        """Check if a file lives in a vendored or build-output directory.
+
+        Matches each path segment (after normalizing Windows separators) against
+        ``SKIP_DIRECTORIES``, so a directory is excluded whether it appears at the
+        top of the path (``node_modules/lib/index.js``) or nested inside it
+        (``packages/app/build/bundle.js``).
 
         Args:
             filepath: File path
@@ -150,15 +168,5 @@ class TechDetector(BaseTool):
         Returns:
             True if file should be skipped
         """
-        skip_patterns = [
-            "/node_modules/",
-            "/vendor/",
-            "/dist/",
-            "/build/",
-            "/.git/",
-            "/__pycache__/",
-            "/.venv/",
-            "/venv/",
-        ]
-
-        return any(pattern in filepath for pattern in skip_patterns)
+        segments = filepath.replace("\\", "/").split("/")
+        return any(segment in cls.SKIP_DIRECTORIES for segment in segments)


### PR DESCRIPTION
## Summary

The `TechDetector` tool infers a repository's primary language by counting source files per language, and it is supposed to ignore vendored dependencies (`node_modules`, `vendor`) and build output (`dist`, `build`). Its `_should_skip_file()` filter was written with leading-slash substring patterns (`"/node_modules/"`, `"/build/"`, …), so `"/node_modules/" in "node_modules/lib/index.js"` evaluated to `False` and **top-level** vendored/build files were never skipped — inflating language counts and misreporting the primary language. This PR rewrites the filter to match individual path segments, so vendored/build directories are excluded whether they sit at the top of the path or nested deeper.

## Issue
Closes #150

## Changes
- Added a `SKIP_DIRECTORIES` frozenset (`node_modules`, `vendor`, `dist`, `build`, `.git`, `__pycache__`, `.venv`, `venv`) to `agent/tools/tech_detector.py`.
- Rewrote `_should_skip_file()` from a `@staticmethod` doing leading-slash substring matching into a `@classmethod` that normalizes Windows separators (`\` → `/`), splits the path into segments, and skips the file if **any** segment is in `SKIP_DIRECTORIES`.
- This fixes the two pre-existing failing tests (`test_node_modules_excluded`, `test_build_directory_excluded`) without altering any other behavior.

## Testing
- [x] Unit tests pass (`make test-unit`) — see pre-existing-failures note below
- [ ] Integration tests pass (`make test-integration`) — not run (unrelated modules)
- [x] Linter passes (`make lint`) — for the changed file; see note below
- [x] Type checker passes (`make typecheck`) — for the changed file; see note below
- [x] New/updated tests cover the changes — the two target tests in `tests/unit/test_tech_detector.py` now pass (27/27 in that file)

**Verification of the fix:**
```
tests/unit/test_tech_detector.py  →  27 passed
```
Reproduced before the change on the pre-fix file: `2 failed, 25 passed`, with the tool logging `primary_lang=JavaScript` for a Python repo whose only JS lived under `node_modules/`. After the change it correctly reports `Python`.

**My changed file passes all three linters individually:**
```
ruff check agent/tools/tech_detector.py   → All checks passed!
black --check agent/tools/tech_detector.py → unchanged
mypy agent/tools/tech_detector.py          → Success: no issues found
```

## Notes for Reviewers

**Pre-existing failures (not introduced by this PR).** On a clean `main`, before any of my changes:
- `make test-unit` reports **51 failing tests** in unrelated modules (`review_service`, `security`, `skill_extractor`, `structural_chunker`) — these are covered by other open issues.
- `make check` reports **181 lint errors** across the repo.

This PR touches only `agent/tools/tech_detector.py` (plus my `JOURNAL.md`/`PLAN.md` contribution docs) and introduces **no new** test or lint failures. The tech_detector test file is fully green (27/27).

**Scope note — a secondary latent bug I deliberately did *not* touch:** `_detect_tech()` computes `primary = sorted(languages)[0]`, which returns the *alphabetically first* language rather than the *most common* one. The two target tests pass with the exclusion fix alone, so I kept this PR scoped to the vendored/build exclusion the issue describes. Happy to open a follow-up issue for the tie-break if that's useful.
