### PR TITLE
fix: support short claims in faithfulness checker

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -43,3 +43,25 @@ I reproduced Issue #152 by running `pytest tests/unit/test_faithfulness_checker.
 
 **Blockers or open questions:**
 I need to determine how `_is_supported()` can accept one-token matches for short, specific technical claims without allowing common or weak single-token matches to create false positives. The test suite also contains an unrelated existing failure involving a context chunk whose `text` value is `None`; I will keep that outside the scope of Issue #152 unless the maintainers indicate otherwise.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+I reproduced Issue #152 and identified two related causes: short claims were
+filtered out during claim extraction, and `_is_supported()` required at least
+two meaningful token matches. I added a regression test based on the issue's
+short-claim example and started updating claim extraction and token matching.
+
+**Next steps:**
+I will finish the implementation, add tests for short technical claims,
+punctuation normalization, and generic-word false positives, then run
+`make check` and `make test-unit`. After the targeted tests pass, I will open a
+draft PR and request peer or mentor feedback.
+
+**Blockers:**
+The main risk is allowing one-token support without treating generic shared
+words such as `project` or `experience` as sufficient evidence.
+
+---

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -34,7 +34,7 @@ failing unit tests, so I can reproduce it and verify a fix locally.
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [add commit link after pushing]
+**Reproduction commit link:** (https://github.com/ascherj/pathreview/commit/e4af14567f9468c932572c9e72bbd08617af54cf)
 
 **Reproduction summary:**
 I reproduced Issue #152 by running `pytest tests/unit/test_faithfulness_checker.py -v`. The three tests associated with the issue—`test_partial_support_returns_middle_score`, `test_multiple_context_chunks`, and `test_multiple_claims_varying_support`—all failed consistently because the checker returned a faithfulness score of `0.0` and identified zero supported claims. The retrieved context contained the relevant technical terms, including Python, JavaScript, and Docker, but short claims with only one strong overlapping token were still classified as unsupported.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -39,7 +39,7 @@ failing unit tests, so I can reproduce it and verify a fix locally.
 **Reproduction summary:**
 I reproduced Issue #152 by running `pytest tests/unit/test_faithfulness_checker.py -v`. The three tests associated with the issue—`test_partial_support_returns_middle_score`, `test_multiple_context_chunks`, and `test_multiple_claims_varying_support`—all failed consistently because the checker returned a faithfulness score of `0.0` and identified zero supported claims. The retrieved context contained the relevant technical terms, including Python, JavaScript, and Docker, but short claims with only one strong overlapping token were still classified as unsupported.
 
-**PLAN.md link:** [add link after PLAN.md is committed and pushed]
+**PLAN.md link:** (https://github.com/ascherj/pathreview/commit/30ab1328f4b1c9dfb15efd43c6fcab4505ae533d)
 
 **Blockers or open questions:**
 I need to determine how `_is_supported()` can accept one-token matches for short, specific technical claims without allowing common or weak single-token matches to create false positives. The test suite also contains an unrelated existing failure involving a context chunk whose `text` value is `None`; I will keep that outside the scope of Issue #152 unless the maintainers indicate otherwise.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -64,4 +64,23 @@ draft PR and request peer or mentor feedback.
 The main risk is allowing one-token support without treating generic shared
 words such as `project` or `experience` as sufficient evidence.
 
+### Check-in 2 (end of week)
+
+**PR link:** (https://github.com/ascherj/pathreview/pull/468)
+
+**Branch:** `fix/152-faithfulness-short-claims`
+
+**What you built:**
+I updated the faithfulness checker so short, grounded claims can be recognized using an adaptive token-overlap rule. The implementation also normalizes punctuation, filters generic terms, and safely handles context chunks whose `text` value is `None`.
+
+**Tests added or updated:**
+I updated `tests/unit/test_faithfulness_checker.py` with regression tests for supported short claims, punctuation normalization, generic-word false positives, mixed supported and unsupported claims, and null context text.
+
+**Self-review confirmation:** [x] make check passes [x] make test-unit passes
+
+**Draft PR feedback received from:** none
+
+**Peer review note:**
+I requested feedback in Slack but did not receive a response before the submission deadline. I completed the self-review checklist and marked the PR ready for review.
+
 ---

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -31,3 +31,15 @@ failing unit tests, so I can reproduce it and verify a fix locally.
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [add commit link after pushing]
+
+**Reproduction summary:**
+I reproduced Issue #152 by running `pytest tests/unit/test_faithfulness_checker.py -v`. The three tests associated with the issue—`test_partial_support_returns_middle_score`, `test_multiple_context_chunks`, and `test_multiple_claims_varying_support`—all failed consistently because the checker returned a faithfulness score of `0.0` and identified zero supported claims. The retrieved context contained the relevant technical terms, including Python, JavaScript, and Docker, but short claims with only one strong overlapping token were still classified as unsupported.
+
+**PLAN.md link:** [add link after PLAN.md is committed and pushed]
+
+**Blockers or open questions:**
+I need to determine how `_is_supported()` can accept one-token matches for short, specific technical claims without allowing common or weak single-token matches to create false positives. The test suite also contains an unrelated existing failure involving a context chunk whose `text` value is `None`; I will keep that outside the scope of Issue #152 unless the maintainers indicate otherwise.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,33 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/152
+
+**Issue title:** Faithfulness checker can never mark short claims as supported
+
+**Tier:** [x] Tier 1 [ ] Tier 2 [ ] Tier 3
+
+**Problem summary:**
+The faithfulness checker in the RAG evaluation layer
+(`rag/evaluator/faithfulness_checker.py`) scores how well each claim in a
+generated review is grounded in the retrieved context. Its `_is_supported()`
+helper only counts a claim as supported when it shares at least two non-stopword
+tokens with the context. Short factual claims like "Knows Python." overlap on
+just one meaningful token even when the context fully supports them, so they are
+always marked unsupported — a review made of short, well-grounded claims scores
+0.0. A correct fix should let short but genuinely grounded claims be recognized
+as supported (e.g. accepting a single strong token match, or a smarter matching
+rule) without letting through claims that truly aren't in the context. This is
+covered by the failing tests `test_partial_support_returns_middle_score`,
+`test_multiple_context_chunks`, and `test_multiple_claims_varying_support` in
+`tests/unit/test_faithfulness_checker.py`.
+
+**Branch name:** fix/152-faithfulness-short-claims
+
+**"Is this right for me?" reasoning:**
+Tier 1, single-file scope in the RAG evaluator, which matches my prior RAG work.
+The bug is a self-contained token-overlap threshold issue with three existing
+failing unit tests, so I can reproduce it and verify a fix locally.
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -83,4 +83,35 @@ I updated `tests/unit/test_faithfulness_checker.py` with regression tests for su
 **Peer review note:**
 I requested feedback in Slack but did not receive a response before the submission deadline. I completed the self-review checklist and marked the PR ready for review.
 
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes [x] No — still awaiting review
+
+**Summary of feedback:**
+No reviewer or maintainer feedback was received before the end of the module. I checked the open pull request for comments and review activity, but no review was available during the Summer 2026 contribution period.
+
+**How you responded:**
+No response or additional code changes were required because no reviewer feedback was received.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The hardest part was designing a matching rule that fixed short claims without creating new false positives. Simply changing the required token overlap from two tokens to one allowed short technical claims such as `Knows Python` to pass, but it also caused contradictory statements like `well documented` and `poorly documented` to be treated as supported because they shared one generic token. I had to refine the solution by normalizing tokens, filtering generic words, and using an adaptive overlap threshold. I also spent more time than expected working through pre-commit checks, especially Ruff, Black, and mypy errors in the existing test file.
+
+**What did you learn about working in a large codebase?**
+I learned that a small code change can affect several existing assumptions and tests. In my own projects, I might change a threshold and move on after checking the main example, but in this repository I needed to understand the surrounding tests, contribution standards, type-checking rules, and existing behavior before deciding whether the fix was safe. I also learned to separate the main issue from unrelated failures, such as the `None` context-text error, and to document scope rather than assuming every nearby problem should be included. Working in someone else's codebase requires more attention to compatibility, conventions, and evidence that the change does not introduce regressions.
+
+**How did AI tools help — and where did they fall short?**
+AI tools were useful for explaining the existing token-overlap logic, identifying why short claims returned a score of `0.0`, drafting the initial `PLAN.md`, and suggesting test cases for punctuation, short technical claims, and generic-word false positives. They also helped me interpret Git and pre-commit output when commits failed. However, the first suggested implementation was too broad because accepting every one-token match caused false positives. I still needed to run the real test suite, inspect the exact failing inputs, and refine the rule based on the repository's behavior. This showed me that AI-generated code is a starting point, but it must be validated against actual tests and project conventions.
+
+**What would you do differently if you started over?**
+I would begin by writing a smaller set of focused regression tests before changing the implementation. In particular, I would test one supported short technical claim, one unsupported short claim, one punctuation case, and one generic-word false-positive case before selecting the final matching rule. I would also run `make check` and the pre-commit hooks earlier so that type annotation and formatting requirements did not appear near the end of the implementation process. Finally, I would avoid expanding the claim-extraction logic until I had confirmed that it was necessary for the issue.
+
+**What are you most proud of from this module?**
+I am most proud that I did not stop after making the original failing tests pass. When the first solution introduced a false positive, I used the additional test failure to improve the design instead of weakening or removing the test. The final work addressed the short-claim problem while preserving stricter behavior for longer or ambiguous claims, and I documented the full process from issue selection through reproduction, planning, implementation, testing, and PR submission.
+
 ---

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,106 @@
+## Solution plan
+
+**Issue:** [Faithfulness checker can never mark short claims as supported](https://github.com/ascherj/pathreview/issues/152)
+
+### Understand
+
+The faithfulness checker determines whether generated feedback is grounded in
+retrieved context by comparing overlapping non-stopword tokens. The current
+`_is_supported()` implementation requires at least two meaningful token matches
+for every claim.
+
+This causes short claims such as `Python expert` or `Skilled with Docker` to be
+marked unsupported even when their main technical keyword appears directly in
+the context. The current whitespace-based tokenization also leaves punctuation
+attached to words, so tokens such as `Python,` do not match `Python`.
+
+The expected behavior is for short, specific claims to be recognized as
+supported when the context contains strong matching terms, while unrelated
+claims and matches based only on common words should remain unsupported.
+
+### Map
+
+Files expected to change:
+
+- `rag/evaluator/faithfulness_checker.py`
+  - `FaithfulnessChecker._is_supported()`
+  - Token normalization and meaningful-overlap logic
+
+- `tests/unit/test_faithfulness_checker.py`
+  - Existing failing tests for partial and short-claim support
+  - Additional regression tests for punctuation and false-positive cases
+
+The `check()` and `_extract_claims()` methods may be reviewed while testing, but
+changes to claim extraction are outside the initial scope unless required to
+satisfy Issue #152.
+
+### Plan
+
+1. Replace whitespace-only tokenization in `_is_supported()` with normalized
+   token extraction so punctuation does not prevent valid matches.
+
+2. Filter stop words before evaluating the overlap between the claim and
+   context.
+
+3. Introduce an adaptive support rule that allows a short claim to be supported
+   by one specific meaningful token while keeping a stricter threshold for
+   longer or less-specific claims.
+
+4. Add or update unit tests covering:
+   - A short supported technical claim
+   - A short unsupported claim
+   - Terms followed by punctuation
+   - Matches containing only stop words or weak common words
+
+5. Run `tests/unit/test_faithfulness_checker.py` and the broader unit test suite
+   to confirm that the fix resolves Issue #152 without causing regressions.
+
+### Inputs & outputs
+
+Input:
+
+- A generated feedback string containing one or more claims
+- A list of retrieved context chunks
+- Individual claim and context strings passed to `_is_supported()`
+
+Current incorrect output:
+
+- Short claims with one strong matching technical term return `False`
+- Their overall faithfulness score can incorrectly become `0.0`
+
+Expected output:
+
+- Short, clearly grounded claims return `True`
+- Unsupported claims still return `False`
+- The final score reflects the proportion of supported claims and remains
+  between `0.0` and `1.0`
+
+### Risks & unknowns
+
+- Allowing every single-token overlap may create false positives for vague words
+  such as `project`, `experience`, or `developer`.
+
+- Token normalization must not break specialized technical terms such as
+  `PostgreSQL`, `C++`, `C#`, `.NET`, `Node.js`, or `CI/CD`.
+
+- The exact distinction between a strong technical token and a weak generic
+  token is not currently defined in the codebase.
+
+- `_extract_claims()` ignores sentences of ten characters or fewer, which may
+  affect short claims such as `Knows Rust`. This appears related but may be
+  outside the direct scope of Issue #152.
+
+- `test_none_context_chunk_text` currently fails because `None` is passed into
+  `" ".join()`. This is an existing separate issue and will not be included in
+  this fix unless maintainers confirm that it belongs in scope.
+
+### Edge cases
+
+- A claim and context share only stop words
+- A claim shares one generic word but is otherwise unrelated
+- A short claim contains one specific technical term
+- Relevant terms include commas, periods, or other punctuation
+- Matching terms use different capitalization
+- The context is empty or contains no useful tokens
+- Technical terms contain special characters
+- Multiple context chunks collectively support a claim

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -99,7 +99,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -449,7 +448,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -473,7 +471,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1561,7 +1558,6 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1579,7 +1575,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1972,7 +1967,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3507,7 +3501,6 @@
       "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^2.0.1",
         "cssstyle": "^4.0.1",
@@ -4094,7 +4087,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4107,7 +4099,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4771,7 +4762,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/rag/evaluator/faithfulness_checker.py
+++ b/rag/evaluator/faithfulness_checker.py
@@ -1,6 +1,7 @@
 """Check if generated feedback is supported by retrieved context."""
 
 import re
+
 import structlog
 
 logger = structlog.get_logger()
@@ -8,6 +9,46 @@ logger = structlog.get_logger()
 
 class FaithfulnessChecker:
     """Verify that feedback claims are supported by context."""
+
+    STOP_WORDS = {
+        "a",
+        "an",
+        "the",
+        "is",
+        "are",
+        "was",
+        "were",
+        "be",
+        "been",
+        "and",
+        "or",
+        "but",
+        "in",
+        "of",
+        "to",
+        "for",
+        "that",
+        "this",
+        "with",
+        "has",
+        "have",
+        "had",
+        "developer",
+        "candidate",
+        "project",
+        "projects",
+        "skill",
+        "skills",
+        "experience",
+        "experienced",
+        "expert",
+        "expertise",
+        "skilled",
+        "shows",
+        "knows",
+        "knowledge",
+        "strong",
+    }
 
     def check(self, feedback: str, context_chunks: list[dict]) -> float:
         """Check faithfulness of feedback to context.
@@ -20,8 +61,11 @@ class FaithfulnessChecker:
             Faithfulness score 0.0-1.0 (ratio of supported claims)
         """
         if not feedback or not context_chunks:
-            logger.info("faithfulness_empty_input", has_feedback=bool(feedback),
-                       has_chunks=bool(context_chunks))
+            logger.info(
+                "faithfulness_empty_input",
+                has_feedback=bool(feedback),
+                has_chunks=bool(context_chunks),
+            )
             return 0.0
 
         # Extract key claims from feedback (sentences)
@@ -31,9 +75,7 @@ class FaithfulnessChecker:
             return 0.5  # Default to neutral if no extractable claims
 
         # Concatenate context text
-        context_text = " ".join([
-            chunk.get("text", "") for chunk in context_chunks
-        ])
+        context_text = " ".join([chunk.get("text", "") for chunk in context_chunks])
 
         # Check each claim for support
         supported = 0
@@ -43,8 +85,9 @@ class FaithfulnessChecker:
 
         score = supported / len(claims) if claims else 0.0
 
-        logger.info("faithfulness_checked", claims_count=len(claims),
-                   supported_count=supported, score=score)
+        logger.info(
+            "faithfulness_checked", claims_count=len(claims), supported_count=supported, score=score
+        )
 
         return score
 
@@ -56,33 +99,59 @@ class FaithfulnessChecker:
             text: Feedback text
 
         Returns:
-            List of claims (sentences)
+            List of claims (sentences or coordinated phrases)
         """
-        # Split by sentence (simple regex)
-        sentences = re.split(r'[.!?]+', text)
-        claims = [s.strip() for s in sentences if s.strip() and len(s.strip()) > 10]
-        return claims[:10]  # Limit to 10 claims for scoring
+        sentences = re.split(r"[.!?]+", text)
+        claims: list[str] = []
+
+        for sentence in sentences:
+            sentence = sentence.strip()
+            if not sentence:
+                continue
+
+            parts = re.split(r"\s*(?:,\s*|\band\b)\s*", sentence)
+            claims.extend(part.strip() for part in parts if part.strip())
+
+        return claims[:10]
 
     @staticmethod
-    def _is_supported(claim: str, context: str) -> bool:
-        """Check if a claim is supported by context.
+    def _tokenize(text: str) -> set[str]:
+        """Normalize text into lowercase searchable tokens.
 
         Args:
-            claim: Claim text
-            context: Context text
+            text: Text to tokenize.
 
         Returns:
-            True if claim is supported
+            A set of normalized tokens.
         """
-        # Tokenize and check for keyword overlap
-        claim_tokens = set(claim.lower().split())
-        context_tokens = set(context.lower().split())
+        return set(
+            re.findall(
+                r"[a-z0-9][a-z0-9+#./-]*",
+                text.lower(),
+            )
+        )
 
-        # Require at least some meaningful overlap
-        overlap = claim_tokens & context_tokens
-        # Filter out common stop words
-        stop_words = {'a', 'an', 'the', 'is', 'are', 'was', 'were', 'be', 'been',
-                     'and', 'or', 'but', 'in', 'of', 'to', 'for', 'that'}
-        meaningful_overlap = overlap - stop_words
+    @classmethod
+    def _is_supported(cls, claim: str, context: str) -> bool:
+        """Check whether a claim has meaningful support in the context.
 
-        return len(meaningful_overlap) >= 2
+        Args:
+            claim: Claim text.
+            context: Context text.
+
+        Returns:
+            True if the claim has sufficient meaningful overlap with context.
+        """
+        claim_tokens = cls._tokenize(claim) - cls.STOP_WORDS
+        context_tokens = cls._tokenize(context) - cls.STOP_WORDS
+
+        if not claim_tokens:
+            return False
+
+        meaningful_overlap = claim_tokens & context_tokens
+
+        # A claim containing only one meaningful token can be supported by
+        # that token. Longer claims still require at least two matches.
+        required_overlap = 1 if len(claim_tokens) == 1 else 2
+
+        return len(meaningful_overlap) >= required_overlap

--- a/rag/evaluator/faithfulness_checker.py
+++ b/rag/evaluator/faithfulness_checker.py
@@ -75,7 +75,7 @@ class FaithfulnessChecker:
             return 0.5  # Default to neutral if no extractable claims
 
         # Concatenate context text
-        context_text = " ".join([chunk.get("text", "") for chunk in context_chunks])
+        context_text = " ".join(chunk.get("text") or "" for chunk in context_chunks)
 
         # Check each claim for support
         supported = 0

--- a/tests/unit/test_faithfulness_checker.py
+++ b/tests/unit/test_faithfulness_checker.py
@@ -10,17 +10,15 @@ class TestFaithfulnessChecker:
     """Test suite for FaithfulnessChecker."""
 
     @pytest.fixture
-    def checker(self):
+    def checker(self) -> FaithfulnessChecker:
         """Create a FaithfulnessChecker instance."""
         return FaithfulnessChecker()
 
-    def test_feedback_fully_supported_by_context(self, checker):
+    def test_feedback_fully_supported_by_context(self, checker: FaithfulnessChecker) -> None:
         """Test feedback fully supported by context returns score close to 1.0."""
         feedback = "The developer has strong Python skills and experience with Django."
         context_chunks = [
-            {
-                "text": "The portfolio shows Python expertise and Django framework experience."
-            },
+            {"text": "The portfolio shows Python expertise and Django framework experience."},
         ]
 
         score = checker.check(feedback, context_chunks)
@@ -30,13 +28,11 @@ class TestFaithfulnessChecker:
         # Should be high score due to support
         assert score > 0.5
 
-    def test_feedback_with_no_support_in_context(self, checker):
+    def test_feedback_with_no_support_in_context(self, checker: FaithfulnessChecker) -> None:
         """Test feedback with no support in context returns score close to 0.0."""
         feedback = "This developer is an expert in Rust systems programming."
         context_chunks = [
-            {
-                "text": "The developer has Python and JavaScript experience."
-            },
+            {"text": "The developer has Python and JavaScript experience."},
         ]
 
         score = checker.check(feedback, context_chunks)
@@ -44,13 +40,11 @@ class TestFaithfulnessChecker:
         assert isinstance(score, float)
         assert score < 0.5  # Should be low score
 
-    def test_partial_support_returns_middle_score(self, checker):
+    def test_partial_support_returns_middle_score(self, checker: FaithfulnessChecker) -> None:
         """Test partial support returns score between 0 and 1."""
         feedback = "The developer shows Python expertise and Kubernetes knowledge."
         context_chunks = [
-            {
-                "text": "Strong Python programming skills demonstrated in projects."
-            },
+            {"text": "Strong Python programming skills demonstrated in projects."},
         ]
 
         score = checker.check(feedback, context_chunks)
@@ -60,36 +54,34 @@ class TestFaithfulnessChecker:
         # Partial support should be middle range
         assert 0.2 < score < 0.8
 
-    def test_empty_feedback_returns_zero(self, checker):
+    def test_empty_feedback_returns_zero(self, checker: FaithfulnessChecker) -> None:
         """Test empty feedback returns 0.0."""
         feedback = ""
-        context_chunks = [
-            {"text": "Some context"}
-        ]
+        context_chunks = [{"text": "Some context"}]
 
         score = checker.check(feedback, context_chunks)
 
         assert score == 0.0
 
-    def test_empty_context_chunks_returns_zero(self, checker):
+    def test_empty_context_chunks_returns_zero(self, checker: FaithfulnessChecker) -> None:
         """Test empty context chunks returns 0.0."""
         feedback = "Some feedback"
-        context_chunks = []
+        context_chunks: list[dict[str, str | None]] = []
 
         score = checker.check(feedback, context_chunks)
 
         assert score == 0.0
 
-    def test_both_empty_returns_zero(self, checker):
+    def test_both_empty_returns_zero(self, checker: FaithfulnessChecker) -> None:
         """Test both empty returns 0.0."""
         feedback = ""
-        context_chunks = []
+        context_chunks: list[dict[str, str | None]] = []
 
         score = checker.check(feedback, context_chunks)
 
         assert score == 0.0
 
-    def test_multiple_context_chunks(self, checker):
+    def test_multiple_context_chunks(self, checker: FaithfulnessChecker) -> None:
         """Test multiple context chunks contribute to score."""
         feedback = "The developer has Python, JavaScript, and Docker experience."
         context_chunks = [
@@ -105,7 +97,7 @@ class TestFaithfulnessChecker:
         # All three claims supported
         assert score > 0.5
 
-    def test_extract_claims(self, checker):
+    def test_extract_claims(self, checker: FaithfulnessChecker) -> None:
         """Test claim extraction from feedback."""
         feedback = "The developer is skilled. They have experience. They work well."
         claims = checker._extract_claims(feedback)
@@ -114,7 +106,7 @@ class TestFaithfulnessChecker:
         assert len(claims) > 0
         assert all(isinstance(c, str) for c in claims)
 
-    def test_extract_claims_with_punctuation(self, checker):
+    def test_extract_claims_with_punctuation(self, checker: FaithfulnessChecker) -> None:
         """Test claim extraction handles various punctuation."""
         feedback = "First claim! Second claim? Third claim. Fourth claim"
         claims = checker._extract_claims(feedback)
@@ -122,7 +114,7 @@ class TestFaithfulnessChecker:
         assert isinstance(claims, list)
         # Should extract at least some claims
 
-    def test_is_supported_with_keyword_overlap(self, checker):
+    def test_is_supported_with_keyword_overlap(self, checker: FaithfulnessChecker) -> None:
         """Test that claim is marked as supported with keyword overlap."""
         claim = "The developer has Python skills"
         context = "Python programming skills demonstrated throughout portfolio"
@@ -132,7 +124,7 @@ class TestFaithfulnessChecker:
         assert isinstance(supported, bool)
         assert supported is True
 
-    def test_is_supported_without_keywords(self, checker):
+    def test_is_supported_without_keywords(self, checker: FaithfulnessChecker) -> None:
         """Test that claim is unsupported without keyword overlap."""
         claim = "Expert in Rust systems programming"
         context = "Strong background in Python web development"
@@ -142,7 +134,7 @@ class TestFaithfulnessChecker:
         assert isinstance(supported, bool)
         assert supported is False
 
-    def test_case_insensitive_support_check(self, checker):
+    def test_case_insensitive_support_check(self, checker: FaithfulnessChecker) -> None:
         """Test that support check is case insensitive."""
         claim = "PYTHON PROGRAMMING SKILLS"
         context = "python programming skills are demonstrated"
@@ -151,31 +143,25 @@ class TestFaithfulnessChecker:
 
         assert supported is True
 
-    def test_score_never_returns_hardcoded_value(self, checker):
+    def test_score_never_returns_hardcoded_value(self, checker: FaithfulnessChecker) -> None:
         """Test that score varies with input, never hardcoded 1.0 or 0.0."""
         # First test: fully supported
         score1 = checker.check(
-            "Python and JavaScript skills",
-            [{"text": "Expert in Python and JavaScript"}]
+            "Python and JavaScript skills", [{"text": "Expert in Python and JavaScript"}]
         )
 
         # Second test: no support
-        score2 = checker.check(
-            "Rust expertise",
-            [{"text": "Java programming background"}]
-        )
+        score2 = checker.check("Rust expertise", [{"text": "Java programming background"}])
 
         # Scores should be different
         assert score1 != score2
         # First should be higher
         assert score1 > score2
 
-    def test_multiple_claims_varying_support(self, checker):
+    def test_multiple_claims_varying_support(self, checker: FaithfulnessChecker) -> None:
         """Test scoring with multiple claims of varying support."""
         feedback = "Python expert. Knows Rust. Skilled with Docker."
-        context_chunks = [
-            {"text": "Python and Docker expertise shown in projects."}
-        ]
+        context_chunks = [{"text": "Python and Docker expertise shown in projects."}]
 
         score = checker.check(feedback, context_chunks)
 
@@ -183,42 +169,38 @@ class TestFaithfulnessChecker:
         assert isinstance(score, float)
         assert 0.2 < score < 0.8
 
-    def test_very_long_feedback(self, checker):
+    def test_very_long_feedback(self, checker: FaithfulnessChecker) -> None:
         """Test handling of very long feedback text."""
         feedback = "The developer. " * 100
-        context_chunks = [
-            {"text": "Developer portfolio content"}
-        ]
+        context_chunks = [{"text": "Developer portfolio content"}]
 
         score = checker.check(feedback, context_chunks)
 
         assert isinstance(score, float)
         assert 0.0 <= score <= 1.0
 
-    def test_very_long_context(self, checker):
+    def test_very_long_context(self, checker: FaithfulnessChecker) -> None:
         """Test handling of very long context."""
         feedback = "The developer has Python skills."
-        context_chunks = [
-            {"text": "Python " * 1000}
-        ]
+        context_chunks = [{"text": "Python " * 1000}]
 
         score = checker.check(feedback, context_chunks)
 
         assert isinstance(score, float)
         assert 0.0 <= score <= 1.0
 
-    def test_common_words_filtered_in_overlap(self, checker):
+    def test_common_words_filtered_in_overlap(self, checker: FaithfulnessChecker) -> None:
         """Test that common stop words are filtered in overlap calculation."""
         # This test verifies that "the", "is", "and" etc. don't count as meaningful overlap
         claim = "The project is well documented"
         context = "The project is poorly documented"  # Opposite meaning but same stop words
 
-        supported = checker._is_supported(claim, context)
+        assert checker._is_supported(claim, context) is False
 
         # Despite word overlap, should look for meaningful overlap (not stop words)
         # This depends on implementation
 
-    def test_minimum_overlap_required(self, checker):
+    def test_minimum_overlap_required(self, checker: FaithfulnessChecker) -> None:
         """Test that minimum meaningful overlap is required for support."""
         claim = "Python expertise"
         context = "Python"  # Only one word match
@@ -228,12 +210,10 @@ class TestFaithfulnessChecker:
         assert isinstance(supported, bool)
         # Need at least 2 meaningful tokens for support
 
-    def test_none_context_chunk_text(self, checker):
+    def test_none_context_chunk_text(self, checker: FaithfulnessChecker) -> None:
         """Test handling of None in context chunk text."""
         feedback = "Has Python skills"
-        context_chunks = [
-            {"text": None}
-        ]
+        context_chunks = [{"text": None}]
 
         score = checker.check(feedback, context_chunks)
 
@@ -241,12 +221,10 @@ class TestFaithfulnessChecker:
         assert isinstance(score, float)
         assert 0.0 <= score <= 1.0
 
-    def test_missing_text_key_in_chunk(self, checker):
+    def test_missing_text_key_in_chunk(self, checker: FaithfulnessChecker) -> None:
         """Test handling of missing 'text' key in context chunk."""
         feedback = "Has Python skills"
-        context_chunks = [
-            {"content": "Python skills"}  # Wrong key
-        ]
+        context_chunks = [{"content": "Python skills"}]  # Wrong key
 
         score = checker.check(feedback, context_chunks)
 
@@ -254,7 +232,7 @@ class TestFaithfulnessChecker:
         assert isinstance(score, float)
         assert 0.0 <= score <= 1.0
 
-    def test_score_consistency(self, checker):
+    def test_score_consistency(self, checker: FaithfulnessChecker) -> None:
         """Test that same input produces same score."""
         feedback = "The developer has strong Python skills."
         context_chunks = [{"text": "Expert Python programmer"}]
@@ -264,7 +242,7 @@ class TestFaithfulnessChecker:
 
         assert score1 == score2
 
-    def test_specialized_technical_terms(self, checker):
+    def test_specialized_technical_terms(self, checker: FaithfulnessChecker) -> None:
         """Test support check with specialized technical terms."""
         claim = "Experienced with PostgreSQL and ORM frameworks"
         context = "Database design with PostgreSQL, SQLAlchemy ORM"
@@ -272,3 +250,51 @@ class TestFaithfulnessChecker:
         supported = checker._is_supported(claim, context)
 
         assert supported is True
+
+    def test_short_claims_supported_by_single_meaningful_token(
+        self, checker: FaithfulnessChecker
+    ) -> None:
+        """Test short claims can be supported by one meaningful token."""
+        feedback = "Knows Python. Knows SQL."
+        context_chunks = [
+            {"text": "Python expert"},
+            {"text": "SQL expert"},
+        ]
+
+        score = checker.check(feedback, context_chunks)
+
+        assert score == 1.0
+
+    def test_short_technical_claim_with_one_match_is_supported(
+        self, checker: FaithfulnessChecker
+    ) -> None:
+        """Test one specific technical term can support a short claim."""
+        claim = "Knows Python"
+        context = "Python expert with backend experience"
+
+        assert checker._is_supported(claim, context) is True
+
+    def test_generic_single_word_does_not_create_support(
+        self, checker: FaithfulnessChecker
+    ) -> None:
+        """Test generic shared words are not treated as evidence."""
+        claim = "Strong project leadership"
+        context = "Project documentation is available"
+
+        assert checker._is_supported(claim, context) is False
+
+    def test_punctuation_does_not_prevent_token_match(self, checker: FaithfulnessChecker) -> None:
+        """Test punctuation is removed during token normalization."""
+        claim = "Experienced with Python,"
+        context = "Python programming experience"
+
+        assert checker._is_supported(claim, context) is True
+
+    def test_meaningful_overlap_required(self, checker: FaithfulnessChecker) -> None:
+        """Test that at least one meaningful overlap is required."""
+        supported = checker._is_supported(
+            "Python expertise",
+            "Java programming background",
+        )
+
+        assert supported is False


### PR DESCRIPTION
## Summary

- allow short claims to be supported by one meaningful technical token
- normalize punctuation before comparing claim and context tokens
- preserve and evaluate short claims
- add regression tests for supported short claims and false positives
- handle context chunks whose `text` value is `None`

## Problem

The faithfulness checker required at least two meaningful token matches for
every claim. This caused short claims such as `Knows Python` to be marked
unsupported even when the retrieved context clearly contained `Python`.

## Solution

The checker now normalizes tokens, filters generic words, and uses an adaptive
overlap threshold. Claims containing one meaningful token can be supported by
one matching token, while longer claims still require stronger overlap.

## Testing

- `pytest tests/unit/test_faithfulness_checker.py -v`
- `make check`
- `make test-unit`

Closes #152