### PR TITLE
Fix/155 health check redis host

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -13,3 +13,17 @@
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Issue Selection Notes - Checklist Reasoning 
+
+**Part 1 - Understanding the Issue:**
+I can explain the issue without re-rereading it, as I have taken time to understand it before moving onto actually solving the issue. The issue is that the health check endpoint is trying to read a 'redis_host' from 'Settings,' but either the wrong field is being references or that field was never created in the Settings model, so an error is thrown which breaks the endpoint. The relevant files include 'api/routes/health.py' and 'core/config.py,' which exist and match the description of the issue. The issue is resolved when when 'GET /health' runs without crashing and Redis status is reported. 
+
+**Part 2 - Tier fit:**
+Although I have done an open source contribution before, I chose a Tier 1 issue as I wanted a refresh on how to go about contributing to an open source project. Since the issue itself is in two files, I can focus on the larger idea, such as how to make a pull request so that the issue can eventually be closed. 
+
+**Part 3 - Codebase Readiness:**
+I located 'api/routes/health.py' and read through the 'Settings' class and figured out that 'redis_host' is not defined there, so I need to create that field in order to fix this issue. 
+
+**Part 4 - Scopre and Time:**
+Since this is a Tier 1 issue, I believe I might spend around 5 hours working on the codebase and make sure my changes do not cause other issues and test everything to make sure that the author can close their issue. 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,15 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/155
+
+**Issue title:** Health check references settings.redis_host, which does not exist on Settings #155
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:** The problem is that the health check endpoint in 'api/routes/health.py' tries to read a 'redis_host' attribute from the app's 'Settings' object to run its Redis probe, but this field does not exist in 'Settings.' Because of this, the endpoint breaks entirely due to the 'AttributeError'. A fix to this problem would be to update the health check to reference the right Settings field or add a field if it is missing, so '/health' will be able to report Redisok status without the endpoint breaking.
+
+**Branch name:** fix/155-health-check-redis-host
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -27,3 +27,16 @@ I located 'api/routes/health.py' and read through the 'Settings' class and figur
 
 **Part 4 - Scopre and Time:**
 Since this is a Tier 1 issue, I believe I might spend around 5 hours working on the codebase and make sure my changes do not cause other issues and test everything to make sure that the author can close their issue. 
+
+## Week 8 - Reproduction & solution planning 
+
+**Reproduction commit link:** 
+
+**Reproduction summary:**
+Ran the API locally and hit the GET /health endpoint. The endpoint returned 503 with "redis": "unhealthy", and the server log shows: `'Settings' object has no attribute 'redis_host'`, confirming health.py
+references a field that doesn't exist on the Settings class.
+
+**PLAN.md link:** 
+
+**Blockers or open questions:**
+A separate error also appeared when reproducting this error, a SQLAlchemny textual SQL warning. 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -41,3 +41,19 @@ https://github.com/pmad06/pathreview/blob/fix/155-health-check-redis-host/PLAN.m
 
 **Blockers or open questions:**
 A separate error also appeared when reproducting this error, a SQLAlchemny textual SQL warning. 
+
+## Week 9 - Solution Building & PR submission 
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+
+So far, I have implemented the fix for #155 by updating 'api/routes/health.py' to use 'settings.redis_url' via 'redis.from_url()' instead of from the 'redis_host'/'redis_port' fields. After making this fix, I was able to verify locally that using the /health endpoint did not raise an 'AttributeError.' Along with the fix, I also added new tests in 'tests/unit/test_health.py' convering the healthy and unhealthy path, and a regression test for the original issue. All 4 tests ended up passing which helped confirm that my changes worked and resolved the issue. 
+
+**Next steps:**
+
+After making this fix, my next steps are to open the PR as a draft and request feedback from a peer or a mentor and then mark the PR as ready for review and submit. 
+
+**Blockers:**
+
+I had some issues with Docker Desktop not running and using the wrong port but after some debugging, I was able to resolve those issues. 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -60,7 +60,7 @@ I had some issues with Docker Desktop not running and using the wrong port but a
 
 ### Check-in 2
 
-**PR link:**
+**PR link:** https://github.com/ascherj/pathreview/pull/458
 
 **Branch:** fix/155-health-check-redis-host
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -30,13 +30,14 @@ Since this is a Tier 1 issue, I believe I might spend around 5 hours working on 
 
 ## Week 8 - Reproduction & solution planning 
 
-**Reproduction commit link:** 
+**Reproduction commit link:** https://github.com/pmad06/pathreview/commit/aabd979
 
 **Reproduction summary:**
 Ran the API locally and hit the GET /health endpoint. The endpoint returned 503 with "redis": "unhealthy", and the server log shows: `'Settings' object has no attribute 'redis_host'`, confirming health.py
 references a field that doesn't exist on the Settings class.
 
 **PLAN.md link:** 
+https://github.com/pmad06/pathreview/blob/fix/155-health-check-redis-host/PLAN.md
 
 **Blockers or open questions:**
 A separate error also appeared when reproducting this error, a SQLAlchemny textual SQL warning. 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -57,3 +57,22 @@ After making this fix, my next steps are to open the PR as a draft and request f
 **Blockers:**
 
 I had some issues with Docker Desktop not running and using the wrong port but after some debugging, I was able to resolve those issues. 
+
+### Check-in 2
+
+**PR link:**
+
+**Branch:** fix/155-health-check-redis-host
+
+**What you built:**
+Updated the health check to use 'redis_url' correctly via 'redis.from_url()' because originally the '/health' endpoint's Redis check referenced 'settings.redis_host' and 'setting.redis_port,' which did not exist on the 'Settings' class. Because of this, an 'AttributeError' was raised that caused the Redis dependency check to fail. 
+
+**Tests added or updates:**
+- 'api/routes/health.py': replaced the manual construction that referenced nonexistent 'redis_host'\'redis_port' fields with 'redis.from_url,' using the connection string that is defined on 'Settings' class
+- 'tests/unit/test_health.py': added new tests to verify my changes for the Redis health check (healthy path, unhealthy path) and a regression test to confirm no 'AttributeError' occurred
+
+**Self-review confirmation:** 
+- [X] Unit tests pass (`make test-unit`)
+- [X] make check pass
+
+**Draft PR feedback recieved from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -76,3 +76,31 @@ Updated the health check to use 'redis_url' correctly via 'redis.from_url()' bec
 - [X] make check pass
 
 **Draft PR feedback recieved from:** none
+
+## Week 10 - Iteration & reflection 
+
+### Reflection
+
+**What was harder than you expected?**
+[Be specific — what part of the process, codebase, or workflow
+surprised you?]
+Something that was harder than I expected was completing this JOURNAL.md file. In my previous projects and hackathons, I've made files, written code, pushed my changes to GitHub, and kept everything updated. However, in this module, I had to keep track of my thought process. I used to think all I had to do was code, push changes, and pull the changes from my team members. But keeping track of my progress each week helped me understand the project on a better level. It was hard because there were still a lot of things I didn't understand and had to look up. Although AI agents tend to be very helpful and can find the issues within a codebase very quickly, I had to actually understand what I was doing and how the changes I made effected the codebase in order to fill out JOURNAL.md. This process hard because there were still a lot of things I didn't understand and had to look up but it taught me valuable things about the codebase and also about good coding practices. 
+
+**What did you learn about working in a large codebase?**
+[What's different about contributing to someone else's production code
+vs. building your own project?]
+Something that was different about contributing to someone else's production code rather than building my own project was that my changes needed approval before they were pushed to the owner's repository. This also meant I had to follow certain guidelines, such as making a pull request with the proper outline, to get my changes approved. Another aspect of contributing to someone else's production code was creating  tests and making sure that the changed code was passing all possible test cases. 
+
+**How did AI tools help — and where did they fall short?**
+[Where was AI assistance most useful this module? Where did you need
+to go beyond what AI could give you?]
+AI assistance was the most useful in understanding the codebase. Because of how many files there are, it was hard to read through everything and find where the exact issue was, especially with the time crunch. So, I told Claude what I was working with and which issue I was planning on fixing and it read through the codebase and pinpointed which exact files to focus on throughout the PathReview project. With the issue I chose to work on, Claude was able to help me through all of my questions so I didn't have to seek help outside of what AI could give me. 
+
+**What would you do differently if you started over?**
+[Issue selection, planning, implementation, or process — anything
+you'd change?]
+Something I would do differently if I had started over is spend more time planning out how I wanted to fix the issue. Because I had other classes and assignments to work on, I could only spend so much time on this project, so I rushed to complete the assignment each week. However, I would have liked to plan out my thought process a little bit more, rather than jumping straight into the fixing the issue once I understood what it was asking me to do. 
+
+**What are you most proud of from this module?**
+[One thing — it doesn't have to be the PR itself.]
+Something I am most proud of from this module is how well I understood the issue. I was able to understand what exactly I needed to fix and which files to search through, with the help of AI breaking down the large codebase. 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,51 @@
+## Solution plan
+
+**Issue:** Health check references settings.redis_host, which does not exist on Settings — #155
+https://github.com/ascherj/pathreview/issues/155
+
+### Understand
+The `/health` endpoint's Redis probe in `api/routes/health.py` references
+`settings.redis_host`, but `Settings` (in `core/config.py`) has no such field. 
+It does define `redis_url: str = Field(default="redis://localhost:6379/0")`.
+But it is a naming mismatch as the health check was written against a field name that never existed, likely
+a typo or leftover from an earlier version of the config. Expected behavior: `/health` should connect using `settings.redis_url` and report real Redis
+connectivity status.
+
+### Map
+- `api/routes/health.py` — contains the Redis probe with the incorrect
+  `settings.redis_host` needs to be updated to `settings.redis_url`
+- `core/config.py` — `redis_url` already exists and
+  is correctly defined
+
+### Plan
+1. Open `api/routes/health.py` and locate the exact line(s) referencing
+   `settings.redis_host`
+2. Confirm how the Redis client/connection is initialized elsewhere in the
+   codebase (if any existing Redis client exists, check how it consumes
+   `redis_url`, since it may need a client object rather than a raw string)
+3. Update the reference from `settings.redis_host` to `settings.redis_url`
+4. Run locally and hit `GET /health` to confirm no AttributeError and that
+   Redis status now reflects actual connectivity
+5. Add or update a test asserting `/health` doesn't crash and correctly
+   reports Redis status using `redis_url`
+
+### Inputs & outputs
+**Input:** `GET /health` request
+**Output:** JSON response with an accurate Redis health status (healthy if
+reachable at `redis_url`, unhealthy if not) 
+
+### Risks & unknowns
+- Need to confirm whether the Redis probe expects just the URL string, or
+  needs to construct a client (e.g. via `redis.asyncio.from_url()`)
+- A local Redis instance needs to actually be running for the probe to
+  return "healthy"; need to confirm this is set up in my dev environment
+- A separate, unrelated postgres health check error also appears in the
+  same endpoint (a SQLAlchemy textual SQL issue: raw `"SELECT 1"` needs to
+  be wrapped in `text()`)
+
+### Edge cases
+- `redis_url` is reachable & should report "healthy"
+- Redis server down/unreachable at that URL & should report "unhealthy"
+  gracefully, not throw an unhandled exception
+- Redis reachable but slow to respond & should still return within a
+  reasonable time rather than hanging indefinitely

--- a/api/routes/health.py
+++ b/api/routes/health.py
@@ -1,6 +1,7 @@
-from fastapi import APIRouter, HTTPException, status, Depends
+from datetime import datetime
+
 import structlog
-from datetime import datetime, timedelta
+from fastapi import APIRouter, Depends, HTTPException, status
 
 from core.database import get_db
 
@@ -39,14 +40,10 @@ async def health_check(db=Depends(get_db)):
     try:
         # Check Redis (if available)
         import redis
+
         from core.config import settings
 
-        r = redis.Redis(
-            host=settings.redis_host,
-            port=settings.redis_port,
-            db=0,
-            decode_responses=True,
-        )
+        r = redis.from_url(settings.redis_url, decode_responses=True)
         r.ping()
         health_status["dependencies"]["redis"] = "healthy"
         log.debug("redis_health_check_passed")

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -1,0 +1,69 @@
+"""Tests for health.py"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.main import app
+
+
+@pytest.mark.unit
+class TestHealthCheck:
+    """Tests for the /health endpoint's dependency checks."""
+
+    @pytest.fixture
+    def client(self) -> TestClient:
+        """Create a TestClient instance for the app."""
+        return TestClient(app)
+
+    @patch("redis.from_url")
+    def test_redis_healthy_when_reachable(
+        self, mock_from_url: MagicMock, client: TestClient
+    ) -> None:
+        """Test /health reports redis as healthy when ping succeeds."""
+        mock_redis_client = MagicMock()
+        mock_redis_client.ping.return_value = True
+        mock_from_url.return_value = mock_redis_client
+
+        response = client.get("/health")
+        body = response.json().get("detail", response.json())
+
+        assert body["dependencies"]["redis"] == "healthy"
+        mock_from_url.assert_called_once()
+
+    @patch("redis.from_url")
+    def test_redis_unhealthy_when_unreachable(
+        self, mock_from_url: MagicMock, client: TestClient
+    ) -> None:
+        """Test /health reports redis as unhealthy without raising an unhandled error."""
+        mock_redis_client = MagicMock()
+        mock_redis_client.ping.side_effect = ConnectionError("Connection refused")
+        mock_from_url.return_value = mock_redis_client
+
+        response = client.get("/health")
+        body = response.json().get("detail", response.json())
+
+        assert body["dependencies"]["redis"] == "unhealthy"
+
+    def test_redis_check_uses_redis_url_not_missing_attribute(self, client: TestClient) -> None:
+        """Regression test for #155: health check must not reference a
+        nonexistent Settings attribute (redis_host/redis_port)."""
+        response = client.get("/health")
+
+        assert response.status_code != 500
+
+    @patch("redis.from_url")
+    def test_redis_from_url_called_with_settings_redis_url(
+        self, mock_from_url: MagicMock, client: TestClient
+    ) -> None:
+        """Test the redis client is built from settings.redis_url."""
+        from core.config import settings
+
+        mock_redis_client = MagicMock()
+        mock_redis_client.ping.return_value = True
+        mock_from_url.return_value = mock_redis_client
+
+        client.get("/health")
+
+        mock_from_url.assert_called_once_with(settings.redis_url, decode_responses=True)


### PR DESCRIPTION
## Summary
<!-- One paragraph describing what this PR does and why -->
This PR updates the health check to use 'redis_url' correctly via 'redis.from_url()' because originally the '/health' endpoint's Redis check referenced 'settings.redis_host' and 'setting.redis_port,' which did not exist on the 'Settings' class. Because of this, an 'AttributeError' was raised that caused the Redis dependency check to fail. 

## Issue
Closes #155 

## Changes
<!-- Bullet list of the specific changes made -->
- 'api/routes/health.py': replaced the manual construction that referenced nonexistent 'redis_host'\'redis_port' fields with 'redis.from_url,' using the connection string that is defined on 'Settings' class
- 'tests/unit/test_health.py': added new tests to verify my changes for the Redis health check (healthy path, unhealthy path) and a regression test to confirm no 'AttributeError' occurred

## Testing
<!-- How did you verify your changes? -->
- [X] Unit tests pass (`make test-unit`)
    - running test_health.py ensured that all of my 4 tests passed
- [ ] Integration tests pass (`make test-integration`)
    - running this command resulted in the output: 'no tests ran,' so I assumed that there were no integration tests for this endpoint 
- [X] Linter passes (`make lint`)
    - verified that the filed I changed were clean but there were pre-existing lint errors when I ran 'make lint'
- [ ] Type checker passes (`make typecheck`)
    - there were pre-existing errors that were unrelated to my changes 
- [X] New/updated tests cover the changes

## Screenshots / Demo
<!-- If applicable, add screenshots or a link to a demo video -->
<img width="1707" height="167" alt="Screenshot 2026-07-30 211207" src="https://github.com/user-attachments/assets/fd4bea25-5be3-4af8-94a9-e32296ea428c" />

## Notes for Reviewers
<!-- Anything the reviewer should pay particular attention to -->
- There is a separate pre-existing issue, not related to this PR, which is that the postgres check shows "unhealthy" in '/health.'
- This codebase has pre-existing failures that were unrelated to my change but still show up when testing.