### PR TITLE
fix(agent): expand readme scorer test fixture to meet word-count threshold

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -21,7 +21,7 @@ The issue is that there is a readme scorer that is hardcoded to have the readme'
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [link to commit documenting the reproduced issue]
+**Reproduction commit link:** https://github.com/oasis-pandey/pathreview/commit/47727a29aa10a668275a48f2db2b56fa5737d07f
 
 **Reproduction summary:**
 I reproduced the issue by running `pytest tests/unit/test_readme_scorer.py -q`. The test failed at `assert data["word_count"] > 100` because the fixture README only produced a word count of 51, which confirms the fixture is too short for the assertion.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -56,7 +56,7 @@ Open draft PR, request peer feedback, finalize and submit PR.
 
 ### Check-in 2 (end of week)
 
-**PR link:** [PR to be added after opening]
+**PR link:** https://github.com/ascherj/pathreview/pull/472
 
 **Branch:** `fix/156-readme-scorer-fixture-length`
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -18,3 +18,17 @@ The issue is that there is a readme scorer that is hardcoded to have the readme'
 **Setup confirmation:** [✅] App runs locally at localhost:5173
 
 **Cohort ledger:** [✅] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [link to commit documenting the reproduced issue]
+
+**Reproduction summary:**
+I reproduced the issue by running `pytest tests/unit/test_readme_scorer.py -q`. The test failed at `assert data["word_count"] > 100` because the fixture README only produced a word count of 51, which confirms the fixture is too short for the assertion.
+
+**PLAN.md link:** [PLAN.md](PLAN.md)
+
+**Walkthrough video (recommended):** [link to your Loom video, ≤2 min — recommended, not graded]
+
+**Blockers or open questions:**
+[Anything you're still uncertain about going into Week 9, or leave blank]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,20 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/156
+
+**Issue title:** README scorer test fixture is too short for its own word-count assertion
+
+**Tier:** Tier 1
+
+**Problem summary:**
+[In 3–5 sentences, in your own words: what the issue is (not a copy-paste of
+the title), what is currently broken or missing, and what a successful fix
+would accomplish. Naming the part of the codebase it affects is helpful context.]
+
+The issue is that there is a readme scorer that is hardcoded to have the readme's word count greater than 100 words and word_count_category = "comprehensive". But our readme only has 51 words. So, I need to either increase the word count or fix the readme scorer from minimum 100 words to something like 50 so that our readme passes the test.
+
+**Branch name:** fix/156-readme-scorer-fixture-length
+
+**Setup confirmation:** [✅] App runs locally at localhost:5173
+
+**Cohort ledger:** [✅] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -32,3 +32,64 @@ I reproduced the issue by running `pytest tests/unit/test_readme_scorer.py -q`. 
 
 **Blockers or open questions:**
 [Anything you're still uncertain about going into Week 9, or leave blank]
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the fix for issue #156. Expanded the README test fixture in
+`tests/unit/test_readme_scorer.py` from ~51 words to 500+ words so it meets
+the scorer's "comprehensive" threshold (≥ 500 words). The fixture now
+includes realistic sections: project description, installation, usage,
+features, tech stack, badges, demo link, API reference, architecture,
+contributing, testing, deployment, and license. Updated the word_count
+assertion from `> 100` to `> 500` to match the scorer's actual boundary.
+All sub-tasks from PLAN.md are done.
+
+**Next steps:**
+Open draft PR, request peer feedback, finalize and submit PR.
+
+**Blockers:**
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [PR to be added after opening]
+
+**Branch:** `fix/156-readme-scorer-fixture-length`
+
+**What you built:**
+Expanded the test fixture in `test_readme_with_all_quality_signals` to be a
+realistic, comprehensive README with 500+ words. This fixes the mismatch
+between the test's assertions (`word_count > 100`, `word_count_category ==
+"comprehensive"`) and the scorer's actual logic (which requires ≥ 500 words
+for "comprehensive"). No changes were made to the scorer implementation — the
+fix is entirely in the test file.
+
+**Tests added or updated:**
+Updated `tests/unit/test_readme_scorer.py` — specifically the
+`test_readme_with_all_quality_signals` test method. The expanded fixture now
+correctly exercises the "comprehensive" word-count category and all quality
+signal detections (installation, usage, badges, demo link, tech stack). All
+23 tests in the file pass.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+Pre-existing failures observed (not introduced by this change):
+- `make check`: 182 ruff errors and mypy type errors across multiple files
+  (test_review_service.py, test_security.py, test_semantic_chunker.py,
+  test_skill_extractor.py, test_structural_chunker.py, test_tech_detector.py).
+  None are in test_readme_scorer.py. The ruff and mypy checks on
+  test_readme_scorer.py pass cleanly.
+- `make test-unit`: 52 pre-existing failures across other test files
+  (test_batch_processor, test_bias_detector, test_faithfulness_checker,
+  test_keyword_search, test_output_parser, test_pii_scrubber,
+  test_prompt_defense, test_readme_parser, test_relevance_scorer,
+  test_resume_parser, test_review_service, test_security,
+  test_skill_extractor, test_structural_chunker, test_tech_detector).
+  My change introduces zero new failures and fixes the 1 pre-existing
+  failure in test_readme_scorer.py (now 23/23 pass).
+
+**Draft PR feedback received from:** [to be updated]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -93,3 +93,81 @@ Pre-existing failures observed (not introduced by this change):
   failure in test_readme_scorer.py (now 23/23 pass).
 
 **Draft PR feedback received from:** [to be updated]
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No reviewer feedback was received on PR #472 by the end of the module.
+
+**How you responded:**
+N/A — no feedback to respond to.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Getting the local environment running was harder than I expected. PathReview
+is a multi-service application that depends on PostgreSQL, Redis, and
+ChromaDB all running via Docker Compose, plus a Python backend and a React
+frontend. Just getting `docker compose up -d`, `make setup`, and `make run`
+to work correctly and seeing the app at localhost:5173 took real effort —
+understanding which services needed to be up first, what the `.env` file
+needed, and how the Makefile targets chained together. Once the app was
+running, understanding the relationship between the scorer implementation in
+`agent/tools/readme_scorer.py` and its test file also took careful reading.
+The bug was a mismatch between the test fixture and the scorer's actual
+word-count thresholds, and figuring out which side was "wrong" (the test, not
+the scorer) required tracing through the logic rather than just looking at
+the failing assertion.
+
+**What did you learn about working in a large codebase?**
+The biggest lesson was that you cannot just look at the file you are changing
+in isolation. I had to understand how `ReadmeScorer` defined its word-count
+categories (minimal < 100, adequate 100–500, comprehensive ≥ 500) before I
+could decide whether to fix the test or change the scorer. In my own
+projects I would have just adjusted whatever was convenient, but in someone
+else's production codebase the scorer's thresholds are intentional product
+decisions — changing them would alter actual behavior for users. I also
+learned the importance of verifying that your change does not introduce new
+failures. There were 52 pre-existing test failures across the codebase, and
+I had to carefully confirm that every single one existed before my change so
+I was not accidentally breaking something else.
+
+**How did AI tools help — and where did they fall short?**
+AI was most useful for understanding the project structure quickly —
+navigating the multi-service architecture, understanding what each subsystem
+(api, ingestion, rag, agent, safety, frontend) does, and figuring out the
+correct commands to run the app locally. It also helped me prepare speaking
+notes for my PR presentation by pulling together the issue context, my
+approach, and the challenges into a structured format that matched the cohort
+rubric. Where AI fell short was in the actual debugging judgment: deciding
+whether to fix the test fixture or lower the scorer threshold required
+understanding the *intent* behind the code, not just the code itself. AI
+could show me both options, but the reasoning about which was the right call
+for a production codebase was something I had to work through myself.
+
+**What would you do differently if you started over?**
+I would spend more time upfront reading the full test file and the scorer
+implementation together before writing my plan. I initially thought the fix
+might involve changing the scorer's threshold, and it was only after mapping
+the code more carefully that I realized the test was the problem, not the
+implementation. Starting with a clearer understanding of the scorer's
+category boundaries would have saved me from considering the wrong approach.
+I would also add a comment in the test explaining why the fixture needs to be
+500+ words, so the next contributor does not trim it down and re-introduce
+the same bug.
+
+**What are you most proud of from this module?**
+I am most proud of keeping the fix scoped correctly. It would have been
+easier and faster to just lower the scorer's word-count threshold from 500 to
+50 and call it done, but that would have changed the product's actual
+behavior. Recognizing that the bug was in the test — not the code under test
+— and fixing only the test file while preserving all 23 existing test
+assertions felt like the right engineering decision. It is a small change in
+terms of lines of code, but making that judgment call correctly is what
+contributing to a real codebase is about.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,26 @@
+## Solution plan
+
+**Issue:** 
+Title:README scorer test fixture is too short for its own word-count assertion
+Link: https://github.com/ascherj/pathreview/issues/156
+
+### Understand
+The root cause is a mismatch between the test fixture and the scorer’s documented behavior. The test `test_readme_with_all_quality_signals` expects a README with `word_count > 100` and `word_count_category == "comprehensive"`, but the multiline README fixture in the test only produces about 51 words. The expected behavior is that a “comprehensive” README should satisfy the scorer’s current threshold, while the actual behavior is that the current fixture is too short and the assertion fails even though the scorer is working correctly.
+
+### Map
+The main files are `tests/unit/test_readme_scorer.py` and `agent/tools/readme_scorer.py`. The scorer implementation in `ReadmeScorer._score_readme` defines the word-count categories, and the unit test currently supplies the fixture and assertions that do not line up with that implementation. I expect the fix to touch only the unit test file unless the plan changes after review.
+
+### Plan
+1. Update the README fixture in `tests/unit/test_readme_scorer.py` so it is long enough to satisfy the current `comprehensive` threshold.
+2. Keep the existing quality-signal assertions so the test still verifies installation, usage, badges, demo link, tech stack, and overall score.
+3. Run the focused unit test to confirm the fixture now produces the expected word count and category.
+4. If needed, refine the test data to stay readable while still being clearly above the threshold.
+
+### Inputs & outputs
+Input is the existing README fixture string in the unit test. The change should produce a test README that reflects a truly long-form, high-quality README and causes the scorer to return a word count above the comprehensive threshold without changing the scorer logic.
+
+### Risks & unknowns
+The main risk is making the test fixture unnecessarily large or awkward to maintain. Another risk is accidentally changing the test in a way that weakens what it is trying to verify, such as lowering the assertions instead of matching the scorer’s current rules. I am still confirming whether the test should assert `comprehensive` specifically or whether a separate test should cover that category more directly.
+
+### Edge cases
+The updated test should still be readable and should not depend on fragile wording that could change the word count unexpectedly. It should also remain stable if whitespace or formatting in the fixture changes slightly, and it should continue to validate the other quality signals independently of the word-count threshold.

--- a/tests/unit/test_readme_scorer.py
+++ b/tests/unit/test_readme_scorer.py
@@ -17,35 +17,148 @@ class TestReadmeScorer:
     def test_readme_with_all_quality_signals(self, scorer):
         """Test README with all quality signals returns high score."""
         readme = """
-        # Project Name
-        A comprehensive project description.
+        # PathReview — AI-Powered Code Review Platform
+
+        PathReview is a comprehensive, open-source code review platform that
+        leverages artificial intelligence to provide detailed, actionable
+        feedback on pull requests and code submissions. The platform combines
+        static analysis, natural language processing, and large language model
+        integration to help development teams maintain high code quality
+        standards across their repositories. Whether you are a solo developer
+        looking for a second pair of eyes or a large engineering organization
+        seeking to standardize review practices, PathReview adapts to your
+        workflow and delivers consistent, high-quality reviews.
 
         ## Installation
+
+        Follow these steps to install PathReview in your local development
+        environment. The platform requires Python 3.9 or higher, Node.js 18
+        or higher, and a running PostgreSQL instance for persistent storage.
+
         ```bash
-        pip install package
+        git clone https://github.com/example/pathreview.git
+        cd pathreview
+        python -m venv .venv
+        source .venv/bin/activate
+        pip install -e ".[dev]"
+        cd frontend && npm install
+        ```
+
+        After installing dependencies, copy the example environment file and
+        configure your local settings. You will need to provide database
+        credentials and an API key for the language model provider you want
+        to use. See the setup guide for a complete list of environment
+        variables and their descriptions.
+
+        ```bash
+        cp .env.example .env
+        # Edit .env with your configuration
+        make migrate
+        make seed
         ```
 
         ## Usage
+
+        Start the development servers with a single command. The backend API
+        server runs on port 8000 and the frontend development server runs on
+        port 5173 with hot module replacement enabled.
+
         ```python
-        import package
-        package.run()
+        import pathreview
+        client = pathreview.Client(api_key="your-key")
+        result = client.review("https://github.com/user/repo/pull/42")
+        print(result.summary)
+        print(result.suggestions)
         ```
 
+        You can also use the command-line interface to submit reviews from
+        your terminal without writing any code. The CLI supports all the same
+        options as the Python client library and can be integrated into your
+        continuous integration pipeline for automated review on every pull
+        request.
+
         ## Features
-        - Feature 1
-        - Feature 2
-        - Feature 3
+
+        - Automated code review with actionable feedback and suggestions
+        - Resume and README quality scoring with detailed breakdowns
+        - Retrieval-augmented generation for context-aware review comments
+        - Built-in safety guardrails including PII scrubbing and bias detection
+        - RESTful API with comprehensive OpenAPI documentation
+        - Modern React frontend with responsive design and dark mode support
+        - Extensible plugin architecture for custom review rules and tools
+        - Batch processing support for reviewing multiple files at once
 
         ## Tech Stack
-        - Python 3.9
-        - FastAPI
-        - PostgreSQL
+
+        - Python 3.9 with FastAPI for the backend API server
+        - React 18 with TypeScript for the frontend application
+        - PostgreSQL 15 for persistent data storage and retrieval
+        - Redis for caching and rate limiting across services
+        - LangChain for orchestrating large language model interactions
+        - Alembic for database schema migrations and version control
+        - Docker and Docker Compose for containerized development
 
         ![Build Status](https://example.com/badge.svg)
         ![Coverage](https://example.com/coverage.svg)
+        ![License](https://example.com/license.svg)
 
         ## Live Demo
+
         [Try it here](https://demo.example.com)
+
+        Visit our hosted demo environment to explore the platform without any
+        local setup. The demo includes sample repositories and pre-generated
+        reviews so you can see the full range of feedback the platform
+        provides.
+
+        ## API Reference
+
+        The PathReview API follows RESTful conventions and returns JSON
+        responses for all endpoints. Authentication is handled via JSON Web
+        Tokens issued at the login endpoint. Rate limiting is applied per
+        user with configurable thresholds to prevent abuse. The API
+        documentation is auto-generated from the FastAPI route definitions
+        and is available at the docs endpoint when the server is running.
+
+        ## Architecture
+
+        The platform follows a modular architecture with clear separation
+        of concerns. The ingestion layer handles document parsing and
+        chunking. The retrieval-augmented generation layer manages vector
+        storage and semantic search. The agent layer orchestrates tool
+        execution and response generation. The safety layer provides
+        guardrails for content filtering and bias detection. Each layer
+        communicates through well-defined interfaces making it easy to
+        extend or replace individual components without affecting the rest
+        of the system.
+
+        ## Contributing
+
+        We welcome contributions from the community. Please read our
+        contributing guide for details on our code of conduct, development
+        workflow, branch naming conventions, and the process for submitting
+        pull requests. All contributions must include relevant tests and
+        pass the automated quality checks before they can be merged.
+
+        ## Testing
+
+        Run the full test suite to verify your changes before submitting
+        a pull request. The project uses pytest for unit and integration
+        testing with comprehensive fixtures and mock objects for external
+        service dependencies.
+
+        ## Deployment
+
+        PathReview can be deployed using Docker Compose for small teams
+        or Kubernetes for larger organizations requiring horizontal
+        scaling and high availability. The deployment guide covers both
+        approaches with step-by-step instructions and configuration
+        templates for common cloud providers.
+
+        ## License
+
+        This project is licensed under the MIT License. See the LICENSE
+        file for the full license text and terms of use.
         """
 
         result = scorer.execute({"readme_content": readme})
@@ -53,7 +166,7 @@ class TestReadmeScorer:
         assert result.success is True
         data = result.data
         assert data["has_readme"] is True
-        assert data["word_count"] > 100
+        assert data["word_count"] > 500
         assert data["word_count_category"] == "comprehensive"
         assert data["has_installation_section"] is True
         assert data["has_usage_section"] is True
@@ -157,9 +270,10 @@ class TestReadmeScorer:
 
         result = scorer.execute({"readme_content": readme})
         # "Getting Started" matches the pattern
-        assert result.data["has_installation_section"] is True or result.data[
-            "has_usage_section"
-        ] is True
+        assert (
+            result.data["has_installation_section"] is True
+            or result.data["has_usage_section"] is True
+        )
 
     def test_quickstart_counts_as_usage(self, scorer):
         """Test that 'quickstart' counts as usage."""


### PR DESCRIPTION
## Summary
The test test_readme_with_all_quality_signals in tests/unit/test_readme_scorer.py expects a README fixture that produces word_count > 100 and word_count_category == "comprehensive", but the scorer requires ≥ 500 words for the "comprehensive" category. The fixture only had ~51 words, causing the test to fail. This PR expands the fixture to a realistic 500+ word README so the test correctly exercises the scorer's "comprehensive" path — without changing any scorer logic.

## Issue
Closes #156

## Changes
- Replaced the short (~51 word) README fixture in test_readme_with_all_quality_signals with a realistic, comprehensive README containing project description, installation, usage, features, tech stack, badges, demo link, API reference, architecture, contributing, testing, deployment, and license sections (500+ words)
- Updated the word_count assertion from > 100 to > 500 to match the scorer's actual boundary for the "comprehensive" category
- All existing quality-signal assertions (installation, usage, badges, demo link, tech stack, overall score) are preserved unchanged

## Testing
<!-- How did you verify your changes? -->
- [x] Unit tests pass (`make test-unit`):  23/23 in test_readme_scorer.py; 52 pre-existing failures in other files, zero new failures introduced
- [x] Integration tests pass (`make test-integration`): N/A, change is limited to unit tests
- [x] Linter passes (`make lint`): ruff check passes on changed file; 182 pre-existing errors in other files
- [x] Type checker passes (`make typecheck`): pre-existing no-untyped-def errors on all test methods (24 total, same count before and after this change)
- [x] New/updated tests cover the changes

## Screenshots / Demo
N/A — test-only change, no UI impact.

## Notes for Reviewers
- No scorer logic was changed. The fix is entirely in the test fixture. The scorer's word-count thresholds (< 100 = minimal, 100–499 = adequate, ≥ 500 = comprehensive) remain as-is.
- Pre-existing failures: make check reports 182 lint/type errors and make test-unit reports 52 failures across other test files — all pre-existing and unrelated to this change. The changed file (test_readme_scorer.py) passes ruff and black cleanly.
- The expanded fixture uses realistic PathReview-themed content to keep it readable and contextually appropriate rather than filler text.
