### PR TITLE
test(ingestion): add end-to-end resume ingestion test with sample fixture

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -154,3 +154,91 @@ before and 53 after, identical set; `make check`: 182 ruff lint errors before
 and after, none in the files I added. All pre-existing and documented in the PR.)
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No review has come in yet. The PR (https://github.com/ascherj/pathreview/pull/502)
+is still open and unreviewed by the maintainer.
+
+**How you responded:**
+N/A — no feedback to respond to. If review lands after this entry, I'll address
+it on the same branch and note it in the PR thread rather than the journal, since
+this is the final entry.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The hardest part was not writing the test — it was proving I didn't need to
+change production code. My instinct on a "add a test" issue was to jump straight
+to writing assertions, but I kept getting stuck because I didn't actually
+understand how the four stages (`parse → chunk → embed → store`) handed data to
+each other. The real work was in Week 8: writing a throwaway script to run the
+whole pipeline once and watch what each stage returned, so I could see the seams
+before I tried to assert on them. The specific thing that surprised me was the
+ChromaDB scalar-only metadata constraint — chunk metadata carries a list
+(`detected_sections`), which a live ChromaDB client would reject, so a naive
+"just use the real DB" integration test would have failed for a reason that had
+nothing to do with the code under test. Discovering that quietly reframed the
+whole approach toward an in-memory `FakeVectorDB` spy. I would not have predicted
+that a metadata typing rule would be the thing that shaped my test architecture.
+
+**What did you learn about working in a large codebase?**
+Contributing to someone else's production code is mostly about reading the room,
+not writing code. On my own projects I set the conventions; here I had to infer
+them and then defer to them even when they felt wrong. The clearest example was
+the mypy pre-commit hook flagging my unannotated test methods. My reflex was to
+add type annotations to "do it right," but the existing `tests/unit/*` files are
+all unannotated, and `make check` excludes `tests/` from typechecking anyway.
+Matching the repo's established style was the correct move — a PR that
+gratuitously annotates only the new test file creates inconsistency and gives a
+reviewer a reason to ask "why is this file different?" I also learned to
+establish a baseline before touching anything: recording that `make test-unit`
+had 53 failures and `make check` had 182 ruff errors *before* my change is what
+let me say with confidence "I introduced zero new failures" instead of panicking
+when I saw red. In my own repo a green suite is the baseline; in a large shared
+codebase the baseline is often already broken, and the honest claim is "no new
+breakage," not "everything passes."
+
+**How did AI tools help — and where did they fall short?**
+AI was most useful for orientation and mechanical scaffolding: tracing which
+files `IngestionPipeline.ingest_resume()` touched, drafting the `FakeVectorDB`
+spy boilerplate, and sanity-checking that my fixture had the sections the chunker
+would actually detect. That saved real time in the exploration phase. Where it
+fell short was exactly the judgment calls above. AI could not have told me the
+ChromaDB metadata constraint would bite until I ran the pipeline and hit it — the
+knowledge lived in runtime behavior, not in any single file it could read. And on
+the mypy/annotation question, AI's default lean is toward "best practice" (add
+the types), which was the *wrong* call for this repo. Deciding to match an
+imperfect local convention over a general best practice is a judgment I had to
+make by reading the surrounding files myself. AI is good at "what does this code
+do"; it is weak at "what will this specific maintainer want," which is the actual
+question a contribution has to answer.
+
+**What would you do differently if you started over?**
+I'd run the pipeline end-to-end on day one instead of reading it statically for
+too long first. The throwaway exploration script in Week 8 unlocked everything —
+the seams, the metadata constraint, the confirmation that no production change
+was needed — and I could have written it in Week 7 and saved myself a lot of
+guessing. On process, I'd also open the PR as a draft earlier and explicitly ask
+the maintainer about the annotation/style question up front, rather than deciding
+it solo and documenting my reasoning in the PR description. My call was defensible,
+but surfacing it as a question would have been a cheaper way to de-risk the review
+than hoping my written justification lands. Issue selection I wouldn't change — a
+test-only, no-production-change issue was a good first contribution because it let
+me learn the codebase's shape without the pressure of also not breaking it.
+
+**What are you most proud of from this module?**
+The discipline of the baseline comparison and the honesty in how I reported it.
+It would have been easy to write "all tests pass" and move on, or to quietly fix
+a couple of the 53 pre-existing failures to make my PR look cleaner. Instead I
+recorded the before/after numbers, kept my change strictly scoped to the missing
+coverage, and stated plainly that the repo has pre-existing failures my work
+neither caused nor fixed. That's the habit I most want to carry forward: making
+a claim I can actually defend, rather than the claim that looks best.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -99,3 +99,58 @@ so no production code changes are needed — the fix is test-only. One decision
 settled during research: use a fake vector DB rather than a live ChromaDB
 client, because chunk metadata includes a list (`detected_sections`) that
 ChromaDB's scalar-only metadata constraint would reject.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Working from PLAN.md, all sub-tasks are done. Sub-task 1: added the sample
+resume fixture at `tests/fixtures/sample_resumes/sample_resume.md`. Sub-tasks
+2–5: added `tests/integration/test_ingestion_pipeline.py`, which builds the
+offline test doubles (existing `MockEmbeddingProvider` + an in-memory
+`FakeVectorDB` spy, with the `db_session` dedup lookup returning `None`), drives
+`IngestionPipeline.ingest_resume()` end-to-end, and asserts both the returned
+`IngestResult` and the stored embeddings/metadata/IDs at the storage seam. All 8
+tests pass under `make test-integration`; each change was committed separately.
+
+**Next steps:**
+Add the edge-case tests (duplicate-skip, empty resume), run the full baseline
+comparison to confirm no new failures, self-review against CONTRIBUTING.md
+(branch name, commit format, docstrings), and open the PR to upstream.
+
+**Blockers:**
+None. Confirmed the mypy pre-commit hook flags unannotated test methods, but
+existing `tests/unit/*` files are unannotated too, so I'm matching the repo's
+established test style (`make check` excludes `tests/` from typecheck anyway).
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/502
+
+**Branch:** `test/18-e2e-ingestion-test-with-sample-resume-fixture`
+
+**What you built:**
+An end-to-end integration test for the resume ingestion pipeline. It feeds a
+sample resume fixture into `IngestionPipeline.ingest_resume()` and verifies the
+full parse → chunk → embed → store flow, using the offline `MockEmbeddingProvider`
+and an in-memory vector-DB spy so it runs with no network or Docker services.
+No production code was changed — the fix is test-only.
+
+**Tests added or updated:**
+- `tests/integration/test_ingestion_pipeline.py` (new) — 8 tests: end-to-end
+  happy path, embedding shape (1536-dim), metadata propagation across stage
+  seams, stored document text, `{source_id}_chunk_{index}` ID convention,
+  duplicate-source skip, empty-resume handling, and mock-embedding determinism.
+- `tests/fixtures/sample_resumes/sample_resume.md` (new) — realistic resume
+  fixture with detectable sections.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+(Interpreted per the pre-existing-failures guidance: this branch introduces no
+new failures. Baseline recorded before starting — `make test-unit`: 53 failing
+before and 53 after, identical set; `make check`: 182 ruff lint errors before
+and after, none in the files I added. All pre-existing and documented in the PR.)
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,24 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/18
+
+**Issue title:** Add end-to-end ingestion test with a sample resume fixture
+
+**Tier:** [ ] Tier 1  [x] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The ingestion pipeline currently only has unit tests that check individual
+parsers in isolation, so there is no coverage proving the pieces work together
+as one flow. This issue asks for an integration test that exercises the full
+path — from a resume file being uploaded, through parsing and processing, to
+the resulting embeddings being stored. The fix lives in the ingestion module and
+adds `tests/integration/test_ingestion_pipeline.py` backed by realistic sample
+resume fixtures under `tests/fixtures/sample_resumes/`. Success means a single
+test can catch regressions where a component works alone but breaks when wired
+into the complete pipeline.
+
+**Branch name:** test/18-e2e-ingestion-test-with-sample-resume-fixture
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -22,3 +22,58 @@ into the complete pipeline.
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+---
+
+### Reproduction of the gap
+
+Because this is a missing-coverage issue (not a runtime bug), "reproducing" it
+means confirming the test does not exist and pinning down exactly where it
+should live. I verified three things locally on this branch.
+
+**1. The integration suite is empty — it collects zero tests:**
+
+```
+$ .venv/bin/pytest tests/integration -v
+collected 0 items
+============================ no tests ran in 1.25s =============================
+```
+
+`tests/integration/` contains only `__init__.py`; there is no
+`test_ingestion_pipeline.py`.
+
+**2. The pipeline orchestrator has no test that exercises it end-to-end:**
+
+```
+$ grep -rl "ingest_resume\|IngestionPipeline" tests/
+(no matches)
+```
+
+The orchestrator lives in
+[`ingestion/pipeline.py`](ingestion/pipeline.py) — `IngestionPipeline.ingest_resume()`
+chains the full flow: `ResumeParser.parse()` → `StrategySelector.chunk()` →
+`BatchEmbeddingProcessor.process()` (embed + store in the vector DB) →
+`_record_ingested_source()`. Every unit test under `tests/unit/` covers one of
+these components in isolation (e.g. `test_resume_parser.py`,
+`test_semantic_chunker.py`, `test_batch_processor.py`), but nothing wires them
+together, so a break at a seam between components would go undetected.
+
+**3. The required fixtures directory does not exist:**
+
+```
+$ ls tests/fixtures/sample_resumes
+ls: tests/fixtures/sample_resumes: No such file or directory
+```
+
+There is no `tests/fixtures/` directory at all. The only resume sample today is
+an inline string fixture, `sample_resume_text`, in
+[`tests/conftest.py`](tests/conftest.py) — not a file-based fixture that
+exercises the upload path.
+
+**Conclusion / where the fix lives:**
+- Add sample resume file(s) under `tests/fixtures/sample_resumes/`.
+- Add `tests/integration/test_ingestion_pipeline.py` that drives
+  `IngestionPipeline.ingest_resume()` from a fixture file through to stored
+  embeddings, asserting each stage's output and the final `IngestResult`
+  (`chunk_count`, `skipped`, `source_id`), with the embedding provider / vector
+  DB stubbed so the test runs offline.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -77,3 +77,25 @@ exercises the upload path.
   embeddings, asserting each stage's output and the final `IngestResult`
   (`chunk_count`, `skipped`, `source_id`), with the embedding provider / vector
   DB stubbed so the test runs offline.
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/emilypmendez/pathreview/commit/ab805f9
+
+**Reproduction summary:**
+Ran `pytest tests/integration -v` and `grep -rl "ingest_resume\|IngestionPipeline" tests/`,
+observing that the integration suite collects 0 tests, no test touches the
+pipeline orchestrator, and `tests/fixtures/sample_resumes/` does not exist —
+confirming the coverage gap is real and isolating exactly where the fix belongs.
+
+**PLAN.md link:** https://github.com/emilypmendez/pathreview/blob/test/18-e2e-ingestion-test-with-sample-resume-fixture/PLAN.md
+
+**Walkthrough video (recommended):** N/A
+
+**Blockers or open questions:**
+None blocking. Verified via a throwaway script that the full pipeline runs
+end-to-end with the existing `MockEmbeddingProvider` and a fake vector-DB spy,
+so no production code changes are needed — the fix is test-only. One decision
+settled during research: use a fake vector DB rather than a live ChromaDB
+client, because chunk metadata includes a list (`detected_sections`) that
+ChromaDB's scalar-only metadata constraint would reject.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,112 @@
+## Solution plan
+
+**Issue:** [Add end-to-end ingestion test with a sample resume fixture (#18)](https://github.com/ascherj/pathreview/issues/18)
+
+### Understand
+
+This is a **missing-coverage** issue, not a runtime bug. The ingestion module
+already works, but every automated test exercises a single component in
+isolation (`tests/unit/test_resume_parser.py`, `test_semantic_chunker.py`,
+`test_batch_processor.py`, …). Nothing drives the orchestrator
+`IngestionPipeline.ingest_resume()` in `ingestion/pipeline.py`, which chains the
+whole flow: **parse → chunk → embed → store → record**.
+
+- **Expected:** an integration test proves that a sample resume, fed in as it
+  would be on upload, flows through all stages and lands as stored embeddings —
+  so a regression at any *seam between components* (e.g. metadata dropped
+  between parser and chunker, wrong text passed to the embedder) is caught.
+- **Actual:** `tests/integration/` contains only `__init__.py` and collects
+  **0 tests**; there is no `tests/fixtures/` directory at all. Verified in the
+  Week 7 reproduction commit.
+
+### Map
+
+Files involved (read during research; the pipeline and its collaborators are
+**not** being modified — the fix is test-only):
+
+| File | Role |
+|------|------|
+| `ingestion/pipeline.py` | Orchestrator under test — `ingest_resume()` |
+| `ingestion/parsers/resume_parser.py` | Markdown/PDF → text + `detected_sections` |
+| `ingestion/chunking/strategy_selector.py` → `semantic_chunker.py` | Resume uses the semantic chunker; adds `chunk_index`, `char_start/end` |
+| `ingestion/embeddings/batch_processor.py` | Batches chunks, calls provider, `vector_db.add(ids, embeddings, metadatas, documents)` |
+| `ingestion/embeddings/provider.py` | Ships `MockEmbeddingProvider` — deterministic 1536-dim vectors, offline |
+
+**Files I expect to create:**
+- `tests/fixtures/sample_resumes/sample_resume.md` — realistic markdown resume fixture.
+- `tests/integration/test_ingestion_pipeline.py` — the end-to-end test.
+- (Possibly) a small fixture/helper in the test file: a `FakeVectorDB` spy and a
+  configured mock `db_session`.
+
+No production code changes are planned.
+
+### Plan
+
+1. **Add the fixture.** Create `tests/fixtures/sample_resumes/sample_resume.md`
+   with clearly detectable sections (Experience, Education, Skills, Projects) so
+   the parser's `detected_sections` and the chunker have real structure to work
+   on. Resolve its path in the test relative to `__file__` (not the cwd).
+2. **Build offline test doubles.** Use the existing `MockEmbeddingProvider`
+   (real class, no network). Add a tiny `FakeVectorDB` spy that records every
+   `add(...)` call. Configure a mock `db_session` so
+   `query(...).filter_by(...).first()` returns `None` — otherwise `_check_skip`
+   treats the source as already ingested and the pipeline no-ops.
+3. **Write the happy-path e2e test.** Instantiate `IngestionPipeline`, call
+   `ingest_resume(profile_id, content=<fixture text>, filename="sample_resume.md")`,
+   and assert on the returned `IngestResult` **and** the side effects captured by
+   the spy (see Inputs & outputs).
+4. **Add seam/behavior assertions.** Verify the data actually threaded through:
+   stored `documents` are non-empty chunk texts, each embedding is 1536-dim,
+   every stored metadata carries `source_id`, `profile_id`, `source_type ==
+   "resume"`, and `chunk_index`; embedding IDs follow
+   `{source_id}_chunk_{index}`.
+5. **Mark and wire in.** Decorate with `@pytest.mark.integration` so it runs
+   under `make test-integration` (`pytest -m integration`), confirm it passes
+   locally, and confirm the previously-empty suite now collects ≥1 test.
+
+### Inputs & outputs
+
+**Input:** a sample resume read from `tests/fixtures/sample_resumes/` (markdown
+string), plus a `profile_id` and `filename`, passed to
+`IngestionPipeline.ingest_resume()` with mocked embedding/storage/DB
+collaborators.
+
+**Output / what changes:** new test + fixture files only. The test *asserts on*
+(does not change) these pipeline outputs:
+- Returns `IngestResult(source_id=…, chunk_count>=1, skipped=False,
+  skip_reason=None)`.
+- `FakeVectorDB.add` called ≥1 time; total stored IDs == `chunk_count`.
+- Each stored embedding has dimension 1536; each metadata dict contains
+  `source_id`, `profile_id`, `filename`, `source_type="resume"`, `chunk_index`,
+  and the parser's `detected_sections`.
+
+### Risks & unknowns
+
+- **Do NOT assert an exact `chunk_count`.** De-risk run showed the semantic
+  chunker merges a short resume into a **single** chunk. Assert `>= 1` and length
+  invariants, not a magic number, so the test isn't brittle to chunker tuning.
+- **A real ChromaDB collection would reject this metadata.** `detected_sections`
+  is a **list**, and ChromaDB only accepts scalar metadata values. Confirmed
+  reason to use an in-memory `FakeVectorDB` spy rather than a live client —
+  which also keeps the test hermetic (the `integration` marker is documented as
+  "require Docker services", but a fully-mocked ingestion test needs none).
+- **`_check_skip` mock shape.** If the mock `db_session` isn't configured to
+  return `None` from `.first()`, the pipeline silently skips and the test would
+  assert against a no-op. Configured explicitly (verified in de-risk run).
+- **PDF fixture (stretch).** A `.pdf` fixture would exercise the `pypdf` path
+  too, but committing binary + generating deterministic PDF text is extra
+  surface. Plan: ship markdown first; add PDF only if time allows, as a second
+  parametrized case.
+
+### Edge cases
+
+- **Duplicate ingestion / skip path:** a second test where `.first()` returns a
+  truthy row asserts `IngestResult.skipped is True` and that `vector_db.add` is
+  **not** called.
+- **Empty / whitespace-only resume:** should not crash; `BatchEmbeddingProcessor`
+  already short-circuits on an empty chunk list — assert graceful handling.
+- **Metadata propagation:** `profile_id`/`filename` supplied at the top must
+  survive all the way into every stored chunk's metadata (the core "seam" this
+  test exists to protect).
+- **Determinism:** `MockEmbeddingProvider` is hash-seeded, so identical input
+  yields identical vectors — assertions on embeddings stay stable across runs.

--- a/tests/fixtures/sample_resumes/sample_resume.md
+++ b/tests/fixtures/sample_resumes/sample_resume.md
@@ -1,0 +1,45 @@
+# Jane Doe
+
+Software Engineer
+jane.doe@example.com | (555) 123-4567 | github.com/janedoe | linkedin.com/in/janedoe
+
+## Summary
+
+Backend-leaning full-stack engineer with 4+ years building and operating
+Python web services. Comfortable owning a feature from schema design through
+deployment and on-call support.
+
+## Experience
+
+**Senior Software Engineer — TechCorp** (2022 – Present)
+- Designed and shipped a REST API in **Python** and **FastAPI** serving 12M
+  requests/day, cutting p95 latency from 480ms to 110ms.
+- Led the migration from synchronous request handling to async background
+  workers backed by Redis, eliminating request timeouts during peak load.
+- Mentored three junior engineers and introduced a lightweight code-review
+  checklist adopted team-wide.
+
+**Software Engineer — DataStart** (2020 – 2022)
+- Built ETL pipelines in Python that ingested 200+ third-party data feeds into
+  PostgreSQL, with automated schema-drift detection.
+- Added end-to-end integration tests that raised pipeline reliability from
+  ~92% to 99.5% successful nightly runs.
+
+## Education
+
+**B.S. in Computer Science — State University** (2016 – 2020)
+- GPA 3.8/4.0. Coursework: Algorithms, Databases, Distributed Systems.
+
+## Projects
+
+**PathReview Ingestion Toolkit** — Open-source resume and README ingestion
+pipeline with pluggable chunking and embedding strategies.
+
+## Skills
+
+Python, JavaScript, TypeScript, FastAPI, React, PostgreSQL, Redis, Docker,
+Kubernetes, pytest, Git
+
+## Certifications
+
+- AWS Certified Solutions Architect – Associate (2023)

--- a/tests/integration/test_ingestion_pipeline.py
+++ b/tests/integration/test_ingestion_pipeline.py
@@ -1,0 +1,211 @@
+"""End-to-end integration test for the resume ingestion pipeline.
+
+Drives ``IngestionPipeline.ingest_resume()`` from a sample resume fixture all the
+way through parsing, chunking, embedding, and storage, asserting on both the
+returned ``IngestResult`` and the side effects captured at the storage seam.
+
+The test is hermetic: it uses the real parser/chunker/pipeline code but swaps in
+the offline ``MockEmbeddingProvider`` and a lightweight in-memory vector-DB spy,
+so it needs no network, API keys, or Docker services.
+"""
+
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from ingestion.embeddings.provider import MockEmbeddingProvider
+from ingestion.pipeline import IngestionPipeline, IngestResult
+
+FIXTURE_DIR = Path(__file__).resolve().parent.parent / "fixtures" / "sample_resumes"
+EMBEDDING_DIM = MockEmbeddingProvider.EMBEDDING_DIM
+
+
+class FakeVectorDB:
+    """In-memory stand-in for a ChromaDB collection.
+
+    Records every ``add()`` call so tests can assert on what was stored. A real
+    ChromaDB collection is deliberately avoided: chunk metadata includes list
+    values (e.g. ``detected_sections``) that ChromaDB's scalar-only metadata
+    constraint would reject.
+    """
+
+    def __init__(self):
+        self.ids: list[str] = []
+        self.embeddings: list[list[float]] = []
+        self.metadatas: list[dict] = []
+        self.documents: list[str] = []
+        self.add_call_count = 0
+
+    def add(self, ids, embeddings, metadatas, documents):
+        self.add_call_count += 1
+        self.ids.extend(ids)
+        self.embeddings.extend(embeddings)
+        self.metadatas.extend(metadatas)
+        self.documents.extend(documents)
+
+
+@pytest.mark.integration
+class TestResumeIngestionPipeline:
+    """End-to-end coverage for the resume ingestion flow."""
+
+    @pytest.fixture
+    def sample_resume_markdown(self) -> str:
+        """Load the sample resume fixture from disk (as an upload would supply)."""
+        return (FIXTURE_DIR / "sample_resume.md").read_text(encoding="utf-8")
+
+    @pytest.fixture
+    def vector_db(self) -> FakeVectorDB:
+        """A fresh in-memory vector-DB spy for each test."""
+        return FakeVectorDB()
+
+    @pytest.fixture
+    def db_session(self) -> Mock:
+        """A DB session whose dedup lookup finds nothing, so ingestion proceeds.
+
+        ``IngestionPipeline._check_skip`` calls
+        ``db_session.query(...).filter_by(...).first()``; returning ``None`` here
+        keeps the pipeline from short-circuiting as an already-ingested source.
+        """
+        session = Mock()
+        session.query.return_value.filter_by.return_value.first.return_value = None
+        return session
+
+    @pytest.fixture
+    def pipeline(self, vector_db, db_session) -> IngestionPipeline:
+        """Pipeline wired with real components and offline test doubles."""
+        return IngestionPipeline(
+            vector_db=vector_db,
+            db_session=db_session,
+            embedding_provider=MockEmbeddingProvider(),
+        )
+
+    def test_ingest_resume_end_to_end(self, pipeline, vector_db, sample_resume_markdown):
+        """A sample resume flows through every stage and lands as stored embeddings."""
+        result = pipeline.ingest_resume(
+            profile_id="profile-123",
+            content=sample_resume_markdown,
+            filename="sample_resume.md",
+        )
+
+        # --- Returned result ---
+        assert isinstance(result, IngestResult)
+        assert result.skipped is False
+        assert result.skip_reason is None
+        assert result.source_id.startswith("resume_profile-123_")
+        assert result.chunk_count >= 1
+
+        # --- Storage side effects (the seam this test exists to protect) ---
+        assert vector_db.add_call_count >= 1
+        # Every chunk the pipeline reported was actually stored, exactly once.
+        assert len(vector_db.ids) == result.chunk_count
+        assert len(set(vector_db.ids)) == result.chunk_count
+        assert len(vector_db.embeddings) == result.chunk_count
+        assert len(vector_db.documents) == result.chunk_count
+
+    def test_stored_embeddings_have_expected_shape(
+        self, pipeline, vector_db, sample_resume_markdown
+    ):
+        """Each stored embedding is a full-dimensional numeric vector."""
+        pipeline.ingest_resume(
+            profile_id="p1",
+            content=sample_resume_markdown,
+            filename="sample_resume.md",
+        )
+
+        assert vector_db.embeddings, "expected at least one stored embedding"
+        for embedding in vector_db.embeddings:
+            assert len(embedding) == EMBEDDING_DIM
+            assert all(isinstance(value, float) for value in embedding)
+
+    def test_metadata_propagated_through_pipeline(
+        self, pipeline, vector_db, sample_resume_markdown
+    ):
+        """Top-level inputs and parser output survive all the way to storage."""
+        result = pipeline.ingest_resume(
+            profile_id="p1",
+            content=sample_resume_markdown,
+            filename="sample_resume.md",
+        )
+
+        assert vector_db.metadatas
+        for index, metadata in enumerate(vector_db.metadatas):
+            # Injected by the pipeline before chunking.
+            assert metadata["source_id"] == result.source_id
+            assert metadata["profile_id"] == "p1"
+            assert metadata["filename"] == "sample_resume.md"
+            assert metadata["source_type"] == "resume"
+            # Added by the chunker.
+            assert metadata["chunk_index"] == index
+            # Produced by the parser and carried through untouched.
+            assert "detected_sections" in metadata
+
+    def test_stored_documents_match_chunk_text(self, pipeline, vector_db, sample_resume_markdown):
+        """The documents stored are the real (non-empty) chunk texts."""
+        pipeline.ingest_resume(
+            profile_id="p1",
+            content=sample_resume_markdown,
+            filename="sample_resume.md",
+        )
+
+        assert vector_db.documents
+        assert all(doc.strip() for doc in vector_db.documents)
+
+    def test_embedding_ids_follow_source_chunk_convention(
+        self, pipeline, vector_db, sample_resume_markdown
+    ):
+        """Stored IDs follow the ``{source_id}_chunk_{index}`` convention."""
+        result = pipeline.ingest_resume(
+            profile_id="p1",
+            content=sample_resume_markdown,
+            filename="sample_resume.md",
+        )
+
+        expected = [f"{result.source_id}_chunk_{index}" for index in range(result.chunk_count)]
+        assert vector_db.ids == expected
+
+    def test_duplicate_source_is_skipped(
+        self, pipeline, vector_db, db_session, sample_resume_markdown
+    ):
+        """When the source already exists, ingestion skips without storing."""
+        # Make the dedup lookup report an existing source.
+        db_session.query.return_value.filter_by.return_value.first.return_value = object()
+
+        result = pipeline.ingest_resume(
+            profile_id="p1",
+            content=sample_resume_markdown,
+            filename="sample_resume.md",
+        )
+
+        assert result.skipped is True
+        assert result.skip_reason == "Source already ingested"
+        assert result.chunk_count == 0
+        assert vector_db.add_call_count == 0
+        assert vector_db.ids == []
+
+    def test_empty_resume_does_not_crash(self, pipeline, vector_db):
+        """A whitespace-only resume is handled gracefully with nothing stored."""
+        result = pipeline.ingest_resume(
+            profile_id="p1",
+            content="   \n\t  \n",
+            filename="empty.md",
+        )
+
+        assert isinstance(result, IngestResult)
+        assert result.skipped is False
+        assert result.chunk_count == 0
+        assert vector_db.add_call_count == 0
+
+    def test_ingestion_is_deterministic(self, pipeline, vector_db, sample_resume_markdown):
+        """Re-embedding identical text yields identical vectors (hash-seeded mock)."""
+        pipeline.ingest_resume(
+            profile_id="p1",
+            content=sample_resume_markdown,
+            filename="sample_resume.md",
+        )
+        first_pass = list(vector_db.embeddings)
+
+        provider = MockEmbeddingProvider()
+        again = provider.embed(list(vector_db.documents))
+
+        assert again == first_pass


### PR DESCRIPTION
## What & why
Closes the coverage gap in [#18](https://github.com/ascherj/pathreview/issues/18): the ingestion module had only isolated unit tests, with nothing exercising the `IngestionPipeline` orchestrator end-to-end. `tests/integration/` collected **0 tests** and `tests/fixtures/` did not exist.

This adds a hermetic end-to-end test that drives `IngestionPipeline.ingest_resume()` from a sample resume fixture through the full flow — **parse → chunk → embed → store → record** — asserting both the returned `IngestResult` and the side effects captured at the storage seam.

## Changes (test-only — no production code touched)
- **`tests/fixtures/sample_resumes/sample_resume.md`** — realistic markdown resume with detectable sections (Summary, Experience, Education, Projects, Skills, Certifications).
- **`tests/integration/test_ingestion_pipeline.py`** — 8 tests:
  - end-to-end happy path (result + storage side effects)
  - embedding shape (1536-dim float vectors)
  - metadata propagation across every stage seam (`source_id`, `profile_id`, `filename`, `source_type`, `chunk_index`, `detected_sections`)
  - stored documents are real non-empty chunk texts
  - `{source_id}_chunk_{index}` ID convention
  - duplicate-source skip path (nothing stored)
  - empty/whitespace resume handled gracefully
  - determinism of the hash-seeded mock embeddings

## Design notes
- Uses the existing offline `MockEmbeddingProvider` and an in-memory `FakeVectorDB` spy → **no network, API keys, or Docker services** required.
- Deliberately does **not** use a live ChromaDB collection: chunk metadata contains a list (`detected_sections`) that ChromaDB's scalar-only metadata constraint would reject.
- `chunk_count` is asserted as `>= 1` with length invariants (not a magic number), since the semantic chunker merges short resumes into a single chunk.

## Verification
- `make test-integration` → **8 passed**.
- Marked `@pytest.mark.integration`; new files are `ruff`- and `black`-clean.

## Pre-existing failures (unrelated to this change)
The repo has failures present **before** this branch's changes. I recorded the baseline and confirmed my change does not affect them:
- `make test-unit`: **53 failing** unit tests at baseline → **still exactly 53** after my change (identical set; `diff` clean). My test is an *integration* test and isn't collected by `make test-unit`.
- `make check`: fails at the `ruff` lint step with **182 errors** at baseline → **still 182** after my change; **none** are in the files I added. (`make check`'s `typecheck` step scopes to `api/ core/ ingestion/ rag/ agent/ safety/` and excludes `tests/`.)
- The `mypy` pre-commit hook flags missing annotations on test methods; existing `tests/unit/*` files are unannotated too, so I matched the project's established test style.

Per the contribution guidance, the requirement is that this change introduces no new failures — verified above.

Refs #18
