### PR TITLE
Fix/44 orchestrator silent failure

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -27,3 +27,36 @@ I reproduced the issue by adding a temporary `raise RuntimeError("Test error")` 
 
 **Blockers or open questions:**
 [Anything you're still uncertain about going into Week 9, or leave blank]
+
+---
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+I added `exc_info=True` to all `logger.error` calls in `agent/orchestrator.py` and `agent/error_handling.py`. This makes structlog emit the full exception traceback whenever a tool fails, instead of just the error string. I also created `tests/unit/test_orchestrator.py` and `tests/unit/test_error_handling.py` with 44 new unit tests, including tests that specifically assert `exc_info=True` is present in the logged calls. All 44 pass.
+
+**Next steps:**
+Open a draft PR, request peer feedback in Slack, and fill in Check-in 2 with the PR link before Sunday.
+
+**Blockers:**
+[Anything slowing you down? Or leave blank.]
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [link to your submitted pull request]
+
+**Branch:** [the branch name you worked on, e.g. `fix/123-short-description`]
+
+**What you built:**
+[1–3 sentences summarizing what your fix does and how it works]
+
+**Tests added or updated:**
+[Which test files did you touch? What do they cover?]
+
+**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+
+**Draft PR feedback received from:** [name or Slack handle, or "none"]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -47,16 +47,16 @@ Open a draft PR, request peer feedback in Slack, and fill in Check-in 2 with the
 
 ### Check-in 2 (end of week)
 
-**PR link:** [link to your submitted pull request]
+**PR link:** https://github.com/ascherj/pathreview/pull/508
 
-**Branch:** [the branch name you worked on, e.g. `fix/123-short-description`]
+**Branch:** `fix/44-orchestrator-silent-failure`
 
 **What you built:**
-[1–3 sentences summarizing what your fix does and how it works]
+Added `exc_info=True` to `logger.error` calls in `orchestrator.py` and `error_handling.py` to ensure structlog emits full exception stack traces when tools fail or retries are exhausted. This resolves the silent failure swallowing issue (Issue #44).
 
 **Tests added or updated:**
-[Which test files did you touch? What do they cover?]
+Created `tests/unit/test_orchestrator.py` and `tests/unit/test_error_handling.py` with 44 tests to verify orchestrator flow, retry context logic, and specifically assert that `exc_info=True` is passed to the logger on failures.
 
-**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
 
-**Draft PR feedback received from:** [name or Slack handle, or "none"]
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,16 @@
+## Week 7 — Issue selection
+
+**Issue link:** [Orchestrator catches all exceptions from tool calls and continues without logging the failure](https://github.com/ascherj/pathreview/issues/44)
+
+**Issue title:** Orchestrator catches all exceptions from tool calls and continues without logging the failure
+
+**Tier:** [ ] Tier 1  [X] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The core agent orchestrator in `agent/orchestrator.py` currently uses a broad exception handler that catches and silences any errors that occur when a tool is executed. This is problematic because when a tool fails (e.g., due to an API error or bad data), the failure is not logged anywhere. The agent just continues on, often producing an incomplete or inaccurate review without any indication to the user or developer that something went wrong. A successful fix will ensure that any exception from a tool call is properly logged, making the system more robust and easier to debug.
+
+**Branch name:** `fix/44-orchestrator-silent-failure`
+
+**Setup confirmation:** [X] App runs locally at localhost:5173
+
+**Cohort ledger:** [X] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -18,12 +18,12 @@ The core agent orchestrator in `agent/orchestrator.py` currently uses a broad ex
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [link to commit documenting the reproduced issue]
+**Reproduction commit link:** https://github.com/ascherj/pathreview/commit/8368de6757de9942cad639da5809277ec200ef8a
 
 **Reproduction summary:**
 I reproduced the issue by adding a temporary `raise RuntimeError("Test error")` inside `github_tool.py` and running the application. I noticed that the orchestrator caught the exception and printed a simple error string (`error='Test error'`), but didn't log the full error details, so you can't tell exactly which file or line of code failed.
 
-**PLAN.md link:** [link to PLAN.md in your fork]
+**PLAN.md link:** https://github.com/vasubawa/pathreview/blob/fix/44-orchestrator-silent-failure/PLAN.md
 
 **Blockers or open questions:**
 [Anything you're still uncertain about going into Week 9, or leave blank]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -14,3 +14,16 @@ The core agent orchestrator in `agent/orchestrator.py` currently uses a broad ex
 **Setup confirmation:** [X] App runs locally at localhost:5173
 
 **Cohort ledger:** [X] Issue added to cohort ledger
+
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [link to commit documenting the reproduced issue]
+
+**Reproduction summary:**
+I reproduced the issue by adding a temporary `raise RuntimeError("Test error")` inside `github_tool.py` and running the application. I noticed that the orchestrator caught the exception and printed a simple error string (`error='Test error'`), but didn't log the full error details, so you can't tell exactly which file or line of code failed.
+
+**PLAN.md link:** [link to PLAN.md in your fork]
+
+**Blockers or open questions:**
+[Anything you're still uncertain about going into Week 9, or leave blank]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -60,3 +60,36 @@ Created `tests/unit/test_orchestrator.py` and `tests/unit/test_error_handling.py
 **Self-review confirmation:** [x] make check passes  [x] make test-unit passes
 
 **Draft PR feedback received from:** none
+
+
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [X] No — still awaiting review
+
+**Summary of feedback:**
+No review comments yet. 
+
+**How you responded:**
+No changes were made. 
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Writing the comprehensive unit tests was more challenging than expected. 
+
+**What did you learn about working in a large codebase?**
+I learned that a simple one-line code change often requires a lot more code in testing just to make sure it works. In a larger project, making sure errors are logged properly is just as important as the feature itself so others can debug issues later.
+
+**How did AI tools help — and where did they fall short?**
+AI tools were great for generating the boilerplate structure for the 44 new tests and pointing out all the places that needed the logging update. But they struggled with the specific mock setup our test suite needed, so I had to go in and manually fix the assertions for the logger calls.
+
+**What would you do differently if you started over?**
+I would spend more time looking at how the existing tests mock dependencies before writing my own. I jumped straight into writing the tests and had to backtrack to fix the mocking setup, which cost me some time.
+
+**What are you most proud of from this module?**
+I'm proud that I was able to figure out the potential problem just by reading the code in the selected files, and it turned out to be completely correct.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,28 @@
+## Solution plan
+
+**Issue:** [Orchestrator catches all exceptions from tool calls and continues without logging the failure](https://github.com/ascherj/pathreview/issues/44)
+
+### Understand
+**Root cause:** The code hides the exact file and line number (stack trace) when a tool crashes, and only logs a simple error message.
+
+**Expected vs. actual:** We expect the terminal to show the full stack trace so we can debug easily. Currently, it hides it.
+
+### Map
+Files to change:
+- `agent/orchestrator.py`: Update error logs in `run` and `_execute_tool`.
+- `agent/error_handling.py`: Update error logs in the retry functions.
+
+### Plan
+1. Find the `logger.error` calls in both files.
+2. Add `exc_info=True` to them so they print the stack trace.
+3. Run the app to verify the stack trace shows up in the terminal when a tool crashes.
+
+### Inputs & outputs
+**Input:** A tool crashes with an error.
+**Output:** The terminal prints the full stack trace, making it easy to debug.
+
+### Risks & unknowns
+- **Messy logs:** Printing a stack trace for expected errors (like a 404) might make the logs too noisy.
+
+### Edge cases
+- **Timeouts:** Tool timeouts should still be handled cleanly without crashing the app.

--- a/agent/error_handling.py
+++ b/agent/error_handling.py
@@ -42,7 +42,7 @@ def retry_with_backoff(max_retries: int = 3, backoff_factor: float = 2.0,
                         time.sleep(wait_time)
                     else:
                         logger.error("retry_exhausted", func=func.__name__,
-                                   max_retries=max_retries, error=str(e))
+                                   max_retries=max_retries, error=str(e), exc_info=True)
 
             if last_exception:
                 raise last_exception
@@ -93,5 +93,5 @@ class RetryContext:
             return True  # Suppress exception and retry
 
         logger.error("retry_context_exhausted", attempt=self.attempt,
-                   max_retries=self.max_retries, error=str(exc_val))
+                   max_retries=self.max_retries, error=str(exc_val), exc_info=True)
         return False  # Re-raise exception

--- a/agent/orchestrator.py
+++ b/agent/orchestrator.py
@@ -58,7 +58,7 @@ class Orchestrator:
                 logger.info("tool_executed", tool=tool_name, success=True)
 
             except Exception as e:
-                logger.error("tool_execution_failed", tool=tool_name, error=str(e))
+                logger.error("tool_execution_failed", tool=tool_name, error=str(e), exc_info=True)
                 results[tool_name] = {"error": str(e), "success": False}
 
         # Persist state
@@ -166,10 +166,10 @@ class Orchestrator:
             return result
 
         except TimeoutError:
-            logger.error("tool_timeout", tool=tool_name, timeout=self.tool_timeout)
+            logger.error("tool_timeout", tool=tool_name, timeout=self.tool_timeout, exc_info=True)
             raise
         except Exception as e:
-            logger.error("tool_execution_error", tool=tool_name, error=str(e))
+            logger.error("tool_execution_error", tool=tool_name, error=str(e), exc_info=True)
             raise
 
     def _execute_with_timeout(self, tool, tool_input: dict, timeout: Optional[float] = None):

--- a/tests/unit/test_error_handling.py
+++ b/tests/unit/test_error_handling.py
@@ -1,0 +1,306 @@
+"""Tests for error_handling.py"""
+
+from unittest.mock import patch
+
+import pytest
+
+from agent.error_handling import RetryContext, retry_with_backoff
+
+
+@pytest.mark.unit
+class TestRetryWithBackoff:
+    """Test suite for the retry_with_backoff decorator."""
+
+    def test_retry_with_backoff_always_succeeds_returns_value(self):
+        """
+        retry_with_backoff() should return the value immediately when no exception occurs.
+        """
+        @retry_with_backoff(max_retries=3)
+        def always_ok():
+            return 42
+
+        result = always_ok()
+
+        assert result == 42
+
+    def test_retry_with_backoff_transient_failure_retries_and_succeeds(self):
+        """
+        retry_with_backoff() should retry the function and eventually succeed on transient failures.
+        """
+        call_count = {"n": 0}
+
+        @retry_with_backoff(max_retries=3, backoff_factor=0)
+        def flaky():
+            call_count["n"] += 1
+            if call_count["n"] < 2:
+                raise ValueError("not yet")
+            return "ok"
+
+        with patch("time.sleep"):
+            result = flaky()
+
+        assert result == "ok"
+        assert call_count["n"] == 2
+
+    def test_retry_with_backoff_exhausted_retries_raises_exception(self):
+        """
+        retry_with_backoff() should re-raise the original exception when all retries fail.
+        """
+        @retry_with_backoff(max_retries=2, backoff_factor=0)
+        def always_fails():
+            raise RuntimeError("always")
+
+        with patch("time.sleep"), pytest.raises(RuntimeError, match="always"):
+            always_fails()
+
+    def test_retry_with_backoff_retry_attempt_logs_warning(self):
+        """
+        retry_with_backoff() should log a warning on each retry attempt.
+        """
+        call_count = {"n": 0}
+
+        @retry_with_backoff(max_retries=3, backoff_factor=0)
+        def sometimes_fails():
+            call_count["n"] += 1
+            if call_count["n"] < 3:
+                raise ValueError("try again")
+            return "done"
+
+        with patch("agent.error_handling.logger") as mock_logger, patch("time.sleep"):
+            sometimes_fails()
+
+        assert mock_logger.warning.called
+
+    def test_retry_with_backoff_exhausted_retries_logs_error(self):
+        """
+        retry_with_backoff() should log an error when all retries are consumed.
+        """
+        @retry_with_backoff(max_retries=2, backoff_factor=0)
+        def always_fails():
+            raise RuntimeError("nope")
+
+        with (
+            patch("agent.error_handling.logger") as mock_logger,
+            patch("time.sleep"),
+            pytest.raises(RuntimeError),
+        ):
+            always_fails()
+
+        assert mock_logger.error.called
+
+    def test_retry_with_backoff_exhausted_retries_logs_with_exc_info(self):
+        """
+        retry_with_backoff() should include exc_info=True when logging retry exhaustion.
+
+        This ensures the full traceback is captured for debugging (Issue #44).
+        """
+        @retry_with_backoff(max_retries=2, backoff_factor=0)
+        def always_fails():
+            raise RuntimeError("trace me")
+
+        with (
+            patch("agent.error_handling.logger") as mock_logger,
+            patch("time.sleep"),
+            pytest.raises(RuntimeError),
+        ):
+            always_fails()
+
+        exhausted_calls = [
+            c for c in mock_logger.error.call_args_list
+            if c.args and c.args[0] == "retry_exhausted"
+        ]
+        assert exhausted_calls
+        for c in exhausted_calls:
+            assert c.kwargs.get("exc_info") is True
+
+    def test_retry_with_backoff_unspecified_exception_not_retried(self):
+        """
+        retry_with_backoff() should not retry exceptions that are not in the exceptions tuple.
+        """
+        call_count = {"n": 0}
+
+        @retry_with_backoff(max_retries=3, exceptions=(ValueError,), backoff_factor=0)
+        def raises_type_error():
+            call_count["n"] += 1
+            raise TypeError("wrong type")
+
+        with patch("time.sleep"), pytest.raises(TypeError):
+            raises_type_error()
+
+        assert call_count["n"] == 1
+
+    def test_retry_with_backoff_between_attempts_calls_sleep(self):
+        """
+        retry_with_backoff() should call time.sleep between retry attempts.
+        """
+        @retry_with_backoff(max_retries=3, backoff_factor=2.0)
+        def always_fails():
+            raise RuntimeError("fail")
+
+        with patch("time.sleep") as mock_sleep, pytest.raises(RuntimeError):
+            always_fails()
+
+        assert mock_sleep.call_count == 2
+
+    def test_retry_with_backoff_wraps_preserves_function_name(self):
+        """
+        retry_with_backoff() should preserve the original function's name using functools.wraps.
+        """
+        @retry_with_backoff(max_retries=3)
+        def my_special_function():
+            return True
+
+        assert my_special_function.__name__ == "my_special_function"
+
+    def test_retry_with_backoff_max_retries_one_runs_once(self):
+        """
+        retry_with_backoff() with max_retries=1 should only execute the function once.
+        """
+        call_count = {"n": 0}
+
+        @retry_with_backoff(max_retries=1, backoff_factor=0)
+        def always_fails():
+            call_count["n"] += 1
+            raise RuntimeError("fail")
+
+        with patch("time.sleep"), pytest.raises(RuntimeError):
+            always_fails()
+
+        assert call_count["n"] == 1
+
+    def test_retry_with_backoff_arguments_are_passed_through(self):
+        """
+        retry_with_backoff() should correctly forward all positional and keyword arguments.
+        """
+        received = {}
+
+        @retry_with_backoff(max_retries=2)
+        def record(a, b, c=None):
+            received.update({"a": a, "b": b, "c": c})
+            return a + b
+
+        result = record(1, 2, c=3)
+
+        assert result == 3
+        assert received == {"a": 1, "b": 2, "c": 3}
+
+
+@pytest.mark.unit
+class TestRetryContext:
+    """Test suite for the RetryContext context manager."""
+
+    def test_retrycontext_no_exception_exits_cleanly(self):
+        """
+        RetryContext should exit cleanly without modifying attempt count when no exception occurs.
+        """
+        with RetryContext(max_retries=3) as ctx:
+            pass
+
+        assert ctx.attempt == 0
+
+    def test_retrycontext_retries_remaining_suppresses_exception(self):
+        """
+        RetryContext should suppress exceptions when retries remain, returning True.
+        """
+        ctx = RetryContext(max_retries=3, backoff_factor=0)
+
+        with patch("time.sleep"):
+            result = ctx.__exit__(ValueError, ValueError("x"), None)
+
+        assert result is True
+
+    def test_retrycontext_retries_exhausted_reraises_exception(self):
+        """
+        RetryContext should return False (re-raise) when max_retries is reached.
+        """
+        ctx = RetryContext(max_retries=1, backoff_factor=0)
+
+        with patch("time.sleep"):
+            ctx.__exit__(ValueError, ValueError("first"), None)
+            result = ctx.__exit__(ValueError, ValueError("second"), None)
+
+        assert result is False
+
+    def test_retrycontext_retry_attempt_logs_warning(self):
+        """
+        RetryContext should log a warning when an exception is caught and suppressed.
+        """
+        ctx = RetryContext(max_retries=3, backoff_factor=0)
+
+        with patch("agent.error_handling.logger") as mock_logger, patch("time.sleep"):
+            ctx.__exit__(ValueError, ValueError("warn me"), None)
+
+        assert mock_logger.warning.called
+
+    def test_retrycontext_exhausted_retries_logs_error_with_exc_info(self):
+        """
+        RetryContext should log an error with exc_info=True when retries are exhausted.
+
+        This prevents silent failures and helps debugging (Issue #44).
+        """
+        ctx = RetryContext(max_retries=1, backoff_factor=0)
+
+        with patch("agent.error_handling.logger") as mock_logger, patch("time.sleep"):
+            ctx.__exit__(RuntimeError, RuntimeError("exhausted"), None)
+
+        exhausted_calls = [
+            c for c in mock_logger.error.call_args_list
+            if c.args and c.args[0] == "retry_context_exhausted"
+        ]
+        assert exhausted_calls
+        for c in exhausted_calls:
+            assert c.kwargs.get("exc_info") is True
+
+    def test_retrycontext_unspecified_exception_returns_false(self):
+        """
+        RetryContext should not suppress exceptions that don't match the configured types.
+        """
+        ctx = RetryContext(max_retries=3, exceptions=(ValueError,))
+
+        result = ctx.__exit__(TypeError, TypeError("nope"), None)
+
+        assert result is False
+
+    def test_retrycontext_no_exception_type_returns_false(self):
+        """
+        RetryContext __exit__ should return False when no exception occurred.
+        """
+        ctx = RetryContext(max_retries=3)
+
+        result = ctx.__exit__(None, None, None)
+
+        assert result is False
+
+    def test_retrycontext_retry_attempt_calls_sleep(self):
+        """
+        RetryContext should call time.sleep when a retry is attempted.
+        """
+        ctx = RetryContext(max_retries=3, backoff_factor=2.0)
+
+        with patch("time.sleep") as mock_sleep:
+            ctx.__exit__(ValueError, ValueError("x"), None)
+
+        mock_sleep.assert_called_once()
+
+    def test_retrycontext_exception_stores_last_exception(self):
+        """
+        RetryContext should store the most recently caught exception in last_exception.
+        """
+        ctx = RetryContext(max_retries=3, backoff_factor=0)
+        exc = ValueError("remember me")
+
+        with patch("time.sleep"):
+            ctx.__exit__(ValueError, exc, None)
+
+        assert ctx.last_exception is exc
+
+    def test_retrycontext_exception_increments_attempt(self):
+        """
+        RetryContext should increment its internal attempt counter upon each exception.
+        """
+        ctx = RetryContext(max_retries=3, backoff_factor=0)
+
+        with patch("time.sleep"):
+            ctx.__exit__(ValueError, ValueError("first"), None)
+
+        assert ctx.attempt == 1

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -1,0 +1,291 @@
+"""Tests for orchestrator.py"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from agent.orchestrator import Orchestrator
+
+
+@pytest.mark.unit
+class TestOrchestrator:
+    """Test suite for Orchestrator."""
+
+    @pytest.fixture
+    def mock_tool(self):
+        """Create a mock tool that succeeds."""
+        tool = Mock()
+        tool.name = "github_tool"
+        tool.execute = Mock(return_value={"stars": 42})
+        return tool
+
+    @pytest.fixture
+    def failing_tool(self):
+        """Create a mock tool that always raises."""
+        tool = Mock()
+        tool.name = "github_tool"
+        tool.execute = Mock(side_effect=RuntimeError("boom"))
+        return tool
+
+    @pytest.fixture
+    def orchestrator(self, mock_tool):
+        """Create an Orchestrator with a single succeeding tool."""
+        return Orchestrator(tools={"github_tool": mock_tool})
+
+    @pytest.fixture
+    def profile_data(self):
+        """Return a minimal profile_data dict with a GitHub repo."""
+        return {
+            "github_username": "alice",
+            "projects": [{"github_repo": "myrepo"}],
+        }
+
+    def test_orchestrator_init_stores_tools(self, mock_tool):
+        """
+        Orchestrator init should correctly store the provided tools dictionary.
+        """
+        orch = Orchestrator(tools={"github_tool": mock_tool})
+
+        assert "github_tool" in orch.tools
+
+    def test_orchestrator_init_sets_default_timeout(self, mock_tool):
+        """
+        Orchestrator init should set the default tool_timeout to 30.0 seconds.
+        """
+        orch = Orchestrator(tools={"github_tool": mock_tool})
+
+        assert orch.tool_timeout == 30.0
+
+    def test_orchestrator_init_sets_custom_timeout(self, mock_tool):
+        """
+        Orchestrator init should respect a provided custom tool_timeout value.
+        """
+        orch = Orchestrator(tools={"github_tool": mock_tool}, tool_timeout=10.0)
+
+        assert orch.tool_timeout == 10.0
+
+    def test_run_valid_profile_returns_profile_id(self, orchestrator, profile_data):
+        """
+        run() should return a dictionary containing the provided profile_id.
+        """
+        result = orchestrator.run("alice-001", profile_data)
+
+        assert result["profile_id"] == "alice-001"
+
+    def test_run_valid_profile_returns_tool_results_key(self, orchestrator, profile_data):
+        """
+        run() should return a dictionary containing a 'tool_results' key.
+        """
+        result = orchestrator.run("alice-001", profile_data)
+
+        assert "tool_results" in result
+
+    def test_run_empty_profile_returns_empty_results(self, orchestrator):
+        """
+        run() with an empty profile should return empty tool results.
+        """
+        result = orchestrator.run("p-empty", {})
+
+        assert result["tool_results"] == {}
+
+    def test_run_profile_with_repo_calls_github_tool(self, mock_tool, profile_data):
+        """
+        run() should execute the github_tool when the profile contains a GitHub repo.
+        """
+        orch = Orchestrator(tools={"github_tool": mock_tool})
+
+        orch.run("alice-001", profile_data)
+
+        mock_tool.execute.assert_called_once()
+
+    def test_run_profile_without_repo_skips_github_tool(self, mock_tool):
+        """
+        run() should not execute the github_tool if the profile has no github_repo.
+        """
+        orch = Orchestrator(tools={"github_tool": mock_tool})
+        profile_data = {
+            "github_username": "carol",
+            "projects": [{"title": "no repo here"}],
+        }
+
+        orch.run("carol-001", profile_data)
+
+        mock_tool.execute.assert_not_called()
+
+    def test_run_tool_failure_stores_error_result(self, failing_tool, profile_data):
+        """
+        run() should record an error result for a tool that raises an exception.
+        """
+        orch = Orchestrator(tools={"github_tool": failing_tool})
+
+        result = orch.run("dave-001", profile_data)
+
+        assert result["tool_results"]["github_tool"]["success"] is False
+
+    def test_run_tool_failure_stores_error_message(self, failing_tool, profile_data):
+        """
+        run() should include the exception message in the tool's error result.
+        """
+        orch = Orchestrator(tools={"github_tool": failing_tool})
+
+        result = orch.run("dave-001", profile_data)
+
+        assert "boom" in result["tool_results"]["github_tool"]["error"]
+
+    def test_run_tool_failure_logs_exc_info(self, failing_tool, profile_data):
+        """
+        run() should log the tool failure with exc_info=True.
+
+        This guarantees stack traces are recorded when a tool crashes (Issue #44).
+        """
+        orch = Orchestrator(tools={"github_tool": failing_tool})
+
+        with patch("agent.orchestrator.logger") as mock_logger:
+            orch.run("dave-001", profile_data)
+
+        error_calls = [
+            c for c in mock_logger.error.call_args_list
+            if c.args and c.args[0] in ("tool_execution_failed", "tool_execution_error")
+        ]
+        assert error_calls
+        for c in error_calls:
+            assert c.kwargs.get("exc_info") is True
+
+    def test_run_tool_failure_continues_execution(self):
+        """
+        run() should continue executing subsequent tools even if one tool fails.
+        """
+        failing = Mock()
+        failing.name = "github_tool"
+        failing.execute = Mock(side_effect=RuntimeError("fail"))
+
+        passing = Mock()
+        passing.name = "readme_scorer"
+        passing.execute = Mock(return_value={"score": 80})
+
+        orch = Orchestrator(tools={"github_tool": failing, "readme_scorer": passing})
+        profile_data = {
+            "github_username": "frank",
+            "projects": [{"github_repo": "repo"}],
+            "readme_content": "# Hello",
+        }
+
+        result = orch.run("frank-001", profile_data)
+
+        assert result["tool_results"]["readme_scorer"]["score"] == 80
+
+    def test_execute_tool_unknown_tool_raises_value_error(self, orchestrator):
+        """
+        _execute_tool() should raise a ValueError when called with an unregistered tool name.
+        """
+        with pytest.raises(ValueError, match="Unknown tool"):
+            orchestrator._execute_tool("no_such_tool", {})
+
+    def test_execute_tool_success_returns_result(self, mock_tool):
+        """
+        _execute_tool() should return the successful result data from the tool.
+        """
+        orch = Orchestrator(tools={"github_tool": mock_tool})
+
+        result = orch._execute_tool("github_tool", {"github_username": "x", "repo_name": "y"})
+
+        assert result == {"stars": 42}
+
+    def test_execute_tool_exception_reraises_exception(self, failing_tool):
+        """
+        _execute_tool() should re-raise any exception thrown by the tool's execute method.
+        """
+        orch = Orchestrator(tools={"github_tool": failing_tool})
+
+        with pytest.raises(RuntimeError, match="boom"):
+            orch._execute_tool("github_tool", {"github_username": "x", "repo_name": "y"})
+
+    def test_execute_tool_timeout_logs_with_exc_info(self):
+        """
+        _execute_tool() should log TimeoutErrors with exc_info=True.
+        """
+        timeout_tool = Mock()
+        timeout_tool.name = "github_tool"
+        timeout_tool.execute = Mock(side_effect=TimeoutError("timed out"))
+        orch = Orchestrator(tools={"github_tool": timeout_tool}, tool_timeout=0.0)
+
+        with patch("agent.orchestrator.logger") as mock_logger, pytest.raises(TimeoutError):
+            orch._execute_tool("github_tool", {"github_username": "x", "repo_name": "y"})
+
+        error_calls = [
+            c for c in mock_logger.error.call_args_list
+            if c.args and c.args[0] in ("tool_timeout", "tool_execution_error")
+        ]
+        assert error_calls
+        for c in error_calls:
+            assert c.kwargs.get("exc_info") is True
+
+    def test_build_plan_empty_profile_returns_empty_list(self, orchestrator):
+        """
+        _build_plan() should return an empty execution plan for an empty profile.
+        """
+        plan = orchestrator._build_plan({})
+
+        assert plan == []
+
+    def test_build_plan_github_data_includes_github_tool(self, orchestrator, profile_data):
+        """
+        _build_plan() should include github_tool if the profile contains repo information.
+        """
+        plan = orchestrator._build_plan(profile_data)
+
+        tool_names = [name for name, _ in plan]
+        assert "github_tool" in tool_names
+
+    def test_build_plan_readme_content_includes_readme_scorer(self, orchestrator):
+        """
+        _build_plan() should include readme_scorer if the profile contains readme content.
+        """
+        plan = orchestrator._build_plan({"readme_content": "# Hello World"})
+
+        tool_names = [name for name, _ in plan]
+        assert "readme_scorer" in tool_names
+
+    def test_build_plan_nonempty_plan_includes_market_analyzer(self, orchestrator):
+        """
+        _build_plan() should append market_analyzer whenever other tools are scheduled.
+        """
+        plan = orchestrator._build_plan({"readme_content": "# Hello World"})
+
+        tool_names = [name for name, _ in plan]
+        assert "market_analyzer" in tool_names
+
+    def test_build_plan_empty_plan_excludes_market_analyzer(self, orchestrator):
+        """
+        _build_plan() should not append market_analyzer if no other tools are in the plan.
+        """
+        plan = orchestrator._build_plan({})
+
+        tool_names = [name for name, _ in plan]
+        assert "market_analyzer" not in tool_names
+
+    def test_run_with_session_store_calls_set(self, mock_tool, profile_data):
+        """
+        run() should persist the results to the session store if one is provided.
+        """
+        mock_store = Mock()
+        mock_store.get = Mock(return_value=None)
+        mock_store.set = Mock()
+        orch = Orchestrator(tools={"github_tool": mock_tool}, session_store=mock_store)
+
+        orch.run("p-session", profile_data)
+
+        mock_store.set.assert_called_once()
+
+    def test_run_with_session_store_loads_previous_state(self, mock_tool, profile_data):
+        """
+        run() should load existing state from the session store if available.
+        """
+        mock_store = Mock()
+        mock_store.get = Mock(return_value={"previous": "data"})
+        mock_store.set = Mock()
+        orch = Orchestrator(tools={"github_tool": mock_tool}, session_store=mock_store)
+
+        orch.run("p-load", profile_data)
+
+        mock_store.get.assert_called_once_with("p-load")


### PR DESCRIPTION
## Summary
The orchestrator previously swallowed exceptions and logged errors without stack traces, making debugging difficult. This PR adds `exc_info=True` to the logger calls so that full stack traces are always emitted when tools fail or retries are exhausted.

## Issue
Closes #44

## Changes
- `agent/orchestrator.py`: Added `exc_info=True` to `logger.error` for tool failures and timeouts.
- `agent/error_handling.py`: Added `exc_info=True` to `logger.error` when all retries fail.
- `tests/unit/test_orchestrator.py` & `tests/unit/test_error_handling.py`: Wrote missing tests 

## Testing
- [x] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`)
- [x] Linter passes (`make lint`)
- [ ] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes

## Screenshots / Demo
N/A 

## Notes for Reviewers
N/A