### PR TITLE
feat(api): reject review creation when profile has no ingested content

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,23 @@
+## Week 7 — Issue selection
+
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/88
+
+
+**Issue title:** `POST /reviews` endpoint has no test for when the profile has no ingested documents
+
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+
+**Problem summary:**
+From reading the issue, it looks like `POST /reviews` is missing a test for the scenario where a profile exists but no resume or repositories have been ingested yet. Since the review generator wouldn't have any data to work with, I'll verify how the endpoint currently handles that situation and add a test in `tests/unit/test_review_routes.py` to ensure it returns an appropriate error rather than crashing.
+
+
+**Branch name:** test/88-review-endpoint-no-ingested-content
+
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -21,3 +21,20 @@ From reading the issue, it looks like `POST /reviews` is missing a test for the 
 
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [link to commit documenting the reproduced issue]
+
+**Reproduction summary:**
+I called the review pipeline directly with a mock profile that had no GitHub, portfolio, or resume data and confirmed the ingestion step returned an empty source list. Even with no sources to process, the downstream generation steps still produced the same hardcoded feedback, and the review completed successfully instead of reporting an error.
+
+**PLAN.md link:** [link to PLAN.md in your fork]
+
+**Walkthrough video (recommended):** [link to your Loom video, ≤2 min — recommended, not graded]
+
+**Blockers or open questions:**
+I'm still deciding where the validation should happen. One option is to check in the create_review endpoint so the request fails immediately before a review record is created. The other option is to let the review be created and have process_review detect the missing data, mark the review as status="failed", and include a clear error message.
+
+Right now I'm leaning toward validating in the endpoint because it prevents creating a misleading pending review in the first place. I just want to make sure that's the approach the frontend is expecting when a submission doesn't include enough information to generate a review.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -25,12 +25,12 @@ From reading the issue, it looks like `POST /reviews` is missing a test for the 
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [link to commit documenting the reproduced issue]
+**Reproduction commit link:** https://github.com/jupitersnow1/pathreview/commit/4323e66 
 
 **Reproduction summary:**
 I called the review pipeline directly with a mock profile that had no GitHub, portfolio, or resume data and confirmed the ingestion step returned an empty source list. Even with no sources to process, the downstream generation steps still produced the same hardcoded feedback, and the review completed successfully instead of reporting an error.
 
-**PLAN.md link:** [link to PLAN.md in your fork]
+**PLAN.md link:** https://github.com/jupitersnow1/pathreview/blob/test/88-review-endpoint-no-ingested-content/PLAN.md
 
 **Walkthrough video (recommended):** [link to your Loom video, ≤2 min — recommended, not graded]
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -38,3 +38,38 @@ I called the review pipeline directly with a mock profile that had no GitHub, po
 I'm still deciding where the validation should happen. One option is to check in the create_review endpoint so the request fails immediately before a review record is created. The other option is to let the review be created and have process_review detect the missing data, mark the review as status="failed", and include a clear error message.
 
 Right now I'm leaning toward validating in the endpoint because it prevents creating a misleading pending review in the first place. I just want to make sure that's the approach the frontend is expecting when a submission doesn't include enough information to generate a review.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+I implemented the fix outlined in PLAN.md by adding check_has_ingested_sources in core/services/review_service.py and calling it from create_review_endpoint in api/routes/reviews.py. Now, if a profile has no ingested sources, the endpoint returns a 400 Bad Request with the message "Profile has no ingested content" before creating a review or scheduling process_review.
+
+I also added unit tests in tests/unit/test_review_routes.py to cover both scenarios: rejecting requests when there are no ingested sources and confirming the normal review creation flow still works when ingested content exists.
+
+Steps 1–4 from PLAN.md are complete. I looked into the stretch service-layer test, but decided it wasn't needed because the new guard prevents process_review from being scheduled in the first place, so the downstream orchestration code is no longer reachable.
+
+**Next steps:**
+Run make check and make test-unit, compare any failures against the existing baseline, split the work into focused commits, and open a draft PR for feedback before submitting the final version.
+
+**Blockers:**
+None.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [link to your submitted pull request]
+
+**Branch:** test/88-review-endpoint-no-ingested-content
+
+**What you built:**
+Added a guard to POST /reviews that returns a 400 Bad Request when the target profile has no IngestedSource records, preventing the endpoint from creating a review with placeholder feedback.
+
+**Tests added or updated:**
+`tests/unit/test_review_routes.py` (new) — tests the 400-rejection path and the happy-path pending-review creation for `create_review_endpoint`.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+**Draft PR feedback received from:** [name or Slack handle, or "none"]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -73,3 +73,34 @@ Added a guard to POST /reviews that returns a 400 Bad Request when the target pr
 **Self-review confirmation:** [x] make check passes  [x] make test-unit passes
 
 **Draft PR feedback received from:** [name or Slack handle, or "none"]
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No review came in.
+
+**How you responded:**
+N/A
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Honestly, the biggest thing that surprised me was just how big the codebase was. Even though this was a "small" guard-clause change, I couldn't just look at one file and make the change. I had to trace through the request lifecycle, including ingestion, review creation, and the guards connecting everything, to make sure the change was actually safe. Building that mental map of how everything connected ended up taking longer than actually writing the fix.
+
+**What did you learn about working in a large codebase?**
+I learned that clear communication is just as important as the code itself. When you're working on your own project, you can usually keep the context in your head and figure things out as you go. But in someone else's codebase, no one else has that context, so a vague PR description, commit message, or comment forces a reviewer to reconstruct your reasoning from scratch. I didn't get reviewer feedback this module to confirm that firsthand, but writing PLAN.md and my PR description made me notice how much I was tempted to skip explaining a decision because it was obvious to me — even though it wouldn't be obvious to someone reading the code for the first time. That's more a lesson I anticipated than one I had proven back to me, but it changed how carefully I wrote those docs.
+
+**How did AI tools help — and where did they fall short?**
+AI was helpful for getting through some of the longer files, especially things in the ingestion folder like pipeline.py and the chunking strategies. It helped me get a general idea of what a module was doing without having to read every single line first, which saved me some time. I also used it to dig deeper once I had narrowed down the part of the code I actually needed to understand. Where it fell short was knowing whether a change was truly safe. I still had to trace through the code myself and understand how everything connected instead of just relying on an AI-generated summary.
+
+**What would you do differently if you started over?**
+I think I would change how I picked the issue. I chose a Tier 1 issue, and while it did require me to trace through the ingestion and review-creation flow to make sure I implemented it correctly, it wasn't actually as difficult as I expected once I understood the codebase. Knowing that now, I probably would have been more willing to pick a higher-tier issue from the beginning. I think I had more room to challenge myself than I gave myself credit for.
+
+**What are you most proud of from this module?**
+I'm most proud of actually learning how to contribute to an open-source project — the whole workflow of reproducing an issue, planning a fix, and getting it into a PR against someone else's codebase, not just writing code. Before this module I'd only ever worked in projects I built myself, so I never had to reason about someone else's existing architecture or write for a reviewer instead of just for myself. Going through that process end to end on a real repo is the skill I'm most proud of picking up.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -60,7 +60,7 @@ None.
 
 ### Check-in 2 (end of week)
 
-**PR link:** [link to your submitted pull request]
+**PR link:** https://github.com/ascherj/pathreview/pull/492
 
 **Branch:** test/88-review-endpoint-no-ingested-content
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -7,7 +7,7 @@ This is a feature gap, not a crash-causing bug, nothing throws or breaks, but th
 
 From reproducing the bug, I found that create_review creates the review and starts the background task without checking whether the profile has any ingested content.
 
-From there, `_run_agent_orchestration` and `_run_rag_retrieval_generation still return the same placeholder feedback even when the ingestion step returns an empty list. Since _run_safety_checks only verifies that the response has the expected format, it doesn't catch that the feedback wasn't generated from any real profile data.
+From there, `_run_agent_orchestration` and `_run_rag_retrieval_generation` still return the same placeholder feedback even when the ingestion step returns an empty list. Since `_run_safety_checks` only verifies that the response has the expected format, it doesn't catch that the feedback wasn't generated from any real profile data.
 
 Expected behavior: `POST /reviews` should reject (or the background task should fail) when a profile has zero ingested sources, with a clear error rather than a silently "complete" review full of fake data.
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,52 @@
+## Solution plan
+
+**Issue:** `POST /reviews` endpoint has no test for when the profile has no ingested documents — https://github.com/ascherj/pathreview/issues/88
+
+### Understand
+This is a feature gap, not a crash-causing bug, nothing throws or breaks, but the endpoint has no precondition check for whether a profile has any ingested content before generating a review.
+
+From reproducing the bug, I found that create_review creates the review and starts the background task without checking whether the profile has any ingested content.
+
+From there, `_run_agent_orchestration` and `_run_rag_retrieval_generation still return the same placeholder feedback even when the ingestion step returns an empty list. Since _run_safety_checks only verifies that the response has the expected format, it doesn't catch that the feedback wasn't generated from any real profile data.
+
+Expected behavior: `POST /reviews` should reject (or the background task should fail) when a profile has zero ingested sources, with a clear error rather than a silently "complete" review full of fake data.
+
+Actual behavior: the review always completes successfully with the same canned feedback, regardless of ingested content.
+
+### Map
+- `api/routes/reviews.py` — create_review_endpoint (possible place to validate that the profile has ingested content)
+
+- `core/services/review_service.py` — create_review, process_review, and _run_ingestion_pipeline
+
+- `core/models/ingested_source.py` — model used to check whether a profile has any ingested sources
+
+- `tests/unit/test_review_routes.py` — new test file to cover the missing case described in the issue
+
+### Plan
+1. Add a query in `create_review` (or the endpoint, before calling `create_review`) that checks for at least one `IngestedSource` row for the profile.
+
+2. If none exist, raise `HTTPException(400, detail="Profile has no ingested content")` before creating the review row or scheduling `process_review`.
+
+3. Create `tests/unit/test_review_routes.py` with a test that mocks the DB to return zero ingested sources and asserts the endpoint returns 400 instead of creating a review.
+
+4. Add a second test confirming the happy path (profile with at least one ingestd source) still creates a 'pending' review as before, to guard against regressions.
+
+5. (Stretch) Add a service-layer unit test confirming `_run_agent_orchestration`/`_run_rag_retrieval_generation` are never reached when sources are empty, once the guard is in place.
+
+### Inputs & outputs
+Input: `POST /reviews` body `{profile_id, user_id}` for a profile with no `IngestedSource` rows.
+
+Expected output: `400 Bad Request` with a clear `detail` message or no `Review` row created or no background task scheduled.
+
+### Risks & unknowns
+- I still need to confirm whether "no ingested content" should also cover a profile that has sources but they're empty/malformed, or strictly "zero rows" 
+— issue title says "no ingested documents," so starting with the zero-row case.
+
+- Adding this check changes existing behavior (previously always succeeded) — need to check the frontend handles a 400 response on submission gracefully rather than assuming every POST succeeds.
+
+- Where to add the check may affect the transaction boundary — want to avoid a partial commit if the check itself needs a query but the review creation is in a separate call.
+
+### Edge cases
+- A profile has a GitHub username or other information, but ingestion fails and no sources are produced. That would still leave the pipeline with nothing to analyze, although handling that scenario may be outside the scope of this issue.
+
+- If two requests happen at the same time, and ingested content is added between the validation check and review creation. That's a possible race condition, but it doesn't seem to be the main focus of this issue.

--- a/api/routes/reviews.py
+++ b/api/routes/reviews.py
@@ -8,6 +8,7 @@ from core.models.user import User
 from core.models.review import Review
 from core.database import get_db
 from core.services.review_service import (
+    check_has_ingested_sources,
     create_review,
     get_review,
     list_reviews,
@@ -32,6 +33,12 @@ async def create_review_endpoint(
     Returns review with status="pending" immediately.
     """
     try:
+        if not await check_has_ingested_sources(db, data.profile_id):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Profile has no ingested content",
+            )
+
         # Create review with status="pending"
         review = await create_review(
             db=db,

--- a/core/services/review_service.py
+++ b/core/services/review_service.py
@@ -12,6 +12,15 @@ from api.schemas.review import FeedbackSection
 log = structlog.get_logger()
 
 
+async def check_has_ingested_sources(db, profile_id: UUID) -> bool:
+    """
+    Check whether a profile has at least one IngestedSource row.
+    """
+    stmt = select(IngestedSource.id).where(IngestedSource.profile_id == profile_id).limit(1)
+    result = await db.execute(stmt)
+    return result.scalars().first() is not None
+
+
 async def create_review(
     db,
     profile_id: UUID,

--- a/core/services/review_service.py
+++ b/core/services/review_service.py
@@ -13,8 +13,14 @@ log = structlog.get_logger()
 
 
 async def check_has_ingested_sources(db, profile_id: UUID) -> bool:
-    """
-    Check whether a profile has at least one IngestedSource row.
+    """Check whether a profile has at least one IngestedSource row.
+
+    Args:
+        db: Active database session.
+        profile_id: ID of the profile to check.
+
+    Returns:
+        True if the profile has at least one IngestedSource row, False otherwise.
     """
     stmt = select(IngestedSource.id).where(IngestedSource.profile_id == profile_id).limit(1)
     result = await db.execute(stmt)

--- a/tests/unit/test_review_routes.py
+++ b/tests/unit/test_review_routes.py
@@ -1,0 +1,96 @@
+"""Tests for api/routes/reviews.py"""
+
+from datetime import datetime
+from unittest.mock import AsyncMock, Mock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from api.routes.reviews import create_review_endpoint
+from api.schemas.review import ReviewCreate
+
+
+@pytest.mark.unit
+class TestCreateReviewEndpoint:
+    """Test suite for create_review_endpoint."""
+
+    @pytest.fixture
+    def mock_db_session(self):
+        session = AsyncMock()
+        session.rollback = AsyncMock()
+        return session
+
+    @pytest.fixture
+    def mock_current_user(self):
+        user = Mock()
+        user.id = uuid4()
+        return user
+
+    @pytest.fixture
+    def mock_background_tasks(self):
+        tasks = Mock()
+        tasks.add_task = Mock()
+        return tasks
+
+    @pytest.mark.asyncio
+    async def test_returns_400_when_profile_has_no_ingested_sources(
+        self, mock_db_session, mock_current_user, mock_background_tasks
+    ):
+        """Endpoint should reject with 400 and not create a review or schedule processing."""
+        data = ReviewCreate(profile_id=uuid4())
+
+        with (
+            patch("api.routes.reviews.check_has_ingested_sources", AsyncMock(return_value=False)),
+            patch("api.routes.reviews.create_review", AsyncMock()) as mock_create_review,
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await create_review_endpoint(
+                    data=data,
+                    background_tasks=mock_background_tasks,
+                    current_user=mock_current_user,
+                    db=mock_db_session,
+                )
+
+            assert exc_info.value.status_code == 400
+            assert exc_info.value.detail == "Profile has no ingested content"
+            mock_create_review.assert_not_called()
+            mock_background_tasks.add_task.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_creates_pending_review_when_profile_has_ingested_sources(
+        self, mock_db_session, mock_current_user, mock_background_tasks
+    ):
+        """Happy path: profile with at least one ingested source still creates a pending review."""
+        data = ReviewCreate(profile_id=uuid4())
+
+        mock_review = Mock()
+        mock_review.id = uuid4()
+        mock_review.profile_id = data.profile_id
+        mock_review.status = "pending"
+        mock_review.sections = None
+        mock_review.overall_score = None
+        mock_review.error_message = None
+        mock_review.created_at = datetime.utcnow()
+        mock_review.updated_at = datetime.utcnow()
+
+        with (
+            patch("api.routes.reviews.check_has_ingested_sources", AsyncMock(return_value=True)),
+            patch(
+                "api.routes.reviews.create_review", AsyncMock(return_value=mock_review)
+            ) as mock_create_review,
+        ):
+            response = await create_review_endpoint(
+                data=data,
+                background_tasks=mock_background_tasks,
+                current_user=mock_current_user,
+                db=mock_db_session,
+            )
+
+            assert response.status == "pending"
+            mock_create_review.assert_called_once_with(
+                db=mock_db_session,
+                profile_id=data.profile_id,
+                user_id=mock_current_user.id,
+            )
+            mock_background_tasks.add_task.assert_called_once()


### PR DESCRIPTION
## Summary
`POST /reviews` previously created a review and scheduled processing regardless of whether the target profile had any ingested content, so a profile with zero `IngestedSource` rows would still complete with the same canned placeholder feedback. This PR adds a precondition check that rejects the request with a 400 before a review row is created or `process_review` is scheduled.

## Issue
Closes #88

## Changes
- Add `check_has_ingested_sources` in `core/services/review_service.py` — queries for at least one `IngestedSource` row for a profile.
- Wire the check into `create_review_endpoint` in `api/routes/reviews.py` — raises `HTTPException(400, detail="Profile has no ingested content")` before creating the review or scheduling the background task.
- Add `tests/unit/test_review_routes.py` covering both the rejection path (zero ingested sources) and the happy path (at least one ingested source still creates a `pending` review).

## Testing
- [x] Unit tests pass (`make test-unit`) — our new `tests/unit/test_review_routes.py` passes 2/2. Note: this branch has pre-existing failures in `make test-unit` unrelated to this change (~53 failing tests across files we did not touch, e.g. `test_pii_scrubber.py`, `test_resume_parser.py`, `test_review_service.py`, etc. — confirmed present before this branch's changes via `git stash` comparison). Our changes do not introduce any new failures.
- [x] Linter passes (`make lint`) — no new lint violations introduced by this change; pre-existing violations in `review_service.py`/`reviews.py` (unsorted imports, unused import, `B008`/`B904` patterns) predate this branch and are unrelated.
- [x] Type checker passes (`make typecheck`) — no new mypy errors introduced; pre-existing "missing type annotation" errors exist throughout both files (and the rest of the codebase) before this change.
- [x] New/updated tests cover the changes
- [ ] Integration tests pass (`make test-integration`) — not run, no integration tests touch this code path.

## Screenshots / Demo
No UI change, so no screenshots — here's how to run and verify the new behavior locally instead:

```bash
source .venv/bin/activate
python -m pytest tests/unit/test_review_routes.py -v
```

To exercise it against a running API: `POST /reviews` with a `profile_id` that has zero `IngestedSource` rows should now return `400 {"detail": "Profile has no ingested content"}` instead of creating a review. A `profile_id` with at least one ingested source still returns `201` with `status: "pending"` as before.

## Notes for Reviewers
Happy to adjust the error status/message or check placement based on feedback. The stretch goal from PLAN.md (a service-layer test confirming `_run_agent_orchestration`/`_run_rag_retrieval_generation` are never reached) was evaluated and skipped: the guard prevents `process_review` from ever being scheduled, so there's no code path left connecting the endpoint to those functions for a rejected request.

## Known limitations / out of scope
- `check_has_ingested_sources` checks for **row existence**, not content quality — an `IngestedSource` row with `chunk_count=0` from a failed/partial ingestion would still pass the guard. This matches the "ingestion fails and no sources are produced" edge case already noted in `PLAN.md`; fixing it would mean checking `chunk_count > 0` instead, which felt like scope creep beyond the issue's "zero ingested documents" framing. Flagging in case reviewers feel otherwise.
- `create_review_endpoint` does not verify that `data.profile_id` belongs to `current_user` before creating a review — this is pre-existing behavior unrelated to issue #88, not something introduced by this PR, but noted here since it's adjacent code.
