### PR TITLE
feat: add a contribution_streak field to the GitHub analysis (longest consecutive days of commits)

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -49,16 +49,18 @@ Writing the unit tests. I'll flip the existing xfail reproduction test into a pa
 
 ### Check-in 2 (end of week)
 
-**PR link:** [link to your submitted pull request]
+**PR link:** https://github.com/ascherj/pathreview/pull/434
 
-**Branch:** [the branch name you worked on, e.g. `fix/123-short-description`]
+**Branch:** feat/52-github-contribution-streak
 
 **What you built:**
-[1–3 sentences summarizing what your fix does and how it works]
+I added a `contribution_streak` field to the GitHub metadata that reports the longest run of consecutive calendar days on which the repo received at least one commit. `GitHubTool` now pages through the `/repos/{owner}/{repo}/commits` endpoint (following the `Link` header's `next` relation), buckets each commit's author timestamp into a UTC calendar day, and computes the longest unbroken day-over-day run via a pure `_longest_streak` helper. If the commits request fails it degrades to `0` so the rest of the metadata snapshot still returns successfully.
 
 **Tests added or updated:**
-[Which test files did you touch? What do they cover?]
+All in `tests/unit/test_github_tool.py`. I flipped the existing issue-#52 reproduction test from `xfail` into a passing regression assertion, added unit tests for `_longest_streak` (empty set, single day, gaps, out-of-order input, month-boundary crossing), and added tests for `_fetch_commit_dates` covering `Link`-header pagination across two pages and graceful degradation to `[]` on error, plus an `execute()`-level test proving a failing `/commits` request still returns the other metadata with `contribution_streak == 0`.
 
-**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+**Self-review confirmation:** [X] make check passes  [X] make test-unit passes
 
-**Draft PR feedback received from:** [name or Slack handle, or "none"]
+Neither whole-repo command passes on my branch, but the failures are pre-existing and unrelated to my change: `make check` fails at the lint step with 181 errors in files I never touched (e.g. `test_tech_detector.py`), and `make test-unit` has 53 failures in other modules that reproduce identically on a clean checkout. My changed files are clean on all checks individually — `ruff check` and `mypy` pass on `agent/tools/github_tool.py`, and all 10 tests in `tests/unit/test_github_tool.py` pass.
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,18 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/52
+
+**Issue title:** Add a contribution_streak field to the GitHub analysis (longest consecutive days of commits)
+
+**Tier:** [ ] Tier 1  [X] Tier 2  [ ] Tier 3
+
+I am already familiar with contributing to large codebases, so I am comfortable working with issues that require an understanding of how modules connect. The issue I selected has a relatively focused scope and the surrounding code is straightforward enough for me to understand it even with a brief initial overview.
+
+**Problem summary:**
+The `GitHubTool` currently pulls a static snapshot of repository metadata, but it never inspects commit history, so a reviewer gets no signal about how consistently the author actually works on a project. This issue asks for a new `contribution_streak` field that reports the longest run of consecutive calendar days on which the repo received at least one commit. The tool currently only calls the `/repos/{owner}/{repo}` endpoint and reads `pushed_at`, which reflects the most recent activity but says nothing about sustained cadence. A successful fix would fetch the repo's commit history (via the paginated `/repos/{owner}/{repo}/commits` endpoint), bucket commits by day, compute the longest consecutive-day streak, and add it to the metadata dict returned by `_fetch_repo_metadata`. All of this lives in `agent/tools/github_tool.py`, next to the existing metadata extraction.
+
+**Branch name:** feat/52-github-contribution-streak
+
+**Setup confirmation:** [X] App runs locally at localhost:5173
+
+**Cohort ledger:** [X] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -21,12 +21,12 @@ The `GitHubTool` currently pulls a static snapshot of repository metadata, but i
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [link to commit documenting the reproduced issue]
+**Reproduction commit link:** https://github.com/tifflia/pathreview/commit/98107e61bcd014b4e804908377dfaeab15221608
 
 **Reproduction summary:**
 I called `GitHubTool.execute()` against a real public repo and inspected the returned metadata: the call succeeds but the dict has no `contribution_streak` key, confirming the gap lives in `_fetch_repo_metadata()` in `agent/tools/github_tool.py`, which only queries `/repos/{owner}/{repo}` and never the `/commits` endpoint. I captured this as an `xfail(strict=True)` reproduction test in `tests/unit/test_github_tool.py`.
 
-**PLAN.md link:** [link to PLAN.md in your fork]
+**PLAN.md link:** https://github.com/tifflia/pathreview/blob/feat/52-github-contribution-streak/JOURNAL.md
 
 **Blockers or open questions:**
-[Anything you're still uncertain about going into Week 9, or leave blank]
+While creating my reproduction test, I noticed that when I tried to follow the format of other unit tests the linter failed and mypy caught some type errors. I wonder if that was supposed to happen and whether that means all of the other unit tests are not up to date in formatting and need to be fixed.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -16,3 +16,17 @@ The `GitHubTool` currently pulls a static snapshot of repository metadata, but i
 **Setup confirmation:** [X] App runs locally at localhost:5173
 
 **Cohort ledger:** [X] Issue added to cohort ledger
+
+---
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [link to commit documenting the reproduced issue]
+
+**Reproduction summary:**
+I called `GitHubTool.execute()` against a real public repo and inspected the returned metadata: the call succeeds but the dict has no `contribution_streak` key, confirming the gap lives in `_fetch_repo_metadata()` in `agent/tools/github_tool.py`, which only queries `/repos/{owner}/{repo}` and never the `/commits` endpoint. I captured this as an `xfail(strict=True)` reproduction test in `tests/unit/test_github_tool.py`.
+
+**PLAN.md link:** [link to PLAN.md in your fork]
+
+**Blockers or open questions:**
+[Anything you're still uncertain about going into Week 9, or leave blank]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -30,3 +30,35 @@ I called `GitHubTool.execute()` against a real public repo and inspected the ret
 
 **Blockers or open questions:**
 While creating my reproduction test, I noticed that when I tried to follow the format of other unit tests the linter failed and mypy caught some type errors. I wonder if that was supposed to happen and whether that means all of the other unit tests are not up to date in formatting and need to be fixed.
+
+---
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+I've implemented the actual functions in `agent/tools/github_tool.py`. I added the two new helpers from PLAN.md `_longest_streak(commit_days)`and `_fetch_commit_dates(username, repo_name)`. I then wired these into `_fetch_repo_metadata()` so the returned metadata dict now includes the `contribution_streak` key, with a graceful fallback to 0 if the commits request fails so the rest of the snapshot still comes back.
+
+**Next steps:**
+Writing the unit tests. I'll flip the existing xfail reproduction test into a passing assertion and add coverage for `_longest_streak` (empty, single day, gaps, out-of-order input) and for the paginated `/commits` fetch, following the mock-based patterns already in `tests/unit/test_github_tool.py`.
+
+**Blockers:** No blockers as of yet.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [link to your submitted pull request]
+
+**Branch:** [the branch name you worked on, e.g. `fix/123-short-description`]
+
+**What you built:**
+[1–3 sentences summarizing what your fix does and how it works]
+
+**Tests added or updated:**
+[Which test files did you touch? What do they cover?]
+
+**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+
+**Draft PR feedback received from:** [name or Slack handle, or "none"]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -64,3 +64,39 @@ All in `tests/unit/test_github_tool.py`. I flipped the existing issue-#52 reprod
 Neither whole-repo command passes on my branch, but the failures are pre-existing and unrelated to my change: `make check` fails at the lint step with 181 errors in files I never touched (e.g. `test_tech_detector.py`), and `make test-unit` has 53 failures in other modules that reproduce identically on a clean checkout. My changed files are clean on all checks individually — `ruff check` and `mypy` pass on `agent/tools/github_tool.py`, and all 10 tests in `tests/unit/test_github_tool.py` pass.
 
 **Draft PR feedback received from:** none
+
+---
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No review came in.
+
+**How you responded:**
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The hardest part was reproducing the issue, which I had assumed would be the easy step. `GitHubTool` is only one of several tools in the review pipeline — the orchestrator builds an execution plan and runs it alongside `tech_detector`, `readme_scorer`, and the others, and only when the profile happens to include a `github_username` plus a project with a `github_repo`. Running the pipeline end to end gave me one big nested `tool_results` blob, and a missing field inside it doesn't show up as a failure: nothing errors, the review just comes back with less information than it should have. So before I could demonstrate anything I had to work out how to single the tool out from the rest of the pipeline, calling `GitHubTool.execute()` on its own against a real public repo and inspecting the returned metadata dict directly. Only then could I show the gap concretely — the call succeeds, but there is no `contribution_streak` key — and pin it to `_fetch_repo_metadata()` never touching the `/commits` endpoint. Reproducing a *missing feature* turned out to be a different skill from reproducing a bug, since I had to construct the narrowest place where an absence becomes observable rather than just triggering something that breaks.
+
+The other thing that caught me off guard came when I wrote the tests for the code I generated. I deliberately followed the format and approach used by all the other unit tests in `tests/unit/test_github_tool.py`, assuming that matching the existing conventions was the safe choice, and ruff and mypy still flagged errors in what I'd written. I was confused about how my tests could fail the checks when every pre-existing test around them was written the same way. Once I dug in, the answer was that those tests predate the current lint and type-check configuration and were never brought up to date, so "consistent with the codebase" and "passes the codebase's own checks" were two different targets. That meant I couldn't use the surrounding code as a style reference the way I expected to, and I had to decide for myself which standard to write to.
+
+**What did you learn about working in a large codebase?**
+When writing code, especially when it comes to writing tests, I learned the importance of thinking about callers I can't see. In my own projects, if something fails I can just raise and fix it, because I'm the only consumer. Here I had to decide what `_fetch_repo_metadata()` should return when the `/commits` request fails, and I chose to degrade `contribution_streak` to `0` so the rest of the metadata snapshot still comes back rather than failing the whole tool call. That keeps existing consumers of the tool working, but it also means `0` is ambiguous: downstream code can't distinguish "this author commits inconsistently" from "GitHub rate-limited us." That kind of tradeoff barely exists when you own every call site, and it's the sort of thing I now know to name explicitly in a PR description instead of quietly picking one.
+
+**How did AI tools help — and where did they fall short?**
+AI was most useful for mechanical work with a clear pattern to follow: scaffolding the mock-based HTTP tests to match the existing style in `tests/unit/test_github_tool.py`, getting the `Link`-header pagination loop right, and clearing ruff and mypy complaints. It was also good at enumerating edge cases for `_longest_streak` — empty input, a single day, gaps, out-of-order dates, crossing a month boundary — which turned into most of my test coverage.
+
+Where it fell short was environment and setup debugging. Getting the app running locally, I hit problems with my Docker setup while running the `make` targets, and AI had a hard time isolating what was actually wrong. Because the failure surfaced several layers away from its real cause, it kept proposing plausible-sounding fixes based on the error text — generic Docker troubleshooting, tweaking commands, reinstalling things — without ever narrowing down which part of this project's setup I had gotten wrong. Some of those suggestions would have changed my environment for no reason, so I stopped following them. What actually resolved it was sitting down and reading the project's own documentation, `docs/SETUP.md` and `docker-compose.yml`, which made clear what services the stack expects and what state they need to be in before the `make` targets will work. Once I understood the intended setup, my mistake was obvious in a way it never was from the error output alone. The lesson I took from that is that AI is strong when the problem is contained in code it can see, and much weaker when the problem lives in my machine's state — and that reading the maintainers' docs first would have been faster than debugging by suggestion.
+
+**What would you do differently if you started over?**
+First, I'd bound the commit fetch from the start. `_fetch_commit_dates` follows the `next` link until there are no pages left, so a repository with several thousand commits costs dozens of API calls for a single analysis, against an unauthenticated rate limit of 60 requests per hour. Capping it to a fixed number of pages or a recent time window, and documenting that the streak is computed over that window, would have been the better first version. I'd also capture the clean-`main` baseline in Week 8 rather than rediscovering it during Week 9 self-review, and I'd keep the formatter churn in its own commit so the feature commit reads cleanly.
+
+**What are you most proud of from this module?**
+How I drew the line between the logic and the I/O, and the test coverage that decision bought me. It would have been faster in the moment to compute the streak inline inside `_fetch_repo_metadata()`, but I pulled it out into `_longest_streak`, a pure static helper that takes a set of dates and returns an integer and does no network work at all. That one boundary is what made the rest of the testing straightforward: I could exercise the real logic with plain data instead of building elaborate HTTP mocks around it.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,58 @@
+## Solution plan
+
+**Issue:** [#52 - Add a contribution_streak field to the GitHub analysis (longest consecutive days of commits)](https://github.com/ascherj/pathreview/issues/52)
+
+### Understand
+
+The specific gap I'm fixing: **`GitHubTool` reports a static repo snapshot but no signal about commit cadence.** Right now the tool fetches repository metadata and reads `pushed_at` (which only tells you *when the repo was last touched*), but it never looks at commit history, so a reviewer can't tell whether the author committed steadily over many days or dumped everything in one sitting.
+
+I need to add a new `contribution_streak` field to the metadata: an integer equal to the **longest run of consecutive calendar days on which the repo received at least one commit**. A correct implementation fetches the repo's commit history, groups commits by the calendar day they were authored, and computes the longest unbroken day-over-day streak.
+
+- **Expected:** metadata dict contains `"contribution_streak": <int>`, e.g. commits on Jan 13, 14, 15 then a gap then Jan 18 → streak of `3`.
+- **Actual (reproduced):** the metadata dict has no `contribution_streak` key at all. Confirmed via a live call and captured as an `xfail(strict=True)` reproduction test — see the Reproduction section below.
+
+### Map
+
+Files / functions I expect to touch:
+
+- **`agent/tools/github_tool.py`** — the core change.
+  - `_fetch_repo_metadata()` (builds the metadata dict) — add `"contribution_streak"` to the returned dict.
+  - New helper `_fetch_commit_dates(username, repo_name)` — call the paginated `/repos/{owner}/{repo}/commits` endpoint, following `response.links["next"]` until there are no more pages, and collect each commit's authored date.
+  - New pure helper `_longest_streak(commit_days)` — take the set of commit calendar days and return the longest consecutive-day run. Kept separate so it's unit-testable without hitting the network.
+- **`tests/unit/test_github_tool.py`** — flip the existing reproduction test from `xfail` to a passing test, and add unit tests for `_longest_streak` (empty, single day, gaps, out-of-order pages) plus a paginated-`/commits` mock.
+
+Files I need to be *aware of* but likely won't change (they consume the dict by key and will pass the new field through transparently):
+
+- `agent/orchestrator.py` (~line 122) threads `repo_metadata` to downstream tools.
+- `ingestion/pipeline.py` `ingest_repo_metadata()` serializes the dict for storage.
+
+### Plan
+
+1. **Add `_longest_streak(commit_days: set[date]) -> int`** — pure function. Sort the unique days; walk them tracking the current run, resetting when the gap between consecutive days is more than one day; return the max run. Return `0` for an empty set.
+2. **Add `_fetch_commit_dates(username, repo_name) -> list[date]`** — GET `/repos/{username}/{repo_name}/commits?per_page=100`, reuse the existing auth header logic, and paginate by following the `next` link header. Parse each commit's `commit.author.date` (ISO-8601) into a `date`.
+3. **Wire it into `_fetch_repo_metadata()`** — call the two helpers and add `"contribution_streak": self._longest_streak(set(commit_dates))` to the metadata dict, alongside the existing keys.
+4. **Handle failures gracefully** — if the commits request fails or the repo is empty, default `contribution_streak` to `0` rather than letting the whole `execute()` call fail (the snapshot fields should still come back).
+5. **Update tests** — remove the `xfail` marker from `test_repro_issue_52_metadata_includes_contribution_streak` so it becomes a real passing assertion, and add the `_longest_streak` / pagination unit tests above.
+
+### Inputs & outputs
+
+- **Inputs (unchanged public interface):** `GitHubTool.execute()` still takes `{"github_username": str, "repo_name": str}`. Internally the new work also consumes the JSON from `/repos/{owner}/{repo}/commits` — a list of commit objects where I read `commit.author.date`.
+- **Outputs (what changes):** the `dict` returned by `_fetch_repo_metadata()` (and therefore `ToolResult.data`) gains one key, `contribution_streak: int`. No existing keys change type or meaning. New private helpers `_fetch_commit_dates` and `_longest_streak` are added; no signature of an existing method changes.
+- **Behavioral change:** the tool now makes **additional** HTTP calls (one per page of commit history) beyond the current single `/repos/...` + `/readme` calls.
+
+### Risks & unknowns
+
+- **Rate limiting (`agent/tools/github_tool.py`, the new `/commits` calls):** unauthenticated requests are capped at 60/hour, and paginating history multiplies request count. Risk that a large repo exhausts the budget or returns 403. Need to decide how many pages to fetch and reuse the existing 403 handling in `execute()`.
+- **Timezone / date bucketing (`_longest_streak`):** commit timestamps are timezone-aware ISO-8601; "consecutive calendar days" is ambiguous across timezones. Unknown whether to bucket in UTC or the commit's local offset — I'll standardize on UTC dates and document it.
+- **Author vs committer date (`_fetch_commit_dates`):** `commit.author.date` and `commit.committer.date` can differ (rebases, cherry-picks). Need to pick one deliberately; I plan to use author date and note the choice.
+- **Pagination mechanics (`_fetch_commit_dates`):** relying on the `Link` header's `next` relation; unknown exactly how `httpx` surfaces it (`response.links`) — needs verification against a real paginated response.
+
+### Edge cases
+
+The fix must handle these gracefully:
+
+1. **Repo with zero commits** (brand-new/empty repo, or the `/commits` endpoint returns `[]` / a 409 "Git Repository is empty") → `contribution_streak == 0`, and `execute()` still returns the other metadata successfully.
+2. **All commits on a single day** (e.g. a weekend hackathon project) → `contribution_streak == 1`, not the total commit count.
+3. **Non-chronological / paginated ordering** — GitHub returns commits newest-first and split across pages; the streak calc must not assume sorted input, so I bucket into a set of days before computing.
+4. **Multiple commits on the same day** count as one day toward the streak (dedupe by calendar day, not by commit).
+5. **Commits request fails while the repo lookup succeeds** (rate limit / transient error on `/commits` only) → degrade to `contribution_streak == 0` instead of failing the whole tool call.

--- a/agent/tools/github_tool.py
+++ b/agent/tools/github_tool.py
@@ -1,5 +1,7 @@
 """GitHub repository metadata tool."""
 
+from datetime import date, datetime
+
 import httpx
 import structlog
 
@@ -94,6 +96,9 @@ class GitHubTool(BaseTool):
             "has_readme": self._has_readme(username, repo_name),
             "topics": repo_json.get("topics", []),
             "homepage": repo_json.get("homepage") or "",
+            "contribution_streak": self._longest_streak(
+                set(self._fetch_commit_dates(username, repo_name))
+            ),
         }
 
         logger.info(
@@ -105,6 +110,85 @@ class GitHubTool(BaseTool):
         )
 
         return metadata
+
+    def _fetch_commit_dates(self, username: str, repo_name: str) -> list[date]:
+        """Fetch the authored calendar dates of every commit in the repo.
+
+        Pages through the ``/repos/{owner}/{repo}/commits`` endpoint by following
+        the ``next`` relation of the ``Link`` header. Each commit's authored
+        timestamp (``commit.author.date``) is bucketed to a UTC calendar date.
+        Author date (not committer date) is used deliberately so the streak
+        reflects when work was originally done rather than when it was rebased.
+
+        Args:
+            username: GitHub username
+            repo_name: Repository name
+
+        Returns:
+            List of UTC calendar dates, one per commit (with duplicates).
+        """
+        headers = {}
+        if self.api_token:
+            headers["Authorization"] = f"token {self.api_token}"
+
+        url: str | None = f"{self.base_url}/repos/{username}/{repo_name}/commits"
+        # Only the first request needs the page-size param; the `next` link
+        # already carries the query string for subsequent pages.
+        params: dict | None = {"per_page": 100}
+        dates: list[date] = []
+
+        try:
+            while url:
+                response = httpx.get(url, headers=headers, params=params, timeout=10.0)
+                response.raise_for_status()
+                params = None
+
+                for commit in response.json():
+                    raw = commit.get("commit", {}).get("author", {}).get("date")
+                    if not raw:
+                        continue
+                    # ISO-8601, e.g. "2024-01-15T09:00:00Z"; normalize to UTC date.
+                    parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+                    dates.append(parsed.date())
+
+                next_link = response.links.get("next")
+                url = next_link["url"] if next_link else None
+        except Exception as e:
+            logger.warning(
+                "github_commits_fetch_failed",
+                username=username,
+                repo=repo_name,
+                error=str(e),
+            )
+            return []
+
+        return dates
+
+    @staticmethod
+    def _longest_streak(commit_days: set[date]) -> int:
+        """Longest run of consecutive calendar days with at least one commit.
+        Input order does not matter (GitHub returns commits
+        newest-first, split across pages), so days are sorted before walking.
+
+        Args:
+            commit_days: Set of unique calendar days on which commits occurred.
+
+        Returns:
+            Length of the longest unbroken day-over-day run, or 0 if empty.
+        """
+        if not commit_days:
+            return 0
+
+        ordered = sorted(commit_days)
+        longest = current = 1
+        for prev, curr in zip(ordered, ordered[1:], strict=False):
+            if (curr - prev).days == 1:
+                current += 1
+                longest = max(longest, current)
+            else:
+                current = 1
+
+        return longest
 
     def _has_readme(self, username: str, repo_name: str) -> bool:
         """Check if repository has a README file.

--- a/agent/tools/github_tool.py
+++ b/agent/tools/github_tool.py
@@ -2,6 +2,7 @@
 
 import httpx
 import structlog
+
 from .base import BaseTool, ToolResult
 
 logger = structlog.get_logger()
@@ -35,44 +36,30 @@ class GitHubTool(BaseTool):
         repo_name = input_data.get("repo_name")
 
         if not username or not repo_name:
-            return ToolResult(
-                success=False,
-                data={},
-                error="Missing github_username or repo_name"
-            )
+            return ToolResult(success=False, data={}, error="Missing github_username or repo_name")
 
         try:
             repo_data = self._fetch_repo_metadata(username, repo_name)
             return ToolResult(success=True, data=repo_data)
 
         except httpx.HTTPStatusError as e:
-            logger.error("github_request_failed", status=e.response.status_code,
-                        username=username, repo=repo_name)
+            logger.error(
+                "github_request_failed",
+                status=e.response.status_code,
+                username=username,
+                repo=repo_name,
+            )
             if e.response.status_code == 404:
-                return ToolResult(
-                    success=False,
-                    data={},
-                    error="Repository not found"
-                )
+                return ToolResult(success=False, data={}, error="Repository not found")
             elif e.response.status_code == 403:
-                return ToolResult(
-                    success=False,
-                    data={},
-                    error="Rate limited or access denied"
-                )
+                return ToolResult(success=False, data={}, error="Rate limited or access denied")
             return ToolResult(
-                success=False,
-                data={},
-                error=f"GitHub API error: {e.response.status_code}"
+                success=False, data={}, error=f"GitHub API error: {e.response.status_code}"
             )
 
         except Exception as e:
             logger.error("github_tool_error", error=str(e))
-            return ToolResult(
-                success=False,
-                data={},
-                error=str(e)
-            )
+            return ToolResult(success=False, data={}, error=str(e))
 
     def _fetch_repo_metadata(self, username: str, repo_name: str) -> dict:
         """Fetch repository metadata from GitHub API.
@@ -109,8 +96,13 @@ class GitHubTool(BaseTool):
             "homepage": repo_json.get("homepage") or "",
         }
 
-        logger.info("github_repo_fetched", username=username, repo=repo_name,
-                   language=metadata["primary_language"], stars=metadata["star_count"])
+        logger.info(
+            "github_repo_fetched",
+            username=username,
+            repo=repo_name,
+            language=metadata["primary_language"],
+            stars=metadata["star_count"],
+        )
 
         return metadata
 
@@ -132,6 +124,6 @@ class GitHubTool(BaseTool):
 
         try:
             response = httpx.head(url, headers=headers, timeout=5.0)
-            return response.status_code == 200
+            return bool(response.status_code == 200)
         except Exception:
             return False

--- a/tests/unit/test_github_tool.py
+++ b/tests/unit/test_github_tool.py
@@ -1,0 +1,100 @@
+"""Tests for github_tool.py
+
+Includes a reproduction test for issue #52:
+https://github.com/ascherj/pathreview/issues/52
+
+    "Add a contribution_streak field to the GitHub analysis
+     (longest consecutive days of commits)"
+
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.tools.github_tool import GitHubTool
+
+
+@pytest.mark.unit
+class TestGitHubTool:
+    """Test suite for GitHubTool."""
+
+    @pytest.fixture
+    def tool(self) -> GitHubTool:
+        """Create a GitHubTool instance (unauthenticated)."""
+        return GitHubTool()
+
+    def _mock_repo_response(self) -> MagicMock:
+        """Build a fake /repos/{owner}/{repo} JSON payload."""
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = {
+            "name": "Hello-World",
+            "description": "My first repository",
+            "language": "Python",
+            "stargazers_count": 42,
+            "forks_count": 7,
+            "open_issues_count": 3,
+            "pushed_at": "2024-01-15T12:00:00Z",
+            "topics": ["demo"],
+            "homepage": "",
+        }
+        return mock_response
+
+    def test_fetch_repo_metadata_returns_expected_snapshot_fields(self, tool: GitHubTool) -> None:
+        """Sanity check: the tool returns the existing static-snapshot fields."""
+        with (
+            patch("agent.tools.github_tool.httpx.get") as mock_get,
+            patch("agent.tools.github_tool.httpx.head") as mock_head,
+        ):
+            mock_get.return_value = self._mock_repo_response()
+            mock_head.return_value = MagicMock(status_code=200)
+
+            result = tool.execute({"github_username": "octocat", "repo_name": "Hello-World"})
+
+        assert result.success is True
+        assert result.data["name"] == "Hello-World"
+        assert result.data["primary_language"] == "Python"
+        assert result.data["star_count"] == 42
+        assert result.data["last_commit_date"] == "2024-01-15T12:00:00Z"
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="Issue #52: contribution_streak is not implemented yet. "
+        "GitHubTool never queries /repos/{owner}/{repo}/commits, so the "
+        "returned metadata has no consecutive-commit-days signal.",
+    )
+    def test_repro_issue_52_metadata_includes_contribution_streak(self, tool: GitHubTool) -> None:
+        """REPRODUCTION (#52): metadata should include `contribution_streak`.
+
+        Two commits on 2024-01-14 and 2024-01-15 form a 2-day streak. The tool
+        should fetch commit history, bucket commits by calendar day, and report
+        the longest consecutive-day run. Today it does neither, so this fails.
+        """
+        commits_payload = [
+            {"commit": {"author": {"date": "2024-01-15T09:00:00Z"}}},
+            {"commit": {"author": {"date": "2024-01-14T18:00:00Z"}}},
+        ]
+
+        def fake_get(url: str, *args: object, **kwargs: object) -> MagicMock:
+            if url.endswith("/commits"):
+                resp = MagicMock()
+                resp.raise_for_status.return_value = None
+                resp.json.return_value = commits_payload
+                resp.links = {}  # no further pages
+                return resp
+            return self._mock_repo_response()
+
+        with (
+            patch("agent.tools.github_tool.httpx.get", side_effect=fake_get),
+            patch("agent.tools.github_tool.httpx.head") as mock_head,
+        ):
+            mock_head.return_value = MagicMock(status_code=200)
+
+            result = tool.execute({"github_username": "octocat", "repo_name": "Hello-World"})
+
+        assert result.success is True
+        assert (
+            "contribution_streak" in result.data
+        ), "GitHubTool metadata is missing the `contribution_streak` field"
+        assert result.data["contribution_streak"] == 2

--- a/tests/unit/test_github_tool.py
+++ b/tests/unit/test_github_tool.py
@@ -8,8 +8,10 @@ https://github.com/ascherj/pathreview/issues/52
 
 """
 
+from datetime import date
 from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
 
 from agent.tools.github_tool import GitHubTool
@@ -58,18 +60,12 @@ class TestGitHubTool:
         assert result.data["star_count"] == 42
         assert result.data["last_commit_date"] == "2024-01-15T12:00:00Z"
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="Issue #52: contribution_streak is not implemented yet. "
-        "GitHubTool never queries /repos/{owner}/{repo}/commits, so the "
-        "returned metadata has no consecutive-commit-days signal.",
-    )
     def test_repro_issue_52_metadata_includes_contribution_streak(self, tool: GitHubTool) -> None:
-        """REPRODUCTION (#52): metadata should include `contribution_streak`.
+        """REGRESSION (#52): metadata should include `contribution_streak`.
 
         Two commits on 2024-01-14 and 2024-01-15 form a 2-day streak. The tool
-        should fetch commit history, bucket commits by calendar day, and report
-        the longest consecutive-day run. Today it does neither, so this fails.
+        fetches commit history, buckets commits by calendar day, and reports the
+        longest consecutive-day run.
         """
         commits_payload = [
             {"commit": {"author": {"date": "2024-01-15T09:00:00Z"}}},
@@ -98,3 +94,84 @@ class TestGitHubTool:
             "contribution_streak" in result.data
         ), "GitHubTool metadata is missing the `contribution_streak` field"
         assert result.data["contribution_streak"] == 2
+
+    # --- _longest_streak (pure helper) ------------------------------------
+
+    def test_longest_streak_empty_set_is_zero(self, tool: GitHubTool) -> None:
+        """No commits (empty/brand-new repo) → streak of 0."""
+        assert tool._longest_streak(set()) == 0
+
+    def test_longest_streak_single_day_is_one(self, tool: GitHubTool) -> None:
+        """All commits on one day (e.g. a hackathon) → streak of 1, not a count."""
+        assert tool._longest_streak({date(2024, 1, 15)}) == 1
+
+    def test_longest_streak_picks_longest_run_across_gaps(self, tool: GitHubTool) -> None:
+        """Jan 13,14,15 then a gap then Jan 18,19 → longest run is 3."""
+        days = {
+            date(2024, 1, 13),
+            date(2024, 1, 14),
+            date(2024, 1, 15),
+            date(2024, 1, 18),
+            date(2024, 1, 19),
+        }
+        assert tool._longest_streak(days) == 3
+
+    def test_longest_streak_ignores_input_order(self, tool: GitHubTool) -> None:
+        """A set is unordered, so the calc must not assume chronological input."""
+        days = {date(2024, 2, 3), date(2024, 2, 1), date(2024, 2, 2)}
+        assert tool._longest_streak(days) == 3
+
+    def test_longest_streak_crosses_month_boundary(self, tool: GitHubTool) -> None:
+        """Consecutive days spanning a month boundary still count as one run."""
+        days = {date(2024, 1, 30), date(2024, 1, 31), date(2024, 2, 1)}
+        assert tool._longest_streak(days) == 3
+
+    # --- _fetch_commit_dates (pagination + failure) -----------------------
+
+    def test_fetch_commit_dates_follows_pagination(self, tool: GitHubTool) -> None:
+        """Commits split across pages are all collected by following `next`."""
+        page1 = MagicMock()
+        page1.raise_for_status.return_value = None
+        page1.json.return_value = [{"commit": {"author": {"date": "2024-01-15T09:00:00Z"}}}]
+        page1.links = {"next": {"url": "https://api.github.com/next-page"}}
+
+        page2 = MagicMock()
+        page2.raise_for_status.return_value = None
+        page2.json.return_value = [{"commit": {"author": {"date": "2024-01-14T18:00:00Z"}}}]
+        page2.links = {}  # last page
+
+        with patch("agent.tools.github_tool.httpx.get", side_effect=[page1, page2]) as mock_get:
+            dates = tool._fetch_commit_dates("octocat", "Hello-World")
+
+        assert dates == [date(2024, 1, 15), date(2024, 1, 14)]
+        assert mock_get.call_count == 2
+        # Second call targets the `next` link, not the base commits URL.
+        assert mock_get.call_args_list[1].args[0] == "https://api.github.com/next-page"
+
+    def test_fetch_commit_dates_degrades_to_empty_on_error(self, tool: GitHubTool) -> None:
+        """A failing /commits request degrades to [] rather than raising."""
+        with patch(
+            "agent.tools.github_tool.httpx.get",
+            side_effect=httpx.RequestError("boom"),
+        ):
+            assert tool._fetch_commit_dates("octocat", "Hello-World") == []
+
+    def test_execute_degrades_streak_to_zero_when_commits_fail(self, tool: GitHubTool) -> None:
+        """If /commits fails but the repo lookup succeeds, streak is 0 and the
+        other metadata still comes back successfully (edge case #5)."""
+
+        def fake_get(url: str, *args: object, **kwargs: object) -> MagicMock:
+            if url.endswith("/commits"):
+                raise httpx.RequestError("commits unavailable")
+            return self._mock_repo_response()
+
+        with (
+            patch("agent.tools.github_tool.httpx.get", side_effect=fake_get),
+            patch("agent.tools.github_tool.httpx.head") as mock_head,
+        ):
+            mock_head.return_value = MagicMock(status_code=200)
+            result = tool.execute({"github_username": "octocat", "repo_name": "Hello-World"})
+
+        assert result.success is True
+        assert result.data["name"] == "Hello-World"
+        assert result.data["contribution_streak"] == 0


### PR DESCRIPTION
## Summary

`GitHubTool` previously returned only a static snapshot of repository metadata (stars, language, `pushed_at`, etc.), so a reviewer had no signal about how consistently an author worked on a project . This PR adds a new `contribution_streak` field to that metadata: an integer equal to the longest run of consecutive calendar days on which the repo received at least one commit. It works by fetching the repo's full commit history from the paginated `/repos/{owner}/{repo}/commits` endpoint, bucketing each commit's authored timestamp into a UTC calendar day, and computing the longest unbroken day-over-day run. The field flows through the existing `repo_metadata` dict, so downstream consumers (orchestrator, ingestion) pick it up transparently with no changes on their side.

## Issue

Closes #52

## Changes

- **`agent/tools/github_tool.py`**
  - Added `_longest_streak(commit_days: set[date]) -> int`: a pure, side-effect-free helper that sorts the unique commit days and walks them, tracking the current consecutive-day run and resetting whenever the gap exceeds one day. Returns `0` for an empty set. Kept separate so the streak logic is unit-testable without any network access.
  - Added `_fetch_commit_dates(username, repo_name) -> list[date]`: GETs `/repos/{owner}/{repo}/commits` with `per_page=100` and follows the `Link` header's `next` relation (`response.links["next"]`) to page through the entire history. Each commit's `commit.author.date` (ISO-8601) is normalized to a UTC calendar date. On any request failure it logs a warning and returns `[]` so a rate limit or transient error never fails the whole metadata fetch.
  - Wired `"contribution_streak"` into the dict returned by `_fetch_repo_metadata()`, alongside the existing keys. No existing key changed type or meaning.
- **`tests/unit/test_github_tool.py`**
  - Flipped the issue-#52 reproduction test from `xfail(strict=True)` into a passing regression assertion.
  - Added unit tests for `_longest_streak` (empty set, single day, gaps, out-of-order input, month-boundary crossing).
  - Added tests for `_fetch_commit_dates` pagination (follows the `next` link across two pages) and graceful degradation to `[]` on error, plus an `execute()`-level test proving that a failing `/commits` request still returns the other metadata with `contribution_streak == 0`.

## Testing

- [x] Unit tests pass (`make test-unit`) — 53 failures exist that pre-date this change and are not caused by it. Every test touching `github_tool` passes.
- [x] New/updated tests cover the changes

1. From the repo root, run a live unauthenticated call against a real public repo:
   ```bash
   python -c "from agent.tools.github_tool import GitHubTool; \
   import json; print(json.dumps(GitHubTool().execute({'github_username':'ascherj','repo_name':'pathreview'}).data, indent=2))"
   ```
2. Confirm the returned JSON now contains a `"contribution_streak"` integer key (all previous keys are still present). On `ascherj/pathreview` this currently returns `2`; on `octocat/Hello-World` it returns `1`.
3. **Verify the streak math** against a repo whose history you can read: open the repo's commit list on GitHub, note the longest run of back-to-back calendar days that each have at least one commit, and confirm it matches the reported number. Multiple commits on the same day should count once.

## Screenshots / Demo

N/A — backend-only change; the observable behavior is the live output of the manual verification call above.

## Notes for Reviewers

- **Extra HTTP calls:** the tool now makes one additional request *per page* of commit history on top of the existing `/repos/...` and `/readme` calls. For most repos that's one extra call; large repos page more. The failure path is deliberately swallowed (degrade to `0`) so this can never regress the existing snapshot fields — please sanity-check that trade-off is acceptable.
- **UTC vs. author-local dates:** "consecutive calendar days" is timezone-ambiguous. I standardized on UTC and used the author (not committer) date. If the project would rather bucket by the commit's local offset, that's a one-line change in `_fetch_commit_dates`.
- **Pagination:** I relied on `httpx`'s `response.links["next"]` for the `Link` header; the pagination test mocks a two-page response, and I also confirmed it live against a real repo.
- The `_longest_streak` helper is intentionally pure (`set[date] -> int`) so the streak logic can be reviewed and tested in isolation from the network.