### PR TITLE
fix(rag): use true partial-overlap fixture in relevance scorer test

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -18,3 +18,8 @@ I can explain the bug without going back to reread the issue: a test fixture tha
 
 **Cohort ledger:** [ ] Issue added to cohort ledger
 (Note: the ledger spreadsheet isn't allowing edit access on my account, issue and claim are documented here and on GitHub instead.)
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction summary:**
+Ran `pytest tests/unit/test_relevance_scorer.py -q` and confirmed the failure described in the issue. The test uses query "Python Django web framework" against a chunk containing "Django is a Python web framework for rapid development" — every query word appears in the chunk, so the scorer correctly returns 1.0. The test asserts `0.3 < score < 0.9`, so it fails with `assert 1.0 < 0.9`. This confirms the fixture data doesn't represent a genuine partial-overlap case.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -32,3 +32,16 @@ I ran `pytest tests/unit/test_relevance_scorer.py -q` and was able to reproduce 
 
 **Blockers or open questions:**
 Still need to confirm the exact scoring formula in `RelevanceScorer.score()` before finalizing new fixture values.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Completed the fix for issue #157 by modifying the fixture in `test_query_with_partial_overlap` (`tests/unit/test_relevance_scorer.py`) so the chunk text overlaps with only 2 of the 4 query tokens, resulting in a relevance score of 0.5 that falls within the expected 0.3–0.9 range. Ran `make test-unit` before and after the update to verify the change was isolated: 53 failures beforehand (all pre-existing and unrelated), 52 afterward, with the only difference being the target test now passing. Created a draft PR (#484), completed the required template, and documented that the remaining mypy and lint issues were already present and unrelated to this fix.
+
+**Next steps:**
+Waiting on peer review after posting a request in both my section Slack channel and the `#ai201-community-su26` channel. After receiving feedback, or once the review window has passed, I'll respond to any comments, mark the PR as ready for review, and complete one final self-review against `CONTRIBUTING.md` before Sunday's deadline.
+
+**Blockers:**
+No implementation blockers at this point. The only outstanding item is peer review, which has been requested but I haven't received any feedback yet.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -45,3 +45,19 @@ Waiting on peer review after posting a request in both my section Slack channel 
 
 **Blockers:**
 No implementation blockers at this point. The only outstanding item is peer review, which has been requested but I haven't received any feedback yet.
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/484
+
+**Branch:** fix/157-relevance-scorer-partial-overlap-fixture
+
+**What you built:**
+Fixed a mislabeled test fixture in `test_query_with_partial_overlap` — the query and chunk previously shared 100% of tokens (a full-match case), so the scorer's correct 1.0 score failed the test's expected 0.3–0.9 range. Updated the chunk text so only 2 of 4 query tokens overlap, producing a score of 0.5 that genuinely represents partial-overlap behavior.
+
+**Tests added or updated:**
+Updated the fixture data in `tests/unit/test_relevance_scorer.py::test_query_with_partial_overlap`. No new test files were needed since the existing test structure was correct, only the fixture data was wrong.
+
+**Self-review confirmation:** [x] make check passes (pre-existing failures documented and unrelated) [x] make test-unit passes (52 pre-existing failures unrelated to this change; target test now passes)
+
+**Draft PR feedback received from:** none (requested in section Slack channel and #ai201-community-su26, no responses received)

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,20 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/157
+
+**Issue title:** Relevance scorer "partial overlap" test fixture actually has full query overlap
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+There's a unit test, `test_query_with_partial_overlap`, that's supposed to check how the system scores a search query against a document chunk when they only partially match. Problem is, the test data doesn't actually represent a partial match. The query "Python Django web framework" and the chunk it's being compared to share all four words, so it's a 100% overlap, not partial. Because of that, the scorer correctly returns a perfect score of 1.0, but the test expects the score to be below 0.9, so it fails even though the scoring logic itself is working fine. The fix is just rewriting the fixture data so the chunk only shares some of the query's words, which will let the test actually verify partial-match behavior instead of accidentally testing full-match behavior. This is all in the `rag/` module, specifically the relevance scoring logic and its test file.
+
+**Scope reasoning ("Is this issue right for me?"):**
+I can explain the bug without going back to reread the issue: a test fixture that's supposed to represent partial overlap actually has full overlap, so the test fails even though the code itself is correct. It's a Tier 1 fix scoped to a single test file, which fits where I'm at as a first-time contributor to a large codebase. I already confirmed the relevant test file exists (`tests/unit/test_relevance_scorer.py`) and can be run directly with `pytest tests/unit/test_relevance_scorer.py -q` to reproduce the failure. There's an open PR (#164) already against this issue, so I know someone else is working it too, but since claims are non-exclusive I'm fine moving forward. I'm estimating this is a 1-2 hour fix once I'm actually in the code, which fits comfortably within the Week 8-9 timeline, and there don't seem to be any blockers or dependencies mentioned in the issue.
+
+**Branch name:** fix/157-relevance-scorer-partial-overlap-fixture
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger
+(Note: the ledger spreadsheet isn't allowing edit access on my account, issue and claim are documented here and on GitHub instead.)

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -22,4 +22,13 @@ I can explain the bug without going back to reread the issue: a test fixture tha
 ## Week 8 — Reproduction & solution planning
 
 **Reproduction summary:**
-Ran `pytest tests/unit/test_relevance_scorer.py -q` and confirmed the failure described in the issue. The test uses query "Python Django web framework" against a chunk containing "Django is a Python web framework for rapid development" — every query word appears in the chunk, so the scorer correctly returns 1.0. The test asserts `0.3 < score < 0.9`, so it fails with `assert 1.0 < 0.9`. This confirms the fixture data doesn't represent a genuine partial-overlap case.
+I ran `pytest tests/unit/test_relevance_scorer.py -q` and was able to reproduce the failure described in the issue. The test uses the query **"Python Django web framework"** and compares it against the chunk **"Django is a Python web framework for rapid development."** Since every query word appears in the chunk, the relevance scorer correctly returns a score of **1.0**. However, the test expects the score to be between **0.3** and **0.9**, so it fails with `assert 1.0 < 0.9`. This confirms that the problem is with the test fixture, not the scoring logic—the current fixture is actually a full-overlap example instead of a partial-overlap one.
+
+**Reproduction commit link:** https://github.com/tanvij69/pathreview/commit/860043b
+
+**PLAN.md link:** https://github.com/tanvij69/pathreview/blob/fix/157-relevance-scorer-partial-overlap-fixture/PLAN.md
+
+**Walkthrough video (recommended):** Not recorded
+
+**Blockers or open questions:**
+Still need to confirm the exact scoring formula in `RelevanceScorer.score()` before finalizing new fixture values.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -61,3 +61,34 @@ Updated the fixture data in `tests/unit/test_relevance_scorer.py::test_query_wit
 **Self-review confirmation:** [x] make check passes (pre-existing failures documented and unrelated) [x] make test-unit passes (52 pre-existing failures unrelated to this change; target test now passes)
 
 **Draft PR feedback received from:** none (requested in section Slack channel and #ai201-community-su26, no responses received)
+
+## Week 10 — Iteration & Reflection
+
+### Reviewer Feedback
+
+**Feedback received:** [ ] Yes  [x] No — still waiting for review
+
+**Summary of feedback:**
+I didn't receive any feedback from a peer or project maintainer. I asked for reviews in my section Slack channel and in #ai201-community-su26, but no one responded. 
+
+**How you responded:**
+N/A — I didn't receive any feedback to respond to.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The environment setup ended up being much harder than the actual code change. Before I could even run the project, I had to work through several unrelated issues with Docker, WSL, and Node.js on Windows. I ran into a numpy version conflict in the Chroma vector database image, a bcrypt/passlib warning during database seeding, and even discovered that Windows didn't have `make` installed. Once everything was finally working, the actual fix only took about 10 minutes because it was just updating one line in a test fixture after I understood how the scoring worked.
+
+**What did you learn about working in a large codebase?**
+One of the biggest things I learned was not to assume that a failing test automatically means the code is wrong. At first I expected there to be a bug in the implementation, but after tracing through the logic, I realized the scoring function was working correctly and the test data was the real issue. I also learned the importance of verifying that a small change doesn't affect anything else. Running the full test suite before and after my fix gave me confidence that only the intended test changed while everything else behaved the same.
+
+**How did AI tools help — and where did they fall short?**
+AI was really helpful when I was troubleshooting environment issues. It made it much easier to understand errors like the numpy/Chroma crash and the WSL installation problem, which saved me a lot of time. It also helped me follow the scoring logic and estimate what test values would fall within the expected range. That said, AI couldn't actually verify that my solution worked. I still had to run the tests myself, review the results, and make sure the fix was correct. I also needed to read through the `RelevanceScorer.score()` implementation to fully understand why the change worked instead of just relying on AI's suggestions.
+
+**What would you do differently if you started over?**
+If I were starting over, I would make sure my development environment was fully set up before choosing an issue. A lot of my time early on was spent installing and troubleshooting missing tools that could have been handled beforehand. I would also ask for peer review earlier in the process so there would be a better chance of getting feedback before the deadline.
+
+**What are you most proud of from this module?**
+I'm most proud that I was able to identify that the problem was in the test rather than the actual implementation. It would have been easy to assume the scoring function was broken and start changing working code. Instead, I took the time to understand how the scoring worked, verified the calculations, and made a small, targeted fix. That experience taught me the importance of understanding the root cause of a problem instead of just making a failing test pass.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,31 @@
+## Solution plan
+
+**Issue:** Relevance scorer "partial overlap" test fixture actually has full query overlap: https://github.com/ascherj/pathreview/issues/157
+
+### Understand
+The issue isn't with the relevance scorer itself—it's with the test data. The test `test_query_with_partial_overlap` is supposed to check that the scorer returns a score somewhere in the middle (between 0.3 and 0.9) when a query and a document chunk only partially match. However, the current test uses the query "Python Django web framework" and the chunk "Django is a Python web framework for rapid development." Since all four query words appear in the chunk, the scorer correctly returns a perfect score of 1.0. The test fails because the fixture represents a full match instead of a partial one. The fix is to update the test data so only some of the query terms appear in the chunk, which should naturally produce a score in the expected range.
+
+### Map
+- `tests/unit/test_relevance_scorer.py` — contains the failing test and the fixture that needs to be updated. This should be the only file that requires changes.
+- `rag/evaluator/relevance_scorer.py` — contains the `RelevanceScorer.score()` implementation. I don't expect to modify this file, but I'll review it to understand exactly how overlap is calculated before creating a new test fixture.
+
+### Plan
+1. Read through `RelevanceScorer.score()` to understand how it calculates overlap and what contributes to the final score.
+2. Create a new query and chunk where only some of the query terms overlap (for example, 2 out of 4 words).
+3. Verify that the new fixture produces a score between 0.3 and 0.9, either manually or with a quick script.
+4. Replace the existing fixture in `test_query_with_partial_overlap` with the new query/chunk pair.
+5. Run `pytest tests/unit/test_relevance_scorer.py -q` to confirm the test passes, then run the full test suite to make sure nothing else is affected.
+
+### Inputs & outputs
+**Input:** A query string and a list of document chunk dictionaries (each containing a `text` field) passed into `scorer.score(query, chunks)`.
+**Output:** A relevance score between 0.0 and 1.0. For this specific test, the updated fixture should produce a score strictly between 0.3 and 0.9 to represent a true partial match.
+
+### Risks & unknowns
+- I don't know the exact scoring formula yet. If the scorer does more than simple word overlap (such as weighting terms or filtering stop words), I may need to adjust the fixture until it lands in the expected range.
+- I want to avoid creating a test that's too close to either boundary (0.3 or 0.9), since that could make it more fragile if the scoring logic changes slightly in the future.
+- I'll also confirm that this fixture isn't shared with any other tests in the file before making changes.
+
+### Edge cases
+- Make sure query words aren't accidentally matching as substrings (for example, "Python" matching "Pythonic"), since that could affect the score unexpectedly.
+- Check whether matching is case-sensitive so the fixture behaves as intended.
+- Empty or whitespace-only chunks aren't part of this issue, but it's worth keeping in mind that the scorer should already handle those cases correctly.

--- a/tests/unit/test_relevance_scorer.py
+++ b/tests/unit/test_relevance_scorer.py
@@ -18,9 +18,7 @@ class TestRelevanceScorer:
         """Test query with perfect keyword match in chunks returns score close to 1.0."""
         query = "Python development framework"
         chunks = [
-            {
-                "text": "Python is a great development language for building frameworks"
-            },
+            {"text": "Python is a great development language for building frameworks"},
         ]
 
         score = scorer.score(query, chunks)
@@ -34,9 +32,7 @@ class TestRelevanceScorer:
         """Test query with zero keyword overlap returns score close to 0.0."""
         query = "Rust Kubernetes microservices"
         chunks = [
-            {
-                "text": "Python is dynamically typed and interpreted language"
-            },
+            {"text": "Python is dynamically typed and interpreted language"},
         ]
 
         score = scorer.score(query, chunks)
@@ -48,9 +44,7 @@ class TestRelevanceScorer:
         """Test query with partial overlap returns score between 0 and 1."""
         query = "Python Django web framework"
         chunks = [
-            {
-                "text": "Django is a Python web framework for rapid development"
-            },
+            {"text": "Python is great for backend systems, though Django works too"},
         ]
 
         score = scorer.score(query, chunks)
@@ -71,9 +65,7 @@ class TestRelevanceScorer:
     def test_empty_query_returns_zero(self, scorer):
         """Test empty query returns 0.0."""
         query = ""
-        chunks = [
-            {"text": "Some content"}
-        ]
+        chunks = [{"text": "Some content"}]
 
         score = scorer.score(query, chunks)
 
@@ -96,9 +88,7 @@ class TestRelevanceScorer:
     def test_case_insensitive_matching(self, scorer):
         """Test that keyword matching is case insensitive."""
         query = "PYTHON PROGRAMMING"
-        chunks = [
-            {"text": "python programming is fun"}
-        ]
+        chunks = [{"text": "python programming is fun"}]
 
         score = scorer.score(query, chunks)
 
@@ -117,10 +107,7 @@ class TestRelevanceScorer:
     def test_empty_text_in_chunk(self, scorer):
         """Test handling of empty text in chunk."""
         query = "Python"
-        chunks = [
-            {"text": ""},
-            {"text": "Python programming"}
-        ]
+        chunks = [{"text": ""}, {"text": "Python programming"}]
 
         score = scorer.score(query, chunks)
 
@@ -130,9 +117,7 @@ class TestRelevanceScorer:
     def test_very_long_query(self, scorer):
         """Test handling of very long query."""
         query = "Python " * 100
-        chunks = [
-            {"text": "Python is a programming language"}
-        ]
+        chunks = [{"text": "Python is a programming language"}]
 
         score = scorer.score(query, chunks)
 
@@ -142,9 +127,7 @@ class TestRelevanceScorer:
     def test_very_long_chunk(self, scorer):
         """Test handling of very long chunk."""
         query = "Python"
-        chunks = [
-            {"text": "Python " * 1000 + "is a great language"}
-        ]
+        chunks = [{"text": "Python " * 1000 + "is a great language"}]
 
         score = scorer.score(query, chunks)
 
@@ -154,9 +137,7 @@ class TestRelevanceScorer:
     def test_special_characters_ignored(self, scorer):
         """Test that special characters are handled."""
         query = "Python c++ golang"
-        chunks = [
-            {"text": "c++ is a systems programming language"}
-        ]
+        chunks = [{"text": "c++ is a systems programming language"}]
 
         score = scorer.score(query, chunks)
 
@@ -166,9 +147,7 @@ class TestRelevanceScorer:
     def test_multiple_keyword_matches(self, scorer):
         """Test scoring improves with multiple keyword matches."""
         query = "Python framework development tools"
-        chunks = [
-            {"text": "Python django flask development framework tools"}
-        ]
+        chunks = [{"text": "Python django flask development framework tools"}]
 
         score = scorer.score(query, chunks)
 
@@ -178,11 +157,7 @@ class TestRelevanceScorer:
     def test_single_word_chunks(self, scorer):
         """Test handling of single-word chunks."""
         query = "Python development"
-        chunks = [
-            {"text": "Python"},
-            {"text": "development"},
-            {"text": "framework"}
-        ]
+        chunks = [{"text": "Python"}, {"text": "development"}, {"text": "framework"}]
 
         score = scorer.score(query, chunks)
 
@@ -204,9 +179,7 @@ class TestRelevanceScorer:
     def test_common_words_not_preventing_scoring(self, scorer):
         """Test that common words don't prevent scoring."""
         query = "the best Python framework"
-        chunks = [
-            {"text": "Django is the best Python web framework"}
-        ]
+        chunks = [{"text": "Django is the best Python web framework"}]
 
         score = scorer.score(query, chunks)
 
@@ -216,9 +189,7 @@ class TestRelevanceScorer:
     def test_chunk_without_text_key(self, scorer):
         """Test handling of chunk missing 'text' key."""
         query = "Python"
-        chunks = [
-            {"content": "Python programming"}  # Wrong key
-        ]
+        chunks = [{"content": "Python programming"}]  # Wrong key
 
         score = scorer.score(query, chunks)
 
@@ -229,10 +200,7 @@ class TestRelevanceScorer:
     def test_whitespace_only_in_chunks(self, scorer):
         """Test chunks with only whitespace."""
         query = "Python"
-        chunks = [
-            {"text": "   "},
-            {"text": "\n\t"}
-        ]
+        chunks = [{"text": "   "}, {"text": "\n\t"}]
 
         score = scorer.score(query, chunks)
 
@@ -244,7 +212,7 @@ class TestRelevanceScorer:
         chunks = [
             {"text": "Python is great"},
             {"text": "Python programming"},
-            {"text": "Java is different"}
+            {"text": "Java is different"},
         ]
 
         score = scorer.score(query, chunks)


### PR DESCRIPTION
## Summary
Fixes a mislabeled test fixture in `test_query_with_partial_overlap`. The test was meant to verify the relevance scorer's behavior on partial keyword overlap, but the query and chunk it used shared 100% of query tokens — a full-match case, not a partial one. The scorer correctly returned 1.0, but the test asserted the score should be between 0.3 and 0.9, so it failed even though the scoring logic itself was working correctly. No changes were made to `relevance_scorer.py`.

## Issue
Closes #157

## Changes
- Updated the chunk text in `test_query_with_partial_overlap` (`tests/unit/test_relevance_scorer.py`) so only 2 of the 4 query tokens overlap, producing a score of 0.5 — solidly within the 0.3–0.9 range and not fragile against either boundary.

## Testing
- [x] Unit tests pass (target test now passes; 52 pre-existing failures unrelated to this change remain — see notes)
- [ ] Integration tests pass (not run — out of scope for this fix)
- [x] Linter passes (`ruff`)
- [ ] Type checker passes (see notes — pre-existing, unrelated)
- [x] New/updated tests cover the changes (existing test now correctly exercises partial-overlap behavior)

**Manual verification steps:**
1. Check out this branch and activate the virtual environment
2. Run `pytest tests/unit/test_relevance_scorer.py -v`
3. Confirm `test_query_with_partial_overlap` passes, with the scorer returning a relevance score of 0.5 (previously failed at 1.0 due to the full-overlap fixture)

## Screenshots / Demo
N/A

## Notes for Reviewers
- Confirmed via `git stash` that `main` has 53 pre-existing unit test failures unrelated to this change. With this fix applied, 52 remain — only `test_query_with_partial_overlap` changed, from fail to pass.
- Pre-commit's `mypy` hook flags missing type annotations on all 21 test functions in this file — pre-existing across the whole file, not introduced by this change. Committed with `--no-verify` since fixing type annotations repo-wide is out of scope for #157.
- Black reformatted some pre-existing lines in the file on commit (whitespace/style only, no logic changes).
- PR #164 is already open against this same issue from another student; noting this per the non-exclusive claim policy.