### PR TITLE
Fix #157: correct partial-overlap relevance scorer fixture

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -30,14 +30,13 @@ The test `test_query_with_partial_overlap` is intended to verify how the relevan
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** TBD
+**Reproduction commit link:** [Reproduce Issue #157](https://github.com/viswanathv4320/pathreview/commit/207c316)
 
 **Reproduction summary:**
-I reproduced Issue #157 by running `pytest tests/unit/test_relevance_scorer.py -q`. The test suite reported `1 failed, 18 passed`, with `test_query_with_partial_overlap` failing because the scorer returned `1.0` while the assertion expected a score between `0.3` and `0.9`. The fixture contains all four query terms—`Python`, `Django`, `web`, and `framework`—so it represents full overlap rather than the intended partial overlap.
+I reproduced Issue #157 by running `pytest tests/unit/test_relevance_scorer.py -q`. The test suite reported `1 failed, 18 passed`, with `test_query_with_partial_overlap` failing because the scorer returned `1.0` while the assertion expected a score between `0.3` and `0.9`.
 
-**PLAN.md link:** TBD
+The original fixture contains all four query terms—`Python`, `Django`, `web`, and `framework`—so it represents complete overlap rather than the intended partial overlap. This confirmed that the issue is located in the test fixture, not in the relevance scorer implementation.
 
-**Walkthrough video (recommended):** Not recorded yet
+**PLAN.md link:** [Solution plan](https://github.com/viswanathv4320/pathreview/blob/fix/157-partial-overlap-fixture/PLAN.md)
 
 **Blockers or open questions:**
-None at this stage.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -58,7 +58,7 @@ The repository currently has pre-existing lint and unit-test failures unrelated 
 
 ### Check-in 2 (end of week)
 
-**PR link:** [add after the PR is opened]
+**PR link:** https://github.com/ascherj/pathreview/pull/519
 
 **Branch:** `fix/157-partial-overlap-fixture`
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,29 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/157
+
+**Issue title:** Relevance scorer “partial overlap” test fixture actually has full query overlap
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The test `test_query_with_partial_overlap` is intended to verify how the relevance scorer handles a partial match between a query and a retrieved chunk. However, the current chunk contains every word from the query, so the scorer correctly calculates a full-overlap score of `1.0`. The test then fails because its assertion expects the score to be below `0.9`. A successful fix would change the test data so that only some query terms overlap, while leaving the correctly functioning relevance scorer unchanged.
+
+**Issue-selection reasoning:**
+
+- **Understanding:** I can explain the problem and expected behavior without referring back to the issue. The test data represents full overlap even though the test is intended to represent partial overlap.
+- **Affected code:** I located and read `test_query_with_partial_overlap` in `tests/unit/test_relevance_scorer.py`. I also reviewed the `score` and `_tokenize` methods in `rag/evaluator/relevance_scorer.py`.
+- **Definition of done:** Before the fix, all four query terms match and the scorer returns `1.0`, causing the partial-overlap assertion to fail. After the fix, only some query terms should match, producing a score between `0.3` and `0.9`, and the test should pass.
+- **Tier fit:** This is a Tier 1 issue and is appropriate for my first contribution to this codebase because the expected change is localized to a test fixture and does not require changes across multiple modules.
+- **Codebase readiness:** I read the relevant test from start to finish and reviewed the scorer implementation to understand how the overlap score is calculated.
+- **Testing:** I ran `pytest tests/unit/test_relevance_scorer.py -q` and reproduced the reported failure. The result was 1 failed and 18 passed, with the failing assertion showing that the score was `1.0`.
+- **Rough plan:** I will update the test fixture so the query and chunk have genuine partial overlap, rerun the relevance scorer tests, and confirm that the production scorer code does not need to be changed.
+- **Claims:** I checked the issue activity and cohort ledger and understand that claims are non-exclusive. I am comfortable continuing with this issue even though other contributors may also be working on it.
+- **Time and scope:** The change is limited and should be achievable well before the Week 9 deadline.
+- **Dependencies:** I did not find any stated unresolved blocker or dependency that must be completed before this issue can be fixed.
+
+**Branch name:** fix/157-partial-overlap-fixture
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -27,3 +27,17 @@ The test `test_query_with_partial_overlap` is intended to verify how the relevan
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** TBD
+
+**Reproduction summary:**
+I reproduced Issue #157 by running `pytest tests/unit/test_relevance_scorer.py -q`. The test suite reported `1 failed, 18 passed`, with `test_query_with_partial_overlap` failing because the scorer returned `1.0` while the assertion expected a score between `0.3` and `0.9`. The fixture contains all four query terms—`Python`, `Django`, `web`, and `framework`—so it represents full overlap rather than the intended partial overlap.
+
+**PLAN.md link:** TBD
+
+**Walkthrough video (recommended):** Not recorded yet
+
+**Blockers or open questions:**
+None at this stage.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -40,3 +40,34 @@ The original fixture contains all four query terms—`Python`, `Django`, `web`, 
 **PLAN.md link:** [Solution plan](https://github.com/viswanathv4320/pathreview/blob/fix/157-partial-overlap-fixture/PLAN.md)
 
 **Blockers or open questions:**
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+I implemented the planned fix for Issue #157 by updating the fixture in `test_query_with_partial_overlap` so that the chunk contains only partial overlap with the query. The production relevance scorer code remains unchanged. The targeted test passes, and all 19 tests in `tests/unit/test_relevance_scorer.py` pass.
+
+**Next steps:**
+I will review the final diff, open the pull request against the upstream repository, and complete Check-in 2 with the final PR link.
+
+**Blockers:**
+The repository currently has pre-existing lint and unit-test failures unrelated to Issue #157. I confirmed that `main` has 182 lint errors and 53 failing unit tests. My branch has the same 182 lint errors and 52 failing unit tests because the intended relevance scorer test now passes.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [add after the PR is opened]
+
+**Branch:** `fix/157-partial-overlap-fixture`
+
+**What you built:**
+Updated the `test_query_with_partial_overlap` fixture so that it represents genuine partial keyword overlap instead of full overlap. This fixes the failing test without changing the production relevance scorer implementation.
+
+**Tests added or updated:**
+Updated `tests/unit/test_relevance_scorer.py::TestRelevanceScorer::test_query_with_partial_overlap`. The targeted test passes, and all 19 relevance scorer unit tests pass.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -68,6 +68,43 @@ Updated the `test_query_with_partial_overlap` fixture so that it represents genu
 **Tests added or updated:**
 Updated `tests/unit/test_relevance_scorer.py::TestRelevanceScorer::test_query_with_partial_overlap`. The targeted test passes, and all 19 relevance scorer unit tests pass.
 
-**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+The broader checks still contain pre-existing repository failures. My branch has the same 182 lint errors as `main` and 52 failing unit tests compared with 53 on `main`; the difference is the relevance scorer test fixed by this PR.
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No reviewer feedback was received.
+
+**How you responded:**
+N/A
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+
+The code change itself was simple. The harder part was confirming that the problem was in the test fixture rather than in the relevance scorer. I had to reproduce the failure, inspect the test and scorer logic, and compare my branch with `main` to confirm that other test failures were pre-existing.
+
+**What did you learn about working in a large codebase?**
+
+I learned that understanding context is important before changing code. I had to locate the relevant files, understand the expected behavior, reproduce the issue, and keep the change limited to the actual problem. I also learned that existing repositories may already have failing tests, so changes should be validated against the baseline.
+
+**How did AI tools help — and where did they fall short?**
+
+AI tools helped me understand unfamiliar code, interpret test results, plan debugging steps, and work through the Git and pull request workflow. However, I still had to verify the behavior by reading the code, reproducing the issue, running tests, and confirming that the proposed change was correct.
+
+**What would you do differently if you started over?**
+
+I would check the relevant test, implementation, and baseline test results earlier. This would help identify the root cause faster and separate pre-existing repository issues from problems introduced by my branch.
+
+**What are you most proud of from this module?**
+
+I am most proud of completing the full contribution workflow on an existing codebase: selecting an issue, reproducing it, planning the fix, making a focused change, testing it, documenting the work, and submitting a pull request.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,94 @@
+## Solution plan
+
+**Issue:** [Fix partial-overlap fixture in relevance scorer test](https://github.com/viswanathv4320/pathreview/issues/157)
+
+
+### Understand
+
+The test `test_query_with_partial_overlap` is intended to verify that a query with only partial overlap produces a relevance score between `0.3` and `0.9`.
+
+The original test used this query:
+
+```text
+Python Django web framework
+```
+
+and this chunk:
+
+```text
+Django is a Python web framework for rapid development
+```
+
+All four meaningful query terms appear in the chunk, so the scorer correctly returns 1.0. The test data therefore represents full overlap, not partial overlap.
+
+The expected behavior is for the fixture to contain only some of the query terms and produce a score in the middle range. The actual behavior was a score of 1.0 because the fixture contained complete overlap.
+
+### Map
+The main files involved are:
+
+- tests/unit/test_relevance_scorer.py
+- rag/evaluator/relevance_scorer.py
+
+The implementation in rag/evaluator/relevance_scorer.py was reviewed to confirm how overlap is calculated, but no implementation change is expected.
+
+The file that needs to be modified is:
+
+- tests/unit/test_relevance_scorer.py
+
+The specific test involved is:
+
+- TestRelevanceScorer.test_query_with_partial_overlap
+
+### Plan
+1. Review the relevance scorer implementation to confirm how matching query terms are counted.
+2. Replace the existing chunk text with text that contains only some of the query terms.
+3. Run the individual partial-overlap test to confirm that the new fixture produces a middle-range score.
+4. Run the full test_relevance_scorer.py test file to check for related failures.
+5. Run the broader test suite and review the Git diff before committing the change.
+
+### Inputs & outputs
+The inputs are:
+
+- A query string
+- A list of chunks containing text
+
+For this test, the query is:
+
+```text
+Python Django web framework
+```
+
+The revised chunk contains only partial overlap:
+
+```text
+Python is widely used for web applications
+```
+
+The expected output is:
+
+- A float
+- A score between 0.3 and 0.9
+- A passing partial-overlap test
+
+The fix changes only the test fixture and does not change the scorer's production behavior.
+
+### Risks & unknowns
+The replacement chunk must create genuine partial overlap according to the scorer's tokenization and matching logic.
+
+A poorly chosen replacement could still produce full overlap, no overlap, or a score outside the expected range.
+
+There is also a risk of unnecessarily changing the scorer implementation when the actual issue is only the inaccurate test fixture. To avoid expanding the scope, the implementation will remain unchanged unless broader tests reveal a separate defect.
+
+There are no major unknowns remaining after reproducing the failure and reviewing the scorer logic.
+
+### Edge cases
+The scorer and its tests should handle these cases gracefully:
+
+- Empty query
+- Empty chunk list
+- Chunk with empty text
+- No matching query terms
+- Partial overlap
+- Complete overlap
+- Repeated query terms
+- Differences in capitalization or punctuation, depending on the current tokenization behavior

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,6 +1,6 @@
 ## Solution plan
 
-**Issue:** [Fix partial-overlap fixture in relevance scorer test](https://github.com/viswanathv4320/pathreview/issues/157)
+**Issue:** [Fix partial-overlap fixture in relevance scorer test](https://github.com/ascherj/pathreview/issues/157)
 
 
 ### Understand

--- a/tests/unit/test_relevance_scorer.py
+++ b/tests/unit/test_relevance_scorer.py
@@ -18,9 +18,7 @@ class TestRelevanceScorer:
         """Test query with perfect keyword match in chunks returns score close to 1.0."""
         query = "Python development framework"
         chunks = [
-            {
-                "text": "Python is a great development language for building frameworks"
-            },
+            {"text": "Python is a great development language for building frameworks"},
         ]
 
         score = scorer.score(query, chunks)
@@ -34,9 +32,7 @@ class TestRelevanceScorer:
         """Test query with zero keyword overlap returns score close to 0.0."""
         query = "Rust Kubernetes microservices"
         chunks = [
-            {
-                "text": "Python is dynamically typed and interpreted language"
-            },
+            {"text": "Python is dynamically typed and interpreted language"},
         ]
 
         score = scorer.score(query, chunks)
@@ -48,9 +44,7 @@ class TestRelevanceScorer:
         """Test query with partial overlap returns score between 0 and 1."""
         query = "Python Django web framework"
         chunks = [
-            {
-                "text": "Django is a Python web framework for rapid development"
-            },
+            {"text": "Python is widely used for web applications"},
         ]
 
         score = scorer.score(query, chunks)
@@ -71,9 +65,7 @@ class TestRelevanceScorer:
     def test_empty_query_returns_zero(self, scorer):
         """Test empty query returns 0.0."""
         query = ""
-        chunks = [
-            {"text": "Some content"}
-        ]
+        chunks = [{"text": "Some content"}]
 
         score = scorer.score(query, chunks)
 
@@ -96,9 +88,7 @@ class TestRelevanceScorer:
     def test_case_insensitive_matching(self, scorer):
         """Test that keyword matching is case insensitive."""
         query = "PYTHON PROGRAMMING"
-        chunks = [
-            {"text": "python programming is fun"}
-        ]
+        chunks = [{"text": "python programming is fun"}]
 
         score = scorer.score(query, chunks)
 
@@ -117,10 +107,7 @@ class TestRelevanceScorer:
     def test_empty_text_in_chunk(self, scorer):
         """Test handling of empty text in chunk."""
         query = "Python"
-        chunks = [
-            {"text": ""},
-            {"text": "Python programming"}
-        ]
+        chunks = [{"text": ""}, {"text": "Python programming"}]
 
         score = scorer.score(query, chunks)
 
@@ -130,9 +117,7 @@ class TestRelevanceScorer:
     def test_very_long_query(self, scorer):
         """Test handling of very long query."""
         query = "Python " * 100
-        chunks = [
-            {"text": "Python is a programming language"}
-        ]
+        chunks = [{"text": "Python is a programming language"}]
 
         score = scorer.score(query, chunks)
 
@@ -142,9 +127,7 @@ class TestRelevanceScorer:
     def test_very_long_chunk(self, scorer):
         """Test handling of very long chunk."""
         query = "Python"
-        chunks = [
-            {"text": "Python " * 1000 + "is a great language"}
-        ]
+        chunks = [{"text": "Python " * 1000 + "is a great language"}]
 
         score = scorer.score(query, chunks)
 
@@ -154,9 +137,7 @@ class TestRelevanceScorer:
     def test_special_characters_ignored(self, scorer):
         """Test that special characters are handled."""
         query = "Python c++ golang"
-        chunks = [
-            {"text": "c++ is a systems programming language"}
-        ]
+        chunks = [{"text": "c++ is a systems programming language"}]
 
         score = scorer.score(query, chunks)
 
@@ -166,9 +147,7 @@ class TestRelevanceScorer:
     def test_multiple_keyword_matches(self, scorer):
         """Test scoring improves with multiple keyword matches."""
         query = "Python framework development tools"
-        chunks = [
-            {"text": "Python django flask development framework tools"}
-        ]
+        chunks = [{"text": "Python django flask development framework tools"}]
 
         score = scorer.score(query, chunks)
 
@@ -178,11 +157,7 @@ class TestRelevanceScorer:
     def test_single_word_chunks(self, scorer):
         """Test handling of single-word chunks."""
         query = "Python development"
-        chunks = [
-            {"text": "Python"},
-            {"text": "development"},
-            {"text": "framework"}
-        ]
+        chunks = [{"text": "Python"}, {"text": "development"}, {"text": "framework"}]
 
         score = scorer.score(query, chunks)
 
@@ -204,9 +179,7 @@ class TestRelevanceScorer:
     def test_common_words_not_preventing_scoring(self, scorer):
         """Test that common words don't prevent scoring."""
         query = "the best Python framework"
-        chunks = [
-            {"text": "Django is the best Python web framework"}
-        ]
+        chunks = [{"text": "Django is the best Python web framework"}]
 
         score = scorer.score(query, chunks)
 
@@ -216,9 +189,7 @@ class TestRelevanceScorer:
     def test_chunk_without_text_key(self, scorer):
         """Test handling of chunk missing 'text' key."""
         query = "Python"
-        chunks = [
-            {"content": "Python programming"}  # Wrong key
-        ]
+        chunks = [{"content": "Python programming"}]  # Wrong key
 
         score = scorer.score(query, chunks)
 
@@ -229,10 +200,7 @@ class TestRelevanceScorer:
     def test_whitespace_only_in_chunks(self, scorer):
         """Test chunks with only whitespace."""
         query = "Python"
-        chunks = [
-            {"text": "   "},
-            {"text": "\n\t"}
-        ]
+        chunks = [{"text": "   "}, {"text": "\n\t"}]
 
         score = scorer.score(query, chunks)
 
@@ -244,7 +212,7 @@ class TestRelevanceScorer:
         chunks = [
             {"text": "Python is great"},
             {"text": "Python programming"},
-            {"text": "Java is different"}
+            {"text": "Java is different"},
         ]
 
         score = scorer.score(query, chunks)


### PR DESCRIPTION
## Summary

The `test_query_with_partial_overlap` fixture contained every meaningful term from the query, so it represented complete overlap and produced a relevance score of `1.0`.

This change updates the fixture so that the chunk contains only some of the query terms. The test now exercises genuine partial overlap without modifying the production relevance scorer implementation.

Closes #157.

## Changes

- Updated the chunk text in `test_query_with_partial_overlap`
- Preserved the existing expected score range of `0.3 < score < 0.9`
- Left `rag/evaluator/relevance_scorer.py` unchanged

## Testing

- Targeted test: `1 passed`
- Full relevance scorer test file: `19 passed`
- `make check`: 182 pre-existing lint errors on both `main` and this branch
- `make test-unit`:
  - `main`: 53 failed, 375 passed
  - this branch: 52 failed, 376 passed

The branch introduces no new failures, and the previously failing relevance scorer test now passes.