### PR TITLE
fix(safety): redact parenthesized US phone numbers

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,40 @@
+# Contribution Journal - PathReview
+
+## Week 7 - Issue Selection & Problem Understanding
+
+### Issue Selected
+
+- **Issue:** [#146 - PII scrubber fails to redact parenthesized US phone numbers](https://github.com/ascherj/pathreview/issues/146)
+- **Tier:** Tier 1, labeled `good first issue`
+- **Labels:** `bug`, `safety`, `tier-1`, `good first issue`
+- **Subsystem:** Safety layer
+- **Primary file:** `safety/pii_scrubber.py`
+- **Test file:** `tests/unit/test_pii_scrubber.py`
+- **Branch name:** `fix/146-pii-parenthesized-phone`
+
+### Problem Summary
+
+PathReview has a safety component called `PIIScrubber` that is supposed to redact personally identifiable information from text. The bug I chose is that the scrubber catches some US phone-number formats, such as `555-123-4567`, but misses the very common parenthesized format `(555) 123-4567`. That means `scrub()` can return text that still contains a phone number, and `detect()` can report no PII even though a phone number is present. A successful fix should make parenthesized US phone numbers redact and detect consistently without breaking already-supported phone formats or causing false positives on unrelated numbers.
+
+### Why This Issue Is a Good Fit
+
+This is a good Tier 1 issue because it is important but tightly scoped. The bug affects privacy/safety behavior, so the outcome matters, but the likely implementation is contained to one regex in `safety/pii_scrubber.py` plus focused tests in `tests/unit/test_pii_scrubber.py`. The issue also has a clear reproduction and objective success criteria: the existing phone tests should pass after the fix.
+
+### Setup Confirmation
+
+- Forked repository: [somtizle/pathreview](https://github.com/somtizle/pathreview)
+- Working branch: `fix/146-pii-parenthesized-phone`
+- Local environment: repository cloned and Python test environment available
+- Setup evidence: the focused PII scrubber tests were run locally and their failing output was committed in `docs/repro-146.txt`
+
+## Week 8 - Reproduction & Solution Planning
+
+**Reproduction commit link:** [14e5fb0 - test: capture failing phone-redaction tests reproducing #146](https://github.com/somtizle/pathreview/commit/14e5fb0ee94ba2621dee5d5ed2c952c8643957d4)
+
+**Reproduction summary:** I reproduced the issue by running the phone-related tests in `tests/unit/test_pii_scrubber.py`. The local run confirms four failures: parenthesized numbers such as `(555) 123-4567` are not redacted by `scrub()`, and `detect()` returns no phone detection for that format.
+
+**PLAN.md link:** [PLAN.md on the working branch](https://github.com/somtizle/pathreview/blob/fix/146-pii-parenthesized-phone/PLAN.md)
+
+**Walkthrough video (recommended):** Not recorded yet. The graded deliverables are the reproduction commit, `PLAN.md`, and this Week 8 journal update.
+
+**Blockers or open questions:** No major blockers. The main implementation risk for Week 9 is widening the US phone regex enough to catch whitespace and parenthesized formats without over-matching SSNs, version numbers, or long digit identifiers.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -53,7 +53,7 @@ This is a good Tier 1 issue because it is important but tightly scoped. The bug 
 
 ### Check-in 2 (end of week)
 
-**PR link:** Pending live PR URL. Open it from this compare page, then replace this line with the created PR link: https://github.com/ascherj/pathreview/compare/main...somtizle:pathreview:fix/146-pii-parenthesized-phone?expand=1
+**PR link:** https://github.com/ascherj/pathreview/pull/442
 
 **Branch:** `fix/146-pii-parenthesized-phone`
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -38,3 +38,29 @@ This is a good Tier 1 issue because it is important but tightly scoped. The bug 
 **Walkthrough video (recommended):** Not recorded yet. The graded deliverables are the reproduction commit, `PLAN.md`, and this Week 8 journal update.
 
 **Blockers or open questions:** No major blockers. The main implementation risk for Week 9 is widening the US phone regex enough to catch whitespace and parenthesized formats without over-matching SSNs, version numbers, or long digit identifiers.
+
+## Week 9 - Solution Building & PR Submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:** I completed the main implementation tasks from `PLAN.md`: I updated the `phone_us` pattern in `safety/pii_scrubber.py` so parenthesized US phone numbers and whitespace-separated US formats are detected, and I kept the pattern bounded so it does not match inside longer word or digit strings. I also updated `tests/unit/test_pii_scrubber.py` to cover the new phone-number formats, full `detect()` values, detection positions, and false-positive guard cases for SSNs, version numbers, and long tracking IDs.
+
+**Next steps:** I need to finish the final self-review, push the implementation branch, open the upstream pull request, and paste the live PR link into Check-in 2. I also need to document the project-wide `make check` and `make test-unit` results honestly because the focused PII scrubber tests pass, but the broader repository currently has unrelated baseline failures outside this fix.
+
+**Blockers:** No code blockers. The only workflow blocker is GitHub authentication/permissions for creating the upstream PR from this environment, so the PR may need to be opened manually from the GitHub compare page.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** Pending live PR URL. Open it from this compare page, then replace this line with the created PR link: https://github.com/ascherj/pathreview/compare/main...somtizle:pathreview:fix/146-pii-parenthesized-phone?expand=1
+
+**Branch:** `fix/146-pii-parenthesized-phone`
+
+**What you built:** I fixed the PII scrubber so common US phone numbers like `(555) 123-4567`, `(555)123-4567`, and `+1 (555) 123-4567` are redacted and detected as `phone_us`. The fix broadens the US phone regex to allow whitespace and balanced parenthesized area codes while preserving boundaries that avoid partial matches inside longer strings.
+
+**Tests added or updated:** I updated `tests/unit/test_pii_scrubber.py`. The tests now cover parenthesized phone-number redaction, no-space parenthesized phone numbers, `+1` plus parenthesized area codes, full detected phone values and positions from `detect()`, and false-positive protection for version numbers, SSNs, and long tracking identifiers.
+
+**Self-review confirmation:** [x] make check passes for changed files; full repo `make check` was run and fails on unrelated pre-existing lint issues outside this PR. [x] make test-unit passes for the changed PII scrubber test file; full repo `make test-unit` was run and fails on unrelated pre-existing unit-test failures outside this PR.
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -64,3 +64,32 @@ This is a good Tier 1 issue because it is important but tightly scoped. The bug 
 **Self-review confirmation:** [x] make check passes for changed files; full repo `make check` was run and fails on unrelated pre-existing lint issues outside this PR. [x] make test-unit passes for the changed PII scrubber test file; full repo `make test-unit` was run and fails on unrelated pre-existing unit-test failures outside this PR.
 
 **Draft PR feedback received from:** none
+
+## Week 10 - Iteration & Reflection
+
+### Reviewer Feedback
+
+**Feedback received:** [ ] Yes  [x] No - still awaiting review
+
+**Summary of feedback:** No reviewer or maintainer feedback had arrived on PR #442 by the time I completed this Week 10 journal entry. I checked the open pull request and it is still awaiting review, which matches the Summer 2026 note that formal reviewer feedback is not part of this version of the module.
+
+**How you responded:** Since no review comments were posted, there was nothing to reply to or revise in response to a reviewer. I left the PR open and ready for review with the filled-out template, testing notes, and manual verification steps so a future reviewer can understand the change.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+I expected the actual code change for issue #146 to be the hard part, but the harder part was proving the regex fix was safe around the edges. Updating `phone_us` in `safety/pii_scrubber.py` to catch `(555) 123-4567` was small, but I had to think carefully about not matching SSNs, version numbers, or long numeric IDs. I also did not expect the existing `street_address` regex to show a false positive in `test_mixed_pii_and_text`, where `Pl` could match inside the word `applications`.
+
+**What did you learn about working in a large codebase?**
+I learned that a small fix can still touch the expectations of a much larger system. `PIIScrubber.scrub()` and `PIIScrubber.detect()` looked simple at first, but they sit in a safety layer where a regex being too narrow leaks PII and a regex being too broad destroys normal user text. I also learned that project-wide commands like `make check` and `make test-unit` may reveal unrelated baseline failures, so it is important to separate "my changed files pass" from "the whole inherited repo is clean."
+
+**How did AI tools help - and where did they fall short?**
+AI tools helped me trace the issue from the failing tests to the exact `phone_us` pattern and helped me turn the Week 8 plan into concrete implementation steps. They were also useful for drafting the PR body, journal entries, and manual verification instructions in a way that matched the rubric. Where AI fell short was that it could not replace actually running the tests: the first focused run exposed the unexpected street-address false positive, and the full repo checks showed many unrelated failures that had to be interpreted rather than blindly "fixed."
+
+**What would you do differently if you started over?**
+If I started over, I would capture a baseline `make check` and `make test-unit` result before making any Week 9 code changes, not just the focused reproduction file. That would make the distinction between pre-existing failures and my PR's behavior even cleaner in the PR description. I would also make the PR description draft before clicking "Create pull request" so I would not accidentally publish the empty GitHub template first and have to edit it afterward.
+
+**What are you most proud of from this module?**
+I am most proud that the final PR is not just a one-line regex change; it includes a reproduction record, a plan, a focused implementation, and tests that explain the intended boundary. The test updates in `tests/unit/test_pii_scrubber.py` cover the actual bug format, adjacent valid formats like `+1 (555) 123-4567`, and false-positive cases like SSNs and long tracking IDs. That made the contribution feel like a real safety fix rather than just making one failing assertion turn green.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,24 +1,38 @@
-# Contribution Journal - PathReview
+## Week 7 - Issue Selection
 
-## Week 7 - Issue Selection & Problem Understanding
+**Issue link:** https://github.com/ascherj/pathreview/issues/146
 
-### Issue Selected
+**Issue title:** PII scrubber fails to redact parenthesized US phone numbers
 
-- **Issue:** [#146 - PII scrubber fails to redact parenthesized US phone numbers](https://github.com/ascherj/pathreview/issues/146)
-- **Tier:** Tier 1, labeled `good first issue`
-- **Labels:** `bug`, `safety`, `tier-1`, `good first issue`
-- **Subsystem:** Safety layer
-- **Primary file:** `safety/pii_scrubber.py`
-- **Test file:** `tests/unit/test_pii_scrubber.py`
-- **Branch name:** `fix/146-pii-parenthesized-phone`
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
 
-### Problem Summary
+**Labels:** `bug`, `safety`, `tier-1`, `good first issue`
 
-PathReview has a safety component called `PIIScrubber` that is supposed to redact personally identifiable information from text. The bug I chose is that the scrubber catches some US phone-number formats, such as `555-123-4567`, but misses the very common parenthesized format `(555) 123-4567`. That means `scrub()` can return text that still contains a phone number, and `detect()` can report no PII even though a phone number is present. A successful fix should make parenthesized US phone numbers redact and detect consistently without breaking already-supported phone formats or causing false positives on unrelated numbers.
+**Subsystem:** Safety layer
+
+**Primary file:** `safety/pii_scrubber.py`
+
+**Test file:** `tests/unit/test_pii_scrubber.py`
+
+**Problem summary:**
+PathReview has a safety component called `PIIScrubber` that is supposed to redact personally identifiable information from text before the text moves through the rest of the app. The bug I chose is that the scrubber catches some US phone-number formats, such as `555-123-4567`, but misses the very common parenthesized format `(555) 123-4567`. The broken behavior is that `scrub()` can return text that still contains a phone number, and `detect()` can report no PII even though a valid phone number is present. A successful fix should make parenthesized US phone numbers redact and detect consistently while preserving already-supported formats and avoiding false positives on unrelated numbers.
+
+**Branch name:** `fix/146-pii-parenthesized-phone`
+
+**Setup confirmation:** [x] App/repo environment set up locally and Python tests runnable. The focused PII scrubber test command was run locally, and the failing reproduction output was committed in `docs/repro-146.txt`.
+
+**Cohort ledger:** [x] Issue selected for my Module 3 PathReview work; if the course ledger requires manual entry, this is the issue/branch to record.
 
 ### Why This Issue Is a Good Fit
 
-This is a good Tier 1 issue because it is important but tightly scoped. The bug affects privacy/safety behavior, so the outcome matters, but the likely implementation is contained to one regex in `safety/pii_scrubber.py` plus focused tests in `tests/unit/test_pii_scrubber.py`. The issue also has a clear reproduction and objective success criteria: the existing phone tests should pass after the fix.
+I chose a Tier 1 issue because this was my first contribution cycle in the PathReview codebase, so I wanted an issue with a small code surface and a clear way to verify success. This issue is important but tightly scoped: it affects privacy/safety behavior, but the likely implementation is contained to one regex in `safety/pii_scrubber.py` plus focused tests in `tests/unit/test_pii_scrubber.py`. It also has a clear reproduction and objective success criteria, because the existing phone tests show the parenthesized-number failure and should pass after the fix.
+
+### Issue Fit Checklist
+
+- **Scoped enough for a first contribution:** Yes. The code target is the `phone_us` regex in `PIIScrubber.PII_PATTERNS`, not a cross-system feature.
+- **Understandable behavior:** Yes. The current behavior misses `(555) 123-4567`; the correct behavior is to redact and detect that full phone number.
+- **Testable definition of done:** Yes. The focused tests in `tests/unit/test_pii_scrubber.py` provide a direct way to prove the bug exists and later prove it is fixed.
+- **Main risk identified:** Yes. The fix must not make the regex so broad that it starts matching SSNs, version numbers, or long numeric identifiers.
 
 ### Setup Confirmation
 
@@ -26,7 +40,7 @@ This is a good Tier 1 issue because it is important but tightly scoped. The bug 
 - Working branch: `fix/146-pii-parenthesized-phone`
 - Local environment: repository cloned and Python test environment available
 - Setup evidence: the focused PII scrubber tests were run locally and their failing output was committed in `docs/repro-146.txt`
-
+- Student-authored setup/progress commits are visible on this branch, including `14e5fb0` for the failing reproduction and later journal/planning commits.
 ## Week 8 - Reproduction & Solution Planning
 
 **Reproduction commit link:** [14e5fb0 - test: capture failing phone-redaction tests reproducing #146](https://github.com/somtizle/pathreview/commit/14e5fb0ee94ba2621dee5d5ed2c952c8643957d4)

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,97 @@
+# Solution Plan
+
+**Issue:** [#146 - PII scrubber fails to redact parenthesized US phone numbers](https://github.com/ascherj/pathreview/issues/146)
+
+**Working branch:** `fix/146-pii-parenthesized-phone`
+
+## Understand
+
+PathReview's safety layer uses `PIIScrubber` to remove personally identifiable information from text before that text is stored, reviewed, or sent through other parts of the system. The specific bug I am fixing is that US phone numbers written in the common parenthesized format, such as `(555) 123-4567`, are not redacted by `scrub()` and are not returned by `detect()`.
+
+The expected behavior is that `(555) 123-4567` should be treated the same way as `555-123-4567`, `555.123.4567`, and `+1 555 123 4567`: the full phone number should be replaced with `[REDACTED]` by `scrub()`, and `detect()` should return a `phone_us` entry with the matched value and character positions.
+
+The actual behavior is confirmed in `docs/repro-146.txt`: four phone-related unit tests currently fail. The failure happens because the current `phone_us` regex in `safety/pii_scrubber.py` only allows hyphens, dots, or no separator between the area code and prefix. It does not allow the space after the closing parenthesis in `(555) 123-4567`. A second issue is the leading `\b` word boundary, which cannot match immediately before `(` when the phone number starts at the beginning of the input.
+
+## Map
+
+The fix is intentionally small and should stay inside the PII scrubbing safety layer.
+
+Likely files involved:
+
+- `safety/pii_scrubber.py`: contains `PIIScrubber.PII_PATTERNS`, including the `phone_us` regex that needs to change.
+- `tests/unit/test_pii_scrubber.py`: contains the failing tests that define the expected behavior for phone redaction and detection.
+- `docs/repro-146.txt`: records the local reproduction output showing the issue exists on this branch before the fix.
+
+Likely functions and data involved:
+
+- `PIIScrubber.scrub(text: str) -> str`: takes raw text and returns text with PII replaced by `[REDACTED]`.
+- `PIIScrubber.detect(text: str) -> list[dict]`: takes raw text and returns structured detections with `type`, `value`, `start`, and `end`.
+- `PIIScrubber.PII_PATTERNS["phone_us"]`: the regex pattern used by both `scrub()` and `detect()` for US phone numbers.
+
+I do not expect to touch the API layer, database layer, frontend, or the international phone regex.
+
+## Plan
+
+1. Re-run the focused phone tests from `tests/unit/test_pii_scrubber.py` to confirm the four failures in `docs/repro-146.txt` still reproduce locally.
+2. Update only the `phone_us` pattern in `safety/pii_scrubber.py` so it accepts whitespace separators as well as hyphen and dot separators.
+3. Adjust the leading boundary of the `phone_us` pattern so numbers that start with `(` can match, while preserving a trailing boundary after the final four digits.
+4. Add focused regression tests in `tests/unit/test_pii_scrubber.py` for parenthesized formats that are easy to break later, including `(555) 123-4567` at the start of text and `(555)123-4567` without a space.
+5. Run the focused PII scrubber test file, then run the broader unit/check commands required by the project to make sure the widened regex does not break existing PII behavior.
+6. Commit the implementation separately in Week 9 using a conventional commit message such as `fix(safety): redact parenthesized US phone numbers`.
+
+## Inputs & Outputs
+
+The fix input is a string passed to `PIIScrubber.scrub()` or `PIIScrubber.detect()`. No public function signature should change.
+
+Inputs that should be handled after the fix:
+
+- `"Call me at (555) 123-4567"`
+- `"(555) 123-4567 is my phone number."`
+- `"Contact: (555)123-4567"`
+- `"Contact: +1 555 123 4567"`
+- `"Contact: 555-123-4567"`
+- `"Contact: 555.123.4567"`
+
+Expected `scrub()` output behavior:
+
+- The complete phone number is replaced with `[REDACTED]`.
+- Non-PII text around the phone number is preserved.
+- Existing email, SSN, street address, and international phone behavior remains unchanged.
+
+Expected `detect()` output behavior:
+
+- A parenthesized US phone number returns at least one detection.
+- The detection has `type == "phone_us"`.
+- The detection's `value` is the full matched phone string, not just a partial group.
+- The detection's `start` and `end` positions point to the phone number inside the original text.
+
+## Risks & Unknowns
+
+- **Risk in `safety/pii_scrubber.py`: over-matching longer digit strings.** If the leading boundary is relaxed too much, the regex could match inside unrelated numeric text. I will keep a trailing word boundary after the final four digits and add/verify tests for longer numeric runs.
+- **Risk in `safety/pii_scrubber.py`: false positives with SSNs.** `phone_us` runs before `ssn` because both patterns live in the same ordered `PII_PATTERNS` dictionary. The phone pattern must keep a strict `3-3-4` shape so it does not consume SSNs like `123-45-6789`, which are `3-2-4`.
+- **Risk in `tests/unit/test_pii_scrubber.py`: tests may be too permissive.** Some existing assertions only check whether `[REDACTED]` appears. I will add focused tests that also assert the original phone number is gone and detection returns the full value.
+- **Unknown in `phone_intl`: overlap with `+1` formats.** The `phone_intl` pattern is separate and should remain untouched. I will verify existing international-phone tests still pass after changing only `phone_us`.
+- **Unknown in project-wide checks:** the regex change is small, but `make check` may reveal formatting or type issues unrelated to this file. If unrelated existing failures appear, I will document them separately rather than mixing them into this fix.
+
+## Edge Cases
+
+The fix must handle these concrete cases gracefully:
+
+- Parenthesized number in the middle of text: `"Call me at (555) 123-4567 after 5."`
+- Parenthesized number at the very start of text: `"(555) 123-4567 is my number."`
+- Parenthesized number with no space after the area code: `"Use (555)123-4567 instead."`
+- Space-separated country-code format: `"Use +1 555 123 4567 for the US office."`
+- Already-supported dashed format: `"Use 555-123-4567."`
+- Already-supported dotted format: `"Use 555.123.4567."`
+- SSN-shaped input that must not become a phone match: `"SSN: 123-45-6789."`
+- Version-number text that must not be detected as PII: `"The project uses version 1.2.3."`
+- Long digit runs that should not be partially redacted as a phone number: `"Tracking id 5551234567890 was generated."`
+
+## Definition of Done
+
+The plan will be ready for Week 9 implementation when:
+
+- The local reproduction is committed in `docs/repro-146.txt`.
+- This `PLAN.md` is committed on `fix/146-pii-parenthesized-phone`.
+- `JOURNAL.md` links both the reproduction commit and this plan.
+- The planned fix is limited to `safety/pii_scrubber.py` plus focused tests in `tests/unit/test_pii_scrubber.py`.

--- a/docs/repro-146.txt
+++ b/docs/repro-146.txt
@@ -1,0 +1,92 @@
+============================= test session starts ==============================
+platform darwin -- Python 3.14.3, pytest-9.1.1, pluggy-1.6.0 -- /Users/somtee/Documents/pathreview/.venv/bin/python
+cachedir: .pytest_cache
+benchmark: 5.2.3 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
+hypothesis profile 'default'
+rootdir: /Users/somtee/Documents/pathreview
+configfile: pyproject.toml
+plugins: benchmark-5.2.3, cov-7.1.0, asyncio-1.4.0, hypothesis-6.158.1, anyio-4.14.2, pytest_httpserver-1.1.5
+asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
+collecting ... collected 25 items / 19 deselected / 6 selected
+
+tests/unit/test_pii_scrubber.py::TestPIIScrubber::test_us_phone_number_redaction FAILED [ 16%]
+tests/unit/test_pii_scrubber.py::TestPIIScrubber::test_us_phone_formats FAILED [ 33%]
+tests/unit/test_pii_scrubber.py::TestPIIScrubber::test_international_phone_redaction PASSED [ 50%]
+tests/unit/test_pii_scrubber.py::TestPIIScrubber::test_detect_phone_pii FAILED [ 66%]
+tests/unit/test_pii_scrubber.py::TestPIIScrubber::test_phone_at_start_of_text FAILED [ 83%]
+tests/unit/test_pii_scrubber.py::TestPIIScrubber::test_phone_at_end_of_text PASSED [100%]
+
+=================================== FAILURES ===================================
+________________ TestPIIScrubber.test_us_phone_number_redaction ________________
+
+self = <tests.unit.test_pii_scrubber.TestPIIScrubber object at 0x105f542b0>
+scrubber = <safety.pii_scrubber.PIIScrubber object at 0x105eb3380>
+
+    def test_us_phone_number_redaction(self, scrubber):
+        """Test US phone number is redacted."""
+        text = "Call me at (555) 123-4567"
+        scrubbed = scrubber.scrub(text)
+    
+>       assert "[REDACTED]" in scrubbed
+E       AssertionError: assert '[REDACTED]' in 'Call me at (555) 123-4567'
+
+tests/unit/test_pii_scrubber.py:39: AssertionError
+____________________ TestPIIScrubber.test_us_phone_formats _____________________
+
+self = <tests.unit.test_pii_scrubber.TestPIIScrubber object at 0x105f54770>
+scrubber = <safety.pii_scrubber.PIIScrubber object at 0x105f0e5d0>
+
+    def test_us_phone_formats(self, scrubber):
+        """Test various US phone number formats."""
+        formats = [
+            "555-123-4567",
+            "(555) 123-4567",
+            "555.123.4567",
+            "+1 555 123 4567",
+        ]
+    
+        for phone in formats:
+            text = f"Contact: {phone}"
+            scrubbed = scrubber.scrub(text)
+>           assert "[REDACTED]" in scrubbed
+E           AssertionError: assert '[REDACTED]' in 'Contact: (555) 123-4567'
+
+tests/unit/test_pii_scrubber.py:54: AssertionError
+____________________ TestPIIScrubber.test_detect_phone_pii _____________________
+
+self = <tests.unit.test_pii_scrubber.TestPIIScrubber object at 0x105f61fd0>
+scrubber = <safety.pii_scrubber.PIIScrubber object at 0x105f54c30>
+
+    def test_detect_phone_pii(self, scrubber):
+        """Test detect() finds phone number PII."""
+        text = "Phone: (555) 123-4567"
+        detected = scrubber.detect(text)
+    
+        phone_detections = [d for d in detected if "phone" in d["type"]]
+>       assert len(phone_detections) > 0
+E       assert 0 > 0
+E        +  where 0 = len([])
+
+tests/unit/test_pii_scrubber.py:128: AssertionError
+----------------------------- Captured stdout call -----------------------------
+2026-07-22 01:14:23 [info     ] pii_detected                   count=0 types=0
+_________________ TestPIIScrubber.test_phone_at_start_of_text __________________
+
+self = <tests.unit.test_pii_scrubber.TestPIIScrubber object at 0x105f843c0>
+scrubber = <safety.pii_scrubber.PIIScrubber object at 0x105f55940>
+
+    def test_phone_at_start_of_text(self, scrubber):
+        """Test phone number at start of text."""
+        text = "(555) 123-4567 is my phone number."
+        scrubbed = scrubber.scrub(text)
+    
+>       assert "[REDACTED]" in scrubbed
+E       AssertionError: assert '[REDACTED]' in '(555) 123-4567 is my phone number.'
+
+tests/unit/test_pii_scrubber.py:184: AssertionError
+=========================== short test summary info ============================
+FAILED tests/unit/test_pii_scrubber.py::TestPIIScrubber::test_us_phone_number_redaction
+FAILED tests/unit/test_pii_scrubber.py::TestPIIScrubber::test_us_phone_formats
+FAILED tests/unit/test_pii_scrubber.py::TestPIIScrubber::test_detect_phone_pii
+FAILED tests/unit/test_pii_scrubber.py::TestPIIScrubber::test_phone_at_start_of_text
+================== 4 failed, 2 passed, 19 deselected in 0.15s ==================

--- a/docs/week9-pr-description.md
+++ b/docs/week9-pr-description.md
@@ -1,0 +1,51 @@
+# PR Description Draft
+
+Use this title:
+
+```text
+fix(safety): redact parenthesized US phone numbers
+```
+
+Use this body:
+
+```markdown
+## Summary
+This PR fixes the PII scrubber so common parenthesized US phone numbers like `(555) 123-4567` are redacted and detected the same way as existing dashed, dotted, and `+1` formats. The root cause was that the `phone_us` regex only allowed `-`, `.`, or no separator between phone-number groups, so it could not consume the space after a closing parenthesis. The updated pattern allows whitespace separators, supports balanced parenthesized area codes, and avoids matching inside longer word/digit runs.
+
+## Issue
+Closes #146
+
+## Changes
+- Updated `PIIScrubber.PII_PATTERNS["phone_us"]` in `safety/pii_scrubber.py` to match parenthesized US numbers, whitespace-separated numbers, dashed numbers, dotted numbers, and `+1` US formats.
+- Preserved safeguards against partial matches inside longer tokens by using leading/trailing word-character lookarounds.
+- Tightened the `street_address` suffix boundary so street abbreviations like `Pl` do not match inside unrelated words such as `applications`; this was exposed by the existing mixed-PII unit test after the phone test file became fully green.
+- Expanded `tests/unit/test_pii_scrubber.py` to cover `(555)123-4567`, `+1 (555) 123-4567`, full-value phone detection, detection positions, and false-positive guards for version numbers, SSNs, and long numeric identifiers.
+- Added type annotations to the touched PII scrubber test file so the repo's pre-commit Mypy hook passes on staged changes.
+
+## Testing
+- [x] Focused unit tests pass: `.venv/bin/python -m pytest tests/unit/test_pii_scrubber.py -v` -> `25 passed`.
+- [x] Linter passes for changed files: `.venv/bin/ruff check safety/pii_scrubber.py tests/unit/test_pii_scrubber.py`.
+- [x] Formatter passes for changed files: `.venv/bin/black --check safety/pii_scrubber.py tests/unit/test_pii_scrubber.py`.
+- [x] Pre-commit hooks pass on the committed files: Ruff, Black, and Mypy all passed during `fix(safety): redact parenthesized US phone numbers`.
+- [ ] Full `make check` was run, but the repository currently reports 181 unrelated Ruff issues across pre-existing files such as `agent/`, `api/`, `rag/`, and unrelated tests before typecheck runs.
+- [ ] Full `make test-unit` was run, but the repository currently has unrelated baseline failures outside this change: the PII scrubber tests pass, while other suites such as `test_bias_detector.py`, `test_review_service.py`, `test_skill_extractor.py`, and chunker tests fail independently.
+
+Manual verification steps for reviewers:
+1. Check out this branch: `git checkout fix/146-pii-parenthesized-phone`.
+2. Run `python -m pytest tests/unit/test_pii_scrubber.py -v`.
+3. Confirm all 25 PII scrubber tests pass.
+4. In a Python shell, run:
+   ```python
+   from safety.pii_scrubber import PIIScrubber
+   scrubber = PIIScrubber()
+   print(scrubber.scrub("Call me at (555) 123-4567 or 555-123-4567"))
+   print(scrubber.detect("Phone: (555) 123-4567"))
+   ```
+5. Confirm both phone numbers are replaced with `[REDACTED]`, and `detect()` returns a `phone_us` entry whose value is `(555) 123-4567`.
+
+## Screenshots / Demo
+Not applicable; this is a backend safety-layer regex and unit-test change.
+
+## Notes for Reviewers
+Please focus review on the US phone-number regex boundaries in `safety/pii_scrubber.py`, especially whether the pattern is broad enough for common US formats without becoming too permissive. I also included a small street-address boundary tightening because the existing mixed PII test showed the address regex could consume ordinary text ending in a word that starts with a street abbreviation (`Pl` inside `applications`).
+```

--- a/safety/pii_scrubber.py
+++ b/safety/pii_scrubber.py
@@ -1,6 +1,7 @@
 """PII detection and scrubbing."""
 
 import re
+
 import structlog
 
 logger = structlog.get_logger()
@@ -12,10 +13,18 @@ class PIIScrubber:
     # Regex patterns for common PII
     PII_PATTERNS = {
         "email": r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b",
-        "phone_us": r"\b(?:\+?1[-.]?)?\(?([0-9]{3})\)?[-.]?([0-9]{3})[-.]?([0-9]{4})\b",
+        "phone_us": (
+            r"(?<!\w)(?:\+?1[-.\s]?)?" r"(?:\(\d{3}\)|\d{3})[-.\s]?\d{3}[-.\s]?\d{4}(?!\w)"
+        ),
         "phone_intl": r"\+[0-9]{1,3}[-.]?[0-9]{1,14}",
         "ssn": r"\b(?!000|666)[0-9]{3}-(?!00)[0-9]{2}-(?!0000)[0-9]{4}\b",
-        "street_address": r"\b\d+\s+[A-Za-z\s]+(?:Street|St|Avenue|Ave|Road|Rd|Boulevard|Blvd|Drive|Dr|Lane|Ln|Court|Ct|Circle|Cir|Park|Pl|Plaza|Place|Drive|Dr|Way|Parkway|Pkwy|Point|Pt|Pike|Run|Summit|Summit|Terrace|Ter|Trail|Trl|Tunnel|Turnpike|View|Vista|Vlg|Village|Vly|Valley)",
+        "street_address": (
+            r"\b\d+\s+[A-Za-z\s]+(?:Street|St|Avenue|Ave|Road|Rd|Boulevard|"
+            r"Blvd|Drive|Dr|Lane|Ln|Court|Ct|Circle|Cir|Park|Pl|Plaza|Place|"
+            r"Drive|Dr|Way|Parkway|Pkwy|Point|Pt|Pike|Run|Summit|Summit|"
+            r"Terrace|Ter|Trail|Trl|Tunnel|Turnpike|View|Vista|Vlg|Village|"
+            r"Vly|Valley)\b"
+        ),
     }
 
     def scrub(self, text: str) -> str:
@@ -29,7 +38,7 @@ class PIIScrubber:
         """
         scrubbed = text
 
-        for pii_type, pattern in self.PII_PATTERNS.items():
+        for _pii_type, pattern in self.PII_PATTERNS.items():
             scrubbed = re.sub(pattern, "[REDACTED]", scrubbed, flags=re.IGNORECASE)
 
         return scrubbed
@@ -47,13 +56,19 @@ class PIIScrubber:
 
         for pii_type, pattern in self.PII_PATTERNS.items():
             for match in re.finditer(pattern, text, flags=re.IGNORECASE):
-                detected.append({
-                    "type": pii_type,
-                    "value": match.group(),
-                    "start": match.start(),
-                    "end": match.end()
-                })
+                detected.append(
+                    {
+                        "type": pii_type,
+                        "value": match.group(),
+                        "start": match.start(),
+                        "end": match.end(),
+                    }
+                )
 
-        logger.info("pii_detected", count=len(detected), types=len(set(d["type"] for d in detected)))
+        logger.info(
+            "pii_detected",
+            count=len(detected),
+            types=len(set(d["type"] for d in detected)),
+        )
 
         return detected

--- a/tests/unit/test_pii_scrubber.py
+++ b/tests/unit/test_pii_scrubber.py
@@ -10,11 +10,11 @@ class TestPIIScrubber:
     """Test suite for PIIScrubber."""
 
     @pytest.fixture
-    def scrubber(self):
+    def scrubber(self) -> PIIScrubber:
         """Create a PIIScrubber instance."""
         return PIIScrubber()
 
-    def test_email_redaction(self, scrubber):
+    def test_email_redaction(self, scrubber: PIIScrubber) -> None:
         """Test email address is redacted."""
         text = "Contact me at john.doe@example.com for more info."
         scrubbed = scrubber.scrub(text)
@@ -22,7 +22,7 @@ class TestPIIScrubber:
         assert "[REDACTED]" in scrubbed
         assert "john.doe@example.com" not in scrubbed
 
-    def test_multiple_emails_redacted(self, scrubber):
+    def test_multiple_emails_redacted(self, scrubber: PIIScrubber) -> None:
         """Test multiple email addresses are redacted."""
         text = "Email alice@example.com or bob@company.org"
         scrubbed = scrubber.scrub(text)
@@ -31,7 +31,7 @@ class TestPIIScrubber:
         assert "alice@example.com" not in scrubbed
         assert "bob@company.org" not in scrubbed
 
-    def test_us_phone_number_redaction(self, scrubber):
+    def test_us_phone_number_redaction(self, scrubber: PIIScrubber) -> None:
         """Test US phone number is redacted."""
         text = "Call me at (555) 123-4567"
         scrubbed = scrubber.scrub(text)
@@ -39,28 +39,31 @@ class TestPIIScrubber:
         assert "[REDACTED]" in scrubbed
         assert "555" not in scrubbed or "1234567" not in scrubbed
 
-    def test_us_phone_formats(self, scrubber):
+    def test_us_phone_formats(self, scrubber: PIIScrubber) -> None:
         """Test various US phone number formats."""
         formats = [
             "555-123-4567",
             "(555) 123-4567",
             "555.123.4567",
             "+1 555 123 4567",
+            "(555)123-4567",
+            "+1 (555) 123-4567",
         ]
 
         for phone in formats:
             text = f"Contact: {phone}"
             scrubbed = scrubber.scrub(text)
             assert "[REDACTED]" in scrubbed
+            assert phone not in scrubbed
 
-    def test_international_phone_redaction(self, scrubber):
+    def test_international_phone_redaction(self, scrubber: PIIScrubber) -> None:
         """Test international phone number is redacted."""
         text = "Reach me at +44 20 7946 0958"
         scrubbed = scrubber.scrub(text)
 
         assert "[REDACTED]" in scrubbed or "20" not in scrubbed
 
-    def test_ssn_redaction(self, scrubber):
+    def test_ssn_redaction(self, scrubber: PIIScrubber) -> None:
         """Test SSN is redacted."""
         text = "SSN: 123-45-6789"
         scrubbed = scrubber.scrub(text)
@@ -68,7 +71,7 @@ class TestPIIScrubber:
         assert "[REDACTED]" in scrubbed
         assert "123-45-6789" not in scrubbed
 
-    def test_ssn_variations(self, scrubber):
+    def test_ssn_variations(self, scrubber: PIIScrubber) -> None:
         """Test various SSN formats are handled."""
         ssns = [
             "123-45-6789",
@@ -81,14 +84,14 @@ class TestPIIScrubber:
             # Should be redacted or modified
             assert ssn not in scrubbed
 
-    def test_street_address_redaction(self, scrubber):
+    def test_street_address_redaction(self, scrubber: PIIScrubber) -> None:
         """Test street address is redacted."""
         text = "Address: 123 Main Street, Apt 4"
         scrubbed = scrubber.scrub(text)
 
         assert "[REDACTED]" in scrubbed or "123" not in scrubbed
 
-    def test_text_with_no_pii(self, scrubber):
+    def test_text_with_no_pii(self, scrubber: PIIScrubber) -> None:
         """Test text with no PII is returned unchanged."""
         text = "This is a normal paragraph with no personally identifiable information."
         scrubbed = scrubber.scrub(text)
@@ -96,7 +99,7 @@ class TestPIIScrubber:
         assert scrubbed == text
         assert "[REDACTED]" not in scrubbed
 
-    def test_detect_returns_list_of_pii(self, scrubber):
+    def test_detect_returns_list_of_pii(self, scrubber: PIIScrubber) -> None:
         """Test detect() returns list with type, value, start, end."""
         text = "Email: john@example.com and call 555-123-4567"
         detected = scrubber.detect(text)
@@ -109,7 +112,7 @@ class TestPIIScrubber:
             assert "start" in item
             assert "end" in item
 
-    def test_detect_email_pii(self, scrubber):
+    def test_detect_email_pii(self, scrubber: PIIScrubber) -> None:
         """Test detect() finds email PII."""
         text = "Contact: alice@example.com"
         detected = scrubber.detect(text)
@@ -119,15 +122,18 @@ class TestPIIScrubber:
         assert len(email_detections) > 0
         assert "alice@example.com" in email_detections[0]["value"]
 
-    def test_detect_phone_pii(self, scrubber):
+    def test_detect_phone_pii(self, scrubber: PIIScrubber) -> None:
         """Test detect() finds phone number PII."""
         text = "Phone: (555) 123-4567"
         detected = scrubber.detect(text)
 
         phone_detections = [d for d in detected if "phone" in d["type"]]
         assert len(phone_detections) > 0
+        assert phone_detections[0]["type"] == "phone_us"
+        assert phone_detections[0]["value"] == "(555) 123-4567"
+        assert text[phone_detections[0]["start"] : phone_detections[0]["end"]] == "(555) 123-4567"
 
-    def test_detect_ssn_pii(self, scrubber):
+    def test_detect_ssn_pii(self, scrubber: PIIScrubber) -> None:
         """Test detect() finds SSN PII."""
         text = "SSN: 123-45-6789"
         detected = scrubber.detect(text)
@@ -135,7 +141,7 @@ class TestPIIScrubber:
         ssn_detections = [d for d in detected if d["type"] == "ssn"]
         assert len(ssn_detections) > 0
 
-    def test_detect_positions_accurate(self, scrubber):
+    def test_detect_positions_accurate(self, scrubber: PIIScrubber) -> None:
         """Test that detected positions are accurate."""
         text = "Email is john@example.com here."
         detected = scrubber.detect(text)
@@ -147,7 +153,7 @@ class TestPIIScrubber:
                 extracted = text[start:end]
                 assert "john@example.com" in extracted
 
-    def test_detect_multiple_pii_items(self, scrubber):
+    def test_detect_multiple_pii_items(self, scrubber: PIIScrubber) -> None:
         """Test detecting multiple PII items."""
         text = "John: 555-123-4567, jane@example.com, SSN: 987-65-4321"
         detected = scrubber.detect(text)
@@ -155,7 +161,7 @@ class TestPIIScrubber:
         # Should find multiple items
         assert len(detected) >= 2
 
-    def test_case_insensitive_email_matching(self, scrubber):
+    def test_case_insensitive_email_matching(self, scrubber: PIIScrubber) -> None:
         """Test email matching is case insensitive."""
         text = "Contact John.Doe@Example.COM"
         scrubbed = scrubber.scrub(text)
@@ -163,7 +169,7 @@ class TestPIIScrubber:
         # Email should be redacted despite case differences
         assert "[REDACTED]" in scrubbed
 
-    def test_complex_email_addresses(self, scrubber):
+    def test_complex_email_addresses(self, scrubber: PIIScrubber) -> None:
         """Test complex email address formats."""
         emails = [
             "user+tag@example.com",
@@ -176,21 +182,21 @@ class TestPIIScrubber:
             scrubbed = scrubber.scrub(text)
             assert email not in scrubbed or "[REDACTED]" in scrubbed
 
-    def test_phone_at_start_of_text(self, scrubber):
+    def test_phone_at_start_of_text(self, scrubber: PIIScrubber) -> None:
         """Test phone number at start of text."""
         text = "(555) 123-4567 is my phone number."
         scrubbed = scrubber.scrub(text)
 
         assert "[REDACTED]" in scrubbed
 
-    def test_phone_at_end_of_text(self, scrubber):
+    def test_phone_at_end_of_text(self, scrubber: PIIScrubber) -> None:
         """Test phone number at end of text."""
         text = "My phone is 555-123-4567"
         scrubbed = scrubber.scrub(text)
 
         assert "[REDACTED]" in scrubbed
 
-    def test_address_variations(self, scrubber):
+    def test_address_variations(self, scrubber: PIIScrubber) -> None:
         """Test various street address formats."""
         addresses = [
             "123 Main Street",
@@ -201,9 +207,9 @@ class TestPIIScrubber:
         for addr in addresses:
             text = f"Address: {addr}"
             scrubbed = scrubber.scrub(text)
-            # Should attempt to redact addresses
+            assert "[REDACTED]" in scrubbed or addr not in scrubbed
 
-    def test_empty_text(self, scrubber):
+    def test_empty_text(self, scrubber: PIIScrubber) -> None:
         """Test with empty text."""
         text = ""
         scrubbed = scrubber.scrub(text)
@@ -212,13 +218,13 @@ class TestPIIScrubber:
         detected = scrubber.detect(text)
         assert detected == []
 
-    def test_whitespace_only(self, scrubber):
+    def test_whitespace_only(self, scrubber: PIIScrubber) -> None:
         """Test with whitespace only."""
         text = "   \n\t  "
         scrubbed = scrubber.scrub(text)
         assert scrubbed == text
 
-    def test_mixed_pii_and_text(self, scrubber):
+    def test_mixed_pii_and_text(self, scrubber: PIIScrubber) -> None:
         """Test text with mix of PII and regular content."""
         text = """
         Professional Background:
@@ -237,7 +243,7 @@ class TestPIIScrubber:
         assert "john.smith@company.com" not in scrubbed
         assert "555-123-4567" not in scrubbed
 
-    def test_scrub_idempotent(self, scrubber):
+    def test_scrub_idempotent(self, scrubber: PIIScrubber) -> None:
         """Test that scrubbing twice produces same result."""
         text = "Email: test@example.com"
         scrubbed_once = scrubber.scrub(text)
@@ -245,10 +251,13 @@ class TestPIIScrubber:
 
         assert scrubbed_once == scrubbed_twice
 
-    def test_detect_no_false_positives(self, scrubber):
+    def test_detect_no_false_positives(self, scrubber: PIIScrubber) -> None:
         """Test that detect doesn't flag legitimate text as PII."""
-        text = "The project uses version 1.2.3. It's available at https://example.com"
+        text = (
+            "The project uses version 1.2.3, tracking id 5551234567890, "
+            "and the sample SSN 123-45-6789."
+        )
         detected = scrubber.detect(text)
 
-        # Should be minimal or no detections
-        # (version number shouldn't be flagged as SSN)
+        phone_detections = [d for d in detected if d["type"] == "phone_us"]
+        assert phone_detections == []


### PR DESCRIPTION
## Summary
This PR fixes the PII scrubber so common parenthesized US phone numbers like `(555) 123-4567` are redacted and detected the same way as existing dashed, dotted, and `+1` formats. The root cause was that the `phone_us` regex only allowed `-`, `.`, or no separator between phone-number groups, so it could not consume the space after a closing parenthesis. The updated pattern allows whitespace separators, supports balanced parenthesized area codes, and avoids matching inside longer word/digit runs.

## Issue
Closes #146

## Changes
- Updated `PIIScrubber.PII_PATTERNS["phone_us"]` in `safety/pii_scrubber.py` to match parenthesized US numbers, whitespace-separated numbers, dashed numbers, dotted numbers, and `+1` US formats.
- Preserved safeguards against partial matches inside longer tokens by using leading/trailing word-character lookarounds.
- Tightened the `street_address` suffix boundary so street abbreviations like `Pl` do not match inside unrelated words such as `applications`; this was exposed by the existing mixed-PII unit test after the phone test file became fully green.
- Expanded `tests/unit/test_pii_scrubber.py` to cover `(555)123-4567`, `+1 (555) 123-4567`, full-value phone detection, detection positions, and false-positive guards for version numbers, SSNs, and long numeric identifiers.
- Added type annotations to the touched PII scrubber test file so the repo's pre-commit Mypy hook passes on staged changes.

## Testing
- [x] Focused unit tests pass: `.venv/bin/python -m pytest tests/unit/test_pii_scrubber.py -v` -> `25 passed`.
- [x] Linter passes for changed files: `.venv/bin/ruff check safety/pii_scrubber.py tests/unit/test_pii_scrubber.py`.
- [x] Formatter passes for changed files: `.venv/bin/black --check safety/pii_scrubber.py tests/unit/test_pii_scrubber.py`.
- [x] Pre-commit hooks pass on the committed files: Ruff, Black, and Mypy all passed during `fix(safety): redact parenthesized US phone numbers`.
- [ ] Full `make check` was run, but the repository currently reports 181 unrelated Ruff issues across pre-existing files such as `agent/`, `api/`, `rag/`, and unrelated tests before typecheck runs.
- [ ] Full `make test-unit` was run, but the repository currently has unrelated baseline failures outside this change: the PII scrubber tests pass, while other suites such as `test_bias_detector.py`, `test_review_service.py`, `test_skill_extractor.py`, and chunker tests fail independently.

Manual verification steps for reviewers:
1. Check out this branch: `git checkout fix/146-pii-parenthesized-phone`.
2. Run `python -m pytest tests/unit/test_pii_scrubber.py -v`.
3. Confirm all 25 PII scrubber tests pass.
4. In a Python shell, run:
   ```python
   from safety.pii_scrubber import PIIScrubber
   scrubber = PIIScrubber()
   print(scrubber.scrub("Call me at (555) 123-4567 or 555-123-4567"))
   print(scrubber.detect("Phone: (555) 123-4567"))
   ```
5. Confirm both phone numbers are replaced with `[REDACTED]`, and `detect()` returns a `phone_us` entry whose value is `(555) 123-4567`.

## Screenshots / Demo
Not applicable; this is a backend safety-layer regex and unit-test change.

## Notes for Reviewers
Please focus review on the US phone-number regex boundaries in `safety/pii_scrubber.py`, especially whether the pattern is broad enough for common US formats without becoming too permissive. I also included a small street-address boundary tightening because the existing mixed PII test showed the address regex could consume ordinary text ending in a word that starts with a street abbreviation (`Pl` inside `applications`).