### PR TITLE
test: capture structlog output in pytest caplog (#159)

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -131,7 +131,7 @@ baseline.)
 
 ### Check-in 2 (end of week)
 
-**PR link:** _<!-- PASTE the live PR URL here once opened, e.g. https://github.com/ascherj/pathreview/pull/NNN -->_
+**PR link:** https://github.com/ascherj/pathreview/pull/501
 
 **Branch:** `fix/159-structlog-pytest-caplog`
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -50,7 +50,7 @@ changing how logs look in dev/production.
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** _(filled in the follow-up commit once the hash is known)_
+**Reproduction commit link:** https://github.com/NeamenEmun/pathreview/commit/38394f9d31bd27a4016c0e90ca899b314b413a11
 
 **Reproduction summary:**
 Ran `pytest tests/unit/test_batch_processor.py -k empty -v` in my local venv.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -45,3 +45,43 @@ changing how logs look in dev/production.
   knowledge — while staying small in surface area.
 - **Real infrastructure fix, not a fixture tweak:** it repairs test capture for
   the entire suite, which makes for a substantive Week 10 reflection.
+
+---
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** _(filled in the follow-up commit once the hash is known)_
+
+**Reproduction summary:**
+Ran `pytest tests/unit/test_batch_processor.py -k empty -v` in my local venv.
+`test_empty_chunks_list_returns_empty` fails because `caplog.text` is the empty
+string — yet the warning **is** emitted: it shows under pytest's *Captured stdout*
+(`[warning  ] Empty chunks list provided to BatchEmbeddingProcessor`), not under
+*Captured log*. That proves structlog writes to stdout and never reaches the
+stdlib `logging` pipeline that `caplog` hooks into. Tracing it, I found
+`core/logging.py::configure_logging()` — the only code that wires structlog into
+stdlib logging — is called **only in `scripts/seed_db.py`**, never in the app
+under test or the test suite, so during tests structlog runs with its default
+stdout logger.
+
+Observed failure:
+```
+FAILED tests/unit/test_batch_processor.py::...::test_empty_chunks_list_returns_empty
+E   AssertionError: assert ('Empty chunks list' in '' or False)
+E    +  where '' = <LogCaptureFixture>.text
+--- Captured stdout call ---
+2026-07-21 20:05:18 [warning  ] Empty chunks list provided to BatchEmbeddingProcessor
+1 failed, 10 passed
+```
+
+**PLAN.md link:** https://github.com/NeamenEmun/pathreview/blob/fix/159-structlog-pytest-caplog/PLAN.md
+
+**Walkthrough video (recommended):** _(not recorded)_
+
+**Blockers or open questions:**
+- Fix test-side only (autouse fixture in `tests/conftest.py`) vs. also making
+  `configure_logging()` caplog-compatible and calling it at app startup. Leaning
+  test-side to keep the change minimal, pending the issue #159 discussion.
+- Need to confirm empirically that the import-time bound logger in
+  `ingestion/embeddings/batch_processor.py` picks up the test fixture's
+  reconfiguration (depends on `cache_logger_on_first_use=False`).

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -85,3 +85,92 @@ E    +  where '' = <LogCaptureFixture>.text
 - Need to confirm empirically that the import-time bound logger in
   `ingestion/embeddings/batch_processor.py` picks up the test fixture's
   reconfiguration (depends on `cache_logger_on_first_use=False`).
+
+---
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Working from `PLAN.md`, I completed the core sub-tasks:
+- **Sub-task 1 — lock in the reproduction (done Week 8):** confirmed
+  `test_empty_chunks_list_returns_empty` fails with an empty `caplog`, while the
+  warning shows under *Captured stdout*.
+- **Sub-task 2 — add the `autouse` fixture in `tests/conftest.py` (done):**
+  `structlog_to_stdlib_logging` reconfigures structlog to end its processor chain
+  with `structlog.stdlib.render_to_log_kwargs`, using
+  `logger_factory=structlog.stdlib.LoggerFactory()`,
+  `wrapper_class=structlog.stdlib.BoundLogger`, and
+  `cache_logger_on_first_use=False`, then calls `structlog.reset_defaults()` on
+  teardown.
+- **Sub-task 3 — level/propagation (done):** confirmed warning/error records are
+  captured at the default root level; info-level assertions use
+  `caplog.set_level(logging.INFO)` (the idiomatic pytest approach), demonstrated
+  in the new tests.
+- **Sub-task 5 — decide the config home (done):** chose the test-scoped
+  `conftest.py` fixture over modifying `configure_logging()`, so dev/prod log
+  rendering is untouched. Also empirically confirmed the Week 8 open question:
+  the import-time bound logger in `batch_processor.py` **does** pick up the
+  fixture config because `cache_logger_on_first_use=False` makes the lazy proxy
+  re-read configuration per call.
+
+**Next steps:**
+- Finish sub-task 4 (verify against the full unit suite) and write dedicated
+  regression tests in `tests/unit/test_logging_caplog.py`.
+- Run `make check` and `make test-unit`, record the pre-existing-failure
+  baseline, and confirm my changes add no new failures.
+- Open the PR against `ascherj/pathreview`, request peer review, and finalize.
+
+**Blockers:**
+None. (The codebase has many pre-existing `make check`/`make test-unit`
+failures unrelated to this issue — see Check-in 2 for how I handled the
+baseline.)
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** _<!-- PASTE the live PR URL here once opened, e.g. https://github.com/ascherj/pathreview/pull/NNN -->_
+
+**Branch:** `fix/159-structlog-pytest-caplog`
+
+**What you built:**
+An `autouse` pytest fixture (`structlog_to_stdlib_logging` in
+`tests/conftest.py`) that reconfigures structlog during the test run to route
+events through the standard-library `logging` pipeline via
+`structlog.stdlib.render_to_log_kwargs` + `LoggerFactory`, with
+`cache_logger_on_first_use=False`. This produces real `LogRecord`s that pytest's
+`caplog` can capture, so log-based assertions work suite-wide again, and it
+restores structlog defaults on teardown so no state leaks between tests. No
+application code changes — dev (`ConsoleRenderer`) and prod (`JSONRenderer`)
+output are unaffected.
+
+**Tests added or updated:**
+- `tests/conftest.py` — added the `structlog_to_stdlib_logging` autouse fixture.
+- `tests/unit/test_logging_caplog.py` (new) — regression tests covering: a
+  warning appears in `caplog.text`; the event becomes a `LogRecord` with the
+  correct level; info-level capture after `caplog.set_level(INFO)`; error-level
+  capture; bound structured fields (e.g. `chunk_count=42`) attach to the record
+  without breaking the message; and a logger bound at import time
+  (`BatchEmbeddingProcessor`) is captured — the original issue #159 scenario.
+- `tests/unit/test_batch_processor.py::test_empty_chunks_list_returns_empty` —
+  the pre-existing reproduction test now passes unchanged.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+> **Pre-existing failures (documented per course guidance).** Before making any
+> changes I recorded a baseline on the clean branch: `make test-unit` = **53
+> failed / 375 passed**; `ruff check .` = **182 errors**; `black --check .` = 52
+> files would reformat; `mypy` (scope `api/ core/ ingestion/ rag/ agent/
+> safety/`) = **5 errors** (missing third-party stubs + a numpy/py3.12 stub
+> issue). After my changes: unit tests = **52 failed / 382 passed** — my fix
+> repairs 1 pre-existing failure (`test_empty_chunks_list_returns_empty`) and
+> adds 6 new passing tests, with **zero new failures** (verified by diffing
+> JUnit-XML failure sets before/after). `ruff`/`black`/`mypy` counts are
+> unchanged, and my two touched files pass `ruff` and `black` cleanly. In this
+> codebase with documented pre-existing failures, "passes" means my changes
+> introduce no new failures — confirmed.
+
+**Draft PR feedback received from:** none
+

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,47 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/159
+
+**Issue title:** structlog output is not captured by pytest caplog — log assertions fail suite-wide
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+This project logs through structlog, configured once in `core/logging.py`.
+Any test that wants to assert something was logged uses pytest's built-in
+`caplog` fixture — but `caplog` captures nothing, so every log-based assertion
+fails across the whole test suite. The cause is in `configure_logging()`: the
+processor chain ends in `ConsoleRenderer`/`JSONRenderer`, which turns each event
+into a finished string *before* it reaches the standard-library logging pipeline,
+and `cache_logger_on_first_use=True` freezes the logger so the handler `caplog`
+attaches per-test is never used. A successful fix routes structlog records through
+stdlib logging in a way `caplog` can see (for example a `ProcessorFormatter`-based
+setup plus a test fixture in `tests/conftest.py` that reconfigures structlog and
+disables caching during tests), so log assertions pass suite-wide again without
+changing how logs look in dev/production.
+
+**Branch name:** fix/159-structlog-pytest-caplog
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger
+<!-- To do: comment on issue #159 to claim it, then add name + GitHub username +
+     issue # to the Section 1B tab of the cohort ledger. -->
+
+---
+
+### "Is this right for me?" — scope reasoning
+
+- **Tier fit:** Tier 1, labeled `good first issue`. Appropriate for a first
+  contribution to this codebase.
+- **Scope is contained:** the change centers on logging configuration
+  (`core/logging.py`) plus a shared test fixture (`tests/conftest.py`). No
+  product feature, database, API, or frontend changes.
+- **Clear "done" condition:** success is objectively testable — the log-based
+  assertions that currently fail suite-wide should pass once `caplog` can
+  capture structlog output.
+- **Good learning value:** it requires understanding how structlog bridges to
+  standard-library logging and how pytest captures logs — useful, transferable
+  knowledge — while staying small in surface area.
+- **Real infrastructure fix, not a fixture tweak:** it repairs test capture for
+  the entire suite, which makes for a substantive Week 10 reflection.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -174,3 +174,87 @@ output are unaffected.
 
 **Draft PR feedback received from:** none
 
+---
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No reviewer feedback arrived. I checked PR
+[#501](https://github.com/ascherj/pathreview/pull/501) — no maintainer or peer
+comments, no requested changes, no approval. Reviewer response is not an enabled
+feature for the Summer 2026 cohort, so this is expected rather than a sign the PR
+was overlooked.
+
+**How you responded:**
+No changes were required since no feedback came in. The PR remains open and ready
+for review with `make check`/`make test-unit` documented as introducing no new
+failures. If a reviewer had asked me to move the fix out of `conftest.py` and
+into `core/logging.py` (the alternative I flagged in my PR "Notes for Reviewers"),
+I would have made `configure_logging()` caplog-friendly with a `ProcessorFormatter`
+and called it at app startup, then re-run the baseline diff to prove no
+regressions.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The actual code change was tiny — a single `conftest.py` fixture — but *proving*
+it was safe was the hard part. This repo ships with 53 failing unit tests, 182
+ruff errors, and 5 mypy errors before you touch anything, so "did my change break
+something?" was not a simple green/red question. I had to stash my work, capture a
+clean baseline, then diff failure sets before and after. Worse, my first
+comparison falsely flagged `test_readme_scorer` and `test_bias_detector` as
+regressions — it turned out a nondeterministic "coroutine was never awaited"
+`RuntimeWarning` was being printed mid-line into pytest's `FAILED` summary,
+corrupting my text diff. I only trusted the result once I switched to comparing
+JUnit-XML `<failure>` nodes instead of grepping stdout.
+
+**What did you learn about working in a large codebase?**
+The biggest shift was that "make the test pass" is not the same as "make the right
+change." My reproduction test (`test_empty_chunks_list_returns_empty`) could have
+been forced green a dozen sloppy ways, but the correct fix had to route *all*
+structlog output through stdlib logging without altering how logs render in dev or
+production — so I deliberately kept `core/logging.py` and every `logger.*` call
+site untouched. I also learned to respect state I didn't write: `batch_processor.py`
+binds `logger = structlog.get_logger()` at import time, before any fixture runs,
+and I couldn't assume it would pick up my config — I had to confirm empirically
+that `cache_logger_on_first_use=False` makes structlog's lazy proxy re-read
+configuration per call. In my own projects I'd have just trusted it worked.
+
+**How did AI tools help — and where did they fall short?**
+AI was strongest at tracing the root cause fast — connecting "caplog is empty" to
+"`configure_logging()` is only called in `scripts/seed_db.py`, so structlog falls
+back to its stdout `PrintLogger`" saved me a lot of reading, and it produced the
+exact `render_to_log_kwargs` + `LoggerFactory` + `BoundLogger` recipe I needed. It
+also structured the tedious safety work: setting up the venv, capturing baselines,
+and the JUnit-XML diff. Where it fell short was judgment under noisy signals — it
+initially reported false regressions from the polluted `FAILED` lines, and it
+can't authenticate to GitHub, so I had to open the PR myself. The lesson was that
+AI accelerates the mechanics but I still own verifying that its confident-sounding
+output is actually true.
+
+**What would you do differently if you started over?**
+I'd establish the pre-existing-failure baseline in Week 8 during reproduction,
+not in Week 9 mid-implementation — discovering 53 failing tests while trying to
+validate my own change made it briefly unclear whether I'd broken the suite. I'd
+also decide the scope question (test-only fixture vs. modifying
+`configure_logging()`) earlier and write it down as a decision rather than
+carrying it as an open "blocker" across two weeks. Finally, I'd have written the
+dedicated `test_logging_caplog.py` regression tests first, so my definition of
+"fixed" was concrete before I started changing configuration.
+
+**What are you most proud of?**
+Not the fix itself — it's four lines of config — but the rigor I put behind
+claiming it was safe. In a codebase this broken it would have been easy to check
+the "make test-unit passes" box loosely, but I actually measured 53→52 failures
+with 6 new passing tests and *zero* new failures, verified with a method immune to
+the stdout noise, and documented the exact before/after numbers in my PR and
+journal. Turning "I think it's fine" into "here is the evidence it's fine" is the
+part I'd be comfortable defending to a real maintainer.
+
+

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,115 @@
+## Solution plan
+
+**Issue:** structlog output is not captured by pytest caplog — log assertions fail suite-wide
+— https://github.com/ascherj/pathreview/issues/159
+
+### Understand
+
+**Expected:** When code under test logs via structlog (e.g.
+`logger.warning("Empty chunks list provided to BatchEmbeddingProcessor")`),
+pytest's `caplog` fixture should capture that record so a test can assert on
+`caplog.text` / `caplog.records`.
+
+**Actual:** `caplog` captures nothing. The reproducing test
+`tests/unit/test_batch_processor.py::test_empty_chunks_list_returns_empty`
+fails with `assert ('Empty chunks list' in '' ...)` — `caplog.text` is the empty
+string — even though the log line *is* emitted (it appears under pytest's
+"Captured stdout", not "Captured log").
+
+**Root cause (verified):** `core/logging.py::configure_logging()` is the only
+place structlog is wired into the standard-library `logging` module (via
+`structlog.stdlib.LoggerFactory`). But a repo-wide search shows it is called
+**only in `scripts/seed_db.py`** — never by the app under test and never by the
+test suite. With structlog left unconfigured during tests, it falls back to its
+**default configuration**, whose logger factory prints rendered events straight
+to `sys.stdout` and never routes them through stdlib `logging`. Because
+`caplog` only observes records that pass through stdlib `logging`, it sees
+nothing — hence "log assertions fail suite-wide."
+
+**Secondary factor:** even when `configure_logging()` *is* called, its processor
+chain ends in `ConsoleRenderer`/`JSONRenderer` (which flatten the event to a
+string before stdlib sees it) and it sets `cache_logger_on_first_use=True`.
+Neither is friendly to `caplog`, which wants real `LogRecord`s and picks up its
+handler per-test. So the durable fix must make structlog hand structured records
+to stdlib during tests, not just call the existing function.
+
+### Map
+
+Files/functions expected to be involved:
+- `core/logging.py` — `configure_logging()` (the structlog config) and
+  `get_logger()`. Primary place the routing behavior is decided.
+- `tests/conftest.py` — shared fixtures; currently has **no** logging fixture.
+  Best home for an `autouse` fixture that configures structlog for capture.
+- `tests/unit/test_batch_processor.py` — the failing test; the reproduction
+  target and first verification point (should go green with no change to the
+  test itself).
+- `core/config.py` — `log_level` (default `INFO`) and `app_env` (default
+  `development`); relevant because level filtering can still drop records.
+- `scripts/seed_db.py` — current sole caller of `configure_logging()`; check the
+  fix doesn't change its behavior.
+
+### Plan
+
+1. **Lock in the reproduction** (done): run
+   `pytest tests/unit/test_batch_processor.py -k empty -v` and confirm it fails
+   with an empty `caplog`, while the message shows under Captured stdout.
+2. **Add an `autouse` fixture in `tests/conftest.py`** that reconfigures
+   structlog for tests to route through stdlib logging: use
+   `logger_factory=structlog.stdlib.LoggerFactory()`, end the processor chain
+   with `structlog.stdlib.render_to_log_kwargs` (hand event + fields to stdlib),
+   and set `cache_logger_on_first_use=False` so the per-test handler is honored.
+3. **Ensure level/propagation** so records actually reach `caplog`: within the
+   fixture (or via `caplog.set_level`) make the relevant logger propagate and
+   sit at `INFO`/`DEBUG`, so `info`/`warning`/`error` calls are all captured.
+4. **Verify** the target test passes unchanged, then run the full unit suite
+   (`make test-unit`) to confirm the other 10 tests in that file — and the rest
+   of the suite — still pass and that stdout-based expectations aren't broken.
+5. **Decide the config home** (investigation, then implement): keep the fix
+   test-scoped in `conftest.py`, or additionally make `configure_logging()`
+   caplog-compatible (ProcessorFormatter) and call it at app startup. Prefer the
+   smallest change that fixes capture without altering dev/prod log formatting.
+
+### Inputs & outputs
+
+- **Input:** structlog log calls made by code under test — an event string plus
+  optional bound key/values (e.g. `logger.info("...", chunk_count=total)`).
+- **Output / behavior change:** those calls now produce standard-library
+  `logging.LogRecord`s that propagate to pytest's capture handler, so
+  `caplog.records` and `caplog.text` are populated and log assertions pass.
+- **No public signatures change.** `logger.warning(...)`/`logger.info(...)`
+  call sites are untouched. The change is configuration- and fixture-level. If
+  `core/logging.py` is touched, the observable difference is that structlog
+  emits stdlib-compatible records; dev (`ConsoleRenderer`) and prod
+  (`JSONRenderer`) *runtime* output must remain visually unchanged.
+
+### Risks & unknowns
+
+- **Global reconfiguration leaks (tests/conftest.py):** an `autouse` structlog
+  fixture reconfigures a process-global. It could alter output for the other 10
+  tests in `test_batch_processor.py` or other suites. Mitigation/investigation:
+  run `make test-unit` before and after and diff pass/fail.
+- **Import-time logger binding (ingestion/embeddings/batch_processor.py:7):**
+  `logger = structlog.get_logger()` is bound at import, before the fixture runs.
+  With `cache_logger_on_first_use=False`, structlog's lazy proxy should re-read
+  config at call time — but this must be confirmed empirically, not assumed.
+- **Level filtering (core/config.py `log_level=INFO`):** if the effective stdlib
+  level stays at `WARNING`, `info`-level assertions elsewhere would still fail;
+  the fixture must set the level explicitly.
+- **Unknown — maintainer preference:** fix in `tests/conftest.py` only, vs.
+  making `configure_logging()` itself caplog-friendly and invoking it at startup.
+  Investigation path: re-read the issue #159 discussion and `docs/CONTRIBUTING.md`.
+
+### Edge cases
+
+1. **A warning-level log** (`logger.warning(...)`, the failing test's case) — must
+   be captured.
+2. **Info- and error-level logs** (`logger.info(...)`, `logger.error(...)` used
+   throughout `batch_processor.py`) — must also be captured, so the fix can't be
+   scoped to a single level.
+3. **Structured/bound fields** (`logger.info("msg", chunk_count=5)`) — extra
+   key/values must not break capture; the record's message should remain
+   assertable.
+4. **Tests that do not use `caplog`** — the 10 currently-passing tests must keep
+   passing; the fixture must not change their behavior or their stdout.
+5. **Test isolation** — reconfiguring per test must not leak logging state
+   between tests (no cross-test contamination of handlers/levels).

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,46 @@
 """Shared test fixtures for PathReview."""
 
 import pytest
+import structlog
+
+
+@pytest.fixture(autouse=True)
+def structlog_to_stdlib_logging():
+    """Route structlog output through the stdlib ``logging`` pipeline for tests.
+
+    The application only wires structlog into standard-library logging inside
+    ``core.logging.configure_logging()``, which is called solely by
+    ``scripts/seed_db.py`` — never by the app under test or the test suite. With
+    structlog left at its default configuration during tests, it renders events
+    straight to stdout and never produces ``logging.LogRecord`` objects, so
+    pytest's ``caplog`` fixture captures nothing and every log-based assertion
+    fails suite-wide (issue #159).
+
+    This autouse fixture reconfigures structlog so its final processor,
+    ``structlog.stdlib.render_to_log_kwargs``, hands each event and its bound
+    key/values to a stdlib logger created by ``LoggerFactory``. That produces
+    real ``LogRecord`` objects that propagate to the handler ``caplog`` installs
+    per test. ``cache_logger_on_first_use=False`` ensures module-level loggers
+    bound at import time (e.g. ``logger = structlog.get_logger()``) pick up this
+    configuration on their next call rather than a cached default logger.
+    ``structlog.reset_defaults()`` runs on teardown so configuration never leaks
+    between tests.
+    """
+    structlog.configure(
+        processors=[
+            structlog.stdlib.add_logger_name,
+            structlog.stdlib.add_log_level,
+            structlog.stdlib.PositionalArgumentsFormatter(),
+            structlog.processors.StackInfoRenderer(),
+            structlog.processors.format_exc_info,
+            structlog.stdlib.render_to_log_kwargs,
+        ],
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        wrapper_class=structlog.stdlib.BoundLogger,
+        cache_logger_on_first_use=False,
+    )
+    yield
+    structlog.reset_defaults()
 
 
 @pytest.fixture

--- a/tests/unit/test_logging_caplog.py
+++ b/tests/unit/test_logging_caplog.py
@@ -1,0 +1,95 @@
+"""Tests that structlog output is captured by pytest's ``caplog`` fixture.
+
+Regression tests for issue #159: structlog was rendering events straight to
+stdout instead of routing them through standard-library logging, so ``caplog``
+captured nothing and every log-based assertion failed suite-wide. The autouse
+``structlog_to_stdlib_logging`` fixture in ``tests/conftest.py`` fixes this; the
+tests below lock in the behavior across log levels, bound structured fields, and
+loggers bound at import time.
+"""
+
+import logging
+
+import pytest
+import structlog
+
+
+@pytest.mark.unit
+class TestStructlogCaplogCapture:
+    """Verify structlog records reach ``caplog`` for the fix in issue #159."""
+
+    def test_warning_is_captured_in_text(self, caplog):
+        """A warning-level structlog event appears in ``caplog.text``."""
+        logger = structlog.get_logger("test.warning")
+
+        logger.warning("Empty chunks list provided to BatchEmbeddingProcessor")
+
+        assert "Empty chunks list provided to BatchEmbeddingProcessor" in caplog.text
+
+    def test_warning_produces_a_log_record(self, caplog):
+        """The event becomes a real ``LogRecord`` with the expected level."""
+        logger = structlog.get_logger("test.record")
+
+        logger.warning("something happened")
+
+        assert len(caplog.records) == 1
+        record = caplog.records[0]
+        assert record.levelno == logging.WARNING
+        assert "something happened" in record.getMessage()
+
+    def test_info_level_captured_when_level_lowered(self, caplog):
+        """Info events are captured once the effective level allows them.
+
+        By default the root logger sits at WARNING, so info records are filtered
+        by stdlib logging before they reach the capture handler. Lowering the
+        level with ``caplog.set_level`` — the idiomatic pytest approach — lets
+        the info event through.
+        """
+        caplog.set_level(logging.INFO)
+        logger = structlog.get_logger("test.info")
+
+        logger.info("Starting batch embedding processing")
+
+        assert "Starting batch embedding processing" in caplog.text
+
+    def test_error_level_captured(self, caplog):
+        """Error-level structlog events are captured."""
+        logger = structlog.get_logger("test.error")
+
+        logger.error("Failed to store embedding")
+
+        assert any(r.levelno == logging.ERROR for r in caplog.records)
+        assert "Failed to store embedding" in caplog.text
+
+    def test_bound_structured_fields_do_not_break_capture(self, caplog):
+        """Extra key/values are attached to the record without breaking capture.
+
+        ``render_to_log_kwargs`` forwards bound fields as ``extra`` on the
+        ``LogRecord``, so the message stays assertable and the structured data is
+        still available on the captured record.
+        """
+        caplog.set_level(logging.INFO)
+        logger = structlog.get_logger("test.bound")
+
+        logger.info("Starting batch embedding processing", chunk_count=42)
+
+        assert "Starting batch embedding processing" in caplog.text
+        record = caplog.records[0]
+        assert record.chunk_count == 42
+
+    def test_import_time_bound_logger_is_captured(self, caplog):
+        """A logger bound at import time still routes through stdlib logging.
+
+        ``BatchEmbeddingProcessor`` binds ``logger = structlog.get_logger()`` at
+        import, before this fixture runs. With ``cache_logger_on_first_use=False``
+        the lazy proxy re-reads the test configuration on its next call, so its
+        warning is captured — the original failing scenario from issue #159.
+        """
+        from ingestion.embeddings.batch_processor import BatchEmbeddingProcessor
+
+        processor = BatchEmbeddingProcessor(embedding_provider=object(), vector_db=object())
+
+        result = processor.process([])
+
+        assert result == []
+        assert "Empty chunks list" in caplog.text


### PR DESCRIPTION
## Summary

structlog output was never captured by pytest's `caplog` fixture, so every log-based assertion failed suite-wide. The application only bridges structlog into the standard-library `logging` module inside `core.logging.configure_logging()`, and that function is called solely by `scripts/seed_db.py` — never by the app under test or the test suite. During tests structlog therefore ran with its **default** configuration, which renders each event straight to stdout and never produces a `logging.LogRecord`. Because `caplog` only observes records that pass through stdlib `logging`, it captured nothing (the log line showed up under pytest's *Captured stdout*, not *Captured log*).

This PR adds an `autouse` fixture in `tests/conftest.py` that reconfigures structlog for the test run to route events through stdlib logging, so `caplog.text` / `caplog.records` are populated and log assertions pass again — without changing how logs are rendered in dev or production.

## Issue

Closes #159

## Changes

- **`tests/conftest.py`** — added an `autouse` fixture `structlog_to_stdlib_logging` that:
  - ends structlog's processor chain with `structlog.stdlib.render_to_log_kwargs`, handing each event and its bound key/values to a stdlib logger,
  - uses `logger_factory=structlog.stdlib.LoggerFactory()` and `wrapper_class=structlog.stdlib.BoundLogger` so real `LogRecord`s are emitted,
  - sets `cache_logger_on_first_use=False` so module-level loggers bound at import time (`logger = structlog.get_logger()`) pick up the test config on their next call,
  - calls `structlog.reset_defaults()` on teardown so configuration never leaks between tests.
- **`tests/unit/test_logging_caplog.py`** — new regression tests covering warning/info/error capture, structured bound fields, and an import-time-bound logger.
- No application/runtime code changed: `core/logging.py` and all `logger.*` call sites are untouched, so dev (`ConsoleRenderer`) and prod (`JSONRenderer`) output is unaffected.

## Testing

- [x] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`) — not run; requires Docker services and unrelated to this change
- [x] Linter passes (`make lint`)
- [x] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes

**How to verify manually:**

1. From the repo root, check out this branch and install dev deps (`make setup`, or `pip install -e ".[dev]"`).
2. Reproduce the original bug on `main` first (optional): `pytest tests/unit/test_batch_processor.py -k empty -v` fails with `caplog.text` empty while the warning shows under *Captured stdout*.
3. On this branch, run the previously failing reproduction test — it now passes with no change to the test itself:
   `pytest tests/unit/test_batch_processor.py::TestBatchEmbeddingProcessor::test_empty_chunks_list_returns_empty -v`
4. Run the new regression suite: `pytest tests/unit/test_logging_caplog.py -v` — all cases (warning/info/error/bound-fields/import-time logger) pass.
5. Run the full unit suite to confirm no regressions: `make test-unit`.

## Screenshots / Demo

N/A — test-infrastructure change with no user-facing output.

## Notes for Reviewers

- **Scope decision:** I kept the fix test-scoped (a `conftest.py` fixture) rather than modifying `core.logging.configure_logging()`, because the app's dev/prod log *rendering* should stay exactly as-is. The fixture only changes how structlog is wired during tests. Happy to additionally make `configure_logging()` caplog-friendly (via `ProcessorFormatter`) and call it at startup if maintainers prefer that direction.
- **Log level:** by default the root logger sits at `WARNING`, so info-level assertions need `caplog.set_level(logging.INFO)` — the idiomatic pytest approach, demonstrated in the new tests. Warning/error assertions work without it.
- **Pre-existing failures (documented per contribution guidance):** the repo has many failures unrelated to this issue. Baseline on the clean branch: `make test-unit` = **53 failed / 375 passed**; `ruff check .` = **182 errors**; `black --check .` = 52 files would reformat; `mypy` (scope `api/ core/ ingestion/ rag/ agent/ safety/`) = **5 errors** (missing third-party stubs + a numpy/py3.12 stub issue). After this change: unit tests = **52 failed / 382 passed** — the fix repairs 1 pre-existing failure and adds 6 new passing tests, with **zero new failures** (verified by diffing JUnit-XML failure sets before/after). `ruff`/`black`/`mypy` counts are unchanged; the two touched files pass `ruff` and `black` cleanly. My changes do not affect the pre-existing failures.
