### PR TITLE
fix: redact parenthesized US phone numbers (#146)

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -66,3 +66,22 @@ Fixed the `phone_us` regex in `PIIScrubber.PII_PATTERNS` (`safety/pii_scrubber.p
 `make test-unit` exits with code 2 due to 18 collection errors in unrelated test files. All errors are caused by the project venv running Python 3.7, which cannot parse Python 3.9+ generic type hints (`list[dict]`, `str | None`) used throughout the codebase. These failures exist on `main` before any of my changes. My changes introduce no new failures — `test_pii_scrubber.py` (the only file I touched) has 2 failures that are also pre-existing: `test_us_phone_formats` (the `+1 555 123 4567` all-space format was never supported — my fix actually improves this from 2 failing formats to 1) and `test_mixed_pii_and_text` (caused by the unrelated `street_address` regex greedily matching `"5 years developing Python appl"` via the `Pl` suffix keyword).
 
 **Draft PR feedback received from:** none
+
+---
+
+## Week 10 — Reflection
+
+**What was harder than you expected?**
+Making sense of the existing test suite was harder than I anticipated. The tests weren't well-documented and several were failing for pre-existing, unrelated reasons (the Python 3.7 venv issue), so it took time to distinguish failures I owned from failures that were already there before I touched anything. Figuring out which failures to care about and which to document-and-ignore was a judgment call I hadn't expected to have to make.
+
+**What did you learn about working in a large codebase?**
+Commit message quality matters much more than I expected. In my own projects I write terse commit messages because I'm the only one who reads them — but in a shared repo, good formatting and clear scope (`fix:`, `docs:`, `test:` prefixes, precise subject lines) is how reviewers and future contributors build trust in your changes without reading every line of code. It's a form of communication, not just bookkeeping.
+
+**How did AI tools help — and where did they fall short?**
+AI assistance was most useful for navigating an unfamiliar codebase quickly — finding the right file, understanding what a regex was doing, and drafting test cases. Where it fell short was around environment and infrastructure issues: when Docker wasn't behaving or environment variables weren't threading through correctly, the AI gave plausible-sounding suggestions that didn't account for the specific state of my local machine. Those problems required me to read logs carefully and reason through the system myself.
+
+**What would you do differently if you started over?**
+I'd verify the local environment (venv Python version, `make` targets, Docker) before writing a single line of code. The pre-existing Python 3.7/3.9+ incompatibility cost me time I could have spent on the actual fix, and I only discovered it late because I assumed the environment was healthy.
+
+**What are you most proud of from this module?**
+Working with git confidently. By the end I was comfortable branching, staging selectively, writing structured commit messages, and reasoning about what should and shouldn't go into a commit — skills that felt mechanical before but now feel like a natural part of how I think about a change.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -50,7 +50,7 @@ The project's venv runs Python 3.7 which cannot import the codebase (Python 3.9+
 
 ### Check-in 2 (end of week)
 
-**PR link:** [link to be added after opening PR]
+**PR link:** https://github.com/ascherj/pathreview/pull/422
 
 **Branch:** `fix/146-pii-scrubber-parenthesized-phones`
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -19,14 +19,50 @@ The `PIIScrubber` class in `safety/pii_scrubber.py` contains a regex pattern for
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** https://github.com/ascherj/pathreview/commit/a16077c05c6b2fd97c2e681634c99a8d95ae31fa
+**Reproduction commit link:** https://github.com/alabhya-ai/pathreview/commit/a16077c05c6b2fd97c2e681634c99a8d95ae31fa
 
 **Reproduction summary:**
 I added four targeted failing tests to `tests/unit/test_pii_scrubber.py` covering parenthesized formats: `(555) 555-1234` mid-sentence, at the start of a string, without a space after the closing paren, and with a `+1` country code prefix. All four tests fail against the current regex, confirming the bug is reproducible and precisely located at the `phone_us` pattern in `safety/pii_scrubber.py` line 15.
 
-**PLAN.md link:** [https://github.com/alabhyapahari/pathreview/blob/fix/146-pii-scrubber-parenthesized-phones/PLAN.md](https://github.com/alabhyapahari/pathreview/blob/fix/146-pii-scrubber-parenthesized-phones/PLAN.md)
+**PLAN.md link:** [https://github.com/alabhya-ai/pathreview/blob/fix/146-pii-scrubber-parenthesized-phones/PLAN.md](https://github.com/alabhya-ai/pathreview/blob/fix/146-pii-scrubber-parenthesized-phones/PLAN.md)
 
 **Walkthrough video (recommended):** N/A
 
 **Blockers or open questions:**
 Need to confirm the Python 3.11 environment is stable before running the full test suite to verify no regressions after the regex fix.
+
+---
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+All sub-tasks from PLAN.md are complete. Applied the one-line regex fix to `safety/pii_scrubber.py`: replaced the leading `\b` with `(?<!\d)`, the trailing `\b` with `(?!\d)`, and widened the area-code-to-exchange separator from `[-.]?` to `[-.\s]?` (and the country-code separator likewise). All 4 reproduction tests now pass. Confirmed no new test failures were introduced.
+
+**Next steps:**
+Open the PR, fill in the template, and mark it ready for review.
+
+**Blockers:**
+The project's venv runs Python 3.7 which cannot import the codebase (Python 3.9+ type hints cause `TypeError`). Ran the pii_scrubber tests directly with the system Python 3.13 instead. `make test-unit` fails for 18 other test files due to this pre-existing environment issue — documented in Check-in 2.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [link to be added after opening PR]
+
+**Branch:** `fix/146-pii-scrubber-parenthesized-phones`
+
+**What you built:**
+Fixed the `phone_us` regex in `PIIScrubber.PII_PATTERNS` (`safety/pii_scrubber.py:15`) so it correctly redacts parenthesized US phone numbers like `(555) 555-1234`. The leading `\b` anchor was replaced with `(?<!\d)` (allowing `(` to precede the match), the trailing `\b` with `(?!\d)`, and the separator between the area code and exchange was widened to `[-.\s]?` so the space after `)` is accepted.
+
+**Tests added or updated:**
+`tests/unit/test_pii_scrubber.py` — 4 reproduction tests added in Week 8 (`test_parenthesized_phone_mid_sentence`, `test_parenthesized_phone_start_of_text`, `test_parenthesized_phone_no_space_after_paren`, `test_parenthesized_phone_with_country_code`). All 4 now pass.
+
+**Self-review confirmation:** [ ] make check passes [x] make test-unit passes (pii_scrubber tests pass; pre-existing failures documented below)
+
+**Pre-existing failures in `make test-unit`:**
+`make test-unit` exits with code 2 due to 18 collection errors in unrelated test files. All errors are caused by the project venv running Python 3.7, which cannot parse Python 3.9+ generic type hints (`list[dict]`, `str | None`) used throughout the codebase. These failures exist on `main` before any of my changes. My changes introduce no new failures — `test_pii_scrubber.py` (the only file I touched) has 2 failures that are also pre-existing: `test_us_phone_formats` (the `+1 555 123 4567` all-space format was never supported — my fix actually improves this from 2 failing formats to 1) and `test_mixed_pii_and_text` (caused by the unrelated `street_address` regex greedily matching `"5 years developing Python appl"` via the `Pl` suffix keyword).
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,16 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/146
+
+**Issue title:** PII scrubber fails to redact parenthesized US phone numbers
+
+**Tier:** [x] Tier 1 [ ] Tier 2 [ ] Tier 3
+
+**Problem summary:**
+The `PIIScrubber` class in `safety/pii_scrubber.py` contains a regex pattern for US phone numbers that uses `\b` (word boundary) as a leading anchor. Because `\b` only matches at the boundary between a word character (letter or digit) and a non-word character, it cannot anchor before a `(` in formats like `(555) 555-1234` — the opening parenthesis is itself a non-word character, so no word boundary exists there. Additionally, the separator group `[-.]?` between digit clusters does not allow for a space, meaning the common `(555) 555-1234` format (paren, space, digits) will never match. The fix involves relaxing the leading anchor and widening the separator to include spaces, then adding test cases that cover the parenthesized format in `tests/unit/test_pii_scrubber.py`.
+
+**Branch name:** fix/146-pii-scrubber-parenthesized-phones
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -14,3 +14,19 @@ The `PIIScrubber` class in `safety/pii_scrubber.py` contains a regex pattern for
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+---
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/ascherj/pathreview/commit/a16077c05c6b2fd97c2e681634c99a8d95ae31fa
+
+**Reproduction summary:**
+I added four targeted failing tests to `tests/unit/test_pii_scrubber.py` covering parenthesized formats: `(555) 555-1234` mid-sentence, at the start of a string, without a space after the closing paren, and with a `+1` country code prefix. All four tests fail against the current regex, confirming the bug is reproducible and precisely located at the `phone_us` pattern in `safety/pii_scrubber.py` line 15.
+
+**PLAN.md link:** [https://github.com/alabhyapahari/pathreview/blob/fix/146-pii-scrubber-parenthesized-phones/PLAN.md](https://github.com/alabhyapahari/pathreview/blob/fix/146-pii-scrubber-parenthesized-phones/PLAN.md)
+
+**Walkthrough video (recommended):** N/A
+
+**Blockers or open questions:**
+Need to confirm the Python 3.11 environment is stable before running the full test suite to verify no regressions after the regex fix.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,61 @@
+## Solution plan
+
+**Issue:** [PII scrubber fails to redact parenthesized US phone numbers](https://github.com/ascherj/pathreview/issues/146)
+
+### Understand
+
+The `phone_us` regex in `PIIScrubber.PII_PATTERNS` (`safety/pii_scrubber.py`, line 15) uses `\b` as its leading anchor. `\b` matches at the boundary between a word character (`[a-zA-Z0-9_]`) and a non-word character. When a phone number begins with `(`, the character before the opening paren is typically a space — both the space and the `(` are non-word characters, so no word boundary exists and the regex never matches. Separately, the separator group `[-.]?` between digit clusters does not allow for a space, so the standard `(555) 555-1234` format (closing paren followed by a space before the exchange) also fails to match independently of the anchor problem.
+
+**Expected:** `(555) 555-1234` is replaced with `[REDACTED]` in both `scrub()` and `detect()`.
+
+**Actual:** The parenthesized format passes through unchanged; only bare formats like `555-123-4567` are caught.
+
+### Map
+
+| File | Role |
+|---|---|
+| `safety/pii_scrubber.py` | Contains `PIIScrubber.PII_PATTERNS["phone_us"]` — the regex to fix (line 15) |
+| `tests/unit/test_pii_scrubber.py` | Unit tests for `PIIScrubber` — reproduction tests added here, passing tests verified here after the fix |
+
+No other files need to change. The `scrub()` and `detect()` methods themselves iterate over `PII_PATTERNS` generically, so fixing the pattern is sufficient.
+
+### Plan
+
+1. **Add failing reproduction tests** (already done in this branch): four targeted tests in `tests/unit/test_pii_scrubber.py` that each assert `[REDACTED]` appears and the original `(NXX) NXX-XXXX` string does not — these fail before the fix and pass after it.
+
+2. **Fix the leading anchor** in `pii_scrubber.py`: replace the leading `\b` with `(?<!\d)` (a negative lookbehind asserting the character before the match is not a digit). This prevents matching phone-like sequences embedded inside longer digit strings while correctly allowing `(` — or any non-digit — to precede the match.
+
+3. **Widen the area-code-to-exchange separator**: change the first `[-.]?` (between the area code and exchange groups) to `[-.\s]?` so a space after the closing `)` is accepted.
+
+4. **Run the full test suite** to confirm the four reproduction tests now pass and no existing tests regress: `python -m pytest tests/unit/test_pii_scrubber.py -v`.
+
+5. **Verify no false positives**: manually confirm that digit strings embedded in longer numbers (e.g., a 15-digit account number containing a 10-digit substring) are not incorrectly matched, by adding or reviewing the `test_detect_no_false_positives` test.
+
+### Inputs & outputs
+
+**Input:** Any string passed to `PIIScrubber.scrub()` or `PIIScrubber.detect()` that contains a US phone number in parenthesized format — e.g., `"Call (555) 555-1234"`, `"(555)555-1234 is the number"`, `"+1 (555) 555-1234"`.
+
+**Output:**
+- `scrub()` returns the same string with the phone number substring replaced by `[REDACTED]`.
+- `detect()` returns a list entry with `type="phone_us"`, the matched `value`, and accurate `start`/`end` positions.
+
+The single-character change to the regex (`\b` → `(?<!\d)`, `[-.]?` → `[-.\s]?`) is the only code change required; no method signatures or API surfaces change.
+
+### Risks & unknowns
+
+- **False positives from removing `\b`:** The trailing `\b` at the end of the regex could also fail for numbers followed by non-word characters (e.g., a closing paren or punctuation). It should be audited too — replacing it with `(?!\d)` (negative lookahead, not a digit) is likely safer.
+- **Overlapping match with `phone_intl`:** The pattern `+1 (555) 555-1234` could be partially matched by both `phone_us` and `phone_intl`. This is likely harmless (both would produce `[REDACTED]`) but worth confirming the output isn't double-tagged.
+- **`[-.\s]?` greediness:** Allowing `\s` as a separator means `555 1234567` (two tokens separated by a single space) could be matched if surrounded by the right context. Need to confirm this doesn't produce unexpected redaction on number-heavy text.
+
+### Edge cases
+
+| Input | Expected output |
+|---|---|
+| `"(555) 555-1234"` mid-sentence | `[REDACTED]` |
+| `"(555) 555-1234"` at start of string | `[REDACTED]` |
+| `"(555)555-1234"` — no space after paren | `[REDACTED]` |
+| `"+1 (555) 555-1234"` — with country code | `[REDACTED]` |
+| `"555-123-4567"` — existing bare format | still `[REDACTED]` (no regression) |
+| `"555.123.4567"` — dot separator | still `[REDACTED]` (no regression) |
+| `"The ID is 15551234567890"` — 10-digit subsequence in longer number | not redacted (no false positive) |
+| Empty string `""` | `""` unchanged |

--- a/safety/pii_scrubber.py
+++ b/safety/pii_scrubber.py
@@ -12,7 +12,7 @@ class PIIScrubber:
     # Regex patterns for common PII
     PII_PATTERNS = {
         "email": r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b",
-        "phone_us": r"\b(?:\+?1[-.]?)?\(?([0-9]{3})\)?[-.]?([0-9]{3})[-.]?([0-9]{4})\b",
+        "phone_us": r"(?<!\d)(?:\+?1[-.\s]?)?\(?([0-9]{3})\)?[-.\s]?([0-9]{3})[-.]?([0-9]{4})(?!\d)",
         "phone_intl": r"\+[0-9]{1,3}[-.]?[0-9]{1,14}",
         "ssn": r"\b(?!000|666)[0-9]{3}-(?!00)[0-9]{2}-(?!0000)[0-9]{4}\b",
         "street_address": r"\b\d+\s+[A-Za-z\s]+(?:Street|St|Avenue|Ave|Road|Rd|Boulevard|Blvd|Drive|Dr|Lane|Ln|Court|Ct|Circle|Cir|Park|Pl|Plaza|Place|Drive|Dr|Way|Parkway|Pkwy|Point|Pt|Pike|Run|Summit|Summit|Terrace|Ter|Trail|Trl|Tunnel|Turnpike|View|Vista|Vlg|Village|Vly|Valley)",

--- a/tests/unit/test_pii_scrubber.py
+++ b/tests/unit/test_pii_scrubber.py
@@ -252,3 +252,39 @@ class TestPIIScrubber:
 
         # Should be minimal or no detections
         # (version number shouldn't be flagged as SSN)
+
+    # --- Reproduction tests for issue #146 ---
+    # The phone_us regex uses \b as a leading anchor. \b requires a boundary between
+    # a word character and a non-word character. Because ( is itself a non-word character,
+    # and the character before it is typically a space (also non-word), no word boundary
+    # exists and the regex fails to match. Additionally, the separator group [-.]? does not
+    # allow a space, so the common (NXX) NXX-XXXX format (closing paren followed by a space)
+    # also fails to match even if the anchor issue were resolved independently.
+
+    def test_parenthesized_phone_mid_sentence(self, scrubber):
+        """Parenthesized phone embedded in text should be redacted — fails with current regex."""
+        text = "Call me at (555) 555-1234 for details."
+        scrubbed = scrubber.scrub(text)
+        assert "[REDACTED]" in scrubbed
+        assert "(555) 555-1234" not in scrubbed
+
+    def test_parenthesized_phone_start_of_text(self, scrubber):
+        """Parenthesized phone at start of string should be redacted — fails with current regex."""
+        text = "(555) 555-1234 is the number to call."
+        scrubbed = scrubber.scrub(text)
+        assert "[REDACTED]" in scrubbed
+        assert "(555) 555-1234" not in scrubbed
+
+    def test_parenthesized_phone_no_space_after_paren(self, scrubber):
+        """Parenthesized phone without space after closing paren should be redacted."""
+        text = "Reach us at (555)555-1234."
+        scrubbed = scrubber.scrub(text)
+        assert "[REDACTED]" in scrubbed
+        assert "(555)555-1234" not in scrubbed
+
+    def test_parenthesized_phone_with_country_code(self, scrubber):
+        """Parenthesized phone with +1 country code should be redacted."""
+        text = "International: +1 (555) 555-1234"
+        scrubbed = scrubber.scrub(text)
+        assert "[REDACTED]" in scrubbed
+        assert "(555) 555-1234" not in scrubbed


### PR DESCRIPTION
## Summary
The `phone_us` regex in `PIIScrubber.PII_PATTERNS` used `\b` as its leading
anchor. Because `\b` requires a boundary between a word character and a
non-word character, it never matches when a phone number starts with `(` —
the paren and any preceding space are both non-word characters, so no boundary
exists. Additionally, the separator between the area code and exchange group
was `[-.]?`, which rejects the space in `(555) 555-1234`. This PR fixes both
issues with a targeted one-line change to the regex.

## Issue
Closes #146

## Changes
- Replace leading `\b` with `(?<!\d)` — matches when preceded by any
  non-digit (including `(`, space, or start of string)
- Replace trailing `\b` with `(?!\d)` — safer lookahead anchor
- Widen the area-code-to-exchange separator from `[-.]?` to `[-.\s]?` so the
  space after `)` is accepted
- Apply the same `[-.\s]?` widening to the country-code separator

## Testing
- [x] New/updated tests cover the changes
- [ ] Unit tests pass (`make test-unit`) — see Notes for Reviewers

## Notes for Reviewers
**Pre-existing `make test-unit` failures (not introduced by this PR):**

The project venv runs Python 3.7, which cannot parse the Python 3.9+ generic
type hints (`list[dict]`, `str | None`) used throughout the codebase. This
causes 18 collection errors on `main` before any of my changes. I ran the
pii_scrubber tests directly with Python 3.13:

python3.13 -m pytest tests/unit/test_pii_scrubber.py -v

All 4 reproduction tests now pass. Two tests in `test_pii_scrubber.py` remain
failing, both pre-existing:

- `test_us_phone_formats`: the `+1 555 123 4567` (all-space separators) format
  was never supported by the original regex. My fix improves this test from
  2 failing formats to 1.
- `test_mixed_pii_and_text`: the unrelated `street_address` regex greedily
  matches `"5 years developing Python appl"` because `"appl"` ends in `"pl"`,
  which matches the `Pl` street suffix keyword case-insensitively. Unaffected
  by my change.