### PR TITLE
Fix/68 health check safety event count

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -21,3 +21,18 @@ The `/health` endpoint already returns a `safety_events_last_hour` field in its 
 - Note: another cohort member (RadRebelSam) commented on this issue two weeks ago saying they started work on branch `fix/68-health-check-safety-event-count`, and there's an open PR (#210) already linked to the issue. Proceeding anyway — duplication is acceptable here — but this is worth being aware of if the issue gets closed out from under this branch.
 
 **Cohort ledger:** [ ] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [link to this commit — fill in after pushing]
+
+**Reproduction summary:**
+Started the backend locally (`uvicorn api.main:app --reload --host 0.0.0.0 --port 8000`) with `db`/`redis`/`vector-db` up via `docker compose up -d`, then sent a `GET http://localhost:8000/health` request via Postman. The response came back `503 Service Unavailable` with `"safety_events_last_hour": 0` in the body — confirmed by reading [api/routes/health.py](api/routes/health.py#L78), the field is hardcoded to `0` and never calls into `SafetyMonitor` (in [safety/monitoring.py](safety/monitoring.py)), which already has a working `log_event()`/`get_event_count()` API but isn't wired into the health check at all.
+
+**PLAN.md link:** [PLAN.md](https://github.com/galipcagan/pathreview/blob/fix/68-health-check-safety-event-count/PLAN.md)
+
+**Walkthrough video (recommended):** (not recorded)
+
+**Blockers or open questions:**
+- While reproducing, the `/health` endpoint also misreported `postgres` and `redis` as `"unhealthy"` even though both containers were confirmed healthy — two separate pre-existing bugs (a raw-SQL string passed where SQLAlchemy requires `text("SELECT 1")`, and a reference to a `Settings.redis_host` attribute that doesn't exist). Both are out of scope for this PR and not something I'm fixing here, but noting them since they're in the same file/function.
+- Also found: `SafetyMonitor.get_event_count()` accepts a `window_hours` parameter but never actually uses it — the Redis counter it reads just has a flat 24h TTL, not a real rolling window. Need to decide in the fix whether "last hour" should be a true rolling window (sorted-set based, mirroring `safety/rate_limiter.py`'s `RateLimiter` pattern) or a simpler hour-bucketed counter — see PLAN.md.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -52,3 +52,20 @@ Run final `make check`/`make test-unit` pass, open the PR (scoped to #68 only, p
 None.
 
 ---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/437
+
+**Branch:** `fix/68-health-check-safety-event-count`
+
+**What you built:**
+Wired `/health`'s `safety_events_last_hour` field to real data by rewriting `SafetyMonitor` to track events in a Redis sorted set (mirroring `RateLimiter`'s rolling-window pattern) instead of a flat 24h-TTL counter, then replacing the hardcoded `0` in `api/routes/health.py` with a live call into it. Verified end-to-end against the real local `db`/`redis` containers.
+
+**Tests added or updated:**
+`tests/unit/test_monitoring.py` (new) — 12 tests covering event logging, unknown-event-type handling, Redis-error fail-safe behavior, rolling-window pruning (default and custom `window_hours`), and the `get_total_event_count()` aggregate across all `VALID_EVENT_TYPES`.
+
+**Self-review confirmation:** [x] make check passes [x] make test-unit passes
+(53 pre-existing test failures and pre-existing lint/type findings unrelated to `safety/`/`api/routes/health.py` remain from before this branch's changes — confirmed no new failures were introduced.)
+
+**Draft PR feedback received from:** none yet

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,23 @@
+# JOURNAL
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/68
+
+**Issue title:** Add a safety event count to the health check endpoint
+
+**Tier:** [x] Tier 1 [ ] Tier 2 [ ] Tier 3
+
+**Problem summary:**
+The `/health` endpoint already returns a `safety_events_last_hour` field in its response, but it's hardcoded to `0` (see `api/routes/health.py`) instead of reflecting real data. Separately, `safety/monitoring.py` already has a working `SafetyMonitor` class that logs safety events (PII detected, injection attempts, content filtered, etc.) into Redis and can return a count per event type via `get_event_count()` — but nothing in the health endpoint calls it. A successful fix wires the health check up to `SafetyMonitor` so it reports a real aggregate count across event types, and addresses the fact that the existing Redis counters use a 24-hour TTL rather than a true rolling one-hour window, so the count returned actually matches what "last hour" claims to mean. This affects the API layer (`api/routes/health.py`) and the safety monitoring module (`safety/monitoring.py`).
+
+**Branch name:** fix/68-health-check-safety-event-count
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Selection notes (scope reasoning):**
+- Labeled `tier-1` / `good first issue`, estimated 2–4 hours — appropriately scoped for a first issue in this codebase.
+- Touches exactly two files with a clear, bounded change (wire an existing class into an existing endpoint), not a cross-cutting refactor.
+- Note: another cohort member (RadRebelSam) commented on this issue two weeks ago saying they started work on branch `fix/68-health-check-safety-event-count`, and there's an open PR (#210) already linked to the issue. Proceeding anyway — duplication is acceptable here — but this is worth being aware of if the issue gets closed out from under this branch.
+
+**Cohort ledger:** [ ] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -69,3 +69,34 @@ Wired `/health`'s `safety_events_last_hour` field to real data by rewriting `Saf
 (53 pre-existing test failures and pre-existing lint/type findings unrelated to `safety/`/`api/routes/health.py` remain from before this branch's changes — confirmed no new failures were introduced.)
 
 **Draft PR feedback received from:** none yet
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No review has landed on PR #437 as of this entry. (Su26 note: reviewer feedback isn't provided this term, so this is the expected outcome rather than a stalled PR.)
+
+**How you responded:**
+N/A — no feedback to respond to. Left the PR scoped exactly as submitted in Week 9 rather than making speculative changes with no review input to react to.
+
+---
+
+### Reflection
+
+**What was harder than expected?**
+The actual code change (wiring `SafetyMonitor` into `/health`) was small, but the path to it wasn't. `get_event_count()` already accepted a `window_hours` argument that did nothing — the underlying Redis counter was a flat 24h TTL, so "last hour" was a lie no matter what I wired up. Fixing that meant redesigning the storage (sorted set with `ZADD`/`ZREMRANGEBYSCORE`/`ZCARD`) before I could touch the endpoint at all. On top of that, I ran into three separate pre-existing bugs in the same function (`text("SELECT 1")`, a nonexistent `Settings.redis_host` attribute, and that same attribute silently starving my new code because I'd first reused the existing Redis client block). Deciding what was in-scope for #68 versus what to just document and leave alone took more judgment than the implementation did.
+
+**What did you learn about working in a large codebase?**
+That "wire A into B" issues are rarely just wiring — they're an invitation to audit whatever A and B are currently doing, and most of that audit is stuff you don't get to fix. I also learned to look for an existing pattern before inventing one: `safety/rate_limiter.py`'s `RateLimiter` already solved the rolling-window problem, so `SafetyMonitor` should look like it rather than reinvent it. And working async with a cohort — finding that RadRebelSam had already started on this same issue and branch name two weeks earlier — made me realize duplicate work is a real cost in a shared codebase, even in a course setting, and worth flagging rather than ignoring.
+
+**How did AI tools help — and where did they fall short?**
+AI assistance was most useful for scaffolding the rolling-window Redis logic quickly once I'd decided on the sorted-set approach, and for generating a broad first pass at the 12 unit tests — including edge cases like unknown event types and Redis-error fail-safe behavior that I might not have prioritized writing myself under time pressure. It fell short wherever the bug lived in the gap between what the code claims and what's actually configured — e.g., `Settings.redis_host` reads like a real field until you check `config.py` and see it's `redis_url`. No amount of static suggestion caught that; it only showed up by actually running the backend against live `db`/`redis` containers and watching it fail.
+
+**What would you do differently if you started over?**
+I'd check the issue thread and existing linked PR (#210) more carefully before picking the branch, since the overlap with another cohort member was avoidable. I'd also spend Week 8's reproduction pass specifically hunting for "is this field actually doing what its name claims" (the `window_hours` no-op) instead of finding that mid-implementation in Week 9 — that one discovery reshaped the whole plan and cost time it didn't need to.
+
+**What are you most proud of from this module?**
+Keeping the PR disciplined: fixing exactly the rolling-window bug the ticket was about, matching an existing codebase pattern (`RateLimiter`) instead of inventing a new one, and documenting — but deliberately not fixing — three unrelated pre-existing bugs I tripped over along the way. That scope discipline, backed by 12 tests and a real end-to-end verification against live containers, is the part I'd defend in a real code review.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -36,3 +36,19 @@ Started the backend locally (`uvicorn api.main:app --reload --host 0.0.0.0 --por
 **Blockers or open questions:**
 - While reproducing, the `/health` endpoint also misreported `postgres` and `redis` as `"unhealthy"` even though both containers were confirmed healthy — two separate pre-existing bugs (a raw-SQL string passed where SQLAlchemy requires `text("SELECT 1")`, and a reference to a `Settings.redis_host` attribute that doesn't exist). Both are out of scope for this PR and not something I'm fixing here, but noting them since they're in the same file/function.
 - Also found: `SafetyMonitor.get_event_count()` accepts a `window_hours` parameter but never actually uses it — the Redis counter it reads just has a flat 24h TTL, not a real rolling window. Need to decide in the fix whether "last hour" should be a true rolling window (sorted-set based, mirroring `safety/rate_limiter.py`'s `RateLimiter` pattern) or a simpler hour-bucketed counter — see PLAN.md.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the full fix per PLAN.md: `SafetyMonitor.log_event()`/`get_event_count()` in `safety/monitoring.py` now use a Redis sorted set (`ZADD`/`ZREMRANGEBYSCORE`/`ZCARD`), mirroring `RateLimiter`'s rolling-window pattern, so `window_hours` is finally honored. Added `get_total_event_count()` to sum across all `VALID_EVENT_TYPES` (the health field is singular, so a sum was the right shape). Wired this into `api/routes/health.py`, replacing the hardcoded `0`. Added 12 unit tests in `tests/unit/test_monitoring.py`. Verified live: started the backend against the real `db`/`redis` containers, manually called `log_event()` twice, and confirmed `GET /health` reported `"safety_events_last_hour": 2`, then back to `0` after cleanup.
+- While wiring this up, found a *third* pre-existing bug (beyond the `text("SELECT 1")` and `Settings.redis_host` ones noted in Week 8): the existing "Check Redis" block's `AttributeError` on `settings.redis_host` would have silently starved my new code too, since I originally reused that block's client. Fixed by having the safety-count block build its own Redis client via `redis.Redis.from_url(settings.redis_url)` — `redis_url` is the field that actually exists on `Settings`. This keeps the fix scoped to #68 without touching the unrelated `redis_host` bug in the existing health-check block.
+
+**Next steps:**
+Run final `make check`/`make test-unit` pass, open the PR (scoped to #68 only, per plan — the `text()` and `redis_host` bugs are documented but left unfixed), and request a peer/mentor review on the draft before finalizing.
+
+**Blockers:**
+None.
+
+---

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,48 @@
+## Solution plan
+
+**Issue:** [Add a safety event count to the health check endpoint (#68)](https://github.com/ascherj/pathreview/issues/68)
+
+### Understand
+
+The `/health` endpoint is supposed to report how many safety events (PII detections, injection attempts, content filtering, bias detections, rate limiting) occurred in the last hour, so operators can monitor safety activity without opening the dashboard. Instead, `safety_events_last_hour` in the response is hardcoded to `0` at [api/routes/health.py:78](api/routes/health.py#L78) — it never reads real data.
+
+`safety/monitoring.py` already has a working `SafetyMonitor` class: `log_event()` increments a Redis counter per event type (`safety:events:{event_type}`, flat 24h TTL), and `get_event_count(event_type, window_hours=1)` reads that counter back — but it accepts `window_hours` and never actually uses it, so it can't answer "how many in the last hour" accurately even if it were called. Nothing in the codebase currently calls `SafetyMonitor` at all — it's implemented but never wired in.
+
+Expected: `/health` returns a `safety_events_last_hour` count reflecting real events from roughly the last hour.
+Actual: always `0`.
+
+### Map
+
+Files to touch:
+- **`api/routes/health.py`** — replace the hardcoded `0` at line 78 with a real call into `SafetyMonitor`.
+- **`safety/monitoring.py`** — `SafetyMonitor.log_event()` / `get_event_count()` need a real rolling-window implementation so `window_hours` is honored.
+
+Reference only (not modified): **`safety/rate_limiter.py`**'s `RateLimiter.check_rate_limit()` already implements a Redis sorted-set rolling window (`ZADD` timestamp-scored members, `ZREMRANGEBYSCORE` to prune, `ZCARD` to count) — a good template to mirror. **`tests/unit/test_rate_limiter.py`** shows the existing test conventions (mocked `redis.Redis`, `@pytest.mark.unit`) to follow.
+
+### Plan
+
+1. Convert `SafetyMonitor.log_event()` to record events in a Redis sorted set per event type (`safety:events:{event_type}`, member = unique id, score = timestamp) instead of a flat `INCR` counter.
+2. Update `SafetyMonitor.get_event_count()` to prune entries older than `window_hours` (`ZREMRANGEBYSCORE`) and return the live count (`ZCARD`), so `window_hours` actually does something.
+3. Add logic to sum counts across all `VALID_EVENT_TYPES` into a single aggregate figure, since the health response field is singular (`safety_events_last_hour`), not per-type.
+4. Wire `SafetyMonitor` into `api/routes/health.py`: construct it with the existing Redis client, call the aggregate count method, and replace the hardcoded `0` at line 78.
+5. Add unit tests for `SafetyMonitor` (mirroring `test_rate_limiter.py`'s mocked-Redis style) covering the rolling window and aggregate count, and verify manually against the running local backend the same way the bug was reproduced.
+
+### Inputs & outputs
+
+**Input:** Safety events logged via `SafetyMonitor.log_event(event_type, details)`.
+**Output:** The `/health` JSON response's `safety_events_last_hour` field — the sum of real event counts across all `VALID_EVENT_TYPES` within the last rolling hour, instead of a hardcoded `0`.
+
+### Risks & unknowns
+
+- **Nothing currently calls `SafetyMonitor.log_event()` anywhere in the app**, so even after this fix the field may show `0` in practice until other safety modules (bias detector, PII scrubber, prompt defense, rate limiter) start logging events. Need to decide if that wiring belongs in this PR or is a separate follow-up.
+- **Changing the Redis data structure** (counter → sorted set) changes the shape of the `safety:events:{event_type}` key. Confirmed via grep that nothing else reads it directly, but worth re-checking before merging.
+- **Redis unavailability:** `get_event_count()` currently swallows exceptions and returns `0` on Redis errors ([safety/monitoring.py:72-74](safety/monitoring.py#L72-L74)) — must preserve that fail-safe behavior so a Redis outage doesn't break `/health` itself.
+- **Clock source:** `RateLimiter` uses `time.time()` for sorted-set scores; matching that (rather than `datetime.utcnow()`) keeps timestamp handling consistent across the two modules.
+
+### Edge cases
+
+- No events logged in the last hour → count should be `0` (current default output; must not regress).
+- Events logged just outside the 1-hour boundary → must be excluded from the count (this is the core bug being fixed — there's currently no boundary at all).
+- Unknown/invalid event type passed to `log_event()` → already handled today (logged as a warning and ignored); must remain unchanged.
+- Redis connection failure at count-read time → `/health` should still respond rather than crash.
+- High event volume → sorted-set reads should stay cheap (`ZCARD` after pruning), avoiding unbounded scans.

--- a/api/routes/health.py
+++ b/api/routes/health.py
@@ -1,6 +1,9 @@
-from fastapi import APIRouter, HTTPException, status, Depends
+from datetime import datetime
+from typing import Any
+
 import structlog
-from datetime import datetime, timedelta
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from core.database import get_db
 
@@ -10,12 +13,12 @@ router = APIRouter(prefix="/health", tags=["health"])
 
 
 @router.get("")
-async def health_check(db=Depends(get_db)):
+async def health_check(db: AsyncSession = Depends(get_db)) -> dict[str, Any]:  # noqa: B008
     """
     Check health of PostgreSQL, Redis, and Vector DB.
     Returns 200 if all healthy, 503 if any dependency is down.
     """
-    health_status = {
+    health_status: dict[str, Any] = {
         "status": "healthy",
         "dependencies": {
             "postgres": "unknown",
@@ -39,6 +42,7 @@ async def health_check(db=Depends(get_db)):
     try:
         # Check Redis (if available)
         import redis
+
         from core.config import settings
 
         r = redis.Redis(
@@ -72,10 +76,16 @@ async def health_check(db=Depends(get_db)):
         health_status["dependencies"]["vector_db"] = "unhealthy"
         health_status["status"] = "unhealthy"
 
-    # Count safety events in last hour (placeholder)
+    # Count safety events in the last hour
     try:
-        # This would be populated by actual safety event logging
-        health_status["safety_events_last_hour"] = 0
+        import redis
+
+        from core.config import settings
+        from safety.monitoring import SafetyMonitor
+
+        safety_redis = redis.Redis.from_url(settings.redis_url, decode_responses=True)
+        monitor = SafetyMonitor(safety_redis)
+        health_status["safety_events_last_hour"] = monitor.get_total_event_count(window_hours=1)
     except Exception as exc:
         log.error("safety_events_check_failed", error=str(exc))
 

--- a/safety/monitoring.py
+++ b/safety/monitoring.py
@@ -1,8 +1,10 @@
 """Safety event monitoring."""
 
+import time
+import uuid
+
 import redis
 import structlog
-from datetime import datetime, timedelta
 
 logger = structlog.get_logger()
 
@@ -16,7 +18,7 @@ class SafetyMonitor:
         "injection_attempt",
         "content_filtered",
         "bias_detected",
-        "rate_limited"
+        "rate_limited",
     }
 
     def __init__(self, redis_client: redis.Redis):
@@ -38,15 +40,15 @@ class SafetyMonitor:
             logger.warning("unknown_event_type", event_type=event_type)
             return
 
-        timestamp = datetime.utcnow().isoformat()
-
         try:
             # Log to structlog
             logger.warning("safety_event", event_type=event_type, **details)
 
-            # Store count in Redis for monitoring
+            # Record event in a Redis sorted set (score = timestamp) so counts
+            # can be read back over an arbitrary rolling window.
             key = f"safety:events:{event_type}"
-            self.redis.incr(key)
+            now = time.time()
+            self.redis.zadd(key, {f"{now}:{uuid.uuid4()}": now})
             # Set expiry to 24 hours
             self.redis.expire(key, 86400)
 
@@ -54,21 +56,37 @@ class SafetyMonitor:
             logger.error("safety_monitor_error", error=str(e))
 
     def get_event_count(self, event_type: str, window_hours: int = 1) -> int:
-        """Get count of safety events.
+        """Get count of safety events in a rolling time window.
 
         Args:
             event_type: Type of event
-            window_hours: Time window in hours (not enforced here; for reference)
+            window_hours: Time window in hours
 
         Returns:
-            Count of events in the window
+            Count of events within the last `window_hours` hours
         """
         key = f"safety:events:{event_type}"
+        window_start = time.time() - (window_hours * 3600)
 
         try:
-            count = self.redis.get(key)
-            return int(count) if count else 0
+            # Prune entries outside the window, then count what remains
+            self.redis.zremrangebyscore(key, 0, window_start)
+            return self.redis.zcard(key)
 
         except Exception as e:
             logger.error("event_count_error", event_type=event_type, error=str(e))
             return 0
+
+    def get_total_event_count(self, window_hours: int = 1) -> int:
+        """Get the total count of safety events across all event types.
+
+        Args:
+            window_hours: Time window in hours
+
+        Returns:
+            Sum of event counts across all VALID_EVENT_TYPES within the window
+        """
+        return sum(
+            self.get_event_count(event_type, window_hours=window_hours)
+            for event_type in self.VALID_EVENT_TYPES
+        )

--- a/tests/unit/test_monitoring.py
+++ b/tests/unit/test_monitoring.py
@@ -1,0 +1,155 @@
+"""Tests for monitoring.py"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from safety.monitoring import SafetyMonitor
+
+
+@pytest.mark.unit
+class TestSafetyMonitor:
+    """Test suite for SafetyMonitor."""
+
+    @pytest.fixture
+    def mock_redis(self) -> Mock:
+        """Create a mock Redis client."""
+        return Mock()
+
+    @pytest.fixture
+    def monitor(self, mock_redis: Mock) -> SafetyMonitor:
+        """Create a SafetyMonitor instance with mocked Redis."""
+        return SafetyMonitor(mock_redis)
+
+    def test_log_event_valid_type_writes_to_redis(
+        self, monitor: SafetyMonitor, mock_redis: Mock
+    ) -> None:
+        """Test that a valid event type is recorded in the Redis sorted set."""
+        mock_redis.zadd = Mock()
+        mock_redis.expire = Mock()
+
+        monitor.log_event("pii_detected", {"count": 1})
+
+        mock_redis.zadd.assert_called_once()
+        key, member_dict = mock_redis.zadd.call_args[0]
+        assert key == "safety:events:pii_detected"
+        assert isinstance(member_dict, dict)
+        assert len(member_dict) == 1
+
+    def test_log_event_sets_expiry(self, monitor: SafetyMonitor, mock_redis: Mock) -> None:
+        """Test that the Redis key expiry is set to 24 hours."""
+        mock_redis.zadd = Mock()
+        mock_redis.expire = Mock()
+
+        monitor.log_event("injection_attempt", {})
+
+        mock_redis.expire.assert_called_once_with("safety:events:injection_attempt", 86400)
+
+    def test_log_event_unknown_type_ignored(self, monitor: SafetyMonitor, mock_redis: Mock) -> None:
+        """Test that an unknown event type is not written to Redis."""
+        mock_redis.zadd = Mock()
+
+        monitor.log_event("not_a_real_event_type", {})
+
+        mock_redis.zadd.assert_not_called()
+
+    def test_log_event_redis_error_handled(self, monitor: SafetyMonitor, mock_redis: Mock) -> None:
+        """Test that Redis errors during logging are swallowed."""
+        mock_redis.zadd = Mock(side_effect=Exception("Redis error"))
+
+        with patch("safety.monitoring.logger"):
+            monitor.log_event("pii_detected", {})  # Should not raise
+
+    def test_get_event_count_returns_zero_when_empty(
+        self, monitor: SafetyMonitor, mock_redis: Mock
+    ) -> None:
+        """Test count is zero when no events are recorded."""
+        mock_redis.zremrangebyscore = Mock()
+        mock_redis.zcard = Mock(return_value=0)
+
+        count = monitor.get_event_count("pii_detected")
+
+        assert count == 0
+
+    def test_get_event_count_returns_current_count(
+        self, monitor: SafetyMonitor, mock_redis: Mock
+    ) -> None:
+        """Test count reflects the number of events currently in the window."""
+        mock_redis.zremrangebyscore = Mock()
+        mock_redis.zcard = Mock(return_value=7)
+
+        count = monitor.get_event_count("bias_detected")
+
+        assert count == 7
+
+    def test_get_event_count_prunes_before_counting(
+        self, monitor: SafetyMonitor, mock_redis: Mock
+    ) -> None:
+        """Test that entries outside the window are pruned before ZCARD is read."""
+        mock_redis.zremrangebyscore = Mock()
+        mock_redis.zcard = Mock(return_value=0)
+
+        with patch("time.time", return_value=10_000):
+            monitor.get_event_count("rate_limited", window_hours=1)
+
+        mock_redis.zremrangebyscore.assert_called_once()
+        key, min_score, max_score = mock_redis.zremrangebyscore.call_args[0]
+        assert key == "safety:events:rate_limited"
+        assert min_score == 0
+        assert max_score == 10_000 - 3600
+
+    def test_get_event_count_respects_custom_window(
+        self, monitor: SafetyMonitor, mock_redis: Mock
+    ) -> None:
+        """Test that a custom window_hours changes the prune boundary."""
+        mock_redis.zremrangebyscore = Mock()
+        mock_redis.zcard = Mock(return_value=0)
+
+        with patch("time.time", return_value=10_000):
+            monitor.get_event_count("rate_limited", window_hours=2)
+
+        max_score = mock_redis.zremrangebyscore.call_args[0][2]
+        assert max_score == 10_000 - 7200
+
+    def test_get_event_count_redis_error_returns_zero(
+        self, monitor: SafetyMonitor, mock_redis: Mock
+    ) -> None:
+        """Test that Redis errors during count reads fail safe to zero."""
+        mock_redis.zremrangebyscore = Mock(side_effect=Exception("Redis error"))
+
+        with patch("safety.monitoring.logger"):
+            count = monitor.get_event_count("pii_detected")
+
+        assert count == 0
+
+    def test_get_total_event_count_sums_all_event_types(
+        self, monitor: SafetyMonitor, mock_redis: Mock
+    ) -> None:
+        """Test that the total count sums counts across every valid event type."""
+        mock_redis.zremrangebyscore = Mock()
+        mock_redis.zcard = Mock(return_value=2)
+
+        total = monitor.get_total_event_count()
+
+        assert total == 2 * len(SafetyMonitor.VALID_EVENT_TYPES)
+
+    def test_get_total_event_count_zero_when_no_events(
+        self, monitor: SafetyMonitor, mock_redis: Mock
+    ) -> None:
+        """Test that the total is zero when nothing has been logged."""
+        mock_redis.zremrangebyscore = Mock()
+        mock_redis.zcard = Mock(return_value=0)
+
+        assert monitor.get_total_event_count() == 0
+
+    def test_get_total_event_count_partial_redis_failure_fails_safe(
+        self, monitor: SafetyMonitor, mock_redis: Mock
+    ) -> None:
+        """Test that a Redis error for one event type doesn't crash the aggregate."""
+        mock_redis.zremrangebyscore = Mock(side_effect=Exception("Redis error"))
+        mock_redis.zcard = Mock(return_value=5)
+
+        with patch("safety.monitoring.logger"):
+            total = monitor.get_total_event_count()
+
+        assert total == 0


### PR DESCRIPTION
## Summary
Wires the `/health` endpoint's `safety_events_last_hour` field to real data. It was hardcoded to `0`; now it reports a live count from `SafetyMonitor`, which was rewritten to track events in a Redis sorted set (mirroring `RateLimiter`'s rolling-window pattern) so the `window_hours` parameter is actually honored instead of being ignored in favor of a flat 24h-TTL counter.

## Issue
Closes #68

## Changes
- `safety/monitoring.py`: `log_event()`/`get_event_count()` rewritten to use a Redis sorted set (`ZADD`/`ZREMRANGEBYSCORE`/`ZCARD`) for a true rolling time window. Added `get_total_event_count()` to sum counts across all `VALID_EVENT_TYPES`.
- `api/routes/health.py`: replaced the hardcoded `0` with a real call into `SafetyMonitor`, using its own Redis client built from `settings.redis_url`.
- `tests/unit/test_monitoring.py`: 12 new unit tests covering event logging, rolling-window pruning, custom windows, the aggregate count, and Redis-failure fail-safe behavior.

## Testing
- [x] Unit tests pass (`make test-unit`) — 387 passed, 53 pre-existing failures unrelated to this change (unaffected by this PR; see Notes for Reviewers)
- [ ] Integration tests pass (`make test-integration`) — not run (no integration tests exist for this module)
- [x] Linter passes (`make lint`) — no new lint errors introduced by this change
- [x] Type checker passes (`make typecheck`) — no new type errors introduced by this change
- [x] New/updated tests cover the changes
- Manually verified against the running local backend (real `db`/`redis` containers): logged 2 test events via `SafetyMonitor.log_event()`, confirmed `GET /health` returned `"safety_events_last_hour": 2`, then cleaned up back to `0`.

## Notes for Reviewers
- **Scope is intentionally limited to #68.** Two other pre-existing bugs surfaced in the same endpoint while working on this and are left unfixed here: (1) `db.execute("SELECT 1")` should be `text("SELECT 1")` for SQLAlchemy 2.0, causing `postgres` to always report `"unhealthy"`; (2) the "Check Redis" block references `settings.redis_host`/`settings.redis_port`, which don't exist on `Settings` (only `redis_url` does), causing `redis` to always report `"unhealthy"` regardless of actual container health. My new code avoids depending on that second bug by building its own Redis client from `settings.redis_url`.
- The 53 pre-existing unit test failures were present before this branch's changes and are unrelated to `safety/` or `api/routes/health.py`.
