### PR TITLE
Tests/88 post /reviews endpoint has no test for when the profile has no ingested documents 

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -17,3 +17,31 @@ The unit tests for the review routes do not cover the case where a valid profile
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [link to commit documenting the reproduced issue]
+
+**Reproduction summary:**
+I created a valid profile without a résumé, GitHub username, portfolio URL, or ingested sources, then submitted `POST /reviews` using that profile’s ID. The endpoint incorrectly returns a pending review instead of a controlled 4xx error indicating there is no content to review.
+
+To reproduce the error I submitted 
+{
+  "access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIyZGJiNDRlNi01N2M1LTQyYTktYWJlNy1mN2IxMjQxZjYwNTAiLCJleHAiOjE3ODQ4NTk0Mzl9.7K5caMJ4nljB5_QH35YcsrpYCGVlAQYIVCR1utQ6xmc",
+  "token_type": "bearer"
+}
+
+{
+  "id": "5a312eb8-1744-40f1-aa77-e773c3c27f39",
+  "user_id": "2dbb44e6-57c5-42a9-abe7-f7b1241f6050",
+  "github_username": "string",
+  "portfolio_url": "string",
+  "created_at": "2026-07-24T06:19:15.677525Z",
+  "resume_filename": null
+}
+
+**PLAN.md link:** [link to PLAN.md in your fork]
+
+**Walkthrough video (recommended):** [link to your Loom video, ≤2 min — recommended, not graded]
+
+**Blockers or open questions:**

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,19 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/88
+
+**Issue title:** `POST /reviews` endpoint has no test for when the profile has no ingested documents
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Selection reasoning:**
+I selected this Tier 1 issue because I am comfortable writing focused unit tests but am still becoming familiar with the project's review API and error-handling flow. The change has a narrow scope in one test file, making it a manageable way to learn how the endpoint handles profiles and ingested content.
+
+**Problem summary:**
+The unit tests for the review routes do not cover the case where a valid profile exists but has no associated ingested content. As a result, a regression could cause the `POST /reviews` endpoint to crash instead of returning a controlled error response. The missing coverage belongs in `tests/unit/test_review_routes.py` and should exercise this empty-content condition. A successful change will verify that the endpoint responds with an appropriate error status and message when there is nothing available to review.
+
+**Branch name:** `tests/88-POST-/reviews-endpoint-has-no-test-for-when-the-profile-has-no-ingested-documents-`
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -20,25 +20,10 @@ The unit tests for the review routes do not cover the case where a valid profile
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [link to commit documenting the reproduced issue]
+**Reproduction commit link:** https://github.com/Rura-M/pathreview/commit/aa8a1aceeee37329043a67b97f64a86618898087
 
 **Reproduction summary:**
 I created a valid profile without a résumé, GitHub username, portfolio URL, or ingested sources, then submitted `POST /reviews` using that profile’s ID. The endpoint incorrectly returns a pending review instead of a controlled 4xx error indicating there is no content to review.
-
-To reproduce the error I submitted 
-{
-  "access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIyZGJiNDRlNi01N2M1LTQyYTktYWJlNy1mN2IxMjQxZjYwNTAiLCJleHAiOjE3ODQ4NTk0Mzl9.7K5caMJ4nljB5_QH35YcsrpYCGVlAQYIVCR1utQ6xmc",
-  "token_type": "bearer"
-}
-
-{
-  "id": "5a312eb8-1744-40f1-aa77-e773c3c27f39",
-  "user_id": "2dbb44e6-57c5-42a9-abe7-f7b1241f6050",
-  "github_username": "string",
-  "portfolio_url": "string",
-  "created_at": "2026-07-24T06:19:15.677525Z",
-  "resume_filename": null
-}
 
 **PLAN.md link:** [link to PLAN.md in your fork]
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -28,3 +28,55 @@ I created a valid profile without a résumé, GitHub username, portfolio URL, or
 **PLAN.md link:** https://github.com/Rura-M/pathreview/blob/tests/88-POST-/reviews-endpoint-has-no-test-for-when-the-profile-has-no-ingested-documents-/PLAN.md
 
 **Blockers or open questions:**
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+I implemented validation for `POST /reviews` so the endpoint confirms that the
+requested profile exists, belongs to the authenticated user, and has at least
+one associated ingested source before creating a review. I also added
+`tests/unit/test_review_routes.py` with a regression test for a valid profile
+that has no ingested documents.
+
+**Next steps:**
+Review the final diff, commit the implementation and test, push the branch, and
+open a pull request. I will also document the repository-wide test failures
+that are unrelated to this change.
+
+**Blockers:**
+The focused regression test passes, but the full unit suite currently has
+pre-existing failures and errors in unrelated modules. Some tests also attempt
+to download tokenizer data while network access is unavailable.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [link to your submitted pull request]
+
+**Branch:** `tests/88-POST-/reviews-endpoint-has-no-test-for-when-the-profile-has-no-ingested-documents-`
+
+**What you built:**
+I updated `create_review_endpoint` to return `404` when the profile is missing
+or not owned by the authenticated user and `400` with `"Profile has no
+ingested documents"` when the profile has no associated `IngestedSource`
+records. The endpoint now stops before creating a review, committing database
+changes, or scheduling background processing in the empty-content case.
+
+**Tests added or updated:**
+I added `tests/unit/test_review_routes.py`. The test covers an authenticated
+request for an existing profile with no ingested documents and verifies the
+`400` status and error message, that `create_review` is not called, that no
+commit occurs, and that no background task is scheduled.
+
+**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+
+**Focused verification:** [x] regression test passes  [x] Ruff passes  [x] Black passes
+
+`make check` remains blocked by pre-existing type errors in
+`core/services/review_service.py`. The full unit suite also contains unrelated
+pre-existing failures, so `make test-unit` is not marked as passing.
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -25,8 +25,6 @@ The unit tests for the review routes do not cover the case where a valid profile
 **Reproduction summary:**
 I created a valid profile without a résumé, GitHub username, portfolio URL, or ingested sources, then submitted `POST /reviews` using that profile’s ID. The endpoint incorrectly returns a pending review instead of a controlled 4xx error indicating there is no content to review.
 
-**PLAN.md link:** [link to PLAN.md in your fork]
-
-**Walkthrough video (recommended):** [link to your Loom video, ≤2 min — recommended, not graded]
+**PLAN.md link:** https://github.com/Rura-M/pathreview/blob/tests/88-POST-/reviews-endpoint-has-no-test-for-when-the-profile-has-no-ingested-documents-/PLAN.md
 
 **Blockers or open questions:**

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -80,3 +80,48 @@ commit occurs, and that no background task is scheduled.
 pre-existing failures, so `make test-unit` is not marked as passing.
 
 **Draft PR feedback received from:** none
+
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No review received yet
+
+**How you responded:**
+N/A
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Following the flow of data through the codebase was harder than I expected. A single feature could span routes, services, database models, background tasks, and tests, so I sometimes lost track of where a behavior originated. I learned to slow down, trace function calls, and map the dependencies before making changes.
+
+**What did you learn about working in a large codebase?**
+I learned that contributing to production code requires more caution than building my own project. In my own projects, I understand most of the decisions because I made them. In an existing codebase, I first have to understand its architecture, conventions, and assumptions. Even a small change can affect other parts of the application, so testing both the expected result and unwanted side effects is important. For example, my test verified not only the error response, but also that no review was created, no database commit occurred, and no background task was scheduled.
+
+**How did AI tools help — and where did they fall short?**
+AI tools helped me trace unfamiliar code, visualize how the different layers connected, and explain concepts such as RAG, embeddings, and LLM-based generation. They were also useful for brainstorming tests and interpreting errors. However, AI could not replace reading the code or running the tests. Its suggestions sometimes lacked project-specific context, and it could not always distinguish problems caused by my changes from pre-existing test failures. I still had to verify every suggestion and decide whether it matched the intended behavior.
+
+**What would you do differently if you started over?**
+I would also run the full test suite at the beginning to identify pre-existing failures and avoid confusing them with regressions from my work. Finally, I would make smaller changes and test each one immediately.
+
+**What are you most proud of from this module?**
+**What was harder than you expected?**  
+Following the flow of data through the codebase was harder than I expected. A single feature could span routes, services, database models, background tasks, and tests, so I sometimes lost track of where a behavior originated. I learned to slow down, trace function calls, and map the dependencies before making changes.
+
+**What did you learn about working in a large codebase?**  
+I learned that contributing to production code requires more caution than building my own project. In my own projects, I understand most of the decisions because I made them. In an existing codebase, I first have to understand its architecture, conventions, and assumptions. Even a small change can affect other parts of the application, so testing both the expected result and unwanted side effects is important. For example, my test verified not only the error response, but also that no review was created, no database commit occurred, and no background task was scheduled.
+
+**How did AI tools help—and where did they fall short?**  
+AI tools helped me trace unfamiliar code, visualize how the different layers connected, and explain concepts such as RAG, embeddings, and LLM-based generation. They were also useful for brainstorming tests and interpreting errors. However, AI could not replace reading the code or running the tests. Its suggestions sometimes lacked project-specific context, and it could not always distinguish problems caused by my changes from pre-existing test failures. I still had to verify every suggestion and decide whether it matched the intended behavior.
+
+**What would you do differently if you started over?**  
+I would begin by studying the architecture documentation and drawing a small map of the request flow before changing any code. I would also run the full test suite at the beginning to identify pre-existing failures and avoid confusing them with regressions from my work. Finally, I would make smaller changes and test each one immediately.
+
+**What are you most proud of from this module?**  
+I am most proud that I developed a practical understanding of how LLM applications work, including ingestion, chunking, embeddings, retrieval, and generation. I also contributed a focused production fix and regression test that prevent the system from creating a review when a profile has no ingested documents. This showed me that I can navigate an unfamiliar codebase and make a small but meaningful improvement.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -54,9 +54,9 @@ to download tokenizer data while network access is unavailable.
 
 ### Check-in 2 (end of week)
 
-**PR link:** [link to your submitted pull request]
+**PR link:** https://github.com/Rura-M/pathreview/pull/1
 
-**Branch:** `tests/88-POST-/reviews-endpoint-has-no-test-for-when-the-profile-has-no-ingested-documents-`
+**Branch:** https://github.com/Rura-M/pathreview/tree/tests/88-POST-/reviews-endpoint-has-no-test-for-when-the-profile-has-no-ingested-documents-
 
 **What you built:**
 I updated `create_review_endpoint` to return `404` when the profile is missing

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ PYTEST := $(VENV_BIN)/pytest
 # ---- Setup ----
 
 setup: ## First-time setup: venv, deps, migrations, seed data
-	python -m venv .venv || python3 -m venv .venv
+	python3 -m venv .venv || python3 -m venv .venv
 	$(PYTHON) -m pip install --upgrade pip setuptools wheel
 	$(PIP) install -e ".[dev]"
 	$(VENV_BIN)/pre-commit install

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,52 @@
+## Solution plan
+
+**Issue:** [`POST /reviews` endpoint has no test for when the profile has no ingested documents](https://github.com/ascherj/pathreview/issues/88)
+
+### Understand
+The `POST /reviews` endpoint has no test covering a valid profile with no
+associated ingested content. The endpoint currently creates a pending review
+and schedules background processing without first checking whether there is
+content available to review. The expected behavior described by the issue is a
+controlled client error rather than creating a review or crashing.
+
+### Map
+The main file to add is `tests/unit/test_review_routes.py`.
+
+The behavior under test is implemented by `create_review_endpoint` in
+`api/routes/reviews.py`. Its dependencies include `create_review` and
+`process_review` from `core/services/review_service.py`, `get_current_user`,
+`get_db`, and FastAPI's `BackgroundTasks`.
+
+### Plan
+1. Confirm the intended HTTP status code and error message for a profile with
+   no ingested content.
+2. Add route-test fixtures for an authenticated user, an empty profile, a
+   mocked database session, and background tasks.
+3. Add a test that calls `POST /reviews` with the empty profile's ID and
+   verifies that the endpoint returns the agreed controlled error.
+4. Verify that the failure path does not create a review, commit database
+   changes, or schedule `process_review`.
+5. Run the focused route test and the full unit-test suite to check for
+   regressions.
+
+### Inputs & outputs
+The input is an authenticated `POST /reviews` request containing the ID of a
+valid profile that has no associated ingested content. The expected output is
+a stable 4xx response with a clear error message. No review record or
+background processing task should be created.
+
+### Risks & unknowns
+The issue does not specify the exact status code or response message. It is
+also unclear whether "no ingested documents" means no `IngestedSource` database
+rows or no source material—such as a resume, GitHub username, or portfolio
+URL—available for ingestion. Current review processing performs ingestion
+after the review is created, so requiring pre-existing `IngestedSource` rows
+may conflict with the existing workflow. The endpoint currently has no
+validation for either interpretation, so a test expecting a 4xx response will
+fail until the intended production behavior is confirmed or implemented.
+
+### Edge cases
+The test should distinguish an existing empty profile from a nonexistent
+profile, a profile owned by another user, and a profile that has valid content.
+It should also ensure that the empty-profile failure does not accidentally
+return a generic 500 response or schedule background work.

--- a/api/routes/reviews.py
+++ b/api/routes/reviews.py
@@ -1,12 +1,17 @@
-from fastapi import APIRouter, Depends, HTTPException, status, BackgroundTasks
+from typing import Annotated
 from uuid import UUID
-import structlog
 
-from api.schemas.review import ReviewCreate, ReviewResponse, ReviewListResponse
+import structlog
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from api.middleware.auth import get_current_user
-from core.models.user import User
-from core.models.review import Review
+from api.schemas.review import ReviewCreate, ReviewListResponse, ReviewResponse
 from core.database import get_db
+from core.models.ingested_source import IngestedSource
+from core.models.profile import Profile
+from core.models.user import User
 from core.services.review_service import (
     create_review,
     get_review,
@@ -23,33 +28,61 @@ router = APIRouter(prefix="/reviews", tags=["reviews"])
 async def create_review_endpoint(
     data: ReviewCreate,
     background_tasks: BackgroundTasks,
-    current_user: User = Depends(get_current_user),
-    db=Depends(get_db),
-):
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> ReviewResponse:
     """
     Create a new review for a profile.
     Triggers ingestion pipeline and agent orchestration asynchronously.
     Returns review with status="pending" immediately.
     """
     try:
+        user_id = UUID(current_user.id)
+        profile_result = await db.execute(
+            select(Profile).where(
+                Profile.id == data.profile_id,
+                Profile.user_id == user_id,
+            )
+        )
+        if not profile_result.scalars().first():
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Profile not found",
+            )
+
+        source_result = await db.execute(
+            select(IngestedSource.id).where(IngestedSource.profile_id == data.profile_id).limit(1)
+        )
+        if source_result.scalars().first() is None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Profile has no ingested documents",
+            )
+
         # Create review with status="pending"
         review = await create_review(
             db=db,
             profile_id=data.profile_id,
-            user_id=current_user.id,
+            user_id=user_id,
         )
 
         # Add background task for processing
-        background_tasks.add_task(process_review, db, review.id, data.profile_id)
+        background_tasks.add_task(
+            process_review,
+            db,
+            UUID(review.id),
+            data.profile_id,
+        )
 
         log.info(
             "review_created",
             review_id=str(review.id),
             profile_id=str(data.profile_id),
-            user_id=str(current_user.id),
+            user_id=str(user_id),
         )
 
-        return ReviewResponse.model_validate(review)
+        response: ReviewResponse = ReviewResponse.model_validate(review)
+        return response
 
     except HTTPException:
         raise
@@ -59,34 +92,36 @@ async def create_review_endpoint(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to create review",
-        )
+        ) from exc
 
 
 @router.get("/{review_id}", response_model=ReviewResponse)
 async def get_review_endpoint(
     review_id: UUID,
-    current_user: User = Depends(get_current_user),
-    db=Depends(get_db),
-):
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> ReviewResponse:
     """
     Get a review by ID.
     Returns 404 if not found or not owned by current user.
     """
     try:
-        review = await get_review(db=db, review_id=review_id, user_id=current_user.id)
+        user_id = UUID(current_user.id)
+        review = await get_review(db=db, review_id=review_id, user_id=user_id)
 
         if not review:
             log.warning(
                 "review_not_found",
                 review_id=str(review_id),
-                user_id=str(current_user.id),
+                user_id=str(user_id),
             )
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail="Review not found",
             )
 
-        return ReviewResponse.model_validate(review)
+        response: ReviewResponse = ReviewResponse.model_validate(review)
+        return response
 
     except HTTPException:
         raise
@@ -95,20 +130,21 @@ async def get_review_endpoint(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to retrieve review",
-        )
+        ) from exc
 
 
 @router.get("", response_model=ReviewListResponse)
 async def list_reviews_endpoint(
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
     page: int = 1,
     page_size: int = 20,
-    current_user: User = Depends(get_current_user),
-    db=Depends(get_db),
-):
+) -> ReviewListResponse:
     """
     List reviews for current user with pagination.
     """
     try:
+        user_id = UUID(current_user.id)
         if page < 1:
             page = 1
         if page_size < 1 or page_size > 100:
@@ -116,7 +152,7 @@ async def list_reviews_endpoint(
 
         reviews, total = await list_reviews(
             db=db,
-            user_id=current_user.id,
+            user_id=user_id,
             page=page,
             page_size=page_size,
         )
@@ -133,27 +169,28 @@ async def list_reviews_endpoint(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to list reviews",
-        )
+        ) from exc
 
 
 @router.get("/{review_id}/status")
 async def get_review_status(
     review_id: UUID,
-    current_user: User = Depends(get_current_user),
-    db=Depends(get_db),
-):
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> dict[str, str | int]:
     """
     Get review status and progress.
     Returns {review_id, status, progress_pct}
     """
     try:
-        review = await get_review(db=db, review_id=review_id, user_id=current_user.id)
+        user_id = UUID(current_user.id)
+        review = await get_review(db=db, review_id=review_id, user_id=user_id)
 
         if not review:
             log.warning(
                 "review_not_found",
                 review_id=str(review_id),
-                user_id=str(current_user.id),
+                user_id=str(user_id),
             )
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
@@ -173,4 +210,4 @@ async def get_review_status(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to retrieve review status",
-        )
+        ) from exc

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -99,7 +99,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -449,7 +448,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -473,7 +471,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1561,7 +1558,6 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1579,7 +1575,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1972,7 +1967,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3507,7 +3501,6 @@
       "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^2.0.1",
         "cssstyle": "^4.0.1",
@@ -4094,7 +4087,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4107,7 +4099,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4771,7 +4762,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/tests/unit/test_review_routes.py
+++ b/tests/unit/test_review_routes.py
@@ -1,0 +1,47 @@
+"""Tests for the review API routes."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import BackgroundTasks, HTTPException, status
+
+from api.routes.reviews import create_review_endpoint
+from api.schemas.review import ReviewCreate
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_create_review_rejects_profile_without_ingested_documents() -> None:
+    """Return a controlled error when a profile has no ingested documents."""
+    profile_id = uuid4()
+    current_user = SimpleNamespace(id=str(uuid4()))
+    profile = SimpleNamespace(id=profile_id, user_id=current_user.id)
+
+    profile_result = Mock()
+    profile_result.scalars.return_value.first.return_value = profile
+    source_result = Mock()
+    source_result.scalars.return_value.first.return_value = None
+
+    db = AsyncMock()
+    db.execute.side_effect = [profile_result, source_result]
+    background_tasks = BackgroundTasks()
+
+    with (
+        patch("api.routes.reviews.create_review", new_callable=AsyncMock) as create_review,
+        patch("api.routes.reviews.process_review", new_callable=AsyncMock),
+        pytest.raises(HTTPException) as exc_info,
+    ):
+        await create_review_endpoint(
+            data=ReviewCreate(profile_id=profile_id),
+            background_tasks=background_tasks,
+            current_user=current_user,
+            db=db,
+        )
+
+    assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
+    assert exc_info.value.detail == "Profile has no ingested documents"
+    create_review.assert_not_awaited()
+    db.commit.assert_not_awaited()
+    assert background_tasks.tasks == []


### PR DESCRIPTION
## Summary
`POST /reviews` previously created a pending review even when the requested profile had no ingested documents. This PR validates the profile and its ingested content before creating a review, returning a controlled error when there is nothing to review.

## Issue
Closes #88 

## Changes
The issue existed because `create_review_endpoint` called `create_review` and scheduled background processing without first confirming that the profile existed, belonged to the authenticated user, or had associated `IngestedSource` records.

- Updated `api/routes/reviews.py`:
  - Added profile existence and ownership validation.
  - Returns `404 Not Found` when the profile is missing or not owned by the authenticated user.
  - Returns `400 Bad Request` with `"Profile has no ingested documents"` when no ingested sources exist.
  - Prevents review creation, database commits, and background-task scheduling when validation fails.
  - Added type annotations and corrected existing Ruff violations in the modified file.
- Added `tests/unit/test_review_routes.py`:
  - Covers an existing profile with no ingested documents.
  - Verifies the `400` status and error message.
  - Verifies that no review is created or committed.
  - Verifies that no background task is scheduled.
-

## Testing
- [x] `.venv/bin/pytest -v tests/unit/test_review_routes.py`
- [x] `.venv/bin/pre-commit run ruff --files api/routes/reviews.py tests/unit/test_review_routes.py`
- [x] `.venv/bin/pre-commit run black --files api/routes/reviews.py tests/unit/test_review_routes.py`
- [ ] `.venv/bin/pre-commit run mypy --files api/routes/reviews.py tests/unit/test_review_routes.py`
- [ ] `make test-unit`

To reproduce the original issue:

1. Start the application and register or authenticate a user.
2. Create a profile with no associated ingested documents.
3. Submit `POST /reviews` with that profile's ID.
4. On the previous implementation, observe that a pending review is created despite there being no content to review.

To verify the fix:

1. Repeat the request using a profile with no associated ingested documents.
2. Confirm that the endpoint returns `400 Bad Request`:

   ```json
   {
     "detail": "Profile has no ingested documents"
   }

## Screenshots / Demo
N/A

## Notes for Reviewers
The focused regression test, Ruff, and Black pass. Mypy remains blocked by six pre-existing missing-annotation errors in core/services/review_service.py, and the full unit suite contains unrelated pre-existing failures.
Please confirm that requiring an existing IngestedSource record is the intended validation rule. The current processing workflow appears to perform ingestion after a review is created, so this validation could reject newly created profiles whose source information has not yet been converted into IngestedSource records.
