### PR TITLE
fix: exclude vendor/build directories from tech detection

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -32,3 +32,24 @@ for Weeks 8–9.
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [ADD LINK AFTER YOU COMMIT — run `git log -1 --format="%H"` after committing, then use https://github.com/faisalkhansk3283/pathreview/commit/<hash>]
+
+**Reproduction summary:**
+Ran the repro snippet from issue #150 against `TechDetector.execute()` with 2 Python files and
+6 vendored/build JS files (`node_modules/`, `build/`) — it returned `primary_language:
+"JavaScript"` instead of the expected `"Python"`. Traced this to `_should_skip_file()` in
+`agent/tools/tech_detector.py:143`, whose skip patterns (e.g. `"/node_modules/"`) require a
+leading `/` that repo-root-relative paths don't have, so vendor/build files are never filtered.
+Confirmed via `pytest tests/unit/test_tech_detector.py -v` that `test_node_modules_excluded`
+and `test_build_directory_excluded` currently fail for this exact reason.
+
+**PLAN.md link:** https://github.com/faisalkhansk3283/pathreview/blob/fix/150-vendored-build-output-detection/PLAN.md
+
+**Walkthrough video (recommended):** https://imgur.com/a/zR11cvH
+
+**Blockers or open questions:**
+None currently — root cause is isolated and the fix path is clear (segment-based path
+matching instead of slash-wrapped substring matching).

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -3,7 +3,7 @@
 **Issue link:** https://github.com/ascherj/pathreview/issues/150
 **Issue title:** Tech detector counts vendored and build-output files, skewing language detection
 
-**Tier:** [ ] Tier 1  [ ] Tier 2  [ ] Tier 3
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
 
 **Problem summary:**
 The `TechDetector` class in `agent/tools/tech_detector.py` scans all files passed to it when

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -35,7 +35,7 @@ for Weeks 8–9.
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [ADD LINK AFTER YOU COMMIT — run `git log -1 --format="%H"` after committing, then use https://github.com/faisalkhansk3283/pathreview/commit/<hash>]
+**Reproduction commit link:** https://github.com/faisalkhansk3283/pathreview/commit/69bb0658eba950df6e28147c80e90e1862433ab0
 
 **Reproduction summary:**
 Ran the repro snippet from issue #150 against `TechDetector.execute()` with 2 Python files and

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -53,3 +53,52 @@ and `test_build_directory_excluded` currently fail for this exact reason.
 **Blockers or open questions:**
 None currently — root cause is isolated and the fix path is clear (segment-based path
 matching instead of slash-wrapped substring matching).
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented segment-based path matching in `_should_skip_file()`
+(`agent/tools/tech_detector.py`), replacing the broken slash-wrapped substring check that
+required a leading `/` and therefore missed repo-root-relative vendor/build paths. All 28
+tests in `tests/unit/test_tech_detector.py` pass, including the two named in the issue
+(`test_node_modules_excluded`, `test_build_directory_excluded`) plus a new test I added
+(`test_filename_containing_skip_word_not_excluded`) guarding against false-positive substring
+matches (e.g. `vendor_utils.py` incorrectly being treated as vendored). Confirmed via
+`git stash` comparison that the `make check` (182 errors) and `make test-unit` (51 failures)
+issues are pre-existing on `main` and unrelated to this change — none touch
+`tech_detector.py` or `test_tech_detector.py`.
+
+**Next steps:**
+Open a draft PR, request peer/mentor review in Slack, address feedback, then finalize and
+submit for review.
+
+**Blockers:**
+None.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [ADD AFTER OPENING PR]
+
+**Branch:** fix/150-vendored-build-output-detection
+
+**What you built:**
+Fixed `TechDetector._should_skip_file()` in `agent/tools/tech_detector.py` so vendor/build
+directories (`node_modules/`, `build/`, `vendor/`, etc.) are excluded from language detection
+even when they appear at the repo root. The fix splits each file path into `/`-separated
+segments and checks for an exact segment match against a set of skip-directory names, instead
+of the old approach of checking for a fixed `/name/`-wrapped substring, which silently failed
+for root-relative paths.
+
+**Tests added or updated:**
+`tests/unit/test_tech_detector.py` — confirmed the two existing tests named in the issue
+(`test_node_modules_excluded`, `test_build_directory_excluded`) now pass, and added
+`test_filename_containing_skip_word_not_excluded` to guard against false-positive substring
+matches (e.g. `vendor_utils.py`).
+
+**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+
+**Draft PR feedback received from:** [ADD AFTER REVIEW]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,34 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/150
+**Issue title:** Tech detector counts vendored and build-output files, skewing language detection
+
+**Tier:** [ ] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The `TechDetector` class in `agent/tools/tech_detector.py` scans all files passed to it when
+determining a repo's primary language, without excluding vendored or build-output directories
+like `node_modules/` and `build/`. Because these directories typically contain far more files
+than actual source code, a repo with mostly Python source can still get misclassified as
+JavaScript — for example, 2 real Python files alongside 6 bundled JS files in `node_modules/`
+and `build/` currently reports `'JavaScript'` as the primary language instead of `'Python'`. A
+successful fix would add path-based filtering so common vendored/build directories are excluded
+before language counts are tallied, which should make the two currently-failing tests
+(`test_node_modules_excluded`, `test_build_directory_excluded`) pass.
+
+**Scope reasoning:**
+This is a Tier 1 issue and a good fit as my first contribution — the fix is isolated to
+`agent/tools/tech_detector.py`, doesn't require understanding how the detector interacts with
+the rest of the agent system, and comes with two existing failing tests
+(`test_node_modules_excluded`, `test_build_directory_excluded`) that define exactly what
+"done" looks like. I read both tests and the relevant function before claiming this issue.
+I checked the issue comments and cohort ledger and I'm comfortable with the number of
+students also on this issue. I don't see any blockers referenced. I estimate this will take
+3–4 hours given the clear repro steps, which fits comfortably within the Tier 1 time budget
+for Weeks 8–9.
+
+**Branch name:** fix/150-vendored-build-output-detection
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -81,7 +81,7 @@ None.
 
 ### Check-in 2 (end of week)
 
-**PR link:** [ADD AFTER OPENING PR]
+**PR link:** https://github.com/ascherj/pathreview/pull/443
 
 **Branch:** fix/150-vendored-build-output-detection
 
@@ -99,6 +99,9 @@ for root-relative paths.
 `test_filename_containing_skip_word_not_excluded` to guard against false-positive substring
 matches (e.g. `vendor_utils.py`).
 
-**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+(Both commands report pre-existing failures unrelated to this change — 181 lint errors and 51
+test failures, confirmed identical on `main` via `git stash` comparison. My change introduces
+no new failures.)
 
-**Draft PR feedback received from:** [ADD AFTER REVIEW]
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -105,3 +105,67 @@ test failures, confirmed identical on `main` via `git stash` comparison. My chan
 no new failures.)
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No review came in on PR #443. Per the Su26 program note, reviewer feedback is not a feature
+this term, so this was expected rather than a sign of a problem with the PR itself.
+
+**How you responded:**
+N/A — nothing to respond to. I kept the PR open and marked ready for review in case a
+maintainer picks it up later.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Git itself, more than the actual code fix. The bug fix in `tech_detector.py` was
+straightforward once I understood the root cause, but I ran into a branch divergence when
+pushing my Week 8 commits — my local branch and the remote branch had each picked up
+different commits since I last synced, so a plain `git push` was rejected. I had to learn
+`git stash` (temporarily shelving uncommitted local changes so they don't block other git
+commands, then restoring them later with `git stash pop`) and `git rebase` (replaying my
+commits on top of the remote's latest commit to keep history linear, instead of creating a
+merge commit) practically for the first time, including resolving a real merge conflict in
+`JOURNAL.md` by hand. Going in, I didn't have a mental model for any of this — I could run
+`git add`/`commit`/`push` fine, but branch divergence and conflicts were new territory.
+
+**What did you learn about working in a large codebase?**
+In my own projects, I can hold the whole thing in my head and understand my code by just
+looking at it. In `pathreview`, understanding `tech_detector.py` wasn't enough — I also had
+to understand the project's existing test conventions before adding a new test, respect
+`CONTRIBUTING.md`'s commit/branch naming rules, and deal with `make check`/`make test-unit`
+surfacing 181 lint errors and 51 test failures across files I never touched. A big part of
+contributing to a large codebase is learning to distinguish "this is broken because of my
+change" from "this was already broken and isn't my problem" — and proving that distinction
+with evidence (like comparing `main` against my branch) rather than just asserting it.
+
+**How did AI tools help — and where did they fall short?**
+AI tools worked well as a pair programmer — pointing me to the exact file and line for the
+bug, helping me reason through why my first instinct (a plain substring check like `"vendor"
+in filepath`) would cause false positives, and drafting boilerplate like the PLAN.md sections
+and PR description so I could focus on the actual logic. Where it fell short was git
+mechanics — reading a set of stash/rebase instructions and actually understanding what was
+happening to my repo were two different things, and I had to ask for a plain-language
+explanation of stash and rebase separately before it really clicked, rather than just
+following commands blindly.
+
+**What would you do differently if you started over?**
+I'd spend more time upfront getting comfortable with git branching and conflict resolution
+before starting the issue itself, instead of learning it under pressure mid-week when my
+push got rejected. I'd also practice on more issues going forward to build the muscle memory
+for the full contribution cycle end-to-end, so branch divergence and conflicts feel routine
+instead of stressful, with the eventual goal of getting a PR actually merged.
+
+**What are you most proud of from this module?**
+Getting comfortable running a real production-scale codebase locally — setting up the venv,
+diagnosing dependency and permission issues, running the actual test suite, and using that
+environment to reproduce and fix a real bug — rather than just reading code in isolation.
+That hands-on ability to spin up, inspect, and modify a codebase I didn't write is the part
+I want to keep building on.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,101 @@
+## Solution plan
+
+**Issue:** #150 — Tech detector counts vendored and build-output files, skewing language detection
+(https://github.com/ascherj/pathreview/issues/150)
+
+### Understand
+`TechDetector._detect_tech()` (agent/tools/tech_detector.py:93) is supposed to filter out
+vendored/build files before counting languages, via `_should_skip_file()` (line 143). That
+method checks `pattern in filepath` against a list of patterns like `"/node_modules/"`,
+`"/vendor/"`, `"/build/"`, all written with a **leading slash**.
+
+The bug: file paths coming from the repo root (e.g. `"node_modules/lib/index.js"`,
+`"build/bundle.js"`) do **not** have a leading slash. The substring `"/node_modules/"` never
+appears in `"node_modules/lib/index.js"`, so `_should_skip_file` returns `False` for exactly
+the paths it's meant to catch, and every vendored/build file gets counted normally. With 6
+JS files in `node_modules/`/`build/` vs. 2 real Python files, `JavaScript` wins as
+`primary_language` instead of `Python`.
+
+Expected behavior: any path that starts with, or contains as a full path segment, one of the
+vendor/build directory names should be excluded, regardless of whether it's nested (e.g.
+`src/node_modules/x.js`) or at the repo root (e.g. `node_modules/x.js`).
+
+**Root cause:** `_should_skip_file`'s patterns assume every match is preceded by a `/`, which
+is false for repo-root-relative paths.
+
+### Map
+Files I expect to touch:
+- `agent/tools/tech_detector.py` — `_should_skip_file()` (line ~143-164): fix the pattern
+  matching so root-level paths match too.
+- `tests/unit/test_tech_detector.py` — `test_node_modules_excluded` (line 66) and
+  `test_build_directory_excluded` (line 94) already exist and currently fail; they define
+  "done" for this fix. I may add one more case for a root-level `vendor/` path since
+  `test_vendor_files_excluded` (line 81) currently has no assertions.
+
+### Plan
+1. Confirm exact failure: run `pytest tests/unit/test_tech_detector.py -v` and record which
+   tests fail and why (already done — both `test_node_modules_excluded` and
+   `test_build_directory_excluded` fail because `primary_language` comes back `JavaScript`
+   instead of `Python`).
+2. Rewrite `_should_skip_file` to normalize the path check — e.g. split `filepath` on `/`
+   and check whether any path segment exactly matches a directory name in a skip-list
+   (`node_modules`, `vendor`, `dist`, `build`, `.git`, `__pycache__`, `.venv`, `venv`),
+   instead of relying on a fixed-slash substring match.
+3. Update/replace the `skip_patterns` list to be directory names instead of slash-wrapped
+   substrings, so both `node_modules/lib/index.js` and `src/node_modules/lib.js` match.
+4. Add an assertion to `test_vendor_files_excluded` (currently missing one) to lock in
+   root-level vendor exclusion too.
+5. Run `pytest tests/unit/test_tech_detector.py -v` again and confirm all tests pass,
+   including the two named in the issue.
+6. Run `make check` (lint + format + typecheck) to make sure the change is clean.
+
+### Inputs & outputs
+**Function I'm changing:** `_should_skip_file(filepath: str) -> bool`
+
+**Existing (broken) behavior:**
+- Input: `"node_modules/lib/index.js"` → Output: `False` (should be `True`)
+- Input: `"src/node_modules/lib.js"` → Output: `True` (already works, has leading `/`)
+
+**Fixed behavior:**
+- Input: `"node_modules/lib/index.js"` → Output: `True`
+- Input: `"build/bundle.js"` → Output: `True`
+- Input: `"src/main.py"` → Output: `False` (unaffected — must not over-match)
+
+**Test I already have to satisfy:**
+```python
+def test_node_modules_excluded(self, detector):
+    files = ["src/main.py", "node_modules/package1/index.js",
+             "node_modules/package2/lib.js", "utils.py"]
+    result = detector.execute({"files": files})
+    assert result.data["primary_language"] == "Python"
+
+def test_build_directory_excluded(self, detector):
+    files = ["src/main.py", "build/generated.js", "build/bundle.js"]
+    result = detector.execute({"files": files})
+    assert result.data["primary_language"] == "Python"
+```
+
+### Risks & unknowns
+1. **Over-matching risk:** if I switch to segment-based matching, I need to make sure a
+   legitimate file like `my_vendor_utils.py` (contains "vendor" as a substring but not as a
+   path segment) doesn't get incorrectly skipped. Segment-based matching (splitting on `/`
+   and comparing whole segments) avoids this, but I need a test for it.
+2. **`.git`/`.venv` patterns currently include a leading dot** (`.venv`, not `venv`) —
+   need to check these still work correctly after refactoring away from the slash-wrapped
+   substring approach, since `.git` and `venv` are different skip entries.
+3. **`primary_language` tie-breaking is alphabetical, not "most common"** (line 126-129 picks
+   `sorted(languages)[0]`, despite the docstring saying "most common") — this is a separate,
+   pre-existing issue not mentioned in #150. I will not fix it as part of this issue, to keep
+   scope contained, but I'll note it as a possible follow-up.
+4. **Windows path separators:** if any file paths ever use `\` instead of `/` (unlikely given
+   GitHub API always returns `/`-separated paths), segment splitting on `/` alone would miss
+   them. I'll confirm the input source (GitHub API) before assuming this isn't a concern.
+
+### Edge cases
+- Root-level vendor/build dirs: `node_modules/x.js`, `build/x.js`, `vendor/x.js` → excluded
+- Nested vendor/build dirs: `src/node_modules/x.js` → excluded (already worked, must not break)
+- File names that merely contain a skip-word as a substring but aren't in that directory,
+  e.g. `vendor_utils.py` or `rebuild/script.py` → NOT excluded (must not over-match)
+- Empty file list → still returns `"Unknown"` (existing behavior, unaffected)
+- A repo that is *entirely* vendored files with no real source → `all_languages` ends up
+  empty and `primary_language` is `"Unknown"`; confirm this doesn't throw an error

--- a/agent/tools/tech_detector.py
+++ b/agent/tools/tech_detector.py
@@ -160,5 +160,18 @@ class TechDetector(BaseTool):
             "/.venv/",
             "/venv/",
         ]
+        skip_dirs = {
+            "node_modules",
+            "vendor",
+            "dist",
+            "build",
+            ".git",
+            "__pycache__",
+            ".venv",
+            "venv",
+        }
+
+        segments = filepath.split("/")
+        return any(segment in skip_dirs for segment in segments)
 
         return any(pattern in filepath for pattern in skip_patterns)

--- a/agent/tools/tech_detector.py
+++ b/agent/tools/tech_detector.py
@@ -1,6 +1,7 @@
 """Technology stack detector tool."""
 
 import structlog
+
 from .base import BaseTool, ToolResult
 
 logger = structlog.get_logger()
@@ -75,7 +76,7 @@ class TechDetector(BaseTool):
                     "primary_language": "Unknown",
                     "all_languages": [],
                     "frameworks": [],
-                }
+                },
             )
 
         try:
@@ -84,11 +85,7 @@ class TechDetector(BaseTool):
 
         except Exception as e:
             logger.error("tech_detector_error", error=str(e))
-            return ToolResult(
-                success=False,
-                data={},
-                error=str(e)
-            )
+            return ToolResult(success=False, data={}, error=str(e))
 
     def _detect_tech(self, files: list[str]) -> dict:
         """Detect technologies from file list.
@@ -100,10 +97,7 @@ class TechDetector(BaseTool):
             Dict with detected languages and frameworks
         """
         # Filter out vendor/build directories
-        filtered_files = [
-            f for f in files
-            if not self._should_skip_file(f)
-        ]
+        filtered_files = [f for f in files if not self._should_skip_file(f)]
 
         languages = set()
         frameworks = set()
@@ -131,8 +125,12 @@ class TechDetector(BaseTool):
         all_languages = sorted(languages)
         all_frameworks = sorted(frameworks)
 
-        logger.info("tech_detected", primary_lang=primary,
-                   languages_count=len(all_languages), frameworks_count=len(all_frameworks))
+        logger.info(
+            "tech_detected",
+            primary_lang=primary,
+            languages_count=len(all_languages),
+            frameworks_count=len(all_frameworks),
+        )
 
         return {
             "primary_language": primary,
@@ -150,16 +148,6 @@ class TechDetector(BaseTool):
         Returns:
             True if file should be skipped
         """
-        skip_patterns = [
-            "/node_modules/",
-            "/vendor/",
-            "/dist/",
-            "/build/",
-            "/.git/",
-            "/__pycache__/",
-            "/.venv/",
-            "/venv/",
-        ]
         skip_dirs = {
             "node_modules",
             "vendor",
@@ -173,5 +161,3 @@ class TechDetector(BaseTool):
 
         segments = filepath.split("/")
         return any(segment in skip_dirs for segment in segments)
-
-        return any(pattern in filepath for pattern in skip_patterns)

--- a/tests/unit/test_tech_detector.py
+++ b/tests/unit/test_tech_detector.py
@@ -104,6 +104,21 @@ class TestTechDetector:
         data = result.data
         assert data["primary_language"] == "Python"
 
+    def test_filename_containing_skip_word_not_excluded(self, detector):
+        """Test that a filename merely containing a skip-word substring
+        (e.g. 'vendor_utils.py') is NOT treated as being inside a skip directory."""
+        files = [
+            "vendor_utils.py",
+            "rebuild_index.py",
+            "main.py",
+        ]
+
+        result = detector.execute({"files": files})
+
+        data = result.data
+        assert data["primary_language"] == "Python"
+        assert "Python" in data["all_languages"]
+
     def test_config_file_detection(self, detector):
         """Test detection from config files."""
         files = [


### PR DESCRIPTION
## Summary
`TechDetector._should_skip_file()` in `agent/tools/tech_detector.py` failed to exclude vendored/build-output files (e.g. `node_modules/`, `build/`) when they appeared at the repository root, because it checked for a fixed `/name/`-wrapped substring that only matched nested paths (e.g. `src/node_modules/x.js`), not root-relative ones (e.g. `node_modules/x.js`). This caused repos with mostly Python source but a few root-level vendored JS files to be misclassified as JavaScript. This PR replaces the substring check with path-segment matching, so both root-level and nested vendor/build directories are correctly excluded.

## Issue
Closes #150

## Changes
Root cause: `_should_skip_file()`'s `skip_patterns` list (e.g. `"/node_modules/"`) required a leading `/` to match, but file paths at the repo root don't have one, so the substring `pattern in filepath` check silently returned `False` for exactly the cases it was meant to catch.

- `agent/tools/tech_detector.py` — rewrote `_should_skip_file()` to split the path on `/` and check whether any full path segment exactly matches a skip-directory name (`node_modules`, `vendor`, `dist`, `build`, `.git`, `__pycache__`, `.venv`, `venv`), instead of relying on a fixed-slash substring match. This also avoids a false-positive case where a legitimate filename merely contains a skip-word as a substring (e.g. `vendor_utils.py`).
- `tests/unit/test_tech_detector.py` — confirmed the two existing tests named in the issue (`test_node_modules_excluded`, `test_build_directory_excluded`) now pass, and added `test_filename_containing_skip_word_not_excluded` to lock in the false-positive guard described above.

## Testing
- [x] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`)
- [ ] Linter passes (`make lint`)
- [ ] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes

**Reproduce the original bug (before the fix):**

    from agent.tools.tech_detector import TechDetector
    t = TechDetector()
    files = ['main.py','core/app.py','node_modules/lib/index.js','node_modules/lib/util.js','node_modules/x/a.js','node_modules/y/b.js','build/bundle.js','build/vendor.js']
    print(t.execute({'files': files}).data['primary_language'])
    # before fix: 'JavaScript' (wrong)
    # after fix: 'Python' (correct)

**Verify the fix:**

    pytest tests/unit/test_tech_detector.py -v

All 28 tests pass, including `test_node_modules_excluded` and `test_build_directory_excluded`.

## Screenshots / Demo
N/A — backend-only change with no UI impact; verification is via the unit test output above.

## Notes for Reviewers
`make check` reports 181 pre-existing lint/type errors and `make test-unit` reports 51 pre-existing test failures, all in files unrelated to this change (`safety/`, `rag/`, `core/services/`, various `ingestion/parsers/` tests). I confirmed via `git stash` that these same counts exist on `main` before my change, so this PR introduces no new failures.