### PR TITLE
Fix/146 parenthesized us phone number redaction

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -62,3 +62,34 @@ The only change I made was to the phone_us pattern in pii_scrubber. I did not ch
 note: there are two ruff failures, but neither failure is related to the code that I changed.
 
 **Draft PR feedback received from:** none
+
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [X] No — still awaiting review
+
+**Summary of feedback:**
+I did not receive PR feedback
+
+**How you responded:**
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+I was surprised how the in taking steps to resolve the issue I managed to break other things. For example, when I changed the regex string at first I accidentally broke phone numbers that used just spaces at first.
+
+**What did you learn about working in a large codebase?**
+Working in a large codebase involves plenty of code and rules that are not your own and you may understand. It is important to pay attention to the rules of the owner of the base as well as to do your due diligence in learning to understand the codebase you're working on.
+
+**How did AI tools help — and where did they fall short?**
+I did not use any AI tools in this module.
+
+**What would you do differently if you started over?**
+If I started over I would probably pick a more challenging issue. My issue was a good first issue but if I was going to do the same project again then I would want to have something more challenging. I would also make sure to run more tests before each commit so I wouldn't find issues after commiting to the code base again.
+
+**What are you most proud of from this module?**
+The thing I am most proud of is managing to decipher and then edit the regex string to fix the bug. I usually struggle with regex so it was a proud moment for me to be able to handle it for this project.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -48,7 +48,7 @@ I will be implementing a change to the phone_us regex in pii_scrubber.py to fix 
 
 ### Check-in 2 (end of week)
 
-**PR link:** [link to your submitted pull request]
+**PR link:** https://github.com/ascherj/pathreview/pull/517
 
 **Branch:** https://github.com/JacobKwiat1/pathreview/tree/fix/146-parenthesized-us-phone-number-redaction
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -18,3 +18,14 @@ Pii_scrubber is failing to detect US phone numbers using the parenthesized forma
 ## Week 8
 
 bug reproduction: running the pytests in tests/unit/test_pii_scrubber.py results in fails for test_us_phone_number_redaction, test_us_phone_formats, test_detect_phone_pii, and test_phone_at_start_of_text.
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/JacobKwiat1/pathreview/commit/052a6c21ca62c589391228b2b0551283ebb8f61c
+
+**Reproduction summary:**
+I ran the pytests for pii_scrubber and observed that formats using parentheses do indeed fail to be caught.
+
+**PLAN.md link:** https://github.com/JacobKwiat1/pathreview/blob/fix/146-parenthesized-us-phone-number-redaction/PLAN.md
+
+**Blockers or open questions:**

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -14,3 +14,7 @@ Pii_scrubber is failing to detect US phone numbers using the parenthesized forma
 **Setup confirmation:** App runs locally at localhost:5173
 
 **Cohort ledger:** Issue added to cohort ledger
+
+## Week 8
+
+bug reproduction: running the pytests in tests/unit/test_pii_scrubber.py results in fails for test_us_phone_number_redaction, test_us_phone_formats, test_detect_phone_pii, and test_phone_at_start_of_text.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,16 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/146
+
+**Issue title:** PII scrubber fails to redact parenthesized US phone numbers
+
+**Tier:**  Tier 1
+
+**Problem summary:**
+Pii_scrubber is failing to detect US phone numbers using the parenthesized format. This issue impacts scrub() and detect(), and is most likely an issue with the regex for US phone numbers.
+
+**Branch name:** fix/146-paranthesized-US-phone-number-redaction
+
+**Setup confirmation:** App runs locally at localhost:5173
+
+**Cohort ledger:** Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -29,3 +29,36 @@ I ran the pytests for pii_scrubber and observed that formats using parentheses d
 **PLAN.md link:** https://github.com/JacobKwiat1/pathreview/blob/fix/146-parenthesized-us-phone-number-redaction/PLAN.md
 
 **Blockers or open questions:**
+
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+I have not had the chance to make any changes yet this week.
+
+**Next steps:**
+I will be implementing a change to the phone_us regex in pii_scrubber.py to fix the issue
+
+**Blockers:**
+
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [link to your submitted pull request]
+
+**Branch:** https://github.com/JacobKwiat1/pathreview/tree/fix/146-parenthesized-us-phone-number-redaction
+
+**What you built:**
+My fix was a change to the phone_us pattern in pii_scrubber.py. I added a space to the character set [-.] which was not detecting spaces between numbers and misaligning space and parthesized phone formats from the pattern.
+
+**Tests added or updated:**
+The only change I made was to the phone_us pattern in pii_scrubber. I did not change any tests because there was already sufficient tests to determine if the code works.
+
+**Self-review confirmation:** [X] make check passes  [X] make test-unit passes
+note: there are two ruff failures, but neither failure is related to the code that I changed.
+
+**Draft PR feedback received from:** none

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,28 @@
+## Solution plan
+
+**Issue:** PII scrubber fails to redact parenthesized US phone numbers #146 https://github.com/ascherj/pathreview/issues/146
+
+### Understand
+The root cause of this issue is in safety/pii_scrubber.py. The "phone_us" pattern in PII_PATTERNS does not properly catch cases that use a parenthesized format of US phone numbers. at present it is capable of reading numbers using formats like 555-123-4567 but not (555) 123-4567. It should be capable of detecting both.
+
+### Map
+Which files, functions, or modules are involved?
+List the specific files you expect to touch.
+While the issue is noticable because of a failure of the scrub() and detect() functions, the issue is only with the scrubber regex. I expect that I will not need to make alterations outside of the "phone_us" regex pattern.
+
+### Plan
+1. understand the current regex pattern
+2. find what is causing the failure
+3. alter the pattern to catch the parenthesized format
+4. test to ensure the pattern works for parenthesized format and to make sure it still catches all other US phone formats
+
+### Inputs & outputs
+What does your fix take as input? What should it produce or change?
+The fix should still take strings as input to scan with regex. It needs to be able to determine that US phone numbers are indeed phone numbers for other functions to be able to detect and scrub them.
+
+### Risks & unknowns
+What could go wrong? What are you still unsure about?
+I am concerned that after altering the pattern I may accidentally cause a different format of phone number to not be caught. I am not particularly experienced with regex so I intend to use online tools to help read and understand what I am working with.
+### Edge cases
+What inputs or states should your fix handle gracefully?
+The fix works only with a regex pattern, so any input other than a US phone number should simply not be caught by the pattern.

--- a/safety/pii_scrubber.py
+++ b/safety/pii_scrubber.py
@@ -13,7 +13,7 @@ class PIIScrubber:
     # Regex patterns for common PII
     PII_PATTERNS = {
         "email": r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b",
-        "phone_us": r"\b(?:\+?1[-. ]?)?(\(?([0-9]{3})\))?[-. ]?([0-9]{3})[-. ]?([0-9]{4})\b",
+        "phone_us": r"\b(?:\+?1[-. ]?)?\(?([0-9]{3})\)?[-. ]?([0-9]{3})[-. ]?([0-9]{4})\b",
         "phone_intl": r"\+[0-9]{1,3}[-.]?[0-9]{1,14}",
         "ssn": r"\b(?!000|666)[0-9]{3}-(?!00)[0-9]{2}-(?!0000)[0-9]{4}\b",
         "street_address": r"\b\d+\s+[A-Za-z\s]+(?:Street|St|Avenue|Ave|Road|Rd|Boulevard|Blvd|Drive|Dr|Lane|Ln|Court|Ct|Circle|Cir|Park|Pl|Plaza|Place|Drive|Dr|Way|Parkway|Pkwy|Point|Pt|Pike|Run|Summit|Summit|Terrace|Ter|Trail|Trl|Tunnel|Turnpike|View|Vista|Vlg|Village|Vly|Valley)",

--- a/safety/pii_scrubber.py
+++ b/safety/pii_scrubber.py
@@ -13,7 +13,7 @@ class PIIScrubber:
     # Regex patterns for common PII
     PII_PATTERNS = {
         "email": r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b",
-        "phone_us": r"\b(?:\+?1[-.]?)?(?:\(?([0-9]{3})\))?[-.]?([0-9]{3})[-.]?([0-9]{4})\b",
+        "phone_us": r"\b(?:\+?1[-. ]?)?(\(?([0-9]{3})\))?[-. ]?([0-9]{3})[-. ]?([0-9]{4})\b",
         "phone_intl": r"\+[0-9]{1,3}[-.]?[0-9]{1,14}",
         "ssn": r"\b(?!000|666)[0-9]{3}-(?!00)[0-9]{2}-(?!0000)[0-9]{4}\b",
         "street_address": r"\b\d+\s+[A-Za-z\s]+(?:Street|St|Avenue|Ave|Road|Rd|Boulevard|Blvd|Drive|Dr|Lane|Ln|Court|Ct|Circle|Cir|Park|Pl|Plaza|Place|Drive|Dr|Way|Parkway|Pkwy|Point|Pt|Pike|Run|Summit|Summit|Terrace|Ter|Trail|Trl|Tunnel|Turnpike|View|Vista|Vlg|Village|Vly|Valley)",

--- a/safety/pii_scrubber.py
+++ b/safety/pii_scrubber.py
@@ -1,6 +1,7 @@
 """PII detection and scrubbing."""
 
 import re
+
 import structlog
 
 logger = structlog.get_logger()
@@ -12,7 +13,7 @@ class PIIScrubber:
     # Regex patterns for common PII
     PII_PATTERNS = {
         "email": r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b",
-        "phone_us": r"\b(?:\+?1[-.]?)?\(?([0-9]{3})\)?[-.]?([0-9]{3})[-.]?([0-9]{4})\b",
+        "phone_us": r"\b(?:\+?1[-.]?)?(?:\(?([0-9]{3})\))?[-.]?([0-9]{3})[-.]?([0-9]{4})\b",
         "phone_intl": r"\+[0-9]{1,3}[-.]?[0-9]{1,14}",
         "ssn": r"\b(?!000|666)[0-9]{3}-(?!00)[0-9]{2}-(?!0000)[0-9]{4}\b",
         "street_address": r"\b\d+\s+[A-Za-z\s]+(?:Street|St|Avenue|Ave|Road|Rd|Boulevard|Blvd|Drive|Dr|Lane|Ln|Court|Ct|Circle|Cir|Park|Pl|Plaza|Place|Drive|Dr|Way|Parkway|Pkwy|Point|Pt|Pike|Run|Summit|Summit|Terrace|Ter|Trail|Trl|Tunnel|Turnpike|View|Vista|Vlg|Village|Vly|Valley)",
@@ -47,13 +48,17 @@ class PIIScrubber:
 
         for pii_type, pattern in self.PII_PATTERNS.items():
             for match in re.finditer(pattern, text, flags=re.IGNORECASE):
-                detected.append({
-                    "type": pii_type,
-                    "value": match.group(),
-                    "start": match.start(),
-                    "end": match.end()
-                })
+                detected.append(
+                    {
+                        "type": pii_type,
+                        "value": match.group(),
+                        "start": match.start(),
+                        "end": match.end(),
+                    }
+                )
 
-        logger.info("pii_detected", count=len(detected), types=len(set(d["type"] for d in detected)))
+        logger.info(
+            "pii_detected", count=len(detected), types=len(set(d["type"] for d in detected))
+        )
 
         return detected


### PR DESCRIPTION
## Summary
'scrub()' and 'detect()' in pii_scrubber.py failed to detect US phone numbers using a parenthesized format. This was caused by the set of characters separating the sections of the number being [.-] rather than [.- ]. Failing to catch the space misaligned the pattern from the number in numbers that used parentheses and spaces. Both functions now properly detect all formats of US phone number.
## Issue
Closes #146

## Changes
-the "phone_us" pattern in PII_PATTERNS in pii_scrubber.py was changed to include spaces as a separator between trios of numbers.

## Testing
<!-- How did you verify your changes? -->
- [ X] Unit tests pass (`make test-unit`)
    - related tests in test_pii_scrubber pass, but test_mixed_pii_and_text still fails for unrelated reasons.
- [N/A ] Integration tests pass (`make test-integration`)
- [ X] Linter passes (`make lint`)
    - two failures due to code unrelated to the changes
- [ X] Type checker passes (`make typecheck`)
- [ X] New/updated tests cover the changes
    -no new/updated tests needed

## Screenshots / Demo

## Notes for Reviewers
related tests: using test_us_phone_number_redaction, test_us_phone_formats, test_detect_phone_pii, test_phone_at_start_of_text in tests/unit/test_pii_scrubber.py