### PR TITLE
fix(ingestion): detect resume sections with leading whitespace

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -36,3 +36,36 @@ I ran the exact indented resume sample from issue #147 through the old `_detect_
 
 **Blockers or open questions:**
 None for the core fix. Optional follow-up: whether multi-line PDF headers (header split across lines) need a separate issue; out of scope for #147.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Completed PLAN.md sub-tasks for reproduction and the core regex fix in `_detect_sections()` (`^\s*` / `\n\s*` before section names). Added `scripts/reproduce_issue_147.py` to show broken vs fixed behavior, and confirmed the issue #147 sample returns Education/Skills instead of `[]`.
+
+**Next steps:**
+Finish regression tests for edge cases (flush-left, multi-word headers, bare lines, empty input), run unit checks, open the PR against `ascherj/pathreview`, and request peer/mentor feedback in Slack.
+
+**Blockers:**
+None.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/430
+
+**Branch:** `fix/147-resume-section-whitespace`
+
+**What you built:**
+Section-header detection in `ingestion/parsers/resume_parser.py` now allows optional leading whitespace so PDF-indented resumes still populate `detected_sections`. Patterns still require end-of-line or `:`/`|`/`-` after the header to reduce false matches.
+
+**Tests added or updated:**
+`tests/unit/test_resume_section_whitespace.py` — covers the issue #147 sample, flush-left headers, indented multi-word headers (`Work Experience`), bare indented headers, and text with no sections.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+Notes: Pre-commit ruff/black/mypy passed on commits for touched files. Targeted unit tests for this change pass (5/5). Two pre-existing failures in `test_resume_parser.py` (`test_parse_markdown_resume`, `test_strip_markdown_syntax`) are unrelated markdown-stripping bugs and were not introduced by this PR (documented in the PR description).
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -22,3 +22,17 @@ Section detection in `ingestion/parsers/resume_parser.py` looks for headers like
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/DanOhsaka/pathreview-week-7-ai201/commit/06591db977b1f934049e0ef1148ac6c33f91efe0
+
+**Reproduction summary:**
+I ran the exact indented resume sample from issue #147 through the old `_detect_sections` regexes (no `\s*` after `^`/`\n`) and got `detected_sections: []`, then compared that to the current parser which returns Education and Skills. That comparison is checked in as `scripts/reproduce_issue_147.py` plus a docstring on `_detect_sections` explaining the failure mode.
+
+**PLAN.md link:** https://github.com/DanOhsaka/pathreview-week-7-ai201/blob/fix/147-resume-section-whitespace/PLAN.md
+
+**Walkthrough video (recommended):** 
+
+**Blockers or open questions:**
+None for the core fix. Optional follow-up: whether multi-line PDF headers (header split across lines) need a separate issue; out of scope for #147.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -19,6 +19,6 @@ Section detection in `ingestion/parsers/resume_parser.py` looks for headers like
 
 **Branch name:** fix/147-resume-section-whitespace
 
-**Setup confirmation:** [ ] App runs locally at localhost:5173
+**Setup confirmation:** [x] App runs locally at localhost:5173
 
-**Cohort ledger:** [ ] Issue added to cohort ledger
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -69,3 +69,34 @@ Section-header detection in `ingestion/parsers/resume_parser.py` now allows opti
 Notes: Pre-commit ruff/black/mypy passed on commits for touched files. Targeted unit tests for this change pass (5/5). Two pre-existing failures in `test_resume_parser.py` (`test_parse_markdown_resume`, `test_strip_markdown_syntax`) are unrelated markdown-stripping bugs and were not introduced by this PR (documented in the PR description).
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No maintainer or reviewer comments on [PR #430](https://github.com/ascherj/pathreview/pull/430) by the end of Week 10. Summer 2026 does not provide formal reviewer feedback, so this is expected.
+
+**How you responded:**
+
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Getting a reliable local environment on Windows was harder than the bug itself. Installing `make`, learning that PowerShell can’t run this Makefile (it needs Git Bash), fixing a UTF-16-corrupted `.bashrc`, and waiting for Docker Desktop before `make setup` / `make run` took more time than editing four regexes. Pre-commit also blocked commits until I fixed a ruff `B904` issue and learned that touching the old `test_resume_parser.py` file triggered mypy on untyped tests that weren’t part of my change.
+
+**What did you learn about working in a large codebase?**
+In your own project you can change anything; here the win was staying scoped. Issue #147 lived in one function (`_detect_sections`), but I still had to read call sites (`_parse_pdf` / `_parse_markdown`), match existing pytest patterns, and document unrelated failing markdown tests so reviewers knew I didn’t introduce them. Contributing means proving the bug, naming exact files, and leaving the rest of the system alone.
+
+**How did AI tools help — and where did they fall short?**
+AI helped navigate setup (PATH, Git Bash vs PowerShell), draft `PLAN.md` / journal sections, and scaffold regression tests. It fell short when environment details were Windows-specific — e.g. PowerShell writing UTF-16 into `.bashrc`, or assuming `source` works outside bash. I still had to run the reproduction script myself, compare broken vs fixed regexes, and decide what belonged in the upstream PR vs course-only docs.
+
+**What would you do differently if you started over?**
+I’d finish local setup in Git Bash on day one before touching code, open a draft PR earlier in Week 9 for peer feedback in Slack, and write the focused regression file (`test_resume_section_whitespace.py`) first so I never fight mypy on the older untyped test module. I’d also keep course artifacts (`JOURNAL.md`, `PLAN.md`) clearly separated from the minimal fix commits in my head when writing the PR description.
+
+**What are you most proud of from this module?**
+Building a clear reproduction path — `scripts/reproduce_issue_147.py` showing old patterns return `[]` and the fixed parser returns Education/Skills — plus a small, targeted test suite that locks the edge cases from the plan. That made the PR feel like a real contribution, not just a one-line tweak.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,24 @@
+# Module 3 Journal
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/147
+
+**Issue title:** Resume section detection fails on text with leading whitespace
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+Section detection in `ingestion/parsers/resume_parser.py` looks for headers like `Education` and `Skills` only when they sit at the very start of a line. PDF-extracted resumes often keep indentation, so those headers never match and `detected_sections` comes back empty even when the sections are clearly present. A successful fix should allow optional leading whitespace in the header regex patterns so indented resumes still report the right sections, and the related unit tests in `tests/unit/test_resume_parser.py` should pass.
+
+**"Is this right for me?" checklist / selection notes:**
+- Scope is small and localized to `_detect_sections()` regex patterns — good first contribution.
+- Tier 1 / good-first-issue label matches my current level for Module 3.
+- Clear reproduce steps and named failing tests make success criteria easy to verify.
+- Touches the ingestion subsystem without requiring frontend, agent, or RAG changes.
+
+**Branch name:** fix/147-resume-section-whitespace
+
+**Setup confirmation:** [ ] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,60 @@
+## Solution plan
+
+**Issue:** Resume section detection fails on text with leading whitespace — https://github.com/ascherj/pathreview/issues/147
+
+### Understand
+
+**Root cause:** `_detect_sections()` in `ingestion/parsers/resume_parser.py` anchors section-header regexes at the start of a line with `^Section` or `\nSection` and does not allow characters between that anchor and the header word. Text from PDFs (and indented fixture strings) often includes leading spaces before headers like `Education:` / `Skills:`, so no pattern matches.
+
+**Expected:** For indented resume text, `ParseResult.metadata["detected_sections"]` should include the headers that are present (e.g. `Education`, `Skills`).
+
+**Actual (pre-fix):** `detected_sections` is `[]` even when those headers appear in the text. Confirmed with the issue sample via `scripts/reproduce_issue_147.py` (broken patterns → `[]`; fixed patterns → Education/Skills).
+
+### Map
+
+| Area | Path | Role |
+|------|------|------|
+| Bug site | `ingestion/parsers/resume_parser.py` → `_detect_sections()` | Regex patterns that miss indented headers |
+| Constants | `SECTION_HEADERS` in same file | Names searched for |
+| Call sites | `_parse_pdf()`, `_parse_markdown()` | Pass extracted text into detection |
+| Tests | `tests/unit/test_resume_parser.py` | `test_detect_sections`, `test_parse_single_column_resume_text`, `test_parse_resume_no_work_experience`, plus new whitespace repro test |
+| Repro helper | `scripts/reproduce_issue_147.py` | Documents broken vs fixed behavior |
+
+**Files expected to touch:**
+1. `ingestion/parsers/resume_parser.py` (primary fix)
+2. `tests/unit/test_resume_parser.py` (lock in regression coverage)
+3. `scripts/reproduce_issue_147.py` (optional local reproduction helper)
+4. `PLAN.md` / `JOURNAL.md` (course planning docs only)
+
+### Plan
+
+1. **Reproduce** — Run the issue sample locally; confirm old patterns return `[]` and note which tests fail without a fix.
+2. **Adjust regexes** — In `_detect_sections()`, insert optional `\s*` after `^` and after `\n` in each header pattern so indentation is allowed.
+3. **Keep match semantics** — Still require end-of-line or `:` / `|` / `-` after the header so body text like “education experience” is less likely to false-match.
+4. **Regression test** — Add a unit test using the exact indented sample from issue #147 asserting `education` and `skills` appear in `detected_sections`.
+5. **Verify** — Run `pytest tests/unit/test_resume_parser.py` (and the reproduction script) to confirm related tests pass.
+
+### Inputs & outputs
+
+**Inputs:** Resume text as `str` (markdown path) or text extracted from PDF bytes; may include leading whitespace on header lines.
+
+**Outputs / changes:**
+- `detected_sections` lists title-cased section names that appear as headers, even when indented.
+- No change to `ParseResult.text` content or overall parse API.
+- Unit tests pass for indented and flush-left headers.
+
+### Risks & unknowns
+
+- **False positives:** `\s*` before the header could match mid-line phrases if patterns are too loose — mitigated by keeping `[:|-]` / end-of-line constraints; watch multi-word headers in `SECTION_HEADERS` (e.g. `work experience`).
+- **PDF layout quirks:** Some extractors insert odd whitespace or split headers across lines — `\s*` helps indentation but not split headers; out of scope unless tests reveal it.
+- **Duplicate titles:** Detection still uses `list(set(detected))`, so order is unstable; fine for metadata, but don’t assert order in tests.
+- **Pre-commit / lint:** Changing `raise ... from e` or formatting may be required when touching `resume_parser.py` (already seen with ruff B904).
+
+### Edge cases
+
+- Headers with spaces before the name (`    Education:`)
+- Headers with trailing colon vs bare line (`Skills:` vs `Skills`)
+- Multi-word headers (`Technical Skills`, `Work Experience`) with indentation
+- Flush-left headers (must keep working — no regression)
+- Resumes with no recognizable sections (still return `[]`, no crash)
+- Mixed case headers (matching is on `text.lower()`)

--- a/ingestion/parsers/resume_parser.py
+++ b/ingestion/parsers/resume_parser.py
@@ -5,7 +5,6 @@ from pypdf import PdfReader
 
 from .base import BaseParser, ParseResult
 
-
 SECTION_HEADERS = {
     "experience",
     "education",
@@ -75,7 +74,7 @@ class ResumeParser(BaseParser):
                 source_type="resume",
             )
         except Exception as e:
-            raise ValueError(f"Failed to parse PDF: {str(e)}")
+            raise ValueError(f"Failed to parse PDF: {str(e)}") from e
 
     def _parse_markdown(self, content: str) -> ParseResult:
         """Extract text from markdown resume, stripping markdown syntax."""
@@ -132,10 +131,10 @@ class ResumeParser(BaseParser):
         for section in SECTION_HEADERS:
             # Look for section header patterns
             patterns = [
-                rf"^{re.escape(section)}\s*$",
-                rf"^{re.escape(section)}\s*[:|-]",
-                rf"\n{re.escape(section)}\s*$",
-                rf"\n{re.escape(section)}\s*[:|-]",
+                rf"^\s*{re.escape(section)}\s*$",
+                rf"^\s*{re.escape(section)}\s*[:|-]",
+                rf"\n\s*{re.escape(section)}\s*$",
+                rf"\n\s*{re.escape(section)}\s*[:|-]",
             ]
 
             for pattern in patterns:

--- a/ingestion/parsers/resume_parser.py
+++ b/ingestion/parsers/resume_parser.py
@@ -124,12 +124,18 @@ class ResumeParser(BaseParser):
         return text.strip()
 
     def _detect_sections(self, text: str) -> list[str]:
-        """Detect common resume sections from text."""
+        """Detect common resume sections from text.
+
+        Issue #147: PDF / indented text often has leading whitespace before
+        headers (e.g. ``    Education:``). Patterns must allow optional ``\\s*``
+        after ``^`` / ``\\n`` or ``detected_sections`` stays empty. Reproduce
+        with ``python scripts/reproduce_issue_147.py``.
+        """
         detected = []
         text_lower = text.lower()
 
         for section in SECTION_HEADERS:
-            # Look for section header patterns
+            # Allow leading whitespace so indented PDF headers still match (#147)
             patterns = [
                 rf"^\s*{re.escape(section)}\s*$",
                 rf"^\s*{re.escape(section)}\s*[:|-]",

--- a/scripts/reproduce_issue_147.py
+++ b/scripts/reproduce_issue_147.py
@@ -1,0 +1,61 @@
+"""Reproduce GitHub issue #147: resume section detection with leading whitespace.
+
+Run from repo root:
+    python scripts/reproduce_issue_147.py
+
+Without the regex fix, indented headers match nothing and detected_sections
+is []. With the fix (optional \\s* after ^ / \\n), Education and Skills appear.
+"""
+
+from __future__ import annotations
+
+import re
+
+from ingestion.parsers.resume_parser import SECTION_HEADERS, ResumeParser
+
+# Exact sample from https://github.com/ascherj/pathreview/issues/147
+SAMPLE = (
+    "\n    John Smith\n    john@example.com\n\n"
+    "    Education:\n    - B.S. Computer Science\n\n"
+    "    Skills: Python\n"
+)
+
+
+def detect_sections_broken(text: str) -> list[str]:
+    """Pre-fix patterns: headers must start at column 0 (no leading whitespace)."""
+    detected: list[str] = []
+    text_lower = text.lower()
+
+    for section in SECTION_HEADERS:
+        patterns = [
+            rf"^{re.escape(section)}\s*$",
+            rf"^{re.escape(section)}\s*[:|-]",
+            rf"\n{re.escape(section)}\s*$",
+            rf"\n{re.escape(section)}\s*[:|-]",
+        ]
+        for pattern in patterns:
+            if re.search(pattern, text_lower, re.MULTILINE):
+                detected.append(section.title())
+                break
+
+    return list(set(detected))
+
+
+def main() -> None:
+    broken = detect_sections_broken(SAMPLE)
+    fixed = ResumeParser().parse(SAMPLE).metadata["detected_sections"]
+
+    print("Issue #147 reproduction")
+    print(f"  broken (old regex): {broken}")
+    print(f"  current parser:     {fixed}")
+    print("  expected:            ['Education', 'Skills'] (order may vary)")
+    print()
+    if broken == [] and {"Education", "Skills"}.issubset(set(fixed)):
+        print("Reproduction confirmed: old patterns miss indented headers;")
+        print("current _detect_sections handles leading whitespace.")
+    else:
+        print("Unexpected result — check resume_parser._detect_sections patterns.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_resume_section_whitespace.py
+++ b/tests/unit/test_resume_section_whitespace.py
@@ -1,0 +1,58 @@
+"""Regression tests for issue #147: indented resume section headers."""
+
+from __future__ import annotations
+
+import pytest
+
+from ingestion.parsers.resume_parser import ResumeParser
+
+
+@pytest.mark.unit
+class TestResumeSectionWhitespace:
+    """Section detection must tolerate leading whitespace (PDF-style extracts)."""
+
+    @pytest.fixture
+    def parser(self) -> ResumeParser:
+        """Create a ResumeParser instance."""
+        return ResumeParser()
+
+    def test_issue_147_indented_education_and_skills(self, parser: ResumeParser) -> None:
+        """Exact sample from https://github.com/ascherj/pathreview/issues/147."""
+        text = (
+            "\n    John Smith\n    john@example.com\n\n"
+            "    Education:\n    - B.S. Computer Science\n\n"
+            "    Skills: Python\n"
+        )
+        result = parser.parse(text)
+        sections_lower = [s.lower() for s in result.metadata["detected_sections"]]
+
+        assert "education" in sections_lower
+        assert "skills" in sections_lower
+
+    def test_detect_sections_flush_left_still_works(self, parser: ResumeParser) -> None:
+        """Flush-left headers must keep working after the whitespace fix."""
+        text = "Experience:\nAcme Corp\n\nEducation:\nBS CS\n\nSkills: Python\n"
+        sections_lower = [s.lower() for s in parser._detect_sections(text)]
+
+        assert "experience" in sections_lower
+        assert "education" in sections_lower
+        assert "skills" in sections_lower
+
+    def test_detect_multiword_header_with_indent(self, parser: ResumeParser) -> None:
+        """Indented multi-word headers like Work Experience are detected."""
+        text = "\n    Work Experience:\n    Engineer at Acme\n"
+        sections_lower = [s.lower() for s in parser._detect_sections(text)]
+
+        assert any("experience" in s for s in sections_lower)
+
+    def test_detect_bare_header_line_with_indent(self, parser: ResumeParser) -> None:
+        """Indented header with no trailing colon still matches end-of-line pattern."""
+        text = "\n    Education\n    BS Computer Science\n"
+        sections_lower = [s.lower() for s in parser._detect_sections(text)]
+
+        assert "education" in sections_lower
+
+    def test_no_sections_returns_empty(self, parser: ResumeParser) -> None:
+        """Text without recognizable headers returns an empty list."""
+        sections = parser._detect_sections("Just a bio with no labeled sections.")
+        assert sections == []


### PR DESCRIPTION
## Summary
`_detect_sections()` in the resume parser only matched section headers at column 0. PDF-extracted text often keeps indentation, so headers like `Education:` / `Skills:` produced an empty `detected_sections` list. This PR allows optional leading whitespace in the header regex patterns so indented resumes still report the correct sections, without changing the parse API.

## Issue
Closes #147

## Changes
- Update `_detect_sections()` patterns in `ingestion/parsers/resume_parser.py` to allow `\s*` after `^` / `\n`
- Document the failure mode in the method docstring and add `scripts/reproduce_issue_147.py` for local reproduction
- Add regression tests in `tests/unit/test_resume_section_whitespace.py` (issue sample, flush-left, multi-word, bare header, empty)
- Course planning artifacts on this branch: `JOURNAL.md`, `PLAN.md` (Module 3)

## Testing
- [x] Unit tests pass (`make test-unit`) — for this change: `pytest tests/unit/test_resume_section_whitespace.py` (5 passed); related `test_resume_parser` section tests pass
- [ ] Integration tests pass (`make test-integration`) — not required for this parser-only change
- [x] Linter passes (`make lint`) — ruff clean on touched files; pre-commit ruff/black/mypy passed on commit
- [x] Type checker passes (`make typecheck`) — mypy clean on touched files via pre-commit
- [x] New/updated tests cover the changes

**Pre-existing failures (unrelated to this PR):**
- `test_parse_markdown_resume` and `test_strip_markdown_syntax` fail because `_strip_markdown` does not strip indented `#` headers (`^#+` without leading `\s*`). Observed before and after this change; not introduced by the section-detection fix.

## Screenshots / Demo
Reproduction:
```bash
python scripts/reproduce_issue_147.py
# broken (old regex): []
# current parser:     ['Education', 'Skills']
```

## Notes for Reviewers
- Core fix is four regexes in `_detect_sections()` gaining `\s*` after line anchors.
- Match still requires end-of-line or `:` / `|` / `-` after the header to limit false positives.
- Please focus review on whether multi-word headers (e.g. `Work Experience`) remain correct with indentation.