### PR TITLE
fix(ingestion): fall back to semantic chunker when no headings found (#149)

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -45,3 +45,14 @@ Ran `pytest tests/unit/test\_structural\_chunker.py -k test\_document\_with\_no\
 
 Confirming semantic\_chunker.py's token-based sub-splitting handles very large headingless documents sensibly.
 
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the fix in structural_chunker.py's chunk() -- falls back to SemanticChunker when no headings are found, instead of returning an empty list. Added missing type annotations to both structural_chunker.py and semantic_chunker.py so ruff/black/mypy pass clean on both files. All tests in test_structural_chunker.py (15/15) and test_semantic_chunker.py (16/16) pass, including the previously-failing test_document_with_no_headings.
+
+**Next steps:**
+Open the pull request against ascherj/pathreview, write the PR description (noting pre-existing unrelated test failures), and request review.
+
+**Blockers:**
+make test-unit shows 52 pre-existing failures across ~15 unrelated test files (bias detector, PII scrubber, faithfulness checker, tech detector, skill extractor, etc.) -- none touch the files I changed, and my two test files pass 100%. Documenting these as pre-existing rather than fixing them, per course guidance.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -23,7 +23,7 @@ The RAG ingestion pipeline chunks documents by splitting on markdown headings. S
 
 
 
-\*\*Reproduction commit link:\*\* \[fill in after pushing]
+**Reproduction commit link:** https://github.com/akshaypsharma-AIA/pathreview/commit/a7452b2
 
 
 
@@ -33,7 +33,7 @@ Ran `pytest tests/unit/test\_structural\_chunker.py -k test\_document\_with\_no\
 
 
 
-\*\*PLAN.md link:\*\* \[fill in after pushing]
+*PLAN.md link:** https://github.com/akshaypsharma-AIA/pathreview/blob/fix/149-structural-chunker-no-headings/PLAN.md
 
 
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,16 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/149
+
+**Issue title:** Structural chunker silently drops documents that contain no headings
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The RAG ingestion pipeline chunks documents by splitting on markdown headings. StructuralChunker's section-extraction logic only starts collecting content once it has already seen a heading, so a document with zero headings never triggers collection and returns no sections at all. Since chunk() has nothing to loop over in that case, it returns an empty list instead of at least one chunk. The pipeline never flags a zero-chunk result as an error, so a real candidate's README that just doesn't use markdown headings would silently contribute nothing to their review. The fix reuses the file's existing SemanticChunker fallback (already used for oversized sections) so headingless documents get chunked too, instead of dropped.
+
+**Branch name:** fix/149-structural-chunker-no-headings
+
+**Setup confirmation:** [ ] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -82,3 +82,61 @@ make test-unit shows 52 pre-existing failures across ~15 unrelated test files (b
   needed for the fix. Confident in correctness pending maintainer approval.
 - **Branch:** fix/149-structural-chunker-no-headings
 - **PR:** https://github.com/ascherj/pathreview/pull/444
+
+
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review (not a feature this term per course note)
+
+**Summary of feedback:**
+No feedback received. Also requested review proactively via Slack (2x)
+and in a PR comment, before learning reviewer feedback isn't enabled
+for Summer 2026 — good practice to keep regardless.
+
+**How you responded:**
+N/A — no feedback to respond to.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Getting the local dev environment running on Windows took longer than
+the actual bug fix — Docker Desktop needed WSL2, `make` wasn't
+available out of the box, and pasting multi-line commands into Git
+Bash silently corrupted them (bracketed paste mode), which cost real
+time before I switched to editing files directly. The other surprise:
+pre-commit hooks check the whole file (and, for mypy, files it
+imports) — not just my diff — so a 3-line fix got blocked by
+pre-existing type-annotation gaps in two files I hadn't touched the
+logic of.
+
+**What did you learn about working in a large codebase?**
+That "don't make it worse" is the actual bar, not "leave everything
+clean." This repo had ~183 pre-existing lint errors and 52 failing
+tests scattered across other modules, and the right move was to
+verify none of them were in my changed files and move on — not to
+fix them. I also got a much clearer mental model of forks: issues and
+PRs live on the upstream repo, not the fork, which is why I was
+commenting on ascherj's thread instead of my own.
+
+**How did AI tools help — and where did they fall short?**
+Most useful for diagnosing the root cause quickly and explaining
+git/tooling concepts I was rusty on, without derailing the fix
+itself. Less useful for judgment calls specific to this codebase —
+like which pre-existing failures were safe to ignore — where I had
+to verify things myself rather than trust it outright.
+
+**What would you do differently if you started over?**
+Set up the dev environment and run a scoped lint/type-check on my
+target file in week 7, before writing any fix — that would've
+surfaced the pre-existing annotation gaps early instead of mid-commit
+under deadline pressure.
+
+**What are you most proud of from this module?**
+Diagnosing and fixing a real silent-data-loss bug end to end — under
+a genuine time crunch — while actually understanding every step
+instead of just executing commands I didn't follow.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -69,3 +69,16 @@ make test-unit shows 52 pre-existing failures across ~15 unrelated test files (b
   - [x] make check passes on changed files (ruff, black, mypy all clean)
   - [x] make test-unit passes for changed files (52 pre-existing failures elsewhere, documented, unrelated to this change)
 - **Draft PR feedback received:** [fill in once someone responds on Slack]
+
+
+
+### Week 9 Closing Note
+
+- **PR status:** Marked "Ready for review" on [date]. Requested review via
+  Slack (2x) and CodePath support email; no reviewer response received by
+  the extended deadline.
+- **Verification in lieu of peer review:** Full test suite passing for
+  changed files, ruff/black/mypy clean, changes scoped to the two files
+  needed for the fix. Confident in correctness pending maintainer approval.
+- **Branch:** fix/149-structural-chunker-no-headings
+- **PR:** https://github.com/ascherj/pathreview/pull/444

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -11,6 +11,6 @@ The RAG ingestion pipeline chunks documents by splitting on markdown headings. S
 
 **Branch name:** fix/149-structural-chunker-no-headings
 
-**Setup confirmation:** [ ] App runs locally at localhost:5173
+**Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [ ] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -4,13 +4,44 @@
 
 **Issue title:** Structural chunker silently drops documents that contain no headings
 
-**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+**Tier:** \[x] Tier 1  \[ ] Tier 2  \[ ] Tier 3
 
 **Problem summary:**
 The RAG ingestion pipeline chunks documents by splitting on markdown headings. StructuralChunker's section-extraction logic only starts collecting content once it has already seen a heading, so a document with zero headings never triggers collection and returns no sections at all. Since chunk() has nothing to loop over in that case, it returns an empty list instead of at least one chunk. The pipeline never flags a zero-chunk result as an error, so a real candidate's README that just doesn't use markdown headings would silently contribute nothing to their review. The fix reuses the file's existing SemanticChunker fallback (already used for oversized sections) so headingless documents get chunked too, instead of dropped.
 
 **Branch name:** fix/149-structural-chunker-no-headings
 
-**Setup confirmation:** [x] App runs locally at localhost:5173
+**Setup confirmation:** \[x] App runs locally at localhost:5173
 
-**Cohort ledger:** [ ] Issue added to cohort ledger
+**Cohort ledger:** \[ ] Issue added to cohort ledger
+
+
+
+
+
+\## Week 8 — Reproduction \& solution planning
+
+
+
+\*\*Reproduction commit link:\*\* \[fill in after pushing]
+
+
+
+\*\*Reproduction summary:\*\*
+
+Ran `pytest tests/unit/test\_structural\_chunker.py -k test\_document\_with\_no\_headings -v` locally. It failed with `assert 0 >= 1` / `where 0 = len(\[])`, confirming `StructuralChunker.chunk()` returns an empty list for a headingless plain-text document instead of at least one chunk.
+
+
+
+\*\*PLAN.md link:\*\* \[fill in after pushing]
+
+
+
+\*\*Walkthrough video (recommended):\*\* \[skip, or add later — not graded]
+
+
+
+\*\*Blockers or open questions:\*\*
+
+Confirming semantic\_chunker.py's token-based sub-splitting handles very large headingless documents sensibly.
+

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -56,3 +56,16 @@ Open the pull request against ascherj/pathreview, write the PR description (noti
 
 **Blockers:**
 make test-unit shows 52 pre-existing failures across ~15 unrelated test files (bias detector, PII scrubber, faithfulness checker, tech detector, skill extractor, etc.) -- none touch the files I changed, and my two test files pass 100%. Documenting these as pre-existing rather than fixing them, per course guidance.
+
+
+
+### Week 9 Check-in 2
+
+- **PR link:** https://github.com/ascherj/pathreview/pull/444
+- **Branch:** fix/149-structural-chunker-no-headings
+- **What was built:** StructuralChunker.chunk() now falls back to SemanticChunker when no headings are found, instead of silently returning an empty list. Also added missing type annotations to structural_chunker.py and semantic_chunker.py (required to pass pre-commit's mypy hook, no behavior change).
+- **Tests added/updated:** test_document_with_no_headings (previously failing) now passes. Full suite: 15/15 in test_structural_chunker.py, 16/16 in test_semantic_chunker.py.
+- **Self-review:**
+  - [x] make check passes on changed files (ruff, black, mypy all clean)
+  - [x] make test-unit passes for changed files (52 pre-existing failures elsewhere, documented, unrelated to this change)
+- **Draft PR feedback received:** [fill in once someone responds on Slack]

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,76 @@
+\## Solution plan
+
+\*\*Issue:\*\* Structural chunker silently drops documents with no headings (#149)
+
+
+
+\### Understand
+
+\_extract\_sections() only appends content once heading\_stack is non-empty.
+
+Headingless docs never trigger that, so sections=\[] -> chunk()=\[] -> the
+
+document is "ingested" with 0 chunks and no error surfaces anywhere.
+
+
+
+\### Map
+
+\- ingestion/chunking/structural\_chunker.py -- chunk(), the only file changed
+
+\- ingestion/chunking/semantic\_chunker.py -- reused as-is for the fallback
+
+\- tests/unit/test\_structural\_chunker.py -- test\_document\_with\_no\_headings
+
+&#x20; already exists and is already failing; this is the acceptance test
+
+
+
+\### Plan
+
+1\. Reproduce: run the issue's snippet + the named pytest, confirm failure (done)
+
+2\. In chunk(), after sections = self.\_extract\_sections(text): if not
+
+&#x20;  sections, return self.semantic\_chunker.chunk(text, metadata)
+
+3\. Re-run test\_structural\_chunker.py in full (confirm no regressions on
+
+&#x20;  the nested-heading / large-section tests)
+
+4\. make check \&\& make test-unit before opening the PR
+
+
+
+\### Inputs \& outputs
+
+Input: raw text + metadata dict. Output: list\[Chunk]. Via the fallback
+
+path, chunks won't carry heading\_path/heading\_level -- confirmed safe,
+
+since existing callers already guard those keys with .get()/"in".
+
+
+
+\### Risks \& unknowns
+
+\- pipeline.py never warns on a 0-chunk result -- out of scope to fix here,
+
+&#x20; worth one line in the PR description so reviewers know it was noticed
+
+\- Leading text before the first heading in docs that do have headings
+
+&#x20; later is dropped by the same root cause -- separate bug, flag not fix
+
+
+
+\### Edge cases
+
+\- Whitespace-only input must still return \[] (don't regress that test)
+
+\- Very large headingless doc must sub-split via semantic\_chunker, not
+
+&#x20; return one oversized chunk
+
+\- Very short headingless text must still return exactly 1 chunk
+

--- a/ingestion/chunking/semantic_chunker.py
+++ b/ingestion/chunking/semantic_chunker.py
@@ -17,7 +17,7 @@ class SemanticChunker(BaseChunker):
     OVERLAP_TOKENS = 50
     MAX_TOKENS = 800
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize the chunker with tiktoken encoder."""
         self.encoder = tiktoken.get_encoding("cl100k_base")
 
@@ -38,25 +38,27 @@ class SemanticChunker(BaseChunker):
         # Split into sentences
         sentences = self._split_sentences(text)
 
-        chunks = []
-        current_chunk = []
+        chunks: list[Chunk] = []
+        current_chunk: list[str] = []
         current_tokens = 0
-        overlap_buffer = []
+        overlap_buffer: list[str] = []
         overlap_tokens = 0
         char_start = 0
 
-        for i, sentence in enumerate(sentences):
+        for _i, sentence in enumerate(sentences):
             sentence_tokens = len(self.encoder.encode(sentence))
 
             # If adding this sentence would exceed our target, save current chunk
             if current_tokens + sentence_tokens > self.TARGET_CHUNK_TOKENS and current_chunk:
                 chunk_text = " ".join(current_chunk)
                 chunk_metadata = metadata.copy()
-                chunk_metadata.update({
-                    "chunk_index": len(chunks),
-                    "char_start": char_start,
-                    "char_end": char_start + len(chunk_text),
-                })
+                chunk_metadata.update(
+                    {
+                        "chunk_index": len(chunks),
+                        "char_start": char_start,
+                        "char_end": char_start + len(chunk_text),
+                    }
+                )
                 chunks.append(Chunk(text=chunk_text, metadata=chunk_metadata))
 
                 # Move to next chunk with overlap
@@ -71,19 +73,19 @@ class SemanticChunker(BaseChunker):
             # Maintain overlap buffer
             if current_tokens > self.TARGET_CHUNK_TOKENS:
                 overlap_buffer = current_chunk[-2:] if len(current_chunk) >= 2 else current_chunk
-                overlap_tokens = sum(
-                    len(self.encoder.encode(s)) for s in overlap_buffer
-                )
+                overlap_tokens = sum(len(self.encoder.encode(s)) for s in overlap_buffer)
 
         # Add final chunk if not empty
         if current_chunk:
             chunk_text = " ".join(current_chunk)
             chunk_metadata = metadata.copy()
-            chunk_metadata.update({
-                "chunk_index": len(chunks),
-                "char_start": char_start,
-                "char_end": char_start + len(chunk_text),
-            })
+            chunk_metadata.update(
+                {
+                    "chunk_index": len(chunks),
+                    "char_start": char_start,
+                    "char_end": char_start + len(chunk_text),
+                }
+            )
             chunks.append(Chunk(text=chunk_text, metadata=chunk_metadata))
 
         return chunks

--- a/ingestion/chunking/structural_chunker.py
+++ b/ingestion/chunking/structural_chunker.py
@@ -16,7 +16,7 @@ class StructuralChunker(BaseChunker):
 
     SECTION_TOKEN_LIMIT = 800
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize the chunker."""
         self.encoder = tiktoken.get_encoding("cl100k_base")
         self.semantic_chunker = SemanticChunker()
@@ -38,6 +38,11 @@ class StructuralChunker(BaseChunker):
         # Extract sections with heading hierarchy
         sections = self._extract_sections(text)
 
+        if not sections:
+            # No headings found at all -- fall back to the semantic
+            # chunker instead of silently dropping the document.
+            return self.semantic_chunker.chunk(text, metadata)
+
         chunks = []
         for section in sections:
             heading_path = " > ".join(section["path"])
@@ -49,22 +54,26 @@ class StructuralChunker(BaseChunker):
             if section_tokens > self.SECTION_TOKEN_LIMIT:
                 # Sub-chunk using semantic chunker
                 section_metadata = metadata.copy()
-                section_metadata.update({
-                    "heading_path": heading_path,
-                    "heading_level": section["level"],
-                })
+                section_metadata.update(
+                    {
+                        "heading_path": heading_path,
+                        "heading_level": section["level"],
+                    }
+                )
                 sub_chunks = self.semantic_chunker.chunk(section_text, section_metadata)
                 chunks.extend(sub_chunks)
             else:
                 # Single chunk for this section
                 section_metadata = metadata.copy()
-                section_metadata.update({
-                    "heading_path": heading_path,
-                    "heading_level": section["level"],
-                    "chunk_index": len(chunks),
-                    "char_start": 0,
-                    "char_end": len(section_text),
-                })
+                section_metadata.update(
+                    {
+                        "heading_path": heading_path,
+                        "heading_level": section["level"],
+                        "chunk_index": len(chunks),
+                        "char_start": 0,
+                        "char_end": len(section_text),
+                    }
+                )
                 chunks.append(Chunk(text=section_text, metadata=section_metadata))
 
         return chunks
@@ -77,9 +86,8 @@ class StructuralChunker(BaseChunker):
         """
         lines = text.split("\n")
         sections = []
-        heading_stack = []  # Stack of (level, heading_text)
-        current_section_lines = []
-        current_level = 0
+        heading_stack: list[tuple[int, str]] = []  # Stack of (level, heading_text)
+        current_section_lines: list[str] = []
 
         for line in lines:
             heading_match = re.match(r"^(#{1,6})\s+(.+)$", line)
@@ -88,11 +96,13 @@ class StructuralChunker(BaseChunker):
                 # Save previous section if exists
                 if current_section_lines:
                     if heading_stack:
-                        sections.append({
-                            "content": "\n".join(current_section_lines).strip(),
-                            "path": [h[1] for h in heading_stack],
-                            "level": heading_stack[-1][0] if heading_stack else 0,
-                        })
+                        sections.append(
+                            {
+                                "content": "\n".join(current_section_lines).strip(),
+                                "path": [h[1] for h in heading_stack],
+                                "level": heading_stack[-1][0] if heading_stack else 0,
+                            }
+                        )
                     current_section_lines = []
 
                 # Process new heading
@@ -104,7 +114,6 @@ class StructuralChunker(BaseChunker):
                     heading_stack.pop()
 
                 heading_stack.append((heading_level, heading_text))
-                current_level = heading_level
 
             else:
                 # Regular content line
@@ -113,10 +122,12 @@ class StructuralChunker(BaseChunker):
 
         # Save final section
         if current_section_lines and heading_stack:
-            sections.append({
-                "content": "\n".join(current_section_lines).strip(),
-                "path": [h[1] for h in heading_stack],
-                "level": heading_stack[-1][0] if heading_stack else 0,
-            })
+            sections.append(
+                {
+                    "content": "\n".join(current_section_lines).strip(),
+                    "path": [h[1] for h in heading_stack],
+                    "level": heading_stack[-1][0] if heading_stack else 0,
+                }
+            )
 
         return sections


### PR DESCRIPTION
## Summary
Fixes #149 — `StructuralChunker.chunk()` silently returned an empty list for documents with no markdown headings, so such a document (e.g. a README without `#` headers) got ingested with zero chunks and no error.

## Problem
`_extract_sections()` only started collecting content once it had seen at least one heading. A document with zero headings never triggered that, so it returned `[]`, and `chunk()` returned `[]` in turn — silently dropping the document from the RAG index.

## Solution
When `_extract_sections()` returns no sections, `chunk()` now falls back to the existing `SemanticChunker` — the same fallback pattern this file already uses for oversized sections.

## Testing
- `test_document_with_no_headings` (previously failing) now passes.
- Full `test_structural_chunker.py`: 15/15 passing.
- Full `test_semantic_chunker.py`: 16/16 passing (also touched to add missing type annotations, no behavior change).
- `ruff`, `black`, `mypy` all pass clean on both changed files.

## Pre-existing failures (unrelated to this change)
- ~183 pre-existing ruff errors across ~20 test files (import order, unused vars, line length) — none in the files this PR touches.
- 52 pre-existing test failures in other modules (bias detector, PII scrubber, faithfulness checker, tech detector, skill extractor) — appear to be other curated course issues, not caused by this change.

## Notes
- A related-but-separate bug: content before the *first* heading in a document that does have headings is also silently dropped by `_extract_sections()`. Flagged, not fixed — out of scope for #149.