### PR TITLE
fix(evaluator): handle None context text in faithfulness checker

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -20,14 +20,12 @@ This issue is narrowly scoped to one method in the RAG evaluation code and has a
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [add commit link after pushing]
+**Reproduction commit link:** [[https://github.com/alexab027/pathreview/commit/9942e192ca9c1f8ff2441f0c9b1e1aa42db0faf8]]
 
 **Reproduction summary:**  
 I reproduced the issue by calling `FaithfulnessChecker.check()` with a context chunk containing `{"text": None}`. The method raised a `TypeError` because `None` was passed into `" ".join(...)`.
 
-**PLAN.md link:** [add PLAN.md GitHub link after pushing]
-
-**Walkthrough video (recommended):**
+**PLAN.md link:** [[https://github.com/alexab027/pathreview/blob/fix/153-faithfulness-none-context/PLAN.md]]
 
 **Blockers or open questions:**  
 I am unsure whether the fix should only handle `None` values or also handle other non-string context values.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -17,3 +17,17 @@ This issue is narrowly scoped to one method in the RAG evaluation code and has a
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [add commit link after pushing]
+
+**Reproduction summary:**  
+I reproduced the issue by calling `FaithfulnessChecker.check()` with a context chunk containing `{"text": None}`. The method raised a `TypeError` because `None` was passed into `" ".join(...)`.
+
+**PLAN.md link:** [add PLAN.md GitHub link after pushing]
+
+**Walkthrough video (recommended):**
+
+**Blockers or open questions:**  
+I am unsure whether the fix should only handle `None` values or also handle other non-string context values.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,19 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/153
+
+**Issue title:** Faithfulness checker crashes when a context chunk has `text: None`
+
+**Tier:** [x] Tier 1 [ ] Tier 2 [ ] Tier 3
+
+**Problem summary:**  
+The faithfulness checker combines text from retrieved context chunks before comparing that context with generated feedback. It currently uses `chunk.get("text", "")`, which handles a missing `text` key but not a key whose value is explicitly `None`. When `None` is passed into `" ".join(...)`, the checker raises a `TypeError` instead of returning a score. A successful fix would normalize unavailable chunk text to an empty string while preserving valid text.
+
+**Why this issue is a good fit:**  
+This issue is narrowly scoped to one method in the RAG evaluation code and has a clear reproduction case. The issue also points to an existing failing unit test, so I can verify the bug and confirm the fix without needing to understand the entire application. The expected change appears small and does not involve database schemas, API design, or major architectural changes. This makes it appropriate for a Tier 1 first open-source contribution.
+
+**Branch name:** `fix/153-faithfulness-none-context`
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,76 @@
+## Solution plan
+
+**Issue:** Faithfulness checker crashes when a context chunk has `text: None` — [issue link]
+
+### Understand
+
+`FaithfulnessChecker.check()` joins the text from each context chunk.
+
+When a chunk contains:
+
+```python
+{"text": None}
+```
+
+`chunk.get("text", "")` returns `None` because the `"text"` key exists. Passing `None` into `" ".join(...)` raises a `TypeError`.
+
+Expected behavior: a context chunk with `None` text should be handled without crashing.
+
+Actual behavior: the checker raises:
+
+```text
+TypeError: sequence item 0: expected str instance, NoneType found
+```
+
+### Map
+
+Files and functions involved:
+
+- `rag/evaluator/faithfulness_checker.py`
+  - `FaithfulnessChecker.check()`
+- `tests/unit/test_faithfulness_checker.py`
+  - `test_none_context_chunk_text`
+
+Files I expect to touch:
+
+- `rag/evaluator/faithfulness_checker.py`
+- `tests/unit/test_faithfulness_checker.py`, if more test coverage is needed
+
+### Plan
+
+1. Review the existing context-building logic and related tests.
+2. Update the context-building logic so missing or `None` text is treated as an empty string.
+3. Run `test_none_context_chunk_text` to verify the bug is fixed.
+4. Run the full faithfulness checker test file.
+5. Run the broader test suite to check for regressions.
+
+### Inputs & outputs
+
+Input:
+
+```python
+FaithfulnessChecker().check(
+    "Knows Python.",
+    [{"text": None}]
+)
+```
+
+Expected behavior:
+
+- The method does not raise a `TypeError`.
+- `None` text is treated as empty text.
+- Valid string context continues to work normally.
+
+### Risks & unknowns
+
+- Treating `None` as empty text could result in an entirely empty context, so I need to check how `FaithfulnessChecker.check()` handles that later in the method.
+- I am unsure whether non-string values besides `None` should also be handled.
+- I need to verify whether the existing test fully covers mixed valid and `None` context chunks.
+
+### Edge cases
+
+- `{"text": None}`
+- A chunk with no `"text"` key
+- `{"text": ""}`
+- An empty context list
+- A mixture of valid text and `None`

--- a/rag/evaluator/faithfulness_checker.py
+++ b/rag/evaluator/faithfulness_checker.py
@@ -1,6 +1,7 @@
 """Check if generated feedback is supported by retrieved context."""
 
 import re
+
 import structlog
 
 logger = structlog.get_logger()
@@ -20,8 +21,11 @@ class FaithfulnessChecker:
             Faithfulness score 0.0-1.0 (ratio of supported claims)
         """
         if not feedback or not context_chunks:
-            logger.info("faithfulness_empty_input", has_feedback=bool(feedback),
-                       has_chunks=bool(context_chunks))
+            logger.info(
+                "faithfulness_empty_input",
+                has_feedback=bool(feedback),
+                has_chunks=bool(context_chunks),
+            )
             return 0.0
 
         # Extract key claims from feedback (sentences)
@@ -31,9 +35,7 @@ class FaithfulnessChecker:
             return 0.5  # Default to neutral if no extractable claims
 
         # Concatenate context text
-        context_text = " ".join([
-            chunk.get("text", "") for chunk in context_chunks
-        ])
+        context_text = " ".join([chunk.get("text") or "" for chunk in context_chunks]).strip()
 
         # Check each claim for support
         supported = 0
@@ -43,8 +45,9 @@ class FaithfulnessChecker:
 
         score = supported / len(claims) if claims else 0.0
 
-        logger.info("faithfulness_checked", claims_count=len(claims),
-                   supported_count=supported, score=score)
+        logger.info(
+            "faithfulness_checked", claims_count=len(claims), supported_count=supported, score=score
+        )
 
         return score
 
@@ -59,7 +62,7 @@ class FaithfulnessChecker:
             List of claims (sentences)
         """
         # Split by sentence (simple regex)
-        sentences = re.split(r'[.!?]+', text)
+        sentences = re.split(r"[.!?]+", text)
         claims = [s.strip() for s in sentences if s.strip() and len(s.strip()) > 10]
         return claims[:10]  # Limit to 10 claims for scoring
 
@@ -81,8 +84,25 @@ class FaithfulnessChecker:
         # Require at least some meaningful overlap
         overlap = claim_tokens & context_tokens
         # Filter out common stop words
-        stop_words = {'a', 'an', 'the', 'is', 'are', 'was', 'were', 'be', 'been',
-                     'and', 'or', 'but', 'in', 'of', 'to', 'for', 'that'}
+        stop_words = {
+            "a",
+            "an",
+            "the",
+            "is",
+            "are",
+            "was",
+            "were",
+            "be",
+            "been",
+            "and",
+            "or",
+            "but",
+            "in",
+            "of",
+            "to",
+            "for",
+            "that",
+        }
         meaningful_overlap = overlap - stop_words
 
         return len(meaningful_overlap) >= 2

--- a/tests/unit/test_faithfulness_checker.py
+++ b/tests/unit/test_faithfulness_checker.py
@@ -18,9 +18,7 @@ class TestFaithfulnessChecker:
         """Test feedback fully supported by context returns score close to 1.0."""
         feedback = "The developer has strong Python skills and experience with Django."
         context_chunks = [
-            {
-                "text": "The portfolio shows Python expertise and Django framework experience."
-            },
+            {"text": "The portfolio shows Python expertise and Django framework experience."},
         ]
 
         score = checker.check(feedback, context_chunks)
@@ -34,9 +32,7 @@ class TestFaithfulnessChecker:
         """Test feedback with no support in context returns score close to 0.0."""
         feedback = "This developer is an expert in Rust systems programming."
         context_chunks = [
-            {
-                "text": "The developer has Python and JavaScript experience."
-            },
+            {"text": "The developer has Python and JavaScript experience."},
         ]
 
         score = checker.check(feedback, context_chunks)
@@ -48,9 +44,7 @@ class TestFaithfulnessChecker:
         """Test partial support returns score between 0 and 1."""
         feedback = "The developer shows Python expertise and Kubernetes knowledge."
         context_chunks = [
-            {
-                "text": "Strong Python programming skills demonstrated in projects."
-            },
+            {"text": "Strong Python programming skills demonstrated in projects."},
         ]
 
         score = checker.check(feedback, context_chunks)
@@ -63,9 +57,7 @@ class TestFaithfulnessChecker:
     def test_empty_feedback_returns_zero(self, checker):
         """Test empty feedback returns 0.0."""
         feedback = ""
-        context_chunks = [
-            {"text": "Some context"}
-        ]
+        context_chunks = [{"text": "Some context"}]
 
         score = checker.check(feedback, context_chunks)
 
@@ -155,15 +147,11 @@ class TestFaithfulnessChecker:
         """Test that score varies with input, never hardcoded 1.0 or 0.0."""
         # First test: fully supported
         score1 = checker.check(
-            "Python and JavaScript skills",
-            [{"text": "Expert in Python and JavaScript"}]
+            "Python and JavaScript skills", [{"text": "Expert in Python and JavaScript"}]
         )
 
         # Second test: no support
-        score2 = checker.check(
-            "Rust expertise",
-            [{"text": "Java programming background"}]
-        )
+        score2 = checker.check("Rust expertise", [{"text": "Java programming background"}])
 
         # Scores should be different
         assert score1 != score2
@@ -173,9 +161,7 @@ class TestFaithfulnessChecker:
     def test_multiple_claims_varying_support(self, checker):
         """Test scoring with multiple claims of varying support."""
         feedback = "Python expert. Knows Rust. Skilled with Docker."
-        context_chunks = [
-            {"text": "Python and Docker expertise shown in projects."}
-        ]
+        context_chunks = [{"text": "Python and Docker expertise shown in projects."}]
 
         score = checker.check(feedback, context_chunks)
 
@@ -186,9 +172,7 @@ class TestFaithfulnessChecker:
     def test_very_long_feedback(self, checker):
         """Test handling of very long feedback text."""
         feedback = "The developer. " * 100
-        context_chunks = [
-            {"text": "Developer portfolio content"}
-        ]
+        context_chunks = [{"text": "Developer portfolio content"}]
 
         score = checker.check(feedback, context_chunks)
 
@@ -198,9 +182,7 @@ class TestFaithfulnessChecker:
     def test_very_long_context(self, checker):
         """Test handling of very long context."""
         feedback = "The developer has Python skills."
-        context_chunks = [
-            {"text": "Python " * 1000}
-        ]
+        context_chunks = [{"text": "Python " * 1000}]
 
         score = checker.check(feedback, context_chunks)
 
@@ -231,9 +213,7 @@ class TestFaithfulnessChecker:
     def test_none_context_chunk_text(self, checker):
         """Test handling of None in context chunk text."""
         feedback = "Has Python skills"
-        context_chunks = [
-            {"text": None}
-        ]
+        context_chunks = [{"text": None}]
 
         score = checker.check(feedback, context_chunks)
 
@@ -244,9 +224,7 @@ class TestFaithfulnessChecker:
     def test_missing_text_key_in_chunk(self, checker):
         """Test handling of missing 'text' key in context chunk."""
         feedback = "Has Python skills"
-        context_chunks = [
-            {"content": "Python skills"}  # Wrong key
-        ]
+        context_chunks = [{"content": "Python skills"}]  # Wrong key
 
         score = checker.check(feedback, context_chunks)
 
@@ -272,3 +250,16 @@ class TestFaithfulnessChecker:
         supported = checker._is_supported(claim, context)
 
         assert supported is True
+
+    def test_none_context_chunk_text_with_valid_chunk(self, checker: FaithfulnessChecker) -> None:
+        """Test handling of None in context chunk text with a valid chunk."""
+        feedback = "Has Python skills"
+        context_chunks = [
+            {"text": None},
+            {"text": "Python experience shown in projects."},
+        ]
+
+        score = checker.check(feedback, context_chunks)
+
+        assert isinstance(score, float)
+        assert 0.0 <= score <= 1.0


### PR DESCRIPTION
## Summary

`FaithfulnessChecker.check()` crashed when a context chunk contained
`{"text": None}` because `chunk.get("text", "")` returned `None` and that
value was passed into `" ".join(...)`.

This PR updates the context-building logic so `None` text is treated as an
empty string instead of causing a `TypeError`.

## Issue

Closes #153

## Changes

Updated `rag/evaluator/faithfulness_checker.py` so context chunks with
`text: None` are normalized to an empty string before joining.

Added a regression test in `tests/unit/test_faithfulness_checker.py` covering
a `None` context chunk alongside a valid text chunk.

Kept the change narrowly scoped to `None` handling without changing the
checker’s scoring logic.

## Testing

- [x] Unit tests pass (`make test-unit`) — no new failures; see pre-existing note
- [ ] Integration tests pass (`make test-integration`) — not run
- [x] Linter passes (`make lint`) — pre-existing issues remain; see note below
- [x] Type checker passes (`make typecheck`) — pre-existing issues remain; see note below
- [x] New/updated tests cover the changes

Targeted `test_none_context_chunk_text` passes after the fix.

The full unit suite went from 375 passing / 53 failing before the change to
376 passing / 52 failing after the change. The resolved failure is
`test_none_context_chunk_text`, and no new failures were introduced.

The faithfulness checker test file now has 20 passing tests and the same
3 unrelated pre-existing failures.

## Screenshots / Demo

N/A — this is a backend evaluator change with no visible UI change.

## Notes for Reviewers

Pre-existing failures unrelated to this change were present before
implementation.

`make test-unit` had 53 failures before the fix and 52 afterward. The only
failure resolved by this PR is `test_none_context_chunk_text`.

The following failures in `tests/unit/test_faithfulness_checker.py` remain
unchanged:

- `test_partial_support_returns_middle_score`
- `test_multiple_context_chunks`
- `test_multiple_claims_varying_support`

The test file also contains pre-existing Ruff and mypy issues in code that was
not changed for this PR. This change introduces no new test failures and does
not modify the unrelated failing behavior.