### PR TITLE
Fix/27 vectordb stale embeddings

### DIFF
--- a/JOURNAL.MD
+++ b/JOURNAL.MD
@@ -14,3 +14,17 @@ When a vector database returns stale embeddings after a document is re-ingested,
 **Setup confirmation:** [ X ] App runs locally at localhost:5173
 
 **Cohort ledger:** [ X ] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [9455a8f](https://github.com/amalrajn/pathreview/commit/9455a8faa13fb929f2d8904eb88bba4915167f4c)
+
+**Reproduction summary:**
+I added an integration test ([tests/integration/test_stale_embeddings_repro.py](https://github.com/amalrajn/pathreview/blob/fix/27-vectordb-stale-embeddings/tests/integration/test_stale_embeddings_repro.py)) that mirrors the pipeline's id scheme — `source_id` embeds the content hash, so an edited README gets a new id, and `VectorStore.delete_by_source_id` is never called. After ingesting a README that says "Flask" and then a re-ingested version that says "FastAPI", I observed both chunks coexisting in the ChromaDB collection and a query returning the stale "Flask" chunk.
+
+**PLAN.md link:** [PLAN.md](https://github.com/amalrajn/pathreview/blob/fix/27-vectordb-stale-embeddings/PLAN.md)
+
+**Walkthrough video (recommended):**
+
+**Blockers or open questions:**
+Need to confirm which write path production actually uses — `batch_processor._store_embedding` calls `vector_db.add(...)` directly, while `VectorStore.add_chunks` reads chunk attributes that the `Chunk` dataclass doesn't have — before finalizing the stable-id/delete scheme.

--- a/JOURNAL.MD
+++ b/JOURNAL.MD
@@ -28,3 +28,76 @@ I added an integration test ([tests/integration/test_stale_embeddings_repro.py](
 
 **Blockers or open questions:**
 Need to confirm which write path production actually uses — `batch_processor._store_embedding` calls `vector_db.add(...)` directly, while `VectorStore.add_chunks` reads chunk attributes that the `Chunk` dataclass doesn't have — before finalizing the stable-id/delete scheme.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Resolved the Week 8 blocker first: confirmed the pipeline's real write path is
+`batch_processor._store_embedding` → the raw ChromaDB collection (it stores
+`chunk.metadata` wholesale), while `VectorStore.add_chunks` is unused dead code
+that reads attributes `Chunk` doesn't have. That settled the id/delete scheme.
+
+Done from PLAN.md:
+- **Sub-task 1 (stable document key):** each source now derives a
+  content-independent `document_id` (e.g. `readme_{profile_id}_{repo_name}`) and
+  keeps `source_id = {document_id}_{content_hash}` (unchanged string). Added
+  `document_id` to every chunk's metadata. ([ingestion/pipeline.py](ingestion/pipeline.py))
+- **Sub-task 2 (delete-before-insert):** added `_delete_existing_chunks(document_id)`
+  and call it before `batch_processor.process(...)` in all three ingest paths
+  (readme/resume/repo).
+- **Sub-task 3 (align id/metadata scheme):** deletion filters on the `document_id`
+  metadata the write path stores, so the delete actually matches stored rows;
+  added `VectorStore.delete_by_document_id` as the retriever-side primitive.
+- **Sub-task 4 (skip logic):** moved the "already ingested" check onto the vector
+  store (`source_id` lookup) instead of the non-functional `db_session`
+  placeholder, so unchanged content is still skipped.
+- **Sub-task 5 (regression test):** inverted the reproduction into a regression
+  test and added focused unit tests. All new tests pass.
+
+**Next steps:**
+Open the draft PR, request peer review in Slack, and finalize the PR description
+once feedback is in.
+
+**Blockers:**
+None.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/PENDING _(to be replaced with the live PR URL on submission)_
+
+**Branch:** `fix/27-vectordb-stale-embeddings`
+
+**What you built:**
+The ingestion pipeline now tags every chunk with a stable, content-independent
+`document_id` and deletes that document's existing chunks before storing a new
+version, so re-ingesting an edited README (or resume/repo metadata) fully
+replaces the old chunks instead of leaving them behind — the retriever can no
+longer return stale content (issue #27).
+
+**Tests added or updated:**
+- `tests/unit/test_ingestion_pipeline.py` (new) — drives the real pipeline against
+  an in-memory ChromaDB collection with `MockEmbeddingProvider`; covers that
+  re-ingestion evicts the stale chunk, retrieval can't return stale content,
+  unchanged content is skipped, first-ingest delete is a safe no-op, a shrinking
+  README leaves no leftover chunks, and re-ingestion is isolated per profile.
+- `tests/unit/test_vector_store.py` (new) — covers `delete_by_document_id`
+  (removes all versions of one document, leaves other documents, no-op on
+  missing/empty collection) and that `delete_by_source_id` only removes the exact
+  content version targeted.
+- `tests/integration/test_stale_embeddings_repro.py` (updated) — the Week 8
+  reproduction, inverted into a regression test asserting only the current README
+  survives, plus a skip-unchanged case.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+_(Documented pre-existing failures: on a clean checkout `make test-unit` reports
+53 failing tests and `make check` fails at `ruff` (182 findings) and `mypy`
+(untyped-defs repo-wide + a numpy stub error). After my change the unit failure
+count is still 53 (same set) and ruff is still 182 — my changes introduce no new
+failures, which is the bar for "passes" in a codebase with documented
+pre-existing failures.)_
+
+**Draft PR feedback received from:** none (pending — will request in the cohort Slack channel)

--- a/JOURNAL.MD
+++ b/JOURNAL.MD
@@ -1,0 +1,16 @@
+## Week 7 — Issue selection
+
+**Issue link:** [https://github.com/ascherj/pathreview/issues/27]
+
+**Issue title:** [https://github.com/ascherj/pathreview/issues/27]
+
+**Tier:** [ ] Tier 1  [ ] Tier 2  [ X ] Tier 3
+
+**Problem summary:**
+When a vector database returns stale embeddings after a document is re-ingested, it means that there are old or stale chunks that don't accurately reflect the new document's chunks. This can lead to incorrect information being retrieved in the retrieval step of the RAG pipeline. this issue takes place in the /rag/retriever/vector_store.py part of the project. 
+
+**Branch name:** [fix/27-vectordb-stale-embeddings]
+
+**Setup confirmation:** [ X ] App runs locally at localhost:5173
+
+**Cohort ledger:** [ X ] Issue added to cohort ledger

--- a/JOURNAL.MD
+++ b/JOURNAL.MD
@@ -101,3 +101,70 @@ failures, which is the bar for "passes" in a codebase with documented
 pre-existing failures.)_
 
 **Draft PR feedback received from:** none (pending — will request in the cohort Slack channel)
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [X] No — still awaiting review
+
+**Summary of feedback:**
+No peer or mentor review has come in yet. I opened the PR and requested review in
+the cohort Slack channel; as of this entry no one has commented. To keep momentum
+I did a second self-review pass instead of waiting idle (see below).
+
+**How you responded:**
+No external feedback to address. My own self-review pass did catch one real issue:
+the new pipeline/regression tests each created an ephemeral ChromaDB collection
+under a fixed name, so when the whole suite ran in one process the second test hit
+`Collection [...] already exists` and failed. I fixed it by giving every test a
+uniquely named collection (`..._{uuid4().hex}`) in the `_make_pipeline` helper, so
+the tests are isolated and order-independent. If reviewer feedback arrives before
+the deadline I'll address it and note the changes here.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Figuring out which code path was actually live. There were two writers into the
+vector store — `VectorStore.add_chunks` (which *looked* like the canonical one)
+and `BatchEmbeddingProcessor._store_embedding` → the raw ChromaDB collection. The
+first reads `chunk.source_id` / `chunk.id` attributes that the `Chunk` dataclass
+never defines, so it's effectively dead code; the real path was the second one.
+`VectorStore.delete_by_source_id` also already existed but had zero callers. Most
+of the difficulty wasn't writing the fix — it was proving to myself where the bug
+actually lived before changing the id/delete scheme.
+
+**What did you learn about working in a large codebase?**
+Someone else's codebase is full of aspirational or half-wired code sitting next to
+the path that actually runs, and the names lie a little — `source_id` quietly
+embedded the content hash, which is exactly what made an edited README look like a
+brand-new document. You fix the path that's exercised, not the one that reads as
+canonical, and you verify with a test rather than trusting the structure. I also
+learned to treat "passing" realistically: this repo already had 53 failing unit
+tests and 182 ruff findings on a clean checkout, so the bar is "introduce no new
+failures," not "leave the whole repo green."
+
+**How did AI tools help — and where did they fall short?**
+AI was fastest at orientation — grepping for callers of `delete_by_source_id`,
+tracing the write path, and drafting the tests and Google-style docstrings to
+match the repo's conventions. Where it fell short: it couldn't tell me which write
+path was actually used — I had to read the code and reason about the `Chunk`
+dataclass myself — and its first draft of the tests used a fixed collection name
+that only failed once I actually ran the whole suite. The lesson held: generated
+code is a starting point you still have to run and verify.
+
+**What would you do differently if you started over?**
+Resolve the "which write path is live" question during Week 8 planning instead of
+carrying it as a blocker into implementation, and run the full `make test-unit` /
+`make check` baseline on day one so I'd know the pre-existing failures up front. I'd
+also open the draft PR earlier in the week to leave real room for peer review
+rather than finishing the code first and requesting review late.
+
+**What are you most proud of from this module?**
+Turning the Week 8 reproduction into a regression test that now guards the fix —
+the same test that proved the bug was real is the one that will fail if anyone
+reintroduces it — and landing a `document_id` scheme that fixes all three ingest
+paths (readme/resume/repo) without changing the existing `source_id` string, so
+nothing downstream breaks.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,100 @@
+## Solution plan
+
+**Issue:** Stale embeddings remain after README re-ingestion — [#27](https://github.com/ascherj/pathreview/issues/27)
+
+### Understand
+When a README is updated and re-ingested, the old embeddings stay in the vector
+store next to the new ones, so the retriever can return chunks that no longer
+reflect the current document.
+
+Two things combine to cause this:
+
+1. **Content-hash source ids.** `IngestionPipeline.ingest_readme`
+   ([ingestion/pipeline.py:143](ingestion/pipeline.py#L143)) builds
+   `source_id = f"readme_{profile_id}_{repo_name}_{self._hash_content(content)}"`.
+   Because the content hash is part of the id, an edited README gets a *new*
+   source_id and its chunks are written under new ids instead of replacing the
+   old ones. The embedding id itself is `f"{source_id}_chunk_{chunk_index}"`
+   ([ingestion/embeddings/batch_processor.py:108](ingestion/embeddings/batch_processor.py#L108)),
+   so the ids never collide across versions.
+2. **Cleanup is never invoked.** `VectorStore.delete_by_source_id`
+   ([rag/retriever/vector_store.py:115](rag/retriever/vector_store.py#L115))
+   exists but has no callers (confirmed by grep). Nothing evicts the previous
+   version's chunks.
+
+- **Expected:** after re-ingesting an updated README, the store holds only the
+  current document's chunks; a query never returns pre-update content.
+- **Actual:** both old and new chunks are present; a query can return stale text
+  (reproduced in [tests/integration/test_stale_embeddings_repro.py](tests/integration/test_stale_embeddings_repro.py)).
+
+### Map
+Files I expect to touch:
+
+- [ingestion/pipeline.py](ingestion/pipeline.py) — `ingest_readme` (and the same
+  pattern in `ingest_resume` / `ingest_repo_metadata`): introduce a stable
+  document id and call cleanup before storing new chunks.
+- [rag/retriever/vector_store.py](rag/retriever/vector_store.py) —
+  `delete_by_source_id`: make it delete by the stable document key; confirm it
+  is safe when the collection is empty / key absent.
+- [ingestion/embeddings/batch_processor.py](ingestion/embeddings/batch_processor.py)
+  — reconcile the id/metadata scheme so the value used for deletion matches the
+  value stored at write time.
+- [tests/integration/test_stale_embeddings_repro.py](tests/integration/test_stale_embeddings_repro.py)
+  — invert the `BUG` assertion into a regression test once the fix lands.
+
+### Plan
+1. **Introduce a stable document key.** Split the current `source_id` into a
+   stable `document_id` (`readme_{profile_id}_{repo_name}`, no content hash) plus
+   a separate `content_hash` used only for the skip/dedup check. Store the
+   `document_id` in each chunk's metadata so it can be targeted for deletion.
+2. **Delete-before-insert on re-ingestion.** In `ingest_readme`, call
+   `VectorStore.delete_by_source_id(document_id, collection)` (renamed/adjusted to
+   filter on `document_id`) *before* `batch_processor.process(chunks)`, so the old
+   version is cleared first.
+3. **Align the vector-store and batch-processor id scheme.** Ensure the metadata
+   key written by `_store_embedding` is the same key `delete_by_source_id`
+   filters on (today one writes raw `chunk.metadata`, the wrapper writes a
+   `source_id` field) so deletion actually matches stored rows.
+4. **Convert the reproduction into a regression test.** Flip the assertion in
+   `test_stale_embeddings_repro.py` to assert only the current chunk survives,
+   and add a case where an unchanged README re-ingest is still skipped.
+5. **Run the suite** (`make test` / `pytest tests/`) to confirm no regressions in
+   ingestion or retrieval.
+
+### Inputs & outputs
+- **Inputs:** `ingest_readme(profile_id, repo_name, content)` — unchanged public
+  signature. Internally it now derives a stable `document_id` and a
+  `content_hash`.
+- **Outputs / behavior changes:**
+  - `delete_by_source_id` is invoked with the stable `document_id` on every
+    re-ingestion, removing prior chunks before new ones are written.
+  - Chunk metadata gains/normalizes a `document_id` field.
+  - Net effect: the collection contains exactly one set of chunks per
+    `(profile_id, repo_name)` README, always reflecting the latest content.
+
+### Risks & unknowns
+- **Two divergent write paths.** `batch_processor._store_embedding` calls
+  `vector_db.add(...)` directly, while `VectorStore.add_chunks` reads
+  `chunk.id`/`chunk.source_id` — but `Chunk` ([ingestion/chunking/base.py](ingestion/chunking/base.py))
+  only has `text` and `metadata`. I need to confirm which path production uses
+  before changing the id scheme, or the delete filter won't match the stored key.
+- **Metadata-filter correctness in ChromaDB.** `delete_by_source_id` uses
+  `where={"source_id": {"$eq": ...}}`; I need to verify the field name and that
+  deleting on an empty/missing key is a no-op rather than an error.
+- **Skip logic coupling.** `_check_skip` ([ingestion/pipeline.py:280](ingestion/pipeline.py#L280))
+  keys on `source_id`; if I stabilize the id I must move the "already ingested"
+  check onto `content_hash` or unchanged READMEs will be needlessly re-embedded.
+- **`_record_ingested_source` is a placeholder** (no real DB write), so I can't
+  rely on it to detect prior versions — the vector store is the source of truth.
+
+### Edge cases
+- **First-time ingestion** (no prior chunks): delete-before-insert must be a safe
+  no-op when `document_id` matches nothing.
+- **Unchanged README re-ingested:** should still be skipped (same `content_hash`),
+  not deleted-and-reinserted.
+- **README shrinks** (v2 has fewer chunks than v1): leftover high-index chunks
+  from v1 must be removed, not just overwritten index-by-index.
+- **Same repo name across two different profiles:** deleting `document_id` for
+  profile A must not touch profile B's chunks (id includes `profile_id`).
+- **Empty / whitespace-only README:** ingestion should not crash and should leave
+  no stale chunks behind.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -99,7 +99,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -449,7 +448,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -473,7 +471,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1561,7 +1558,6 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1579,7 +1575,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1972,7 +1967,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3507,7 +3501,6 @@
       "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^2.0.1",
         "cssstyle": "^4.0.1",
@@ -4094,7 +4087,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4107,7 +4099,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4771,7 +4762,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/ingestion/pipeline.py
+++ b/ingestion/pipeline.py
@@ -69,7 +69,9 @@ class IngestionPipeline:
         Returns:
             IngestResult with ingestion status
         """
-        source_id = f"resume_{profile_id}_{self._hash_content(content)}"
+        content_hash = self._hash_content(content)
+        document_id = f"resume_{profile_id}"
+        source_id = f"{document_id}_{content_hash}"
 
         logger.info(
             "Starting resume ingestion",
@@ -92,6 +94,7 @@ class IngestionPipeline:
             metadata = parse_result.metadata.copy()
             metadata.update({
                 "source_id": source_id,
+                "document_id": document_id,
                 "profile_id": profile_id,
                 "filename": filename,
                 "source_type": "resume",
@@ -100,6 +103,9 @@ class IngestionPipeline:
             # Chunk the content
             chunks = self.strategy_selector.chunk(parse_result.text, metadata)
             logger.info("Resume chunked successfully", chunk_count=len(chunks))
+
+            # Evict any prior version of this document before storing the new one
+            self._delete_existing_chunks(document_id)
 
             # Generate embeddings and store
             self.batch_processor.process(chunks)
@@ -140,7 +146,9 @@ class IngestionPipeline:
         Returns:
             IngestResult with ingestion status
         """
-        source_id = f"readme_{profile_id}_{repo_name}_{self._hash_content(content)}"
+        content_hash = self._hash_content(content)
+        document_id = f"readme_{profile_id}_{repo_name}"
+        source_id = f"{document_id}_{content_hash}"
 
         logger.info(
             "Starting README ingestion",
@@ -167,6 +175,7 @@ class IngestionPipeline:
             metadata = parse_result.metadata.copy()
             metadata.update({
                 "source_id": source_id,
+                "document_id": document_id,
                 "profile_id": profile_id,
                 "repo_name": repo_name,
                 "source_type": "readme",
@@ -175,6 +184,9 @@ class IngestionPipeline:
             # Chunk the content
             chunks = self.strategy_selector.chunk(parse_result.text, metadata)
             logger.info("README chunked successfully", chunk_count=len(chunks))
+
+            # Evict any prior version of this README before storing the new one
+            self._delete_existing_chunks(document_id)
 
             # Generate embeddings and store
             self.batch_processor.process(chunks)
@@ -214,7 +226,9 @@ class IngestionPipeline:
             IngestResult with ingestion status
         """
         repo_name = repo_data.get("name", "unknown")
-        source_id = f"repo_{profile_id}_{repo_name}_{self._hash_content(str(repo_data))}"
+        content_hash = self._hash_content(str(repo_data))
+        document_id = f"repo_{profile_id}_{repo_name}"
+        source_id = f"{document_id}_{content_hash}"
 
         logger.info(
             "Starting repo metadata ingestion",
@@ -241,6 +255,7 @@ class IngestionPipeline:
             metadata = parse_result.metadata.copy()
             metadata.update({
                 "source_id": source_id,
+                "document_id": document_id,
                 "profile_id": profile_id,
                 "source_type": "repo",
             })
@@ -248,6 +263,9 @@ class IngestionPipeline:
             # Chunk the content
             chunks = self.strategy_selector.chunk(parse_result.text, metadata)
             logger.info("Repository metadata chunked successfully", chunk_count=len(chunks))
+
+            # Evict any prior version of this repo metadata before storing the new one
+            self._delete_existing_chunks(document_id)
 
             # Generate embeddings and store
             self.batch_processor.process(chunks)
@@ -279,18 +297,24 @@ class IngestionPipeline:
 
     def _check_skip(self, source_id: str, source_type: str) -> Optional[IngestResult]:
         """
-        Check if source has already been ingested.
+        Check if this exact content has already been ingested.
 
-        Returns IngestResult if should skip, None if should proceed.
+        The vector store is the source of truth: ``source_id`` embeds the content
+        hash, so if chunks with this id already exist the content is unchanged and
+        we skip re-embedding it. A changed document has a different ``source_id``
+        and is not skipped here — its stale chunks are evicted by
+        ``_delete_existing_chunks`` before the new version is stored.
+
+        Args:
+            source_id: Content-addressed id for this exact version of the source.
+            source_type: Type of source (resume, readme, repo).
+
+        Returns:
+            IngestResult if ingestion should be skipped, None if it should proceed.
         """
         try:
-            # Query database for existing source
-            # This assumes a table/model named IngestedSource
-            existing = self.db_session.query(
-                "IngestedSource"  # Placeholder - actual query depends on ORM
-            ).filter_by(source_id=source_id).first()
-
-            if existing:
+            existing = self.vector_db.get(where={"source_id": {"$eq": source_id}}, limit=1)
+            if existing and existing.get("ids"):
                 logger.info("Source already ingested, skipping", source_id=source_id)
                 return IngestResult(
                     source_id=source_id,
@@ -306,6 +330,37 @@ class IngestionPipeline:
             )
 
         return None
+
+    def _delete_existing_chunks(self, document_id: str) -> None:
+        """
+        Remove any previously stored chunks for a document before re-ingesting.
+
+        Chunks are keyed on a stable ``document_id`` (independent of content), so
+        an edited document fully replaces its prior version instead of piling new
+        chunks alongside the old ones. This prevents the retriever from returning
+        stale content after a re-ingestion (issue #27). Safe no-op when the
+        document has never been ingested.
+
+        Args:
+            document_id: Stable identifier for the document, independent of its
+                content hash (e.g. ``readme_{profile_id}_{repo_name}``).
+        """
+        try:
+            existing = self.vector_db.get(where={"document_id": {"$eq": document_id}})
+            stale_ids = existing.get("ids") if existing else None
+            if stale_ids:
+                self.vector_db.delete(ids=stale_ids)
+                logger.info(
+                    "Evicted stale chunks before re-ingestion",
+                    document_id=document_id,
+                    count=len(stale_ids),
+                )
+        except Exception as e:
+            logger.warning(
+                "Could not delete existing chunks",
+                document_id=document_id,
+                error=str(e),
+            )
 
     def _record_ingested_source(
         self,

--- a/rag/retriever/vector_store.py
+++ b/rag/retriever/vector_store.py
@@ -113,7 +113,11 @@ class VectorStore:
         return retrieved
 
     def delete_by_source_id(self, source_id: str, collection_name: str) -> None:
-        """Delete all chunks from a source (for re-ingestion).
+        """Delete all chunks with an exact source_id (a single content version).
+
+        ``source_id`` embeds the content hash, so this only matches one version of
+        a document. To clear every version of a document on re-ingestion, use
+        :meth:`delete_by_document_id` with the content-independent document key.
 
         Args:
             source_id: Source identifier
@@ -130,3 +134,28 @@ class VectorStore:
             collection.delete(ids=all_docs["ids"])
             logger.info("deleted_by_source", source_id=source_id,
                        count=len(all_docs["ids"]), collection=collection_name)
+
+    def delete_by_document_id(self, document_id: str, collection_name: str) -> None:
+        """Delete every chunk belonging to a document, across all its versions.
+
+        Chunks are tagged with a stable ``document_id`` that is independent of the
+        content hash, so this removes the previously ingested version of a
+        document before its replacement is stored. This is what keeps the store
+        from returning stale chunks after a document is re-ingested (issue #27).
+        Safe no-op when no chunks match.
+
+        Args:
+            document_id: Stable, content-independent document identifier
+                (e.g. ``readme_{profile_id}_{repo_name}``).
+            collection_name: Collection to delete from.
+        """
+        collection = self.get_collection(collection_name)
+
+        stale = collection.get(
+            where={"document_id": {"$eq": document_id}}
+        )
+
+        if stale["ids"]:
+            collection.delete(ids=stale["ids"])
+            logger.info("deleted_by_document", document_id=document_id,
+                       count=len(stale["ids"]), collection=collection_name)

--- a/tests/integration/test_stale_embeddings_repro.py
+++ b/tests/integration/test_stale_embeddings_repro.py
@@ -1,0 +1,108 @@
+"""Reproduction for issue #27 — stale embeddings persist after README re-ingestion.
+
+https://github.com/ascherj/pathreview/issues/27
+
+Root cause
+----------
+When a README is updated and re-ingested, the ingestion pipeline never removes
+the previously stored chunks, so the vector store ends up holding BOTH the old
+and the new embeddings. Two facts in the codebase combine to cause this:
+
+1. `ingestion/pipeline.py::IngestionPipeline.ingest_readme` builds the source id
+   as ``f"readme_{profile_id}_{repo_name}_{self._hash_content(content)}"``. The
+   content hash is part of the id, so an edited README produces a *different*
+   source_id and its chunks land under brand-new ids instead of overwriting the
+   old ones.
+
+2. `rag/retriever/vector_store.py::VectorStore.delete_by_source_id` exists but is
+   never called anywhere in the pipeline (verified: it has no callers). Nothing
+   ever evicts the previous version's chunks.
+
+Result: the retriever can surface chunks that describe content the current
+README no longer contains.
+
+This test reproduces the bug by mimicking exactly what the pipeline does today
+(embedding id == ``f"{source_id}_chunk_{chunk_index}"`` per
+`ingestion/embeddings/batch_processor.py::_store_embedding`). It asserts the
+CURRENT (buggy) behavior so it passes today and proves the bug is real. Once the
+fix lands, the assertion marked ``BUG`` below should be inverted to assert that
+the stale chunk is gone.
+"""
+
+import hashlib
+
+import chromadb
+import pytest
+from chromadb.api.models.Collection import Collection
+
+
+def _hash_content(content: str) -> str:
+    """Mirror IngestionPipeline._hash_content."""
+    return hashlib.sha256(content.encode()).hexdigest()[:16]
+
+
+def _readme_source_id(profile_id: str, repo_name: str, content: str) -> str:
+    """Mirror the source_id scheme in IngestionPipeline.ingest_readme."""
+    return f"readme_{profile_id}_{repo_name}_{_hash_content(content)}"
+
+
+def _ingest(
+    collection: Collection,
+    profile_id: str,
+    repo_name: str,
+    content: str,
+    embedding: list[float],
+) -> str:
+    """Simulate one README ingestion the way the pipeline does it today.
+
+    Stores a single chunk (chunk_index=0) with an id of
+    ``f"{source_id}_chunk_0"`` — matching batch_processor._store_embedding.
+    Critically, it performs NO deletion of prior chunks, exactly like the
+    real pipeline.
+    """
+    source_id = _readme_source_id(profile_id, repo_name, content)
+    embedding_id = f"{source_id}_chunk_0"
+    collection.add(
+        ids=[embedding_id],
+        embeddings=[embedding],
+        documents=[content],
+        metadatas=[{"source_id": source_id, "chunk_index": 0, "source_type": "readme"}],
+    )
+    return source_id
+
+
+@pytest.mark.integration
+def test_stale_embeddings_remain_after_readme_reingestion() -> None:
+    """Re-ingesting an updated README leaves the old chunk in the store."""
+    client = chromadb.EphemeralClient()
+    collection = client.create_collection(name="readme_repro", metadata={"hnsw:space": "cosine"})
+
+    profile_id, repo_name = "profile1", "weather-app"
+
+    # --- v1: original README, mentions "Flask" ---
+    old_content = "# Weather App\nBuilt with Flask and a REST API."
+    old_source_id = _ingest(collection, profile_id, repo_name, old_content, [0.1, 0.2, 0.3])
+
+    # --- v2: README edited; "Flask" replaced with "FastAPI" ---
+    new_content = "# Weather App\nBuilt with FastAPI and a REST API."
+    new_source_id = _ingest(collection, profile_id, repo_name, new_content, [0.11, 0.21, 0.31])
+
+    # The content change produced a different source_id, so nothing overwrote v1.
+    assert old_source_id != new_source_id
+
+    stored = collection.get()
+    stored_docs = stored["documents"]
+
+    # BUG (issue #27): BOTH versions are present. The store should contain only
+    # the current README, but the stale "Flask" chunk was never evicted.
+    assert old_content in stored_docs, "expected the stale v1 chunk to still be present (bug)"
+    assert new_content in stored_docs
+    assert (
+        len(stored["ids"]) == 2
+    ), f"expected 2 chunks (1 stale + 1 current), got {len(stored['ids'])}"
+
+    # A retrieval can therefore return outdated content ("Flask") that no longer
+    # reflects the live README ("FastAPI").
+    hits = collection.query(query_embeddings=[[0.1, 0.2, 0.3]], n_results=2)
+    returned_docs = hits["documents"][0]
+    assert old_content in returned_docs, "retriever returned the stale chunk (bug reproduced)"

--- a/tests/integration/test_stale_embeddings_repro.py
+++ b/tests/integration/test_stale_embeddings_repro.py
@@ -1,108 +1,92 @@
-"""Reproduction for issue #27 — stale embeddings persist after README re-ingestion.
+"""Regression test for issue #27 — stale embeddings after README re-ingestion.
 
 https://github.com/ascherj/pathreview/issues/27
 
-Root cause
+Background
 ----------
-When a README is updated and re-ingested, the ingestion pipeline never removes
-the previously stored chunks, so the vector store ends up holding BOTH the old
-and the new embeddings. Two facts in the codebase combine to cause this:
+When a README was updated and re-ingested, the ingestion pipeline never removed
+the previously stored chunks, so the vector store held BOTH the old and the new
+embeddings and the retriever could surface content the current README no longer
+contained. Two facts combined to cause it:
 
-1. `ingestion/pipeline.py::IngestionPipeline.ingest_readme` builds the source id
-   as ``f"readme_{profile_id}_{repo_name}_{self._hash_content(content)}"``. The
-   content hash is part of the id, so an edited README produces a *different*
-   source_id and its chunks land under brand-new ids instead of overwriting the
-   old ones.
+1. ``IngestionPipeline.ingest_readme`` built the source id with the content hash
+   baked in, so an edited README produced a *different* id and its chunks landed
+   under brand-new ids instead of overwriting the old ones.
+2. ``VectorStore.delete_by_source_id`` existed but was never called, so nothing
+   evicted the previous version's chunks.
 
-2. `rag/retriever/vector_store.py::VectorStore.delete_by_source_id` exists but is
-   never called anywhere in the pipeline (verified: it has no callers). Nothing
-   ever evicts the previous version's chunks.
+The fix keys each chunk on a stable, content-independent ``document_id`` and has
+the pipeline delete that document's existing chunks before storing the new
+version. This test was originally the reproduction (asserting both versions
+coexisted); the assertions are now inverted to guard the fix — re-ingesting an
+updated README must leave only the current content behind.
 
-Result: the retriever can surface chunks that describe content the current
-README no longer contains.
-
-This test reproduces the bug by mimicking exactly what the pipeline does today
-(embedding id == ``f"{source_id}_chunk_{chunk_index}"`` per
-`ingestion/embeddings/batch_processor.py::_store_embedding`). It asserts the
-CURRENT (buggy) behavior so it passes today and proves the bug is real. Once the
-fix lands, the assertion marked ``BUG`` below should be inverted to assert that
-the stale chunk is gone.
+This drives the real ``IngestionPipeline`` (parser + structural chunker + batch
+processor) against an in-memory ChromaDB collection using the deterministic
+``MockEmbeddingProvider``.
 """
 
-import hashlib
+import uuid
+from unittest.mock import Mock
 
 import chromadb
 import pytest
-from chromadb.api.models.Collection import Collection
+
+from ingestion.embeddings.provider import MockEmbeddingProvider
+from ingestion.pipeline import IngestionPipeline
 
 
-def _hash_content(content: str) -> str:
-    """Mirror IngestionPipeline._hash_content."""
-    return hashlib.sha256(content.encode()).hexdigest()[:16]
-
-
-def _readme_source_id(profile_id: str, repo_name: str, content: str) -> str:
-    """Mirror the source_id scheme in IngestionPipeline.ingest_readme."""
-    return f"readme_{profile_id}_{repo_name}_{_hash_content(content)}"
-
-
-def _ingest(
-    collection: Collection,
-    profile_id: str,
-    repo_name: str,
-    content: str,
-    embedding: list[float],
-) -> str:
-    """Simulate one README ingestion the way the pipeline does it today.
-
-    Stores a single chunk (chunk_index=0) with an id of
-    ``f"{source_id}_chunk_0"`` — matching batch_processor._store_embedding.
-    Critically, it performs NO deletion of prior chunks, exactly like the
-    real pipeline.
-    """
-    source_id = _readme_source_id(profile_id, repo_name, content)
-    embedding_id = f"{source_id}_chunk_0"
-    collection.add(
-        ids=[embedding_id],
-        embeddings=[embedding],
-        documents=[content],
-        metadatas=[{"source_id": source_id, "chunk_index": 0, "source_type": "readme"}],
+def _make_pipeline() -> tuple[IngestionPipeline, "chromadb.api.models.Collection.Collection"]:
+    client = chromadb.EphemeralClient()
+    collection = client.create_collection(
+        name=f"readme_regression_{uuid.uuid4().hex}", metadata={"hnsw:space": "cosine"}
     )
-    return source_id
+    pipeline = IngestionPipeline(
+        vector_db=collection,
+        db_session=Mock(),
+        embedding_provider=MockEmbeddingProvider(),
+    )
+    return pipeline, collection
 
 
 @pytest.mark.integration
-def test_stale_embeddings_remain_after_readme_reingestion() -> None:
-    """Re-ingesting an updated README leaves the old chunk in the store."""
-    client = chromadb.EphemeralClient()
-    collection = client.create_collection(name="readme_repro", metadata={"hnsw:space": "cosine"})
-
+def test_reingested_readme_leaves_no_stale_chunks() -> None:
+    """Re-ingesting an updated README replaces the old chunk instead of adding to it."""
+    pipeline, collection = _make_pipeline()
     profile_id, repo_name = "profile1", "weather-app"
 
     # --- v1: original README, mentions "Flask" ---
     old_content = "# Weather App\nBuilt with Flask and a REST API."
-    old_source_id = _ingest(collection, profile_id, repo_name, old_content, [0.1, 0.2, 0.3])
+    pipeline.ingest_readme(profile_id, repo_name, old_content)
 
     # --- v2: README edited; "Flask" replaced with "FastAPI" ---
     new_content = "# Weather App\nBuilt with FastAPI and a REST API."
-    new_source_id = _ingest(collection, profile_id, repo_name, new_content, [0.11, 0.21, 0.31])
+    pipeline.ingest_readme(profile_id, repo_name, new_content)
 
-    # The content change produced a different source_id, so nothing overwrote v1.
-    assert old_source_id != new_source_id
+    stored_docs = collection.get()["documents"]
 
-    stored = collection.get()
-    stored_docs = stored["documents"]
+    # Fixed behavior (issue #27): only the current README survives.
+    assert any("FastAPI" in d for d in stored_docs), "current README content is missing"
+    assert not any("Flask" in d for d in stored_docs), "stale v1 chunk was not evicted"
 
-    # BUG (issue #27): BOTH versions are present. The store should contain only
-    # the current README, but the stale "Flask" chunk was never evicted.
-    assert old_content in stored_docs, "expected the stale v1 chunk to still be present (bug)"
-    assert new_content in stored_docs
-    assert (
-        len(stored["ids"]) == 2
-    ), f"expected 2 chunks (1 stale + 1 current), got {len(stored['ids'])}"
-
-    # A retrieval can therefore return outdated content ("Flask") that no longer
-    # reflects the live README ("FastAPI").
-    hits = collection.query(query_embeddings=[[0.1, 0.2, 0.3]], n_results=2)
+    # A retrieval can therefore never return the outdated "Flask" content.
+    query_vec = MockEmbeddingProvider().embed([old_content])[0]
+    hits = collection.query(query_embeddings=[query_vec], n_results=5)
     returned_docs = hits["documents"][0]
-    assert old_content in returned_docs, "retriever returned the stale chunk (bug reproduced)"
+    assert all("Flask" not in d for d in returned_docs), "retriever returned a stale chunk"
+
+
+@pytest.mark.integration
+def test_unchanged_readme_is_not_reembedded() -> None:
+    """Re-ingesting identical content is skipped rather than deleted and rewritten."""
+    pipeline, collection = _make_pipeline()
+    content = "# Weather App\nBuilt with FastAPI and a REST API."
+
+    first = pipeline.ingest_readme("profile1", "weather-app", content)
+    ids_after_first = set(collection.get()["ids"])
+
+    second = pipeline.ingest_readme("profile1", "weather-app", content)
+
+    assert first.skipped is False
+    assert second.skipped is True
+    assert set(collection.get()["ids"]) == ids_after_first

--- a/tests/unit/test_ingestion_pipeline.py
+++ b/tests/unit/test_ingestion_pipeline.py
@@ -1,0 +1,127 @@
+"""Unit tests for IngestionPipeline re-ingestion behavior (issue #27).
+
+These exercise the delete-before-insert logic that keeps the vector store from
+holding stale chunks after a document is edited and re-ingested. They drive the
+real pipeline (parser + structural chunker + batch processor) against an
+in-memory ChromaDB collection, using the deterministic MockEmbeddingProvider so
+no network or external services are required.
+"""
+
+import uuid
+from unittest.mock import Mock
+
+import chromadb
+import pytest
+
+from ingestion.embeddings.provider import MockEmbeddingProvider
+from ingestion.pipeline import IngestionPipeline
+
+
+def _make_pipeline() -> tuple[IngestionPipeline, "chromadb.api.models.Collection.Collection"]:
+    """Build a pipeline backed by a fresh in-memory ChromaDB collection."""
+    client = chromadb.EphemeralClient()
+    collection = client.create_collection(
+        name=f"pipeline_test_{uuid.uuid4().hex}", metadata={"hnsw:space": "cosine"}
+    )
+    pipeline = IngestionPipeline(
+        vector_db=collection,
+        db_session=Mock(),
+        embedding_provider=MockEmbeddingProvider(),
+    )
+    return pipeline, collection
+
+
+@pytest.mark.unit
+class TestReadmeReingestion:
+    """Re-ingesting an updated README must fully replace the previous version."""
+
+    def test_reingested_readme_evicts_stale_chunks(self):
+        """After re-ingestion the store holds only the current README content."""
+        pipeline, collection = _make_pipeline()
+        profile_id, repo_name = "profile1", "weather-app"
+
+        old = "# Weather App\nBuilt with Flask and a REST API."
+        new = "# Weather App\nBuilt with FastAPI and a REST API."
+
+        pipeline.ingest_readme(profile_id, repo_name, old)
+        pipeline.ingest_readme(profile_id, repo_name, new)
+
+        docs = collection.get()["documents"]
+        assert any("FastAPI" in d for d in docs), "current README content is missing"
+        assert not any("Flask" in d for d in docs), "stale README content was not evicted"
+
+    def test_retrieval_never_returns_stale_content(self):
+        """A query after re-ingestion cannot surface the pre-update chunk."""
+        pipeline, collection = _make_pipeline()
+        provider = MockEmbeddingProvider()
+        profile_id, repo_name = "profile1", "weather-app"
+
+        pipeline.ingest_readme(profile_id, repo_name, "# App\nBuilt with Flask.")
+        pipeline.ingest_readme(profile_id, repo_name, "# App\nBuilt with FastAPI.")
+
+        # Query with the embedding of the *old* content; the stale chunk is gone,
+        # so it can never be returned.
+        query_vec = provider.embed(["# App\nBuilt with Flask."])[0]
+        hits = collection.query(query_embeddings=[query_vec], n_results=5)
+        returned = hits["documents"][0]
+        assert all("Flask" not in d for d in returned)
+
+    def test_unchanged_readme_is_skipped(self):
+        """Re-ingesting identical content is skipped, not deleted-and-reinserted."""
+        pipeline, collection = _make_pipeline()
+        content = "# Weather App\nBuilt with FastAPI."
+
+        first = pipeline.ingest_readme("profile1", "weather-app", content)
+        count_after_first = len(collection.get()["ids"])
+
+        second = pipeline.ingest_readme("profile1", "weather-app", content)
+
+        assert first.skipped is False
+        assert second.skipped is True
+        assert second.chunk_count == 0
+        # Nothing was added or removed on the no-op re-ingestion.
+        assert len(collection.get()["ids"]) == count_after_first
+
+    def test_first_ingestion_delete_is_safe_noop(self):
+        """First-time ingestion (no prior chunks) stores chunks without error."""
+        pipeline, collection = _make_pipeline()
+
+        result = pipeline.ingest_readme("profile1", "weather-app", "# App\nHello.")
+
+        assert result.skipped is False
+        assert result.chunk_count >= 1
+        assert len(collection.get()["ids"]) >= 1
+
+    def test_shrinking_readme_removes_leftover_chunks(self):
+        """A shorter v2 must not leave high-index chunks from a longer v1 behind."""
+        pipeline, collection = _make_pipeline()
+        profile_id, repo_name = "profile1", "big-repo"
+
+        big = "# Intro\nIntro text.\n" "# Setup\nSetup text.\n" "# Usage\nUsage text.\n"
+        small = "# Intro\nJust the intro now."
+
+        pipeline.ingest_readme(profile_id, repo_name, big)
+        big_chunks = len(collection.get()["ids"])
+
+        pipeline.ingest_readme(profile_id, repo_name, small)
+        docs = collection.get()["documents"]
+
+        assert big_chunks > len(docs), "expected fewer chunks after shrinking"
+        assert not any("Setup text" in d for d in docs)
+        assert not any("Usage text" in d for d in docs)
+
+    def test_reingestion_is_isolated_per_profile(self):
+        """Re-ingesting one profile's README must not touch another profile's chunks."""
+        pipeline, collection = _make_pipeline()
+        repo_name = "shared-name"
+
+        pipeline.ingest_readme("profileA", repo_name, "# A\nUses Django.")
+        pipeline.ingest_readme("profileB", repo_name, "# B\nUses Rails.")
+
+        # Update profile A only.
+        pipeline.ingest_readme("profileA", repo_name, "# A\nUses Flask now.")
+
+        docs = collection.get()["documents"]
+        assert any("Rails" in d for d in docs), "profile B's chunk was wrongly deleted"
+        assert any("Flask" in d for d in docs), "profile A's updated chunk is missing"
+        assert not any("Django" in d for d in docs), "profile A's stale chunk survived"

--- a/tests/unit/test_vector_store.py
+++ b/tests/unit/test_vector_store.py
@@ -1,0 +1,81 @@
+"""Unit tests for VectorStore deletion primitives (issue #27).
+
+Focus on delete_by_document_id, the content-independent cleanup used to evict a
+previous version of a document on re-ingestion, and on confirming
+delete_by_source_id only removes the exact content version it targets.
+"""
+
+import pytest
+
+from rag.retriever.vector_store import VectorStore
+
+
+def _seed(store: VectorStore, collection_name: str) -> None:
+    """Store two versions of one document plus an unrelated document."""
+    collection = store.get_collection(collection_name)
+    collection.add(
+        ids=["readme_p_repo_v1_chunk_0", "readme_p_repo_v2_chunk_0", "readme_p_other_chunk_0"],
+        embeddings=[[0.1, 0.2, 0.3], [0.4, 0.5, 0.6], [0.7, 0.8, 0.9]],
+        documents=["old flask readme", "new fastapi readme", "unrelated readme"],
+        metadatas=[
+            {"source_id": "readme_p_repo_v1", "document_id": "readme_p_repo"},
+            {"source_id": "readme_p_repo_v2", "document_id": "readme_p_repo"},
+            {"source_id": "readme_p_other_v1", "document_id": "readme_p_other"},
+        ],
+    )
+
+
+@pytest.fixture
+def store(tmp_path) -> VectorStore:
+    """A VectorStore persisted to a throwaway temp directory."""
+    return VectorStore(persist_dir=str(tmp_path / "chroma"))
+
+
+@pytest.mark.unit
+class TestDeleteByDocumentId:
+    """delete_by_document_id removes every version of one document only."""
+
+    def test_removes_all_versions_of_document(self, store):
+        _seed(store, "col")
+
+        store.delete_by_document_id("readme_p_repo", "col")
+
+        remaining = store.get_collection("col").get()
+        assert remaining["ids"] == ["readme_p_other_chunk_0"]
+
+    def test_does_not_touch_other_documents(self, store):
+        _seed(store, "col")
+
+        store.delete_by_document_id("readme_p_repo", "col")
+
+        docs = store.get_collection("col").get()["documents"]
+        assert "unrelated readme" in docs
+
+    def test_missing_document_is_noop(self, store):
+        _seed(store, "col")
+
+        # Should not raise and should delete nothing.
+        store.delete_by_document_id("does_not_exist", "col")
+
+        assert len(store.get_collection("col").get()["ids"]) == 3
+
+    def test_empty_collection_is_noop(self, store):
+        store.get_collection("empty")  # create but add nothing
+
+        store.delete_by_document_id("anything", "empty")
+
+        assert store.get_collection("empty").get()["ids"] == []
+
+
+@pytest.mark.unit
+class TestDeleteBySourceId:
+    """delete_by_source_id only removes the exact content version targeted."""
+
+    def test_removes_only_matching_version(self, store):
+        _seed(store, "col")
+
+        store.delete_by_source_id("readme_p_repo_v1", "col")
+
+        ids = store.get_collection("col").get()["ids"]
+        assert "readme_p_repo_v1_chunk_0" not in ids
+        assert "readme_p_repo_v2_chunk_0" in ids


### PR DESCRIPTION
## Summary
When a README (or resume / repo-metadata) was edited and re-ingested, the vector store kept the **old** chunks alongside the new ones, so the retriever could return content the current document no longer contained. Two things combined to cause it: `IngestionPipeline` built each `source_id` with the content hash baked in, so an edited document got a *brand-new* id and its chunks landed next to the old ones instead of replacing them; and `VectorStore.delete_by_source_id` existed but was never called, so nothing ever evicted the previous version. This PR gives every chunk a stable, content-independent `document_id` (e.g. `readme_{profile_id}_{repo_name}`) and has the pipeline delete that document's existing chunks **before** storing the new version, so the store holds exactly one set of chunks per document and a query can never surface stale text.

## Issue
Closes #27

## Changes
- **`ingestion/pipeline.py`** — derive a stable `document_id` (no content hash) for every source, keeping `source_id = {document_id}_{content_hash}` (the id string is unchanged); store `document_id` in each chunk's metadata.
- **`ingestion/pipeline.py`** — add `_delete_existing_chunks(document_id)` and call it immediately before embedding/storing in all three ingest paths (`ingest_readme`, `ingest_resume`, `ingest_repo_metadata`) — the delete-before-insert that evicts the prior version.
- **`ingestion/pipeline.py`** — `_check_skip` now consults the vector store by `source_id` (the source of truth) instead of the non-functional `db_session` placeholder, so unchanged content is still skipped and not re-embedded.
- **`rag/retriever/vector_store.py`** — add `delete_by_document_id()`, the retriever-side cleanup primitive keyed on the stable `document_id`; clarify `delete_by_source_id`'s docstring (it only targets one content version).
- **Tests** — new `tests/unit/test_ingestion_pipeline.py` and `tests/unit/test_vector_store.py`; the Week-8 reproduction in `tests/integration/test_stale_embeddings_repro.py` inverted into a regression test.

## Testing
<!-- How did you verify your changes? -->
Ran the targeted suite; also verified manually with the snippet below (asserts fail on `main`, pass on this branch). New change adds 11 passing tests and introduces **no new failures** — see the pre-existing note under Notes for Reviewers.

Here is my test case that was failing before but now passes.

from unittest.mock import Mock
import chromadb
from ingestion.embeddings.provider import MockEmbeddingProvider
from ingestion.pipeline import IngestionPipeline

col = chromadb.EphemeralClient().create_collection("demo", metadata={"hnsw:space": "cosine"})
pipe = IngestionPipeline(vector_db=col, db_session=Mock(), embedding_provider=MockEmbeddingProvider())

pipe.ingest_readme("p1", "weather-app", "# Weather App\nBuilt with Flask.")
pipe.ingest_readme("p1", "weather-app", "# Weather App\nBuilt with FastAPI.")  # edited + re-ingested

docs = col.get()["documents"]
assert any("FastAPI" in d for d in docs)     # current content present
assert not any("Flask" in d for d in docs)   # stale content evicted (was present before this PR)
