### PR TITLE
Fix/158 review service async mocks

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,16 @@
+## Week 7 — Issue selection
+
+**Issue link:** [https://github.com/ascherj/pathreview/issues/158](https://github.com/ascherj/pathreview/issues/158)
+
+**Issue title:** review_service unit tests misconfigure async mocks — 13 of 19 tests fail
+
+**Tier:** [x] Tier 1 [ ] Tier 2 [ ] Tier 3
+
+**Problem summary:**
+The unit tests for the `review_service` currently fail because they incorrectly use `AsyncMock` for synchronous database result objects. Specifically, when the tests mock `db.execute()`, they return an `AsyncMock`. This raises an `AttributeError` in the service code. A successful fix will update the test setup in `tests/unit/test_review_service.py` to use a regular `Mock` or `MagicMock` for the query result object. This will correctly simulate the synchronous behavior of SQLAlchemy's query results, allowing all 19 tests to pass.
+
+**Branch name:** [fix/158-review-service-async-mocks]
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -41,3 +41,34 @@ I ran pytest tests/unit/test_review_service.py -q in the activated virtual envir
 
 **Blockers or open questions:**
 [Anything you're still uncertain about going into Week 9, or leave blank]
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+I've implemented the fix by changing AsyncMock to MagicMock for the query results in tests/unit/test_review_service.py. I also updated the assertion in test_list_reviews_ordered_by_created_at to check for two calls instead of one. I've tested and confirmed that all 19 tests pass!
+
+**Next steps:**
+Submit PR for review
+
+**Blockers:**
+N/A
+
+---
+
+### Check-in 2 (end of week; done early)
+
+**PR link:** [https://github.com/ascherj/pathreview/pull/432](https://github.com/ascherj/pathreview/pull/432)
+
+**Branch:** fix/158-review-service-async-mocks
+
+**What you built:**
+I fixed the review service unit tests by replacing `AsyncMock` with `MagicMock` for the mocked database query results. This ensures that the mocked objects correctly simulate the synchronous behavior of SQLAlchemy's `execute().scalars().first()`, preventing the coroutine `AttributeError`s that were causing the tests to fail. I also corrected the pagination test to expect two database calls instead of one.
+
+**Tests added or updated:**
+I updated `tests/unit/test_review_service.py`. I modified the mock configurations for 13 failing tests in this file so they properly return synchronous database result objects. All 19 tests in the file now pass.
+
+**Self-review confirmation:** All 19 tests in review service pass. make check and make test-unit have pre-existing failures which I have documented.[x] make check passes [x] make test-unit passes
+
+**Draft PR feedback received from:**

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -30,12 +30,12 @@ The unit tests for the `review_service` currently fail because they incorrectly 
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [link to commit documenting the reproduced issue]
+**Reproduction commit link:** https://github.com/mmicat/pathreview/commit/a6e797a
 
 **Reproduction summary:**
 I ran pytest tests/unit/test_review_service.py -q in the activated virtual environment. I observed 13 out of 19 tests failing with an AttributeError: 'coroutine' object has no attribute 'first', confirming that the AsyncMock configuration is causing the query results to incorrectly evaluate as coroutines.
 
-**PLAN.md link:** [link to PLAN.md in your fork]
+**PLAN.md link:** https://github.com/mmicat/pathreview/blob/fix/158-review-service-async-mocks/PLAN.md
 
 **Walkthrough video (recommended):** [link to your Loom video, ≤2 min — recommended, not graded]
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -27,3 +27,17 @@ The unit tests for the `review_service` currently fail because they incorrectly 
 [x] I've checked the issue comments and the ledger's Claims count, and I'm fine with how many others are on this issue.
 [x] I've estimated the time this will take and I'm confident I can complete it before the Week 9 deadline.
 [x] This issue has no open blockers or dependencies on other unresolved issues.
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [link to commit documenting the reproduced issue]
+
+**Reproduction summary:**
+I ran pytest tests/unit/test_review_service.py -q in the activated virtual environment. I observed 13 out of 19 tests failing with an AttributeError: 'coroutine' object has no attribute 'first', confirming that the AsyncMock configuration is causing the query results to incorrectly evaluate as coroutines.
+
+**PLAN.md link:** [link to PLAN.md in your fork]
+
+**Walkthrough video (recommended):** [link to your Loom video, ≤2 min — recommended, not graded]
+
+**Blockers or open questions:**
+[Anything you're still uncertain about going into Week 9, or leave blank]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -14,3 +14,16 @@ The unit tests for the `review_service` currently fail because they incorrectly 
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+**"Is This Issue Right For Me?" checklist**
+[x] I can explain the problem and the expected behavior in 2–3 sentences without reading the issue.
+[x] I've located the relevant files and confirmed they exist in the codebase (tests/unit/test_review_service.py).
+[x] I can describe a concrete before-and-after: what the user sees before the fix and what they see after. (Before: Running pytest tests/unit/test_review_service.py throws 13 AttributeError failures. After: Running the same command will show 19 passing tests in green.)
+[x] I have confirmed that the repository runs locally at localhost:5173.
+[x] This is my first open source contribution: I'm choosing Tier 1.
+[x] I'm not choosing a Tier 3 issue to "challenge myself" if I haven't completed a Tier 1 or 2 first — scope surprises in Week 9 don't have a safety net.
+[x] I've found and read the specific code the issue references (not just the file — the function or section).
+[x] I've read enough surrounding context that I can write a rough plan for the fix without looking anything up.I've found the test file for my module and read at least one test end-to-end.
+[x] I've checked the issue comments and the ledger's Claims count, and I'm fine with how many others are on this issue.
+[x] I've estimated the time this will take and I'm confident I can complete it before the Week 9 deadline.
+[x] This issue has no open blockers or dependencies on other unresolved issues.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -72,3 +72,58 @@ I updated `tests/unit/test_review_service.py`. I modified the mock configuration
 **Self-review confirmation:** All 19 tests in review service pass. make check and make test-unit have pre-existing failures which I have documented.[x] make check passes [x] make test-unit passes
 
 **Draft PR feedback received from:**
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes [x] No — still awaiting review
+
+**Summary of feedback:**
+No review feedback
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Some of it was dealing with my local environment setup. Docker Desktop and Windows Subsystem for Linux (WSL) encountered a catastrophic failure (`E_UNEXPECTED`) right when I was trying to run tests. Because of that, I completely lost access to the standard `make` commands. It was definitely harder than expected to pivot and figure out how to bypass Docker entirely by running `pytest` and the linting tools directly through the Python virtual environment on Windows PowerShell.
+
+**What did you learn about working in a large codebase?**
+Mostly the context... that applies to just about anything I would be given to pick up on if I haven't ever worked in it or seen it before. Not only that, but finding the exact reason why the unit tests were failing took a while to figure out, as I hadn't worked with SQLAlchemy before, and didn't realize there were two different query objects (one for async and one for sync).
+
+**How did AI tools help — and where did they fall short?**
+AI assistance was most useful in giving feedback on existing code, and suggesting changes after scanning the codebase, which I delegated to Antigravity. I self-relied on my own knowledge of Python and pytest to run the tests and cross-check the fix!
+
+**What would you do differently if you started over?**
+I would have chosen an issue that was more self-contained. While this issue was well-documented, it took me a while to get up to speed with the codebase. Or, I would have chosen a different issue that challenged me differently!
+
+**What are you most proud of from this module?**
+I'm most proud of the fact that I followed through on all aspects of the module, even when I faced challenges and had to learn new things to overcome certain blockers. I also learned a lot about open source development and how to contribute to a codebase. I'm looking forward to continuing to contribute to open source projects in the future!
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes [x] No — still awaiting review
+
+**Summary of feedback:**
+No review feedback
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+
+**What did you learn about working in a large codebase?**
+Mostly the context... that applies to just about anything I would be given to pick up on if I haven't ever worked in it or seen it before. Not only that, but finding the exact reason why the unit tests were failing took a while to figure out, as I hadn't worked with SQLAlchemy before, and didn't realize there were two different query objects (one for async and one for sync).
+
+**How did AI tools help — and where did they fall short?**
+AI assistance was most useful in giving feedback on existing code, and suggesting changes after scanning the codebase, which I delegated to Antigravity. I self-relied on my own knowledge of Python and pytest to run the tests and cross-check the fix!
+
+**What would you do differently if you started over?**
+I would have chosen an issue that was more self-contained. While this issue was well-documented, it took me a while to get up to speed with the codebase. Or, I would have chosen a different issue that challenged me differently!
+
+**What are you most proud of from this module?**
+I'm most proud of the fact that I followed through on all aspects of the module, even when I faced challenges and had to learn new things to overcome certain blockers. I also learned a lot about open source development and how to contribute to a codebase. I'm looking forward to continuing to contribute to open source projects in the future!

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -100,30 +100,3 @@ I would have chosen an issue that was more self-contained. While this issue was 
 
 **What are you most proud of from this module?**
 I'm most proud of the fact that I followed through on all aspects of the module, even when I faced challenges and had to learn new things to overcome certain blockers. I also learned a lot about open source development and how to contribute to a codebase. I'm looking forward to continuing to contribute to open source projects in the future!
-
-## Week 10 — Iteration & reflection
-
-### Reviewer feedback
-
-**Feedback received:** [ ] Yes [x] No — still awaiting review
-
-**Summary of feedback:**
-No review feedback
-
----
-
-### Reflection
-
-**What was harder than you expected?**
-
-**What did you learn about working in a large codebase?**
-Mostly the context... that applies to just about anything I would be given to pick up on if I haven't ever worked in it or seen it before. Not only that, but finding the exact reason why the unit tests were failing took a while to figure out, as I hadn't worked with SQLAlchemy before, and didn't realize there were two different query objects (one for async and one for sync).
-
-**How did AI tools help — and where did they fall short?**
-AI assistance was most useful in giving feedback on existing code, and suggesting changes after scanning the codebase, which I delegated to Antigravity. I self-relied on my own knowledge of Python and pytest to run the tests and cross-check the fix!
-
-**What would you do differently if you started over?**
-I would have chosen an issue that was more self-contained. While this issue was well-documented, it took me a while to get up to speed with the codebase. Or, I would have chosen a different issue that challenged me differently!
-
-**What are you most proud of from this module?**
-I'm most proud of the fact that I followed through on all aspects of the module, even when I faced challenges and had to learn new things to overcome certain blockers. I also learned a lot about open source development and how to contribute to a codebase. I'm looking forward to continuing to contribute to open source projects in the future!

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,32 @@
+## Solution plan
+
+**Issue:** review_service unit tests misconfigure async mocks — 13 of 19 tests fail [#158](https://github.com/ascherj/pathreview/issues/158)
+
+### Understand
+
+The test suite incorrectly uses `AsyncMock` for the return values of synchronous database query results. Because of this, chained methods like `.scalars().first()` evaluate as coroutines instead of returning the expected mocked objects, causing `AttributeError`s inside the otherwise correct service code.
+
+### Map
+
+The only file that needs to be touched is:
+
+- `tests/unit/test_review_service.py`
+
+### Plan
+
+1. Import `MagicMock` from `unittest.mock` at the top of the test file.
+2. Locate all 13 instances of `mock_result = AsyncMock()` that are used to mock `db.execute()` returns.
+3. Change those specific `AsyncMock` assignments to `MagicMock()`.
+4. Update the faulty assertion in `test_list_reviews_ordered_by_created_at` from `assert_called_once()` to `assert mock_db_session.execute.call_count == 2`, because the `list_reviews` function actually executes two separate queries (one for the total count, one for the data).
+
+### Inputs & outputs
+
+The fix takes the existing test environment and injects synchronous `MagicMock` objects as the output of the database query mocks, simulating how SQLAlchemy synchronously handles result chains.
+
+### Risks & unknowns
+
+One risk is accidentally changing a genuine asynchronous call to a synchronous mock. We must be careful to leave `mock_db_session.execute = AsyncMock(...)` alone, because the `.execute()` method itself is `async` and must remain an `AsyncMock`.
+
+### Edge cases
+
+We must ensure that the fix handles the pagination logic gracefully—specifically, recognizing that fetching paginated lists inherently requires two queries, which breaks any pre-existing tests that strictly asserted only a single database call was made.

--- a/tests/unit/test_review_service.py
+++ b/tests/unit/test_review_service.py
@@ -1,9 +1,9 @@
 """Tests for review_service.py"""
 
-import pytest
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 from uuid import uuid4
-from unittest.mock import AsyncMock, Mock, patch
-import asyncio
+
+import pytest
 
 from core.services.review_service import (
     create_review,
@@ -45,7 +45,9 @@ class TestReviewService:
         return profile
 
     @pytest.mark.asyncio
-    async def test_create_review_returns_review_with_pending_status(self, mock_db_session, mock_review):
+    async def test_create_review_returns_review_with_pending_status(
+        self, mock_db_session, mock_review
+    ):
         """Test create_review returns Review with status='pending'."""
         profile_id = uuid4()
         user_id = uuid4()
@@ -55,7 +57,7 @@ class TestReviewService:
         mock_db_session.commit = AsyncMock()
         mock_db_session.refresh = AsyncMock()
 
-        with patch('core.services.review_service.Review') as MockReview:
+        with patch("core.services.review_service.Review") as MockReview:
             mock_instance = MockReview.return_value
             mock_instance.status = "pending"
             mock_instance.sections = None
@@ -66,7 +68,7 @@ class TestReviewService:
             # Check that Review was instantiated
             MockReview.assert_called()
             call_kwargs = MockReview.call_args[1]
-            assert call_kwargs['status'] == "pending"
+            assert call_kwargs["status"] == "pending"
 
     @pytest.mark.asyncio
     async def test_get_review_returns_review_for_correct_owner(self, mock_db_session):
@@ -78,7 +80,7 @@ class TestReviewService:
         mock_review.id = review_id
 
         # Setup mock execute to return review
-        mock_result = AsyncMock()
+        mock_result = MagicMock()
         mock_result.scalars.return_value.first.return_value = mock_review
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
@@ -95,7 +97,7 @@ class TestReviewService:
         wrong_user_id = uuid4()
 
         # Setup mock to return None
-        mock_result = AsyncMock()
+        mock_result = MagicMock()
         mock_result.scalars.return_value.first.return_value = None
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
@@ -112,7 +114,7 @@ class TestReviewService:
         mock_reviews = [Mock() for _ in range(5)]
 
         # Setup execute mock to return reviews
-        mock_result = AsyncMock()
+        mock_result = MagicMock()
         mock_result.scalars.return_value.all.return_value = mock_reviews
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
@@ -129,13 +131,11 @@ class TestReviewService:
         page_size = 20
 
         # Setup mock
-        mock_result = AsyncMock()
+        mock_result = MagicMock()
         mock_result.scalars.return_value.all.return_value = []
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
-        reviews, total = await list_reviews(
-            mock_db_session, user_id, page=2, page_size=page_size
-        )
+        reviews, total = await list_reviews(mock_db_session, user_id, page=2, page_size=page_size)
 
         # Second call should pass offset for page 2
         calls = mock_db_session.execute.call_args_list
@@ -147,7 +147,7 @@ class TestReviewService:
         """Test list_reviews returns (reviews, total) tuple."""
         user_id = uuid4()
 
-        mock_result = AsyncMock()
+        mock_result = MagicMock()
         mock_result.scalars.return_value.all.return_value = []
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
@@ -165,7 +165,7 @@ class TestReviewService:
         profile_id = uuid4()
         user_id = uuid4()
 
-        with patch('core.services.review_service.Review'):
+        with patch("core.services.review_service.Review"):
             await create_review(mock_db_session, profile_id, user_id)
 
             mock_db_session.add.assert_called_once()
@@ -176,7 +176,7 @@ class TestReviewService:
         profile_id = uuid4()
         user_id = uuid4()
 
-        with patch('core.services.review_service.Review'):
+        with patch("core.services.review_service.Review"):
             await create_review(mock_db_session, profile_id, user_id)
 
             mock_db_session.commit.assert_called_once()
@@ -187,7 +187,7 @@ class TestReviewService:
         profile_id = uuid4()
         user_id = uuid4()
 
-        with patch('core.services.review_service.Review'):
+        with patch("core.services.review_service.Review"):
             await create_review(mock_db_session, profile_id, user_id)
 
             mock_db_session.refresh.assert_called_once()
@@ -198,7 +198,7 @@ class TestReviewService:
         review_id = uuid4()
         user_id = uuid4()
 
-        mock_result = AsyncMock()
+        mock_result = MagicMock()
         mock_result.scalars.return_value.first.return_value = None
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
@@ -212,7 +212,7 @@ class TestReviewService:
         """Test list_reviews uses default pagination."""
         user_id = uuid4()
 
-        mock_result = AsyncMock()
+        mock_result = MagicMock()
         mock_result.scalars.return_value.all.return_value = []
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
@@ -228,7 +228,7 @@ class TestReviewService:
         user_id = uuid4()
         custom_page_size = 50
 
-        mock_result = AsyncMock()
+        mock_result = MagicMock()
         mock_result.scalars.return_value.all.return_value = []
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
@@ -244,13 +244,13 @@ class TestReviewService:
         profile_id = uuid4()
         user_id = uuid4()
 
-        with patch('core.services.review_service.Review') as MockReview:
+        with patch("core.services.review_service.Review") as MockReview:
             MockReview.return_value = Mock()
             await create_review(mock_db_session, profile_id, user_id)
 
             call_kwargs = MockReview.call_args[1]
-            assert 'profile_id' in call_kwargs
-            assert 'status' in call_kwargs
+            assert "profile_id" in call_kwargs
+            assert "status" in call_kwargs
 
     @pytest.mark.asyncio
     async def test_get_review_verifies_ownership(self, mock_db_session):
@@ -258,7 +258,7 @@ class TestReviewService:
         review_id = uuid4()
         user_id = uuid4()
 
-        mock_result = AsyncMock()
+        mock_result = MagicMock()
         mock_result.scalars.return_value.first.return_value = None
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
@@ -273,7 +273,7 @@ class TestReviewService:
         user_id = uuid4()
 
         mock_reviews = [Mock() for _ in range(5)]
-        mock_result = AsyncMock()
+        mock_result = MagicMock()
         mock_result.scalars.return_value.all.return_value = mock_reviews
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
@@ -287,8 +287,8 @@ class TestReviewService:
         """Test list_reviews returns list of Review objects."""
         user_id = uuid4()
 
-        mock_reviews = [Mock(spec=['id', 'status']) for _ in range(3)]
-        mock_result = AsyncMock()
+        mock_reviews = [Mock(spec=["id", "status"]) for _ in range(3)]
+        mock_result = MagicMock()
         mock_result.scalars.return_value.all.return_value = mock_reviews
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
@@ -302,13 +302,13 @@ class TestReviewService:
         profile_id = uuid4()
         user_id = uuid4()
 
-        with patch('core.services.review_service.Review') as MockReview:
+        with patch("core.services.review_service.Review") as MockReview:
             MockReview.return_value = Mock()
             await create_review(mock_db_session, profile_id, user_id)
 
             call_kwargs = MockReview.call_args[1]
-            assert call_kwargs['sections'] is None
-            assert call_kwargs['overall_score'] is None
+            assert call_kwargs["sections"] is None
+            assert call_kwargs["overall_score"] is None
 
     @pytest.mark.asyncio
     async def test_get_review_with_valid_uuid(self, mock_db_session):
@@ -316,7 +316,7 @@ class TestReviewService:
         review_id = uuid4()
         user_id = uuid4()
 
-        mock_result = AsyncMock()
+        mock_result = MagicMock()
         mock_result.scalars.return_value.first.return_value = None
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
@@ -330,11 +330,11 @@ class TestReviewService:
         """Test list_reviews returns results ordered by created_at desc."""
         user_id = uuid4()
 
-        mock_result = AsyncMock()
+        mock_result = MagicMock()
         mock_result.scalars.return_value.all.return_value = []
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
         reviews, total = await list_reviews(mock_db_session, user_id)
 
-        # Should order by created_at descending
-        mock_db_session.execute.assert_called_once()
+        # Should order by created_at descending (and also executes a count query)
+        assert mock_db_session.execute.call_count == 2


### PR DESCRIPTION
## Summary
This PR fixes the failing unit tests in `tests/unit/test_review_service.py` by properly configuring the mocked database execution results. Previously, the tests used `AsyncMock` for synchronous SQLAlchemy scalar results, which caused `AttributeError`s when properties were chained. By updating these to `MagicMock`, the tests now correctly simulate synchronous behavior and pass successfully. 

## Issue
Closes #158

## Changes
- Replaced `AsyncMock` with `MagicMock` for the 13 mocked `db.execute()` query results in `test_review_service.py`
- Updated the assertion in `test_list_reviews_ordered_by_created_at` from `assert_called_once()` to `assert mock_db_session.execute.call_count == 2` to correctly account for both the data and count queries used in pagination

## Testing
- [x] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`)
- [x] Linter passes (`make lint`)
- [x] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes

## Screenshots / Demo
<!-- N/A at the moment -->
N/A

## Notes for Reviewers
I noticed I could be done a bit early, and so I hope doing so isn't an issue! I ran make check and make test-unit, and saw there are 40 failing tests, 179 ruff errors, and 5 mypy errors that are pre-existing in the codebase. My changes only touch `test_review_service.py` and do not affect these failures!