### PR TITLE
Feat/11 portfolio url ingestion

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,18 @@
+## Week 7 — Issue selection
+
+**Issue link:** [paste link here]
+
+**Issue title:** [paste issue title here]
+
+**Tier:** [ ] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+[In 3–5 sentences, in your own words: what the issue is (not a copy-paste of
+the title), what is currently broken or missing, and what a successful fix
+would accomplish. Naming the part of the codebase it affects is helpful context.]
+
+**Branch name:** [paste branch name here]
+
+**Setup confirmation:** [ ] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,18 +1,21 @@
 ## Week 7 — Issue selection
 
-**Issue link:** [paste link here]
+**Issue link:** https://github.com/ascherj/pathreview/issues/11
 
-**Issue title:** [paste issue title here]
+**Issue title:** Add support for ingesting a portfolio website URL
 
-**Tier:** [ ] Tier 1  [ ] Tier 2  [ ] Tier 3
+**Tier:** [ ] Tier 1  [X] Tier 2  [ ] Tier 3
+
+I picked Tier 2 because I have previously built RAG pipeline and I can mirror existing pipline for resume to build new feature
 
 **Problem summary:**
-[In 3–5 sentences, in your own words: what the issue is (not a copy-paste of
-the title), what is currently broken or missing, and what a successful fix
-would accomplish. Naming the part of the codebase it affects is helpful context.]
+The is no existing ingestion pipeline for the portfolio submitted through the URL. The successful implemention would fetch the page content, extract relevant text (bio, project descriptions), and include it in the vector store. The parts of database that are involved: 
+ingestion/parsers/ (new web_parser.py)
+ingestion/pipeline.py
+api/schemas/profile.py
 
-**Branch name:** [paste branch name here]
+**Branch name:** feat/11-portfolio-url-ingestion
 
 **Setup confirmation:** [ ] App runs locally at localhost:5173
 
-**Cohort ledger:** [ ] Issue added to cohort ledger
+**Cohort ledger:** [X] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -33,3 +33,34 @@ I added `tests/unit/test_web_parser.py`, which imports `ingestion.parsers.web_pa
 
 **Blockers or open questions:**
 When I tried replicating the issue through the UI, I couldn't see any ingested sources in the database after submitting a new profile — but all the info was saved correctly in `profiles`.  Is there a bug? Typeerror with ingestion? 
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+[What have you implemented so far? Which sub-tasks from PLAN.md are done?]
+
+**Next steps:**
+[What are you working on for the rest of the week?]
+
+**Blockers:**
+[Anything slowing you down? Or leave blank.]
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [link to your submitted pull request]
+
+**Branch:** [the branch name you worked on, e.g. `fix/123-short-description`]
+
+**What you built:**
+[1–3 sentences summarizing what your fix does and how it works]
+
+**Tests added or updated:**
+[Which test files did you touch? What do they cover?]
+
+**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+
+**Draft PR feedback received from:** [name or Slack handle, or "none"]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -40,27 +40,38 @@ When I tried replicating the issue through the UI, I couldn't see any ingested s
 
 **Current progress:**
 [What have you implemented so far? Which sub-tasks from PLAN.md are done?]
+I have implemented a Webparser part: 1. Write `WebParser` — fetch the URL, strip boilerplate, pull out the readable text
 
 **Next steps:**
 [What are you working on for the rest of the week?]
+I am looking to get steps done:
+2. Add `ingest_portfolio` to the pipeline, following the same shape as `ingest_resume`
+3. Hook it into `profile_service.py` so saving a profile with a portfolio URL kicks off ingestion
+4. Make `_record_ingested_source` actually write to the DB instead of just logging, so dedup works
+5. Turn the reproduction stubs in `test_web_parser.py` into real tests
 
 **Blockers:**
 [Anything slowing you down? Or leave blank.]
+I need to figure out all files I need to update and add URL ingestion
 
 ---
 
 ### Check-in 2 (end of week)
 
-**PR link:** [link to your submitted pull request]
+**PR link:** https://github.com/ascherj/pathreview/pull/450
 
-**Branch:** [the branch name you worked on, e.g. `fix/123-short-description`]
+**Branch:** feat/11-portfolio-url-ingestion
+
 
 **What you built:**
 [1–3 sentences summarizing what your fix does and how it works]
+I build a portfolio URL ingestion: a new WebParse that fetches porfolio page and extracts text and an ingest_portfolio method that runs tesx through the same chenk and embed flow. I wired this into profile_service.py so saving a profile with a portfolio_url automatically triggers ingestion in the background, failing quietly if the site is down or unparseable. You also fixed _record_ingested_source/_check_skip to actually read and write the IngestedSource table.
 
 **Tests added or updated:**
 [Which test files did you touch? What do they cover?]
+14 tests were added
+WebParser.parse() is tested for extracting readable text from portfolio HTML, stripping script/style/nav boilerplate, capturing title and word-count metadata, handling bytes input, and rejecting invalid content types. WebParser.fetch() is tested for a successful fetch, an HTTP/connection error, and a non-HTML content type, all raising ValueError appropriately. IngestionPipeline.ingest_portfolio() is tested end-to-end (fetch → parse → chunk → embed → DB record), for skipping re-ingestion of unchanged content (dedup), and for propagating exceptions when a fetch fails.
 
-**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+**Self-review confirmation:** [ x] make check passes  [x ] make test-unit passes
 
-**Draft PR feedback received from:** [name or Slack handle, or "none"]
+**Draft PR feedback received from:**  "none"

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -16,6 +16,20 @@ api/schemas/profile.py
 
 **Branch name:** feat/11-portfolio-url-ingestion
 
-**Setup confirmation:** [ ] App runs locally at localhost:5173
+**Setup confirmation:** [X] App runs locally at localhost:5173
 
 **Cohort ledger:** [X] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/Tanya703/pathreview/commit/67149a3d194a6364d27765e0a0f69f7120b34eb3
+
+**Reproduction summary:**
+I added `tests/unit/test_web_parser.py`, which imports `ingestion.parsers.web_parser.WebParser` and calls `IngestionPipeline.ingest_portfolio(...)`. Running `pytest tests/unit/test_web_parser.py -v` confirmed the gap: the import fails with `ModuleNotFoundError: No module named 'ingestion.parsers.web_parser'`, and the pipeline test fails with `AssertionError` because `IngestionPipeline` has no `ingest_portfolio` method. This confirms that although the UI, API, and DB already accept and store a profile's `portfolio_url`, nothing ever fetches or ingests that page's content into the vector store.
+
+**PLAN.md link:** https://github.com/Tanya703/pathreview/blob/feat/11-portfolio-url-ingestion/PLAN.md
+
+**Walkthrough video (recommended):** [link to your Loom video, ≤2 min — recommended, not graded]
+
+**Blockers or open questions:**
+When I tried replicating the issue through the UI, I couldn't see any ingested sources in the database after submitting a new profile — but all the info was saved correctly in `profiles`.  Is there a bug? Typeerror with ingestion? 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -75,3 +75,45 @@ WebParser.parse() is tested for extracting readable text from portfolio HTML, st
 **Self-review confirmation:** [ x] make check passes  [x ] make test-unit passes
 
 **Draft PR feedback received from:**  "none"
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [] Yes  [ x] No — still awaiting review
+
+**Summary of feedback:**
+[What did reviewers comment on? Or note that no review came in.]
+One area to focus on going forward is tightening the connection between your tests and the actual production code paths. Your test descriptions mention 14 tests covering fetch, parse, chunking, and dedup scenarios, which is great coverage in principle. However, when tests rely heavily on mocking every dependency (the HTTP client, the database session, the vector store, the embedding provider), it's easy to end up testing that your mocks behave correctly rather than that your code handles real-world edge cases. A practical habit to build: after writing mock-heavy unit tests, ask yourself "what would break in production that these tests wouldn't catch?" For example, testing that WebParser.parse() strips <script> and <nav> tags is valuable, but also consider whether your fetch timeout, redirect-following behavior, or character encoding handling would survive contact with a real portfolio site. Even one or two tests with realistic HTML fixtures (saved from actual portfolio pages) can catch parsing bugs that synthetic test HTML misses. This kind of thinking — bridging the gap between test confidence and production reliability — is one of the most transferable skills in professional engineering work.
+
+
+
+**How you responded:**
+[What changes did you make, or what did you reply? If no feedback,
+leave blank.]
+I need to update the tests to cover edge cases.
+---
+
+### Reflection
+
+**What was harder than you expected?**
+[Be specific — what part of the process, codebase, or workflow
+surprised you?]
+Navigating and understanding the codebase was harder than expected. It required more time to trace where methods are being imported from, undetrstanding archetecture of the app. This experience also taught me to be more thoughtful on the way I leverage Claude and parts that I should do by myself.
+
+**What did you learn about working in a large codebase?**
+[What's different about contributing to someone else's production code
+vs. building your own project?]
+When working in a large codebase, adding a small feature can result into a need to update a lot of other files which requires understanding of how all the pieces of the codebase fit together.When contributing to someone elso project you need to pay attention to contribution guidelines, align the formate of your code with the codebase format.
+
+**How did AI tools help — and where did they fall short?**
+[Where was AI assistance most useful this module? Where did you need
+to go beyond what AI could give you?] Claude was very hrlpful with understanding the structure of the codebase. It also provided a nice draft of the solution. Claude fell short when generating test for new feature. It didn't cover edge cases and would need more precise promting.
+
+**What would you do differently if you started over?**
+[Issue selection, planning, implementation, or process — anything
+you'd change?] I rushed through understanding the problem and codebase which slowed me down when it came to implementation as it needed multiple revisions. Next time I would spend more time using Claude to understand codebase. 
+
+**What are you most proud of from this module?**
+[One thing — it doesn't have to be the PR itself.]
+I am proud of being able to leverage Claude to contribute to large codebases

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,47 @@
+## Solution plan
+
+**Issue:** Add support for ingesting a portfolio website URL
+
+### Understand
+What is the root cause of this issue? What behavior is expected vs. actual?
+
+The portfolio URL gets saved on the profile, but nothing ever fetches or reads it. The form, the profile routes, and the DB all handle `portfolio_url` fine — it's just never used. The reason is that `IngestionPipeline` only has `ingest_resume`, `ingest_readme`, and `ingest_repo_metadata`. There's no `ingest_portfolio` and no `web_parser.py`. It should work like the other sources: fetch the page, parse the bio/project text, chunk it, and embed it so it actually feeds into RAG.
+
+### Map
+Which files, functions, or modules are involved?
+List the specific files you expect to touch.
+
+- `ingestion/parsers/web_parser.py` — new `WebParser`, based on `resume_parser.py`
+- `ingestion/pipeline.py` — add `ingest_portfolio(profile_id, url)`
+- `core/services/profile_service.py` — call ingestion when a profile is saved with a portfolio URL
+- `tests/unit/test_pipeline.py` — tests for `ingest_portfolio`
+
+### Plan
+What are the steps to fix this issue?
+Break it into 3–5 concrete sub-tasks.
+
+1. Write `WebParser` — fetch the URL, strip boilerplate, pull out the readable text
+2. Add `ingest_portfolio` to the pipeline, following the same shape as `ingest_resume`
+3. Hook it into `profile_service.py` so saving a profile with a portfolio URL kicks off ingestion
+4. Make `_record_ingested_source` actually write to the DB instead of just logging, so dedup works
+5. Turn the reproduction stubs in `test_web_parser.py` into real tests
+
+### Inputs & outputs
+What does your fix take as input? What should it produce or change?
+
+Takes a `profile_id` and `portfolio_url`. Produces the same `IngestResult` as the other ingest methods, and writes new embeddings into the vector store.
+
+### Risks & unknowns
+What could go wrong? What are you still unsure about?
+
+- External sites are unreliable — timeouts, redirects, weird content types. Needs to fail quietly, not break profile creation.
+- Haven't decided if ingestion should run inline on save or get pushed to a background job.
+
+### Edge cases
+What inputs or states should your fix handle gracefully?
+
+- No portfolio URL — just skip it
+- URL is down or errors out — log it, move on
+- URL isn't actually an HTML page (PDF, image, etc.)
+- Same URL submitted twice with no changes — shouldn't re-embed
+- Portfolio content changes later — should pick that up instead of skipping forever

--- a/core/database.py
+++ b/core/database.py
@@ -2,8 +2,9 @@
 
 from typing import AsyncGenerator
 
+from sqlalchemy import create_engine
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine, async_sessionmaker
-from sqlalchemy.orm import declarative_base
+from sqlalchemy.orm import declarative_base, sessionmaker
 
 from core.config import settings
 
@@ -25,6 +26,13 @@ AsyncSessionLocal = async_sessionmaker(
     autocommit=False,
     autoflush=False,
 )
+
+# Sync engine/session, for code (like the ingestion pipeline) that isn't async-native
+sync_engine = create_engine(
+    settings.database_url.replace("+asyncpg", "+psycopg2"),
+    pool_pre_ping=True,
+)
+SyncSessionLocal = sessionmaker(bind=sync_engine, autocommit=False, autoflush=False)
 
 # Declarative base for models
 Base = declarative_base()

--- a/core/services/profile_service.py
+++ b/core/services/profile_service.py
@@ -1,13 +1,45 @@
+import asyncio
 from uuid import UUID
 import structlog
 from sqlalchemy import select
 
+from core.config import settings
+from core.database import SyncSessionLocal
 from core.models.profile import Profile
 from core.models.review import Review
 from core.models.ingested_source import IngestedSource
 from api.schemas.profile import ProfileCreate, ProfileUpdate
+from ingestion.embeddings.provider import get_embedding_provider
+from ingestion.pipeline import IngestionPipeline
+from rag.retriever.vector_store import VectorStore
 
 log = structlog.get_logger()
+
+
+def _ingest_portfolio(profile_id: str, portfolio_url: str) -> None:
+    """
+    Fetch and embed a profile's portfolio page.
+
+    Runs synchronously against the ingestion pipeline. Failures (unreachable
+    site, non-HTML content, etc.) are logged and swallowed so that a bad
+    portfolio URL never breaks profile creation/update.
+    """
+    try:
+        vector_db = VectorStore().get_collection(f"profile_{profile_id}")
+        with SyncSessionLocal() as session:
+            pipeline = IngestionPipeline(
+                vector_db=vector_db,
+                db_session=session,
+                embedding_provider=get_embedding_provider(settings.llm_provider),
+            )
+            pipeline.ingest_portfolio(profile_id=profile_id, url=portfolio_url)
+    except Exception as exc:
+        log.warning(
+            "portfolio_ingestion_failed",
+            profile_id=profile_id,
+            portfolio_url=portfolio_url,
+            error=str(exc),
+        )
 
 
 async def create_profile(
@@ -30,6 +62,10 @@ async def create_profile(
     db.add(profile)
     await db.commit()
     await db.refresh(profile)
+
+    if profile.portfolio_url:
+        await asyncio.to_thread(_ingest_portfolio, str(profile.id), profile.portfolio_url)
+
     return profile
 
 
@@ -69,6 +105,10 @@ async def update_profile(
     db.add(profile)
     await db.commit()
     await db.refresh(profile)
+
+    if data.portfolio_url:
+        await asyncio.to_thread(_ingest_portfolio, str(profile.id), profile.portfolio_url)
+
     return profile
 
 

--- a/ingestion/chunking/strategy_selector.py
+++ b/ingestion/chunking/strategy_selector.py
@@ -27,6 +27,8 @@ class StrategySelector:
             return self.structural_chunker
         elif source_type == "repo":
             return self.semantic_chunker
+        elif source_type == "web":
+            return self.semantic_chunker
         else:
             # Default to semantic chunking
             return self.semantic_chunker

--- a/ingestion/chunking/strategy_selector.py
+++ b/ingestion/chunking/strategy_selector.py
@@ -16,7 +16,7 @@ class StrategySelector:
         Select appropriate chunker based on document type.
 
         Args:
-            source_type: One of "resume", "readme", "repo", or default
+            source_type: One of "resume", "readme", "repo", "web", or default
 
         Returns:
             Appropriate BaseChunker instance
@@ -25,9 +25,7 @@ class StrategySelector:
             return self.semantic_chunker
         elif source_type == "readme":
             return self.structural_chunker
-        elif source_type == "repo":
-            return self.semantic_chunker
-        elif source_type == "web":
+        elif source_type in ("repo", "web"):
             return self.semantic_chunker
         else:
             # Default to semantic chunking

--- a/ingestion/parsers/web_parser.py
+++ b/ingestion/parsers/web_parser.py
@@ -1,0 +1,121 @@
+import re
+from html.parser import HTMLParser
+
+import httpx
+import structlog
+
+from .base import BaseParser, ParseResult
+
+logger = structlog.get_logger()
+
+
+SKIP_TAGS = {"script", "style", "noscript", "head", "nav", "footer"}
+BLOCK_TAGS = {"p", "div", "section", "article", "li", "br", "h1", "h2", "h3", "h4", "h5", "h6"}
+
+
+class _HTMLTextExtractor(HTMLParser):
+    """Extracts readable text from HTML, skipping script/style/nav boilerplate."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._skip_depth = 0
+        self._parts: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag in SKIP_TAGS:
+            self._skip_depth += 1
+        elif tag in BLOCK_TAGS:
+            self._parts.append("\n")
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag in SKIP_TAGS:
+            self._skip_depth = max(0, self._skip_depth - 1)
+        elif tag in BLOCK_TAGS:
+            self._parts.append("\n")
+
+    def handle_data(self, data: str) -> None:
+        if self._skip_depth == 0:
+            self._parts.append(data)
+
+    def get_text(self) -> str:
+        text = "".join(self._parts)
+        text = re.sub(r"[ \t]+", " ", text)
+        text = re.sub(r" *\n *", "\n", text)
+        text = re.sub(r"\n{3,}", "\n\n", text)
+        return text.strip()
+
+
+class WebParser(BaseParser):
+    """Parser for portfolio website pages."""
+
+    TIMEOUT_SECONDS = 10.0
+
+    def fetch(self, url: str) -> str:
+        """
+        Fetch a portfolio page's HTML content.
+
+        Args:
+            url: The portfolio URL to fetch
+
+        Returns:
+            Raw HTML content as a string
+
+        Raises:
+            ValueError: If the page can't be fetched or isn't an HTML page
+        """
+        try:
+            response = httpx.get(url, timeout=self.TIMEOUT_SECONDS, follow_redirects=True)
+            response.raise_for_status()
+        except httpx.HTTPError as e:
+            raise ValueError(f"Failed to fetch {url}: {str(e)}") from e
+
+        content_type = response.headers.get("content-type", "")
+        if "html" not in content_type.lower():
+            raise ValueError(f"Unsupported content type for {url}: {content_type or 'unknown'}")
+
+        return response.text
+
+    def parse(self, content: str | bytes) -> ParseResult:
+        """
+        Parse a portfolio page from HTML content.
+
+        Args:
+            content: HTML string or bytes
+
+        Returns:
+            ParseResult with extracted readable text and metadata
+
+        Raises:
+            ValueError: If content is neither str nor bytes
+        """
+        if isinstance(content, bytes):
+            content = content.decode("utf-8", errors="replace")
+        elif not isinstance(content, str):
+            raise ValueError("Content must be bytes or str (HTML)")
+
+        try:
+            extractor = _HTMLTextExtractor()
+            extractor.feed(content)
+            text = extractor.get_text()
+        except Exception as e:
+            raise ValueError(f"Failed to parse HTML: {str(e)}") from e
+
+        title = self._extract_title(content)
+        word_count = len(text.split())
+
+        metadata = {
+            "source_type": "web",
+            "title": title,
+            "word_count": word_count,
+        }
+
+        return ParseResult(
+            text=text,
+            metadata=metadata,
+            source_type="web",
+        )
+
+    def _extract_title(self, content: str) -> str | None:
+        """Extract the page <title>, if present."""
+        match = re.search(r"<title[^>]*>(.*?)</title>", content, re.IGNORECASE | re.DOTALL)
+        return match.group(1).strip() if match else None

--- a/ingestion/pipeline.py
+++ b/ingestion/pipeline.py
@@ -4,12 +4,15 @@ from typing import Optional
 
 import structlog
 
+from core.models.ingested_source import IngestedSource
+
 from .chunking.strategy_selector import StrategySelector
 from .embeddings.batch_processor import BatchEmbeddingProcessor
 from .embeddings.provider import EmbeddingProvider
 from .parsers.readme_parser import ReadmeParser
 from .parsers.repo_analyzer import RepoAnalyzer
 from .parsers.resume_parser import ResumeParser
+from .parsers.web_parser import WebParser
 
 
 logger = structlog.get_logger()
@@ -51,6 +54,7 @@ class IngestionPipeline:
         self.resume_parser = ResumeParser()
         self.readme_parser = ReadmeParser()
         self.repo_analyzer = RepoAnalyzer()
+        self.web_parser = WebParser()
 
     def ingest_resume(
         self,
@@ -69,7 +73,8 @@ class IngestionPipeline:
         Returns:
             IngestResult with ingestion status
         """
-        source_id = f"resume_{profile_id}_{self._hash_content(content)}"
+        content_hash = self._hash_content(content)
+        source_id = f"resume_{profile_id}_{content_hash}"
 
         logger.info(
             "Starting resume ingestion",
@@ -79,7 +84,7 @@ class IngestionPipeline:
         )
 
         # Check if already ingested
-        skip_result = self._check_skip(source_id, "resume")
+        skip_result = self._check_skip(profile_id, "resume", content_hash)
         if skip_result:
             return skip_result
 
@@ -106,7 +111,9 @@ class IngestionPipeline:
             logger.info("Resume embeddings stored", chunk_count=len(chunks))
 
             # Record in database
-            self._record_ingested_source(source_id, "resume", profile_id, len(chunks))
+            self._record_ingested_source(
+                profile_id, "resume", content_hash, len(chunks), filename=filename
+            )
 
             return IngestResult(
                 source_id=source_id,
@@ -140,7 +147,8 @@ class IngestionPipeline:
         Returns:
             IngestResult with ingestion status
         """
-        source_id = f"readme_{profile_id}_{repo_name}_{self._hash_content(content)}"
+        content_hash = self._hash_content(content)
+        source_id = f"readme_{profile_id}_{repo_name}_{content_hash}"
 
         logger.info(
             "Starting README ingestion",
@@ -150,7 +158,7 @@ class IngestionPipeline:
         )
 
         # Check if already ingested
-        skip_result = self._check_skip(source_id, "readme")
+        skip_result = self._check_skip(profile_id, "readme", content_hash)
         if skip_result:
             return skip_result
 
@@ -181,7 +189,9 @@ class IngestionPipeline:
             logger.info("README embeddings stored", chunk_count=len(chunks))
 
             # Record in database
-            self._record_ingested_source(source_id, "readme", profile_id, len(chunks))
+            self._record_ingested_source(
+                profile_id, "readme", content_hash, len(chunks), filename=repo_name
+            )
 
             return IngestResult(
                 source_id=source_id,
@@ -214,7 +224,8 @@ class IngestionPipeline:
             IngestResult with ingestion status
         """
         repo_name = repo_data.get("name", "unknown")
-        source_id = f"repo_{profile_id}_{repo_name}_{self._hash_content(str(repo_data))}"
+        content_hash = self._hash_content(str(repo_data))
+        source_id = f"repo_{profile_id}_{repo_name}_{content_hash}"
 
         logger.info(
             "Starting repo metadata ingestion",
@@ -224,7 +235,7 @@ class IngestionPipeline:
         )
 
         # Check if already ingested
-        skip_result = self._check_skip(source_id, "repo")
+        skip_result = self._check_skip(profile_id, "repo", content_hash)
         if skip_result:
             return skip_result
 
@@ -254,7 +265,13 @@ class IngestionPipeline:
             logger.info("Repository embeddings stored", chunk_count=len(chunks))
 
             # Record in database
-            self._record_ingested_source(source_id, "repo", profile_id, len(chunks))
+            self._record_ingested_source(
+                profile_id,
+                "repo",
+                content_hash,
+                len(chunks),
+                source_url=repo_data.get("html_url"),
+            )
 
             return IngestResult(
                 source_id=source_id,
@@ -271,37 +288,125 @@ class IngestionPipeline:
             )
             raise
 
+    def ingest_portfolio(
+        self,
+        profile_id: str,
+        url: str,
+    ) -> IngestResult:
+        """
+        Ingest a portfolio website.
+
+        Args:
+            profile_id: ID of the profile owner
+            url: Portfolio URL to fetch and ingest
+
+        Returns:
+            IngestResult with ingestion status
+        """
+        logger.info("Starting portfolio ingestion", profile_id=profile_id, url=url)
+
+        try:
+            # Fetch the page
+            html = self.web_parser.fetch(url)
+
+            content_hash = self._hash_content(html)
+            source_id = f"web_{profile_id}_{content_hash}"
+
+            # Check if already ingested
+            skip_result = self._check_skip(profile_id, "web", content_hash)
+            if skip_result:
+                return skip_result
+
+            # Parse portfolio page
+            parse_result = self.web_parser.parse(html)
+            logger.info(
+                "Portfolio parsed successfully",
+                word_count=parse_result.metadata.get("word_count"),
+            )
+
+            # Prepare metadata
+            metadata = parse_result.metadata.copy()
+            metadata.update({
+                "source_id": source_id,
+                "profile_id": profile_id,
+                "source_url": url,
+                "source_type": "web",
+            })
+
+            # Chunk the content
+            chunks = self.strategy_selector.chunk(parse_result.text, metadata)
+            logger.info("Portfolio chunked successfully", chunk_count=len(chunks))
+
+            # Generate embeddings and store
+            self.batch_processor.process(chunks)
+            logger.info("Portfolio embeddings stored", chunk_count=len(chunks))
+
+            # Record in database
+            self._record_ingested_source(
+                profile_id, "web", content_hash, len(chunks), source_url=url
+            )
+
+            return IngestResult(
+                source_id=source_id,
+                chunk_count=len(chunks),
+                skipped=False,
+            )
+
+        except Exception as e:
+            logger.error(
+                "Portfolio ingestion failed",
+                profile_id=profile_id,
+                url=url,
+                error=str(e),
+            )
+            raise
+
     def _hash_content(self, content: str | bytes) -> str:
         """Generate a hash of content for deduplication."""
         if isinstance(content, str):
             content = content.encode()
         return hashlib.sha256(content).hexdigest()[:16]
 
-    def _check_skip(self, source_id: str, source_type: str) -> Optional[IngestResult]:
+    def _check_skip(
+        self,
+        profile_id: str,
+        source_type: str,
+        content_hash: str,
+    ) -> Optional[IngestResult]:
         """
-        Check if source has already been ingested.
+        Check if this exact content was already ingested for this profile.
 
         Returns IngestResult if should skip, None if should proceed.
         """
         try:
-            # Query database for existing source
-            # This assumes a table/model named IngestedSource
-            existing = self.db_session.query(
-                "IngestedSource"  # Placeholder - actual query depends on ORM
-            ).filter_by(source_id=source_id).first()
+            existing = (
+                self.db_session.query(IngestedSource)
+                .filter_by(
+                    profile_id=profile_id,
+                    source_type=source_type,
+                    content_hash=content_hash,
+                )
+                .first()
+            )
 
             if existing:
-                logger.info("Source already ingested, skipping", source_id=source_id)
+                logger.info(
+                    "Source already ingested, skipping",
+                    profile_id=profile_id,
+                    source_type=source_type,
+                    content_hash=content_hash,
+                )
                 return IngestResult(
-                    source_id=source_id,
-                    chunk_count=0,
+                    source_id=str(existing.id),
+                    chunk_count=existing.chunk_count,
                     skipped=True,
                     skip_reason="Source already ingested",
                 )
         except Exception as e:
             logger.warning(
                 "Could not check if source already ingested",
-                source_id=source_id,
+                profile_id=profile_id,
+                source_type=source_type,
                 error=str(e),
             )
 
@@ -309,33 +414,46 @@ class IngestionPipeline:
 
     def _record_ingested_source(
         self,
-        source_id: str,
-        source_type: str,
         profile_id: str,
+        source_type: str,
+        content_hash: str,
         chunk_count: int,
+        filename: Optional[str] = None,
+        source_url: Optional[str] = None,
     ) -> None:
         """
-        Record that a source has been ingested.
+        Persist a record of an ingested source so future ingestion can dedup against it.
 
         Args:
-            source_id: Unique ID for the source
-            source_type: Type of source (resume, readme, repo)
             profile_id: ID of profile owner
+            source_type: Type of source (resume, readme, repo, web)
+            content_hash: SHA256 hash of the ingested content
             chunk_count: Number of chunks created
+            filename: Original filename, if applicable (e.g. resume)
+            source_url: Source URL, if applicable (e.g. repo, web)
         """
         try:
-            # This is a placeholder for actual database recording
-            # In a real implementation, would create IngestedSource record
-            logger.info(
-                "Recording ingested source",
-                source_id=source_id,
-                source_type=source_type,
+            record = IngestedSource(
                 profile_id=profile_id,
+                source_type=source_type,
+                source_url=source_url,
+                filename=filename,
+                content_hash=content_hash,
+                chunk_count=chunk_count,
+            )
+            self.db_session.add(record)
+            self.db_session.commit()
+            logger.info(
+                "Recorded ingested source",
+                profile_id=profile_id,
+                source_type=source_type,
                 chunk_count=chunk_count,
             )
         except Exception as e:
             logger.error(
                 "Failed to record ingested source",
-                source_id=source_id,
+                profile_id=profile_id,
+                source_type=source_type,
                 error=str(e),
             )
+            self.db_session.rollback()

--- a/tests/unit/test_web_parser.py
+++ b/tests/unit/test_web_parser.py
@@ -1,0 +1,58 @@
+"""Reproduction test for issue #11: portfolio URL ingestion is missing.
+
+There is no ingestion path for a profile's portfolio_url today: no
+ingestion/parsers/web_parser.py exists, and IngestionPipeline has no
+ingest_portfolio method. These tests fail against the current codebase,
+demonstrating the gap described in the issue.
+"""
+
+import pytest
+
+from ingestion.parsers.base import ParseResult
+
+
+@pytest.mark.unit
+class TestWebParser:
+    """Test suite for the not-yet-implemented WebParser."""
+
+    def test_web_parser_module_exists(self):
+        """A web_parser module should exist alongside the other parsers."""
+        from ingestion.parsers.web_parser import WebParser  # noqa: F401
+
+    def test_parse_portfolio_page_html(self):
+        """Parsing a portfolio page's HTML should extract bio/project text."""
+        from ingestion.parsers.web_parser import WebParser
+
+        sample_html = """
+        <html>
+          <body>
+            <h1>Jane Doe</h1>
+            <p>Software engineer building web apps.</p>
+            <section id="projects">
+              <h2>Weather App</h2>
+              <p>A weather forecasting app built with React.</p>
+            </section>
+          </body>
+        </html>
+        """
+
+        parser = WebParser()
+        result = parser.parse(sample_html)
+
+        assert isinstance(result, ParseResult)
+        assert result.source_type == "web"
+        assert "Jane Doe" in result.text
+        assert "Weather App" in result.text
+
+
+@pytest.mark.unit
+class TestIngestionPipelinePortfolio:
+    """The pipeline should be able to ingest a portfolio URL end-to-end."""
+
+    def test_ingest_portfolio_method_exists(self):
+        """IngestionPipeline should expose an ingest_portfolio method."""
+        from ingestion.pipeline import IngestionPipeline
+
+        pipeline = IngestionPipeline(vector_db=None, db_session=None, embedding_provider=None)
+
+        assert hasattr(pipeline, "ingest_portfolio")

--- a/tests/unit/test_web_parser.py
+++ b/tests/unit/test_web_parser.py
@@ -1,28 +1,25 @@
-"""Reproduction test for issue #11: portfolio URL ingestion is missing.
+"""Tests for web_parser.py and IngestionPipeline.ingest_portfolio."""
 
-There is no ingestion path for a profile's portfolio_url today: no
-ingestion/parsers/web_parser.py exists, and IngestionPipeline has no
-ingest_portfolio method. These tests fail against the current codebase,
-demonstrating the gap described in the issue.
-"""
+from unittest.mock import MagicMock, Mock, patch
 
+import httpx
 import pytest
 
 from ingestion.parsers.base import ParseResult
+from ingestion.parsers.web_parser import WebParser
 
 
 @pytest.mark.unit
 class TestWebParser:
-    """Test suite for the not-yet-implemented WebParser."""
+    """Test suite for WebParser."""
 
-    def test_web_parser_module_exists(self):
-        """A web_parser module should exist alongside the other parsers."""
-        from ingestion.parsers.web_parser import WebParser  # noqa: F401
+    @pytest.fixture
+    def parser(self):
+        """Create a WebParser instance."""
+        return WebParser()
 
-    def test_parse_portfolio_page_html(self):
+    def test_parse_portfolio_page_html(self, parser):
         """Parsing a portfolio page's HTML should extract bio/project text."""
-        from ingestion.parsers.web_parser import WebParser
-
         sample_html = """
         <html>
           <body>
@@ -36,7 +33,6 @@ class TestWebParser:
         </html>
         """
 
-        parser = WebParser()
         result = parser.parse(sample_html)
 
         assert isinstance(result, ParseResult)
@@ -44,10 +40,136 @@ class TestWebParser:
         assert "Jane Doe" in result.text
         assert "Weather App" in result.text
 
+    def test_parse_strips_script_and_style_boilerplate(self, parser):
+        """Script, style, and nav content should not appear in extracted text."""
+        html = """
+        <html>
+          <head><style>body { color: red; }</style></head>
+          <body>
+            <nav>Home About Contact</nav>
+            <script>console.log("tracking");</script>
+            <p>Real portfolio content.</p>
+          </body>
+        </html>
+        """
+
+        result = parser.parse(html)
+
+        assert "Real portfolio content" in result.text
+        assert "console.log" not in result.text
+        assert "color: red" not in result.text
+        assert "Home About Contact" not in result.text
+
+    def test_parse_extracts_title_metadata(self, parser):
+        """The page <title> should be captured in metadata."""
+        html = "<html><head><title>Jane Doe - Portfolio</title></head><body><p>Hi</p></body></html>"
+
+        result = parser.parse(html)
+
+        assert result.metadata["title"] == "Jane Doe - Portfolio"
+
+    def test_parse_no_title_returns_none(self, parser):
+        """Missing <title> should not raise, just leave metadata title as None."""
+        html = "<html><body><p>No title here</p></body></html>"
+
+        result = parser.parse(html)
+
+        assert result.metadata["title"] is None
+
+    def test_parse_word_count_metadata(self, parser):
+        """Word count should reflect the extracted text, not the raw HTML."""
+        html = "<html><body><p>One two three four five</p></body></html>"
+
+        result = parser.parse(html)
+
+        assert result.metadata["word_count"] == 5
+
+    def test_parse_bytes_input(self, parser):
+        """Bytes input should be decoded before parsing."""
+        html_bytes = b"<html><body><p>Bytes portfolio content</p></body></html>"
+
+        result = parser.parse(html_bytes)
+
+        assert isinstance(result, ParseResult)
+        assert "Bytes portfolio content" in result.text
+
+    def test_parse_invalid_content_type(self, parser):
+        """Non-str/bytes content should raise ValueError."""
+        with pytest.raises(ValueError) as exc_info:
+            parser.parse(12345)
+
+        assert "Content must be" in str(exc_info.value)
+
+    def test_fetch_success(self, parser):
+        """A successful fetch should return the response's HTML text."""
+        mock_response = Mock()
+        mock_response.text = "<html><body><p>Fetched</p></body></html>"
+        mock_response.headers = {"content-type": "text/html; charset=utf-8"}
+        mock_response.raise_for_status = Mock()
+
+        with patch(
+            "ingestion.parsers.web_parser.httpx.get", return_value=mock_response
+        ) as mock_get:
+            html = parser.fetch("https://example.com/portfolio")
+
+        mock_get.assert_called_once()
+        assert html == "<html><body><p>Fetched</p></body></html>"
+
+    def test_fetch_http_error_raises_value_error(self, parser):
+        """HTTP errors (timeouts, connection errors, 4xx/5xx) should raise ValueError."""
+        with patch(
+            "ingestion.parsers.web_parser.httpx.get",
+            side_effect=httpx.ConnectTimeout("timed out"),
+        ), pytest.raises(ValueError) as exc_info:
+            parser.fetch("https://example.com/portfolio")
+
+        assert "Failed to fetch" in str(exc_info.value)
+
+    def test_fetch_non_html_content_type_raises_value_error(self, parser):
+        """A non-HTML response (e.g. a PDF) should raise ValueError."""
+        mock_response = Mock()
+        mock_response.headers = {"content-type": "application/pdf"}
+        mock_response.raise_for_status = Mock()
+
+        with (
+            patch("ingestion.parsers.web_parser.httpx.get", return_value=mock_response),
+            pytest.raises(ValueError) as exc_info,
+        ):
+            parser.fetch("https://example.com/resume.pdf")
+
+        assert "Unsupported content type" in str(exc_info.value)
+
 
 @pytest.mark.unit
 class TestIngestionPipelinePortfolio:
     """The pipeline should be able to ingest a portfolio URL end-to-end."""
+
+    @pytest.fixture
+    def mock_db_session(self):
+        """Create a mock db session with no existing ingested sources."""
+        session = MagicMock()
+        session.query.return_value.filter_by.return_value.first.return_value = None
+        return session
+
+    @pytest.fixture
+    def mock_embedding_provider(self):
+        provider = Mock()
+        provider.embed = Mock(return_value=[[0.1] * 1536])
+        return provider
+
+    @pytest.fixture
+    def mock_vector_db(self):
+        return Mock()
+
+    @pytest.fixture
+    def pipeline(self, mock_vector_db, mock_db_session, mock_embedding_provider):
+        from ingestion.pipeline import IngestionPipeline
+
+        return IngestionPipeline(
+            vector_db=mock_vector_db,
+            db_session=mock_db_session,
+            embedding_provider=mock_embedding_provider,
+        )
 
     def test_ingest_portfolio_method_exists(self):
         """IngestionPipeline should expose an ingest_portfolio method."""
@@ -56,3 +178,52 @@ class TestIngestionPipelinePortfolio:
         pipeline = IngestionPipeline(vector_db=None, db_session=None, embedding_provider=None)
 
         assert hasattr(pipeline, "ingest_portfolio")
+
+    def test_ingest_portfolio_success(self, pipeline, mock_db_session):
+        """A fresh portfolio URL should be fetched, parsed, chunked, embedded, and recorded."""
+        sample_html = "<html><body><h1>Jane Doe</h1><p>Building things.</p></body></html>"
+
+        with patch.object(pipeline.web_parser, "fetch", return_value=sample_html):
+            result = pipeline.ingest_portfolio(profile_id="profile-1", url="https://janedoe.dev")
+
+        assert result.skipped is False
+        assert result.chunk_count > 0
+        assert result.source_id.startswith("web_profile-1_")
+        # Recorded in the DB for future dedup
+        mock_db_session.add.assert_called_once()
+        mock_db_session.commit.assert_called_once()
+        recorded = mock_db_session.add.call_args[0][0]
+        assert recorded.profile_id == "profile-1"
+        assert recorded.source_type == "web"
+        assert recorded.source_url == "https://janedoe.dev"
+
+    def test_ingest_portfolio_skips_when_already_ingested(
+        self, pipeline, mock_db_session
+    ):
+        """The same portfolio content should not be re-embedded."""
+        sample_html = "<html><body><p>Same content every time</p></body></html>"
+
+        existing = Mock()
+        existing.id = "existing-source-id"
+        existing.chunk_count = 3
+        mock_db_session.query.return_value.filter_by.return_value.first.return_value = existing
+
+        with patch.object(pipeline.web_parser, "fetch", return_value=sample_html):
+            result = pipeline.ingest_portfolio(profile_id="profile-1", url="https://janedoe.dev")
+
+        assert result.skipped is True
+        assert result.skip_reason == "Source already ingested"
+        assert result.chunk_count == 3
+        mock_db_session.add.assert_not_called()
+
+    def test_ingest_portfolio_fetch_failure_propagates(self, pipeline):
+        """An unreachable portfolio URL should raise so the caller can decide how to handle it."""
+        with (
+            patch.object(
+                pipeline.web_parser,
+                "fetch",
+                side_effect=ValueError("Failed to fetch https://down.example"),
+            ),
+            pytest.raises(ValueError),
+        ):
+            pipeline.ingest_portfolio(profile_id="profile-1", url="https://down.example")


### PR DESCRIPTION
## Summary
Portfolio URLs were saved on a profile but never used — nothing fetched the page or fed it into the RAG pipeline. This PR adds a `WebParser` that fetches and extracts readable text from a portfolio site, wires it into `IngestionPipeline` as `ingest_portfolio` (mirroring the existing `ingest_resume` flow), and hooks it into profile creation/update so submitting a portfolio URL now actually ingests it. It also fixes source-tracking (`_check_skip`/`_record_ingested_source`), which was a logging-only placeholder, so re-ingesting unchanged content is now correctly skipped.

## Issue
Closes #11

## Changes
- Added `ingestion/parsers/web_parser.py` — `WebParser.fetch(url)` fetches and validates the page is HTML; `WebParser.parse(content)` strips script/style/nav boilerplate and extracts readable text, title, and word count.
- Added `IngestionPipeline.ingest_portfolio(profile_id, url)` in `ingestion/pipeline.py`, following the same fetch → dedup-check → parse → chunk → embed → record shape as `ingest_resume`.
- Made `_check_skip`/`_record_ingested_source` actually query/write the `IngestedSource` table (profile_id + source_type + content_hash) instead of logging only — updated the other `ingest_*` methods to pass `content_hash` through so dedup works uniformly across resume/readme/repo/web.
- Hooked ingestion into `core/services/profile_service.py`: `create_profile`/`update_profile` now trigger `ingest_portfolio` in a background thread whenever a `portfolio_url` is present, with failures caught and logged so a dead/non-HTML site never breaks profile save.
- Added a sync `SyncSessionLocal` in `core/database.py` for the ingestion pipeline's synchronous ORM session (the rest of the app is async-only).
- Registered `"web"` as a source type in `ingestion/chunking/strategy_selector.py` (uses the semantic chunker, same as repo metadata).
- Wrote 14 tests `tests/unit/test_web_parser.py` w

## Testing
- [x] Unit tests pass (`make test-unit`) — for the files touched in this PR (`tests/unit/test_web_parser.py`, 14 tests). Note: the full repo-wide suite has 53 pre-existing failures unrelated to this change (confirmed via `git stash` diff against `main` before/after this branch's commits).
- [ ] Integration tests pass (`make test-integration`) — not run; no integration tests exist for ingestion yet.
- [x] Linter passes (`make lint`) — clean on all files touched by this PR; `make lint` on the whole repo surfaces ~185 pre-existing errors unrelated to this change.
- [x] Type checker passes (`make typecheck`) — clean on `ingestion/parsers/web_parser.py` and `ingestion/pipeline.py`; the whole-repo `make typecheck` has 104 pre-existing errors unrelated to this change.
- [x] New/updated tests cover the changes

## Screenshots / Demo
N/A — backend ingestion pipeline change, no UI changes.


