### PR TITLE
Fix/155 health check redis settings

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -70,3 +70,29 @@ to issue #155. These pre-existing failures will be compared with the
 post-change results and documented in the PR description.
 
 ---
+
+### Check-in 2 (end of week)
+
+**PR link:** [Add the submitted pull request URL]
+
+**Branch:** `fix/155-health-check-redis-settings`
+
+**What you built:**
+
+I updated the Redis health check to create its client from the existing
+`settings.redis_url` configuration. This removes references to the undefined
+`redis_host` and `redis_port` settings while preserving URL components such as
+the host, port, database, authentication, and TLS scheme.
+
+**Tests added or updated:**
+
+I added `tests/unit/test_health.py` with tests for a successful Redis ping and a
+failed Redis connection. The two new tests pass, and the full unit test run has
+the same 53 pre-existing failures observed before the change.
+
+**Self-review confirmation:** [x] make check introduces no new failures  [x] make test-unit introduces no new failures
+
+**Draft PR feedback received from:** Eddie (Oregon State University)
+
+Eddie reviewed the draft PR and said that it looked good and that everything
+was organized. Based on this feedback, no additional changes were required.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -42,3 +42,31 @@ The health check expects separate `redis_host` and `redis_port` values, while
 the existing configuration provides a single `redis_url`. I need to confirm
 whether the preferred fix is to reuse `redis_url` directly or introduce
 separate typed settings without creating duplicate configuration sources.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+
+I completed the issue reproduction and solution plan. Before changing the
+health-check implementation, I ran the required checks to establish a baseline.
+`make check` failed during Ruff with 182 pre-existing lint errors, so its Black
+and mypy steps did not run. `make test-unit` collected 428 tests: 375 passed and
+53 failed, with 4 warnings. These results were recorded before implementing the
+issue #155 fix.
+
+**Next steps:**
+
+Update the Redis health check to use the existing `settings.redis_url`, add
+focused unit tests for successful and failed Redis connections, and rerun both
+commands to confirm that the change introduces no new failures. Then open a
+draft PR and request feedback.
+
+**Blockers:**
+
+The repository already has 182 lint errors and 53 failing unit tests unrelated
+to issue #155. These pre-existing failures will be compared with the
+post-change results and documented in the PR description.
+
+---

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,17 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/155
+
+**Issue title:** Health check references settings.redis_host, which does not exist on Settings
+
+**Tier:** [X] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+
+When we call the `GET /health` endpoint, the application crashes with an `AttributeError`. This happens because `api/routes/health.py` tries to check Redis status using `settings.redis_host`. However, the `Settings` model in `core/config.py` does not define this field, so it cannot find the host information. A successful fix will add `redis_host` to the configuration so the health check can report the Redis status correctly without any errors.
+
+**Branch name:** fix/155-health-check-redis-settings
+
+**Setup confirmation:** [X] App runs locally at localhost:5173
+
+**Cohort ledger:** [X] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -22,7 +22,7 @@ When we call the `GET /health` endpoint, the application crashes with an `Attrib
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [Add the GitHub commit URL after pushing this reproduction commit]
+**Reproduction commit link:** https://github.com/Masaki0827/pathreview/commit/bd2afd230f27a299f980221308653af187130f20
 
 **Reproduction summary:**
 
@@ -32,7 +32,7 @@ Redis Docker container was healthy. The Redis health check failed because
 `api/routes/health.py` accesses `settings.redis_host`, but the `Settings` model
 in `core/config.py` defines only `redis_url`.
 
-**PLAN.md link:** [Add the GitHub link to PLAN.md after pushing this branch]
+**PLAN.md link:** https://github.com/Masaki0827/pathreview/blob/fix/155-health-check-redis-settings/PLAN.md
 
 **Walkthrough video (recommended):** Not recorded
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -6,6 +6,10 @@
 
 **Tier:** [X] Tier 1  [ ] Tier 2  [ ] Tier 3
 
+**Selection reasoning:**
+
+I selected this Tier 1 issue because I am still becoming familiar with the PathReview codebase and wanted a focused first contribution. The issue has a clear scope limited to the health-check route and application settings, so it is a good fit for my current skill level while still giving me practice tracing configuration values through the backend.
+
 **Problem summary:**
 
 When we call the `GET /health` endpoint, the application crashes with an `AttributeError`. This happens because `api/routes/health.py` tries to check Redis status using `settings.redis_host`. However, the `Settings` model in `core/config.py` does not define this field, so it cannot find the host information. A successful fix will add `redis_host` to the configuration so the health check can report the Redis status correctly without any errors.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -19,3 +19,26 @@ When we call the `GET /health` endpoint, the application crashes with an `Attrib
 **Setup confirmation:** [X] App runs locally at localhost:5173
 
 **Cohort ledger:** [X] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [Add the GitHub commit URL after pushing this reproduction commit]
+
+**Reproduction summary:**
+
+I reproduced the issue by starting the local services and calling `GET /health`.
+The endpoint returned HTTP 503 and reported Redis as unhealthy even though the
+Redis Docker container was healthy. The Redis health check failed because
+`api/routes/health.py` accesses `settings.redis_host`, but the `Settings` model
+in `core/config.py` defines only `redis_url`.
+
+**PLAN.md link:** [Add the GitHub link to PLAN.md after pushing this branch]
+
+**Walkthrough video (recommended):** Not recorded
+
+**Blockers or open questions:**
+
+The health check expects separate `redis_host` and `redis_port` values, while
+the existing configuration provides a single `redis_url`. I need to confirm
+whether the preferred fix is to reuse `redis_url` directly or introduce
+separate typed settings without creating duplicate configuration sources.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -96,3 +96,71 @@ the same 53 pre-existing failures observed before the change.
 
 Eddie reviewed the draft PR and said that it looked good and that everything
 was organized. Based on this feedback, no additional changes were required.
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+
+No official maintainer review was provided during Summer 2026. I did receive
+peer feedback on my draft PR from Eddie, who said that the work looked good and
+was well organized, as documented in my Week 9 entry.
+
+**How you responded:**
+
+Because there was no official reviewer feedback requesting a change, I did not
+make any additional code changes.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+
+Finding where the bug came from was harder than I expected. The visible problem
+was the `/health` endpoint returning an unhealthy Redis status, but the cause
+was a mismatch between `api/routes/health.py` and the `Settings` model in
+`core/config.py`. I had to trace how Redis configuration moved through the
+codebase before I could see that the health check referenced fields that did
+not exist. It was also difficult to separate my change from the repository's
+182 existing lint errors and 53 failing unit tests.
+
+**What did you learn about working in a large codebase?**
+
+I learned that I need to understand why existing code is designed in a certain
+way before changing it. In my own projects, I can choose the structure and
+rules, but in someone else's production code I need to follow its conventions
+and avoid creating a second source of truth. For this issue, reusing the
+existing `redis_url` was safer than adding duplicate host and port settings. I
+also learned to run baseline checks so I can distinguish pre-existing failures
+from problems caused by my contribution.
+
+**How did AI tools help — and where did they fall short?**
+
+AI tools helped me search unfamiliar files, understand the relationship between
+the health-check route and the settings model, draft focused tests, and improve
+the clarity of my documentation. However, AI could not decide the best change
+from the issue description alone. I still needed to inspect the actual
+codebase, reproduce the problem, compare test results before and after the
+change, and confirm that using `redis_url` matched the project's existing
+design.
+
+**What would you do differently if you started over?**
+
+I would map the relevant request and configuration flow earlier, starting from
+the failing endpoint and following every setting it uses before planning a fix.
+I would also run the baseline lint and unit tests immediately after setup and
+record the results. That would help me identify the real scope of the issue
+faster and avoid spending time investigating failures that were already in the
+repository.
+
+**What are you most proud of from this module?**
+
+I am most proud that I learned how to explain my work specifically to a
+supervisor or maintainer. Instead of only saying that I fixed a bug, I can now
+describe the original behavior, identify the configuration mismatch that
+caused it, explain why I chose the existing `redis_url`, and provide test
+results that show what changed and what did not.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,101 @@
+## Solution plan
+
+**Issue:** [Health check references settings.redis_host, which does not exist on Settings](https://github.com/ascherj/pathreview/issues/155)
+
+### Understand
+
+Calling `GET /health` runs the Redis probe in `api/routes/health.py`. The probe
+constructs a Redis client with `settings.redis_host` and `settings.redis_port`,
+but the `Settings` model in `core/config.py` defines only `redis_url`. Accessing
+`settings.redis_host` therefore raises `AttributeError` before the Redis client
+is created or `r.ping()` is called. The route catches that exception, logs
+`redis_health_check_failed`, marks Redis and the overall service as unhealthy,
+and returns HTTP 503.
+
+The expected behavior is for the health check to use configuration fields that
+are defined by `Settings`, attempt an actual Redis ping, and report Redis as
+healthy when the configured Redis instance is reachable. A connection failure
+should still be caught and reported as an unhealthy dependency rather than
+causing an unhandled application error.
+
+### Map
+
+- `core/config.py`
+  - `Settings`: defines the available application configuration.
+  - `settings`: singleton read by the health-check route.
+- `api/routes/health.py`
+  - `health_check()`: reads the Redis configuration, creates the client, calls
+    `ping()`, and builds the dependency-status response.
+- `.env.example`
+  - Documents the supported Redis environment variables and their local
+    defaults. It may need updating if separate host and port settings are
+    introduced.
+- `tests/unit/` or `tests/integration/`
+  - Add focused coverage for a successful Redis probe and a Redis connection
+    failure. The exact test file will follow the repository's existing test
+    organization.
+
+### Plan
+
+1. Confirm how `redis_url` is used elsewhere in the repository and choose one
+   canonical Redis configuration format, avoiding conflicting URL and
+   host/port settings.
+2. Make the Redis probe consume fields that are actually defined by `Settings`.
+   Prefer reusing `settings.redis_url` directly if supported by the Redis client;
+   otherwise add typed `redis_host` and `redis_port` fields to `core/config.py`
+   and document them in `.env.example`.
+3. Update `health_check()` in `api/routes/health.py` so configuration is read
+   consistently and `ping()` is reached when the configuration is valid.
+4. Add tests that mock or control the Redis client and verify both success and
+   connection-failure responses without requiring an uncontrolled external
+   Redis service.
+5. Run the relevant unit tests and manually call `GET /health` with the local
+   Docker Redis container to confirm that the `AttributeError` is gone and the
+   Redis status reflects the actual probe result.
+
+### Inputs & outputs
+
+**Inputs**
+
+- Redis connection configuration loaded from `.env` through `Settings`.
+- The result of the Redis client's `ping()` operation.
+- Availability or unavailability of the configured Redis service.
+
+**Outputs**
+
+- When Redis is reachable, `GET /health` reports
+  `dependencies.redis` as `healthy`.
+- When Redis is unreachable or misconfigured, the route reports Redis as
+  `unhealthy`, sets the overall status to `unhealthy`, and returns HTTP 503.
+- Accessing the Redis configuration no longer raises an `AttributeError` for
+  `redis_host` or `redis_port`.
+
+### Risks & unknowns
+
+- `core/config.py` currently exposes `redis_url`, while `health.py` expects
+  separate host and port values. Adding both representations could allow them
+  to disagree, so existing Redis consumers must be searched before selecting
+  the final representation.
+- `redis.Redis` is synchronous but is called from the asynchronous
+  `health_check()` route. This issue may not require changing that design, but a
+  slow Redis connection could block the event loop and should be noted.
+- Redis URLs can contain authentication credentials, non-default databases,
+  TLS (`rediss://`), or non-default ports. Manually extracting only a host and
+  port could discard those settings.
+- `api/routes/health.py` also reports PostgreSQL and vector-store health. Tests
+  must isolate or override those checks so unrelated dependency failures do not
+  hide the Redis behavior under test.
+- The PostgreSQL probe currently passes `"SELECT 1"` directly to SQLAlchemy and
+  may independently report PostgreSQL as unhealthy. That behavior is outside
+  issue #155 and should not be mixed into this fix unless maintainers expand
+  the scope.
+
+### Edge cases
+
+- Redis is running at the configured URL and responds successfully to `ping()`.
+- Redis is stopped, refuses the connection, or times out.
+- Redis uses a non-default port or database number.
+- Redis requires a password or uses a `rediss://` TLS URL.
+- The Redis URL is empty or malformed.
+- PostgreSQL is unhealthy while Redis is healthy, so each dependency status
+  remains independently accurate.

--- a/api/routes/health.py
+++ b/api/routes/health.py
@@ -1,6 +1,8 @@
-from fastapi import APIRouter, HTTPException, status, Depends
+from datetime import datetime
+from typing import Annotated, Any
+
 import structlog
-from datetime import datetime, timedelta
+from fastapi import APIRouter, Depends, HTTPException, status
 
 from core.database import get_db
 
@@ -10,12 +12,12 @@ router = APIRouter(prefix="/health", tags=["health"])
 
 
 @router.get("")
-async def health_check(db=Depends(get_db)):
+async def health_check(db: Annotated[Any, Depends(get_db)]) -> dict[str, Any]:
     """
     Check health of PostgreSQL, Redis, and Vector DB.
     Returns 200 if all healthy, 503 if any dependency is down.
     """
-    health_status = {
+    health_status: dict[str, Any] = {
         "status": "healthy",
         "dependencies": {
             "postgres": "unknown",
@@ -39,15 +41,15 @@ async def health_check(db=Depends(get_db)):
     try:
         # Check Redis (if available)
         import redis
+
         from core.config import settings
 
-        r = redis.Redis(
-            host=settings.redis_host,
-            port=settings.redis_port,
-            db=0,
+        redis_client = redis.Redis.from_url(
+            settings.redis_url,
             decode_responses=True,
+            socket_connect_timeout=1,
         )
-        r.ping()
+        redis_client.ping()
         health_status["dependencies"]["redis"] = "healthy"
         log.debug("redis_health_check_passed")
     except Exception as exc:

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -1,0 +1,50 @@
+"""Unit tests for the health-check route."""
+
+from typing import Any, cast
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from fastapi import HTTPException, status
+
+from api.routes.health import health_check
+from core.config import settings
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_health_check_reports_redis_healthy_when_ping_succeeds() -> None:
+    """Report Redis as healthy when the configured instance responds to ping."""
+    db = AsyncMock()
+    redis_client = Mock()
+
+    with patch("redis.Redis.from_url", return_value=redis_client) as from_url:
+        result = await health_check(db)
+
+    from_url.assert_called_once_with(
+        settings.redis_url,
+        decode_responses=True,
+        socket_connect_timeout=1,
+    )
+    redis_client.ping.assert_called_once_with()
+    assert result["dependencies"]["redis"] == "healthy"
+    assert result["status"] == "healthy"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_health_check_reports_redis_unhealthy_when_ping_fails() -> None:
+    """Return 503 with an unhealthy Redis status when ping raises an error."""
+    db = AsyncMock()
+    redis_client = Mock()
+    redis_client.ping.side_effect = ConnectionError("Redis is unavailable")
+
+    with (
+        patch("redis.Redis.from_url", return_value=redis_client),
+        pytest.raises(HTTPException) as exc_info,
+    ):
+        await health_check(db)
+
+    detail = cast(dict[str, Any], exc_info.value.detail)
+    assert exc_info.value.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+    assert detail["dependencies"]["redis"] == "unhealthy"
+    assert detail["status"] == "unhealthy"


### PR DESCRIPTION
## Summary

This PR fixes the Redis health check by using the existing `settings.redis_url`
configuration instead of referencing the undefined `settings.redis_host` and
`settings.redis_port` attributes. The health endpoint can now create a Redis
client successfully and report the result of the actual Redis ping.

## Issue

Closes #155

## Changes

- Updated the Redis health check to create the client with
  `redis.Redis.from_url(settings.redis_url)`.
- Preserved response decoding and added a one-second connection timeout.
- Added a unit test verifying that a successful Redis ping reports Redis as
  healthy.
- Added a unit test verifying that a failed Redis ping reports Redis as
  unhealthy and returns HTTP 503.
- Added the Week 9 mid-week check-in and pre-change baseline results to
  `JOURNAL.md`.
- Added type annotations required by the project's pre-commit checks.

## Testing

- [ ] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`)
- [ ] Linter passes (`make lint`)
- [ ] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes

Verification performed:

- `pytest tests/unit/test_health.py -q -m unit`
  - 2 passed
- Full `make test-unit` comparison:
  - Before the change: 375 passed, 53 failed
  - After the change: 377 passed, 53 failed
  - No new unit-test failures were introduced.
- Full Ruff comparison:
  - Before the change: 182 pre-existing errors
  - After the change: 182 pre-existing errors
  - No new lint errors were introduced.
- Pre-commit checks for the changed files:
  - Ruff passed
  - Black passed
  - mypy passed
- Integration tests were not run because this change is covered by mocked unit
  tests and does not require a live Redis instance.

## Screenshots / Demo
This is a backend health-check fix covered by unit tests.

## Notes for Reviewers

The repository had 53 failing unit tests and 182 Ruff errors before this change.
The same failures remain after the change, and this PR does not introduce any
new failures.

Please pay particular attention to the use of the existing `redis_url` as the
single Redis configuration source. Using `Redis.from_url()` preserves URL
components such as the host, port, database number, authentication, and TLS
scheme without introducing separate settings that could become inconsistent.