### PR TITLE
docs(api): document POST /profiles and POST /reviews request bodies

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -13,15 +13,78 @@ Base URL: `http://localhost:8000`
 `POST /auth/register` — Create a new account.
 `POST /auth/login` — Obtain a JWT access token.
 
+All profile and review endpoints require a bearer token. Obtain one from
+`POST /auth/login`, which takes an `application/x-www-form-urlencoded` body with
+`username` (your email address) and `password`:
+
+```bash
+curl -X POST http://localhost:8000/auth/login \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "username=you@example.com&password=your-password"
+```
+
+The response is `{"access_token": "<token>", "token_type": "bearer"}`. Send the
+token as `Authorization: Bearer <token>` on every request below. A missing,
+malformed, or expired token returns `401`.
+
 ### Profiles
 
 `POST /profiles` — Create a profile with resume and GitHub username.
+
+Content type: `multipart/form-data`. All fields are optional, so a request with
+no fields creates an empty profile.
+
+| Field | Type | Required | Constraints |
+| --- | --- | --- | --- |
+| `github_username` | string | No | Max 255 characters |
+| `portfolio_url` | string | No | Max 500 characters |
+| `resume_file` | file | No | PDF, Markdown, or plain text only |
+
+The resume type is taken from the upload's content type, falling back to a guess
+from the filename extension. Only `application/pdf`, `text/markdown`, and
+`text/plain` are accepted; Markdown and plain text are read as UTF-8, and PDFs
+are parsed for their text content.
+
+```bash
+curl -X POST http://localhost:8000/profiles \
+  -H "Authorization: Bearer $TOKEN" \
+  -F "github_username=octocat" \
+  -F "portfolio_url=https://octocat.example.com" \
+  -F "resume_file=@resume.pdf;type=application/pdf"
+```
+
+Returns the created profile (`id`, `user_id`, `github_username`, `portfolio_url`,
+`resume_filename`, `created_at`). Errors: `422` if `resume_file` is any other type
+(`"Resume must be a PDF or Markdown file"`), `422` if a PDF cannot be parsed
+(`"Failed to parse PDF resume"`), and `422` if a field exceeds its length limit.
+
 `GET /profiles/{profile_id}` — Retrieve a profile.
 `DELETE /profiles/{profile_id}` — Delete a profile and associated data.
 
 ### Reviews
 
 `POST /reviews` — Request a new portfolio review for a profile.
+
+Content type: `application/json`.
+
+| Field | Type | Required | Constraints |
+| --- | --- | --- | --- |
+| `profile_id` | UUID | Yes | ID of an existing profile you own |
+
+```bash
+curl -X POST http://localhost:8000/reviews \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"profile_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6"}'
+```
+
+Returns immediately with `status: "pending"`; ingestion and review generation run
+in the background, so poll `GET /reviews/{review_id}` for the result. Errors:
+`422` if `profile_id` is missing or is not a valid UUID. The endpoint does not
+check that the profile exists before creating the review, so an unknown
+`profile_id` fails the database foreign-key constraint and returns `500` rather
+than `404`.
+
 `GET /reviews/{review_id}` — Retrieve a completed review.
 `GET /reviews` — List reviews for the authenticated user (paginated).
 

--- a/tests/unit/test_api_doc_reproduction.py
+++ b/tests/unit/test_api_doc_reproduction.py
@@ -1,0 +1,64 @@
+"""Reproduction test for issue #89.
+
+https://github.com/ascherj/pathreview/issues/89
+
+The API reference (``docs/API.md``) lists ``POST /profiles`` and ``POST /reviews``
+as one-line endpoint summaries but never documents their request bodies. A reader
+cannot tell which fields are accepted, which are required, or what content type to
+send without reading the FastAPI routes and Pydantic schemas.
+
+These tests assert that ``docs/API.md`` documents the request-body fields that are
+actually accepted by the routes. They FAIL on the current documentation, which is
+the reproduction of the gap. Week 9's fix should turn them green.
+
+Sources of truth for the expected field names:
+- ``api/routes/profiles.py`` / ``api/schemas/profile.py`` -> github_username,
+  portfolio_url, resume_file (multipart/form-data).
+- ``api/routes/reviews.py`` / ``api/schemas/review.py`` -> profile_id
+  (application/json).
+"""
+
+from pathlib import Path
+
+import pytest
+
+API_DOC = Path(__file__).resolve().parents[2] / "docs" / "API.md"
+
+
+@pytest.mark.unit
+class TestApiDocRequestSchemas:
+    """Reproduce issue #89: missing request-body documentation."""
+
+    @pytest.fixture
+    def api_doc_text(self) -> str:
+        return API_DOC.read_text(encoding="utf-8")
+
+    def test_post_profiles_documents_request_fields(self, api_doc_text: str) -> None:
+        """POST /profiles accepts multipart form fields that must be documented."""
+        expected_fields = ["github_username", "portfolio_url", "resume_file"]
+        missing = [f for f in expected_fields if f not in api_doc_text]
+        assert not missing, (
+            "docs/API.md does not document the POST /profiles request body "
+            f"fields: {missing}. See api/routes/profiles.py (issue #89)."
+        )
+
+    def test_post_profiles_documents_content_type(self, api_doc_text: str) -> None:
+        """POST /profiles is a multipart upload; the content type must be stated."""
+        assert "multipart/form-data" in api_doc_text, (
+            "docs/API.md does not state that POST /profiles uses "
+            "multipart/form-data. See api/routes/profiles.py (issue #89)."
+        )
+
+    def test_post_reviews_documents_json_request_body(self, api_doc_text: str) -> None:
+        """POST /reviews takes an application/json body with a required profile_id.
+
+        ``profile_id`` already appears in docs as a *path* parameter for the
+        profile endpoints, so its bare presence proves nothing. The gap is that
+        the JSON request body and its content type are never documented, so this
+        asserts the content type is stated.
+        """
+        assert "application/json" in api_doc_text, (
+            "docs/API.md does not document the POST /reviews JSON request body "
+            "(no application/json content type stated). See api/routes/reviews.py "
+            "and api/schemas/review.py (issue #89)."
+        )

--- a/tests/unit/test_api_doc_reproduction.py
+++ b/tests/unit/test_api_doc_reproduction.py
@@ -8,8 +8,10 @@ cannot tell which fields are accepted, which are required, or what content type 
 send without reading the FastAPI routes and Pydantic schemas.
 
 These tests assert that ``docs/API.md`` documents the request-body fields that are
-actually accepted by the routes. They FAIL on the current documentation, which is
-the reproduction of the gap. Week 9's fix should turn them green.
+actually accepted by the routes. They FAILED on the documentation as it stood when
+issue #89 was filed, which is the reproduction of the gap; the documentation fix
+turns them green. They now stand as regression guards against the reference drifting
+back out of sync with the routes.
 
 Sources of truth for the expected field names:
 - ``api/routes/profiles.py`` / ``api/schemas/profile.py`` -> github_username,
@@ -18,11 +20,27 @@ Sources of truth for the expected field names:
   (application/json).
 """
 
+import re
 from pathlib import Path
 
 import pytest
 
 API_DOC = Path(__file__).resolve().parents[2] / "docs" / "API.md"
+
+
+def _sections(text: str) -> dict[str, str]:
+    """Split the reference into a mapping of heading -> section body.
+
+    Args:
+        text: The full Markdown source of ``docs/API.md``.
+
+    Returns:
+        A dict keyed by ``##``/``###`` heading text, whose values are the body
+        of each section. Used to scope assertions to a single endpoint group so
+        that a term documented elsewhere in the file cannot satisfy them.
+    """
+    parts = re.split(r"^#{2,3} (.+)$", text, flags=re.MULTILINE)
+    return {parts[i].strip(): parts[i + 1] for i in range(1, len(parts) - 1, 2)}
 
 
 @pytest.mark.unit
@@ -32,6 +50,16 @@ class TestApiDocRequestSchemas:
     @pytest.fixture
     def api_doc_text(self) -> str:
         return API_DOC.read_text(encoding="utf-8")
+
+    @pytest.fixture
+    def profiles_section(self, api_doc_text: str) -> str:
+        """The body of the ``### Profiles`` section."""
+        return _sections(api_doc_text)["Profiles"]
+
+    @pytest.fixture
+    def reviews_section(self, api_doc_text: str) -> str:
+        """The body of the ``### Reviews`` section."""
+        return _sections(api_doc_text)["Reviews"]
 
     def test_post_profiles_documents_request_fields(self, api_doc_text: str) -> None:
         """POST /profiles accepts multipart form fields that must be documented."""
@@ -62,3 +90,62 @@ class TestApiDocRequestSchemas:
             "(no application/json content type stated). See api/routes/reviews.py "
             "and api/schemas/review.py (issue #89)."
         )
+
+    def test_post_profiles_documents_accepted_resume_types(self, profiles_section: str) -> None:
+        """The route accepts exactly three resume MIME types; all must be listed.
+
+        ``api/routes/profiles.py`` rejects anything outside this set with a 422,
+        so omitting one from the reference would send readers down a failing path.
+        """
+        accepted = ["application/pdf", "text/markdown", "text/plain"]
+        missing = [mime for mime in accepted if mime not in profiles_section]
+        assert not missing, (
+            "The Profiles section of docs/API.md does not document these accepted "
+            f"resume types: {missing}. See the MIME allow-list in "
+            "api/routes/profiles.py."
+        )
+
+    def test_post_profiles_documents_field_length_limits(self, profiles_section: str) -> None:
+        """``ProfileCreate`` caps github_username at 255 and portfolio_url at 500."""
+        for limit in ("255", "500"):
+            assert limit in profiles_section, (
+                f"The Profiles section of docs/API.md does not document the {limit} "
+                "character limit declared in api/schemas/profile.py."
+            )
+
+    def test_post_reviews_documents_profile_id_in_its_own_section(
+        self, reviews_section: str
+    ) -> None:
+        """``profile_id`` must be documented as the JSON body field for reviews.
+
+        Scoped to the Reviews section because ``profile_id`` also appears as a
+        path parameter under Profiles, where its presence proves nothing about
+        the ``POST /reviews`` request body.
+        """
+        assert "profile_id" in reviews_section, (
+            "The Reviews section of docs/API.md does not document the required "
+            "profile_id body field. See ReviewCreate in api/schemas/review.py."
+        )
+        assert "application/json" in reviews_section, (
+            "The Reviews section of docs/API.md does not state the "
+            "application/json content type for POST /reviews."
+        )
+
+    def test_write_endpoints_document_bearer_authentication(self, api_doc_text: str) -> None:
+        """Both write endpoints depend on ``get_current_user`` and need a token."""
+        assert "Bearer" in api_doc_text, (
+            "docs/API.md does not document the bearer token required by the "
+            "profile and review endpoints. See get_current_user in "
+            "api/middleware/auth.py."
+        )
+
+    def test_write_endpoints_include_example_requests(
+        self, profiles_section: str, reviews_section: str
+    ) -> None:
+        """Issue #89 asks for example requests, not just field lists."""
+        assert (
+            "curl" in profiles_section
+        ), "The Profiles section of docs/API.md has no example request (issue #89)."
+        assert (
+            "curl" in reviews_section
+        ), "The Reviews section of docs/API.md has no example request (issue #89)."


### PR DESCRIPTION
## Summary

`docs/API.md` listed `POST /profiles` and `POST /reviews` as one-line summaries with no request body, so anyone calling either endpoint had to read the FastAPI routes and Pydantic schemas to discover which fields were accepted, which were required, and what content type to send. This PR documents the request body of both endpoints — content type, a field table with types and constraints, a runnable `curl` example, and the error paths — with every field and limit taken from the source rather than written from memory. It is a documentation-only change: no application code, schema, or API behavior is modified.

## Issue

Closes #89

## Changes

- **`docs/API.md` — `POST /profiles`:** documents the `multipart/form-data` content type, the `github_username` (≤255), `portfolio_url` (≤500), and `resume_file` fields, that all three are optional, the accepted resume types (`application/pdf`, `text/markdown`, `text/plain`) and how the type is resolved, a `curl` example, the response fields, and the `422` paths for an unsupported file type, an unparseable PDF, and an over-length field.
- **`docs/API.md` — `POST /reviews`:** documents the `application/json` content type, the required `profile_id` UUID, a `curl` example, and the `status: "pending"` / background-processing behavior with the poll endpoint.
- **`docs/API.md` — Authentication:** adds a short note on obtaining the bearer token from `POST /auth/login`, including its `application/x-www-form-urlencoded` body (`username` = email, `password`). Both examples above need a token, so without this the examples are not runnable end to end.
- **`tests/unit/test_api_doc_reproduction.py`:** the three reproduction assertions now pass; adds five regression assertions (accepted resume MIME types, the 255/500 limits, `profile_id` + JSON content type scoped to the Reviews section, the bearer requirement, an example request per endpoint).

Sources of truth: `api/routes/profiles.py`, `api/schemas/profile.py`, `api/routes/reviews.py`, `api/schemas/review.py`, `api/routes/auth.py`, `api/middleware/auth.py`.

## Testing

- [x] Unit tests pass (`make test-unit`) — see the pre-existing failures note below
- [ ] Integration tests pass (`make test-integration`) — not run; requires Docker services and is untouched by a docs-only change
- [x] Linter passes (`make lint`) — see note below
- [x] Type checker passes (`make typecheck`) — see note below
- [x] New/updated tests cover the changes

**Pre-existing failures.** I recorded a baseline before making any change, and my changes introduce no new failures:

| Check | Before | After |
| --- | --- | --- |
| `make test-unit` | 56 failed, 375 passed | 53 failed, 383 passed |
| `make lint` (ruff) | 182 errors | 182 errors |
| `make typecheck` (mypy) | 103 errors in 26 files | 103 errors in 26 files |

Comparing the set of failing test IDs before and after, the only difference is the three issue #89 reproduction tests going from red to green; nothing newly fails. The remaining 53 failures, the 182 ruff errors, and the 103 mypy errors are all pre-existing on `main` and unrelated to this change. Ruff and mypy counts are unchanged because the only Python file I touched is clean under both (`ruff check` and `black --check` pass on it, and `mypy`'s configured paths do not include `tests/`).

One note on `make check`: it runs `black .` in write mode, which would reformat 52 pre-existing files across the repo. I deliberately did not run it repo-wide, since that would bury a small docs change under unrelated churn. I ran `black` on the single file I added to instead, plus `make lint` and `make typecheck` in full.

## Screenshots / Demo

N/A — Markdown-only change. The rendered tables and fenced `curl` blocks were checked in preview.

## Notes for Reviewers

- **`text/plain` resumes.** The route's allow-list accepts `application/pdf`, `text/markdown`, **and** `text/plain`, while its docstring and its 422 message both say only "PDF or Markdown." I documented all three, since the reference should describe what the code enforces, and I quoted the existing 422 message verbatim so the mismatch is visible rather than silently smoothed over. Happy to narrow this to PDF/Markdown if `text/plain` is meant to be incidental — that would be a code fix rather than a docs fix.
- **`POST /reviews` does not validate `profile_id`.** `create_review` in `core/services/review_service.py` takes `user_id` but never uses it, and the route does not check that the profile exists or belongs to the caller. An unknown `profile_id` therefore fails the `reviews.profile_id` foreign key and surfaces as a `500`, not a `404`, and a `profile_id` belonging to another user appears to be accepted. I documented the observable `500` behavior rather than claiming a constraint the code does not enforce. The ownership gap looks like a genuine bug and is out of scope here — happy to open a separate issue if you'd like.
- **Deliberately out of scope.** `PUT /profiles/{profile_id}` and `GET /reviews/{review_id}/status` both exist as routes but are absent from the reference entirely. That is a different gap from the one #89 describes, so I left it alone rather than widening this PR; say the word and I'll file it.
