### PR TITLE
Fix/155 health check redis host

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -51,3 +51,33 @@ unit test so this regression can't slip back in.
 - **No special access needed.** Runs entirely against the local mock/dev stack —
   no external API keys or paid services.
 - **Tier fit:** labeled `tier-1` / `good first issue`, matching where I should start.
+
+---
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/Jeremy-Tian/pathreview/commit/bdc826cb98c408554fe24d0144a4a7e1cc28e48f
+
+**Reproduction summary:**
+I added a failing unit test ([tests/unit/test_health_redis_config.py](tests/unit/test_health_redis_config.py))
+that mounts the real `/health` route with a healthy Redis stub (`ping()` → `True`)
+and a working DB, then asserts Redis is reported `healthy`. It fails: `/health`
+returns **HTTP 503** with `redis: "unhealthy"`, and the logs show
+`redis_health_check_failed error="'Settings' object has no attribute 'redis_host'"`.
+Root cause confirmed — `api/routes/health.py` reads `settings.redis_host` /
+`settings.redis_port`, but `core/config.py`'s `Settings` only defines `redis_url`.
+Note: the `AttributeError` is *caught* by the probe's `try/except`, so the endpoint
+doesn't hard-crash — it just reports Redis unhealthy and 503s **even when Redis is
+up** (a refinement of my Week 7 description).
+
+**PLAN.md link:** https://github.com/Jeremy-Tian/pathreview/blob/fix/155-health-check-redis-host/PLAN.md
+
+**Walkthrough video (recommended):** _(not recorded yet)_
+
+**Blockers or open questions:**
+- Local `.venv` is broken (Intel-arch wheels vs. this arm64 Mac), so I reproduced
+  in a clean Python 3.11 venv. Need the project venv rebuilt to run the full suite
+  and `pre-commit` (these commits used `--no-verify` to bypass the missing hook).
+- Fix approach to confirm in Week 9: probe from the existing `redis_url` via
+  `redis.Redis.from_url(...)` (my preference — single source of truth) vs. adding
+  explicit `redis_host` / `redis_port` fields to `Settings`.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,53 @@
+# PathReview Contribution Journal
+
+> My running record of progress through Module 3. I add a new section each week.
+> All Module 3 work lives on my working branch `fix/155-health-check-redis-host`.
+
+---
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/155
+
+**Issue title:** Health check references `settings.redis_host`, which does not exist on Settings
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The `GET /health` endpoint is meant to report whether the app's dependencies
+(like Redis) are reachable, but it reads a `redis_host` attribute off the
+settings object that was never defined on the `Settings` model. Because that
+field doesn't exist, every call to `/health` throws an `AttributeError` and the
+endpoint fails instead of returning a status — so readiness/liveness monitoring
+can't actually tell whether the service is healthy. The root cause is a mismatch
+between `api/routes/health.py`, which expects `settings.redis_host`, and
+`core/config.py`, which only exposes Redis through a `REDIS_URL`. A successful
+fix makes `/health` respond without crashing by pointing the Redis probe at the
+configuration that actually exists (rather than a phantom field), and adds a
+unit test so this regression can't slip back in.
+
+**Branch name:** `fix/155-health-check-redis-host`
+
+**Setup confirmation:** [ ] App runs locally at localhost:5173
+<!-- Frontend confirmed serving at http://localhost:5173/ (HTTP 200). Full stack
+     pending local Docker/Colima install for the Postgres/Redis/Chroma backing
+     services; this box gets checked once the backend is up. -->
+
+**Cohort ledger:** [ ] Issue added to cohort ledger
+
+---
+
+### "Is this right for me?" — selection notes
+
+- **Scope is small and bounded.** The bug lives in one route (`api/routes/health.py`)
+  plus one config file (`core/config.py`) — roughly one focused change, not a
+  cross-cutting refactor. Good size for my first contribution to a large codebase.
+- **I understand the area.** It's plain FastAPI + a Pydantic-style settings object;
+  no deep RAG/agent internals required to be confident in the fix.
+- **Clear, reproducible failure.** The issue gives an exact repro (`GET /health` →
+  `AttributeError` on `redis_host`), so I can verify "before" and "after".
+- **Testable success condition.** "`/health` returns a valid payload without
+  raising" is easy to assert, so I can add a real unit test.
+- **No special access needed.** Runs entirely against the local mock/dev stack —
+  no external API keys or paid services.
+- **Tier fit:** labeled `tier-1` / `good first issue`, matching where I should start.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -81,3 +81,55 @@ up** (a refinement of my Week 7 description).
 - Fix approach to confirm in Week 9: probe from the existing `redis_url` via
   `redis.Redis.from_url(...)` (my preference — single source of truth) vs. adding
   explicit `redis_host` / `redis_port` fields to `Settings`.
+
+---
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the #155 fix using the preferred approach from PLAN.md — `api/routes/health.py`
+now builds the Redis client via `redis.Redis.from_url(settings.redis_url, decode_responses=True)`
+instead of the nonexistent `settings.redis_host` / `settings.redis_port`. Confirmed
+(via grep) that no other module reads those fields, so the change is safe and localized.
+My Week 8 reproduction test now passes, and I added a companion test asserting a
+genuinely-unreachable Redis still reports `unhealthy` / 503.
+
+**Next steps:**
+Open a draft PR and request peer review in Slack; finalize wording and self-review
+against `make check` / `make test-unit`.
+
+**Blockers:**
+Local `.venv` is broken (x86_64 wheels on this arm64 Mac), so I couldn't run the
+project's `make` targets directly. I reproduced an equivalent clean Python 3.11 venv
+to run the unit suite, `ruff`, and `black` on my changes. Need the project venv
+rebuilt to run `make check` / `make test-unit` natively (tracked for follow-up).
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** _<!-- paste the PR URL here once the draft PR is opened -->_
+
+**Branch:** `fix/155-health-check-redis-host`
+
+**What you built:**
+`GET /health` now probes Redis using the configured `redis_url` via
+`redis.Redis.from_url(...)`, the single source of truth already on `Settings`.
+This removes the `AttributeError` on the phantom `settings.redis_host` field, so the
+endpoint reports Redis health based on real reachability instead of always returning 503.
+
+**Tests added or updated:**
+- [tests/unit/test_health_redis_config.py](tests/unit/test_health_redis_config.py) —
+  regression test for #155: asserts redis `healthy`/200 when reachable (the repro) and
+  `unhealthy`/503 when unreachable (guards against a fix that skips the check).
+- [tests/conftest.py](tests/conftest.py) — autouse fixture routing structlog into
+  stdlib logging so `caplog`-based assertions work in the suite.
+
+**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+<!-- Not run natively (broken local .venv). Verified in an equivalent clean venv:
+     unit subset shows no new failures vs. baseline; ruff/black clean on changed files;
+     the 4 ruff findings and other unit failures are pre-existing and unrelated (see PR). -->
+
+**Draft PR feedback received from:** none yet (draft PR pending)

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -110,7 +110,7 @@ rebuilt to run `make check` / `make test-unit` natively (tracked for follow-up).
 
 ### Check-in 2 (end of week)
 
-**PR link:** _<!-- paste the PR URL here once the draft PR is opened -->_
+**PR link:** https://github.com/ascherj/pathreview/pull/427
 
 **Branch:** `fix/155-health-check-redis-host`
 
@@ -133,3 +133,83 @@ endpoint reports Redis health based on real reachability instead of always retur
      the 4 ruff findings and other unit failures are pre-existing and unrelated (see PR). -->
 
 **Draft PR feedback received from:** none yet (draft PR pending)
+
+---
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No reviewer or maintainer feedback came in. My PR (https://github.com/ascherj/pathreview/pull/427)
+is open with 0 comments, 0 review comments, and 0 reviews as of the submission
+deadline. (Per the Summer 2026 course note, peer review isn't a feature this term,
+so this is expected.)
+
+**How you responded:**
+No changes were required since no feedback arrived. I re-read the PR one last time
+against `docs/CONTRIBUTING.md` — branch name (`fix/<issue#>-<desc>`), Conventional
+Commit messages with the `api` scope, and Google-style docstrings on the new test
+functions — and confirmed it still reflects the final state of the branch.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The environment, by a wide margin — not the bug. My machine had no Docker, no
+Homebrew, and a `.venv` that was silently broken (it held x86_64 wheels but I'm on
+an arm64 Mac, so every import of `pydantic_core` died with an "incompatible
+architecture" error). I couldn't even *run* a test until I'd installed Homebrew and
+Python 3.11 and stood up a clean venv from scratch. The second surprise was the bug
+itself being subtler than the issue described: the issue (and my own Week 7 note)
+said `/health` "throws an AttributeError and the endpoint fails," but the error is
+actually *caught* by the probe's `try/except`. The real symptom is a permanent
+false-negative — `/health` returns 503 with Redis "unhealthy" even when Redis is
+perfectly reachable. Getting that distinction right changed how I wrote the
+reproduction.
+
+**What did you learn about working in a large codebase?**
+The hardest skill wasn't writing the fix — it was telling *my* breakage apart from
+the codebase's existing breakage. When I added the `conftest.py` structlog fix, the
+unit suite showed 51 failures; I only trusted that number after diffing the failing
+test IDs **with vs. without** my change and proving the delta was exactly the tests
+I intended to fix. The suite already had ~46 pre-existing failures and several
+modules that don't even collect without optional deps. In my own projects "the tests
+pass" is binary; here "passes" means "introduces no *new* failures," and you have to
+establish a baseline before you can claim that. I also felt the pull of contribution
+hygiene — resisting the urge to fix the 4 unrelated `ruff` findings in the file I was
+already editing, and keeping commits small, scoped, and conventionally named.
+
+**How did AI tools help — and where did they fall short?**
+Most useful: locating the exact config/route mismatch fast, scaffolding the FastAPI
+`TestClient` reproduction, and explaining the structlog→stdlib→`caplog` routing,
+which I'd never wired up before. Where it fell short — twice, both instructive.
+First, it initially surfaced the *wrong* issue (a resume-parser bug) as "the issue
+to work on" before I confirmed against my branch and journal that my real issue was
+#155; I had to verify, not trust. Second, the first structlog fix it produced
+(`render_to_log_kwargs`) looked completely reasonable and passed the one test I
+checked — but it silently broke six `test_prompt_templates` tests, because the app
+logs with a `name` key that collides with a reserved `LogRecord` attribute and
+raises `KeyError`. Only running the *whole* suite and diffing the baseline caught it.
+The lesson: AI is good at plausible; verification is still mine to own.
+
+**What would you do differently if you started over?**
+Fix the environment first, before touching any code — I lost real time discovering
+the broken venv mid-reproduction instead of validating `make test-unit` on day one.
+I'd also keep the unrelated `conftest.py` structlog fix on its own branch/PR from the
+start instead of folding it into the #155 PR (I flagged it for the reviewer, but it'd
+have been cleaner to separate it). And I'd write the reproduction test to be
+fix-agnostic from the beginning — my first version stubbed Redis by constructor args,
+so when I switched the fix to `redis.Redis.from_url(...)` I had to go back and update
+the stub. Testing behavior at the endpoint boundary, not the construction details,
+would have avoided that.
+
+**What are you most proud of?**
+Catching my own regression. It would have been easy to see the target test go green,
+call the structlog fix done, and ship six new failures into the PR. Instead I diffed
+the full suite against a baseline and found the `KeyError` collision before it left my
+machine. Being skeptical of a fix that *looked* finished — and proving it with data
+rather than assuming — is the habit I most want to keep.

--- a/PLAN.md
+++ b/PLAN.md
@@ -2,6 +2,13 @@
 
 **Issue:** [Health check references `settings.redis_host`, which does not exist on Settings (#155)](https://github.com/ascherj/pathreview/issues/155)
 
+> **Status (Week 9): implemented via the preferred approach.** `api/routes/health.py`
+> now probes Redis with `redis.Redis.from_url(settings.redis_url, decode_responses=True)`.
+> Confirmed no other module reads `redis_host`/`redis_port` (grep). Regression test
+> [tests/unit/test_health_redis_config.py](tests/unit/test_health_redis_config.py)
+> now passes (healthy Redis → 200) and a companion case asserts a down Redis still
+> yields `unhealthy`/503. Verified in a clean venv: no new unit-test/lint failures.
+
 ### Understand
 
 **Root cause.** `api/routes/health.py` builds its Redis probe with

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,86 @@
+# Solution plan
+
+**Issue:** [Health check references `settings.redis_host`, which does not exist on Settings (#155)](https://github.com/ascherj/pathreview/issues/155)
+
+### Understand
+
+**Root cause.** `api/routes/health.py` builds its Redis probe with
+`redis.Redis(host=settings.redis_host, port=settings.redis_port, ...)`, but the
+`Settings` model in `core/config.py` never defines `redis_host` or `redis_port`.
+It only exposes Redis through a single `redis_url` field
+(`redis://localhost:6379/0`). Accessing `settings.redis_host` therefore raises
+`AttributeError`.
+
+**Expected vs. actual.**
+- *Expected:* `GET /health` pings Redis using the configured connection and
+  reports `redis: "healthy"` (HTTP 200) when Redis is reachable, `redis:
+  "unhealthy"` (HTTP 503) only when it is genuinely down.
+- *Actual:* The `AttributeError` is caught by the probe's `try/except Exception`,
+  so the endpoint does not crash — instead it *always* reports `redis:
+  "unhealthy"` and returns **HTTP 503**, even when Redis is up. Readiness/liveness
+  monitoring can never see the service as healthy.
+
+  (This refines the Week 7 description: the error is swallowed, not raised to the
+  caller. The real-world impact is a permanent false-negative 503, not a 500.)
+
+### Map
+
+Files/functions involved:
+
+- **`api/routes/health.py`** → `health_check()` — the Redis probe block that
+  reads `settings.redis_host` / `settings.redis_port`. **Primary file to change.**
+- **`core/config.py`** → `Settings` — defines `redis_url` but no host/port.
+  Only touched if we go with the "add fields" approach (see Plan).
+- **`tests/unit/test_health_redis_config.py`** — new reproduction test (already
+  added this week); becomes the regression test after the fix.
+
+### Plan
+
+**Preferred approach — probe from the existing `redis_url` (single source of truth):**
+
+1. In `health_check()`, replace
+   `redis.Redis(host=settings.redis_host, port=settings.redis_port, db=0, decode_responses=True)`
+   with `redis.Redis.from_url(settings.redis_url, decode_responses=True)`.
+2. Confirm no other module reads `settings.redis_host` / `redis_port`
+   (`grep -rn "redis_host\|redis_port"`), so the removal is safe.
+3. Run `tests/unit/test_health_redis_config.py` — it should now pass (redis
+   `healthy` / HTTP 200 when reachable).
+4. Add/keep a second assertion that Redis is reported `unhealthy` when `ping()`
+   raises, so the fix doesn't accidentally mark a down Redis as healthy.
+
+**Alternative approach (if maintainer prefers explicit fields):** add
+`redis_host: str = "localhost"` and `redis_port: int = 6379` to `Settings`. Simpler
+diff, but introduces a second source of truth alongside `redis_url` that can drift
+— I'll propose approach #1 first and fall back if requested.
+
+### Inputs & outputs
+
+- **Input:** the application `Settings` (specifically the Redis connection config)
+  and the live Redis server's reachability.
+- **Output / change:** `GET /health` returns a JSON payload whose
+  `dependencies.redis` is `"healthy"` (HTTP 200) when Redis responds to `ping()`
+  and `"unhealthy"` (HTTP 503) when it does not — driven by real reachability
+  rather than a config `AttributeError`. No change to the response schema.
+
+### Risks & unknowns
+
+- **`decode_responses` / client options** — `from_url` must preserve the same
+  options the old call used; verify the ping path behaves identically.
+- **Other consumers** — need to confirm nothing else depends on `redis_host`
+  existing (grep first).
+- **`redis_url` format assumptions** — `from_url` should handle the default
+  `redis://host:port/db`; confirm auth'd URLs (`redis://:pass@host`) also work if
+  the deployment uses them.
+- **Test environment** — the project `.venv` was broken locally (Intel wheels vs.
+  arm64); reproduction was verified in a clean arm64 Python 3.11 venv. Need the
+  project venv rebuilt before running the full suite. (Open question for Week 9.)
+
+### Edge cases
+
+- Redis **down / connection refused** → `redis: "unhealthy"`, HTTP 503 (still
+  works, must not regress).
+- Redis **URL with auth or non-default db** (`redis://:pass@host:6379/1`) →
+  probe still connects.
+- **Missing / empty `redis_url`** → probe fails gracefully as `unhealthy`, not an
+  unhandled crash.
+- The other dependencies (Postgres, vector DB) must be unaffected by the change.

--- a/api/routes/health.py
+++ b/api/routes/health.py
@@ -41,12 +41,11 @@ async def health_check(db=Depends(get_db)):
         import redis
         from core.config import settings
 
-        r = redis.Redis(
-            host=settings.redis_host,
-            port=settings.redis_port,
-            db=0,
-            decode_responses=True,
-        )
+        # Build the client from the configured redis_url (the single source of
+        # truth on Settings). Previously this read settings.redis_host /
+        # settings.redis_port, which do not exist on Settings and raised
+        # AttributeError, so the probe always reported Redis unhealthy (#155).
+        r = redis.Redis.from_url(settings.redis_url, decode_responses=True)
         r.ping()
         health_status["dependencies"]["redis"] = "healthy"
         log.debug("redis_health_check_passed")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,47 @@
 """Shared test fixtures for PathReview."""
 
+import logging
+
 import pytest
+import structlog
+
+
+@pytest.fixture(autouse=True)
+def structlog_to_caplog(caplog):
+    """Route structlog events into stdlib logging so pytest's ``caplog`` sees them.
+
+    The app only configures structlog at startup (``core.logging.configure_logging``),
+    which the test suite never calls. Without it, structlog uses its default
+    ``PrintLogger`` and writes straight to stdout, so ``caplog`` — a stdlib logging
+    handler — captures nothing and every ``caplog``-based assertion fails even
+    though the code under test does emit the expected event.
+
+    This autouse fixture points structlog at ``LoggerFactory`` and ends the
+    processor chain with a ``ConsoleRenderer``, so each event is rendered to a
+    single string that becomes the stdlib ``LogRecord`` message. Rendering to a
+    string (rather than ``render_to_log_kwargs``) is deliberate: the codebase logs
+    with bound keys such as ``name`` that collide with reserved ``LogRecord``
+    attributes and would raise ``KeyError`` if passed through as ``extra``.
+    ``caplog.set_level`` lowers the threshold to DEBUG so INFO/DEBUG events are
+    captured too, and defaults are reset after each test so configuration does not
+    leak between tests.
+    """
+    structlog.configure(
+        processors=[
+            structlog.contextvars.merge_contextvars,
+            structlog.stdlib.add_log_level,
+            structlog.stdlib.PositionalArgumentsFormatter(),
+            structlog.processors.StackInfoRenderer(),
+            structlog.processors.format_exc_info,
+            structlog.dev.ConsoleRenderer(colors=False),
+        ],
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        wrapper_class=structlog.stdlib.BoundLogger,
+        cache_logger_on_first_use=False,
+    )
+    caplog.set_level(logging.DEBUG)
+    yield
+    structlog.reset_defaults()
 
 
 @pytest.fixture

--- a/tests/unit/test_health_redis_config.py
+++ b/tests/unit/test_health_redis_config.py
@@ -1,18 +1,24 @@
-"""Reproduction test for issue #155.
+"""Regression tests for issue #155.
 
-Health check references ``settings.redis_host`` (and ``settings.redis_port``),
-which do not exist on ``Settings`` -- only ``settings.redis_url`` is defined in
-``core/config.py``. When ``api/routes/health.py`` builds its Redis probe it
-evaluates ``settings.redis_host`` first, which raises ``AttributeError``. That
-error is swallowed by the surrounding ``try/except Exception``, so ``GET /health``
-does not crash outright -- instead it *always* reports Redis as ``"unhealthy"``
-and returns HTTP 503, even when Redis is perfectly reachable.
+Originally the health check built its Redis probe with
+``redis.Redis(host=settings.redis_host, port=settings.redis_port, ...)``, but
+``Settings`` (``core/config.py``) only defines ``redis_url`` -- no ``redis_host``
+or ``redis_port``. Evaluating ``settings.redis_host`` raised ``AttributeError``,
+which the probe's ``try/except Exception`` swallowed, so ``GET /health`` *always*
+reported Redis ``"unhealthy"`` and returned HTTP 503 even when Redis was
+reachable.
 
-This test stubs a fully healthy Redis (``ping()`` -> ``True``) and a working DB,
-so the only reason Redis can be reported unhealthy is bug #155. It therefore
-FAILS on the current code (503 / "unhealthy") and should PASS once #155 is fixed,
-regardless of whether the fix adds the missing settings fields or switches the
-probe to ``settings.redis_url``.
+The fix probes Redis via ``redis.Redis.from_url(settings.redis_url, ...)`` -- the
+single source of truth already on ``Settings``.
+
+These tests stub the ``redis`` module so no live server is required:
+
+* ``test_health_reports_redis_healthy_when_reachable`` -- Redis pings fine, so
+  ``/health`` must return 200 with redis ``"healthy"``. This FAILED before the
+  fix (503 / "unhealthy") and now passes -- it is the direct reproduction of #155.
+* ``test_health_reports_redis_unhealthy_when_unreachable`` -- Redis ping raises,
+  so ``/health`` must still report ``"unhealthy"`` / 503. This guards against a
+  fix that "passes" by never actually checking Redis.
 
 Issue: https://github.com/ascherj/pathreview/issues/155
 """
@@ -28,54 +34,76 @@ from api.routes.health import router
 from core.database import get_db
 
 
-@pytest.fixture
-def healthy_redis(monkeypatch):
-    """Inject a stub ``redis`` module whose client always pings successfully."""
+def _install_fake_redis(monkeypatch, *, reachable):
+    """Install a stub ``redis`` module whose client ping reflects ``reachable``.
+
+    Supports both ``Redis(...)`` and ``Redis.from_url(...)`` construction so the
+    test is agnostic to how the health check builds its client.
+    """
     fake_redis = types.ModuleType("redis")
 
     class _FakeRedis:
-        def __init__(self, **kwargs):
+        def __init__(self, *args, **kwargs):
+            self.args = args
             self.kwargs = kwargs
 
+        @classmethod
+        def from_url(cls, url, **kwargs):
+            return cls(url, **kwargs)
+
         def ping(self):
+            if not reachable:
+                raise ConnectionError("Error connecting to Redis")
             return True
 
     fake_redis.Redis = _FakeRedis
     monkeypatch.setitem(sys.modules, "redis", fake_redis)
-    return fake_redis
 
 
 @pytest.fixture
-def client(healthy_redis):
-    """FastAPI test client with the DB dependency overridden to a healthy stub."""
+def make_client(monkeypatch):
+    """Return a factory building a /health test client with a stubbed Redis + DB."""
 
-    class _FakeDB:
-        async def execute(self, *args, **kwargs):
-            return None
+    def _make(*, redis_reachable):
+        _install_fake_redis(monkeypatch, reachable=redis_reachable)
 
-    async def _fake_get_db():
-        yield _FakeDB()
+        class _FakeDB:
+            async def execute(self, *args, **kwargs):
+                return None
 
-    app = FastAPI()
-    app.include_router(router)
-    app.dependency_overrides[get_db] = _fake_get_db
-    return TestClient(app)
+        async def _fake_get_db():
+            yield _FakeDB()
+
+        app = FastAPI()
+        app.include_router(router)
+        app.dependency_overrides[get_db] = _fake_get_db
+        return TestClient(app)
+
+    return _make
+
+
+def _dependencies(resp):
+    """Unwrap the dependencies dict from a 200 body or a 503 ``detail`` body."""
+    body = resp.json()
+    return body.get("detail", body)["dependencies"]
 
 
 @pytest.mark.unit
-def test_health_reports_redis_healthy_when_reachable(client):
-    """With Redis reachable, /health should return 200 and redis 'healthy'.
+def test_health_reports_redis_healthy_when_reachable(make_client):
+    """With Redis reachable, /health returns 200 and redis 'healthy' (repro #155)."""
+    resp = make_client(redis_reachable=True).get("/health")
 
-    Currently fails (503 / 'unhealthy') because of issue #155 -- the probe
-    raises AttributeError on settings.redis_host before it can ping Redis.
-    """
-    resp = client.get("/health")
-    body = resp.json()
-    # On a 503 FastAPI nests the payload under "detail"; unwrap either shape.
-    payload = body.get("detail", body)
-
-    assert payload["dependencies"]["redis"] == "healthy", (
+    assert _dependencies(resp)["redis"] == "healthy", (
         "Redis is reachable (ping succeeds) but the health check reports it "
-        "unhealthy -- reproduces issue #155 (settings.redis_host does not exist)."
+        "unhealthy -- issue #155 (settings.redis_host does not exist)."
     )
     assert resp.status_code == 200
+
+
+@pytest.mark.unit
+def test_health_reports_redis_unhealthy_when_unreachable(make_client):
+    """With Redis down, /health must still report redis 'unhealthy' and 503."""
+    resp = make_client(redis_reachable=False).get("/health")
+
+    assert _dependencies(resp)["redis"] == "unhealthy"
+    assert resp.status_code == 503

--- a/tests/unit/test_health_redis_config.py
+++ b/tests/unit/test_health_redis_config.py
@@ -1,0 +1,81 @@
+"""Reproduction test for issue #155.
+
+Health check references ``settings.redis_host`` (and ``settings.redis_port``),
+which do not exist on ``Settings`` -- only ``settings.redis_url`` is defined in
+``core/config.py``. When ``api/routes/health.py`` builds its Redis probe it
+evaluates ``settings.redis_host`` first, which raises ``AttributeError``. That
+error is swallowed by the surrounding ``try/except Exception``, so ``GET /health``
+does not crash outright -- instead it *always* reports Redis as ``"unhealthy"``
+and returns HTTP 503, even when Redis is perfectly reachable.
+
+This test stubs a fully healthy Redis (``ping()`` -> ``True``) and a working DB,
+so the only reason Redis can be reported unhealthy is bug #155. It therefore
+FAILS on the current code (503 / "unhealthy") and should PASS once #155 is fixed,
+regardless of whether the fix adds the missing settings fields or switches the
+probe to ``settings.redis_url``.
+
+Issue: https://github.com/ascherj/pathreview/issues/155
+"""
+
+import sys
+import types
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.routes.health import router
+from core.database import get_db
+
+
+@pytest.fixture
+def healthy_redis(monkeypatch):
+    """Inject a stub ``redis`` module whose client always pings successfully."""
+    fake_redis = types.ModuleType("redis")
+
+    class _FakeRedis:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        def ping(self):
+            return True
+
+    fake_redis.Redis = _FakeRedis
+    monkeypatch.setitem(sys.modules, "redis", fake_redis)
+    return fake_redis
+
+
+@pytest.fixture
+def client(healthy_redis):
+    """FastAPI test client with the DB dependency overridden to a healthy stub."""
+
+    class _FakeDB:
+        async def execute(self, *args, **kwargs):
+            return None
+
+    async def _fake_get_db():
+        yield _FakeDB()
+
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_db] = _fake_get_db
+    return TestClient(app)
+
+
+@pytest.mark.unit
+def test_health_reports_redis_healthy_when_reachable(client):
+    """With Redis reachable, /health should return 200 and redis 'healthy'.
+
+    Currently fails (503 / 'unhealthy') because of issue #155 -- the probe
+    raises AttributeError on settings.redis_host before it can ping Redis.
+    """
+    resp = client.get("/health")
+    body = resp.json()
+    # On a 503 FastAPI nests the payload under "detail"; unwrap either shape.
+    payload = body.get("detail", body)
+
+    assert payload["dependencies"]["redis"] == "healthy", (
+        "Redis is reachable (ping succeeds) but the health check reports it "
+        "unhealthy -- reproduces issue #155 (settings.redis_host does not exist)."
+    )
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
`GET /health` always returned **503 with Redis `"unhealthy"` even when Redis was reachable**. The probe built its client with `redis.Redis(host=settings.redis_host, port=settings.redis_port, ...)`, but `Settings` (`core/config.py`) only defines `redis_url` — there is no `redis_host`/`redis_port`. Accessing `settings.redis_host` raised `AttributeError`, which the probe's `try/except Exception` swallowed, so the endpoint could never report the service as healthy and readiness/liveness monitoring was effectively broken. This PR probes Redis from the existing `redis_url` (the single source of truth already on `Settings`), so `/health` reflects real reachability.

## Issue
Closes #155

## Changes
- **`api/routes/health.py`** — build the Redis client with `redis.Redis.from_url(settings.redis_url, decode_responses=True)` instead of the nonexistent `settings.redis_host` / `settings.redis_port`. No new config fields and no second source of truth that can drift from `redis_url`.
- **`tests/unit/test_health_redis_config.py`** — regression test for #155: mounts the real `/health` route with a stubbed Redis + DB and asserts `healthy`/200 when Redis is reachable (the original reproduction) and `unhealthy`/503 when it is not (guards against a "fix" that never actually checks Redis).
- **`tests/conftest.py`** *(supporting test-infra fix)* — autouse fixture routing structlog into stdlib logging so pytest's `caplog` captures events. Without it, `caplog`-based assertions (e.g. `test_batch_processor.py::test_empty_chunks_list_returns_empty`) fail even though the code emits the event. Happy to split into its own PR if preferred.

## Testing
- [ ] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`)
- [ ] Linter passes (`make lint`)
- [ ] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes

> **Note on the `make` checkboxes:** my local `.venv` was broken (x86_64 wheels on an arm64 Mac), so I couldn't run the `make` targets natively. I verified in an equivalent clean Python 3.11 venv:
> - Both `test_health_redis_config.py` tests pass, and the previously-failing `caplog` test now passes.
> - Ran the unit suite **with vs. without** my changes — they introduce **no new failures** and fix 2 previously-failing tests.
> - `black` reports my changed files clean; `ruff` and `mypy` add no new findings on my changes.

## Screenshots / Demo
_Not applicable — backend-only change. Behavior is covered by `test_health_redis_config.py`:_
- Redis reachable → `GET /health` returns **200** with `dependencies.redis: "healthy"`.
- Redis unreachable → `GET /health` returns **503** with `dependencies.redis: "unhealthy"`.

## Notes for Reviewers
**Pre-existing failures (not introduced by this PR):**
- `ruff` reports 4 findings in `api/routes/health.py` (unused `datetime.timedelta` import, import sorting, `Depends()` in an argument default). All are present on `main` before this change — I left them alone to keep the PR scoped to #155.
- The unit suite has unrelated pre-existing failures (e.g. `test_review_service.py`, `test_tech_detector.py`, `test_skill_extractor.py`), and several modules fail to collect in a fresh env due to optional deps (`tiktoken`, `pypdf`, etc.). None are touched here.

**Please look at:** the folded-in `tests/conftest.py` structlog fix — it's unrelated to #155, so I'm glad to extract it into a separate PR if you'd rather keep this one to the `/health` change only.
