### PR TITLE
test(ingestion): capture structlog events with pytest caplog

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -11,6 +11,14 @@
 **Problem summary:**
 The application uses structlog, but the test configuration does not route its output through Python's standard logging system. As a result, pytest's `caplog` fixture cannot capture emitted log events, causing log assertions to fail even when the expected messages are printed to standard error. This affects shared test configuration in `tests/conftest.py` and multiple unit tests that rely on `caplog`. A successful fix will configure logging during tests so that `caplog` reliably captures structlog events without changing application behavior.
 
+### Selection notes — "Is this right for me?"
+
+- **Understanding:** I can explain the failure and the expected result: structlog currently prints the warning, but pytest does not receive it as a standard logging record; after the fix, `caplog` should capture the same event and the assertion should pass.
+- **Tier fit:** This is a realistic Tier 1 issue for my first contribution because the change should be localized to one or two test-related files and does not require modifying the application's business logic.
+- **Codebase readiness:** I located and read the shared fixtures in `tests/conftest.py`, the logging setup in `core/logging.py`, the `BatchEmbeddingProcessor` code that emits the warning, and the complete `test_empty_chunks_list_returns_empty` test in `tests/unit/test_batch_processor.py`.
+- **Scope and validation:** My rough plan is to add a test-only structlog configuration, reproduce the current failure with the single test named in the issue, and then run the related unit tests to check for regressions. This is a bounded change that I expect to complete within the Tier 1 estimate of 3–6 focused hours.
+- **Claims and blockers:** I checked the issue and the cohort ledger, recorded my claim, and found no listed blockers or dependencies. I am comfortable proceeding with the current number of claims.
+
 **Branch name:** fix/159-structlog-caplog
 
 **Setup confirmation:** [x] App runs locally at localhost:5173

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -13,6 +13,6 @@ The application uses structlog, but the test configuration does not route its ou
 
 **Branch name:** fix/159-structlog-caplog
 
-**Setup confirmation:** [ ] App runs locally at localhost:5173
+**Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [ ] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -66,7 +66,7 @@ No implementation blocker. The repository has pre-existing lint errors and unit-
 
 ### Check-in 2 (end of week)
 
-**PR link:** Pending — no submitted PR for this branch was found on GitHub yet.
+**PR link:** https://github.com/ascherj/pathreview/pull/474
 
 **Branch:** `fix/159-structlog-caplog`
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,18 @@
+# Development Journal
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/159
+
+**Issue title:** structlog output is not captured by pytest caplog — log assertions fail suite-wide
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The application uses structlog, but the test configuration does not route its output through Python's standard logging system. As a result, pytest's `caplog` fixture cannot capture emitted log events, causing log assertions to fail even when the expected messages are printed to standard error. This affects shared test configuration in `tests/conftest.py` and multiple unit tests that rely on `caplog`. A successful fix will configure logging during tests so that `caplog` reliably captures structlog events without changing application behavior.
+
+**Branch name:** fix/159-structlog-caplog
+
+**Setup confirmation:** [ ] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -42,4 +42,9 @@ No current blocker. I chose a test-only `structlog.stdlib` configuration because
 **Implementation commit:** https://github.com/YSWFelicity/pathreview/commit/cb2391e822c581a6bfe93abe666947727e9f9b46
 
 **Implementation progress:**
-Added shared test configuration in `tests/conftest.py` that routes structlog events through standard logging without changing production code. The original focused test now passes, all 11 batch processor unit tests pass, and the changed file passes ruff, black, and the repository's pre-commit mypy hook. The full unit suite reached 346 passing tests; its remaining failures cover existing unrelated issue fixtures and unavailable tokenizer network data, so they were not changed as part of Issue #159.
+Added shared test configuration in `tests/conftest.py` that routes structlog events through standard logging without changing production code. The original focused test now passes, all 11 batch processor unit tests pass, and the changed file passes ruff, black, and the repository's pre-commit mypy hook.
+
+**Test commit:** https://github.com/YSWFelicity/pathreview/commit/d0df1fcec2d1b5edde872f58ea84008b5e7eb2e5
+
+**Test coverage and results:**
+Added `tests/unit/test_logging_config.py` to verify that a structlog warning becomes a standard logging record, retains the `WARNING` level, and preserves its structured `issue` field. The new regression test and all 11 batch processor tests pass, and the new file passes ruff, black, and mypy. Running `make test-unit` collected 429 tests and produced 347 passes; the remaining 51 failures cover existing unrelated issue fixtures, while 31 setup errors come from unavailable tokenizer network data, so they were not changed as part of Issue #159.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -15,4 +15,4 @@ The application uses structlog, but the test configuration does not route its ou
 
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
-**Cohort ledger:** [ ] Issue added to cohort ledger
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -27,7 +27,7 @@ The application uses structlog, but the test configuration does not route its ou
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** Pending — add the GitHub commit URL after the reproduction commit is created and pushed.
+**Reproduction commit link:** https://github.com/YSWFelicity/pathreview/commit/210ed4de13892ed931cd276a6a784562624de0b9
 
 **Reproduction summary:**
 I reproduced the issue by running `.venv/bin/pytest tests/unit/test_batch_processor.py::TestBatchEmbeddingProcessor::test_empty_chunks_list_returns_empty -q`. The processor returned the expected empty list and printed the warning, but pytest captured it as stdout while `caplog.text` and `caplog.records` remained empty, causing the assertion at `tests/unit/test_batch_processor.py:42` to fail.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -24,3 +24,17 @@ The application uses structlog, but the test configuration does not route its ou
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** Pending — add the GitHub commit URL after the reproduction commit is created and pushed.
+
+**Reproduction summary:**
+I reproduced the issue by running `.venv/bin/pytest tests/unit/test_batch_processor.py::TestBatchEmbeddingProcessor::test_empty_chunks_list_returns_empty -q`. The processor returned the expected empty list and printed the warning, but pytest captured it as stdout while `caplog.text` and `caplog.records` remained empty, causing the assertion at `tests/unit/test_batch_processor.py:42` to fail.
+
+**PLAN.md link:** https://github.com/YSWFelicity/pathreview/blob/fix/159-structlog-caplog/PLAN.md
+
+**Walkthrough video (recommended):** Not recorded yet.
+
+**Blockers or open questions:**
+I still need to confirm whether a test-only `structlog.stdlib` configuration or structlog's test capture utilities provide the best integration with the existing `caplog` assertions while avoiding global logging state leaking between tests.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -81,3 +81,33 @@ Added `tests/unit/test_logging_config.py`, which verifies that a structlog warni
 For this repository, "passes" means the contribution introduces no new failures, per the course guidance. The unmodified `main` snapshot and this branch both report 182 Ruff errors. Before the change, the unit suite reported 346 passed, 51 failed, and 31 errors; after adding the regression test, it reports 347 passed, 51 failed, and 31 errors.
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No reviewer or maintainer comments have been posted on PR #474 yet. The pull request remains open and ready for review, so there was no requested code change to address this week.
+
+**How you responded:**
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The hardest part was separating failures caused by my change from failures that already existed in the repository. `make check` reported 182 Ruff errors, and `make test-unit` reported dozens of failures and setup errors across unrelated modules, so a simple red-or-green result was not enough. I had to compare the same commands before and after my change, inspect the failing test names, and confirm that my focused tests passed. I also underestimated how strict the contribution workflow would be: my first implementation commit was blocked because the new pytest fixture was missing a generator return type annotation, even though Ruff, Black, and the focused test had passed.
+
+**What did you learn about working in a large codebase?**
+I learned that contributing to an existing codebase is as much about controlling scope and producing evidence as it is about writing the fix. I could not treat every failure as mine to solve, because changing unrelated parsers, services, and tests would have made Issue #159 harder to review. I needed to read `CONTRIBUTING.md`, follow the existing pytest structure, preserve global structlog state, and keep the production logging path unchanged. In my own projects I can change conventions as I go, but in someone else's repository I need to understand the current contracts and make the smallest change that fits them.
+
+**How did AI tools help — and where did they fall short?**
+AI assistance was most useful for navigating unfamiliar files, translating the failure output into a root-cause hypothesis, comparing possible structlog configurations, and turning the investigation into concrete reproduction and verification steps. It also helped me keep the journal, plan, test evidence, and pull request description consistent. However, AI output still required review against the repository's actual hooks and state. The initial fixture suggestion omitted the return type required by Mypy, and an early attempt to update a legacy test file triggered many unrelated type and lint problems. I had to run the real commands, read their output, narrow the change, and choose a dedicated regression test instead of accepting the first generated approach.
+
+**What would you do differently if you started over?**
+I would run `make check` and `make test-unit` immediately after setup and save the exact baseline before editing anything. That would make the before-and-after comparison easier and prevent uncertainty near the PR stage. I would also read the PR template and commit-message convention earlier, create the Wednesday check-in on time, and avoid letting the automatically changed `frontend/package-lock.json` remain in my working tree throughout the project. Technically, I would still choose a test-only stdlib logging configuration, but I would add the typed fixture and focused logging test together from the beginning.
+
+**What are you most proud of from this module?**
+I am most proud of building a clear chain of evidence from the original failure to the final fix. I reproduced the empty `caplog` state, documented the root cause, implemented a scoped configuration change, added a regression test for both the log record and its structured field, and showed that the repository's existing failure counts did not increase. Even though the pull request is still awaiting review, the work is understandable and verifiable by someone who did not participate in the debugging process.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -37,4 +37,9 @@ I reproduced the issue by running `.venv/bin/pytest tests/unit/test_batch_proces
 **Walkthrough video (recommended):** Not recorded yet.
 
 **Blockers or open questions:**
-I still need to confirm whether a test-only `structlog.stdlib` configuration or structlog's test capture utilities provide the best integration with the existing `caplog` assertions while avoiding global logging state leaking between tests.
+No current blocker. I chose a test-only `structlog.stdlib` configuration because it integrates directly with the existing `caplog` assertion. The session fixture saves the previous structlog configuration, disables first-use caching, and restores the saved configuration during teardown to limit global state leakage.
+
+**Implementation commit:** https://github.com/YSWFelicity/pathreview/commit/cb2391e822c581a6bfe93abe666947727e9f9b46
+
+**Implementation progress:**
+Added shared test configuration in `tests/conftest.py` that routes structlog events through standard logging without changing production code. The original focused test now passes, all 11 batch processor unit tests pass, and the changed file passes ruff, black, and the repository's pre-commit mypy hook. The full unit suite reached 346 passing tests; its remaining failures cover existing unrelated issue fixtures and unavailable tokenizer network data, so they were not changed as part of Issue #159.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -48,3 +48,36 @@ Added shared test configuration in `tests/conftest.py` that routes structlog eve
 
 **Test coverage and results:**
 Added `tests/unit/test_logging_config.py` to verify that a structlog warning becomes a standard logging record, retains the `WARNING` level, and preserves its structured `issue` field. The new regression test and all 11 batch processor tests pass, and the new file passes ruff, black, and mypy. Running `make test-unit` collected 429 tests and produced 347 passes; the remaining 51 failures cover existing unrelated issue fixtures, while 31 setup errors come from unavailable tokenizer network data, so they were not changed as part of Issue #159.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+I completed the PLAN.md implementation tasks: configured structlog to route test events through standard logging, preserved and restored the previous global configuration, and verified the original failing `caplog` assertion. I also added a focused regression test that checks the warning level, message capture, and preservation of structured fields.
+
+**Next steps:**
+Finish the contribution self-review, document pre-existing repository failures, submit the pull request, and respond to any CI or reviewer feedback.
+
+**Blockers:**
+No implementation blocker. The repository has pre-existing lint errors and unit-test failures, so I documented the before-and-after counts to show that this change introduces no new failures.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** Pending — no submitted PR for this branch was found on GitHub yet.
+
+**Branch:** `fix/159-structlog-caplog`
+
+**What you built:**
+I added a test-session structlog configuration that routes structured events through Python's standard logging system so pytest's `caplog` fixture can capture them. The fixture avoids first-use logger caching and restores the previous structlog configuration after the test session, leaving production logging behavior unchanged.
+
+**Tests added or updated:**
+Added `tests/unit/test_logging_config.py`, which verifies that a structlog warning is captured as a standard logging record with the correct `WARNING` level and its structured `issue` field intact. The original test in `tests/unit/test_batch_processor.py` also passes with the new configuration.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+For this repository, "passes" means the contribution introduces no new failures, per the course guidance. The unmodified `main` snapshot and this branch both report 182 Ruff errors. Before the change, the unit suite reported 346 passed, 51 failed, and 31 errors; after adding the regression test, it reports 347 passed, 51 failed, and 31 errors.
+
+**Draft PR feedback received from:** none

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,37 @@
+# Issue #159 Solution Plan
+
+## Problem
+
+The application emits warnings through structlog, but pytest's `caplog` fixture does not capture them as standard logging records. The focused unit test confirms that the warning appears under captured stdout while both `caplog.text` and `caplog.records` remain empty.
+
+## Reproduction
+
+Run:
+
+```bash
+.venv/bin/pytest tests/unit/test_batch_processor.py::TestBatchEmbeddingProcessor::test_empty_chunks_list_returns_empty -q
+```
+
+The test fails at `tests/unit/test_batch_processor.py:42` even though `BatchEmbeddingProcessor.process([])` returns `[]` and prints the expected warning.
+
+## Proposed approach
+
+1. Add test-only structlog configuration in `tests/conftest.py` that routes events through Python's standard logging system.
+2. Preserve pytest logging capture and isolate or reset global structlog state so the configuration does not leak between tests.
+3. Rerun the focused failing test to confirm the warning appears in `caplog`.
+4. Run the related batch processor tests, then the full unit-test suite, to detect regressions.
+
+## Expected files
+
+- `tests/conftest.py`
+- Tests only if additional coverage is needed to verify configuration isolation
+
+## Risks
+
+Structlog configuration is global and loggers may be cached. The main risk is changing logging behavior for unrelated tests or allowing test configuration to persist beyond its intended scope.
+
+## Definition of done
+
+- The focused `caplog` assertion passes.
+- Existing application behavior is unchanged.
+- Related tests and the full unit-test suite pass without new logging-related failures.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,37 +1,42 @@
-# Issue #159 Solution Plan
+# Solution plan
 
-## Problem
+**Issue:** [structlog output is not captured by pytest caplog — log assertions fail suite-wide (#159)](https://github.com/ascherj/pathreview/issues/159)
 
-The application emits warnings through structlog, but pytest's `caplog` fixture does not capture them as standard logging records. The focused unit test confirms that the warning appears under captured stdout while both `caplog.text` and `caplog.records` remain empty.
+### Understand
 
-## Reproduction
+The focused test calls `BatchEmbeddingProcessor.process([])`, which correctly returns an empty list and emits the expected warning. However, the test suite never configures structlog to use Python's standard logging system. Structlog therefore keeps its default `PrintLoggerFactory` and writes the rendered warning to stdout, while pytest's `caplog` fixture only observes standard logging records. The expected behavior is for test-time structlog events to reach standard logging so `caplog.text` or `caplog.records` contains the warning; the actual behavior leaves both empty and fails the assertion.
 
-Run:
+### Map
 
-```bash
-.venv/bin/pytest tests/unit/test_batch_processor.py::TestBatchEmbeddingProcessor::test_empty_chunks_list_returns_empty -q
-```
+- `tests/conftest.py`: add shared, test-only structlog configuration and restore global state after the test session.
+- `core/logging.py`: reference the application's existing stdlib-backed structlog configuration; no production change is currently planned.
+- `ingestion/embeddings/batch_processor.py`: source of the warning used to reproduce the issue; no business-logic change is expected.
+- `tests/unit/test_batch_processor.py`: existing focused regression test and `caplog` assertion; change only if an additional assertion is needed to verify capture behavior clearly.
 
-The test fails at `tests/unit/test_batch_processor.py:42` even though `BatchEmbeddingProcessor.process([])` returns `[]` and prints the expected warning.
+### Plan
 
-## Proposed approach
+1. Add a test-session fixture or pytest lifecycle hook in `tests/conftest.py` that configures structlog with `structlog.stdlib.LoggerFactory` and processors compatible with standard logging capture.
+2. Preserve the previous structlog configuration before changing it, disable first-use caching if needed, and restore the prior configuration after the test session to prevent global state leakage.
+3. Run the focused reproduction test and confirm the warning appears in `caplog` while `process([])` still returns `[]`.
+4. Run all tests in `tests/unit/test_batch_processor.py`, followed by the complete unit-test suite, to catch logging-format, isolation, or ordering regressions.
+5. Keep the change limited to test infrastructure unless the regression results demonstrate that a production logging change is necessary.
 
-1. Add test-only structlog configuration in `tests/conftest.py` that routes events through Python's standard logging system.
-2. Preserve pytest logging capture and isolate or reset global structlog state so the configuration does not leak between tests.
-3. Rerun the focused failing test to confirm the warning appears in `caplog`.
-4. Run the related batch processor tests, then the full unit-test suite, to detect regressions.
+### Inputs & outputs
 
-## Expected files
+The relevant input is a structlog warning emitted while pytest is running, demonstrated by passing an empty chunk list to `BatchEmbeddingProcessor.process([])`. The processor's return value must remain `[]`. The change should produce a standard logging record that pytest can expose through `caplog.text` and `caplog.records`, without changing application runtime logging outside tests.
 
-- `tests/conftest.py`
-- Tests only if additional coverage is needed to verify configuration isolation
+### Risks & unknowns
 
-## Risks
+- Structlog configuration is process-global, so a test fixture could affect unrelated tests or make results depend on execution order.
+- Module-level logger proxies may be cached; the configuration must account for logger creation before the fixture runs.
+- Processor choices may change the rendered message stored in `record.message`, even when the event is captured successfully.
+- I still need to confirm whether restoring the saved configuration or calling `structlog.reset_defaults()` provides better isolation with the project's installed structlog version.
+- If the full unit suite contains tests that expect stdout rendering, routing all test logs through stdlib logging could expose additional assumptions.
 
-Structlog configuration is global and loggers may be cached. The main risk is changing logging behavior for unrelated tests or allowing test configuration to persist beyond its intended scope.
+### Edge cases
 
-## Definition of done
-
-- The focused `caplog` assertion passes.
-- Existing application behavior is unchanged.
-- Related tests and the full unit-test suite pass without new logging-related failures.
+- Loggers imported before test configuration is applied.
+- Multiple tests using `caplog` at different log levels.
+- Structured events containing keyword fields, exceptions, or non-string values.
+- Repeated test runs in the same Python process and tests executed in different orders.
+- Cleanup after a failing test so test-only logging configuration does not leak into later tests.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,33 @@
 """Shared test fixtures for PathReview."""
 
+from collections.abc import Generator
+
 import pytest
+import structlog
+
+
+@pytest.fixture(scope="session", autouse=True)
+def configure_structlog_for_tests() -> Generator[None, None, None]:
+    """Route structlog events through stdlib logging during tests."""
+    previous_config = structlog.get_config()
+
+    structlog.configure(
+        processors=[
+            structlog.stdlib.filter_by_level,
+            structlog.stdlib.add_logger_name,
+            structlog.stdlib.add_log_level,
+            structlog.stdlib.PositionalArgumentsFormatter(),
+            structlog.stdlib.render_to_log_kwargs,
+        ],
+        context_class=dict,
+        wrapper_class=structlog.stdlib.BoundLogger,
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        cache_logger_on_first_use=False,
+    )
+
+    yield
+
+    structlog.configure(**previous_config)
 
 
 @pytest.fixture

--- a/tests/unit/test_logging_config.py
+++ b/tests/unit/test_logging_config.py
@@ -1,0 +1,23 @@
+"""Tests for the shared test logging configuration."""
+
+import logging
+
+import pytest
+import structlog
+
+
+@pytest.mark.unit
+def test_structlog_warning_is_captured_by_caplog(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that structlog events become standard logging records."""
+    logger = structlog.get_logger("test.logging")
+
+    with caplog.at_level(logging.WARNING):
+        logger.warning("structured warning", issue=159)
+
+    record = next(
+        record for record in caplog.records if record.getMessage() == "structured warning"
+    )
+    assert record.levelno == logging.WARNING
+    assert record.issue == 159


### PR DESCRIPTION
## Summary

Configure structlog during pytest sessions so application log events flow through Python's standard logging system and can be captured by `caplog`. The test-only configuration restores the previous structlog state after the session and does not change production logging behavior.

## Issue

Closes #159

## Changes

- Add a session-scoped pytest fixture that configures structlog with `structlog.stdlib.LoggerFactory` and `render_to_log_kwargs`.
- Disable first-use logger caching during tests and restore the previous global configuration during teardown.
- Add a focused regression test for message capture, warning level, and preservation of structured fields.
- Document reproduction, planning, implementation, testing, and self-review results in the course journal.

## Testing

- [x] Unit tests pass (`make test-unit`) — no new failures: before the change, 346 passed, 51 failed, and 31 errored; after the change, 347 passed, 51 failed, and 31 errored.
- [ ] Integration tests pass (`make test-integration`) — not run because this change is limited to pytest unit-test logging configuration.
- [x] Linter passes (`make lint`) — changed files pass Ruff; the unmodified `main` snapshot and this branch both retain the same 182 pre-existing repository-wide Ruff errors.
- [x] Type checker passes (`make typecheck`) — changed files pass the repository's pre-commit Mypy hook.
- [x] New/updated tests cover the changes

Focused verification:

- `pytest tests/unit/test_logging_config.py` — 1 passed
- `pytest tests/unit/test_batch_processor.py` — 11 passed
- Pre-commit Ruff, Black, and Mypy hooks pass for the changed Python files

## Screenshots / Demo

Not applicable; this is a test-infrastructure change with no user-interface changes.

## Notes for Reviewers

`make check` stops at 182 pre-existing Ruff findings. Running the same Ruff version against an unmodified `main` snapshot produces the same 182 findings, so this PR introduces no new lint errors.

`make test-unit` has pre-existing failures across unrelated issue fixtures, including bias detection, review-service mocks, and technology detection. Tokenizer data download failures also produce 31 setup errors in the local restricted-network environment. This PR does not modify those areas and introduces no new unit-test failures or errors.
