### PR TITLE
fix(health): use redis_url instead of nonexistent redis_host in health check

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -90,9 +90,9 @@ None identified. PostgreSQL showing "unhealthy" is a separate pre-existing issue
 
 ### Check-in 2 (end of week)
 
-**PR link:** [LINK_TO_YOUR_PR]
+**PR link:** https://github.com/ascherj/pathreview/pull/486
 
-**Branch:** fix/155-redis-health-check
+**Branch:** [fix/155-redis-health-check](https://github.com/fperezrugama/pathreview/tree/fix/155-redis-health-check)
 
 **What you built:**
 Updated the health check endpoint to use `settings.redis_url` instead of the nonexistent `settings.redis_host` and `settings.redis_port`. This fixes the false "unhealthy" report when Redis is actually running.
@@ -102,4 +102,4 @@ Created `tests/unit/test_health.py` with tests for Redis healthy/unhealthy scena
 
 **Self-review confirmation:** [x] make check passes  [x] make test-unit passes
 
-**Draft PR feedback received from:** [Add name/handle if you got feedback]
+**Draft PR feedback received from:** @theoneineed

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,42 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/155
+
+**Issue title:** Health check references settings.redis_host, which does not exist on Settings
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The health check endpoint at api/routes/health.py tries to access settings.redis_host and settings.redis_port to check Redis connectivity, but these fields don't exist in the Settings model (core/config.py). Instead of properly reporting Redis status, the endpoint raises an AttributeError that's silently caught and always reports "redis": "unhealthy" regardless of whether Redis is actually running. A successful fix will modify the health check to use the existing redis_url configuration from Settings, allowing it to correctly report Redis status.
+
+**Branch name:** fix/155-redis-health-check
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger
+
+**Is this issue right for me? — Reasoning:**
+
+**Part 1 — Understanding the Issue**
+- ✅ I can explain the problem: The health check tries to read settings.redis_host but it doesn't exist, causing a false "unhealthy" report
+- ✅ I understand which part is affected: api/routes/health.py and core/config.py
+- ✅ I understand what "done" looks like: The health check properly reports Redis status using settings.redis_url
+
+**Code Analysis:**
+- `core/config.py` defines Settings with `redis_url` (line 10)
+- `api/routes/health.py` incorrectly uses `settings.redis_host` and `settings.redis_port` (lines 39-40)
+- The fix is to use `redis.Redis.from_url(settings.redis_url)` instead
+
+**Part 2 — Tier Fit**
+- ✅ This is my first contribution, so Tier 1 is appropriate
+- ✅ The fix is localized to the health check endpoint
+
+**Part 3 — Codebase Readiness**
+- ✅ I've found the relevant code: api/routes/health.py and core/config.py
+- ✅ I understand the surrounding code: The Settings model uses redis_url, and the health check should use it too
+- ✅ I've read the relevant test file: tests/unit/test_health.py exists and I understand the pattern
+
+**Part 4 — Scope and Time**
+- ✅ I've checked the issue comments and understand multiple students are working on this
+- ✅ The scope is realistic: 1-2 hours of focused work
+- ✅ No blockers or dependencies on other issues

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -40,3 +40,26 @@ The health check endpoint at api/routes/health.py tries to access settings.redis
 - ✅ I've checked the issue comments and understand multiple students are working on this
 - ✅ The scope is realistic: 1-2 hours of focused work
 - ✅ No blockers or dependencies on other issues
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/fperezrugama/pathreview/commit/421f7256c5949eddbe3cb07258f1bafc42014da5
+
+**Reproduction summary:**
+Successfully reproduced the issue by calling `GET /health` endpoint. Redis container is running (verified with `docker compose ps` showing "Up 6 days (healthy)" and `redis-cli ping` returning PONG), but the health check incorrectly reports `"redis": "unhealthy"`. The bug exists because the health check code tries to access `settings.redis_host` and `settings.redis_port`, but these fields don't exist in the Settings model (`core/config.py`). The error is silently caught and always reports unhealthy.
+
+**Reproduction Steps:**
+1. Started the app with `make run`
+2. In a new terminal, ran `curl http://localhost:8000/health`
+3. Received response showing `"redis": "unhealthy"`
+4. Verified Redis is actually running with:
+   - `docker compose ps` → shows "Up 6 days (healthy)"
+   - `docker exec -it pathreview-redis-1 redis-cli ping` → returns `PONG`
+5. Confirmed the bug: Redis is working but health check says unhealthy
+
+**Test Results:**
+- Created `tests/unit/test_health.py` with initial tests for the health endpoint ([see commit](https://github.com/fperezrugama/pathreview/commit/421f7256c5949eddbe3cb07258f1bafc42014da5))
+- Ran `make test-unit` - health tests pass, confirming the tests work
+- The bug is confirmed: Redis is running but health check says unhealthy
+- The tests mock Redis, so they pass, but they demonstrate the real issue
+
+

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -62,4 +62,7 @@ Successfully reproduced the issue by calling `GET /health` endpoint. Redis conta
 - The bug is confirmed: Redis is running but health check says unhealthy
 - The tests mock Redis, so they pass, but they demonstrate the real issue
 
+**PLAN.md link:** https://github.com/fperezrugama/pathreview/blob/fix/155-redis-health-check/PLAN.md
 
+**Blockers or open questions:**
+None identified. The actual bug is that `settings.redis_host` doesn't exist, causing the false "unhealthy" status. I'll fix this in Week 9 by using `settings.redis_url` instead.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -66,3 +66,40 @@ Successfully reproduced the issue by calling `GET /health` endpoint. Redis conta
 
 **Blockers or open questions:**
 None identified. The actual bug is that `settings.redis_host` doesn't exist, causing the false "unhealthy" status. I'll fix this in Week 9 by using `settings.redis_url` instead.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+- ✅ Sub-task 1: Updated Redis connection in `api/routes/health.py` — replaced `redis.Redis(host=settings.redis_host, port=settings.redis_port)` with `redis.Redis.from_url(settings.redis_url)`
+- ✅ Sub-task 2: Tested locally — `curl http://localhost:8000/health` now returns `"redis": "healthy"` ✅
+- ✅ Sub-task 3: Ran `make check` and `make test-unit` — no new failures introduced
+- ✅ Sub-task 4: Created `tests/unit/test_health.py` with tests for Redis healthy/unhealthy scenarios
+- ✅ Sub-task 5: Opened draft PR for peer feedback
+
+**Next steps:**
+- Get peer feedback on draft PR
+- Address any feedback I agree with
+- Mark PR as ready for review
+
+**Blockers:**
+None identified. PostgreSQL showing "unhealthy" is a separate pre-existing issue (#154) not related to my fix.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [LINK_TO_YOUR_PR]
+
+**Branch:** fix/155-redis-health-check
+
+**What you built:**
+Updated the health check endpoint to use `settings.redis_url` instead of the nonexistent `settings.redis_host` and `settings.redis_port`. This fixes the false "unhealthy" report when Redis is actually running.
+
+**Tests added or updated:**
+Created `tests/unit/test_health.py` with tests for Redis healthy/unhealthy scenarios and PostgreSQL healthy/unhealthy scenarios.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+**Draft PR feedback received from:** [Add name/handle if you got feedback]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -103,3 +103,39 @@ Created `tests/unit/test_health.py` with tests for Redis healthy/unhealthy scena
 **Self-review confirmation:** [x] make check passes  [x] make test-unit passes
 
 **Draft PR feedback received from:** @theoneineed
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [x] Yes
+
+**Summary of feedback:**
+Received positive feedback from @theoneineed, who was working on the same issue (#155). They commented: "I was working on the same issue. Nice fix! Good job adding the new test file." No changes were requested — the feedback was purely encouraging.
+
+**How you responded:**
+I thanked @theoneineed for the feedback and noted that both of us approached the same issue with different solutions, which was a great learning opportunity.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+
+The most challenging part was getting the development environment set up correctly. I had issues with Docker, PostgreSQL ports, and the `.env` configuration. The database connection was tricky because the health check was looking for `settings.redis_host` which didn't exist, and I had to trace through multiple files to understand the Settings model. Once I found the root cause, the fix was simple, but finding it took more time than I expected.
+
+**What did you learn about working in a large codebase?**
+
+I learned that production codebases have many moving parts. You can't just change one file and assume everything works — you need to understand how modules connect and what dependencies exist. I also learned the importance of testing: writing tests for the health endpoint helped me verify that my fix actually worked and didn't break anything else. Another big takeaway was that large projects have pre-existing issues (like the PostgreSQL health check bug #154) that you need to document and work around without trying to fix everything at once.
+
+**How did AI tools help — and where did they fall short?**
+
+AI tools were most helpful for explaining the codebase structure, suggesting the correct Redis connection pattern (`redis.Redis.from_url()`), and debugging errors during setup. However, AI fell short when it came to understanding the full context of the project — it couldn't tell me that PostgreSQL showing "unhealthy" was a separate issue. I had to investigate manually to confirm the bug was isolated to Redis.
+
+**What would you do differently if you started over?**
+
+I would have spent more time understanding the Settings model and the health check endpoint before writing any code. I also would have committed more frequently to show progress. I think I could have been more thorough in my PLAN.md by adding more specific edge cases to test.
+
+**What are you most proud of from this module?**
+
+I'm most proud of successfully fixing the bug and verifying it with `curl` — seeing `"redis": "healthy"` after running the health check was really satisfying. I'm also proud of creating a complete test file and following the proper PR process, including writing a detailed PR description and getting peer feedback from @theoneineed. It was great to see someone else working on the same issue and to compare our different approaches.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,126 @@
+# Solution plan
+
+**Issue:** [Health check references settings.redis_host, which does not exist on Settings](https://github.com/ascherj/pathreview/issues/155)
+
+## Understand
+
+**What is the root cause?**
+The health check endpoint at `api/routes/health.py` tries to access `settings.redis_host` and `settings.redis_port`, but these fields don't exist in the Settings model defined in `core/config.py`. The Settings model only defines `redis_url`. The error is caught by an exception handler and always reports Redis as "unhealthy" even when it's actually running.
+
+**Reproduction evidence:**
+
+***What I did***
+# 1. Started the app
+make run
+
+# 2. In a new terminal, tested the health endpoint
+curl http://localhost:8000/health
+
+***What I saw***
+``` JSON
+
+{
+  "detail": {
+    "status": "unhealthy",
+    "dependencies": {
+      "postgres": "unhealthy",
+      "redis": "unhealthy",  // ❌ BUG: Redis is actually running!
+      "vector_db": "healthy"
+    }
+  }
+}
+
+```
+
+### How I Verified Redis is Actually Running:
+
+- Check Redis container status
+docker compose ps
+ Output: pathreview-redis-1   Up 6 days (healthy)
+
+- Test Redis directly
+docker exec -it pathreview-redis-1 redis-cli ping
+  Output: PONG ✅
+
+### Conclusion:
+✅ BUG CONFIRMED: Redis is running and responding, but the health check says it's unhealthy!
+
+## Map
+
+**Files I'll touch:**
+1. `api/routes/health.py` - Lines 37-44 (the Redis connection code)
+2. `tests/unit/test_health.py` - Already created, may need updates
+
+**Functions involved:**
+- `health_check()` in `api/routes/health.py`
+- `Settings` class in `core/config.py` (has `redis_url`)
+
+## Plan
+
+### Sub-task 1: Update Redis connection in health check
+- Replace lines 39-40: `redis.Redis(host=settings.redis_host, port=settings.redis_port)`
+- With: `redis.Redis.from_url(settings.redis_url)`
+
+### Sub-task 2: Test the fix locally
+- Run `make run`
+- Call `curl http://localhost:8000/health`
+- Verify `"redis": "healthy"` appears
+
+### Sub-task 3: Run tests
+- Run `make check` (lint, format, type check)
+- Run `make test-unit` to ensure all tests pass
+
+### Sub-task 4: Update tests if needed
+- If the health tests need adjustment, update them
+- Ensure both healthy and unhealthy scenarios are covered
+
+### Sub-task 5: Open PR
+- Follow PR template
+- Include before/after screenshots or curl outputs
+- Reference issue #155
+
+## Inputs & outputs
+
+**Inputs:**
+- `settings.redis_url` from `.env` (e.g., `redis://localhost:6379/0`)
+- Redis server availability (running or down)
+
+**Outputs:**
+- ✅ `"redis": "healthy"` when Redis is running
+- ❌ `"redis": "unhealthy"` when Redis is down
+- Correct HTTP status (200 OK or 503 Service Unavailable)
+
+## Risks & unknowns
+
+**What could go wrong?**
+
+1. **Redis URL format**: The URL might be malformed or missing
+   - Mitigation: The URL comes from Settings with a valid default
+   - Add try/except to handle connection errors gracefully
+
+2. **Tests might need adjustment**: The health tests use mocks
+   - Mitigation: The tests already work, just need to verify they pass after the fix
+
+3. **Other students working on same issue**: Multiple PRs for same issue
+   - Mitigation: The course allows multiple PRs; grade is based on my work
+
+4. **PostgreSQL showing unhealthy**: This is a separate issue
+   - Mitigation: My fix only addresses Redis, won't affect PostgreSQL
+
+## Edge cases
+
+**What should the fix handle gracefully?**
+
+1. **Redis is down** → Should report "unhealthy"
+2. **Redis is running** → Should report "healthy"
+3. **Redis URL is invalid** → Should report "unhealthy" with error log
+4. **Redis connection timeout** → Should report "unhealthy"
+5. **PostgreSQL check** → Should continue to work independently
+
+## Testing Plan
+
+| Scenario | Expected Result |
+|----------|-----------------|
+| Redis running | `"redis": "healthy"` |
+| Redis stopped | `"redis": "unhealthy"` |
+| Redis restarted | `"redis": "healthy"` |

--- a/api/routes/health.py
+++ b/api/routes/health.py
@@ -40,13 +40,10 @@ async def health_check(db=Depends(get_db)):
         # Check Redis (if available)
         import redis
         from core.config import settings
-
-        r = redis.Redis(
-            host=settings.redis_host,
-            port=settings.redis_port,
-            db=0,
-            decode_responses=True,
-        )
+            # host=settings.redis_host, # this doesn't exist
+            # port=settings.redis_port, # this doesn't exist
+            # Use redis_url from Settings instead of nonexistent redis_host/redis_port
+        r = redis.Redis.from_url(settings.redis_url)
         r.ping()
         health_status["dependencies"]["redis"] = "healthy"
         log.debug("redis_health_check_passed")

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -99,7 +99,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -449,7 +448,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -473,7 +471,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1561,7 +1558,6 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1579,7 +1575,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1972,7 +1967,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3507,7 +3501,6 @@
       "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^2.0.1",
         "cssstyle": "^4.0.1",
@@ -4094,7 +4087,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4107,7 +4099,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4771,7 +4762,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -1,0 +1,61 @@
+"""Unit tests for health check endpoint."""
+
+import pytest
+from fastapi.testclient import TestClient
+from unittest.mock import patch, MagicMock
+
+from api.main import app
+
+client = TestClient(app)
+
+
+def test_health_check_redis_healthy() -> None:  # ✅ Added -> None
+    """Test health check when Redis is running."""
+    # Mock Redis connection to return healthy
+    with patch("api.routes.health.redis.Redis") as mock_redis:
+        mock_instance = MagicMock()
+        mock_instance.ping.return_value = True
+        mock_redis.from_url.return_value = mock_instance
+        
+        response = client.get("/health")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["dependencies"]["redis"] == "healthy"
+
+
+def test_health_check_redis_unhealthy() -> None:  # ✅ Added -> None
+    """Test health check when Redis is down."""
+    # Mock Redis connection to raise exception
+    with patch("api.routes.health.redis.Redis") as mock_redis:
+        mock_redis.from_url.side_effect = Exception("Connection refused")
+        
+        response = client.get("/health")
+        assert response.status_code == 503
+        data = response.json()
+        assert data["detail"]["dependencies"]["redis"] == "unhealthy"
+
+
+def test_health_check_postgres_healthy() -> None:  # ✅ Added -> None
+    """Test health check when PostgreSQL is healthy."""
+    # Mock database connection
+    with patch("api.routes.health.get_db") as mock_db:
+        mock_conn = MagicMock()
+        mock_conn.execute.return_value = None
+        mock_db.return_value.__aenter__.return_value = mock_conn
+        
+        response = client.get("/health")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["dependencies"]["postgres"] == "healthy"
+
+
+def test_health_check_postgres_unhealthy() -> None:  # ✅ Added -> None
+    """Test health check when PostgreSQL is down."""
+    # Mock database to raise exception
+    with patch("api.routes.health.get_db") as mock_db:
+        mock_db.return_value.__aenter__.side_effect = Exception("Connection failed")
+        
+        response = client.get("/health")
+        assert response.status_code == 503
+        data = response.json()
+        assert data["detail"]["dependencies"]["postgres"] == "unhealthy"


### PR DESCRIPTION
## Summary

Fixes #155 — The Redis health check endpoint was silently failing and always reporting `"redis": "unhealthy"` because it tried to access `settings.redis_host` and `settings.redis_port`, which don't exist in the Settings model. The fix replaces these with `settings.redis_url`, allowing the health check to correctly verify Redis connectivity.

## Issue

Closes #155

## Changes

**Root cause:** The Settings model in `core/config.py` defines `redis_url`, but the health check in `api/routes/health.py` attempted to use `settings.redis_host` and `settings.redis_port` instead. This raised an `AttributeError` that was silently caught, always reporting Redis as "unhealthy" regardless of actual status.

- `api/routes/health.py` — Replaced `redis.Redis(host=settings.redis_host, port=settings.redis_port)` with `redis.Redis.from_url(settings.redis_url)` in the Redis probe section
- `tests/unit/test_health.py` — Created new test file with tests for Redis healthy/unhealthy scenarios and PostgreSQL healthy/unhealthy scenarios

## Testing

- [x] `make check` passes (pre-existing mypy errors in other files, unchanged)
- [x] `make test-unit` passes
- [x] Manual verification completed

**Reproduce the original bug (before the fix):**
1. Check out `main` branch
2. Run `make run`
3. Run `curl http://localhost:8000/health`
4. Observe: `"redis": "unhealthy"` even though Redis is running

**Verify the fix (on this branch):**
1. Check out `fix/155-redis-health-check`
2. Run `make run`
3. Run `curl http://localhost:8000/health`
4. Expected: `"redis": "healthy"` appears in the response

## Screenshots / Demo

N/A — backend-only change. Observable behavior is the health endpoint now correctly reports Redis status.

## Notes for Reviewers

- Pre-existing mypy errors in other files (type annotations) are unrelated to this change
- PostgreSQL showing "unhealthy" is a separate pre-existing issue (#154) not addressed by this PR
