### PR TITLE
Test/156 readme scorer fixture

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -9,7 +9,7 @@
 **Problem summary:**
 This is an issue with the tests. Specifically, the README is too short and the test says that it is. The correct fix would be to lengthen the README to the correct length or change the test so that it accepts the README. 
 
-**Branch name:** [paste branch name here]
+**Branch name:** test/156-readme-scorer-fixture
 
 **Setup confirmation:** [Y] App runs locally at localhost:5173
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -136,16 +136,16 @@ leave blank.]
 ### Reflection
 
 **What was harder than you expected?**
-Setting up docker was harder than expected
+Setting up docker was harder than expected. Without AI, I probably would have struggled with the setup for hours.
 
 **What did you learn about working in a large codebase?**
 Working in a large codebase is really difficult. It is like trying to help on a topic that you have no idea about. 
 
 **How did AI tools help — and where did they fall short?**
-AI tools were helpful in guiding me on the correct steps whenever I got stuck. 
+AI tools were helpful in guiding me on the correct steps whenever I got stuck. They were also helpful in familiarizing myself with a codebase. If I needed to know where something is, AI is a great tool for that. I can not recall any times where is fell significantly short. 
 
 **What would you do differently if you started over?**
-If I could start over, I would have chosen a more difficult problem to work on. 
+If I could start over, I would have chosen a more difficult problem to work on. My problem was fairly easy and in hindsight I could have taken on a more difficult problem. 
 
 **What are you most proud of from this module?**
-I am most proud of finishing my first Codepath course. 
+I am most proud of finishing my first Codepath course. I definitely plan to take more in the future. 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,16 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/156
+
+**Issue title:** README scorer test fixture is too short for its own word-count assertion
+
+**Tier:** [Y] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+This is an issue with the tests. Specifically, the README is too short and the test says that it is. The correct fix would be to lengthen the README to the correct length or change the test so that it accepts the README. 
+
+**Branch name:** [paste branch name here]
+
+**Setup confirmation:** [Y] App runs locally at localhost:5173
+
+**Cohort ledger:** [Y] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -128,24 +128,23 @@ no new failures:
 No feedback
 
 **How you responded:**
-[What changes did you make, or what did you reply? If no feedback,
-leave blank.]
+No feedback came in, so there was nothing to respond to.
 
 ---
 
 ### Reflection
 
 **What was harder than you expected?**
-Setting up docker was harder than expected. Without AI, I probably would have struggled with the setup for hours.
+Setting up docker was harder than expected. Without AI, I probably would have struggled with the setup for hours. I also did not expect the repo's tests to already be failing when I cloned it. make check and make test-unit both fail before you change anything, so I could not just say the tests pass. I ended up writing down the numbers before and after my change, 53 failed to 52 failed, to show I did not break anything.
 
 **What did you learn about working in a large codebase?**
-Working in a large codebase is really difficult. It is like trying to help on a topic that you have no idea about. 
+Working in a large codebase is really difficult. It is like trying to help on a topic that you have no idea about. In my own projects I know where everything is. Here I guessed the wrong file in my Week 7 entry and did not find out until I opened it, the word count code was in agent/tools/readme_scorer.py. I also learned to leave things alone. There were 52 other failing tests and I did not touch any of them so my PR stayed on issue #156.
 
 **How did AI tools help — and where did they fall short?**
-AI tools were helpful in guiding me on the correct steps whenever I got stuck. They were also helpful in familiarizing myself with a codebase. If I needed to know where something is, AI is a great tool for that. I can not recall any times where is fell significantly short. 
+AI tools were helpful in guiding me on the correct steps whenever I got stuck. They were also helpful in familiarizing myself with a codebase. If I needed to know where something is, AI is a great tool for that. Where it fell short is that it sounds sure of itself even when it is wrong, which is where my wrong file path came from. It also could not decide for me. When the test failed with assert 51 > 100 I had to pick between changing the category to adequate or making the fixture 500+ words, and I had to read the scorer myself to know which one was right.
 
 **What would you do differently if you started over?**
-If I could start over, I would have chosen a more difficult problem to work on. My problem was fairly easy and in hindsight I could have taken on a more difficult problem. 
+If I could start over, I would have chosen a more difficult problem to work on. My problem was fairly easy and in hindsight I could have taken on a more difficult problem. It was one test where the fixture was 51 words and the assertion wanted over 100, so most of my time went to checking I did not break anything instead of writing code. I would also look at whether the repo's own checks even run first. mypy crashes in the numpy files before it gets to the project, so I had to commit with --no-verify.
 
 **What are you most proud of from this module?**
-I am most proud of finishing my first Codepath course. I definitely plan to take more in the future. 
+I am most proud of finishing my first Codepath course. I definitely plan to take more in the future. I am also proud that I opened a real PR on someone else's repo. Before this I had only ever worked on my own projects, so pushing my branch to ascherj/pathreview and filling out their PR template was new to me. It is a small fix but it is on a real project and my name is on it.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -20,3 +20,20 @@ The README scorer test is supposed to verify that a strong README is counted as 
 **Setup confirmation:** [Y] App runs locally at localhost:5173
 
 **Cohort ledger:** [Y] Issue added to cohort ledger
+
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [paste commit URL here after pushing]
+
+**Reproduction summary:**
+I ran `pytest tests/unit/test_readme_scorer.py -q` in my local venv. One test,
+`test_readme_with_all_quality_signals`, failed with `assert 51 > 100`. The sample README in
+the test is only 51 words, but the test expects more than 100 words and a "comprehensive"
+category, so the assertions and the fixture don't match.
+
+**PLAN.md link:** [paste PLAN.md URL in my fork here]
+
+**Walkthrough video (recommended):** [paste Loom link here, optional]
+
+**Blockers or open questions:**

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -10,7 +10,7 @@
 I chose this Tier 1 issue because it is a focused testing problem and matches my current comfort level with the codebase. The scope is small enough for a first contribution: I can inspect one README scorer test, compare the fixture text to the expected word-count behavior, and update the test data or assertion without changing unrelated application logic.
 
 **Checklist reasoning:**
-I can explain the issue in my own words: one README scorer test expects a comprehensive README result, but the sample README is too short for that expectation. The affected code is in `tests/unit/test_readme_scorer.py`, with related word-count behavior in `ingestion/parsers/readme_parser.py`. Done means `pytest tests/unit/test_readme_scorer.py -q` should pass because the fixture and assertion describe the same expected behavior. This is a realistic Tier 1 issue because it is a localized test fix, should take a few focused hours, and the GitHub issue does not list blockers or unresolved dependencies.
+I can explain the issue in my own words: one README scorer test expects a comprehensive README result, but the sample README is too short for that expectation. The affected code is in `tests/unit/test_readme_scorer.py`, with related word-count behavior in `agent/tools/readme_scorer.py`. Done means `pytest tests/unit/test_readme_scorer.py -q` should pass because the fixture and assertion describe the same expected behavior. This is a realistic Tier 1 issue because it is a localized test fix, should take a few focused hours, and the GitHub issue does not list blockers or unresolved dependencies.
 
 **Problem summary:**
 The README scorer test is supposed to verify that a strong README is counted as "comprehensive." Right now, the test fixture is only about 51 words, but the test expects the scorer to report more than 100 words. Because of that mismatch, the test fails even if the README scorer is behaving correctly. A successful fix would make the test fixture and assertion agree, either by lengthening the sample README enough to meet the comprehensive threshold or by correcting the expected result so the test validates the intended behavior.
@@ -37,3 +37,61 @@ category, so the assertions and the fixture don't match.
 **Walkthrough video (recommended):** [paste Loom link here, optional]
 
 **Blockers or open questions:**
+
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+The fix is implemented. I worked through the steps in PLAN.md: I reproduced the failure, grew
+the sample README in `test_readme_with_all_quality_signals` from 51 words to 218 words, and
+changed the category assertion from `"comprehensive"` to `"adequate"` since 100–499 words is
+the adequate range. I kept every quality signal in the fixture (installation, usage, features,
+tech stack, two badges, demo link) so the other assertions still pass. I also fixed the wrong
+file reference in my Week 7 entry — the word-count logic is in `agent/tools/readme_scorer.py`,
+not `ingestion/parsers/readme_parser.py`. `pytest tests/unit/test_readme_scorer.py -q` is now
+23 passed.
+
+**Next steps:**
+
+
+**Blockers:**
+none
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** not added yet
+
+**Branch:** `test/156-readme-scorer-fixture`
+
+**What you built:**
+I fixed a unit test whose fixture didn't match its own assertions. The test built a 51-word
+sample README but asserted the scorer would report more than 100 words and a "comprehensive"
+category (which needs 500+). I grew the fixture to 218 words of realistic README prose and
+changed the expected category to "adequate", so the fixture and the assertions now describe
+the same README. The scorer itself was behaving correctly, so I didn't change it.
+
+**Tests added or updated:**
+`tests/unit/test_readme_scorer.py` — updated `test_readme_with_all_quality_signals` only. It
+covers a strong README hitting all the quality signals: word count over 100, adequate
+category, installation / usage / badges / demo / tech-stack all detected, and an overall score
+above 0.7 (it now scores 0.92). No new test was needed; the word-count buckets are already
+covered by the three `test_word_count_category_*` tests.
+
+**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+
+I left both unchecked because neither passes on a clean checkout of this repo, before my
+change. I couldn't turn them green without editing a lot of code unrelated to my issue, so
+instead I checked that my change doesn't make anything worse:
+
+- `pytest tests/unit/test_readme_scorer.py -q` — 23 passed. The file I changed is green.
+- `make check` — 182 lint errors before my change and 182 after, so I added none. Two of them
+  are in files I touched; I left them alone so the PR stays focused on the issue.
+- `make test-unit` — 53 failures before, 52 after. The one difference is the test I fixed.
+- The pre-commit `mypy` hook fails on this test file with 24 "missing type annotation" errors
+  both before and after my change, so it needs `--no-verify` to commit.
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -54,10 +54,16 @@ not `ingestion/parsers/readme_parser.py`. `pytest tests/unit/test_readme_scorer.
 23 passed.
 
 **Next steps:**
-make PR
+Remaining PLAN.md steps are the verification and submission ones: re-run `make check` and
+`make test-unit` to record before/after numbers so I can show my change doesn't add failures,
+push the branch, and open the PR against `ascherj/pathreview` using the repo's PR template —
+filling in Summary, Issue (`Closes #156`), Changes, Testing, and Notes for Reviewers, including
+why I chose "adequate" over padding the fixture to 500+ words.
 
 **Blockers:**
-none
+None blocking the fix itself. One thing I had to work around: `make check` and `make test-unit`
+already fail on a clean checkout of this repo, so I can't use "everything is green" as my
+signal. Instead I measured before/after to show I added nothing new (numbers in Check-in 2).
 
 ---
 
@@ -76,22 +82,38 @@ the same README. The scorer itself was behaving correctly, so I didn't change it
 
 **Tests added or updated:**
 `tests/unit/test_readme_scorer.py` — updated `test_readme_with_all_quality_signals` only. It
-covers a strong README hitting all the quality signals: word count over 100, adequate
-category, installation / usage / badges / demo / tech-stack all detected, and an overall score
-above 0.7 (it now scores 0.92). No new test was needed; the word-count buckets are already
-covered by the three `test_word_count_category_*` tests.
+covers a strong README hitting all the quality signals: word count over 100 (the fixture is
+now 218 words), `word_count_category == "adequate"`, installation / usage / badges / demo /
+tech-stack all detected as True, and an overall score above 0.7 (it now scores 0.919). The
+regression it locks in is the fixture/assertion mismatch from #156: the test now proves a
+218-word README with every quality marker lands in the 100–499 "adequate" band instead of
+asserting "comprehensive", which needs 500+. No new test was needed — the three
+`test_word_count_category_minimal` / `_adequate` / `_comprehensive` tests (lines 147–175)
+already cover the bucket boundaries with their own correctly-sized READMEs, so adding a fourth
+would duplicate them.
 
 **Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
 
-I left both unchecked because neither passes on a clean checkout of this repo, before my
-change. I couldn't turn them green without editing a lot of code unrelated to my issue, so
-instead I checked that my change doesn't make anything worse:
+I left both unchecked because neither passes on a clean checkout of this repo, *before* my
+change — checking them would be a false claim. I couldn't turn them green without editing a
+lot of code unrelated to #156, so instead I measured before and after to prove my change adds
+no new failures:
 
-- `pytest tests/unit/test_readme_scorer.py -q` — 23 passed. The file I changed is green.
-- `make check` — 182 lint errors before my change and 182 after, so I added none. Two of them
-  are in files I touched; I left them alone so the PR stays focused on the issue.
-- `make test-unit` — 53 failures before, 52 after. The one difference is the test I fixed.
-- The pre-commit `mypy` hook fails on this test file with 24 "missing type annotation" errors
-  both before and after my change, so it needs `--no-verify` to commit.
+| Check | Before my change | After my change |
+| --- | --- | --- |
+| `make test-unit` | 53 failed, 375 passed | 52 failed, 376 passed |
+| `make check` (ruff) | 182 errors | 182 errors |
+| `make typecheck` | fails in `numpy/__init__.pyi` before reaching project files | identical |
+
+- `pytest tests/unit/test_readme_scorer.py -q` — 23 passed. The file I changed is fully green.
+- `ruff check tests/unit/test_readme_scorer.py` — "All checks passed!". None of the repo's 182
+  lint errors are in the file I touched, and I added none.
+- The single `make test-unit` difference is the test I fixed. The other 52 failures are
+  pre-existing and in unrelated files (`test_tech_detector.py`, etc.); I left them alone so the
+  PR stays scoped to the issue.
+- `make typecheck` can't complete: mypy errors out in the numpy stubs with "Type statement is
+  only supported in Python 3.12 and greater" before it checks any project file. Same before and
+  after my change. This also makes the pre-commit `mypy` hook fail, so committing needed
+  `--no-verify`.
 
 **Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -9,6 +9,9 @@
 **Selection reasoning:**
 I chose this Tier 1 issue because it is a focused testing problem and matches my current comfort level with the codebase. The scope is small enough for a first contribution: I can inspect one README scorer test, compare the fixture text to the expected word-count behavior, and update the test data or assertion without changing unrelated application logic.
 
+**Checklist reasoning:**
+I can explain the issue in my own words: one README scorer test expects a comprehensive README result, but the sample README is too short for that expectation. The affected code is in `tests/unit/test_readme_scorer.py`, with related word-count behavior in `ingestion/parsers/readme_parser.py`. Done means `pytest tests/unit/test_readme_scorer.py -q` should pass because the fixture and assertion describe the same expected behavior. This is a realistic Tier 1 issue because it is a localized test fix, should take a few focused hours, and the GitHub issue does not list blockers or unresolved dependencies.
+
 **Problem summary:**
 The README scorer test is supposed to verify that a strong README is counted as "comprehensive." Right now, the test fixture is only about 51 words, but the test expects the scorer to report more than 100 words. Because of that mismatch, the test fails even if the README scorer is behaving correctly. A successful fix would make the test fixture and assertion agree, either by lengthening the sample README enough to meet the comprehensive threshold or by correcting the expected result so the test validates the intended behavior.
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -32,7 +32,7 @@ I ran `pytest tests/unit/test_readme_scorer.py -q` in my local venv. One test,
 the test is only 51 words, but the test expects more than 100 words and a "comprehensive"
 category, so the assertions and the fixture don't match.
 
-**PLAN.md link:** [paste PLAN.md URL in my fork here]
+**PLAN.md link:** https://github.com/JamesVillanueva-Dev/pathreview/blob/test/156-readme-scorer-fixture/PLAN.md
 
 **Walkthrough video (recommended):** [paste Loom link here, optional]
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -24,7 +24,7 @@ The README scorer test is supposed to verify that a strong README is counted as 
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [paste commit URL here after pushing]
+**Reproduction commit link:** https://github.com/JamesVillanueva-Dev/pathreview/commit/b93c24795741757bca0f57b2ec2581bd267d6ca9
 
 **Reproduction summary:**
 I ran `pytest tests/unit/test_readme_scorer.py -q` in my local venv. One test,

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -6,8 +6,11 @@
 
 **Tier:** [Y] Tier 1  [ ] Tier 2  [ ] Tier 3
 
+**Selection reasoning:**
+I chose this Tier 1 issue because it is a focused testing problem and matches my current comfort level with the codebase. The scope is small enough for a first contribution: I can inspect one README scorer test, compare the fixture text to the expected word-count behavior, and update the test data or assertion without changing unrelated application logic.
+
 **Problem summary:**
-This is an issue with the tests. Specifically, the README is too short and the test says that it is. The correct fix would be to lengthen the README to the correct length or change the test so that it accepts the README. 
+The README scorer test is supposed to verify that a strong README is counted as "comprehensive." Right now, the test fixture is only about 51 words, but the test expects the scorer to report more than 100 words. Because of that mismatch, the test fails even if the README scorer is behaving correctly. A successful fix would make the test fixture and assertion agree, either by lengthening the sample README enough to meet the comprehensive threshold or by correcting the expected result so the test validates the intended behavior.
 
 **Branch name:** test/156-readme-scorer-fixture
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -117,3 +117,35 @@ no new failures:
   `--no-verify`.
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [N] No — still awaiting review
+
+**Summary of feedback:**
+No feedback
+
+**How you responded:**
+[What changes did you make, or what did you reply? If no feedback,
+leave blank.]
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Setting up docker was harder than expected
+
+**What did you learn about working in a large codebase?**
+Working in a large codebase is really difficult. It is like trying to help on a topic that you have no idea about. 
+
+**How did AI tools help — and where did they fall short?**
+AI tools were helpful in guiding me on the correct steps whenever I got stuck. 
+
+**What would you do differently if you started over?**
+If I could start over, I would have chosen a more difficult problem to work on. 
+
+**What are you most proud of from this module?**
+I am most proud of finishing my first Codepath course. 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -54,7 +54,7 @@ not `ingestion/parsers/readme_parser.py`. `pytest tests/unit/test_readme_scorer.
 23 passed.
 
 **Next steps:**
-
+make PR
 
 **Blockers:**
 none
@@ -63,7 +63,7 @@ none
 
 ### Check-in 2 (end of week)
 
-**PR link:** not added yet
+**PR link:** https://github.com/ascherj/pathreview/pull/451
 
 **Branch:** `test/156-readme-scorer-fixture`
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,127 @@
+# Solution plan
+
+**Issue:** #156 — README scorer test fixture is too short for its own word-count assertion
+
+## Understand
+
+The failing test is `test_readme_with_all_quality_signals` in
+`tests/unit/test_readme_scorer.py`. It builds a sample README, runs it through
+`ReadmeScorer.execute()`, and checks the result. It fails on `assert 51 > 100`.
+
+The sample README in the test is only 51 words. But two of the assertions expect a bigger
+README:
+
+- line 56: `assert data["word_count"] > 100`
+- line 57: `assert data["word_count_category"] == "comprehensive"`
+
+I looked at how the scorer decides the category in `agent/tools/readme_scorer.py` (lines
+70–75):
+
+```python
+if word_count < 100:      word_count_category = "minimal"
+elif word_count < 500:    word_count_category = "adequate"
+else:                     word_count_category = "comprehensive"
+```
+
+So "comprehensive" needs at least 500 words, and 100–499 words is "adequate". A 51-word
+README comes back as "minimal", which is what the log in the failing run showed
+(`category=minimal word_count=51`). The scorer is doing the right thing. The test data and
+the assertions just don't line up.
+
+I also noticed the two word-count assertions have to agree on the size of the README. Line 56
+says more than 100 words, but line 57 asks for "comprehensive", which is 500+. Those don't
+match each other, and neither matches the 51-word sample.
+
+**Root cause:** The sample README is too short (51 words) and the category assertion asks for
+"comprehensive" (500+), which don't match each other or the fixture.
+
+**My decision:** Make the README "adequate" instead of "comprehensive". 500 words is a lot to
+stuff into a test fixture and doesn't look like a realistic README. "Adequate" (100–499
+words) is a more reasonable size. So I'll grow the sample README to around 150–200 words and
+change the category assertion to "adequate". Then line 56 (`> 100`) and line 57 both agree
+with the fixture.
+
+## Map
+
+Files I plan to change:
+
+- `tests/unit/test_readme_scorer.py` — `test_readme_with_all_quality_signals` (lines 17–63):
+  - Grow the sample README (lines 19–49) to ~150–200 words, keeping all the existing
+    sections and signals (installation, usage, features, tech stack, badges, demo link).
+  - Keep line 56 (`word_count > 100`) as is.
+  - Change line 57 from `== "comprehensive"` to `== "adequate"`.
+
+Files I read to be sure, but won't change:
+
+- `agent/tools/readme_scorer.py` — `_score_readme` (lines 56–124). This is where word count
+  and the categories come from. It's working correctly, so I'm leaving it alone.
+- `ingestion/parsers/repo_analyzer.py` — has the same category logic, which tells me the
+  100/500 thresholds are intentional, not a bug.
+- `tests/unit/test_readme_scorer.py` lines 147–175 — the category tests
+  (`test_word_count_category_minimal/adequate/comprehensive`) that already cover the buckets
+  on their own with correctly-sized READMEs.
+
+One correction: my JOURNAL.md said the word-count behavior was in
+`ingestion/parsers/readme_parser.py`, but the code the test actually uses is in
+`agent/tools/readme_scorer.py`. I'll fix that in the JOURNAL.
+
+## Plan
+
+1. Run `make test-unit` first to reproduce the failure and confirm it's just this one test.
+2. Grow the sample README in `test_readme_with_all_quality_signals` to ~150–200 words. I'll
+   pad it with real sentences in the description and section bodies, not filler symbols,
+   since word count is just `content.split()`. Keep every signal marker so the other
+   assertions still pass.
+3. Change line 57 from `"comprehensive"` to `"adequate"`. Leave line 56 (`> 100`) alone.
+4. Confirm the fixture actually lands in the 100–499 range. Quick check:
+   `len(readme.split())` should be between 100 and 499 (aiming ~150–200).
+5. Run `make test-unit` again and confirm the file is all green (should be 23 passed).
+6. Run `make check` for lint / format / types.
+7. Fix the file reference in JOURNAL.md.
+
+## Inputs & outputs
+
+The function being tested is `ReadmeScorer.execute()`, called like
+`scorer.execute({"readme_content": readme})`.
+
+After my change (README grown to ~150–200 words):
+
+- `result.success is True`
+- `data["has_readme"] is True`
+- `data["word_count"] > 100` — now passes because the README is longer.
+- `data["word_count_category"] == "adequate"` — 100–499 words is "adequate".
+- installation / usage / badges / demo / tech-stack are all still True (I keep the markers).
+- `data["overall_score"] > 0.7` — should stay high; a longer README with all signals gives an
+  even better score than the current 0.87.
+
+I don't think I need a brand new test. The category logic is already covered by the tests on
+lines 147–175. "Done" means the whole file passes and the fixture and assertions describe the
+same README.
+
+## Risks & unknowns
+
+1. I need to actually count the words after padding so I stay in the 100–499 range. If I
+   accidentally go over 500 it flips to "comprehensive" and line 57 fails again. I'll check
+   with `len(readme.split())`.
+2. The issue title says the fixture is "too short", so growing it fits the issue. But I'm also
+   changing the category assertion from "comprehensive" to "adequate", which is a small change
+   to what the test expects. I'll mention this in the PR so the reviewer knows why.
+3. There's a simpler alternative: the two word-count assertions are kind of redundant (the
+   category is already tested on lines 147–175), so I could just delete lines 56–57 and leave
+   the short README as is. I'm not going with that because I'd rather keep this test checking
+   that a good README counts as at least "adequate", but I'll mention it as an option.
+4. I'm not going to touch the 500 threshold in the scorer. That would change how every real
+   README is scored (there's a copy of the logic in `repo_analyzer.py` too) and would probably
+   break the adequate/comprehensive tests.
+5. I want to make sure nothing else depends on this README. I grepped the tests folder and the
+   word-count checks only show up in this file, and the category tests build their own
+   READMEs. I'll still run the full unit suite to be safe.
+
+## Edge cases
+
+- README right at ~150–200 words with all signals: "adequate", `word_count > 100`, high score.
+  This is the case I'm building.
+- Right at the 100 / 500 boundaries: covered by `test_word_count_category_adequate` (line 157,
+  checks `100 <= word_count <= 500`) and the minimal/comprehensive tests next to it.
+- Empty / whitespace-only README: covered by `test_readme_with_no_content` and
+  `test_whitespace_only_readme`. I'm not touching those.

--- a/tests/unit/test_readme_scorer.py
+++ b/tests/unit/test_readme_scorer.py
@@ -18,33 +18,44 @@ class TestReadmeScorer:
         """Test README with all quality signals returns high score."""
         readme = """
         # Project Name
-        A comprehensive project description.
+        A comprehensive project description that explains what the service does,
+        who it is for, and why someone would want to run it. The project ingests
+        events from an upstream queue, scores them against a set of rules, and
+        exposes the results over a small HTTP API.
 
         ## Installation
+        Install the package from PyPI into a virtual environment. Python 3.9 or
+        newer is required, and a running PostgreSQL instance is needed for the
+        persistence layer.
         ```bash
         pip install package
         ```
 
         ## Usage
+        Import the package and call run() to start the worker. Configuration is
+        read from environment variables, so no config file is required for a
+        local development run.
         ```python
         import package
         package.run()
         ```
 
         ## Features
-        - Feature 1
-        - Feature 2
-        - Feature 3
+        - Feature 1: streaming ingestion with automatic retries and backoff
+        - Feature 2: pluggable scoring rules loaded from a simple YAML file
+        - Feature 3: a JSON API for querying historical scores by date range
 
         ## Tech Stack
-        - Python 3.9
-        - FastAPI
-        - PostgreSQL
+        - Python 3.9 for the worker and the API layer
+        - FastAPI for request handling and automatic schema documentation
+        - PostgreSQL for durable storage of events and their computed scores
 
         ![Build Status](https://example.com/badge.svg)
         ![Coverage](https://example.com/coverage.svg)
 
         ## Live Demo
+        A hosted sandbox is available with a small set of seeded example events,
+        so you can explore the API without installing anything locally.
         [Try it here](https://demo.example.com)
         """
 
@@ -54,7 +65,7 @@ class TestReadmeScorer:
         data = result.data
         assert data["has_readme"] is True
         assert data["word_count"] > 100
-        assert data["word_count_category"] == "comprehensive"
+        assert data["word_count_category"] == "adequate"
         assert data["has_installation_section"] is True
         assert data["has_usage_section"] is True
         assert data["has_badges"] is True
@@ -157,9 +168,10 @@ class TestReadmeScorer:
 
         result = scorer.execute({"readme_content": readme})
         # "Getting Started" matches the pattern
-        assert result.data["has_installation_section"] is True or result.data[
-            "has_usage_section"
-        ] is True
+        assert (
+            result.data["has_installation_section"] is True
+            or result.data["has_usage_section"] is True
+        )
 
     def test_quickstart_counts_as_usage(self, scorer):
         """Test that 'quickstart' counts as usage."""
@@ -218,7 +230,8 @@ class TestReadmeScorer:
 
     def test_overall_score_calculation(self, scorer):
         """Test that overall score aggregates components."""
-        readme = """
+        readme = (
+            """
         # Good README
 
         ## Installation
@@ -233,7 +246,9 @@ class TestReadmeScorer:
         ![Build](https://example.com/build.svg)
 
         This readme has lots of content here.
-        """ * 3  # Make it comprehensive
+        """
+            * 3
+        )  # Make it comprehensive
 
         result = scorer.execute({"readme_content": readme})
 


### PR DESCRIPTION
## Summary
This PR addresses the README scorer not having correct behavior. To fix this, I increased the README length to about 280 characters and made the criteria for a README to be at least 100 words and no more than 500 by changing "comprehensive" to "adequate". 

## Issue
Closes #156 

## Changes
-Increased length of sample README 
-changed criteria from "comprehensive" to "adequate"

## Testing
<!-- How did you verify your changes? -->
- [ ] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`)
- [ ] Linter passes (`make lint`)
- [ ] Type checker passes (`make typecheck`)
- [Y ] New/updated tests cover the changes

## Screenshots / Demo
By running `pytest tests/unit/test_readme_scorer.py -q` , it will say "23 passed in 0.35s"
<img width="910" height="51" alt="image" src="https://github.com/user-attachments/assets/0ca31393-1226-4c9d-b10c-5fb24a04ce75" />


## Notes for Reviewers
none