### PR TITLE
fix(ingestion): skip re-embedding unchanged documents via content hash

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -55,16 +55,32 @@ submit the PR.
 
 ### Check-in 2 (end of week)
 
-**PR link:** [link to your submitted pull request]
+**PR link:** [fix(ingestion): skip re-embedding unchanged documents via content hash - #507
+](https://github.com/ascherj/pathreview/pull/507)
 
-**Branch:** [the branch name you worked on, e.g. `fix/123-short-description`]
+**Branch:** `fix/13-add-content-hash-to-detect-unchanged-docs`
 
 **What you built:**
-[1–3 sentences summarizing what your fix does and how it works]
+This PR fixes unchanged READMEs (and resumes/repo metadata) being needlessly re-embedded on every re-submission by 
+wiring up the content-hash deduplication that was already half-built but never functional. _hash_content already 
+computed a SHA256 hash, but _check_skip used a broken, always-failing DB query and _record_ingested_source never 
+actually persisted anything, so the "already ingested" check silently no-op'd and every ingestion re-ran the embedding 
+pipeline regardless of content. Both methods now query/write real IngestedSource rows (keyed by profile_id, source_type, 
+and filename, with content_hash compared against the most recent record), and 
+ingest_resume/ingest_readme/ingest_repo_metadata were converted to async to match the app's async-only DB session and 
+updated to call the fixed methods correctly — eliminating wasted embedding-provider API calls for content that hasn't 
+changed.
 
 **Tests added or updated:**
-[Which test files did you touch? What do they cover?]
+- tests/unit/test_ingestion_pipeline_dedup.py (new) — covers the shared dedup helpers directly:
+  - _check_skip returns None when no prior IngestedSource exists for the profile/type/filename.
+  - _check_skip returns a skipped IngestResult when the stored content_hash matches the incoming one.
+  - _check_skip returns None (proceeds with ingestion) when the stored hash differs from the incoming one.
+  - _record_ingested_source builds and persists (add + commit) an IngestedSource row with the correct profile_id, source_type, content_hash, source_url, and chunk_count.
+- tests/unit/test_readme_unchanged_detection.py (new) — covers the end-to-end black-box behavior through the public ingest_readme API:
+  - Re-submitting the exact same README content is skipped on the second call.
+  - Re-submitting unchanged README content only triggers the embedding batch processor once, not on every call.
 
-**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+**Self-review confirmation:** [✅] make check passes  [✅] make test-unit passes - both checks pass with pre-existing failures that are unrelated to this fix
 
-**Draft PR feedback received from:** [name or Slack handle, or "none"]
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -24,3 +24,16 @@ translates to reducing unnecessary API calls. This issue affects directly the in
 **Setup confirmation:** [✅] App runs locally at localhost:5173
 
 **Cohort ledger:** [✅] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [link to commit documenting the reproduced issue]
+
+**Reproduction summary:**
+I wrote a unit tests that verify if the `ingest_readme` function that is part of the `IngestionPipeline` embeds unchanged 
+READMEs more than once. I observed that the logic in the pipeline is not fully implemented: the functions that record 
+and check for ingested sources have placeholder code.
+
+**PLAN.md link:** [link to PLAN.md in your fork]
+
+**Blockers or open questions:** -

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -84,3 +84,51 @@ changed.
 **Self-review confirmation:** [✅] make check passes  [✅] make test-unit passes - both checks pass with pre-existing failures that are unrelated to this fix
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [✅] No — still awaiting review
+
+**Summary of feedback:** No feedback came in
+
+**How you responded:** -
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Figuring out where exactly the issues was located. During my initial code review, I had a good idea of which files I 
+was going to be working on. But once I started reading the files, I got a little bit confused. My main source of 
+confusion is that I first I thought the issue didn't exist, why? Because the code and database schema to handle 
+duplicates using the content hash was already there! So I had to dive deeper, and at the end it turned out the actual
+issue was that the embedding history was not getting persisted in the database, so there was no way to know if a file
+was a duplicate. 
+
+**What did you learn about working in a large codebase?** Large codebases have a ton of moving pieces, and sometimes 
+making the smallest change on one of its pieces can bring everything down. It is important that no matter how simple or
+small a fix might look, you have to make sure that it doesn't affect other parts of the project. 
+
+It is also important to pay attention to contributing guidelines or coding/testing pattern/styles because these have a 
+direct impact on the work you have to make. If you don't pay attention to an existing contributing guideline, and make
+a change that doesn't meet the guidelines at all, you are probably going to end up rewriting your fix/change. Which 
+means you could end up spending more time than expected on an issue.
+
+**How did AI tools help — and where did they fall short?** I found AI to be really helpful at navigating the large 
+codebase, and helping me understand how all the pieces were connected. While I had a pretty good general idea of how
+the codebase worked (at least the part related to the issue I was fixing), AI helped me notice some small aspects of the
+codebase that I was ignoring.
+
+I don't know if it is fair to say that AI tools fell short at being aware of coding patterns/styles, but I felt that 
+this is something you have to be pretty clear on. It was important for me to be aware of this because I was able to
+explicitly tell AI what was I expecting from its output when I asked it to generate some unit tests for my fix.
+
+**What would you do differently if you started over?** Maybe planning or the process itself. The fix I was working on 
+was not implemented in the project yet, which meant I was never going to be able to replicate it via the frontend. I 
+spent sometime trying to trigger the issue until I realized it was a hopeless task. After that I change my strategy and
+focused on replicating the issue through unit testing. If I had planned this replicating process a little better at 
+first, I would have caught this and wouldn't have "wasted" time trying to replicate the issue the wrong way.
+
+**What are you most proud of from this module?** Making it all the way to the end.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -38,3 +38,33 @@ and check for ingested sources have placeholder code.
 **PLAN.md link:** [PLAN.md](https://github.com/JoseLoarca/pathreview/blob/fix/13-add-content-hash-to-detect-unchanged-docs/PLAN.md)
 
 **Blockers or open questions:** -
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (Wed 29 Jul)
+
+**Current progress:** I have implemented all the subtasks listed in PLAN.md: fix `_check_skip`, 
+fix `_record_ingested_source`, update calls, add unit tests.
+
+**Next steps:** My next steps are to self-review against contribution standards, open a draft PR, and finalize and 
+submit the PR.
+
+**Blockers:** -
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [link to your submitted pull request]
+
+**Branch:** [the branch name you worked on, e.g. `fix/123-short-description`]
+
+**What you built:**
+[1–3 sentences summarizing what your fix does and how it works]
+
+**Tests added or updated:**
+[Which test files did you touch? What do they cover?]
+
+**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+
+**Draft PR feedback received from:** [name or Slack handle, or "none"]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -27,13 +27,14 @@ translates to reducing unnecessary API calls. This issue affects directly the in
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [link to commit documenting the reproduced issue]
+**Reproduction commit link:** [Commit fb21f2a
+](https://github.com/JoseLoarca/pathreview/commit/fb21f2afd7318f382f4e99f6c77de25680b0f0a2)
 
 **Reproduction summary:**
 I wrote a unit tests that verify if the `ingest_readme` function that is part of the `IngestionPipeline` embeds unchanged 
 READMEs more than once. I observed that the logic in the pipeline is not fully implemented: the functions that record 
 and check for ingested sources have placeholder code.
 
-**PLAN.md link:** [link to PLAN.md in your fork]
+**PLAN.md link:** [PLAN.md](https://github.com/JoseLoarca/pathreview/blob/fix/13-add-content-hash-to-detect-unchanged-docs/PLAN.md)
 
 **Blockers or open questions:** -

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,26 @@
+## Week 7 — Issue selection
+
+**Issue link:** [Issue #13](https://github.com/ascherj/pathreview/issues/13)
+
+**Issue title:** "Add a content hash to detect unchanged documents and skip re-embedding"
+
+**Tier:** This is a **Tier 2** issue. I am comfortably with this tier because:
+* I understand the issue (read Problem summary).
+* I have contributed to large codebases before.
+* I was able to find the relevant code (e.g., `ingestion/pipeline.py`).
+* I understand the surrounding code well enough to change it safely.
+* I have read the relevant test files in `tests/unit/`.
+* I have estimated the time this will take, and I'm confident I can complete it before the Week 9 deadline.
+* The issue has no open blockers or dependencies on other unresolved issues.
+
+**Problem summary:**
+When a user re-submits the same README file without, the pipeline does not detect if the content hasn't changed
+and re-embeds the document. What is missing is a check that detects if the content hash has changed, and if it
+hasn't it skips the embedding step. Fixing this would help reducing unnecessary embedding of unchanged READMEs, which
+translates to reducing unnecessary API calls. This issue affects directly the ingestion pipeline logic in `ingestion/pipeline.py`.
+
+**Branch name:** `fix/13-add-content-hash-to-detect-unchanged-docs`
+
+**Setup confirmation:** [✅] App runs locally at localhost:5173
+
+**Cohort ledger:** [✅] Issue added to cohort ledger

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,81 @@
+## Solution plan
+
+**Issue:** [Add a content hash to detect unchanged documents and skip re-embedding](https://github.com/ascherj/pathreview/issues/13)
+
+### Understand
+Currently, the `IngestionPipeline` in `pipeline.py` has two functions with placeholder code: `_check_skip` and 
+`_record_ingested_source`. 
+
+`_check_skip` is supposed to check if a source has already been ingested. If it has already been ingested,
+then it is skipped. If it hasn't, then the pipeline should proceed and embed the source.
+
+`_record_ingested_source` is supposed to keep track of the sources that have already been ingested. How? By assigning a
+unique ID (using a hash) and inserting a record in the database. 
+
+Since these functions have placeholder code, there is no way to check if a README.md file has been submitted twice 
+without any changes.
+
+The expected behavior is for the `IngestionPipeline` to detect unchanged documents, with the help of these two
+functions, and to skip README.md files that have been submitted more than once without any changes.
+
+### Map
+I'll work in `pipeline.py`. In this file, I'll implement the missing logic in `_check_skip` and 
+`_record_ingested_source`. I will also update the signature of both functions, so I'll have to update any calls.
+
+The `IngestedSource` model already includes a field to store the `content_hash`, so I don't have any planned updates here.
+
+### Plan
+#### Fix `_record_ingested_source`
+My first step will be to fix this function. To start with, I'll update the function signature so that it also
+expects to receive source content's hash.
+
+After that, I'll implement the database insertion. Once this has been implemented, I'll have a function that
+correctly stores ingested sources in the database.
+
+#### Fix `_check_skip`
+My second step will be to implement the logic in this function. I'll update this function's signature as well so that 
+it expects to receive the source content's hash.
+
+After that, I'll implement the query-and-check logic. This logic will: query for matching `profile_id` + `source_type` 
+records. If no matching records are found, then the function returns `None` and signals the pipeline to proceed with the 
+embedding. If a matching record is found, the matching record's hash is compared to the incoming file's hash. If the hash
+is the same, it means the file has been previously ingested and there are no changes so it should be skipped. If the 
+hash is not the same, then the function returns `None` and signals the pipeline to proceed with the embedding.
+
+#### Update the functions calls
+Finally, any call to these functions will be updated. After this update, `ingest_readme` will be handling unchanged 
+documents correctly.
+
+#### Tests
+To confirm that this solution is working, I'll run the tests I wrote to reproduce the behavior. If all the tests pass,
+it means the fix correctly addressed this issue.
+
+### Inputs & outputs
+
+#### `_check_skip`
+**Inputs:** source_id, profile_id, source_type, and content_hash
+
+Using the inputs it checks for a profile_id + source_type match in the ingested sources history.
+If a match is found, then the stored content hash and the incoming content hash are compared. If they are the same,
+it means the incoming file has already been ingested before. If they don't match, the file is new.
+
+For previously ingested sources, the function will return an `IngestResult` object that signals the 
+pipeline to skip the source.
+
+For new sources, the function will return `None`, which will signal the pipeline to proceed with the ingestion 
+process for the source.
+
+#### `_record_ingested_source`
+**Inputs:** source_id, source_type, profile_id, chunk_count, content_hash, filename
+
+The function inserts a new record in the database that represents an ingested source. 
+
+It doesn't return any value, but can raise an `Exception` if it failed to save the ingested source.
+
+
+### Risks & unknowns
+Right now, the ingestion pipeline is not implemented in the project. Once implemented, new issues / bugs could come up.
+
+### Edge cases
+* Unchanged README.md files submitted more than once -> skip
+* Same README.md content but different profile_id -> must not skip

--- a/ingestion/pipeline.py
+++ b/ingestion/pipeline.py
@@ -2,6 +2,7 @@ import hashlib
 from dataclasses import dataclass
 
 import structlog
+from sqlalchemy import and_, select
 
 from core.models.ingested_source import IngestedSource
 
@@ -287,28 +288,46 @@ class IngestionPipeline:
             content = content.encode()
         return hashlib.sha256(content).hexdigest()[:16]
 
-    def _check_skip(self, source_id: str, source_type: str) -> IngestResult | None:
+    async def _check_skip(
+        self,
+        source_id: str,
+        source_type: str,
+        profile_id: str,
+        content_hash: str,
+        filename: str | None = None,
+    ) -> IngestResult | None:
         """
-        Check if source has already been ingested.
+        Check if source has already been ingested with unchanged content.
+
+        Looks up the most recent IngestedSource for this profile/source_type
+        (and filename, when applicable) and compares its content_hash to
+        the incoming content_hash.
 
         Returns IngestResult if should skip, None if should proceed.
         """
         try:
-            # Query database for existing source
-            # This assumes a table/model named IngestedSource
-            existing = (
-                self.db_session.query("IngestedSource")  # Placeholder - actual query depends on ORM
-                .filter_by(source_id=source_id)
-                .first()
+            stmt = (
+                select(IngestedSource)
+                .where(
+                    and_(
+                        IngestedSource.profile_id == profile_id,
+                        IngestedSource.source_type == source_type,
+                        IngestedSource.filename == filename,
+                    )
+                )
+                .order_by(IngestedSource.ingested_at.desc())
             )
 
-            if existing:
-                logger.info("Source already ingested, skipping", source_id=source_id)
+            result = await self.db_session.execute(stmt)
+            existing = result.scalars().first()
+
+            if existing and existing.content_hash == content_hash:
+                logger.info("Source unchanged, skipping re-embedding", source_id=source_id)
                 return IngestResult(
                     source_id=source_id,
-                    chunk_count=0,
+                    chunk_count=existing.chunk_count,
                     skipped=True,
-                    skip_reason="Source already ingested",
+                    skip_reason="Content unchanged since last ingestion",
                 )
         except Exception as e:
             logger.warning(

--- a/ingestion/pipeline.py
+++ b/ingestion/pipeline.py
@@ -54,7 +54,7 @@ class IngestionPipeline:
         self.readme_parser = ReadmeParser()
         self.repo_analyzer = RepoAnalyzer()
 
-    def ingest_resume(
+    async def ingest_resume(
         self,
         profile_id: str,
         content: str | bytes,
@@ -71,7 +71,8 @@ class IngestionPipeline:
         Returns:
             IngestResult with ingestion status
         """
-        source_id = f"resume_{profile_id}_{self._hash_content(content)}"
+        content_hash = self._hash_content(content)
+        source_id = f"resume_{profile_id}_{content_hash}"
 
         logger.info(
             "Starting resume ingestion",
@@ -81,7 +82,9 @@ class IngestionPipeline:
         )
 
         # Check if already ingested
-        skip_result = self._check_skip(source_id, "resume")
+        skip_result = await self._check_skip(
+            source_id, "resume", profile_id, content_hash, filename=filename
+        )
         if skip_result:
             return skip_result
 
@@ -113,7 +116,14 @@ class IngestionPipeline:
             logger.info("Resume embeddings stored", chunk_count=len(chunks))
 
             # Record in database
-            self._record_ingested_source(source_id, "resume", profile_id, len(chunks))
+            await self._record_ingested_source(
+                source_id,
+                "resume",
+                profile_id,
+                len(chunks),
+                content_hash=content_hash,
+                filename=filename,
+            )
 
             return IngestResult(
                 source_id=source_id,
@@ -130,7 +140,7 @@ class IngestionPipeline:
             )
             raise
 
-    def ingest_readme(
+    async def ingest_readme(
         self,
         profile_id: str,
         repo_name: str,
@@ -147,7 +157,8 @@ class IngestionPipeline:
         Returns:
             IngestResult with ingestion status
         """
-        source_id = f"readme_{profile_id}_{repo_name}_{self._hash_content(content)}"
+        content_hash = self._hash_content(content)
+        source_id = f"readme_{profile_id}_{repo_name}_{content_hash}"
 
         logger.info(
             "Starting README ingestion",
@@ -157,7 +168,9 @@ class IngestionPipeline:
         )
 
         # Check if already ingested
-        skip_result = self._check_skip(source_id, "readme")
+        skip_result = await self._check_skip(
+            source_id, "readme", profile_id, content_hash, filename=repo_name
+        )
         if skip_result:
             return skip_result
 
@@ -190,7 +203,14 @@ class IngestionPipeline:
             logger.info("README embeddings stored", chunk_count=len(chunks))
 
             # Record in database
-            self._record_ingested_source(source_id, "readme", profile_id, len(chunks))
+            await self._record_ingested_source(
+                source_id,
+                "readme",
+                profile_id,
+                len(chunks),
+                content_hash=content_hash,
+                filename=repo_name,
+            )
 
             return IngestResult(
                 source_id=source_id,
@@ -207,7 +227,7 @@ class IngestionPipeline:
             )
             raise
 
-    def ingest_repo_metadata(
+    async def ingest_repo_metadata(
         self,
         profile_id: str,
         repo_data: dict,
@@ -223,7 +243,8 @@ class IngestionPipeline:
             IngestResult with ingestion status
         """
         repo_name = repo_data.get("name", "unknown")
-        source_id = f"repo_{profile_id}_{repo_name}_{self._hash_content(str(repo_data))}"
+        content_hash = self._hash_content(str(repo_data))
+        source_id = f"repo_{profile_id}_{repo_name}_{content_hash}"
 
         logger.info(
             "Starting repo metadata ingestion",
@@ -233,7 +254,9 @@ class IngestionPipeline:
         )
 
         # Check if already ingested
-        skip_result = self._check_skip(source_id, "repo")
+        skip_result = await self._check_skip(
+            source_id, "repo", profile_id, content_hash, filename=repo_name
+        )
         if skip_result:
             return skip_result
 
@@ -265,7 +288,14 @@ class IngestionPipeline:
             logger.info("Repository embeddings stored", chunk_count=len(chunks))
 
             # Record in database
-            self._record_ingested_source(source_id, "repo", profile_id, len(chunks))
+            await self._record_ingested_source(
+                source_id,
+                "repo",
+                profile_id,
+                len(chunks),
+                content_hash=content_hash,
+                filename=repo_name,
+            )
 
             return IngestResult(
                 source_id=source_id,

--- a/ingestion/pipeline.py
+++ b/ingestion/pipeline.py
@@ -1,8 +1,9 @@
 import hashlib
 from dataclasses import dataclass
-from typing import Optional
 
 import structlog
+
+from core.models.ingested_source import IngestedSource
 
 from .chunking.strategy_selector import StrategySelector
 from .embeddings.batch_processor import BatchEmbeddingProcessor
@@ -11,17 +12,17 @@ from .parsers.readme_parser import ReadmeParser
 from .parsers.repo_analyzer import RepoAnalyzer
 from .parsers.resume_parser import ResumeParser
 
-
 logger = structlog.get_logger()
 
 
 @dataclass
 class IngestResult:
     """Result of ingesting a source."""
+
     source_id: str
     chunk_count: int
     skipped: bool
-    skip_reason: Optional[str] = None
+    skip_reason: str | None = None
 
 
 class IngestionPipeline:
@@ -86,16 +87,21 @@ class IngestionPipeline:
         try:
             # Parse resume
             parse_result = self.resume_parser.parse(content)
-            logger.info("Resume parsed successfully", sections=parse_result.metadata.get("detected_sections"))
+            logger.info(
+                "Resume parsed successfully",
+                sections=parse_result.metadata.get("detected_sections"),
+            )
 
             # Prepare metadata
             metadata = parse_result.metadata.copy()
-            metadata.update({
-                "source_id": source_id,
-                "profile_id": profile_id,
-                "filename": filename,
-                "source_type": "resume",
-            })
+            metadata.update(
+                {
+                    "source_id": source_id,
+                    "profile_id": profile_id,
+                    "filename": filename,
+                    "source_type": "resume",
+                }
+            )
 
             # Chunk the content
             chunks = self.strategy_selector.chunk(parse_result.text, metadata)
@@ -165,12 +171,14 @@ class IngestionPipeline:
 
             # Prepare metadata
             metadata = parse_result.metadata.copy()
-            metadata.update({
-                "source_id": source_id,
-                "profile_id": profile_id,
-                "repo_name": repo_name,
-                "source_type": "readme",
-            })
+            metadata.update(
+                {
+                    "source_id": source_id,
+                    "profile_id": profile_id,
+                    "repo_name": repo_name,
+                    "source_type": "readme",
+                }
+            )
 
             # Chunk the content
             chunks = self.strategy_selector.chunk(parse_result.text, metadata)
@@ -239,11 +247,13 @@ class IngestionPipeline:
 
             # Prepare metadata
             metadata = parse_result.metadata.copy()
-            metadata.update({
-                "source_id": source_id,
-                "profile_id": profile_id,
-                "source_type": "repo",
-            })
+            metadata.update(
+                {
+                    "source_id": source_id,
+                    "profile_id": profile_id,
+                    "source_type": "repo",
+                }
+            )
 
             # Chunk the content
             chunks = self.strategy_selector.chunk(parse_result.text, metadata)
@@ -277,7 +287,7 @@ class IngestionPipeline:
             content = content.encode()
         return hashlib.sha256(content).hexdigest()[:16]
 
-    def _check_skip(self, source_id: str, source_type: str) -> Optional[IngestResult]:
+    def _check_skip(self, source_id: str, source_type: str) -> IngestResult | None:
         """
         Check if source has already been ingested.
 
@@ -286,9 +296,11 @@ class IngestionPipeline:
         try:
             # Query database for existing source
             # This assumes a table/model named IngestedSource
-            existing = self.db_session.query(
-                "IngestedSource"  # Placeholder - actual query depends on ORM
-            ).filter_by(source_id=source_id).first()
+            existing = (
+                self.db_session.query("IngestedSource")  # Placeholder - actual query depends on ORM
+                .filter_by(source_id=source_id)
+                .first()
+            )
 
             if existing:
                 logger.info("Source already ingested, skipping", source_id=source_id)
@@ -307,12 +319,15 @@ class IngestionPipeline:
 
         return None
 
-    def _record_ingested_source(
+    async def _record_ingested_source(
         self,
         source_id: str,
         source_type: str,
         profile_id: str,
         chunk_count: int,
+        content_hash: str,
+        filename: str | None = None,
+        source_url: str | None = None,
     ) -> None:
         """
         Record that a source has been ingested.
@@ -322,15 +337,27 @@ class IngestionPipeline:
             source_type: Type of source (resume, readme, repo)
             profile_id: ID of profile owner
             chunk_count: Number of chunks created
+            content_hash: SHA256 hash of the ingested content
+            filename: Original filename, if applicable
+            source_url: Source URL (e.g. repo name), if applicable
         """
         try:
-            # This is a placeholder for actual database recording
-            # In a real implementation, would create IngestedSource record
+            ingested_source = IngestedSource(
+                profile_id=profile_id,
+                source_type=source_type,
+                source_url=source_url,
+                filename=filename,
+                content_hash=content_hash,
+                chunk_count=chunk_count,
+            )
+            self.db_session.add(ingested_source)
+            await self.db_session.commit()
             logger.info(
-                "Recording ingested source",
+                "Recorded ingested source",
                 source_id=source_id,
                 source_type=source_type,
                 profile_id=profile_id,
+                content_hash=content_hash,
                 chunk_count=chunk_count,
             )
         except Exception as e:

--- a/tests/unit/test_ingestion_pipeline_dedup.py
+++ b/tests/unit/test_ingestion_pipeline_dedup.py
@@ -1,0 +1,134 @@
+"""Tests for shared dedup helpers in ingestion/pipeline.py"""
+
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from core.models.ingested_source import IngestedSource
+from ingestion.pipeline import IngestionPipeline
+
+
+@pytest.mark.unit
+class TestIngestionPipelineDedup:
+    """Test suite for _check_skip and _record_ingested_source."""
+
+    @pytest.fixture
+    def mock_vector_db(self):
+        """Create a mock vector database."""
+        return Mock()
+
+    @pytest.fixture
+    def mock_db_session(self):
+        """Create a mock async database session."""
+        session = AsyncMock()
+        session.add = Mock()
+        session.commit = AsyncMock()
+        session.execute = AsyncMock()
+        return session
+
+    @pytest.fixture
+    def mock_embedding_provider(self):
+        """Create a mock embedding provider."""
+        provider = Mock()
+        provider.embed = Mock(return_value=[[0.1] * 1536])
+        return provider
+
+    @pytest.fixture
+    def pipeline(self, mock_vector_db, mock_db_session, mock_embedding_provider):
+        """Create an IngestionPipeline instance with mocked dependencies."""
+        pipeline = IngestionPipeline(
+            vector_db=mock_vector_db,
+            db_session=mock_db_session,
+            embedding_provider=mock_embedding_provider,
+        )
+        pipeline.batch_processor.process = Mock(return_value=[])
+        return pipeline
+
+    @pytest.mark.asyncio
+    async def test_check_skip_returns_none_when_no_existing_source(self, pipeline, mock_db_session):
+        """Test _check_skip returns None when no prior source is recorded."""
+        mock_result = Mock()
+        mock_result.scalars.return_value.first.return_value = None
+        mock_db_session.execute = AsyncMock(return_value=mock_result)
+
+        result = await pipeline._check_skip(
+            "readme_profile-123_my-repo_abcdef",
+            "readme",
+            "profile-123",
+            "abcdef1234567890",
+            filename="my-repo",
+        )
+
+        assert result is None
+        mock_db_session.execute.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_check_skip_skips_when_content_hash_matches(self, pipeline, mock_db_session):
+        """Test _check_skip returns a skipped IngestResult when the stored hash matches."""
+        existing_source = Mock()
+        existing_source.content_hash = "abcdef1234567890"
+        existing_source.chunk_count = 5
+
+        mock_result = Mock()
+        mock_result.scalars.return_value.first.return_value = existing_source
+        mock_db_session.execute = AsyncMock(return_value=mock_result)
+
+        result = await pipeline._check_skip(
+            "readme_profile-123_my-repo_abcdef",
+            "readme",
+            "profile-123",
+            "abcdef1234567890",
+            filename="my-repo",
+        )
+
+        assert result is not None
+        assert result.skipped is True
+        assert result.chunk_count == 5
+
+    @pytest.mark.asyncio
+    async def test_check_skip_does_not_skip_when_content_hash_differs(
+        self, pipeline, mock_db_session
+    ):
+        """Test _check_skip returns None when stored content hash differs from incoming hash."""
+        existing_source = Mock()
+        existing_source.content_hash = "old_hash_1234567"
+        existing_source.chunk_count = 5
+
+        mock_result = Mock()
+        mock_result.scalars.return_value.first.return_value = existing_source
+        mock_db_session.execute = AsyncMock(return_value=mock_result)
+
+        result = await pipeline._check_skip(
+            "readme_profile-123_my-repo_newhash",
+            "readme",
+            "profile-123",
+            "new_hash_7654321",
+            filename="my-repo",
+        )
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_record_ingested_source_persists_to_db(self, pipeline, mock_db_session):
+        """_record_ingested_source should add and commit an IngestedSource row."""
+        content_hash = "abcdef1234567890"
+
+        await pipeline._record_ingested_source(
+            "readme_profile-123_my-repo_abcdef",
+            "readme",
+            "profile-123",
+            3,
+            content_hash=content_hash,
+            source_url="my-repo",
+        )
+
+        mock_db_session.add.assert_called_once()
+        mock_db_session.commit.assert_called_once()
+
+        recorded_source = mock_db_session.add.call_args[0][0]
+        assert isinstance(recorded_source, IngestedSource)
+        assert recorded_source.profile_id == "profile-123"
+        assert recorded_source.source_type == "readme"
+        assert recorded_source.content_hash == content_hash
+        assert recorded_source.source_url == "my-repo"
+        assert recorded_source.chunk_count == 3

--- a/tests/unit/test_readme_unchanged_detection.py
+++ b/tests/unit/test_readme_unchanged_detection.py
@@ -4,7 +4,6 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 
-from core.models.ingested_source import IngestedSource
 from ingestion.pipeline import IngestionPipeline
 
 
@@ -19,11 +18,11 @@ class TestUnchangedDocumentDetection:
 
     @pytest.fixture
     def mock_db_session(self):
-        """Create a mock database session."""
-        session = Mock()
-        session.query = Mock(side_effect=Exception("no such table: IngestedSource"))
+        """Create a mock async database session."""
+        session = AsyncMock()
         session.add = Mock()
         session.commit = AsyncMock()
+        session.execute = AsyncMock()
         return session
 
     @pytest.fixture
@@ -44,62 +43,53 @@ class TestUnchangedDocumentDetection:
         pipeline.batch_processor.process = Mock(return_value=[])
         return pipeline
 
-    def test_reingesting_unchanged_readme_is_not_skipped(self, pipeline):
-        """Re-submitting the exact same README content should skip re-embedding, but currently
-        doesn't."""
+    @pytest.mark.asyncio
+    async def test_reingesting_unchanged_readme_is_skipped(self, pipeline, mock_db_session):
+        """Re-submitting the exact same README content should skip re-embedding."""
         profile_id = "profile-123"
         repo_name = "my-repo"
         content = "# Hello World\nSame content every time"
 
-        first_result = pipeline.ingest_readme(profile_id, repo_name, content)
-        second_result = pipeline.ingest_readme(profile_id, repo_name, content)
+        no_existing_result = Mock()
+        no_existing_result.scalars.return_value.first.return_value = None
+        mock_db_session.execute = AsyncMock(return_value=no_existing_result)
+
+        first_result = await pipeline.ingest_readme(profile_id, repo_name, content)
+
+        existing_source = Mock()
+        existing_source.content_hash = pipeline._hash_content(content)
+        existing_source.chunk_count = first_result.chunk_count
+        mock_result = Mock()
+        mock_result.scalars.return_value.first.return_value = existing_source
+        mock_db_session.execute = AsyncMock(return_value=mock_result)
+
+        second_result = await pipeline.ingest_readme(profile_id, repo_name, content)
 
         assert first_result.skipped is False
-        # BUG: this currently fails because _check_skip never finds a
-        # previously recorded source, so unchanged content is re-embedded.
         assert second_result.skipped is True
 
-    def test_reingesting_unchanged_readme_calls_batch_processor_twice(self, pipeline):
-        """Unchanged README content triggers embedding generation on every ingest call."""
+    @pytest.mark.asyncio
+    async def test_reingesting_unchanged_readme_calls_batch_processor_once(
+        self, pipeline, mock_db_session
+    ):
+        """Unchanged README content should only trigger embedding generation once."""
         profile_id = "profile-123"
         repo_name = "my-repo"
         content = "# Hello World\nSame content every time"
 
-        pipeline.ingest_readme(profile_id, repo_name, content)
-        pipeline.ingest_readme(profile_id, repo_name, content)
+        no_existing_result = Mock()
+        no_existing_result.scalars.return_value.first.return_value = None
+        mock_db_session.execute = AsyncMock(return_value=no_existing_result)
 
-        # BUG: batch_processor.process should only be called once for unchanged
-        # content, but it currently runs on every ingestion.
+        await pipeline.ingest_readme(profile_id, repo_name, content)
+
+        existing_source = Mock()
+        existing_source.content_hash = pipeline._hash_content(content)
+        existing_source.chunk_count = 0
+        mock_result = Mock()
+        mock_result.scalars.return_value.first.return_value = existing_source
+        mock_db_session.execute = AsyncMock(return_value=mock_result)
+
+        await pipeline.ingest_readme(profile_id, repo_name, content)
+
         assert pipeline.batch_processor.process.call_count == 1
-
-    def test_check_skip_never_finds_existing_source(self, pipeline):
-        """_check_skip is a placeholder that never returns a match, so it never skips."""
-        result = pipeline._check_skip("readme_profile-123_my-repo_abcdef", "readme")
-
-        # BUG: with no real DB query/record in place, this always returns None.
-        assert result is not None
-
-    @pytest.mark.asyncio
-    async def test_record_ingested_source_persists_to_db(self, pipeline, mock_db_session):
-        """_record_ingested_source should add and commit an IngestedSource row."""
-        content_hash = "abcdef1234567890"
-
-        await pipeline._record_ingested_source(
-            "readme_profile-123_my-repo_abcdef",
-            "readme",
-            "profile-123",
-            3,
-            content_hash=content_hash,
-            source_url="my-repo",
-        )
-
-        mock_db_session.add.assert_called_once()
-        mock_db_session.commit.assert_called_once()
-
-        recorded_source = mock_db_session.add.call_args[0][0]
-        assert isinstance(recorded_source, IngestedSource)
-        assert recorded_source.profile_id == "profile-123"
-        assert recorded_source.source_type == "readme"
-        assert recorded_source.content_hash == content_hash
-        assert recorded_source.source_url == "my-repo"
-        assert recorded_source.chunk_count == 3

--- a/tests/unit/test_readme_unchanged_detection.py
+++ b/tests/unit/test_readme_unchanged_detection.py
@@ -1,0 +1,87 @@
+"""Tests reproducing missing content-hash-based skip detection in ingestion pipeline."""
+
+from unittest.mock import Mock
+
+import pytest
+
+from ingestion.pipeline import IngestionPipeline
+
+
+@pytest.mark.unit
+class TestUnchangedDocumentDetection:
+    """Reproduction suite for issue: re-embedding unchanged documents."""
+
+    @pytest.fixture
+    def mock_vector_db(self):
+        """Create a mock vector database."""
+        return Mock()
+
+    @pytest.fixture
+    def mock_db_session(self):
+        """Create a mock database session."""
+        session = Mock()
+        session.query = Mock(side_effect=Exception("no such table: IngestedSource"))
+        return session
+
+    @pytest.fixture
+    def mock_embedding_provider(self):
+        """Create a mock embedding provider."""
+        provider = Mock()
+        provider.embed = Mock(return_value=[[0.1] * 1536])
+        return provider
+
+    @pytest.fixture
+    def pipeline(self, mock_vector_db, mock_db_session, mock_embedding_provider):
+        """Create an IngestionPipeline instance with mocked dependencies."""
+        pipeline = IngestionPipeline(
+            vector_db=mock_vector_db,
+            db_session=mock_db_session,
+            embedding_provider=mock_embedding_provider,
+        )
+        pipeline.batch_processor.process = Mock(return_value=[])
+        return pipeline
+
+    def test_reingesting_unchanged_readme_is_not_skipped(self, pipeline):
+        """Re-submitting the exact same README content should skip re-embedding, but currently
+        doesn't."""
+        profile_id = "profile-123"
+        repo_name = "my-repo"
+        content = "# Hello World\nSame content every time"
+
+        first_result = pipeline.ingest_readme(profile_id, repo_name, content)
+        second_result = pipeline.ingest_readme(profile_id, repo_name, content)
+
+        assert first_result.skipped is False
+        # BUG: this currently fails because _check_skip never finds a
+        # previously recorded source, so unchanged content is re-embedded.
+        assert second_result.skipped is True
+
+    def test_reingesting_unchanged_readme_calls_batch_processor_twice(self, pipeline):
+        """Unchanged README content triggers embedding generation on every ingest call."""
+        profile_id = "profile-123"
+        repo_name = "my-repo"
+        content = "# Hello World\nSame content every time"
+
+        pipeline.ingest_readme(profile_id, repo_name, content)
+        pipeline.ingest_readme(profile_id, repo_name, content)
+
+        # BUG: batch_processor.process should only be called once for unchanged
+        # content, but it currently runs on every ingestion.
+        assert pipeline.batch_processor.process.call_count == 1
+
+    def test_check_skip_never_finds_existing_source(self, pipeline):
+        """_check_skip is a placeholder that never returns a match, so it never skips."""
+        result = pipeline._check_skip("readme_profile-123_my-repo_abcdef", "readme")
+
+        # BUG: with no real DB query/record in place, this always returns None.
+        assert result is not None
+
+    def test_record_ingested_source_does_not_persist_to_db(self, pipeline, mock_db_session):
+        """_record_ingested_source is a placeholder that never writes to the database."""
+        pipeline._record_ingested_source(
+            "readme_profile-123_my-repo_abcdef", "readme", "profile-123", 3
+        )
+
+        # BUG: nothing is ever added or committed to the db_session.
+        mock_db_session.add.assert_called_once()
+        mock_db_session.commit.assert_called_once()

--- a/tests/unit/test_readme_unchanged_detection.py
+++ b/tests/unit/test_readme_unchanged_detection.py
@@ -1,9 +1,10 @@
 """Tests reproducing missing content-hash-based skip detection in ingestion pipeline."""
 
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
+from core.models.ingested_source import IngestedSource
 from ingestion.pipeline import IngestionPipeline
 
 
@@ -21,6 +22,8 @@ class TestUnchangedDocumentDetection:
         """Create a mock database session."""
         session = Mock()
         session.query = Mock(side_effect=Exception("no such table: IngestedSource"))
+        session.add = Mock()
+        session.commit = AsyncMock()
         return session
 
     @pytest.fixture
@@ -76,12 +79,27 @@ class TestUnchangedDocumentDetection:
         # BUG: with no real DB query/record in place, this always returns None.
         assert result is not None
 
-    def test_record_ingested_source_does_not_persist_to_db(self, pipeline, mock_db_session):
-        """_record_ingested_source is a placeholder that never writes to the database."""
-        pipeline._record_ingested_source(
-            "readme_profile-123_my-repo_abcdef", "readme", "profile-123", 3
+    @pytest.mark.asyncio
+    async def test_record_ingested_source_persists_to_db(self, pipeline, mock_db_session):
+        """_record_ingested_source should add and commit an IngestedSource row."""
+        content_hash = "abcdef1234567890"
+
+        await pipeline._record_ingested_source(
+            "readme_profile-123_my-repo_abcdef",
+            "readme",
+            "profile-123",
+            3,
+            content_hash=content_hash,
+            source_url="my-repo",
         )
 
-        # BUG: nothing is ever added or committed to the db_session.
         mock_db_session.add.assert_called_once()
         mock_db_session.commit.assert_called_once()
+
+        recorded_source = mock_db_session.add.call_args[0][0]
+        assert isinstance(recorded_source, IngestedSource)
+        assert recorded_source.profile_id == "profile-123"
+        assert recorded_source.source_type == "readme"
+        assert recorded_source.content_hash == content_hash
+        assert recorded_source.source_url == "my-repo"
+        assert recorded_source.chunk_count == 3


### PR DESCRIPTION
## Summary
This PR fixes unchanged READMEs (and resumes/repo metadata) being needlessly re-embedded on every re-submission by wiring up the content-hash deduplication that was already half-built but never functional. `_hash_content` already computed a SHA256 hash, but `_check_skip` used a broken, always-failing DB query and `_record_ingested_source` never actually persisted anything, so the "already ingested" check silently no-op'd and every ingestion re-ran the embedding pipeline regardless of content. Both methods now query/write real `IngestedSource` rows (keyed by `profile_id`, `source_type`, and `filename`, with `content_hash` compared against the most recent record), and `ingest_resume`/`ingest_readme`/`ingest_repo_metadata` were converted to `async` to match the app's async-only DB session and updated to call the fixed methods correctly — eliminating wasted embedding-provider API calls for content that hasn't changed.

## Issue
Closes #13 

## Changes
- Fixed `_check_skip` in `ingestion/pipeline.py` to query the `IngestedSource` table by `profile_id` + `source_type` + `filename`, ordered by `ingested_at` descending, and compare the stored `content_hash` against the incoming one — replacing the previous broken query that always silently failed and returned `None`.
- Fixed `_record_ingested_source` in `ingestion/pipeline.py` to actually construct and persist an `IngestedSource` row (`db_session.add` + `commit`) — previously a no-op that only logged.
- Converted `_check_skip`, `_record_ingested_source`, `ingest_resume`, `ingest_readme`, and `ingest_repo_metadata` to `async` to match the app's async-only SQLAlchemy session.
- Updated `ingest_resume`, `ingest_readme`, and `ingest_repo_metadata` to compute `content_hash` once and pass it (along with `profile_id` and `filename`/`repo_name`) into the fixed `_check_skip`/`_record_ingested_source` calls.
- Added `tests/unit/test_ingestion_pipeline_dedup.py` covering `_check_skip` (no prior record, hash match → skip, hash mismatch → don't skip) and `_record_ingested_source` (persists the correct fields).
- Added/updated `tests/unit/test_readme_unchanged_detection.py` to verify end-to-end that re-submitting an unchanged README via `ingest_readme` is skipped and only triggers embedding generation once.

## Testing
- [x] Unit tests pass (`make test-unit`) — all 6 tests covering this fix pass; 53 pre-existing failures elsewhere in the suite are unrelated (see Notes)
- [ ] Integration tests pass (`make test-integration`) — not applicable to this fix (no integration test coverage touches ingestion; scope was unit-level only)
- [x] Linter passes (`make lint`) — zero ruff errors in the files this PR touches; pre-existing repo-wide errors unrelated (see Notes)
- [x] Type checker passes (`make typecheck`) — zero mypy errors in `ingestion/`; pre-existing errors unrelated (see Notes)
- [x] New/updated tests cover the changes

## Screenshots / Demo
Not Applicable

## Notes for Reviewers
`make check` surfaces pre-existing issues unrelated to this PR, confirmed to predate these changes: `ruff` reports 178 errors repo-wide (mostly unused-variable warnings in unrelated test files like `test_tech_detector.py`), `black --check` flags 51 files needing reformatting, `mypy` reports 5 errors from missing type stubs (`PyPDF2`, `passlib`, `rank_bm25`) and a numpy/Python 3.14 syntax incompatibility, and `pytest tests/unit` has 53 failing tests — notably `test_review_service.py`, which has a broken `AsyncMock` mocking pattern (`mock_result = AsyncMock()` then calling `.scalars().first()` without awaiting `.scalars()`, causing an `AttributeError`) affecting 13 of its 19 tests. None of these touch `ingestion/pipeline.py` or the test files added/modified in this PR — verified by diffing lint/type/test output against the specific files this PR changes.
