### PR TITLE
test(api): add auth middleware edge case coverage

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -53,28 +53,51 @@ Currently, tests for auth middleware check if a token is valid or not. However, 
 ### Check-in 1 (mid-week)
 
 **Current progress:**
-[What have you implemented so far? Which sub-tasks from PLAN.md are done?]
+Implemented the two sub-tasks from PLAN.md that make up the actual fix:
+`tests/integration/conftest.py` (shared fixtures — a DB-backed `test_user`,
+a valid `auth_token`, and an `httpx.AsyncClient` wired to the app) and
+`tests/integration/test_auth_middleware.py` (5 tests: baseline valid-token
+pass, missing header, malformed token, wrong-secret token, expired token).
+No changes to `api/middleware/auth.py` or `core/security.py`, per the
+"not in scope" note in PLAN.md.
 
 **Next steps:**
-[What are you working on for the rest of the week?]
+Confirm `make test-integration` and `make check` pass in my own local
+environment [confirm this — you were last debugging a missing
+`.venv/bin/alembic`], then open a draft PR for review.
 
 **Blockers:**
-[Anything slowing you down? Or leave blank.]
+Using `make setup` and `make run` was not working as intended
 
 ---
 
 ### Check-in 2 (end of week)
 
-**PR link:** [link to your submitted pull request]
+**PR link:** https://github.com/ascherj/pathreview/pull/464
 
-**Branch:** [the branch name you worked on, e.g. `fix/123-short-description`]
+**Branch:** feat/90-auth-edge-cases-tests
 
 **What you built:**
-[1–3 sentences summarizing what your fix does and how it works]
+Added integration test coverage for `get_current_user()` (the auth
+dependency guarding every protected route), covering four previously
+untested edge cases — expired, malformed, and wrong-secret tokens, plus a
+missing `Authorization` header — alongside a valid-token baseline. All five
+were manually reproduced against a running instance beforehand (see Week 8
+entry); the middleware was already correct, so this closes a test-coverage
+gap rather than fixing a bug.
 
 **Tests added or updated:**
-[Which test files did you touch? What do they cover?]
+- `tests/integration/conftest.py` (new) — `test_user`, `auth_token`,
+  `client` fixtures, plus an autouse fixture disposing the SQLAlchemy
+  engine's connection pool between tests (needed to avoid cross-event-loop
+  asyncpg errors under pytest-asyncio's per-test event loops).
+- `tests/integration/test_auth_middleware.py` (new) — 5 tests against
+  `GET /profiles/{profile_id}`, asserting the exact status codes/messages
+  confirmed during Week 8 reproduction.
 
-**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+**Self-review confirmation:** [✅] make check passes  [✅] make test-unit passes
+[Check these only once you've actually run them yourself and confirmed —
+note any pre-existing failures you saw and that your branch doesn't add
+new ones, per the "Pre-existing failures" guidance above]
 
-**Draft PR feedback received from:** [name or Slack handle, or "none"]
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -19,12 +19,31 @@ Currently, tests for auth middleware check if a token is valid or not. However, 
 
 **Reproduction commit link:** [link to commit documenting the reproduced issue]
 
-**Reproduction summary:**
-[1–2 sentences: How did you reproduce the issue? What did you observe?]
+**Reproduction steps:**
+1. Started the app locally (`make run`) and registered a test user via
+   `POST /auth/register` to get a valid token.
+2. Confirmed a baseline: `GET /profiles/{uuid}` with the valid token returns
+   404 "not found" (not 401) — proves the happy path passes auth correctly.
+3. Triggered each missing case by hand against the same route:
+   - No `Authorization` header → `401 "Not authenticated"`
+   - Malformed token (`Bearer not-a-real-jwt`) → `401 "Invalid authentication credentials"`
+   - Token signed with a different secret (forged via a throwaway script using
+     `jose.jwt.encode` directly) → `401 "Invalid authentication credentials"`
+   - Expired token (forged via `create_access_token` with a negative
+     `expires_delta`) → `401 "Invalid authentication credentials"`
+4. Result: all four cases are already handled correctly by the middleware
+   (each returns 401) — this is a test-coverage gap, not a security bug.
+5. Found one discrepancy while tracing the code: the expired-token case
+   returns the generic "Invalid authentication credentials" message instead
+   of the more specific "Token has expired" message a separate branch of
+   `get_current_user` appears to produce. `decode_access_token()` already
+   catches expired tokens via `jose.JWTError` and returns `None` before that
+   branch runs, so it's currently unreachable dead code. Flagged as a
+   possible follow-up, not fixed here.
 
-**PLAN.md link:** [link to PLAN.md in your fork]
+**PLAN.md link:** https://github.com/atile4/pathreview/blob/feat/90-auth-edge-cases-tests/PLAN.md
 
-**Walkthrough video (recommended):** [link to your Loom video, ≤2 min — recommended, not graded]
+<!-- **Walkthrough video (recommended):** [link to your Loom video, ≤2 min — recommended, not graded] -->
 
 **Blockers or open questions:**
-[Anything you're still uncertain about going into Week 9, or leave blank]
+<!-- [Anything you're still uncertain about going into Week 9, or leave blank] -->

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -14,3 +14,17 @@ Currently, tests for auth middleware check if a token is valid or not. However, 
 **Setup confirmation:** [✅] App runs locally at localhost:5173
 
 **Cohort ledger:** [✅] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [link to commit documenting the reproduced issue]
+
+**Reproduction summary:**
+[1–2 sentences: How did you reproduce the issue? What did you observe?]
+
+**PLAN.md link:** [link to PLAN.md in your fork]
+
+**Walkthrough video (recommended):** [link to your Loom video, ≤2 min — recommended, not graded]
+
+**Blockers or open questions:**
+[Anything you're still uncertain about going into Week 9, or leave blank]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -9,7 +9,7 @@
 **Problem summary:**
 Currently, tests for auth middleware check if a token is valid or not. However, these tests do not include edge cases like expired tokens, malformed tokens, tokens assigned with a different secret, and missing `Authorization` headers, all of which follow a valid token format but aren't tokens that can be used. This PR adds those edge cases into the unit tests to ensure the bad tokens can be caught instead of silently ignored. 
 
-**Branch name:** auth-edge-cases-tests
+**Branch name:** feat/90-auth-edge-cases-tests
 
 **Setup confirmation:** [✅] App runs locally at localhost:5173
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -7,9 +7,7 @@
 **Tier:** [ ] Tier 1  [✅] Tier 2  [ ] Tier 3
 
 **Problem summary:**
-[In 3–5 sentences, in your own words: what the issue is (not a copy-paste of
-the title), what is currently broken or missing, and what a successful fix
-would accomplish. Naming the part of the codebase it affects is helpful context.]
+Currently, tests for auth middleware check if a token is valid or not. However, these tests do not include edge cases like expired tokens, malformed tokens, tokens assigned with a different secret, and missing `Authorization` headers, all of which follow a valid token format but aren't tokens that can be used. This PR adds those edge cases into the unit tests to ensure the bad tokens can be caught instead of silently ignored. 
 
 **Branch name:** auth-edge-cases-tests
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,18 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/90
+
+**Issue title:** Add integration tests for authentication edge cases
+
+**Tier:** [ ] Tier 1  [✅] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+[In 3–5 sentences, in your own words: what the issue is (not a copy-paste of
+the title), what is currently broken or missing, and what a successful fix
+would accomplish. Naming the part of the codebase it affects is helpful context.]
+
+**Branch name:** auth-edge-cases-tests
+
+**Setup confirmation:** [✅] App runs locally at localhost:5173
+
+**Cohort ledger:** [✅] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -17,7 +17,7 @@ Currently, tests for auth middleware check if a token is valid or not. However, 
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [link to commit documenting the reproduced issue]
+**Reproduction commit link:** https://github.com/atile4/pathreview/commit/f26aa836567c233fd32890817addbad87abf3679
 
 **Reproduction steps:**
 1. Started the app locally (`make run`) and registered a test user via

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -47,3 +47,34 @@ Currently, tests for auth middleware check if a token is valid or not. However, 
 
 **Blockers or open questions:**
 <!-- [Anything you're still uncertain about going into Week 9, or leave blank] -->
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+[What have you implemented so far? Which sub-tasks from PLAN.md are done?]
+
+**Next steps:**
+[What are you working on for the rest of the week?]
+
+**Blockers:**
+[Anything slowing you down? Or leave blank.]
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [link to your submitted pull request]
+
+**Branch:** [the branch name you worked on, e.g. `fix/123-short-description`]
+
+**What you built:**
+[1–3 sentences summarizing what your fix does and how it works]
+
+**Tests added or updated:**
+[Which test files did you touch? What do they cover?]
+
+**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+
+**Draft PR feedback received from:** [name or Slack handle, or "none"]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -101,3 +101,37 @@ note any pre-existing failures you saw and that your branch doesn't add
 new ones, per the "Pre-existing failures" guidance above]
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [✅] No — still awaiting review
+
+**Summary of feedback:**
+No review came in.
+
+**How you responded:**
+N/A
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The most unexpectedly difficult part of this setting up. I had issues with running `make setup` and `make run`,  as I didn't know I needed Docker to be running, and I also had trouble with the Python version not being correct, which lead me down a rabbit hole of Python being half installed such that I couldn't reinstall it nor could I delete it. 
+
+
+**What did you learn about working in a large codebase?**
+Working in a much larger codebase compared to my own felt like navigating a new country. I could understand the code (kind of) like I could recognize buildings/people, but the overall structure was foreign and I didn't know what was going on, and how files connected. Still, through these past weeks, learning to work in this environment taught me that at the very least, having a rock-solid understanding of one part of the codebase that encompasses my task is significantly better than having a shallow understanding of the entire codebase, because I'd still be able to get the task done without missing anything.
+
+**How did AI tools help — and where did they fall short?**
+AI tools like Claude and Copilot were extremely helpful in helping me to navigate the codebase. It helped me to understand what files did, how different files connected, and pointed me towards where the issue needed to be fixed. 
+
+However, those tools didn't help me much when I was trying to fix push issues. I had difficulty committing because of the automated checks that needed to be ran, and AI tools weren't very helpful in deciphering the warnings that were returned, nor was it helpful in figuring out why they were going wrong. I had to go through the documentation to figure out that the errors were pre-existing, and had to ignore them in order to be able to push my changes.
+
+**What would you do differently if you started over?**
+If I started over, I'd create a document, or a Google Doc for notes, outlining all the connectors between files. I'd also extensively note down my task, what was required of my task, like related files, paths to those files, and what those files did, to ensure I had a good understanding of the issue. 
+
+**What are you most proud of from this module?**
+From all I did in this module, I was most proud of writing my final pull request. That PR was a culmination of all my work across the past three weeks, and it felt extremely satisfying breaking down my work, writing out what I did, and sending it off to be reviewed and merged. Seeing everything I'd built come together into one clean, well-documented submission made all the earlier tests and iteration feel worth it.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,23 @@
+## Solution plan
+
+**Issue:** [issue title and link]
+
+### Understand
+What is the root cause of this issue? What behavior is expected vs. actual?
+
+### Map
+Which files, functions, or modules are involved?
+List the specific files you expect to touch.
+
+### Plan
+What are the steps to fix this issue?
+Break it into 3–5 concrete sub-tasks.
+
+### Inputs & outputs
+What does your fix take as input? What should it produce or change?
+
+### Risks & unknowns
+What could go wrong? What are you still unsure about?
+
+### Edge cases
+What inputs or states should your fix handle gracefully?

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,23 +1,84 @@
 ## Solution plan
 
-**Issue:** [issue title and link]
+**Issue:** [Add integration tests for authentication edge cases](https://github.com/ascherj/pathreview/issues/90)
 
 ### Understand
-What is the root cause of this issue? What behavior is expected vs. actual?
+<!-- What is the root cause of this issue? What behavior is expected vs. actual? -->
+The root cause of the issue is that existing tests for tokens only cover whether or not a token is valid — there are no tests that exist to capture the presence of expired tokens, malformed tokens, missing `Authorization` header, and tokens signed with a different secret being *rejected*.
+
+**Expected behavior:** all four bad-token cases should return 401 Unauthorized, since `get_current_user()` (api/middleware/auth.py) is the single dependency guarding every protected route.
+
+**Actual behavior, confirmed by manual reproduction against a running instance:**
+all four cases already return 401 correctly — the middleware itself is not broken. The gap is purely a lack of test coverage, not a security bug:
+
+| Case | Response |
+|---|---|
+| Valid token (baseline) | Passes auth (404 on a nonexistent profile, not 401) |
+| Missing `Authorization` header | 401 "Not authenticated" |
+| Malformed token | 401 "Invalid authentication credentials" |
+| Token signed with wrong secret | 401 "Invalid authentication credentials" |
+| Expired token | 401 "Invalid authentication credentials" |
+
+One discrepancy worth noting: the expired-token case returns the generic "Invalid authentication credentials" message rather than the more specific "Token has expired" message that a separate branch of `get_current_user` appears to handle. Tracing the code shows `decode_access_token()` (core/security.py) already catches `jose.ExpiredSignatureError` (a subclass of `JWTError`) and returns `None` before that branch is ever reached — so the "Token has expired" branch is currently dead code for real tokens. This doesn't affect security (still a correct 401), just the specificity of the error message. Flagging it as a possible follow-up rather than in-scope for this tests-only issue.
 
 ### Map
-Which files, functions, or modules are involved?
-List the specific files you expect to touch.
+<!-- Which files, functions, or modules are involved?
+List the specific files you expect to touch. -->
+- `tests/integration/test_auth_middleware.py` — does not exist yet; will be
+  created new. This is the only file that needs to change.
+- Read-only references (no changes expected):
+  - `api/middleware/auth.py` — `get_current_user()`, the dependency under test
+  - `core/security.py` — `create_access_token()` / `decode_access_token()`,
+    used to build valid/expired tokens and understand decode failures
+  - `api/routes/profiles.py` — has a `GET /{profile_id}` route, a convenient
+    protected endpoint to test against without needing extra setup
+  - `tests/conftest.py` — check whether a DB session / test client fixture
+    already exists here before adding a new one
 
-### Plan
+<!-- ### Plan
 What are the steps to fix this issue?
-Break it into 3–5 concrete sub-tasks.
+Break it into 3–5 concrete sub-tasks. -->
+1. Set up a shared fixture for an authenticated test user (create a `User`
+   row in the test DB, return both the user and a valid token for it) —
+   check `tests/conftest.py` first in case something reusable exists.
+2. Write the baseline valid-token test to confirm the fixture works end to end.
+3. Write the 4 edge-case tests, asserting `401` for each, using the exact
+   commands/results already confirmed manually:
+   - missing header
+   - malformed token
+   - wrong-secret token
+   - expired token
+4. Run `make test-integration`, confirm all 5 pass.
+5. Run `make check` (lint/format/typecheck) before opening the PR.
 
 ### Inputs & outputs
-What does your fix take as input? What should it produce or change?
+<!-- What does your fix take as input? What should it produce or change? -->
+- Input: HTTP requests to a protected route (`GET /profiles/{id}`) with
+  varying `Authorization` header states (valid, missing, malformed, wrong
+  secret, expired).
+- Output: this is a test-only change — no production code changes. The
+  "output" is a passing test suite that locks in the already-correct 401
+  behavior, so a future regression would be caught by CI instead of going
+  unnoticed.
 
 ### Risks & unknowns
-What could go wrong? What are you still unsure about?
+<!-- What could go wrong? What are you still unsure about? -->
+- Don't yet know if `tests/conftest.py` or elsewhere already has a
+  DB-backed test client / test user fixture — need to check before writing
+  a duplicate one.
+- Integration tests are marked as requiring Docker services per
+  `pyproject.toml` — need to confirm `docker compose up -d` is sufficient
+  for the test DB, or if there's separate test-only config.
+- The expired-token case's dead-code finding (generic message instead of
+  "Token has expired") is out of scope to fix, but the test needs to assert
+  the *actual* current message, not the one the code seems to intend —
+  otherwise the test would fail for the wrong reason.
 
 ### Edge cases
-What inputs or states should your fix handle gracefully?
+<!-- What inputs or states should your fix handle gracefully? -->
+- Token with a valid signature but for a user ID that doesn't exist in the
+  DB (not explicitly in the issue, but worth a quick check since
+  `get_current_user` has a distinct code path for "user not found")
+- Token with no `sub` claim at all
+- `Authorization` header present but with the wrong scheme (e.g. `Basic`
+  instead of `Bearer`)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,82 @@
+"""Shared fixtures for integration tests.
+
+These tests exercise the real FastAPI app against a real Postgres database
+(via `core.database`/`core.config.settings`) — there is no SQLite fallback
+or DB mocking in this codebase, so a Postgres instance must be reachable at
+`settings.database_url` before running them.
+
+Locally:
+
+    docker compose up -d db
+    DATABASE_URL=postgresql+asyncpg://pathreview:pathreview@localhost:5433/pathreview_dev \
+        .venv/bin/alembic upgrade head
+    make test-integration
+
+This mirrors the `postgres` service the `test-integration` job in
+`.github/workflows/ci.yml` spins up for CI.
+"""
+
+from collections.abc import AsyncGenerator
+from uuid import uuid4
+
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.main import app
+from core.database import AsyncSessionLocal, engine
+from core.models.user import User
+from core.security import create_access_token, hash_password
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _dispose_engine_after_test() -> AsyncGenerator[None, None]:
+    """Dispose pooled connections after each test.
+
+    pytest-asyncio gives each test function its own event loop by default.
+    The SQLAlchemy async engine (and its asyncpg connection pool) is a
+    module-level singleton, so without this a connection opened in one
+    test's loop gets reused/closed against a different, already-closed
+    loop in the next test, raising "Event loop is closed" during teardown.
+    """
+    yield
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def db_session() -> AsyncGenerator[AsyncSession, None]:
+    """Yield a DB session bound to the same engine the app uses."""
+    async with AsyncSessionLocal() as session:
+        yield session
+
+
+@pytest_asyncio.fixture
+async def test_user(db_session: AsyncSession) -> AsyncGenerator[User, None]:
+    """Create a persisted user for auth tests and clean it up afterwards."""
+    user = User(
+        email=f"auth-test-{uuid4()}@example.com",
+        hashed_password=hash_password("Sup3rSecret!123"),
+        is_active=True,
+    )
+    db_session.add(user)
+    await db_session.commit()
+    await db_session.refresh(user)
+
+    yield user
+
+    await db_session.delete(user)
+    await db_session.commit()
+
+
+@pytest_asyncio.fixture
+def auth_token(test_user: User) -> str:
+    """A valid JWT access token for `test_user`."""
+    return create_access_token(data={"sub": str(test_user.id)})
+
+
+@pytest_asyncio.fixture
+async def client() -> AsyncGenerator[AsyncClient, None]:
+    """An httpx client wired directly to the FastAPI app (no network)."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac

--- a/tests/integration/test_auth_middleware.py
+++ b/tests/integration/test_auth_middleware.py
@@ -1,0 +1,111 @@
+"""Integration tests for `get_current_user()` (api/middleware/auth.py).
+
+`get_current_user` is the single dependency guarding every protected route,
+but it had only ever been exercised with a valid token. These tests cover
+the previously-untested edge cases: expired tokens, malformed tokens, a
+missing `Authorization` header, and tokens signed with a different secret.
+
+All five cases below were manually reproduced against a running instance
+first (see JOURNAL.md / PLAN.md) — the middleware already behaves correctly.
+This file locks that behavior in so a future regression is caught by CI
+instead of going unnoticed.
+
+Tested against `GET /profiles/{profile_id}`, a real protected route, rather
+than mocking the dependency directly, so the tests cover the full stack:
+`OAuth2PasswordBearer` -> `decode_access_token()` -> `get_current_user()`.
+
+Known follow-up (out of scope here, see PLAN.md): the expired-token case
+returns the generic "Invalid authentication credentials" message rather
+than the more specific "Token has expired" message. That's because
+`decode_access_token()` already swallows `ExpiredSignatureError` (a
+`JWTError` subclass) and returns `None`, so the dedicated expiry check in
+`get_current_user()` is dead code. Still a correct 401, just a less
+specific message -- asserted as-is below, not as it "should" be.
+"""
+
+from datetime import timedelta
+from uuid import uuid4
+
+import pytest
+from httpx import AsyncClient
+from jose import jwt
+
+from core.config import settings
+from core.models.user import User
+from core.security import create_access_token
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.asyncio
+async def test_valid_token_passes_auth(client: AsyncClient, auth_token: str) -> None:
+    """Baseline: a valid token reaches the route handler (404, not 401)."""
+    response = await client.get(
+        f"/profiles/{uuid4()}",
+        headers={"Authorization": f"Bearer {auth_token}"},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Profile not found"
+
+
+@pytest.mark.asyncio
+async def test_missing_authorization_header(client: AsyncClient) -> None:
+    """No `Authorization` header at all is rejected before reaching the route."""
+    response = await client.get(f"/profiles/{uuid4()}")
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Not authenticated"
+
+
+@pytest.mark.asyncio
+async def test_malformed_token(client: AsyncClient) -> None:
+    """A token that isn't valid JWT structure is rejected."""
+    response = await client.get(
+        f"/profiles/{uuid4()}",
+        headers={"Authorization": "Bearer not-a-real-jwt"},
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Invalid authentication credentials"
+
+
+@pytest.mark.asyncio
+async def test_wrong_secret_token(client: AsyncClient, test_user: User) -> None:
+    """A well-formed token signed with a different secret is rejected."""
+    forged_token = jwt.encode(
+        {"sub": str(test_user.id)},
+        "a-completely-different-secret",
+        algorithm=settings.jwt_algorithm,
+    )
+
+    response = await client.get(
+        f"/profiles/{uuid4()}",
+        headers={"Authorization": f"Bearer {forged_token}"},
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Invalid authentication credentials"
+
+
+@pytest.mark.asyncio
+async def test_expired_token(client: AsyncClient, test_user: User) -> None:
+    """An expired token is rejected.
+
+    Asserts the generic message the code actually returns today (see the
+    module docstring for the dead-code finding), not the more specific
+    "Token has expired" message a separate branch of `get_current_user`
+    appears to intend.
+    """
+    expired_token = create_access_token(
+        data={"sub": str(test_user.id)},
+        expires_delta=timedelta(seconds=-10),
+    )
+
+    response = await client.get(
+        f"/profiles/{uuid4()}",
+        headers={"Authorization": f"Bearer {expired_token}"},
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Invalid authentication credentials"


### PR DESCRIPTION
## Summary
Adds integration test coverage for `get_current_user()` (`api/middleware/auth.py`), the dependency guarding every protected route. Previously it was only ever exercised with a valid token; this adds tests for the four untested edge cases (expired, malformed, wrong-secret, and missing-header tokens) plus a valid-token baseline. No production code changes — this closes a test-coverage gap, not a bug.

## Issue
Closes #90

## Changes
- `tests/integration/conftest.py` (new) — shared fixtures: `test_user` (persists a real user, cleans up after), `auth_token` (a valid JWT for that user via the app's own `create_access_token()`), `client` (`httpx.AsyncClient` wired to the app via `ASGITransport`), and an autouse fixture that disposes the SQLAlchemy engine's connection pool after each test (needed to avoid cross-event-loop asyncpg errors under pytest-asyncio's per-test event loops).
- `tests/integration/test_auth_middleware.py` (new) — 5 tests against `GET /profiles/{profile_id}`, a real protected route: valid token (baseline), missing `Authorization` header, malformed token, wrong-secret token, expired token.

## Testing
- [x] Unit tests pass (`make test-unit`) - no new failures vs. pre-existing baseline (see note below)
- [x] Integration tests pass (`make test-integration`) - 5/5 new tests pass
- [x] Linter passes (`make lint`) on the two new files
- [x] Type checker passes (`make typecheck`) - only scopes `api/ core/ ingestion/ rag/ agent/ safety/` and doesn't touch `tests/`, so it's unaffected by this PR
- [x] New/updated tests cover the changes

Checks
✅ make lint — passes on the two new files
✅ make typecheck — passes; this target only scopes api/ core/ ingestion/ rag/ agent/ safety/ and doesn't include tests/, so it's unaffected by this PR either way
✅ make test-integration — 5/5 new tests pass
❌ make test-unit — **53** pre-existing failures/errors; this PR adds none
❌ mypy via the pre-commit hook (not make typecheck) — fails on committing with 44 errors across 8 files. Breakdown:
- All errors are pre-existing and are not handled in this PR. 