### PR TITLE
Fix/43 clear session state

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -30,3 +30,37 @@ Wrote `scripts/reproduce_43.py`, which runs the same `Orchestrator.run()` call t
 
 **Blockers or open questions:**
 Still need to confirm how `Orchestrator` is instantiated in the FastAPI app (singleton vs. per-request) before finalizing the exact fix approach. Also need to check whether the Redis-backed `session_store` (separate from `ContextManager`) needs its own invalidation logic once the `ContextManager` issue is fixed.
+
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the fix in `agent/orchestrator.py` — `ContextManager` is now created fresh inside `run()` instead of persisting on the `Orchestrator` instance across requests, and `_execute_tool()` now takes it as a parameter. Added `tests/unit/test_orchestrator.py` with 4 tests covering the regression (tool re-executes on a second review, results are fresh not cached, no cross-user leakage). Confirmed `make test-unit` (53 pre-existing failures, unrelated, 379 passed including my new tests) and `make check` (179 pre-existing errors, down slightly from the 182 baseline, no new errors introduced). Opened draft PR #485.
+
+**Next steps:**
+Share the draft PR in Slack for peer/mentor feedback, address any comments, then mark it ready for review before the deadline.
+
+**Blockers:**
+None currently.
+
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/485
+
+**Branch:** fix/43-clear-session-state
+
+**What you built:**
+Fixed the root cause of #43 — `Orchestrator` was creating a single long-lived `ContextManager` instance that persisted across every review, silently returning cached tool results from a previous review instead of re-running tools for a user's updated portfolio. `ContextManager` is now created fresh inside `run()`, scoped to a single review, while still allowing legitimate within-review memoization.
+
+**Tests added or updated:**
+Added `tests/unit/test_orchestrator.py` with 4 tests: tool executes on first review, tool re-executes on a second review with the same input (core regression test for #43), second review returns fresh (not cached) results, and two different users don't share cached results.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+(179 pre-existing lint errors and 53 pre-existing test failures remain, unrelated to this change and documented in the PR description; my changes introduce zero new failures/errors and add 4 new passing tests.)
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,6 @@
+# Contribution Journal
+
+## Issue #43: Session state not cleared between reviews
+- Set up local dev environment (Docker, make setup/run confirmed working)
+- Investigating agent/memory/session_store.py
+

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -14,3 +14,19 @@ The orchestrator caches agent state by user ID inside `agent/memory/session_stor
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/akao335/pathreview/commit/4310aac
+
+**Reproduction summary:**
+Wrote `scripts/reproduce_43.py`, which runs the same `Orchestrator.run()` call twice in a row for the same profile_id and portfolio data using a stub tool that counts its own executions. The first review executes the tool (`tool_result_cache_miss`, `call_count: 1`). The second review returns a cache hit (`tool_result_cache_hit`) and never re-executes the tool (`call_count` stays at `1`), proving the orchestrator's `ContextManager` cache persists across separate reviews instead of resetting.
+
+**PLAN.md link:** https://github.com/akao335/pathreview/blob/fix/43-clear-session-state/PLAN.md
+
+**Walkthrough video (recommended):** (none recorded)
+
+**Blockers or open questions:**
+Still need to confirm how `Orchestrator` is instantiated in the FastAPI app (singleton vs. per-request) before finalizing the exact fix approach. Also need to check whether the Redis-backed `session_store` (separate from `ContextManager`) needs its own invalidation logic once the `ContextManager` issue is fixed.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,6 +1,16 @@
-# Contribution Journal
+## Week 7 — Issue selection
 
-## Issue #43: Session state not cleared between reviews
-- Set up local dev environment (Docker, make setup/run confirmed working)
-- Investigating agent/memory/session_store.py
+**Issue link:** https://github.com/ascherj/pathreview/issues/43
 
+**Issue title:** Agent session state is not cleared between reviews for the same user
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The orchestrator caches agent state by user ID inside `agent/memory/session_store.py`. When a user submits a second portfolio review after updating their portfolio, the system reuses the cached tool results from their previous session instead of re-running the tools against the new portfolio data. This means the review a user receives can be based on stale information rather than what they actually just submitted. A successful fix would ensure each new review request triggers fresh tool execution (or properly invalidates/clears the cached session state) so results always reflect the current portfolio.
+
+**Branch name:** fix/43-clear-session-state
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -64,3 +64,32 @@ Added `tests/unit/test_orchestrator.py` with 4 tests: tool executes on first rev
 (179 pre-existing lint errors and 53 pre-existing test failures remain, unrelated to this change and documented in the PR description; my changes introduce zero new failures/errors and add 4 new passing tests.)
 
 **Draft PR feedback received from:** none
+
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No review has come in yet as of submission.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Environment setup took far longer than I expected, and it wasn't the "real" work of the issue at all. I hit a chain of small, unrelated blockers before I ever touched the bug: cloning the wrong repo, a nested clone-inside-a-clone from re-running commands in the wrong directory, missing `make` and Docker entirely on Windows. It was just a lot of small friction that ate time before I could start reasoning about the actual code. I underestimated how much of "contributing to a codebase" is actually tooling and environment plumbing. Otherwise, actually fixing the issue and pushing it was easier than I thought. 
+
+**What did you learn about working in a large codebase?**
+The biggest lesson was that the given explanation for a bug is not always right. The issue title and description pointed straight at `session_store.py`, and that file's code was actually correct. The real bug was one layer up, in `orchestrator.py`, in a completely different caching mechanism (`ContextManager`) that happened to produce the same symptom. I had to trace the actual call path (`grep` for where `SessionStore` was used, then read `orchestrator.py` line by line) instead of trusting the issue description's framing. I also learned that a large codebase comes with baggage you didn't create — 53 pre-existing failing tests and 179 pre-existing lint errors were there before I touched anything. Learning to document that clearly, rather than either ignoring it or trying to fix all of it, was its own skill.
+
+**How did AI tools help — and where did they fall short?**
+AI assistance was most useful for the mechanical, high-friction parts: diagnosing why a specific terminal command failed, explaining exactly what a `mypy`/`ruff` error meant and whether it was mine to fix, and turning my exploration (grep output, file contents) into a specific, falsifiable hypothesis about the root cause. It also helped me write a clean, isolated reproduction script instead of trying to trigger the bug through the full UI. Where it fell short was that I still had to be the one running commands, reading actual output, and catching when something didn't match — for example, when I edited `orchestrator.py` myself, the edit was inconsistent (some references still pointed at `self.context_manager`, which no longer existed), and only running the reproduction script surfaced that. AI could explain the fix, but couldn't verify my own hand-edit was applied correctly — that required actually running the code.
+
+**What would you do differently if you started over?**
+I'd invest a little time up front getting comfortable with my terminal (fixing the Git Bash paste issue, confirming `make`/Docker work) before starting the actual issue, rather than discovering each gap one at a time while trying to make forward progress. I'd also read the full call path of a bug before committing to a root-cause theory — my first instinct was to trust the issue title's framing (`session_store.py`) instead of verifying it against the actual code, which cost some time.
+
+**What are you most proud of from this module?**
+Writing `scripts/reproduce_43.py`. It's a small file, but it turned a vague, hard-to-verify bug report into something I could prove and disprove in under a second, and it made every later step — confirming the root cause, confirming the fix, writing the regression test — much more concrete and evidence-based instead of "I think this works."

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,103 @@
+## Solution plan
+
+**Issue:** Agent session state is not cleared between reviews for the same user (#43)
+https://github.com/ascherj/pathreview/issues/43
+
+### Understand
+The root cause is not in `session_store.py` (the Redis-backed store), which
+is correctly keyed per-user with a TTL. The actual bug is in
+`agent/orchestrator.py`. The `Orchestrator` creates a single `ContextManager`
+instance in `__init__` (`self.context_manager = ContextManager()`). Because
+the `Orchestrator` is long-lived (instantiated once and reused across
+requests), this cache persists across separate calls to `run()`, including
+separate reviews.
+
+In `_execute_tool()`, before running any tool, the orchestrator computes
+`input_hash = ContextManager.hash_input(tool_input)` and checks
+`self.context_manager.get_tool_result(tool_name, input_hash)`. If a hit is
+found, it returns the cached result immediately and never re-executes the
+tool. The cache key only depends on `tool_name` + a hash of the tool's
+input dict (e.g. `github_username` + `repo_name`). If a user updates their
+portfolio but the specific fields fed into a tool are unchanged (e.g. same
+repo name, even though the repo's contents changed on GitHub), the hash is
+identical, so the second review silently returns stale data instead of
+fresh results.
+
+Expected behavior: each new review request should produce fresh tool
+results reflecting the user's current portfolio state.
+Actual behavior: a second review for the same user can return byte-for-byte
+identical results to a previous review, even when the underlying data
+(e.g. repo content) has changed.
+
+### Map
+Files expected to be touched:
+- `agent/orchestrator.py` — `Orchestrator.__init__`, `Orchestrator.run()`,
+  and `Orchestrator._execute_tool()`. Need to change how (and whether) the
+  `ContextManager` cache persists across separate `run()` calls.
+- `agent/memory/context_manager.py` — may need a new method (e.g. `clear()`)
+  or a change so a fresh `ContextManager` is created per review rather than
+  per orchestrator instance.
+- `scripts/reproduce_43.py` — reproduction script already added; will be
+  extended or kept as a regression check.
+- Possibly a new/updated test file, e.g. `tests/test_orchestrator.py`, to
+  cover this behavior with an automated test (not just the manual repro
+  script).
+
+### Plan
+1. Change `Orchestrator` so `context_manager` is scoped to a single `run()`
+   call instead of the whole orchestrator instance — e.g. instantiate a new
+   `ContextManager()` at the top of `run()` instead of in `__init__`, so
+   each review starts with a clean cache.
+2. Update `_execute_tool()` (and any other method that references
+   `self.context_manager`) to work correctly with a per-run instance rather
+   than an instance attribute set once at construction time.
+3. Add an automated regression test (e.g. `tests/test_orchestrator.py`)
+   that calls `orchestrator.run()` twice with the same `profile_id` and
+   tool input, using a stub tool that increments a call counter, and
+   asserts the tool is executed twice (not cached across reviews).
+4. Re-run `scripts/reproduce_43.py` to confirm the "BUG REPRODUCED" message
+   no longer appears, and instead see `stub_tool.call_count == 2`.
+5. Review whether within-review memoization (the original intended purpose
+   of `ContextManager`, e.g. two tools in the same plan needing the same
+   input) still works correctly after the fix — this behavior should be
+   preserved, only cross-review caching should be removed.
+
+### Inputs & outputs
+Input: `Orchestrator.run(profile_id, profile_data)`, called once per review
+request from the API layer.
+Output: `run()` returns a dict of fresh `tool_results` for that specific
+call reflecting the current `profile_data`, with no unintended reuse of
+another call's cached results. Within a single `run()` call, if the exact
+same tool+input pair is needed twice (legitimate memoization), it may still
+be cached, but this must not survive between separate `run()` calls.
+
+### Risks & unknowns
+- Need to confirm whether `ContextManager` is used anywhere else in the
+  codebase (e.g. directly by tools, or referenced outside `orchestrator.py`)
+  that could break if its lifecycle changes — need to grep for
+  `ContextManager` and `context_manager` usage across the repo before
+  finalizing the fix.
+- Need to confirm how `Orchestrator` is instantiated in the FastAPI app
+  (single instance at startup vs. per-request) — this affects exactly how
+  the fix should be implemented (e.g. per-run instantiation vs. a
+  `reset()`/`clear()` call at the start of `run()`).
+- Redis-backed `session_store` state (separate from `context_manager`) also
+  persists per `profile_id` with a 1-hour TTL and is merged into
+  `session_state` on each `run()` call via `session_state.update(results)`.
+  Need to verify this doesn't reintroduce a related staleness issue even
+  after the `ContextManager` fix — may need its own invalidation on
+  portfolio update, or may be intentional (unclear yet, worth asking in
+  Slack/office hours).
+
+### Edge cases
+- Two different users triggering reviews concurrently should not share or
+  leak cached results between each other.
+- A user requesting the same review twice in immediate succession with an
+  *unchanged* portfolio (no update in between) — is fresh execution every
+  time acceptable performance-wise, or should there be a legitimate
+  short-lived cache for true no-change cases? Needs product/design input.
+- Tools that fail (like the `market_analyzer` "Unknown tool" error seen in
+  the reproduction) should not be cached as if they succeeded, and should
+  be safely retried on the next review.
+- Empty or missing `profile_data` fields (e.g. no `github_username`) should
+  not break the plan-building or caching logic.

--- a/agent/orchestrator.py
+++ b/agent/orchestrator.py
@@ -1,12 +1,12 @@
 """Plan-execute orchestrator for agent tools."""
 
 import time
-import structlog
-from typing import Optional
 
-from .memory.session_store import SessionStore
-from .memory.context_manager import ContextManager
+import structlog
+
 from .error_handling import retry_with_backoff
+from .memory.context_manager import ContextManager
+from .memory.session_store import SessionStore
 
 logger = structlog.get_logger()
 
@@ -14,8 +14,9 @@ logger = structlog.get_logger()
 class Orchestrator:
     """Orchestrate tool execution with planning and memoization."""
 
-    def __init__(self, tools: dict, session_store: Optional[SessionStore] = None,
-                 tool_timeout: float = 30.0):
+    def __init__(
+        self, tools: dict, session_store: SessionStore | None = None, tool_timeout: float = 30.0
+    ):
         """Initialize orchestrator.
 
         Args:
@@ -26,7 +27,6 @@ class Orchestrator:
         self.tools = tools
         self.session_store = session_store
         self.tool_timeout = tool_timeout
-        self.context_manager = ContextManager()
 
     def run(self, profile_id: str, profile_data: dict) -> dict:
         """Execute analysis plan for a profile.
@@ -40,6 +40,8 @@ class Orchestrator:
         """
         logger.info("orchestrator_start", profile_id=profile_id)
 
+        context_manager = ContextManager()
+
         # Build execution plan
         plan = self._build_plan(profile_data)
 
@@ -52,8 +54,8 @@ class Orchestrator:
         results = {}
         for tool_name, tool_input in plan:
             try:
-                result = self._execute_tool(tool_name, tool_input)
-                results[tool_name] = result.data if hasattr(result, 'data') else result
+                result = self._execute_tool(tool_name, tool_input, context_manager)
+                results[tool_name] = result.data if hasattr(result, "data") else result
 
                 logger.info("tool_executed", tool=tool_name, success=True)
 
@@ -66,13 +68,12 @@ class Orchestrator:
             session_state.update(results)
             self.session_store.set(profile_id, session_state)
 
-        logger.info("orchestrator_complete", profile_id=profile_id,
-                   tools_executed=len(results))
+        logger.info("orchestrator_complete", profile_id=profile_id, tools_executed=len(results))
 
         return {
             "profile_id": profile_id,
             "tool_results": results,
-            "cached_results": self.context_manager.get_all_results()
+            "cached_results": context_manager.get_all_results(),
         }
 
     def _build_plan(self, profile_data: dict) -> list[tuple[str, dict]]:
@@ -90,55 +91,54 @@ class Orchestrator:
         if profile_data.get("github_username"):
             for project in profile_data.get("projects", []):
                 if project.get("github_repo"):
-                    plan.append((
-                        "github_tool",
-                        {
-                            "github_username": profile_data["github_username"],
-                            "repo_name": project["github_repo"]
-                        }
-                    ))
+                    plan.append(
+                        (
+                            "github_tool",
+                            {
+                                "github_username": profile_data["github_username"],
+                                "repo_name": project["github_repo"],
+                            },
+                        )
+                    )
                     break  # Only process first repo for now
 
         # Tech detector (if files available)
         if profile_data.get("files"):
-            plan.append((
-                "tech_detector",
-                {"files": profile_data["files"]}
-            ))
+            plan.append(("tech_detector", {"files": profile_data["files"]}))
 
         # README scorer
         if profile_data.get("readme_content"):
-            plan.append((
-                "readme_scorer",
-                {"readme_content": profile_data["readme_content"]}
-            ))
+            plan.append(("readme_scorer", {"readme_content": profile_data["readme_content"]}))
 
         # Skill extractor
         if profile_data.get("resume_text"):
-            plan.append((
-                "skill_extractor",
-                {
-                    "resume_text": profile_data["resume_text"],
-                    "repo_metadata": profile_data.get("repo_metadata", {})
-                }
-            ))
+            plan.append(
+                (
+                    "skill_extractor",
+                    {
+                        "resume_text": profile_data["resume_text"],
+                        "repo_metadata": profile_data.get("repo_metadata", {}),
+                    },
+                )
+            )
 
         # Market analyzer (if skills detected)
         if plan:  # Only if other tools executed
-            plan.append((
-                "market_analyzer",
-                {"detected_skills": {}}  # Will be populated by context
-            ))
+            plan.append(
+                ("market_analyzer", {"detected_skills": {}})  # Will be populated by context
+            )
 
         logger.info("plan_built", plan_size=len(plan))
         return plan
 
-    def _execute_tool(self, tool_name: str, tool_input: dict):
+    def _execute_tool(self, tool_name: str, tool_input: dict, context_manager: ContextManager):
         """Execute a single tool with retry and memoization.
 
         Args:
             tool_name: Name of tool to execute
             tool_input: Input dict for tool
+            context_manager: Per-review context manager (not shared across
+                separate run() calls)
 
         Returns:
             Tool result
@@ -146,9 +146,9 @@ class Orchestrator:
         if tool_name not in self.tools:
             raise ValueError(f"Unknown tool: {tool_name}")
 
-        # Check context cache
+        # Check context cache (scoped to this single review only)
         input_hash = ContextManager.hash_input(tool_input)
-        cached_result = self.context_manager.get_tool_result(tool_name, input_hash)
+        cached_result = context_manager.get_tool_result(tool_name, input_hash)
 
         if cached_result:
             logger.info("tool_cache_hit", tool=tool_name)
@@ -160,8 +160,8 @@ class Orchestrator:
         try:
             result = self._execute_with_timeout(tool, tool_input)
 
-            # Cache result
-            self.context_manager.store_tool_result(tool_name, input_hash, result)
+            # Cache result (within this review only)
+            context_manager.store_tool_result(tool_name, input_hash, result)
 
             return result
 
@@ -172,7 +172,7 @@ class Orchestrator:
             logger.error("tool_execution_error", tool=tool_name, error=str(e))
             raise
 
-    def _execute_with_timeout(self, tool, tool_input: dict, timeout: Optional[float] = None):
+    def _execute_with_timeout(self, tool, tool_input: dict, timeout: float | None = None):
         """Execute tool with timeout.
 
         Args:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -99,7 +99,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -449,7 +448,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -473,7 +471,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1561,7 +1558,6 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1579,7 +1575,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1972,7 +1967,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3507,7 +3501,6 @@
       "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^2.0.1",
         "cssstyle": "^4.0.1",
@@ -4094,7 +4087,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4107,7 +4099,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4771,7 +4762,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/scripts/reproduce_43.py
+++ b/scripts/reproduce_43.py
@@ -1,0 +1,64 @@
+"""
+Reproduction script for issue #43:
+Agent session state / tool-result cache is not cleared between reviews
+for the same user, so a second review can silently return stale results.
+
+Root cause: Orchestrator holds a single long-lived ContextManager instance
+(self.context_manager) created once in __init__. _execute_tool() checks
+this cache BEFORE running a tool, keyed only on hash(tool_name + tool_input).
+If a second review's tool_input hashes the same as a previous review's
+(e.g. same repo_name string, even though the repo's contents changed on
+GitHub), the tool is never re-executed -- the old cached result is returned.
+
+Run with:
+    python scripts/reproduce_43.py
+"""
+
+from agent.orchestrator import Orchestrator
+
+
+class StubGithubTool:
+    """Fake tool that records how many times it actually executes."""
+
+    name = "github_tool"
+
+    def __init__(self) -> None:
+        self.call_count = 0
+
+    def execute(self, tool_input: dict) -> dict:
+        self.call_count += 1
+        return {"stars": 10 * self.call_count, "call_number": self.call_count}
+
+
+def main() -> None:
+    stub_tool = StubGithubTool()
+    orchestrator = Orchestrator(tools={"github_tool": stub_tool})
+
+    profile_data = {
+        "github_username": "someuser",
+        "projects": [{"github_repo": "my-portfolio-site"}],
+    }
+
+    print("--- First review ---")
+    first = orchestrator.run(profile_id="user-123", profile_data=profile_data)
+    print("tool_results:", first["tool_results"])
+    print("stub_tool.call_count:", stub_tool.call_count)
+
+    print("\n--- User updates their portfolio (repo content changes on GitHub), ---")
+    print("--- then requests a SECOND review with the same repo_name ---")
+    second = orchestrator.run(profile_id="user-123", profile_data=profile_data)
+    print("tool_results:", second["tool_results"])
+    print("stub_tool.call_count:", stub_tool.call_count)
+
+    print("\n--- Verdict ---")
+    if stub_tool.call_count == 1:
+        print(
+            "BUG REPRODUCED: tool only executed once. The second review "
+            "returned a cached/stale result instead of re-running the tool."
+        )
+    else:
+        print("Tool executed twice as expected -- bug not present.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -1,0 +1,79 @@
+"""Tests for orchestrator.py"""
+import pytest
+
+from agent.orchestrator import Orchestrator
+
+
+class StubTool:
+    """Fake tool that records how many times it actually executes."""
+
+    name = "stub_tool"
+
+    def __init__(self) -> None:
+        self.call_count = 0
+
+    def execute(self, tool_input: dict) -> dict:
+        self.call_count += 1
+        return {"call_number": self.call_count}
+
+
+@pytest.mark.unit
+class TestOrchestrator:
+    """Test suite for Orchestrator."""
+
+    @pytest.fixture
+    def stub_tool(self):
+        """Create a StubTool instance."""
+        return StubTool()
+
+    @pytest.fixture
+    def orchestrator(self, stub_tool):
+        """Create an Orchestrator wired up with a single stub tool."""
+        return Orchestrator(tools={"github_tool": stub_tool})
+
+    @pytest.fixture
+    def profile_data(self):
+        """Profile data that triggers exactly one tool call (github_tool)."""
+        return {
+            "github_username": "someuser",
+            "projects": [{"github_repo": "my-portfolio-site"}],
+        }
+
+    def test_tool_executes_on_first_review(self, orchestrator, stub_tool, profile_data):
+        """Test that the tool actually runs on the first review."""
+        orchestrator.run(profile_id="user-123", profile_data=profile_data)
+
+        assert stub_tool.call_count == 1
+
+    def test_tool_re_executes_on_second_review_same_input(
+        self, orchestrator, stub_tool, profile_data
+    ):
+        """Regression test for #43: a second review for the same user with
+        the same tool input must re-run the tool rather than returning a
+        cached result from the previous review."""
+        orchestrator.run(profile_id="user-123", profile_data=profile_data)
+        orchestrator.run(profile_id="user-123", profile_data=profile_data)
+
+        assert stub_tool.call_count == 2
+
+    def test_second_review_returns_fresh_result_not_stale(
+        self, orchestrator, stub_tool, profile_data
+    ):
+        """Regression test for #43: the tool_results from a second review
+        must reflect a fresh execution, not the first review's cached data."""
+        first = orchestrator.run(profile_id="user-123", profile_data=profile_data)
+        second = orchestrator.run(profile_id="user-123", profile_data=profile_data)
+
+        assert first["tool_results"]["github_tool"]["call_number"] == 1
+        assert second["tool_results"]["github_tool"]["call_number"] == 2
+
+    def test_different_users_do_not_share_cache(self, profile_data):
+        """Test that two different users' reviews don't leak cached results
+        between each other."""
+        stub_tool = StubTool()
+        orchestrator = Orchestrator(tools={"github_tool": stub_tool})
+
+        orchestrator.run(profile_id="user-A", profile_data=profile_data)
+        orchestrator.run(profile_id="user-B", profile_data=profile_data)
+
+        assert stub_tool.call_count == 2


### PR DESCRIPTION
## Summary

Fixes #43 — agent session state was not cleared between reviews for the
same user, causing a second review to silently return stale tool results
instead of fresh ones.

## Root cause

The bug was not in `session_store.py` (the Redis-backed store), which is
correctly scoped per-user with a TTL. The actual issue was in
`agent/orchestrator.py`: `Orchestrator` created a single `ContextManager`
instance in `__init__`, which persisted for the lifetime of the
`Orchestrator` object (i.e. across every request, not just one review).

`_execute_tool()` checks this cache before running any tool, keyed on
`tool_name` + a hash of the tool's input dict. If a user's second review
happens to produce the same tool input as a previous review (e.g. same
`repo_name`, even though the repo's contents changed on GitHub), the hash
matches, the cache returns a hit, and the tool is never re-executed —
silently returning stale data.

## Fix

- `ContextManager` is now instantiated fresh inside `run()`, scoped to a
  single review, instead of being a persistent instance attribute set in
  `__init__`.
- `_execute_tool()` now accepts `context_manager` as a parameter instead
  of reading `self.context_manager`, so caching still works correctly
  *within* a single review (legitimate memoization of repeated tool calls)
  but never leaks *across* separate reviews.

## Tests

Added `tests/unit/test_orchestrator.py` with 4 tests:
- Tool executes on first review
- Tool re-executes on a second review with the same input (regression test
  for #43)
- Second review returns fresh results, not the first review's cached data
- Two different users' reviews don't share cached results

Also added `scripts/reproduce_43.py`, a standalone reproduction script
used during investigation to confirm the bug and later confirm the fix.

## Verification

- `make test-unit`: 53 failed, 379 passed. The 53 failures are
  pre-existing and unrelated to this change (spread across
  `review_service.py`, `bias_detector.py`, `pii_scrubber.py`,
  `resume_parser.py`, `tech_detector.py`, etc. — confirmed present before
  any of my changes). My change adds 4 new passing tests and introduces
  no new failures.
- `make check`: 179 errors, down from a 182-error baseline (no new errors
  introduced by this change; a stray whitespace issue from an earlier
  version of my diff was cleaned up).

## Files changed
- `agent/orchestrator.py` — core fix
- `tests/unit/test_orchestrator.py` — new regression tests
- `scripts/reproduce_43.py` — reproduction script
- `JOURNAL.md`, `PLAN.md` — course documentation