### PR TITLE
docs: add Google-style docstrings to core/services (closes #119)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,7 @@ htmlcov/
 
 # Build artifacts
 *.pyc
+
+# Claude Code / graphify local artifacts
+CLAUDE.local.md
+graphify-out/

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -33,3 +33,16 @@ I confirmed the gap by running `git show 10d3713:core/services/profile_service.p
 
 **Blockers or open questions:**
 The actual docstring fix — and the type-annotation fixes needed to get the mypy pre-commit hook passing — were already completed and committed back in Week 7, ahead of this week's plan-then-build pacing. `PLAN.md` below documents the approach I actually followed rather than a forward-looking plan. No PR has been opened yet; that's a Week 9 step per the module schedule.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Docstring work and mypy fixes were completed in Week 7. This week I ran a baseline check (`make check`, `make test-unit`) to confirm my two changed files are clean and documented the pre-existing unrelated failures (53 total, including 13 in `test_review_service.py` traced to a pre-existing mock/coroutine bug - confirmed unrelated by running the same suite against the commit before my changes). Opened a draft PR (#489) against `ascherj/pathreview` with the full write-up.
+
+**Next steps:**
+Share the PR in Slack for peer/mentor feedback, address anything that comes back, then mark it ready for review.
+
+**Blockers:**
+None currently - waiting on peer/mentor review before finalizing.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -46,3 +46,22 @@ Share the PR in Slack for peer/mentor feedback, address anything that comes back
 
 **Blockers:**
 None currently - waiting on peer/mentor review before finalizing.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/489
+
+**Branch:** docs/119-service-docstrings
+
+**What you built:**
+Added Google-style docstrings (description, Args, Returns, Raises) to every function in `core/services/profile_service.py` (4 functions) and `core/services/review_service.py` (9 functions, including 4 private `_run_*` helpers). No runtime behavior changed - this is a documentation-only fix, with accompanying `db: AsyncSession` type annotations needed to get the mypy pre-commit hook passing.
+
+**Tests added or updated:**
+None added or updated. Since this is a docstring-only change with no behavior modification, there's nothing new to test. Confirmed via baseline diff that `make test-unit`'s 53 failures are all pre-existing and unrelated (identical failure set on the commit before my changes).
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+(Both pass in the sense required for a codebase with documented pre-existing failures: my two changed files are clean under `ruff`/`mypy`, and my changes introduce zero new test failures.)
+
+**Draft PR feedback received from:** none - posted in the course Slack channel with time to spare before the deadline, no response received.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -29,7 +29,7 @@ I confirmed the gap by running `git show 10d3713:core/services/profile_service.p
 
 **PLAN.md link:** https://github.com/vzan2012/pathreview/blob/docs/119-service-docstrings/PLAN.md
 
-**Walkthrough video (recommended):** Not recorded.
+**Walkthrough video (recommended):** https://www.loom.com/share/8f939ed837304910a3650b729159fe58
 
 **Blockers or open questions:**
 The actual docstring fix — and the type-annotation fixes needed to get the mypy pre-commit hook passing — were already completed and committed back in Week 7, ahead of this week's plan-then-build pacing. `PLAN.md` below documents the approach I actually followed rather than a forward-looking plan. No PR has been opened yet; that's a Week 9 step per the module schedule.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,21 @@
+# Module 3 Journal
+
+## Week 7 - Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/119
+
+**Issue title:** Add inline docstrings to all public methods in `core/services/`
+
+**Tier:** [ ] Tier 1 [x] Tier 2 [ ] Tier 3
+
+**Problem summary:**
+The service layer in `core/services/` was missing proper documentation - most functions had at most a one-line description, with no information about what parameters they accept, what they return, or when they raise an exception. Issue #119 asks for full Google-style docstrings (description, Args, Returns, and Raises) on every public method across `profile_service.py`, `review_service.py`, and `notification_service.py`. A successful fix means someone reading these files can understand how to call each function and what to expect back without tracing through the implementation. One catch I ran into: `notification_service.py` is listed in the issue, but that file doesn't exist anywhere in the repo - only `profile_service.py` and `review_service.py` are present under `core/services/`, so my actual scope was those two files.
+
+**Is this right for me? — checklist reasoning:**
+This felt like a reasonable scope for a first contribution, though in practice it turned out to be easier than expected - despite the tier-2 label, the work was mechanical documentation rather than anything requiring deep architectural changes. The main scope surprise was discovering that `notification_service.py`, one of the three files the issue names, doesn't exist in the codebase at all, so I scoped my work to the two files that do exist and noted the discrepancy here rather than guessing at what a nonexistent file should contain.
+
+**Branch name:** docs/119-service-docstrings
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -22,12 +22,12 @@ This felt like a reasonable scope for a first contribution, though in practice i
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [to be filled in after this commit is pushed]
+**Reproduction commit link:** https://github.com/vzan2012/pathreview/commit/c02d7eaac82b359315a463dfba7f592f3f62bdbb
 
 **Reproduction summary:**
 I confirmed the gap by running `git show 10d3713:core/services/profile_service.py` to view the original functions before my fix — each one had only a one-line docstring (e.g. `create_profile` just said `"""Create a new profile for a user."""`) with no Args, Returns, or Raises sections, matching exactly what issue #119 describes.
 
-**PLAN.md link:** [to be filled in after this commit is pushed]
+**PLAN.md link:** https://github.com/vzan2012/pathreview/blob/docs/119-service-docstrings/PLAN.md
 
 **Walkthrough video (recommended):** Not recorded.
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -19,3 +19,17 @@ This felt like a reasonable scope for a first contribution, though in practice i
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [to be filled in after this commit is pushed]
+
+**Reproduction summary:**
+I confirmed the gap by running `git show 10d3713:core/services/profile_service.py` to view the original functions before my fix — each one had only a one-line docstring (e.g. `create_profile` just said `"""Create a new profile for a user."""`) with no Args, Returns, or Raises sections, matching exactly what issue #119 describes.
+
+**PLAN.md link:** [to be filled in after this commit is pushed]
+
+**Walkthrough video (recommended):** Not recorded.
+
+**Blockers or open questions:**
+The actual docstring fix — and the type-annotation fixes needed to get the mypy pre-commit hook passing — were already completed and committed back in Week 7, ahead of this week's plan-then-build pacing. `PLAN.md` below documents the approach I actually followed rather than a forward-looking plan. No PR has been opened yet; that's a Week 9 step per the module schedule.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -22,7 +22,7 @@ This felt like a reasonable scope for a first contribution, though in practice i
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** https://github.com/vzan2012/pathreview/commit/c02d7eaac82b359315a463dfba7f592f3f62bdbb
+**Reproduction commit link:** https://github.com/vzan2012/pathreview/commit/50e8159f7bff63a23af87688474b322e639fe92a
 
 **Reproduction summary:**
 I confirmed the gap by running `git show 10d3713:core/services/profile_service.py` to view the original functions before my fix — each one had only a one-line docstring (e.g. `create_profile` just said `"""Create a new profile for a user."""`) with no Args, Returns, or Raises sections, matching exactly what issue #119 describes.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -65,3 +65,34 @@ None added or updated. Since this is a docstring-only change with no behavior mo
 (Both pass in the sense required for a codebase with documented pre-existing failures: my two changed files are clean under `ruff`/`mypy`, and my changes introduce zero new test failures.)
 
 **Draft PR feedback received from:** none - posted in the course Slack channel with time to spare before the deadline, no response received.
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No - still awaiting review
+
+**Summary of feedback:**
+I checked my PR (#489) a few times over the week and there were no comments or reviews left on it. This also matches what the course mentioned - reviewer feedback isn't really active this term.
+
+**How you responded:**
+Nothing to respond to since no feedback came in.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+I thought writing the docstrings would be quick, but following the Google style properly meant I actually had to understand what each function was doing step by step instead of just skimming the code. That took way more time than I planned for.
+
+**What did you learn about working in a large codebase?**
+Working on someone else's codebase is different from my own projects - I had to actually read through the docs and contribution guidelines, understand the code before changing anything, stick to their naming conventions, and go through a proper PR process instead of just committing and moving on.
+
+**How did AI tools help - and where did they fall short?**
+AI helped me a lot with understanding the codebase and catching mistakes I made along the way, which gave me confidence I was doing things right. But the bigger decisions - like whether to rewrite my commit history or when to actually mark the PR ready - were calls I had to make myself.
+
+**What would you do differently if you started over?**
+I'd spend more time understanding the service code before jumping into writing the docstrings, and I'd expect to run into ruff/mypy issues early on instead of being surprised by them later.
+
+**What are you most proud of from this module?**
+Getting the PR done aside, I'm proud that I picked up a good understanding of RAG, safety guardrails, and LLM classifiers just from digging through the codebase to document it properly.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,94 @@
+## Solution plan
+
+**Issue:** #119 - Add inline docstrings to all public methods in `core/services/`
+https://github.com/ascherj/pathreview/issues/119
+
+### Understand
+
+The service layer functions in `core/services/` had at most a one-line docstring (e.g. `"""Create a new profile for a user."""`), with no `Args`, `Returns`, or `Raises` sections.
+Confirmed by performing `git show 10d3713:core/services/profile_service.py` (the commit before this
+fix) - every function matched this pattern. There's no runtime bug here; the "expected vs. actual" gap is purely documentation: CONTRIBUTING.md requires Google-style docstrings on all public functions, and none of the functions in `core/services/` had them.
+
+**Root cause:** The service layer was written without documentation conventions being enforced or followed at the time.
+
+**Scope note:** The issue lists three files - `profile_service.py`, `review_service.py`, and `notification_service.py`. Only the first two exist in the repo; `notification_service.py` is not present anywhere in the codebase. Scope was limited to the two files that exist.
+
+### Map
+
+Files touched:
+
+- `core/services/profile_service.py` - 4 functions: `create_profile`, `get_profile`, `update_profile`,
+  `delete_profile`.
+- `core/services/review_service.py` - 9 functions: the 4 public functions (`create_review`,
+  `get_review`, `list_reviews`, `process_review`) and 4 private helpers
+  (`_run_ingestion_pipeline`, `_run_agent_orchestration`, `_run_rag_retrieval_generation`,
+  `_run_safety_checks`), documented too even though the issue says "public methods," since they were effectively undocumented and small enough to cover in the same pass.
+
+Not touched: `core/services/notification_service.py` (does not exist).
+
+### Plan
+
+1. Read each function's implementation (not just its signature) to understand its actual behavior - what
+   it queries, what it mutates, what it returns, and where it can raise.
+2. Write a Google-style docstring (description, Args, Returns, and Raises where applicable)
+   for each of the 4 functions in `profile_service.py`.
+3. Write the same for each of the 9 functions in `review_service.py`, explicitly noting
+   where a function is currently a placeholder (`_run_agent_orchestration` and
+   `_run_rag_retrieval_generation` both return hardcoded data and ignore their inputs) so
+   future readers aren't misled into thinking they do real work.
+4. Run `make check` and `make test-unit` to confirm the change doesn't break anything.
+   `make check` includes a pre-commit `mypy` pass, which failed on pre-existing missing type
+   annotations on the `db` parameter across nearly every function - added `db: AsyncSession`
+   type hints and fixed two implicit-`Optional` defaults to get a clean pass, since those
+   were blocking the commit hook regardless of the docstring work.
+5. Commit and push the branch.
+
+### Inputs & outputs
+
+**No functions changed behavior** - this is a docstring-only change with the described type
+annotation additions (signatures gained explicit types on `db`, no argument order or default
+behavior changed).
+
+**Input:** existing source files with sparse/absent docstrings.
+**Output:** same files, same runtime behavior, full Google-style docstrings on every
+function, and `db` parameters properly typed as `AsyncSession`.
+
+### Risks & unknowns
+
+1. **Whether to document the 4 private helpers in `review_service.py`.** The issue says
+   "public methods," and the four `_run_*` functions are private by convention (leading
+   underscore). Decided to document them anyway for completeness - the issue's spirit is
+   "the service layer has no docstrings," and these functions were part of that gap.
+2. **The mypy pre-commit hook surfaced pre-existing bugs unrelated to docstrings once `db`
+   was properly typed** - previously `db` being untyped meant everything downstream was
+   silently `Any`, hiding real problems:
+   - `list_reviews` returned `Sequence[Review]` where the signature promised `list[Review]`
+     - fixed with an explicit `list(...)` wrap.
+   - `process_review` assigns a `list` of dicts to `review.sections`, but the `Review` model
+     (`core/models/review.py:34`) types `sections` as a single `dict | None`. This is a real,
+     pre-existing mismatch that likely needs a database migration to fix properly - out of
+     scope for a docstring PR. Documented in place with a comment and a narrow
+     `# type: ignore[assignment]` rather than silently patched or left to fail CI.
+   - A `resume_filename: str | None` value being placed into a dict inferred as
+     `dict[str, str]` - fixed by explicitly annotating `sources: list[dict]`.
+3. **pre-commit's mypy environment doesn't match the project's local mypy setup** - it's
+   missing SQLAlchemy type stubs (`.pre-commit-config.yaml` only adds `types-redis`), so it
+   infers `result.scalars().first()` as returning `Any` where local mypy correctly infers
+   `Profile | None` / `Review | None`. Added narrow, commented `# type: ignore[no-any-return]`
+   on the two affected lines rather than modifying the shared pre-commit config, since that
+   config is unrelated to `core/services/` and a bigger change than this issue calls for.
+
+### Edge cases
+
+- `create_review` accepts a `user_id` parameter that is never actually used in the function
+  body - no ownership check happens at creation time. Documented as-is in the Args section
+  (noted as "currently unused") rather than silently glossed over.
+- `delete_profile` can raise partway through its cascading delete (reviews → ingested
+  sources → profile); documented with a `Raises` section describing the rollback-then-raise
+  behavior.
+- `process_review` never raises under any circumstance, even on unexpected internal errors -
+  every path, including the nested exception handler, ends by returning `None`. Documented
+  explicitly since a caller might otherwise assume this could throw.
+- GitHub and portfolio ingestion in `_run_ingestion_pipeline` currently store placeholder
+  text instead of real API/scraping data, while resume ingestion stores the real
+  `resume_text`. Documented as a `Note` so this asymmetry isn't mistaken for a bug later.

--- a/core/services/profile_service.py
+++ b/core/services/profile_service.py
@@ -1,24 +1,37 @@
 from uuid import UUID
+
 import structlog
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
+from api.schemas.profile import ProfileCreate, ProfileUpdate
+from core.models.ingested_source import IngestedSource
 from core.models.profile import Profile
 from core.models.review import Review
-from core.models.ingested_source import IngestedSource
-from api.schemas.profile import ProfileCreate, ProfileUpdate
 
 log = structlog.get_logger()
 
 
 async def create_profile(
-    db,
+    db: AsyncSession,
     user_id: UUID,
     data: ProfileCreate,
-    resume_filename: str = None,
-    resume_text: str = None,
+    resume_filename: str | None = None,
+    resume_text: str | None = None,
 ) -> Profile:
-    """
-    Create a new profile for a user.
+    """Create a new profile for a user.
+
+    Args:
+        db: Database session used to persist the new profile.
+        user_id: ID of the user who will own the profile.
+        data: Profile fields (GitHub username, portfolio URL) submitted in the
+            create request.
+        resume_filename: Original filename of the uploaded resume, if provided.
+        resume_text: Extracted text content of the resume, if provided.
+
+    Returns:
+        The newly created Profile, with its generated ID and timestamps
+        populated.
     """
     profile = Profile(
         user_id=user_id,
@@ -34,28 +47,48 @@ async def create_profile(
 
 
 async def get_profile(
-    db,
+    db: AsyncSession,
     profile_id: UUID,
     user_id: UUID,
 ) -> Profile | None:
+    """Get a profile by ID, checking ownership.
+
+    Args:
+        db: Database session used to query the profile.
+        profile_id: ID of the profile to fetch.
+        user_id: ID of the user who must own the profile.
+
+    Returns:
+        The matching Profile, or None if no profile with that ID exists
+        for this user.
     """
-    Get a profile by ID, checking ownership.
-    """
-    stmt = select(Profile).where(
-        (Profile.id == profile_id) & (Profile.user_id == user_id)
-    )
+    stmt = select(Profile).where((Profile.id == profile_id) & (Profile.user_id == user_id))
     result = await db.execute(stmt)
-    return result.scalars().first()
+    # pre-commit's isolated mypy env lacks SQLAlchemy stubs, so it can't
+    # infer this as Profile | None the way the project's local mypy does.
+    return result.scalars().first()  # type: ignore[no-any-return]
 
 
 async def update_profile(
-    db,
+    db: AsyncSession,
     profile_id: UUID,
     user_id: UUID,
     data: ProfileUpdate,
 ) -> Profile | None:
-    """
-    Update a profile, checking ownership.
+    """Update a profile, checking ownership.
+
+    Only fields present in `data` are applied, so a partial update (e.g.
+    changing just the portfolio URL) leaves other fields untouched.
+
+    Args:
+        db: Database session used to fetch and persist the profile.
+        profile_id: ID of the profile to update.
+        user_id: ID of the user who must own the profile.
+        data: Fields to update; `None` values are left unchanged.
+
+    Returns:
+        The updated Profile, or None if no profile with that ID exists
+        for this user.
     """
     profile = await get_profile(db, profile_id, user_id)
     if not profile:
@@ -73,13 +106,25 @@ async def update_profile(
 
 
 async def delete_profile(
-    db,
+    db: AsyncSession,
     profile_id: UUID,
     user_id: UUID,
 ) -> bool:
-    """
-    Delete a profile and cascade delete reviews and ingested sources.
-    Returns True if deleted, False if not found.
+    """Delete a profile and cascade delete reviews and ingested sources.
+
+    Args:
+        db: Database session used to fetch and delete records.
+        profile_id: ID of the profile to delete.
+        user_id: ID of the user who must own the profile.
+
+    Returns:
+        True if the profile (and its reviews/ingested sources) was
+        deleted, False if no profile with that ID exists for this user.
+
+    Raises:
+        Exception: If deletion fails partway through. The transaction is
+            rolled back and the original exception is re-raised after
+            being logged.
     """
     profile = await get_profile(db, profile_id, user_id)
     if not profile:

--- a/core/services/review_service.py
+++ b/core/services/review_service.py
@@ -1,24 +1,35 @@
-from uuid import UUID
-import structlog
 import json
 from datetime import datetime
-from sqlalchemy import select, and_
+from uuid import UUID
 
-from core.models.review import Review
-from core.models.profile import Profile
-from core.models.ingested_source import IngestedSource
+import structlog
+from sqlalchemy import and_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from api.schemas.review import FeedbackSection
+from core.models.ingested_source import IngestedSource
+from core.models.profile import Profile
+from core.models.review import Review
 
 log = structlog.get_logger()
 
 
 async def create_review(
-    db,
+    db: AsyncSession,
     profile_id: UUID,
     user_id: UUID,
 ) -> Review:
-    """
-    Create a new review with status="pending".
+    """Create a new review with status="pending".
+
+    Args:
+        db: Database session used to persist the new review.
+        profile_id: ID of the profile this review is for.
+        user_id: ID of the requesting user. Currently unused — no
+            ownership check is performed against profile_id.
+
+    Returns:
+        The newly created Review, with status "pending" and no sections
+        or score yet.
     """
     review = Review(
         profile_id=profile_id,
@@ -33,29 +44,49 @@ async def create_review(
 
 
 async def get_review(
-    db,
+    db: AsyncSession,
     review_id: UUID,
     user_id: UUID,
 ) -> Review | None:
+    """Get a review by ID, checking that it belongs to the user's profile.
+
+    Args:
+        db: Database session used to query the review.
+        review_id: ID of the review to fetch.
+        user_id: ID of the user who must own the review's profile.
+
+    Returns:
+        The matching Review, or None if no review with that ID exists
+        for a profile owned by this user.
     """
-    Get a review by ID, checking that it belongs to the user's profile.
-    """
-    stmt = select(Review).join(Profile).where(
-        and_(Review.id == review_id, Profile.user_id == user_id)
+    stmt = (
+        select(Review).join(Profile).where(and_(Review.id == review_id, Profile.user_id == user_id))
     )
     result = await db.execute(stmt)
-    return result.scalars().first()
+    # pre-commit's isolated mypy env lacks SQLAlchemy stubs, so it can't
+    # infer this as Review | None the way the project's local mypy does.
+    return result.scalars().first()  # type: ignore[no-any-return]
 
 
 async def list_reviews(
-    db,
+    db: AsyncSession,
     user_id: UUID,
     page: int = 1,
     page_size: int = 20,
 ) -> tuple[list[Review], int]:
-    """
-    List reviews for a user with pagination.
-    Returns (reviews, total_count).
+    """List reviews for a user with pagination.
+
+    Results are ordered by creation date, newest first.
+
+    Args:
+        db: Database session used to query reviews.
+        user_id: ID of the user whose reviews are listed.
+        page: 1-indexed page number to fetch.
+        page_size: Number of reviews per page.
+
+    Returns:
+        A tuple of (reviews for the requested page, total count of
+        reviews across all pages).
     """
     offset = (page - 1) * page_size
 
@@ -76,24 +107,40 @@ async def list_reviews(
     result = await db.execute(stmt)
     reviews = result.scalars().all()
 
-    return reviews, total
+    return list(reviews), total
 
 
 async def process_review(
-    db,
+    db: AsyncSession,
     review_id: UUID,
     profile_id: UUID,
 ) -> None:
-    """
-    Background task to process a review.
-    Steps:
+    """Background task to process a review.
+
+    Runs the full pipeline for a single review:
     1. Set status="processing"
-    2. Run ingestion pipeline on profile's sources
+    2. Run ingestion pipeline on the profile's sources
     3. Run agent orchestration
     4. Run RAG retrieval + generation
-    5. Run safety checks on output
-    6. Set status="complete", store sections in review.sections
-    7. On exception: set status="failed", log error
+    5. Run safety checks on the generated output
+    6. Set status="complete" and store sections + score on the review
+
+    If the review or profile can't be found, or the safety checks
+    fail, the review's status is set to "failed" (except when the
+    review itself is missing, in which case there's no review to
+    update) and processing stops early.
+
+    Args:
+        db: Database session used for all reads/writes in this pipeline.
+        review_id: ID of the review to process.
+        profile_id: ID of the profile the review is generated from.
+
+    Returns:
+        None. This function never raises — any unexpected exception
+        during processing is caught, logged, and used to mark the
+        review "failed" on a best-effort basis (that status update
+        itself is wrapped in its own try/except, so a failure there is
+        only logged, not propagated).
     """
     try:
         # Get the review
@@ -166,7 +213,11 @@ async def process_review(
         ]
 
         review.status = "complete"
-        review.sections = [s.model_dump() for s in sections]
+        # Pre-existing mismatch: Review.sections is typed as a single dict
+        # in the model (core/models/review.py), but a list of section
+        # dicts is stored here. Out of scope for this docstring change;
+        # the model's column type likely needs a migration to fix properly.
+        review.sections = [s.model_dump() for s in sections]  # type: ignore[assignment]
         review.overall_score = rag_output.get("overall_score", None)
         review.updated_at = datetime.utcnow()
 
@@ -194,12 +245,31 @@ async def process_review(
             log.error("review_status_update_failed", review_id=str(review_id), error=str(e))
 
 
-async def _run_ingestion_pipeline(db, profile: Profile) -> list[dict]:
+async def _run_ingestion_pipeline(db: AsyncSession, profile: Profile) -> list[dict]:
+    """Run ingestion pipeline to extract data from profile sources.
+
+    Each available source (GitHub, portfolio URL, resume) is ingested
+    independently: a data dict is appended to the returned list and a
+    matching IngestedSource record is added to the db session for
+    persistence. A failure ingesting one source is logged and skipped
+    rather than aborting the others.
+
+    Note:
+        GitHub and portfolio ingestion currently store placeholder text
+        rather than real API/scraping data. Resume ingestion is real —
+        it stores the profile's actual `resume_text`.
+
+    Args:
+        db: Database session used to persist IngestedSource records.
+        profile: Profile whose sources (`github_username`,
+            `portfolio_url`, `resume_text`) are ingested if present.
+
+    Returns:
+        List of source data dicts, one per successfully ingested
+        source. Empty if the profile has no sources or all ingestion
+        attempts failed.
     """
-    Run ingestion pipeline to extract data from profile sources.
-    Returns list of ingested source data.
-    """
-    sources = []
+    sources: list[dict] = []
 
     # Ingest from GitHub if available
     if profile.github_username:
@@ -280,9 +350,22 @@ async def _run_ingestion_pipeline(db, profile: Profile) -> list[dict]:
 
 
 async def _run_agent_orchestration(profile: Profile, ingestion_results: list[dict]) -> dict:
-    """
-    Run agent orchestration to analyze ingested data.
-    Returns agent output with initial analysis.
+    """Run agent orchestration to analyze ingested data.
+
+    Note:
+        This is currently a placeholder — it returns a fixed set of
+        sections and score regardless of the inputs.
+
+    Args:
+        profile: Profile being analyzed. Currently unused by the
+            placeholder implementation.
+        ingestion_results: Ingested source data from
+            `_run_ingestion_pipeline`. Currently unused by the
+            placeholder implementation.
+
+    Returns:
+        A dict with a "sections" list (each a dict with section_name,
+        content, confidence, and suggestions) and an "overall_score".
     """
     # Placeholder: actual agent orchestration logic
     return {
@@ -309,9 +392,26 @@ async def _run_rag_retrieval_generation(
     ingestion_results: list[dict],
     agent_output: dict,
 ) -> dict:
-    """
-    Run RAG retrieval and generation to create detailed feedback.
-    Returns enhanced review output.
+    """Run RAG retrieval and generation to create detailed feedback.
+
+    Note:
+        This is currently a placeholder — it returns a fixed set of
+        sections and score regardless of the inputs. In production this
+        would embed ingested content, store it in a vector DB, retrieve
+        relevant context, and generate feedback with an LLM.
+
+    Args:
+        profile: Profile the review is being generated for. Currently
+            unused by the placeholder implementation.
+        ingestion_results: Ingested source data from
+            `_run_ingestion_pipeline`. Currently unused by the
+            placeholder implementation.
+        agent_output: Output from `_run_agent_orchestration`. Currently
+            unused by the placeholder implementation.
+
+    Returns:
+        A dict with a "sections" list (each a dict with section_name,
+        content, confidence, and suggestions) and an "overall_score".
     """
     # Placeholder: actual RAG logic
     # In production, this would:
@@ -355,9 +455,21 @@ async def _run_rag_retrieval_generation(
 
 
 async def _run_safety_checks(output: dict) -> bool:
-    """
-    Run safety checks on the review output.
-    Returns True if all checks pass, False otherwise.
+    """Run safety checks on the review output.
+
+    Validates that sections exist and each has a non-empty
+    `section_name` and `content`, and that `confidence` is within
+    [0, 1]. Any unexpected exception during validation is caught and
+    treated as a failed check rather than propagated.
+
+    Args:
+        output: Review output dict with a "sections" list, where each
+            section is a dict with "section_name", "content", and
+            "confidence" keys.
+
+    Returns:
+        True if all checks pass, False if any check fails (including on
+        an unexpected error during validation).
     """
     # Placeholder: actual safety checks logic
     # In production, this would:


### PR DESCRIPTION
## Summary
This PR adds proper Google-style docstrings (description, Args, Returns, Raises) to every function in `core/services/profile_service.py` and `core/services/review_service.py`. Before this, most functions had at most a one-line description and no way to tell what they took in, returned, or could raise without reading the implementation. Nothing about how these functions behave has changed — this is documentation only.

## Issue
Closes #119

## Changes
- Documented all 4 functions in `profile_service.py` (`create_profile`, `get_profile`, `update_profile`, `delete_profile`).
- Documented all 9 functions in `review_service.py` — the 4 public ones (`create_review`, `get_review`, `list_reviews`, `process_review`) plus the 4 private `_run_*` helpers. The issue technically only asks for "public methods," but the helpers were just as undocumented, so I covered them too rather than leaving a gap.
- Along the way, `mypy` (run through the pre-commit hook) failed on a bunch of pre-existing missing type hints on the `db` parameter across both files. Added `db: AsyncSession` typing and fixed two implicit-`Optional` defaults so the hook would actually pass — these were blocking the commit regardless of the docstring work.
- One scope note worth flagging: the issue also lists `core/services/notification_service.py` as a file to document, but it doesn't exist anywhere in this repo. I limited my scope to the two files that actually exist.

## Testing
- [x] Unit tests pass (`make test-unit`) — mostly. There are 53 pre-existing test failures on this codebase that have nothing to do with my change. I checked this out by running the same test suite against the commit right before mine, and got the exact same 13 failures in `test_review_service.py` (a mock/coroutine setup bug that predates this PR). So: my change adds zero new failures, it just doesn't fix ones that were already there.
- [ ] Integration tests (`make test-integration`) — didn't run these. Since this is a docs-only change with no behavior difference, there shouldn't be anything for integration tests to catch either way.
- [x] Linter (`make lint`) — clean on both files I touched. There's a decent amount of pre-existing lint noise elsewhere in the repo (`agent/`, `api/schemas/`, `ingestion/`), but that's unrelated to this PR.
- [x] Type checker (`make typecheck`) — clean on both files.
- [ ] New/updated tests — none added. Since no behavior changed, there wasn't anything new to test. Small note: `profile_service.py` doesn't have a dedicated test file at all in this repo — that's a pre-existing gap, not something in scope for a docstring issue.

## Screenshots / Demo
Recorded a short walkthrough here: https://www.loom.com/share/8f939ed837304910a3650b729159fe58

## Notes for Reviewers
- You'll see two `# type: ignore[no-any-return]` comments on `result.scalars().first()` calls — the pre-commit mypy environment doesn't have SQLAlchemy's type stubs installed, so it infers `Any` there where local mypy correctly figures out `Profile | None` / `Review | None`.
- There's also one `# type: ignore[assignment]` in `review_service.py`, where `process_review` assigns a list of dicts to `Review.sections`, but the model defines `sections` as a single `dict | None`. That's a real, pre-existing mismatch — probably needs a migration to fix properly — so I just documented it in place rather than trying to fix it here.
- If you want the full reasoning behind any of these calls, `PLAN.md` on this branch walks through it.
