### PR TITLE
fix(agent): isolate state between reviews

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -36,3 +36,48 @@ I reproduced the issue by running two reviews for the same profile through one o
 
 **Blockers or open questions:**
 I need to confirm whether one `Orchestrator` instance can serve concurrent reviews and whether Redis session state is intended to support resuming an interrupted review. The planned review-local context avoids cross-review cache races without changing that future persistence contract.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+I implemented review-local memoization in the agent orchestrator so cached tool results
+cannot leak between reviews. Each review now replaces its persisted session data instead
+of merging with older results, and the focused regression suite has seven passing tests
+covering repeated reviews, empty plans, profile isolation, same-review memoization, and
+failed reruns.
+
+**Next steps:**
+Review the final diff, run the focused tests and required repository checks again, document
+the pre-existing failures, and prepare the change for peer or mentor feedback before
+submitting the pull request.
+
+**Blockers:**
+The baseline repository had 182 pre-existing lint errors; after this change it has 179,
+with the touched files passing Ruff and Black. The full unit suite went from 54 failures
+and 31 errors to 52 failures and 31 errors because the two Issue #43 reproductions now
+pass. The remaining failures are outside this issue.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** Pending final PR submission
+
+**Branch:** `fix/43-clear-agent-session`
+
+**What you built:**
+The orchestrator now creates a review-local memoization context and persists only the
+current review's results. This prevents earlier tool output from leaking into later
+reviews while preserving duplicate-call caching inside a single review.
+
+**Tests added or updated:**
+`tests/unit/test_orchestrator_session_isolation.py` covers fresh state between reviews,
+replacement of persisted state, empty plans, profile isolation, same-review memoization,
+and failed reruns.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+(No new failures compared with the documented baseline.)
+
+**Draft PR feedback received from:** Pending peer or mentor review

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -63,7 +63,7 @@ pass. The remaining failures are outside this issue.
 
 ### Check-in 2 (end of week)
 
-**PR link:** Pending final PR submission
+**PR link:** https://github.com/ascherj/pathreview/pull/499
 
 **Branch:** `fix/43-clear-agent-session`
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,24 @@
+## Week 7 — Issue selection
+
+**Issue link:** [Issue #43](https://github.com/ascherj/pathreview/issues/43)
+
+**Issue title:** Agent session state is not cleared between reviews for the same user
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+PathReview stores agent session data in Redis through `agent/memory/session_store.py`, and the issue reports that the stored state can carry over when the same user requests another portfolio review. If the user updates their portfolio, stale results from the earlier review may be reused instead of every relevant tool analyzing the new information. The session store is connected to the review workflow in `agent/orchestrator.py`, so the fix will need to ensure that cached state is scoped to one review or cleared at the correct point in the workflow. A successful fix will make a second review use the updated portfolio data and will include tests proving that results from the first review do not leak into it.
+
+**Is this right for me?:**
+1. I can explain the issues in my own words
+2. This is my first open source contribution. So I'm choosing Tier 1.
+3. I have found and read the relevant code and test file
+4. The scope is realistic, and I'm fine with others working on this as well
+
+All boxes checked!
+
+**Branch name:** `fix/43-clear-agent-session`
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -22,3 +22,17 @@ All boxes checked!
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [93b87f1 - reproduce stale agent state between reviews](https://github.com/rueiliu/pathreview/commit/93b87f16ed46cd12d3c0d860f7953a7846aab711)
+
+**Reproduction summary:**
+I reproduced the issue by running two reviews for the same profile through one orchestrator with different portfolio data. The second review reused the first review's cached `market_analyzer` result, and its persisted session also retained a `readme_scorer` result that was no longer part of the updated review.
+
+**PLAN.md link:** [Solution plan](https://github.com/rueiliu/pathreview/blob/fix/43-clear-agent-session/PLAN.md)
+
+**Walkthrough video (recommended):** Not recorded
+
+**Blockers or open questions:**
+I need to confirm whether one `Orchestrator` instance can serve concurrent reviews and whether Redis session state is intended to support resuming an interrupted review. The planned review-local context avoids cross-review cache races without changing that future persistence contract.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -55,9 +55,10 @@ submitting the pull request.
 
 **Blockers:**
 The baseline repository had 182 pre-existing lint errors; after this change it has 179,
-with the touched files passing Ruff and Black. The full unit suite went from 54 failures
-and 31 errors to 52 failures and 31 errors because the two Issue #43 reproductions now
-pass. The remaining failures are outside this issue.
+with the touched files passing Ruff and Black. `make test-unit` reports the same 53
+pre-existing failures before and after this change (baseline: 53 failed / 375 passed;
+after: 53 failed / 382 passed, 0 errors) — this change adds 7 new passing isolation tests
+and introduces no new failures. The remaining failures are outside this issue.
 
 ---
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -82,3 +82,70 @@ and failed reruns.
 (No new failures compared with the documented baseline.)
 
 **Draft PR feedback received from:** Pending peer or mentor review
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes [x] No — still awaiting review
+
+**Summary of feedback:**
+No reviewer or maintainer feedback was available for PR #499 as of August 7, 2026.
+This is expected for the Summer 2026 course, where reviewer feedback is not part of
+the project. The PR remains open and mergeable, with no review comments or requested
+changes.
+
+**How you responded:**
+Not applicable because no feedback was received. I kept the branch and journal ready
+for review and documented the validation results and pre-existing repository failures
+clearly in the PR description so a future reviewer can evaluate the change efficiently.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The hardest part was defining the correct lifetime for agent state. The visible symptom
+looked like a simple cache-clearing bug, but resetting the orchestrator's shared context
+at the start of `run()` could still create a race if one orchestrator handled concurrent
+reviews. Redis added a second failure path because merging a new result into the stored
+session preserved tools that were no longer scheduled. I had to separate memoization
+that is useful inside one review from state that must never cross a review boundary, then
+test both behaviors without expanding the issue into a redesign of tool dependencies.
+
+**What did you learn about working in a large codebase?**
+I learned that a small behavioral bug can cross several ownership boundaries. To trace
+this issue, I followed data from `Orchestrator.run()` through `ContextManager` and the
+Redis-backed `SessionStore`, then checked how the existing tests and service layer used
+those components. I also learned to establish a baseline before judging repository-wide
+checks: the project already had 182 lint errors and 53 unit-test failures, so the useful
+comparison was whether my touched files passed and whether my change introduced any new
+failures. Contributing to someone else's codebase required preserving existing contracts,
+keeping the patch focused, and documenting evidence instead of assuming every failing
+check was caused by my work.
+
+**How did AI tools help — and where did they fall short?**
+AI tools helped me navigate unfamiliar modules, trace the two stale-state paths, turn the
+bug report into a reproducible test, and enumerate edge cases such as identical reviews,
+empty plans, different profiles, same-review duplicate calls, and a failed rerun replacing
+an older success. They were also useful for reviewing the diff and organizing the plan and
+PR notes. However, AI could not decide the intended session-lifecycle contract from the
+code alone or prove that a broad test failure was pre-existing. I still had to compare the
+baseline with the changed branch, inspect the actual call flow, and choose a review-local
+context rather than a superficially simpler shared reset.
+
+**What would you do differently if you started over?**
+I would run and record the full lint and unit-test baseline immediately after setup, before
+writing the reproduction. That would make later validation faster and avoid spending time
+investigating unrelated failures. I would also diagram the lifetime of the orchestrator,
+in-memory context, and Redis session earlier, because the key design question was ownership
+of state rather than the mechanics of clearing a dictionary. With that model in place, I
+could move more directly from the reproduction to the review-local solution and focused
+regression matrix.
+
+**What are you most proud of from this module?**
+I am most proud that the final seven-test regression suite protects both sides of the
+intended cache boundary. It proves that separate reviews start from fresh state while also
+confirming that duplicate work is still memoized within a single review. That gives future
+maintainers a precise, executable description of the bug and makes the contribution useful
+even before the PR is reviewed or merged.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,107 @@
+## Solution plan
+
+**Issue:** [Agent session state is not cleared between reviews for the same user](https://github.com/ascherj/pathreview/issues/43)
+
+### Understand
+
+`Orchestrator` creates one `ContextManager` in `agent/orchestrator.py` and reuses it
+across every call to `run()`. Because `_execute_tool()` checks that shared context
+before calling a tool, a later review can reuse a result cached during an earlier
+review. The reproduction makes this visible with `market_analyzer`, whose plan input
+is currently the same empty `detected_skills` dictionary on both runs: the second
+review reports the first execution's result and never calls the tool again.
+
+There is a second stale-state path in the Redis-backed session data. `run()` loads
+the dictionary stored under the profile ID, merges the current results into that
+dictionary, and writes it back. If the updated portfolio no longer schedules a tool,
+that tool's result from the earlier review remains in the persisted session.
+
+The expected behavior is for each new review to begin with fresh in-memory and
+persisted tool state, while still allowing memoization among repeated tool calls
+inside that one review. The actual behavior lets results outlive the review that
+created them.
+
+### Map
+
+- `agent/orchestrator.py`
+  - `Orchestrator.__init__()` creates the long-lived `ContextManager`.
+  - `Orchestrator.run()` loads and merges stored state by `profile_id`.
+  - `Orchestrator._execute_tool()` reads and writes the long-lived memoization cache.
+- `agent/memory/context_manager.py`
+  - `ContextManager.results` owns the in-memory tool-result cache and currently has
+    no review boundary or reset operation.
+- `agent/memory/session_store.py`
+  - `SessionStore.get()`, `set()`, and `delete()` operate on the
+    `session:{profile_id}` Redis key. The store already supports replacement and
+    deletion, but the orchestrator currently supplies a merged historical value.
+- `tests/unit/test_orchestrator_session_isolation.py`
+  - Contains the failing reproduction and will become the regression suite for
+    sequential review isolation.
+
+Expected implementation files: `agent/orchestrator.py`,
+`agent/memory/context_manager.py`, and
+`tests/unit/test_orchestrator_session_isolation.py`. I will change
+`agent/memory/session_store.py` only if the implementation needs an explicit
+replace/clear contract that cannot be expressed safely with its existing methods.
+
+### Plan
+
+1. Give each `Orchestrator.run()` call its own `ContextManager`, and pass that
+   review-local context through tool execution so memoization still works within a
+   review without leaking across reviews.
+2. Stop loading and merging the previous profile session when a new review begins.
+   Persist only the current review's `results` so tools omitted from the new plan are
+   removed from Redis state.
+3. Keep the no-Redis path working and make Redis cleanup/replacement failures
+   observable without allowing old in-memory results to be reused.
+4. Update the reproduction tests to verify fresh execution, replacement of stored
+   state, isolation between different profiles, empty plans, and preservation of
+   same-review memoization; then run the focused tests and the broader unit suite.
+
+### Inputs & outputs
+
+The fix takes the existing `profile_id`, `profile_data`, tool registry, and optional
+`SessionStore` passed to `Orchestrator.run()`. No API request or response schema
+should change.
+
+For each call, the orchestrator should produce `tool_results` and `cached_results`
+derived only from that call's execution plan and inputs. Redis should contain only
+that review's current tool results under the profile session key. A second review
+must invoke its relevant tools again even when a tool receives the same hashed input
+as it did during the first review.
+
+### Risks & unknowns
+
+- Moving cache ownership in `agent/orchestrator.py` could accidentally disable useful
+  memoization inside a single review. A test must call the same tool twice within one
+  run and confirm that only the duplicate call is cached.
+- Resetting a shared `self.context_manager` at the start of `run()` would be unsafe
+  if one `Orchestrator` instance handles concurrent reviews. A review-local context
+  avoids that race, but I still need to confirm how orchestrators are instantiated
+  in the eventual API integration.
+- `SessionStore` currently catches and logs Redis errors rather than surfacing them.
+  The fix must not treat a failed `delete()` as proof that old state is gone; writing
+  the current results as a replacement is safer than relying on deletion alone.
+- `market_analyzer` currently receives an empty `detected_skills` input instead of
+  prior tool output. That data-flow issue makes the cache bug easy to reproduce but
+  is outside issue #43; the session-isolation fix should not expand into redesigning
+  agent tool dependencies.
+- The production review service currently contains a placeholder
+  `_run_agent_orchestration()` implementation, so the regression belongs at the
+  orchestrator unit boundary until the API is wired to the real agent.
+
+### Edge cases
+
+- Two consecutive reviews for the same profile have identical inputs: tools should
+  still rerun because they belong to distinct reviews.
+- The second review removes a source, so a previously scheduled tool is absent: its
+  old result must not remain in persisted or returned state.
+- A review has an empty execution plan: returned caches and persisted current state
+  should be empty rather than preserving the prior review.
+- No `SessionStore` is configured: review-local in-memory isolation must still work.
+- Redis `get`, `delete`, or `set` fails: the current review should not fall back to
+  an earlier review's in-memory result.
+- Different profiles are reviewed sequentially or concurrently by one orchestrator:
+  neither profile may see the other's cached tool results.
+- A tool fails during the second review: the current error result should replace any
+  older successful result for that tool instead of merging with it.

--- a/agent/orchestrator.py
+++ b/agent/orchestrator.py
@@ -1,12 +1,13 @@
 """Plan-execute orchestrator for agent tools."""
 
 import time
-import structlog
-from typing import Optional
+from typing import Any
 
-from .memory.session_store import SessionStore
-from .memory.context_manager import ContextManager
+import structlog
+
 from .error_handling import retry_with_backoff
+from .memory.context_manager import ContextManager
+from .memory.session_store import SessionStore
 
 logger = structlog.get_logger()
 
@@ -14,8 +15,12 @@ logger = structlog.get_logger()
 class Orchestrator:
     """Orchestrate tool execution with planning and memoization."""
 
-    def __init__(self, tools: dict, session_store: Optional[SessionStore] = None,
-                 tool_timeout: float = 30.0):
+    def __init__(
+        self,
+        tools: dict[str, Any],
+        session_store: SessionStore | None = None,
+        tool_timeout: float = 30.0,
+    ) -> None:
         """Initialize orchestrator.
 
         Args:
@@ -26,9 +31,8 @@ class Orchestrator:
         self.tools = tools
         self.session_store = session_store
         self.tool_timeout = tool_timeout
-        self.context_manager = ContextManager()
 
-    def run(self, profile_id: str, profile_data: dict) -> dict:
+    def run(self, profile_id: str, profile_data: dict[str, Any]) -> dict[str, Any]:
         """Execute analysis plan for a profile.
 
         Args:
@@ -40,20 +44,19 @@ class Orchestrator:
         """
         logger.info("orchestrator_start", profile_id=profile_id)
 
+        # Memoized tool results belong to one review only. Keeping this context
+        # local also prevents concurrent runs from sharing cached results.
+        context_manager = ContextManager()
+
         # Build execution plan
         plan = self._build_plan(profile_data)
 
-        # Load previous session state if available
-        session_state = {}
-        if self.session_store:
-            session_state = self.session_store.get(profile_id) or {}
-
         # Execute plan
-        results = {}
+        results: dict[str, Any] = {}
         for tool_name, tool_input in plan:
             try:
-                result = self._execute_tool(tool_name, tool_input)
-                results[tool_name] = result.data if hasattr(result, 'data') else result
+                result = self._execute_tool(tool_name, tool_input, context_manager)
+                results[tool_name] = result.data if hasattr(result, "data") else result
 
                 logger.info("tool_executed", tool=tool_name, success=True)
 
@@ -63,19 +66,24 @@ class Orchestrator:
 
         # Persist state
         if self.session_store:
-            session_state.update(results)
-            self.session_store.set(profile_id, session_state)
+            self.session_store.set(profile_id, results)
 
-        logger.info("orchestrator_complete", profile_id=profile_id,
-                   tools_executed=len(results))
+        logger.info(
+            "orchestrator_complete",
+            profile_id=profile_id,
+            tools_executed=len(results),
+        )
 
         return {
             "profile_id": profile_id,
             "tool_results": results,
-            "cached_results": self.context_manager.get_all_results()
+            "cached_results": context_manager.get_all_results(),
         }
 
-    def _build_plan(self, profile_data: dict) -> list[tuple[str, dict]]:
+    def _build_plan(
+        self,
+        profile_data: dict[str, Any],
+    ) -> list[tuple[str, dict[str, Any]]]:
         """Build execution plan based on available data.
 
         Args:
@@ -84,61 +92,64 @@ class Orchestrator:
         Returns:
             List of (tool_name, tool_input) tuples
         """
-        plan = []
+        plan: list[tuple[str, dict[str, Any]]] = []
 
         # Conditionally add GitHub tool
         if profile_data.get("github_username"):
             for project in profile_data.get("projects", []):
                 if project.get("github_repo"):
-                    plan.append((
-                        "github_tool",
-                        {
-                            "github_username": profile_data["github_username"],
-                            "repo_name": project["github_repo"]
-                        }
-                    ))
+                    plan.append(
+                        (
+                            "github_tool",
+                            {
+                                "github_username": profile_data["github_username"],
+                                "repo_name": project["github_repo"],
+                            },
+                        )
+                    )
                     break  # Only process first repo for now
 
         # Tech detector (if files available)
         if profile_data.get("files"):
-            plan.append((
-                "tech_detector",
-                {"files": profile_data["files"]}
-            ))
+            plan.append(("tech_detector", {"files": profile_data["files"]}))
 
         # README scorer
         if profile_data.get("readme_content"):
-            plan.append((
-                "readme_scorer",
-                {"readme_content": profile_data["readme_content"]}
-            ))
+            plan.append(("readme_scorer", {"readme_content": profile_data["readme_content"]}))
 
         # Skill extractor
         if profile_data.get("resume_text"):
-            plan.append((
-                "skill_extractor",
-                {
-                    "resume_text": profile_data["resume_text"],
-                    "repo_metadata": profile_data.get("repo_metadata", {})
-                }
-            ))
+            plan.append(
+                (
+                    "skill_extractor",
+                    {
+                        "resume_text": profile_data["resume_text"],
+                        "repo_metadata": profile_data.get("repo_metadata", {}),
+                    },
+                )
+            )
 
         # Market analyzer (if skills detected)
         if plan:  # Only if other tools executed
-            plan.append((
-                "market_analyzer",
-                {"detected_skills": {}}  # Will be populated by context
-            ))
+            plan.append(
+                ("market_analyzer", {"detected_skills": {}})  # Will be populated by context
+            )
 
         logger.info("plan_built", plan_size=len(plan))
         return plan
 
-    def _execute_tool(self, tool_name: str, tool_input: dict):
+    def _execute_tool(
+        self,
+        tool_name: str,
+        tool_input: dict[str, Any],
+        context_manager: ContextManager,
+    ) -> Any:
         """Execute a single tool with retry and memoization.
 
         Args:
             tool_name: Name of tool to execute
             tool_input: Input dict for tool
+            context_manager: Review-local memoization context
 
         Returns:
             Tool result
@@ -148,9 +159,9 @@ class Orchestrator:
 
         # Check context cache
         input_hash = ContextManager.hash_input(tool_input)
-        cached_result = self.context_manager.get_tool_result(tool_name, input_hash)
+        cached_result = context_manager.get_tool_result(tool_name, input_hash)
 
-        if cached_result:
+        if cached_result is not None:
             logger.info("tool_cache_hit", tool=tool_name)
             return cached_result
 
@@ -161,7 +172,7 @@ class Orchestrator:
             result = self._execute_with_timeout(tool, tool_input)
 
             # Cache result
-            self.context_manager.store_tool_result(tool_name, input_hash, result)
+            context_manager.store_tool_result(tool_name, input_hash, result)
 
             return result
 
@@ -172,7 +183,12 @@ class Orchestrator:
             logger.error("tool_execution_error", tool=tool_name, error=str(e))
             raise
 
-    def _execute_with_timeout(self, tool, tool_input: dict, timeout: Optional[float] = None):
+    def _execute_with_timeout(
+        self,
+        tool: Any,
+        tool_input: dict[str, Any],
+        timeout: float | None = None,
+    ) -> Any:
         """Execute tool with timeout.
 
         Args:
@@ -189,7 +205,7 @@ class Orchestrator:
         timeout = timeout or self.tool_timeout
 
         @retry_with_backoff(max_retries=2, backoff_factor=1.5)
-        def _execute():
+        def _execute() -> Any:
             return tool.execute(tool_input)
 
         start = time.time()

--- a/tests/unit/test_orchestrator_session_isolation.py
+++ b/tests/unit/test_orchestrator_session_isolation.py
@@ -24,13 +24,43 @@ class RecordingTool:
         )
 
 
+class FailAfterFirstTool(RecordingTool):
+    """Succeed once, then fail so replacement of an old success is testable."""
+
+    def execute(self, input_data: dict) -> ToolResult:
+        self.calls += 1
+        if self.calls > 1:
+            raise RuntimeError("current review failed")
+        return ToolResult(
+            success=True,
+            data={"execution": self.calls, "input": deepcopy(input_data)},
+        )
+
+
+class SingleToolPlanOrchestrator(Orchestrator):
+    """Build a controlled one-tool plan for cache-boundary tests."""
+
+    def _build_plan(self, profile_data: dict) -> list[tuple[str, dict]]:
+        return [("review_tool", deepcopy(profile_data))]
+
+
+class DuplicateToolPlanOrchestrator(Orchestrator):
+    """Schedule the same call twice inside one review."""
+
+    def _build_plan(self, profile_data: dict) -> list[tuple[str, dict]]:
+        tool_input = deepcopy(profile_data)
+        return [("review_tool", tool_input), ("review_tool", tool_input)]
+
+
 class FakeSessionStore(SessionStore):
     """In-memory stand-in with the same interface as the Redis session store."""
 
     def __init__(self) -> None:
         self.sessions: dict[str, dict] = {}
+        self.get_calls = 0
 
     def get(self, session_id: str) -> dict | None:
+        self.get_calls += 1
         state = self.sessions.get(session_id)
         return deepcopy(state) if state is not None else None
 
@@ -86,3 +116,89 @@ def test_second_review_replaces_persisted_state_instead_of_merging_old_results()
         "skill_extractor",
         "market_analyzer",
     }
+    assert store.get_calls == 0
+
+
+@pytest.mark.unit
+def test_identical_reviews_without_session_store_do_not_share_cache() -> None:
+    """Each run should reexecute identical tool inputs without Redis configured."""
+    review_tool = RecordingTool("review_tool")
+    orchestrator = SingleToolPlanOrchestrator(tools={"review_tool": review_tool})
+
+    first_review = orchestrator.run("profile-123", {"resume_text": "Skills: Python"})
+    second_review = orchestrator.run("profile-123", {"resume_text": "Skills: Python"})
+
+    assert review_tool.calls == 2
+    assert first_review["tool_results"]["review_tool"]["execution"] == 1
+    assert second_review["tool_results"]["review_tool"]["execution"] == 2
+    assert len(second_review["cached_results"]) == 1
+
+
+@pytest.mark.unit
+def test_same_tool_call_is_memoized_within_one_review() -> None:
+    """Review-local isolation must preserve useful same-review memoization."""
+    review_tool = RecordingTool("review_tool")
+    orchestrator = DuplicateToolPlanOrchestrator(tools={"review_tool": review_tool})
+
+    review = orchestrator.run("profile-123", {"resume_text": "Skills: Python"})
+
+    assert review_tool.calls == 1
+    assert review["tool_results"]["review_tool"]["execution"] == 1
+    assert len(review["cached_results"]) == 1
+
+
+@pytest.mark.unit
+def test_empty_review_replaces_old_persisted_results_with_empty_state() -> None:
+    """An empty plan should not retain tools produced by an earlier review."""
+    readme_scorer = RecordingTool("readme_scorer")
+    market_analyzer = RecordingTool("market_analyzer")
+    store = FakeSessionStore()
+    orchestrator = Orchestrator(
+        tools={
+            "readme_scorer": readme_scorer,
+            "market_analyzer": market_analyzer,
+        },
+        session_store=store,
+    )
+
+    orchestrator.run("profile-123", {"readme_content": "# Original project"})
+    empty_review = orchestrator.run("profile-123", {})
+
+    assert empty_review["tool_results"] == {}
+    assert empty_review["cached_results"] == {}
+    assert store.sessions["profile-123"] == {}
+
+
+@pytest.mark.unit
+def test_different_profiles_with_identical_inputs_do_not_share_cache() -> None:
+    """One orchestrator instance must isolate sequential reviews by profile."""
+    review_tool = RecordingTool("review_tool")
+    orchestrator = SingleToolPlanOrchestrator(tools={"review_tool": review_tool})
+
+    first_profile = orchestrator.run("profile-a", {"resume_text": "Skills: Python"})
+    second_profile = orchestrator.run("profile-b", {"resume_text": "Skills: Python"})
+
+    assert review_tool.calls == 2
+    assert first_profile["tool_results"]["review_tool"]["execution"] == 1
+    assert second_profile["tool_results"]["review_tool"]["execution"] == 2
+
+
+@pytest.mark.unit
+def test_current_failure_replaces_older_successful_persisted_result() -> None:
+    """A failed rerun should not leave an earlier successful result in storage."""
+    review_tool = FailAfterFirstTool("review_tool")
+    store = FakeSessionStore()
+    orchestrator = SingleToolPlanOrchestrator(
+        tools={"review_tool": review_tool},
+        session_store=store,
+    )
+
+    orchestrator.run("profile-123", {"resume_text": "Original"})
+    failed_review = orchestrator.run("profile-123", {"resume_text": "Updated"})
+
+    expected_failure = {
+        "error": "current review failed",
+        "success": False,
+    }
+    assert failed_review["tool_results"]["review_tool"] == expected_failure
+    assert store.sessions["profile-123"]["review_tool"] == expected_failure

--- a/tests/unit/test_orchestrator_session_isolation.py
+++ b/tests/unit/test_orchestrator_session_isolation.py
@@ -1,0 +1,88 @@
+"""Regression tests reproducing stale agent state across portfolio reviews."""
+
+from copy import deepcopy
+
+import pytest
+
+from agent.memory.session_store import SessionStore
+from agent.orchestrator import Orchestrator
+from agent.tools.base import ToolResult
+
+
+class RecordingTool:
+    """Return the execution number so cache reuse is visible in assertions."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.calls = 0
+
+    def execute(self, input_data: dict) -> ToolResult:
+        self.calls += 1
+        return ToolResult(
+            success=True,
+            data={"execution": self.calls, "input": deepcopy(input_data)},
+        )
+
+
+class FakeSessionStore(SessionStore):
+    """In-memory stand-in with the same interface as the Redis session store."""
+
+    def __init__(self) -> None:
+        self.sessions: dict[str, dict] = {}
+
+    def get(self, session_id: str) -> dict | None:
+        state = self.sessions.get(session_id)
+        return deepcopy(state) if state is not None else None
+
+    def set(self, session_id: str, data: dict, ttl_seconds: int = 3600) -> None:
+        self.sessions[session_id] = deepcopy(data)
+
+    def delete(self, session_id: str) -> None:
+        self.sessions.pop(session_id, None)
+
+
+@pytest.mark.unit
+def test_second_review_reexecutes_tools_instead_of_reusing_first_review_cache() -> None:
+    """A changed portfolio should start a fresh tool-execution session."""
+    skill_extractor = RecordingTool("skill_extractor")
+    market_analyzer = RecordingTool("market_analyzer")
+    store = FakeSessionStore()
+    orchestrator = Orchestrator(
+        tools={
+            "skill_extractor": skill_extractor,
+            "market_analyzer": market_analyzer,
+        },
+        session_store=store,
+    )
+
+    orchestrator.run("profile-123", {"resume_text": "Skills: Python"})
+    second_review = orchestrator.run("profile-123", {"resume_text": "Skills: Rust"})
+
+    assert skill_extractor.calls == 2
+    assert market_analyzer.calls == 2
+    assert second_review["tool_results"]["market_analyzer"]["execution"] == 2
+
+
+@pytest.mark.unit
+def test_second_review_replaces_persisted_state_instead_of_merging_old_results() -> None:
+    """Tools omitted from an updated portfolio must not remain in Redis state."""
+    readme_scorer = RecordingTool("readme_scorer")
+    skill_extractor = RecordingTool("skill_extractor")
+    market_analyzer = RecordingTool("market_analyzer")
+    store = FakeSessionStore()
+    orchestrator = Orchestrator(
+        tools={
+            "readme_scorer": readme_scorer,
+            "skill_extractor": skill_extractor,
+            "market_analyzer": market_analyzer,
+        },
+        session_store=store,
+    )
+
+    orchestrator.run("profile-123", {"readme_content": "# Original project"})
+    orchestrator.run("profile-123", {"resume_text": "Updated portfolio"})
+
+    assert set(store.sessions["profile-123"]) == {
+        "skill_extractor",
+        "market_analyzer",
+    }


### PR DESCRIPTION
## Summary

PathReview reused in-memory and Redis-backed tool results across separate portfolio reviews. This change scopes memoization to a single `Orchestrator.run()` call and replaces persisted session data with only the current review's results, so updated portfolios are always analyzed with fresh state.

## Issue

Closes #43

## Changes

- Create a review-local `ContextManager` for every orchestrator run.
- Pass the local context through tool execution so duplicate calls can still be memoized within one review.
- Stop loading and merging historical session data before a new review.
- Replace the stored profile session with only the current review's results.
- Expand the regression suite to cover repeated reviews, identical inputs, empty plans, different profiles, same-review memoization, and failed reruns.

## Testing

- [ ] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`)
- [ ] Linter passes (`make lint`)
- [ ] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes

Validation performed:

- `pytest tests/unit/test_orchestrator_session_isolation.py -v`: 7 passed.
- Ruff and Black checks pass for the changed Python files.
- Targeted mypy check passes for `agent/orchestrator.py` with imported modules skipped.
- `make check`: 179 pre-existing lint errors; the pre-change baseline was 182.
- `make test-unit: 53 failures / 382 passed / 0 errors; the pre-change baseline was 53 failures / 375 passed. This change adds 7 new passing isolation tests and introduces no new failures; the remaining pre-existing failures are unrelated to this change.
- 
Manual verification:

1. Run two reviews through one orchestrator instance for the same profile.
2. Change or remove portfolio inputs before the second run.
3. Confirm relevant tools execute again and omitted tool results are absent from the returned and persisted state.
4. Schedule an identical tool call twice within one review and confirm it executes only once.

## Screenshots / Demo

N/A - this is agent state-management behavior verified through unit tests rather than a visible UI change.

## Notes for Reviewers

The repository had broad lint, type-check, and unit-test failures before this work began. This contribution does not touch those failing modules and introduces no new global failures. The focused Issue #43 suite, changed-file Ruff and Black checks, and targeted orchestrator type check all pass.
