### PR TITLE
fix(ingestion): detect resume sections despite leading whitespace (#147)

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -27,7 +27,7 @@ all contained within `resume_parser.py` and `tests/unit/test_resume_parser.py`.
 
 **Branch name:** fix/147-resume-section-leading-whitespace
 
-**Setup confirmation:** [ ] App runs locally at localhost:5173
+**Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [ ] Issue added to cohort ledger
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -45,3 +45,24 @@ all contained within `resume_parser.py` and `tests/unit/test_resume_parser.py`.
   tests pass, and new coverage guards the leading-whitespace case.
 - **Right-sized effort.** Estimated a few hours — appropriate for a first
   Module 3 contribution without risking scope creep.
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/newairforces/pathreview/commit/fa08842a68b223aa42e4f08e1ab51dc626037d25
+
+**Reproduction summary:**
+I added a failing regression test (`test_detect_sections_with_leading_whitespace`)
+and reproduced the bug directly: `_detect_sections()` returns
+`['Education', 'Experience']` for flush-left text but `[]` for the identical text
+indented with leading whitespace, which also causes the three previously-failing
+tests (`test_parse_single_column_resume_text`, `test_parse_resume_no_work_experience`,
+`test_detect_sections`) to fail because their fixtures are indented.
+
+**PLAN.md link:** https://github.com/newairforces/pathreview/blob/fix/147-resume-section-leading-whitespace/PLAN.md
+
+**Walkthrough video (recommended):**
+
+**Blockers or open questions:**
+Need to confirm CRLF (`\r\n`) line endings from PDF extraction are handled by the
+relaxed leading anchor, and verify no downstream consumer treats an empty
+`detected_sections` as a meaningful signal rather than a bug.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -29,7 +29,7 @@ all contained within `resume_parser.py` and `tests/unit/test_resume_parser.py`.
 
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
-**Cohort ledger:** [ ] Issue added to cohort ledger
+**Cohort ledger:** [x] Issue added to cohort ledger
 
 ### Selection notes — "Is this right for me?" checklist
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,47 @@
+# Module 3 Journal
+
+A running record of my Module 3 work on PathReview. A new section is added each week.
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/147
+
+**Issue title:** Resume section detection fails on text with leading whitespace
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The résumé ingestion parser fails to recognize section headers whenever the
+extracted text carries leading indentation. `_detect_sections()` in
+`ingestion/parsers/resume_parser.py` anchors every header pattern to the very
+start of a line (e.g. `^Experience`, `\nExperience`), but text pulled out of PDFs
+routinely preserves leading spaces or tabs — so an indented single-column résumé
+matches nothing and `detected_sections` comes back empty. That silent failure
+matters because downstream review generation relies on knowing which sections a
+résumé contains (Education, Skills, Experience, …), so an empty result quietly
+degrades the entire review. A successful fix makes the header patterns tolerant
+of leading whitespace, brings the three currently-failing unit tests
+(`test_parse_single_column_resume_text`, `test_parse_resume_no_work_experience`,
+`test_detect_sections`) back to green, and adds coverage for indented input —
+all contained within `resume_parser.py` and `tests/unit/test_resume_parser.py`.
+
+**Branch name:** fix/147-resume-section-leading-whitespace
+
+**Setup confirmation:** [ ] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger
+
+### Selection notes — "Is this right for me?" checklist
+
+- **Scope is small and well-bounded.** The fix lives in a single module
+  (`resume_parser.py`) plus its test file; no cross-cutting changes to the RAG,
+  agent, safety, or API layers. Labeled `tier-1` / `good first issue`.
+- **Reproducible and testable.** The issue ships an exact repro snippet and names
+  three existing failing tests, so I have a clear pass/fail signal and can work
+  test-first.
+- **I understand the domain.** It's a plain text-parsing / regex bug in the
+  ingestion pipeline — no external services or credentials required to reproduce.
+- **Clear definition of done.** Indented headers are detected, the three named
+  tests pass, and new coverage guards the leading-whitespace case.
+- **Right-sized effort.** Estimated a few hours — appropriate for a first
+  Module 3 contribution without risking scope creep.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -102,7 +102,7 @@ documenting these; my change introduces zero new failures.
 
 ### Check-in 2 (end of week)
 
-**PR link:** https://github.com/newairforces/pathreview/pull/1
+**PR link:** https://github.com/ascherj/pathreview/pull/515
 
 **Branch:** `fix/147-resume-section-leading-whitespace`
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -66,3 +66,70 @@ tests (`test_parse_single_column_resume_text`, `test_parse_resume_no_work_experi
 Need to confirm CRLF (`\r\n`) line endings from PDF extraction are handled by the
 relaxed leading anchor, and verify no downstream consumer treats an empty
 `detected_sections` as a meaningful signal rather than a bug.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+The fix is implemented and committed. `_detect_sections()` now inserts `[ \t]*`
+after each line anchor (`^` / `\n`) so indented headers are detected, while the
+trailing `\s*$` / `\s*[:|-]` boundary is preserved to avoid substring false
+positives. This completes PLAN.md steps 1–3: the three fixture-driven tests plus
+the #147 regression test (`test_detect_sections_with_leading_whitespace`) are now
+green. I also resolved the two open questions from Week 8 — CRLF is handled (the
+`^`-under-MULTILINE anchor plus horizontal-only `[ \t]*` covers `\r\n`), and a grep
+confirmed the only consumer of `detected_sections` is logging in
+`ingestion/pipeline.py`, so an empty result was purely a silent bug.
+
+**Next steps:**
+PLAN.md step 4 (extend coverage — tabs, mixed indent, first line, CRLF, negative
+mid-sentence case) and step 5 (full-suite regression run). Then self-review against
+CONTRIBUTING.md, open the PR, and request peer feedback in Slack.
+
+**Blockers:**
+None on the fix itself. One thing to flag: the repo has a large set of pre-existing
+failures unrelated to #147 — `make test-unit` shows 54 failing tests on the branch
+before my change (e.g. `test_review_service`, `test_skill_extractor`,
+`test_tech_detector`), and `make check` reports 182 ruff / 52 black / 103 mypy
+issues repo-wide. Two of the six `test_resume_parser.py` failures
+(`test_strip_markdown_syntax`, `test_parse_markdown_resume`) are also pre-existing —
+they live in `_strip_markdown`, a different method, and fail on `main` too. Per the
+Week 9 pre-existing-failure guidance, I'm scoping my PR to `_detect_sections` and
+documenting these; my change introduces zero new failures.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/newairforces/pathreview/pull/1
+
+**Branch:** `fix/147-resume-section-leading-whitespace`
+
+**What you built:**
+Made resume section-header detection tolerant of leading indentation. PDF text
+extraction routinely preserves leading spaces/tabs, so headers like
+`"    Experience:"` previously matched none of the anchored regex patterns and
+`detected_sections` came back empty — silently degrading downstream review
+generation. The fix inserts a horizontal-only `[ \t]*` run after each line anchor
+so indentation is absorbed without letting a match leak across a newline, and keeps
+the trailing field boundary so substrings like `"Work Experience Highlights"` are
+not falsely detected.
+
+**Tests added or updated:**
+`tests/unit/test_resume_parser.py` — the Week 8 regression test now passes, and I
+added five sibling cases: tab-indented headers, mixed space/tab indentation, an
+indented header on the first line, CRLF line endings, and a negative case asserting
+a mid-sentence occurrence is not falsely detected.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+Notes: interpreted per the Week 9 pre-existing-failure policy — "passes" means my
+changes introduce **no new failures**. `make test-unit` goes from 54 → 50 failures:
+my change fixes exactly the 4 #147 detection tests and adds zero new failures
+(verified by diffing the failure set before/after). The remaining 50 failures, and
+all `make check` findings (182 ruff / 52 black / 103 mypy repo-wide), are
+pre-existing and unrelated to this PR — my two touched files carry the same ruff
+findings as baseline and `resume_parser.py` is mypy-clean.
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -133,3 +133,81 @@ pre-existing and unrelated to this PR — my two touched files carry the same ru
 findings as baseline and `resume_parser.py` is mypy-clean.
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No review came in. PR [ascherj#515](https://github.com/ascherj/pathreview/pull/515)
+has been open and marked ready for review since Week 9, but has received no reviews
+or comments (reviewer feedback is not a provided feature in Summer 2026, and #515 is
+one of ~195 open student PRs on the upstream repo). Checked via
+`gh pr view 515 --repo ascherj/pathreview` — 0 reviews, 0 comments.
+
+**How you responded:**
+No feedback to respond to. I left the PR ready for review as-is.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The actual code change was four string literals — inserting `[ \t]*` after each
+line anchor in `_detect_sections()`. What was genuinely hard had nothing to do with
+the fix: it was working inside a codebase that was already broken. Before touching
+anything, `make test-unit` showed 54 failing tests and `make check` reported 182
+ruff / 52 black / 103 mypy issues, none of them mine. The Makefile's `test-unit`
+target even pointed at a `.venv` that didn't exist, so just getting to a runnable
+baseline took real effort. The deliverable said "make check and make test-unit
+pass," but that was literally impossible without fixing hundreds of unrelated
+problems. The hard part was deciding what "passes" honestly means here — I settled
+on establishing a baseline first, then proving my change added *zero* new failures
+by diffing the failure set before and after (54 → 50, and the 4 that flipped were
+exactly the #147 tests). Learning to work confidently against a red baseline,
+rather than assuming red means I broke something, was the real skill.
+
+**What did you learn about working in a large codebase?**
+Restraint. My PLAN scoped the fix to a single method, and I kept discovering
+adjacent things that were *also* broken — most notably `_strip_markdown`, which has
+the exact same leading-whitespace regex bug (`^#+\s+`) and whose tests fail on
+`main` for the same reason. In my own project I'd have just fixed it. Here, fixing
+it would have blurred the diff, contradicted my plan, and made the PR harder to
+review, so I left it documented as out of scope. Contributing to someone else's
+production code means the smallest correct change wins, and that "correct" includes
+proving you didn't touch anything you weren't supposed to. I also learned to read
+before changing: a grep confirmed the only consumer of `detected_sections` was a
+log line, which is what made the empty-list failure a silent bug rather than a
+crash — and told me the blast radius of my change was tiny.
+
+**How did AI tools help — and where did they fall short?**
+AI was strongest at the mechanical-but-tedious work: standing up the venv,
+capturing the before/after failure baselines and diffing them, drafting the regex
+and the five edge-case tests (tabs, mixed indent, CRLF, first-line, and the
+negative mid-sentence case), and writing up the PR body. Where it fell short was
+judgment that depends on context it couldn't see. Two concrete examples: it wanted
+to open my PR against my own fork, when the cohort convention — obvious the moment I
+actually looked at the ~195 PRs on the upstream repo — is to PR against
+`ascherj/pathreview`. And it checked the "make check passes" box on a literal
+reading of the rubric when the honest answer needed the cohort's
+pre-existing-failure policy to make sense. AI got me to a defensible draft fast, but
+the "is this actually the right call for *this* course" decisions were mine.
+
+**What would you do differently if you started over?**
+Two things. First, I'd verify the contribution *mechanics* — where PRs go, what the
+grader actually opens — at the very start of Week 7, not Week 9. I burned time
+opening a PR on my fork and then re-opening it upstream because I never checked the
+convention up front. Second, I'd sanity-check whether an issue was already being
+worked: PR #478 is another student fixing the identical issue #147, which I only
+noticed after submitting. It didn't cost me anything, but on a real open-source
+project I'd have commented on the issue first to avoid duplicate work.
+
+**What are you most proud of?**
+Not the fix itself — it's four characters of regex. I'm proud of the verification
+discipline: establishing a documented baseline, proving my change strictly reduced
+the failure count with zero regressions, and being honest in the PR and journal
+about exactly what was pre-existing versus mine, rather than quietly checking boxes.
+In a codebase this broken, the trustworthy thing wasn't a green checkmark — it was a
+claim a reviewer could actually verify.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,105 @@
+## Solution plan
+
+**Issue:** Resume section detection fails on text with leading whitespace — [#147](https://github.com/ascherj/pathreview/issues/147)
+
+### Understand
+
+**Root cause.** `ResumeParser._detect_sections()` in
+`ingestion/parsers/resume_parser.py` matches each known section header with four
+regex patterns that anchor the header to the *exact* start of a line:
+
+```python
+rf"^{section}\s*$"        rf"^{section}\s*[:|-]"
+rf"\n{section}\s*$"       rf"\n{section}\s*[:|-]"
+```
+
+Both anchors (`^` under `re.MULTILINE`, and the literal `\n`) require the header
+word to be the first character of the line. But text extracted from PDFs — the
+primary ingestion path (`_parse_pdf`) — routinely preserves leading spaces and
+tabs. An indented header such as `"    Experience:"` therefore matches none of
+the patterns.
+
+**Expected vs. actual.**
+- *Expected:* `_detect_sections("    Experience:\n    Education:")` returns
+  `["Experience", "Education"]` — indentation is irrelevant to which sections a
+  résumé contains.
+- *Actual:* it returns `[]`. Verified directly: identical content is detected
+  flush-left but not when indented (reproduction commit
+  [`fa08842`](https://github.com/newairforces/pathreview/commit/fa08842a68b223aa42e4f08e1ab51dc626037d25)).
+
+The failure is silent: `detected_sections` is stored in `ParseResult.metadata`
+and only logged (`ingestion/pipeline.py:89`), so an empty result degrades
+downstream review generation without raising an error.
+
+### Map
+
+Files involved:
+
+- **`ingestion/parsers/resume_parser.py`** — `_detect_sections()` (the four
+  patterns at lines ~140–145). This is the only production code that needs to
+  change.
+- **`tests/unit/test_resume_parser.py`** — home of the three failing tests
+  (`test_parse_single_column_resume_text`, `test_parse_resume_no_work_experience`,
+  `test_detect_sections`) plus the new regression test
+  `test_detect_sections_with_leading_whitespace`. New coverage lands here.
+- **`tests/conftest.py`** — `sample_resume_text` fixture (indented) drives one of
+  the failing tests. Read-only reference; no change expected.
+
+Not touched but confirmed as consumers (no change needed): `ingestion/pipeline.py`
+(logs `detected_sections`), `_parse_pdf` / `_parse_markdown` (both call
+`_detect_sections` and pass the result straight into `metadata`).
+
+### Plan
+
+1. **Make the anchors whitespace-tolerant.** Insert an optional run of
+   horizontal whitespace after each line anchor — `^[ \t]*{section}...` and
+   `\n[ \t]*{section}...`. Use `[ \t]*` (not `\s*`) so the match cannot leak
+   across newlines and cause false positives on a following line.
+2. **Keep the trailing boundary intact.** Preserve the `\s*$` and `\s*[:|-]`
+   suffixes so a header still has to end the "field" — this prevents substring
+   false positives like `"Work Experience Highlights"`.
+3. **Turn the reds green.** Run the three named tests plus the new regression
+   test; all four must pass.
+4. **Add coverage.** Extend `test_detect_sections_with_leading_whitespace` (or
+   add sibling cases) for tabs, mixed space/tab indentation, and a
+   negative case asserting a mid-sentence occurrence is *not* falsely detected.
+5. **Guard against regressions.** Run the full parser test file
+   (`make test-unit` / `pytest tests/unit/test_resume_parser.py`) to confirm no
+   previously-passing test breaks.
+
+### Inputs & outputs
+
+- **Input:** a résumé text string (from `_parse_pdf` or `_parse_markdown`), which
+  may contain arbitrary leading horizontal whitespace on each line.
+- **Output:** `_detect_sections()` returns a deduplicated `list[str]` of
+  `.title()`-cased section names, now independent of indentation. Only the
+  regex matching changes — the return type, dedup behavior, and `metadata`
+  shape are unchanged, so no downstream contract shifts.
+
+### Risks & unknowns
+
+- **False positives from over-broad anchoring.** Relaxing the anchor could make a
+  header match where it shouldn't. Mitigated by using `[ \t]*` (horizontal only)
+  and keeping the `$` / `[:|-]` trailing boundary; step 4's negative test guards
+  this explicitly.
+- **`\s` already swallows `\r`.** Some PDFs emit CRLF. The trailing `\s*` handles
+  `\r`, but I need to confirm the *leading* side handles `\r\n` correctly — a bare
+  `\n` literal anchor won't see a line starting after `\r`. Worth verifying and,
+  if needed, extending the anchor.
+- **Multi-word headers overlap** ("experience" vs. "professional experience" vs.
+  "work experience"). The existing `set(...)` dedup + `.title()` already collapse
+  these; I'll confirm the relaxed patterns don't change which of the overlapping
+  variants win.
+- **Unknown:** whether any consumer treats an empty `detected_sections` as a
+  meaningful signal (vs. a bug). Grep shows only logging today, so low risk, but
+  I'll re-check before finalizing.
+
+### Edge cases
+
+- Headers indented with **spaces**, with **tabs**, and with **mixed** space/tab.
+- Header on the **first line** of the text (no preceding `\n`).
+- Header followed by `:`, `-`, `|`, or nothing (bare header line).
+- **CRLF** (`\r\n`) line endings from PDF extraction.
+- **Negative:** the header word appearing mid-sentence (e.g.
+  `"...gained experience building..."`) must **not** be detected.
+- Empty string / whitespace-only input → returns `[]` without error.

--- a/ingestion/parsers/resume_parser.py
+++ b/ingestion/parsers/resume_parser.py
@@ -130,7 +130,12 @@ class ResumeParser(BaseParser):
         text_lower = text.lower()
 
         for section in SECTION_HEADERS:
-            # Look for section header patterns
+            # Look for section header patterns.
+            # BUG (issue #147): these patterns anchor the header to the exact
+            # start of a line (`^`/`\n`). PDF-extracted text often keeps leading
+            # spaces/tabs, so an indented header (e.g. "    Experience:") matches
+            # nothing and detected_sections comes back empty. See regression test
+            # test_detect_sections_with_leading_whitespace.
             patterns = [
                 rf"^{re.escape(section)}\s*$",
                 rf"^{re.escape(section)}\s*[:|-]",

--- a/ingestion/parsers/resume_parser.py
+++ b/ingestion/parsers/resume_parser.py
@@ -130,17 +130,20 @@ class ResumeParser(BaseParser):
         text_lower = text.lower()
 
         for section in SECTION_HEADERS:
-            # Look for section header patterns.
-            # BUG (issue #147): these patterns anchor the header to the exact
-            # start of a line (`^`/`\n`). PDF-extracted text often keeps leading
-            # spaces/tabs, so an indented header (e.g. "    Experience:") matches
-            # nothing and detected_sections comes back empty. See regression test
-            # test_detect_sections_with_leading_whitespace.
+            # Look for section header patterns (issue #147).
+            # A header can carry leading indentation — PDF text extraction
+            # routinely preserves leading spaces/tabs (e.g. "    Experience:").
+            # `[ \t]*` after each line anchor absorbs that indentation. It is
+            # deliberately horizontal-only (not `\s*`) so a match cannot leak
+            # across a newline onto the following line. The trailing `\s*$` /
+            # `\s*[:|-]` boundary is kept so the header still has to end its
+            # field, which prevents substring false positives like
+            # "Work Experience Highlights".
             patterns = [
-                rf"^{re.escape(section)}\s*$",
-                rf"^{re.escape(section)}\s*[:|-]",
-                rf"\n{re.escape(section)}\s*$",
-                rf"\n{re.escape(section)}\s*[:|-]",
+                rf"^[ \t]*{re.escape(section)}\s*$",
+                rf"^[ \t]*{re.escape(section)}\s*[:|-]",
+                rf"\n[ \t]*{re.escape(section)}\s*$",
+                rf"\n[ \t]*{re.escape(section)}\s*[:|-]",
             ]
 
             for pattern in patterns:

--- a/tests/unit/test_resume_parser.py
+++ b/tests/unit/test_resume_parser.py
@@ -143,6 +143,30 @@ class TestResumeParser:
         assert any("education" in s for s in sections_lower)
         assert any("skills" in s for s in sections_lower)
 
+    def test_detect_sections_with_leading_whitespace(self, parser):
+        """Regression test for issue #147.
+
+        Section detection must tolerate leading indentation. PDF text extraction
+        routinely preserves leading spaces/tabs, but `_detect_sections()` anchors
+        every header pattern to the exact start of a line (`^Experience`,
+        `\\nExperience`), so an indented header matches nothing and
+        `detected_sections` silently comes back empty.
+
+        Reproduction: identical content, only difference is leading whitespace.
+        The flush-left variant is detected; the indented variant currently is not.
+        """
+        flush = "Experience:\nSenior Dev\nEducation:\nBS CS\nSkills: Python"
+        indented = "    Experience:\n    Senior Dev\n    Education:\n    BS CS\n    Skills: Python"
+
+        # Sanity check: flush-left text detects sections today.
+        assert len(parser._detect_sections(flush)) > 0
+
+        # The bug: the same text with leading whitespace detects nothing.
+        indented_sections = [s.lower() for s in parser._detect_sections(indented)]
+        assert any("experience" in s for s in indented_sections)
+        assert any("education" in s for s in indented_sections)
+        assert any("skills" in s for s in indented_sections)
+
     def test_strip_markdown_syntax(self, parser):
         """Test markdown syntax stripping."""
         markdown_text = """

--- a/tests/unit/test_resume_parser.py
+++ b/tests/unit/test_resume_parser.py
@@ -167,6 +167,44 @@ class TestResumeParser:
         assert any("education" in s for s in indented_sections)
         assert any("skills" in s for s in indented_sections)
 
+    def test_detect_sections_tab_indented(self, parser):
+        """Headers indented with tabs are detected (issue #147)."""
+        text = "\tExperience:\n\tSenior Dev\n\tEducation:\n\tBS CS"
+        sections = [s.lower() for s in parser._detect_sections(text)]
+        assert any("experience" in s for s in sections)
+        assert any("education" in s for s in sections)
+
+    def test_detect_sections_mixed_space_tab_indent(self, parser):
+        """Headers indented with mixed spaces and tabs are detected (issue #147)."""
+        text = " \t Experience:\n\t  Skills: Python"
+        sections = [s.lower() for s in parser._detect_sections(text)]
+        assert any("experience" in s for s in sections)
+        assert any("skills" in s for s in sections)
+
+    def test_detect_sections_first_line_indented(self, parser):
+        """An indented header on the very first line (no preceding newline) is detected."""
+        text = "    Summary:\nExperienced engineer"
+        sections = [s.lower() for s in parser._detect_sections(text)]
+        assert any("summary" in s for s in sections)
+
+    def test_detect_sections_crlf_line_endings(self, parser):
+        """Indented headers survive CRLF (\\r\\n) line endings from PDF extraction (issue #147)."""
+        text = "    Experience:\r\n    Senior Dev\r\n    Education:\r\n    BS CS"
+        sections = [s.lower() for s in parser._detect_sections(text)]
+        assert any("experience" in s for s in sections)
+        assert any("education" in s for s in sections)
+
+    def test_detect_sections_ignores_midsentence_occurrence(self, parser):
+        """A header word appearing mid-sentence must not be falsely detected (issue #147).
+
+        Guards against the whitespace-tolerant anchors over-matching: the
+        trailing boundary still requires the header to end its own field.
+        """
+        text = "    I gained experience building scalable education tools."
+        sections = [s.lower() for s in parser._detect_sections(text)]
+        assert not any("experience" in s for s in sections)
+        assert not any("education" in s for s in sections)
+
     def test_strip_markdown_syntax(self, parser):
         """Test markdown syntax stripping."""
         markdown_text = """


### PR DESCRIPTION
## Summary
Resume section-header detection failed on any text with leading indentation.
`ResumeParser._detect_sections()` anchored every header pattern to the exact start
of a line (`^Experience` / `\nExperience`), but PDF text extraction — the primary
ingestion path — routinely preserves leading spaces and tabs. An indented header
like `"    Experience:"` therefore matched nothing and `detected_sections` came
back empty, silently degrading downstream review generation (the value is only
logged in `ingestion/pipeline.py`, so nothing raised). This PR makes the anchors
tolerant of leading horizontal whitespace.

## Issue
Closes #147

## Changes
- `ingestion/parsers/resume_parser.py`: insert `[ \t]*` after each line anchor
  (`^` / `\n`) in `_detect_sections()`. Horizontal-only (not `\s*`) so a match
  cannot leak across a newline; the trailing `\s*$` / `\s*[:|-]` boundary is kept
  so a header still has to end its field — preventing substring false positives
  like `"Work Experience Highlights"`.
- `tests/unit/test_resume_parser.py`: the Week 8 regression test
  (`test_detect_sections_with_leading_whitespace`) now passes; added five sibling
  cases — tab-indented, mixed space/tab, first-line (no preceding newline), CRLF
  (`\r\n`) line endings, and a negative mid-sentence case guarding against
  over-matching.

## Testing

### Automated
- [x] Unit tests pass (`make test-unit`) — ⚠️ see **Pre-existing failures** below
- [ ] Integration tests pass (`make test-integration`) — not run (require Docker services; out of scope for this parser-only change)
- [x] Linter passes (`make lint`) — ⚠️ see **Pre-existing failures** below
- [x] Type checker passes (`make typecheck`) — ⚠️ see **Pre-existing failures** below
- [x] New/updated tests cover the changes

Run just the section-detection tests (7 pass, including the regression + 5 new edge cases):
```bash
.venv/bin/pytest tests/unit/test_resume_parser.py -k detect_sections -v
```

### Manual verification (reviewer steps)
Reproduce the bug and confirm the fix without relying on the test suite:

1. Check out this branch and set up the env (`python3 -m venv .venv && .venv/bin/pip install -e ".[dev]"`).
2. Open a Python shell (`.venv/bin/python`) and run:
   ```python
   from ingestion.parsers.resume_parser import ResumeParser
   p = ResumeParser()

   # The bug case — indented headers (as produced by PDF extraction):
   p._detect_sections("    Experience:\n    Education:\n    Skills: Python")
   # BEFORE this PR: []          AFTER: ['Experience', 'Education', 'Skills'] (order may vary)

   # Regression guard — flush-left still works:
   p._detect_sections("Experience:\nEducation:")
   # -> ['Experience', 'Education']

   # Tabs and CRLF (also from PDF/Windows extraction):
   p._detect_sections("\tExperience:\r\n\tEducation:")
   # -> ['Experience', 'Education']

   # Negative case — a header word mid-sentence must NOT be detected:
   p._detect_sections("I gained experience building education tools.")
   # -> []
   ```
3. To see the before/after on one command, stash the fix and re-run step 2's first call:
   `git stash && .venv/bin/python -c "..."` returns `[]`; `git stash pop` restores the fix.

Expected: the indented input returns a populated section list after the fix and an
empty list before it; the negative case stays empty in both.

## Pre-existing failures (this PR introduces none)
The repo has substantial pre-existing tooling/test debt unrelated to #147.
Measured on the branch **before** my change:
- `make test-unit`: **54 failing tests** (e.g. `test_review_service`,
  `test_skill_extractor`, `test_tech_detector`).
- `make check`: **182 ruff**, **52 black would-reformat**, **103 mypy** issues repo-wide.

After my change: **50 failing tests** — my fix turns exactly the 4 `#147`
detection tests green and adds no new failures (verified by diffing the failure set
before/after). Two `test_resume_parser.py` failures remain
(`test_strip_markdown_syntax`, `test_parse_markdown_resume`); both live in the
separate `_strip_markdown` method, fail on `main`, and are out of scope for #147.
My two touched files carry the same ruff findings as baseline (`I001`, `B904`,
`F401`) and `resume_parser.py` is mypy-clean. Per the Week 9 pre-existing-failure
policy, "passes" here means **no new failures introduced**.

## Notes for Reviewers
- The core change is four string literals in `_detect_sections()` — deliberately
  minimal per PLAN.md.
- Please pay particular attention to the trailing-boundary reasoning: I used
  `[ \t]*` rather than `\s*` specifically so a relaxed anchor can't match a header
  word that begins the *next* line; the negative test
  (`test_detect_sections_ignores_midsentence_occurrence`) locks this in.
- I left the pre-existing lint (unused test imports, import sort, `B904`) untouched
  to keep the diff scoped strictly to the fix; happy to clean those up in a
  follow-up if you'd prefer.
