### PR TITLE
fix(safety): redact parenthesized US phone numbers and fix street address false positives

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -65,3 +65,19 @@ The regex fix is one line. The work for next week is:
 |---|---|
 | `safety/pii_scrubber.py` | Update `phone_us` regex in `PII_PATTERNS` |
 | `tests/unit/test_pii_scrubber.py` | Possibly add one additional test for a space-separated format if the existing four do not already cover it |
+
+---
+
+## Week 8 — Reproduction & Solution Planning
+
+**Reproduction commit link:** https://github.com/Morgan971-pixel/ai201-pathreview/commit/edf7188
+
+**Reproduction summary:**
+Ran `pytest tests/unit/test_pii_scrubber.py -v` on the unmodified codebase and observed 5 failures: the four tests cited in the issue (`test_us_phone_number_redaction`, `test_us_phone_formats`, `test_detect_phone_pii`, `test_phone_at_start_of_text`) plus a fifth (`test_mixed_pii_and_text`) caused by a related false-positive bug in the street address pattern.
+
+**PLAN.md link:** https://github.com/Morgan971-pixel/ai201-pathreview/blob/fix/146-pii-scrubber-parenthesized-phone-format/PLAN.md
+
+**Walkthrough video (recommended):** N/A
+
+**Blockers or open questions:**
+None. The fix has been implemented and all 25 tests pass.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,67 @@
+# PathReview Contribution Journal
+
+## Week 7 — Issue Selection
+
+**Issue chosen:** [#146 — PII scrubber fails to redact parenthesized US phone numbers](https://github.com/ascherj/pathreview/issues/146)
+
+**Module:** `safety/pii_scrubber.py`
+
+**Tier:** 1 (localized to a single file)
+
+---
+
+### What the bug is
+
+`PIIScrubber.scrub()` and `PIIScrubber.detect()` both use a dict of compiled regex patterns. The `phone_us` pattern is:
+
+```
+\b(?:\+?1[-.]?)?\(?([0-9]{3})\)?[-.]?([0-9]{3})[-.]?([0-9]{4})\b
+```
+
+Two problems compound to make `(555) 123-4567` invisible to this pattern:
+
+1. The leading `\b` is a word-boundary assertion. A word boundary requires a transition between a word character (`\w`) and a non-word character. In `Call me at (555) 123-4567`, the `(` sits between two non-word characters (space before, `(` itself), so `\b` fails to match there. The engine then tries matching at the first `5`, but by then the `(` is behind it and `\)?[-.]?` can no longer pick up the `)` and the space that follows it.
+
+2. The separator class `[-.]?` only allows a dash or a dot. The `(555) 123-4567` format uses a space between `)` and `123`, so even if the area-code section matched, the rest would fail.
+
+The same space issue also breaks the `+1 555 123 4567` international format.
+
+---
+
+### Why I chose this issue
+
+- **Contained scope.** The entire fix lives in `PII_PATTERNS["phone_us"]` inside `safety/pii_scrubber.py`. No schema changes, no API changes, no cross-module coordination.
+
+- **Pre-written failing tests.** The issue cites four tests that already exist in `tests/unit/test_pii_scrubber.py` and are currently red: `test_us_phone_number_redaction`, `test_us_phone_formats`, `test_detect_phone_pii`, `test_phone_at_start_of_text`. This is a clean red-green cycle: fix the regex, run the suite, all four should go green.
+
+- **Safety-critical domain.** A PII scrubber that misses a common phone format is not just a unit-test failure. If a resume with a parenthesized phone number passes through `scrub()` before storage or display, that number is exposed. The safety module is where correctness matters most, which makes this a high-value fix for a small diff.
+
+- **Checklist:**
+  - Tier 1 (1-2 files)? Yes.
+  - Do I understand the bug from the description alone? Yes (regex boundary + delimiter gap).
+  - Are there failing tests I can run locally to verify the fix? Yes, four of them.
+  - Does the fix require touching other modules? No.
+
+---
+
+### Plan for Week 8
+
+The regex fix is one line. The work for next week is:
+
+1. Run `pytest tests/unit/test_pii_scrubber.py -v` to confirm which tests are currently failing.
+2. Update `phone_us` pattern to:
+   - Replace leading `\b` with `(?<!\d)` (negative lookbehind for a digit) so the pattern can anchor correctly when the phone number starts with `(`.
+   - Expand the separator class from `[-.]` to `[-. ]` to allow a space between groups, handling both `(555) 123-4567` and `+1 555 123 4567`.
+   - Replace trailing `\b` with `(?!\d)` for symmetry.
+3. Re-run the four failing tests and confirm they pass.
+4. Run the full unit suite (`make test-unit`) to confirm nothing regressed.
+5. Run `make check` (ruff + black + mypy) to match the project's code-style requirements before opening a PR.
+
+---
+
+### Files I expect to touch
+
+| File | Change |
+|---|---|
+| `safety/pii_scrubber.py` | Update `phone_us` regex in `PII_PATTERNS` |
+| `tests/unit/test_pii_scrubber.py` | Possibly add one additional test for a space-separated format if the existing four do not already cover it |

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,82 @@
+# Solution Plan
+
+**Issue:** [#146 — PII scrubber fails to redact parenthesized US phone numbers](https://github.com/ascherj/pathreview/issues/146)
+
+---
+
+## Understand
+
+**Root cause:** Two independent bugs in the `phone_us` regex inside `PIIScrubber.PII_PATTERNS`.
+
+**Bug 1:** The pattern starts with `\b` (word boundary). A word boundary requires a transition between a word character and a non-word character. The `(` in `(555) 123-4567` is not a word character, so `\b` cannot match before it. The engine then tries anchoring at the first digit, but by then the `(` is already behind the cursor and the pattern fails to consume it correctly.
+
+**Bug 2:** The separator between digit groups is `[-.]?` -- dash or dot only. The format `(555) 123-4567` uses a space between `)` and `123`, so even if the area code matched, the rest of the pattern would fail.
+
+**Secondary bug (found during investigation):** The `street_address` pattern has no word boundary at the end. The suffix `Pl` (short for Place/Plaza) matches inside unrelated words like `applications` (`app` + `Pl` + `ications`), causing false positives.
+
+**Expected behavior:** `scrub("Call me at (555) 123-4567")` returns `"Call me at [REDACTED]"`. `detect("Phone: (555) 123-4567")` returns a list containing a phone detection.
+
+**Actual behavior (before fix):** Both return as if no phone number is present.
+
+---
+
+## Map
+
+All changes live in a single file:
+
+| File | What changes |
+|---|---|
+| `safety/pii_scrubber.py` | `PII_PATTERNS["phone_us"]` and `PII_PATTERNS["street_address"]` |
+
+No other files require changes. The fix does not touch the `scrub()` or `detect()` methods, only the pattern strings they iterate over.
+
+Related test file (read-only reference, no changes needed):
+- `tests/unit/test_pii_scrubber.py` -- four pre-written failing tests that serve as the acceptance criteria
+
+---
+
+## Plan
+
+1. **Confirm reproduction.** Run `pytest tests/unit/test_pii_scrubber.py -v` and observe the four failing tests cited in the issue plus one additional failing test (`test_mixed_pii_and_text`) caused by the street address bug.
+
+2. **Fix `phone_us` boundary.** Replace the leading `\b` with `(?<!\d)` (negative lookbehind: "not preceded by a digit"). This anchors correctly regardless of whether the preceding character is `(`, a space, or start of string.
+
+3. **Fix `phone_us` separator.** Expand `[-.]` to `[-. ]` to include a space. Apply the same expansion to the trailing `\b` → `(?!\d)` for symmetry.
+
+4. **Fix `street_address` false positives.** Append `\b` after the closing `)` of the suffix alternation group. This forces the matched suffix to end at a real word boundary, preventing `Pl` from matching inside `applications`.
+
+5. **Verify.** Run the full unit suite (`pytest tests/unit/test_pii_scrubber.py -v`) and confirm 25/25 pass. Run `make check` to confirm no linting or type errors.
+
+---
+
+## Inputs & outputs
+
+**Input:** Any string passed to `scrub()` or `detect()` -- in practice, resume text extracted from a PDF upload.
+
+**`scrub()` output:** The same string with all matched PII replaced by `[REDACTED]`. A parenthesized phone like `(555) 123-4567` should become `[REDACTED]`.
+
+**`detect()` output:** A list of dicts, each with `type`, `value`, `start`, `end`. A parenthesized phone should appear as `{"type": "phone_us", "value": "(555) 123-4567", "start": ..., "end": ...}`.
+
+---
+
+## Risks & unknowns
+
+- **Space separator false positives:** Adding `[ ]` to the separator could theoretically match a space between unrelated digit sequences. In practice the full pattern (`\d{3}[-. ]?\d{3}[-. ]?\d{4}`) is specific enough -- a random sequence of digits with spaces matching all three groups in a resume is unlikely. The `test_detect_no_false_positives` test guards against this.
+
+- **Street address alternation order:** Python's `re` module uses leftmost-longest matching within an alternation group. `Place` must appear before `Pl` in the list for the longer suffix to win. The existing order already satisfies this, so no reordering is needed.
+
+- **International format overlap:** The `phone_us` and `phone_intl` patterns can both match numbers starting with `+1`. This was true before the fix and is unchanged -- not a regression introduced here.
+
+---
+
+## Edge cases
+
+| Case | Expected behavior |
+|---|---|
+| `(555) 123-4567` at start of string | Redacted -- no preceding character, `(?<!\d)` passes |
+| `(555) 123-4567` at end of string | Redacted -- `(?!\d)` passes at end of string |
+| `+1 555 123 4567` (space-separated) | Redacted -- space is now a valid separator |
+| Two phone numbers in the same string | Both redacted independently |
+| Non-phone digit sequences (e.g., years, zip codes) | Not redacted -- pattern requires exactly 10 digits in the right grouping |
+| Street address ending in `Pl` (e.g., "10 Park Pl") | Redacted -- `\b` passes after `Pl` when followed by space or end of string |
+| Word containing address suffix (e.g., "applications") | Not redacted -- `\b` fails after `Pl` when followed by `i` |

--- a/safety/pii_scrubber.py
+++ b/safety/pii_scrubber.py
@@ -12,10 +12,10 @@ class PIIScrubber:
     # Regex patterns for common PII
     PII_PATTERNS = {
         "email": r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b",
-        "phone_us": r"\b(?:\+?1[-.]?)?\(?([0-9]{3})\)?[-.]?([0-9]{3})[-.]?([0-9]{4})\b",
+        "phone_us": r"(?<!\d)(?:\+?1[-. ]?)?\(?\d{3}\)?[-. ]?\d{3}[-. ]?\d{4}(?!\d)",
         "phone_intl": r"\+[0-9]{1,3}[-.]?[0-9]{1,14}",
         "ssn": r"\b(?!000|666)[0-9]{3}-(?!00)[0-9]{2}-(?!0000)[0-9]{4}\b",
-        "street_address": r"\b\d+\s+[A-Za-z\s]+(?:Street|St|Avenue|Ave|Road|Rd|Boulevard|Blvd|Drive|Dr|Lane|Ln|Court|Ct|Circle|Cir|Park|Pl|Plaza|Place|Drive|Dr|Way|Parkway|Pkwy|Point|Pt|Pike|Run|Summit|Summit|Terrace|Ter|Trail|Trl|Tunnel|Turnpike|View|Vista|Vlg|Village|Vly|Valley)",
+        "street_address": r"\b\d+\s+[A-Za-z\s]+(?:Street|St|Avenue|Ave|Road|Rd|Boulevard|Blvd|Drive|Dr|Lane|Ln|Court|Ct|Circle|Cir|Park|Pl|Plaza|Place|Drive|Dr|Way|Parkway|Pkwy|Point|Pt|Pike|Run|Summit|Terrace|Ter|Trail|Trl|Tunnel|Turnpike|View|Vista|Vlg|Village|Vly|Valley)\b",
     }
 
     def scrub(self, text: str) -> str:


### PR DESCRIPTION
## Summary
The phone regex in PIIScrubber.PII_PATTERNS failed to match the (555) 123-4567 format for two reasons: the leading \b word-boundary assertion cannot anchor before a non-word character like (, and the separator class [-.]? did not include a space, so formats like (555) 123-4567 and +1 555 123 4567 passed through scrub() unredacted.

While reproducing the issue, a second pre-existing bug was found in the street_address pattern: no word boundary at the end allowed short suffixes like Pl (Place/Plaza) to match inside unrelated words such as "applications", causing false positives. A \b was added after the suffix group to fix this.

## Issue
Closes #146

## Changes
- Replace leading \b with (?<!\d) in phone_us pattern so the regex anchors correctly when a phone number starts with (
- Expand separator class from [-.]  to [-. ] to allow spaces between digit groups, covering (555) 123-4567 and +1 555 123 4567
- Replace trailing \b with (?!\d) in phone_us for symmetry
- Add \b after the suffix alternation group in street_address to prevent short suffixes matching inside longer words

## Testing
- [x] Unit tests pass (make test-unit) — 25/25
- [ ] Integration tests pass (make test-integration) — skipped, requires Docker
- [ ] Linter passes (make lint) — 4 pre-existing failures, 0 new
- [ ] Type checker passes (make typecheck) — pre-existing failures only
- [x] New/updated tests cover the changes — 5 previously failing tests now pass

## Screenshots / Demo
N/A

## Notes for Reviewers
make check has 4 pre-existing failures on main (I001 import sort, E501 on lines 18 and 57, B007 unused loop variable). None of these are introduced by this PR — verified by running ruff against the original file on main.

The street_address fix was not listed in issue #146 but was found during reproduction and fixes a related false-positive bug in the same pattern dict.