### PR TITLE
fix(ingestion): clear stale README chunks on re-ingest

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,26 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/27
+
+**Issue title:** Vector store returns stale embeddings after a document is re-ingested
+
+**Tier:** [ ] Tier 1  [ ] Tier 2  [x] Tier 3
+
+**Problem summary:**
+When a README is edited and re-ingested, the ingestion pipeline adds new embeddings for the updated content but never removes the embeddings from the prior version. Both the old and new chunks end up coexisting in the vector store under the same source, since nothing currently deletes stale entries before or after a re-ingest. As a result, the retriever can return outdated chunks — content that no longer matches the current document — alongside or instead of the up-to-date version. This affects the ingestion pipeline (`ingestion/pipeline.py`) and the vector store layer (`rag/retriever/vector_store.py`), which currently lacks a way to delete existing chunks by source before adding new ones. A successful fix would ensure re-ingesting a source clears its old embeddings first, so only the current version is ever retrievable.
+
+**"Is this right for me?" checklist reasoning:**
+
+*Part 1 — Understanding the issue:* I can explain the problem without re-reading it: re-ingesting a README adds new embeddings but never deletes the old ones, so the vector store accumulates stale chunks and the retriever can surface outdated content. "Done" means re-ingestion clears prior embeddings for that source before adding the new ones, leaving only current content retrievable.
+
+*Part 2 — Tier fit:* This is my first formal contribution to this codebase, which per the checklist would normally point me to Tier 1. I'm choosing Tier 3 anyway because I already work with this exact class of problem professionally as an Analytics Engineer — Slowly Changing Dimensions (SCD Type 2) solve the same underlying issue in a data warehouse context: when a record is updated, the old version must be closed out or removed rather than left alongside the new one, or queries can return stale data. I've built and maintained pipelines that explicitly guard against this. The unfamiliarity the checklist guards against is with this specific codebase, not the underlying concept — I recognize this bug pattern immediately from professional experience, which narrows the real risk to codebase navigation rather than domain knowledge.
+
+*Part 3 — Codebase readiness:* I've read both `ingestion/pipeline.py` and `rag/retriever/vector_store.py` in full, including the specific ingestion function and the vector store's storage/query methods, and can sketch a rough plan for the fix: add a delete-by-source-id method to `vector_store.py`, and call it at the start of the re-ingest flow in `pipeline.py` before new chunks are added.
+
+*Part 4 — Scope and time:* I've checked the issue comments and the ledger's Claims column and confirmed the current claim count and no open blockers. I'm targeting completion well before the Week 9 deadline, with Week 10 held as buffer rather than my actual estimate.
+
+**Branch name:** fix/27-stale-vectordb-embeddings
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger`

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -24,3 +24,18 @@ When a README is edited and re-ingested, the ingestion pipeline adds new embeddi
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger`
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/Aniruthan-0709/pathreview/commit/fffceaa
+
+**Reproduction summary:**
+Added a failing unit test (`tests/unit/test_stale_embeddings_repro.py`) that drives the real `IngestionPipeline` against an in-memory ChromaDB collection. Ingesting a README, then re-ingesting an edited version, leaves both versions' chunks in the store — the edited README gets a new content-hashed `source_id` and its chunks are added without deleting the old ones. Observed: after re-ingesting v2, v1's unique marker text is still retrievable (4 chunks in the store instead of 2), confirming the retriever can return stale content.
+
+**PLAN.md link:** https://github.com/Aniruthan-0709/pathreview/blob/fix/27-stale-vectordb-embeddings/PLAN.md
+
+**Walkthrough video (recommended):** N/A
+
+**Blockers or open questions:**
+- Where should the "current version" hash live — read back from chunk metadata (keeps the fix inside the files the issue names) or implement real `IngestedSource` persistence? Leaning toward metadata for scope.
+- Delete/add ordering: a naive "delete old then add new" risks wiping the good version if embedding fails. Deciding whether to delete only after the new chunks embed successfully.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -39,3 +39,35 @@ Added a failing unit test (`tests/unit/test_stale_embeddings_repro.py`) that dri
 **Blockers or open questions:**
 - Where should the "current version" hash live — read back from chunk metadata (keeps the fix inside the files the issue names) or implement real `IngestedSource` persistence? Leaning toward metadata for scope.
 - Delete/add ordering: a naive "delete old then add new" risks wiping the good version if embedding fails. Deciding whether to delete only after the new chunks embed successfully.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Captured a baseline of pre-existing `make check` / `make test-unit` failures, then implemented the #27 fix in `ingestion/pipeline.py` per PLAN.md — all three sub-tasks: stable `source_id` + `content_hash` in metadata, content-based skip detection, and delete-before-add to clear stale chunks.
+
+**Next steps:**
+Finish the regression tests (replace / skip / orphan cases), confirm no new failures vs baseline, open a draft PR for feedback, then mark ready.
+
+**Blockers:**
+None.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/510
+
+**Branch:** `fix/27-stale-vectordb-embeddings`
+
+**What you built:**
+Re-ingesting an edited README now replaces the previous version's chunks instead of leaving them behind. A README is identified by a stable `source_id` with a separate `content_hash`; unchanged content is skipped, and changed content deletes the old chunks (by `source_id`) before storing the new ones, so the retriever only ever sees the current version.
+
+**Tests added or updated:**
+`tests/unit/test_stale_embeddings_repro.py` — the Week 8 reproduction, now a passing regression suite: stable-identity, replace-on-edit (the original repro), skip-on-identical, and no-orphans-on-shorter-edit.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+(In this codebase "passes" = no new failures: unit 54→53 with only the #27 repro fixed; ruff 182→182, mypy 5→5, black 52→52 — zero new issues.)
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -71,3 +71,34 @@ Re-ingesting an edited README now replaces the previous version's chunks instead
 (In this codebase "passes" = no new failures: unit 54→53 with only the #27 repro fixed; ruff 182→182, mypy 5→5, black 52→52 — zero new issues.)
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+Reviewer feedback is not a feature in Summer 2026, and no comments came in on PR #510 ([ascherj/pathreview#510](https://github.com/ascherj/pathreview/pull/510)) by the end of the week.
+
+**How you responded:**
+N/A — no feedback to respond to.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Finding the *real* root cause. My first instinct from the plan — "call `delete_by_source_id` before adding the new chunks" — turned out to be wrong: the `source_id` embedded the content hash, so it changed on every edit and a delete keyed on it would have matched nothing. I only saw this by tracing the full ingest flow line by line. Two more surprises: the repo had two disconnected "worlds" (`IngestionPipeline` writing to a raw ChromaDB collection vs. an unused `VectorStore` wrapper), and the running app didn't even wire ingestion into the vector store, so I couldn't reproduce the bug in the app — I had to reproduce it at the unit level instead. Locating where the bug actually lived, versus where the issue text pointed, was the hard part.
+
+**What did you learn about working in a large codebase?**
+Navigating this RAG project end-to-end (ingestion → chunking → embedding → vector-store retrieval, plus the agent/tool-call and safety/guardrail layers) taught me how a production RAG system actually fits together — very different from a toy project. On contributing to someone else's code specifically: scope discipline matters more than cleverness. I deliberately fixed only the README path and left the resume/repo paths alone, matched the existing test style and formatting conventions instead of imposing my own, and — crucially — learned to work in a codebase that's already failing its own checks. Rather than "fix everything," I captured a baseline (54 failing unit tests, 182 ruff, 5 mypy) before touching anything and proved my change added zero new failures. Minimal, reviewable diffs and reading before writing were the recurring themes.
+
+**How did AI tools help — and where did they fall short?**
+AI was strongest at fast codebase navigation — tracing how metadata flows through the pipeline, mapping which files mattered, and drafting the reproduction test, regression cases, and PR description. Where it fell short: its first reproduction test had a real bug (a ChromaDB in-memory client name collision) that only surfaced when I ran it and watched it fail — a reminder to verify AI output by executing it, not trusting it. More importantly, the judgment calls were mine: choosing SCD Type 1 (overwrite) over Type 2 (keep history), accepting the delete-before-add atomicity tradeoff, and keeping scope to README-only. AI also can't verify behavior in the real running app, and would have happily committed straight through the pre-existing failures if I hadn't decided to baseline first. I chose to write the test myself so I actually understood the reproduction instead of pasting generated code.
+
+**What would you do differently if you started over?**
+I'd verify the runtime wiring earlier — I initially assumed `IngestionPipeline` was live in the app and lost a little time before discovering it wasn't. I'd also lock down the open design decisions (where the content hash lives, how to handle atomicity) before writing code instead of resolving them mid-implementation. Issue selection I'd keep the same — picking a stale-data problem that mirrors the SCD Type 2 work I already knew from analytics engineering was a good fit.
+
+**What are you most proud of?**
+The rigor of the process, not just the fix: a failing test that proved the bug was real, a documented before/after baseline showing zero new failures, and an honest PR description that left the "tests pass" boxes unchecked and openly documented both the pre-existing failures and the atomicity limitation. It would have been easier to overclaim — I'm proud that the contribution is trustworthy.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,151 @@
+# Solution plan
+
+**Issue:** Vector store returns stale embeddings after a document is re-ingested — [#27](https://github.com/ascherj/pathreview/issues/27)
+
+### Understand
+
+The root cause is how `source_id` is defined during ingestion. Today it is:
+
+```
+source_id = f"readme_{profile_id}_{repo_name}_{hash(content)}"
+```
+
+The content hash is baked into the identity of the source. That id is used to
+decide whether a document has already been ingested (the skip check) and to key
+every chunk stored in the vector DB.
+
+Because the hash changes whenever the README text changes, the **same** README
+with edited content is treated as a **brand new** source: it gets a new
+`source_id`, the skip check never matches, and its chunks are written alongside
+the old version's chunks. Nothing ever deletes the previous version.
+
+- **Expected:** after re-ingesting an edited README, only the current version's
+  chunks are retrievable.
+- **Actual:** old and new chunks coexist under different hashed ids, so the
+  retriever can surface stale, outdated content.
+
+Confirmed by the reproduction test `tests/unit/test_stale_embeddings_repro.py`
+([commit fffceaa](https://github.com/Aniruthan-0709/pathreview/commit/fffceaa)):
+ingesting README v1 then an edited v2 leaves v1's text in the store.
+
+Two related observations that shape the fix:
+
+1. **The skip check is also non-functional.** `_check_skip` and
+   `_record_ingested_source` in `pipeline.py` are placeholders — they log but
+   never read/write a real `IngestedSource` row — so there is currently no
+   reliable record of "have we seen this source before, and at what version?"
+2. **Ingestion and the delete helper live in different abstractions.** The
+   pipeline writes through `BatchEmbeddingProcessor` directly onto a raw
+   ChromaDB collection, while `delete_by_source_id` lives on the `VectorStore`
+   wrapper and filters on the `source_id` *metadata* field. The fix must delete
+   on the same collection the pipeline writes to, and that metadata field must
+   hold the stable key.
+
+### Map
+
+Files/functions involved:
+
+- `ingestion/pipeline.py` — `ingest_readme`, `_hash_content`, `_check_skip`,
+  `_record_ingested_source` *(primary change)*
+- `ingestion/embeddings/batch_processor.py` — `process`, `_store_embedding`
+  (chunk id + metadata written to Chroma)
+- `rag/retriever/vector_store.py` — `delete_by_source_id` *(delete-before-add)*
+- `ingestion/chunking/strategy_selector.py`, `ingestion/chunking/structural_chunker.py`
+  — read-through only; they propagate metadata but shouldn't need changes
+- `tests/unit/test_stale_embeddings_repro.py` — flips from failing to passing;
+  add a "same content is skipped" test
+
+Core change: split identity from version.
+
+- **Stable `source_id`** = `{doc_type}_{profile_id}_{repo_name}` (no hash) — the
+  logical key that is constant across edits.
+- **`content_hash`** = `hash(content)` — stored in chunk metadata as the version
+  stamp, used only for skip detection.
+
+Re-ingest logic becomes: if a source with this stable `source_id` already exists
+**and** its stored `content_hash` matches → skip. If it exists but the hash
+differs → `delete_by_source_id(source_id)` first, then chunk, embed, and add the
+new version.
+
+### Plan
+
+1. **Make `source_id` stable and add a version stamp.** In `ingest_readme`
+   (and the resume/repo paths for consistency), compute
+   `source_id = f"readme_{profile_id}_{repo_name}"` and compute
+   `content_hash` separately. Add `content_hash` to the metadata dict so it
+   lands in ChromaDB on every chunk.
+2. **Detect same-vs-changed content.** Replace the placeholder skip check with a
+   real one: look up existing chunks for this `source_id` (query the vector
+   store, or a persisted `IngestedSource` row — see Risks) and read their stored
+   `content_hash`. Same hash → return a skipped result; different or absent →
+   proceed.
+3. **Delete the old version before adding the new one.** When content changed,
+   clear all existing chunks for the stable `source_id` (via
+   `delete_by_source_id`, wired to the collection the pipeline actually writes
+   to) *before* chunking/embedding the new content.
+4. **Add the new version and record it.** Run the existing chunk → embed →
+   store flow, then record the new `content_hash` for the source so the next
+   re-ingest can compare.
+5. **Prove it with tests.** The reproduction test's failing assertion should now
+   pass (only v2 content remains); add a test that re-ingesting identical
+   content is skipped (no delete, no re-embed) and one that a shorter v2 leaves
+   no orphaned chunks.
+
+### Inputs & outputs
+
+- **Inputs:** `profile_id`, `repo_name`, README `content` (and `doc_type`),
+  routed through `ingest_readme`.
+- **Outputs / state changes:**
+  - Vector store holds **exactly one** version of chunks per
+    `(doc_type, profile_id, repo_name)` — the current one.
+  - Editing + re-ingesting **replaces** the prior chunks (old ones deleted).
+  - Re-ingesting **identical** content is a no-op (skipped; no duplicate work).
+  - Each stored chunk carries a stable `source_id` plus a `content_hash` in its
+    metadata.
+  - `IngestResult` still reports `chunk_count` / `skipped` as before.
+
+### Risks & unknowns
+
+- **How do we track "the current version"? (your SCD question.)** The issue only
+  requires that stale embeddings stop being retrievable. The simplest correct
+  approach is **SCD Type 1 — overwrite**: hard-delete the old chunks and insert
+  the new ones, keeping no history. **SCD Type 2** (keep old versions with an
+  `is_current` flag and filter on read) is more than #27 asks for — it grows the
+  store unboundedly and forces every retrieval query to add an `is_current=true`
+  filter, which touches the whole read path. **Recommendation: Type 1 for this
+  fix**, and note Type 2 as a future enhancement only if version history/audit
+  is ever a requirement.
+- **Where does the "current hash" live — vector store or a DB row?** The raw
+  README text isn't stored in the vector DB (only chunk text + embedding +
+  metadata are). Reading the hash back from chunk metadata keeps the fix inside
+  the two files named in the issue and avoids depending on the broken
+  `IngestedSource` bookkeeping. The more "production-correct" option is to
+  actually implement `IngestedSource` persistence (a `sources` table keyed by
+  `source_id` with a `content_hash` column). **Open decision** — I lean toward
+  the vector-store-metadata approach to stay in scope, and will confirm before
+  building.
+- **Delete/add ordering (data-loss risk).** If we delete the old version and the
+  embedding/add step then fails, the source is left empty — worse than stale.
+  Need error handling so a failed re-ingest doesn't wipe a good prior version
+  (e.g. only delete after new chunks are successfully embedded, or guard the
+  sequence).
+- **Two-abstraction mismatch.** `delete_by_source_id` must run against the same
+  collection object the pipeline writes through; otherwise it's a silent no-op.
+- **Concurrency.** Two re-ingests of the same source racing delete + add could
+  interleave. Likely out of scope for #27, but worth noting.
+
+### Edge cases
+
+- **First ingest (no prior version):** delete is a no-op; proceed normally.
+- **Identical re-ingest:** hash matches → skip; no delete, no duplicate chunks.
+- **Edited content:** delete old chunks, add new.
+- **New version has fewer chunks than the old one:** must delete *by source*, not
+  overwrite per chunk-index, or higher-index chunks from the old version orphan
+  and linger.
+- **Empty / whitespace / heading-less README:** the chunker returns zero chunks;
+  decide whether deleting the old version and storing nothing (source cleared) is
+  acceptable, or whether such input should be rejected before deletion.
+- **Same `repo_name` across different profiles:** the stable key includes
+  `profile_id`, so no cross-profile collision.
+- **Failed re-ingest mid-flow:** prior version should not be left in a
+  half-deleted state (ties back to delete/add ordering).

--- a/PLAN.md
+++ b/PLAN.md
@@ -106,15 +106,6 @@ new version.
 
 ### Risks & unknowns
 
-- **How do we track "the current version"? (your SCD question.)** The issue only
-  requires that stale embeddings stop being retrievable. The simplest correct
-  approach is **SCD Type 1 — overwrite**: hard-delete the old chunks and insert
-  the new ones, keeping no history. **SCD Type 2** (keep old versions with an
-  `is_current` flag and filter on read) is more than #27 asks for — it grows the
-  store unboundedly and forces every retrieval query to add an `is_current=true`
-  filter, which touches the whole read path. **Recommendation: Type 1 for this
-  fix**, and note Type 2 as a future enhancement only if version history/audit
-  is ever a requirement.
 - **Where does the "current hash" live — vector store or a DB row?** The raw
   README text isn't stored in the vector DB (only chunk text + embedding +
   metadata are). Reading the hash back from chunk metadata keeps the fix inside

--- a/ingestion/pipeline.py
+++ b/ingestion/pipeline.py
@@ -132,6 +132,12 @@ class IngestionPipeline:
         """
         Ingest a README document.
 
+        Re-ingestion is version-aware: a README is identified by a stable
+        source_id (profile + repo), while content_hash records the revision. If
+        the content is unchanged since the last ingestion it is skipped; if it
+        changed, the previous version's chunks are removed before the new ones
+        are stored, so stale content is never left behind.
+
         Args:
             profile_id: ID of the profile owner
             repo_name: Name of the repository
@@ -140,7 +146,10 @@ class IngestionPipeline:
         Returns:
             IngestResult with ingestion status
         """
-        source_id = f"readme_{profile_id}_{repo_name}_{self._hash_content(content)}"
+        # Split identity from version: source_id is a stable logical key for this
+        # README (constant across edits), while content_hash stamps the revision.
+        source_id = f"readme_{profile_id}_{repo_name}"
+        content_hash = self._hash_content(content)
 
         logger.info(
             "Starting README ingestion",
@@ -149,10 +158,19 @@ class IngestionPipeline:
             source_id=source_id,
         )
 
-        # Check if already ingested
-        skip_result = self._check_skip(source_id, "readme")
-        if skip_result:
-            return skip_result
+        # Skip only if this exact content was already ingested. Otherwise fall
+        # through so an edited README replaces its stale chunks (deleted below).
+        if self._existing_content_hash(source_id) == content_hash:
+            logger.info(
+                "README unchanged since last ingestion, skipping",
+                source_id=source_id,
+            )
+            return IngestResult(
+                source_id=source_id,
+                chunk_count=0,
+                skipped=True,
+                skip_reason="Content unchanged since last ingestion",
+            )
 
         try:
             # Parse README
@@ -167,6 +185,7 @@ class IngestionPipeline:
             metadata = parse_result.metadata.copy()
             metadata.update({
                 "source_id": source_id,
+                "content_hash": content_hash,
                 "profile_id": profile_id,
                 "repo_name": repo_name,
                 "source_type": "readme",
@@ -175,6 +194,13 @@ class IngestionPipeline:
             # Chunk the content
             chunks = self.strategy_selector.chunk(parse_result.text, metadata)
             logger.info("README chunked successfully", chunk_count=len(chunks))
+
+            # Replace any prior version: clear its chunks before storing the new
+            # ones so stale content can no longer be retrieved. Guard on chunks so
+            # an empty parse can't wipe a good previously ingested version.
+            if chunks:
+                self.vector_db.delete(where={"source_id": source_id})
+                logger.info("Cleared previous README version", source_id=source_id)
 
             # Generate embeddings and store
             self.batch_processor.process(chunks)
@@ -276,6 +302,35 @@ class IngestionPipeline:
         if isinstance(content, str):
             content = content.encode()
         return hashlib.sha256(content).hexdigest()[:16]
+
+    def _existing_content_hash(self, source_id: str) -> str | None:
+        """Return the content_hash of a previously ingested source, or None.
+
+        Reads stored chunk metadata for this source_id straight from the vector
+        store, which is the source of truth for what has already been ingested.
+        Used to decide whether re-ingested content is unchanged (skip) or edited
+        (replace).
+
+        Args:
+            source_id: Stable logical identifier for the source.
+
+        Returns:
+            The stored content_hash, or None if this source has no chunks yet.
+        """
+        try:
+            existing = self.vector_db.get(where={"source_id": source_id})
+        except Exception as e:
+            logger.warning(
+                "Could not look up existing source",
+                source_id=source_id,
+                error=str(e),
+            )
+            return None
+
+        metadatas = existing.get("metadatas") or []
+        if not metadatas:
+            return None
+        return metadatas[0].get("content_hash")
 
     def _check_skip(self, source_id: str, source_type: str) -> Optional[IngestResult]:
         """

--- a/tests/unit/test_stale_embeddings_repro.py
+++ b/tests/unit/test_stale_embeddings_repro.py
@@ -7,9 +7,10 @@ never deletes the old ones, so the vector store ends up holding BOTH versions
 and the retriever can return stale content.
 
 These tests drive the real ingestion units (IngestionPipeline ->
-BatchEmbeddingProcessor) against an in-memory ChromaDB collection.
-`test_reingest_leaves_stale_chunks` is EXPECTED TO FAIL on current code — that
-failure is the reproduction. Once the fix lands, it becomes the regression test.
+BatchEmbeddingProcessor) against an in-memory ChromaDB collection. They cover the
+fix for issue #27: re-ingesting an edited README replaces the previous version's
+chunks instead of leaving stale ones behind, while an unchanged re-ingest is
+skipped and a shorter edit leaves no orphaned chunks.
 """
 
 import uuid
@@ -68,16 +69,17 @@ class TestStaleEmbeddingsReingest:
         """Create an IngestionPipeline wired to the in-memory collection."""
         return IngestionPipeline(collection, db_session, MockEmbeddingProvider())
 
-    def test_source_id_rotates_on_edit(self, pipeline):
-        """Editing the README changes the content-hashed source_id.
+    def test_source_id_is_stable_across_edits(self, pipeline):
+        """The source_id identifies the logical README and is constant across edits.
 
-        This is why a naive delete-by-current-source_id would match nothing:
-        the old chunks live under the previous hash.
+        Identity (source_id) is now separate from version (content_hash), so an
+        edited README maps to the same source and its old chunks can be found and
+        cleared instead of accumulating under a new hashed id.
         """
         r1 = pipeline.ingest_readme("profile1", "repo1", README_V1)
         r2 = pipeline.ingest_readme("profile1", "repo1", README_V2)
 
-        assert r1.source_id != r2.source_id
+        assert r1.source_id == r2.source_id
 
     def test_both_versions_are_ingested(self, pipeline):
         """Both re-ingests actually run and produce chunks (neither is skipped)."""
@@ -87,8 +89,21 @@ class TestStaleEmbeddingsReingest:
         assert r1.skipped is False and r2.skipped is False
         assert r1.chunk_count > 0 and r2.chunk_count > 0
 
-    def test_reingest_leaves_stale_chunks(self, pipeline, collection):
-        """After re-ingesting v2, the store still holds v1 content (the bug)."""
+    def test_identical_reingest_is_skipped(self, pipeline):
+        """Re-ingesting identical content is a no-op: skipped, no duplicate work."""
+        r1 = pipeline.ingest_readme("profile1", "repo1", README_V1)
+        r2 = pipeline.ingest_readme("profile1", "repo1", README_V1)
+
+        assert r1.skipped is False
+        assert r2.skipped is True
+        assert r2.chunk_count == 0
+
+    def test_reingest_removes_stale_chunks(self, pipeline, collection):
+        """Re-ingesting edited content removes the previous version's chunks.
+
+        This is the core issue #27 guarantee: after an edit, v1's content must no
+        longer be retrievable from the store.
+        """
         pipeline.ingest_readme("profile1", "repo1", README_V1)
         pipeline.ingest_readme("profile1", "repo1", README_V2)
 
@@ -99,3 +114,26 @@ class TestStaleEmbeddingsReingest:
             "stale v1 content is still retrievable after re-ingesting v2 "
             f"({len(stored['ids'])} total chunks in store)"
         )
+
+    def test_shorter_reingest_leaves_no_orphan_chunks(self, pipeline, collection):
+        """A shorter edited README must not leave orphaned chunks from the old version.
+
+        Deleting by source_id (not overwriting per chunk index) guarantees that a
+        v2 with fewer chunks than v1 leaves nothing behind.
+        """
+        long_readme = (
+            "# Project\n\n"
+            "## A\nAlpha section ONE.\n\n"
+            "## B\nBravo section TWO.\n\n"
+            "## C\nCharlie section THREE.\n"
+        )
+        short_readme = "# Project\n\n## A\nOnly one section now.\n"
+
+        pipeline.ingest_readme("profile1", "repo1", long_readme)
+        r2 = pipeline.ingest_readme("profile1", "repo1", short_readme)
+
+        stored = collection.get()
+        all_text = " ".join(stored["documents"])
+
+        assert len(stored["ids"]) == r2.chunk_count
+        assert "Bravo" not in all_text and "Charlie" not in all_text

--- a/tests/unit/test_stale_embeddings_repro.py
+++ b/tests/unit/test_stale_embeddings_repro.py
@@ -1,0 +1,101 @@
+"""Reproduction for issue #27 — stale embeddings survive a re-ingest.
+
+https://github.com/ascherj/pathreview/issues/27
+
+When a README is edited and re-ingested, the pipeline stores the new chunks but
+never deletes the old ones, so the vector store ends up holding BOTH versions
+and the retriever can return stale content.
+
+These tests drive the real ingestion units (IngestionPipeline ->
+BatchEmbeddingProcessor) against an in-memory ChromaDB collection.
+`test_reingest_leaves_stale_chunks` is EXPECTED TO FAIL on current code — that
+failure is the reproduction. Once the fix lands, it becomes the regression test.
+"""
+
+import uuid
+from unittest.mock import MagicMock
+
+import chromadb
+import pytest
+
+from ingestion.embeddings.provider import MockEmbeddingProvider
+from ingestion.pipeline import IngestionPipeline
+
+# Two versions of the same logical README (same profile + repo).
+# v1 carries a unique marker absent from v2 -> our staleness probe.
+# Both need headings + body, or StructuralChunker emits zero chunks.
+README_V1 = """# My Project
+
+## Deprecated Feature
+This section documents the OLD_MARKER_XYZ behavior that we are about to remove.
+"""
+
+README_V2 = """# My Project
+
+## New Feature
+This section documents the brand new behavior. The deprecated part is gone.
+"""
+
+
+@pytest.mark.unit
+class TestStaleEmbeddingsReingest:
+    """Reproduction suite for stale embeddings after re-ingestion (issue #27)."""
+
+    @pytest.fixture
+    def collection(self):
+        """Create a real in-memory ChromaDB collection.
+
+        EphemeralClient shares in-process state, so use a unique name per test
+        to keep them isolated.
+        """
+        client = chromadb.EphemeralClient()
+        return client.create_collection(name=f"repro_{uuid.uuid4().hex}")
+
+    @pytest.fixture
+    def db_session(self):
+        """Mock DB session whose skip-check finds no existing source.
+
+        _check_skip() calls db_session.query(...).filter_by(...).first(). A bare
+        MagicMock returns a truthy value there, which would make the pipeline
+        skip ingestion entirely, so force .first() to return None.
+        """
+        session = MagicMock()
+        session.query.return_value.filter_by.return_value.first.return_value = None
+        return session
+
+    @pytest.fixture
+    def pipeline(self, collection, db_session):
+        """Create an IngestionPipeline wired to the in-memory collection."""
+        return IngestionPipeline(collection, db_session, MockEmbeddingProvider())
+
+    def test_source_id_rotates_on_edit(self, pipeline):
+        """Editing the README changes the content-hashed source_id.
+
+        This is why a naive delete-by-current-source_id would match nothing:
+        the old chunks live under the previous hash.
+        """
+        r1 = pipeline.ingest_readme("profile1", "repo1", README_V1)
+        r2 = pipeline.ingest_readme("profile1", "repo1", README_V2)
+
+        assert r1.source_id != r2.source_id
+
+    def test_both_versions_are_ingested(self, pipeline):
+        """Both re-ingests actually run and produce chunks (neither is skipped)."""
+        r1 = pipeline.ingest_readme("profile1", "repo1", README_V1)
+        r2 = pipeline.ingest_readme("profile1", "repo1", README_V2)
+
+        assert r1.skipped is False and r2.skipped is False
+        assert r1.chunk_count > 0 and r2.chunk_count > 0
+
+    def test_reingest_leaves_stale_chunks(self, pipeline, collection):
+        """After re-ingesting v2, the store still holds v1 content (the bug)."""
+        pipeline.ingest_readme("profile1", "repo1", README_V1)
+        pipeline.ingest_readme("profile1", "repo1", README_V2)
+
+        stored = collection.get()
+        all_text = " ".join(stored["documents"])
+
+        assert "OLD_MARKER_XYZ" not in all_text, (
+            "stale v1 content is still retrievable after re-ingesting v2 "
+            f"({len(stored['ids'])} total chunks in store)"
+        )


### PR DESCRIPTION
## Summary

Re-ingesting an edited README used to leave the previous version's chunks in the vector store, so the retriever could return stale, outdated content. The ingestion pipeline now identifies a README by a **stable `source_id`** and stamps each revision with a **`content_hash`**: unchanged content is skipped, and changed content clears the prior version's chunks before storing the new ones   so only the current version is ever retrievable.

## Issue

Closes #27

## Changes

**Root cause:** the README `source_id` embedded the content hash (`readme_{profile}_{repo}_{hash}`), fusing the document's *identity* with its *version*. Editing the README produced a new hash → a new `source_id`, so the pipeline treated the edit as a brand-new document, wrote its chunks alongside the old ones, and nothing ever removed the previous version. (The existing `_check_skip` was also a non-functional placeholder that never queried a real store.)

- `ingestion/pipeline.py` — `ingest_readme()`:
  - `source_id` is now a stable logical key (`readme_{profile_id}_{repo_name}`); the content hash is stored separately as `content_hash` in each chunk's metadata.
  - Added `_existing_content_hash()`, which reads the stored hash for a source directly from the vector store (the source of truth). Unchanged content → skip; changed content → proceed.
  - Before storing a changed version, existing chunks for the source are deleted (`vector_db.delete(where={"source_id": ...})`), **guarded** so an empty parse can't wipe a good previously ingested version.
  - The resume/repo paths and `_check_skip`/`_record_ingested_source` are intentionally left untouched — out of scope for #27.
- `tests/unit/test_stale_embeddings_repro.py` — the Week 8 reproduction test is now a passing regression suite covering replace-on-edit, skip-on-identical, and no-orphans-on-shorter-edit.

## Testing

- [ ] Unit tests pass (`make test-unit`) — suite has **53 pre-existing failures** unrelated to this PR (see Notes); the 5 tests in this PR pass and no previously-passing test regressed.
- [ ] Integration tests pass (`make test-integration`) — not run; no integration surface for this change.
- [ ] Linter passes (`make lint`) — **182 pre-existing ruff errors**; this PR adds none (see Notes).
- [ ] Type checker passes (`make typecheck`) — **5 pre-existing mypy errors**; this PR adds none (see Notes).
- [x] New/updated tests cover the changes

**Reproduce the original bug (before the fix):**
1. `git checkout fffceaa` (the reproduction commit)  or any commit before `2103c08`
2. `pytest tests/unit/test_stale_embeddings_repro.py::TestStaleEmbeddingsReingest::test_reingest_leaves_stale_chunks -v`
3. Observe: the test **fails** after re-ingesting an edited README, v1's marker text is still retrievable from the store.
