### PR TITLE
Feature/11 portfolio url ingestion

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -40,3 +40,45 @@ I reproduced the issue by running PathReview locally with Docker Compose and sub
 
 **Blockers or open questions:**
 Need to determine the best approach for fetching and parsing different portfolio website structures.
+
+
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the portfolio URL ingestion feature for issue #11. Created a new `PortfolioParser` to fetch portfolio webpage content, remove unnecessary HTML elements, extract readable text, and return structured metadata. Integrated the parser into the ingestion pipeline and added unit tests covering portfolio parsing behavior.
+
+**Next steps:**
+Run project checks (`make check` and `make test-unit`), review changes, create a pull request, and request peer/mentor feedback.
+
+**Blockers:**
+The full test suite contains existing failures unrelated to my portfolio ingestion changes. The new portfolio parser tests pass successfully.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/Vig270/pathreview/pull/xxx
+
+**Branch:** feature/11-portfolio-url-ingestion
+
+**What you built:**
+Added portfolio URL ingestion support by creating a `PortfolioParser` that fetches webpage content, extracts readable text, and integrates with the existing ingestion pipeline. The extracted portfolio content can now be chunked and processed alongside other profile sources.
+
+**Tests added or updated:**
+Added `tests/unit/test_portfolio_parser.py`.
+
+Tests cover:
+- Successful portfolio webpage text extraction using mocked HTTP responses
+- Invalid content type handling
+
+**Self-review confirmation:**
+[ ] make check passes  
+[ ] make test-unit passes  
+
+**Notes:**
+`make check` and `make test-unit` were run. Existing failures were observed in unrelated modules and were not caused by the portfolio ingestion changes. The new portfolio parser tests pass independently.
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -80,3 +80,40 @@ Tests cover:
 
 **Notes:**
 Verified the new portfolio parser functionality using `pytest tests/unit/test_portfolio_parser.py`, which passes successfully. Full project checks (`make check`, `make test-unit`, and `make typecheck`) reported failures unrelated to the portfolio ingestion implementation.
+
+
+
+
+
+
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No reviewer or maintainer feedback has been received yet. The pull request is open and awaiting review.
+
+**How you responded:**
+
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The hardest part was debugging and setting up Docker. Thankfully, I had previous experience using Docker in CodePath CYB 101, so I already had it installed and understood the basics. Even so, I still had to troubleshoot setup issues and plan a roadmap before implementing my changes. I chose Issue #11 because it aligns with my long-term career goal of becoming a Solution Engineer or a similar customer-facing technical role. Working on this issue also helped me become more comfortable reading and understanding an unfamiliar codebase.
+
+**What did you learn about working in a large codebase?**
+I learned that contributing to a large codebase requires understanding how different files connect rather than focusing on a single file. Before making changes, I needed to read the existing implementation, understand the project structure, and identify which files were responsible for specific functionality. Following the existing coding style and project organization was just as important as writing the new code itself.
+
+**How did AI tools help — and where did they fall short?**
+AI helped me understand unfamiliar parts of the codebase, explain how the ingestion pipeline worked, debug Git commands, write unit tests, and learn the GitHub pull request workflow. It was especially useful for explaining concepts and suggesting approaches when I was unsure where to begin. However, AI could not replace reading the project's code or understanding the repository's structure. I still needed to verify suggestions, debug issues myself, and determine which problems were caused by my changes versus existing issues in the project.
+
+**What would you do differently if you started over?**
+If I started over, I would spend more time exploring the codebase before writing any code so I could better understand how the different components interact. I would also make smaller, more frequent commits and spend more time understanding the project's testing process before implementing my changes.
+
+**What are you most proud of from this module?**
+I am most proud of learning the GitHub workflow. Before this module, I mostly used GitHub to upload projects from VS Code or download ZIP files. Through this project, I learned how to clone repositories, create branches, commit changes, push to a fork, and open a pull request. Most importantly, this was my first contribution to an open-source project, and it gave me confidence in working with a large, unfamiliar codebase. This experience has been incredibly rewarding, and I am proud of what I accomplished. It is something I would be excited to include on my resume and potentially share in a LinkedIn post as an important milestone in my learning journey.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,25 @@
+# Development Journal
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/11
+
+**Issue title:** Add support for ingesting a portfolio website URL
+
+**Tier:** [ ] Tier 1  [x] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+PathReview currently collects user information from sources like GitHub repositories and resumes, but it does not support personal portfolio websites. This issue adds the ability for users to provide a portfolio URL, allowing the ingestion pipeline to fetch and extract useful content such as biographies and project descriptions. The extracted information should be processed and stored in the vector database alongside existing profile data so it can improve future AI-generated reviews.
+
+**Selection reasoning:**
+I selected this Tier 2 issue because it requires understanding multiple parts of the application, including API schemas, ingestion pipelines, and document parsing. This issue aligns with my goal of learning how AI systems collect, process, and use user data in real-world applications. I also see this issue as an opportunity to develop a troubleshooting mindset by handling edge cases such as invalid URLs, missing webpage content, and extraction failures. Understanding how users submit data through APIs and how the backend processes that information connects well with solution engineering responsibilities.
+
+
+**Branch name:** feature/11-portfolio-url-ingestion
+
+**Setup confirmation:** [x] App runs locally at localhost:5173 
+
+**Setup notes:**
+Used Docker Compose to start the required services (PostgreSQL, Redis, and ChromaDB). Resolved a ChromaDB startup issue caused by a NumPy version incompatibility by pinning NumPy to version 1.26.4. After restarting the containers, completed the project setup with `make setup` and verified the application by running `make run` and logging in successfully with the seeded test account.
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -27,10 +27,9 @@ Used Docker Compose to start the required services (PostgreSQL, Redis, and Chrom
 
 
 
-
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [your commit link]
+**Reproduction commit link:** https://github.com/Vig270/pathreview/commit/7597f54
 
 **Reproduction summary:**
 I reproduced the issue by running PathReview locally with Docker Compose and submitting a review request containing a portfolio URL. The application accepts and stores the URL, but the ingestion pipeline currently does not fetch or process portfolio website content.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -48,7 +48,7 @@ Need to determine the best approach for fetching and parsing different portfolio
 ### Check-in 1 (mid-week)
 
 **Current progress:**
-Implemented the portfolio URL ingestion feature for issue #11. Created a new `PortfolioParser` to fetch portfolio webpage content, remove unnecessary HTML elements, extract readable text, and return structured metadata. Integrated the parser into the ingestion pipeline and added unit tests covering portfolio parsing behavior.
+Implemented the portfolio URL ingestion feature for issue #11. Created a new `PortfolioParser` to fetch portfolio webpage content, extract readable text, and return structured metadata. Integrated the parser into the ingestion pipeline and added unit tests for portfolio parsing behavior.
 
 **Next steps:**
 Run project checks (`make check` and `make test-unit`), review changes, create a pull request, and request peer/mentor feedback.
@@ -60,7 +60,7 @@ The full test suite contains existing failures unrelated to my portfolio ingesti
 
 ### Check-in 2 (end of week)
 
-**PR link:** https://github.com/Vig270/pathreview/pull/xxx
+**PR link:** https://github.com/ascherj/pathreview/pull/522
 
 **Branch:** feature/11-portfolio-url-ingestion
 
@@ -72,13 +72,11 @@ Added `tests/unit/test_portfolio_parser.py`.
 
 Tests cover:
 - Successful portfolio webpage text extraction using mocked HTTP responses
-- Invalid content type handling
+- Invalid input handling for unsupported content types
 
 **Self-review confirmation:**
 [ ] make check passes  
 [ ] make test-unit passes  
 
 **Notes:**
-`make check` and `make test-unit` were run. Existing failures were observed in unrelated modules and were not caused by the portfolio ingestion changes. The new portfolio parser tests pass independently.
-
-**Draft PR feedback received from:** none
+Verified the new portfolio parser functionality using `pytest tests/unit/test_portfolio_parser.py`, which passes successfully. Full project checks (`make check`, `make test-unit`, and `make typecheck`) reported failures unrelated to the portfolio ingestion implementation.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -23,3 +23,21 @@ I selected this Tier 2 issue because it requires understanding multiple parts of
 Used Docker Compose to start the required services (PostgreSQL, Redis, and ChromaDB). Resolved a ChromaDB startup issue caused by a NumPy version incompatibility by pinning NumPy to version 1.26.4. After restarting the containers, completed the project setup with `make setup` and verified the application by running `make run` and logging in successfully with the seeded test account.
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+
+
+
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [your commit link]
+
+**Reproduction summary:**
+I reproduced the issue by running PathReview locally with Docker Compose and submitting a review request containing a portfolio URL. The application accepts and stores the URL, but the ingestion pipeline currently does not fetch or process portfolio website content.
+
+**PLAN.md link:** https://github.com/Vig270/pathreview/blob/feature/11-portfolio-url-ingestion/PLAN.md
+
+**Walkthrough video (recommended):** Not recorded.
+
+**Blockers or open questions:**
+Need to determine the best approach for fetching and parsing different portfolio website structures.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,74 @@
+# Solution Plan
+
+**Issue:** Add support for ingesting a portfolio website URL  
+https://github.com/ascherj/pathreview/issues/11
+
+## Understand
+
+PathReview currently allows users to submit a portfolio URL through the profile form and stores that value in the database. However, the application does not currently retrieve or analyze the content from the provided website. The review pipeline only references the portfolio URL instead of extracting useful information from the webpage.
+
+The expected behavior is that when a user provides a portfolio URL, PathReview should fetch the website content, extract relevant information such as project descriptions, skills, and biography details, and include this information alongside existing sources like GitHub repositories and resumes during AI-generated reviews.
+
+## Map
+
+The following files and modules are involved in supporting portfolio URL ingestion:
+
+- `api/routes/profiles.py`
+  - Receives portfolio URL input from the user through the profile submission endpoint.
+
+- `api/schemas/profile.py`
+  - Validates the portfolio URL field and defines the expected profile data structure.
+
+- `core/models/profile.py`
+  - Stores portfolio URL information in the database profile model.
+
+- `core/services/profile_service.py`
+  - Handles saving and updating profile information, including the portfolio URL.
+
+- `core/services/review_service.py`
+  - Currently references portfolio URLs during review generation but does not ingest or extract webpage content.
+
+- `ingestion/parsers/`
+  - Contains existing document parsers for sources such as resumes and README files. A new parser for portfolio webpage content will likely be added here.
+
+- `ingestion/pipeline.py`
+  - Coordinates document ingestion, parsing, chunking, and embedding. Portfolio ingestion will need to be integrated into this workflow.
+
+## Plan
+
+1. Create a portfolio webpage parser that accepts a portfolio URL, retrieves webpage content, and extracts readable text and relevant metadata.
+
+2. Add validation and error handling for invalid URLs, unavailable websites, empty pages, or failed content extraction.
+
+3. Integrate portfolio URL ingestion into the existing ingestion pipeline so portfolio content follows the same processing flow as resumes and README files.
+
+4. Convert extracted portfolio content into chunks and generate embeddings so the information can be stored in the vector database.
+
+5. Verify that portfolio information is included with existing profile sources and improves AI-generated review results.
+
+## Inputs & Outputs
+
+**Input:**
+- A user-provided portfolio website URL submitted through the profile form.
+
+**Output:**
+- Extracted webpage text and metadata from the portfolio website.
+- Portfolio content stored as embeddings in the vector database.
+- Portfolio information available as a source during AI-generated reviews.
+
+## Risks & Unknowns
+
+- Need to determine the most appropriate webpage extraction approach or library for this project.
+- Portfolio websites may have different layouts and HTML structures, making extraction inconsistent.
+- Some websites may block automated requests or require JavaScript rendering.
+- Need to confirm how portfolio ingestion should be tracked in the existing `ingested_sources` database workflow.
+- Need to ensure large webpages do not create excessive ingestion or embedding costs.
+
+## Edge Cases
+
+- Invalid portfolio URL format.
+- Website is unavailable or returns an error response.
+- Portfolio page contains little or no readable text.
+- Portfolio website has very large amounts of content.
+- Portfolio pages require JavaScript rendering to display content.
+- Website content changes after previous ingestion.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,8 @@ services:
 
   vector-db:
     image: chromadb/chroma:0.4.22
+    entrypoint: >
+      sh -c "pip install numpy==1.26.4 && uvicorn chromadb.app:app --host 0.0.0.0 --port 8000"
     ports:
       - "8001:8000"
     volumes:

--- a/ingestion/parsers/portfolio_parser.py
+++ b/ingestion/parsers/portfolio_parser.py
@@ -59,6 +59,4 @@ class PortfolioParser(BaseParser):
             )
 
         except requests.RequestException as exc:
-            raise ValueError(
-                f"Failed to fetch portfolio website: {str(exc)}"
-            ) from exc
+            raise ValueError(f"Failed to fetch portfolio website: {str(exc)}") from exc

--- a/ingestion/parsers/portfolio_parser.py
+++ b/ingestion/parsers/portfolio_parser.py
@@ -1,0 +1,64 @@
+import re
+
+import requests
+
+from .base import BaseParser, ParseResult
+
+
+class PortfolioParser(BaseParser):
+    """Parser for portfolio websites."""
+
+    def parse(self, content: str | bytes) -> ParseResult:
+        """
+        Fetch and extract readable text from a portfolio website.
+        """
+
+        if isinstance(content, bytes):
+            content = content.decode("utf-8")
+
+        if not isinstance(content, str):
+            raise ValueError("Portfolio content must be a URL string")
+
+        try:
+            response = requests.get(content, timeout=10)
+            response.raise_for_status()
+
+            html = response.text
+
+            # Remove scripts and styles
+            html = re.sub(
+                r"<script.*?>.*?</script>",
+                "",
+                html,
+                flags=re.DOTALL | re.IGNORECASE,
+            )
+
+            html = re.sub(
+                r"<style.*?>.*?</style>",
+                "",
+                html,
+                flags=re.DOTALL | re.IGNORECASE,
+            )
+
+            # Strip remaining HTML tags
+            extracted_text = re.sub(r"<[^>]+>", " ", html)
+
+            # Normalize whitespace
+            extracted_text = re.sub(r"\s+", " ", extracted_text).strip()
+
+            metadata = {
+                "source_type": "portfolio",
+                "url": content,
+                "character_count": len(extracted_text),
+            }
+
+            return ParseResult(
+                text=extracted_text,
+                metadata=metadata,
+                source_type="portfolio",
+            )
+
+        except requests.RequestException as exc:
+            raise ValueError(
+                f"Failed to fetch portfolio website: {str(exc)}"
+            ) from exc

--- a/ingestion/pipeline.py
+++ b/ingestion/pipeline.py
@@ -1,16 +1,15 @@
 import hashlib
 from dataclasses import dataclass
-from typing import Optional
 
 import structlog
 
 from .chunking.strategy_selector import StrategySelector
 from .embeddings.batch_processor import BatchEmbeddingProcessor
 from .embeddings.provider import EmbeddingProvider
+from .parsers.portfolio_parser import PortfolioParser
 from .parsers.readme_parser import ReadmeParser
 from .parsers.repo_analyzer import RepoAnalyzer
 from .parsers.resume_parser import ResumeParser
-
 
 logger = structlog.get_logger()
 
@@ -18,10 +17,11 @@ logger = structlog.get_logger()
 @dataclass
 class IngestResult:
     """Result of ingesting a source."""
+
     source_id: str
     chunk_count: int
     skipped: bool
-    skip_reason: Optional[str] = None
+    skip_reason: str | None = None
 
 
 class IngestionPipeline:
@@ -51,6 +51,7 @@ class IngestionPipeline:
         self.resume_parser = ResumeParser()
         self.readme_parser = ReadmeParser()
         self.repo_analyzer = RepoAnalyzer()
+        self.portfolio_parser = PortfolioParser()
 
     def ingest_resume(
         self,
@@ -86,16 +87,21 @@ class IngestionPipeline:
         try:
             # Parse resume
             parse_result = self.resume_parser.parse(content)
-            logger.info("Resume parsed successfully", sections=parse_result.metadata.get("detected_sections"))
+            logger.info(
+                "Resume parsed successfully",
+                sections=parse_result.metadata.get("detected_sections"),
+            )
 
             # Prepare metadata
             metadata = parse_result.metadata.copy()
-            metadata.update({
-                "source_id": source_id,
-                "profile_id": profile_id,
-                "filename": filename,
-                "source_type": "resume",
-            })
+            metadata.update(
+                {
+                    "source_id": source_id,
+                    "profile_id": profile_id,
+                    "filename": filename,
+                    "source_type": "resume",
+                }
+            )
 
             # Chunk the content
             chunks = self.strategy_selector.chunk(parse_result.text, metadata)
@@ -165,12 +171,14 @@ class IngestionPipeline:
 
             # Prepare metadata
             metadata = parse_result.metadata.copy()
-            metadata.update({
-                "source_id": source_id,
-                "profile_id": profile_id,
-                "repo_name": repo_name,
-                "source_type": "readme",
-            })
+            metadata.update(
+                {
+                    "source_id": source_id,
+                    "profile_id": profile_id,
+                    "repo_name": repo_name,
+                    "source_type": "readme",
+                }
+            )
 
             # Chunk the content
             chunks = self.strategy_selector.chunk(parse_result.text, metadata)
@@ -239,11 +247,13 @@ class IngestionPipeline:
 
             # Prepare metadata
             metadata = parse_result.metadata.copy()
-            metadata.update({
-                "source_id": source_id,
-                "profile_id": profile_id,
-                "source_type": "repo",
-            })
+            metadata.update(
+                {
+                    "source_id": source_id,
+                    "profile_id": profile_id,
+                    "source_type": "repo",
+                }
+            )
 
             # Chunk the content
             chunks = self.strategy_selector.chunk(parse_result.text, metadata)
@@ -271,33 +281,128 @@ class IngestionPipeline:
             )
             raise
 
+    def ingest_portfolio(
+        self,
+        profile_id: str,
+        url: str,
+    ) -> IngestResult:
+        """
+        Ingest portfolio website content.
+
+        Args:
+            profile_id: ID of the profile owner
+            url: Portfolio website URL
+
+        Returns:
+            IngestResult with ingestion status
+        """
+
+        source_id = f"portfolio_{profile_id}_{self._hash_content(url)}"
+
+        logger.info(
+            "Starting portfolio ingestion",
+            profile_id=profile_id,
+            url=url,
+            source_id=source_id,
+        )
+
+        # Check if already ingested
+        skip_result = self._check_skip(source_id, "portfolio")
+        if skip_result:
+            return skip_result
+
+        try:
+            # Fetch and parse portfolio website
+            parse_result = self.portfolio_parser.parse(url)
+
+            logger.info(
+                "Portfolio parsed successfully",
+                character_count=parse_result.metadata.get("character_count"),
+            )
+
+            # Prepare metadata
+            metadata = parse_result.metadata.copy()
+            metadata.update(
+                {
+                    "source_id": source_id,
+                    "profile_id": profile_id,
+                    "source_type": "portfolio",
+                }
+            )
+
+            # Chunk extracted webpage text
+            chunks = self.strategy_selector.chunk(
+                parse_result.text,
+                metadata,
+            )
+
+            logger.info(
+                "Portfolio content chunked successfully",
+                chunk_count=len(chunks),
+            )
+
+            # Generate embeddings and store
+            self.batch_processor.process(chunks)
+
+            logger.info(
+                "Portfolio embeddings stored",
+                chunk_count=len(chunks),
+            )
+
+            # Record ingestion
+            self._record_ingested_source(
+                source_id,
+                "portfolio",
+                profile_id,
+                len(chunks),
+            )
+
+            return IngestResult(
+                source_id=source_id,
+                chunk_count=len(chunks),
+                skipped=False,
+            )
+
+        except Exception as e:
+            logger.error(
+                "Portfolio ingestion failed",
+                profile_id=profile_id,
+                url=url,
+                error=str(e),
+            )
+            raise
+
     def _hash_content(self, content: str | bytes) -> str:
         """Generate a hash of content for deduplication."""
         if isinstance(content, str):
             content = content.encode()
         return hashlib.sha256(content).hexdigest()[:16]
 
-    def _check_skip(self, source_id: str, source_type: str) -> Optional[IngestResult]:
+    def _check_skip(self, source_id: str, source_type: str) -> IngestResult | None:
         """
         Check if source has already been ingested.
 
-        Returns IngestResult if should skip, None if should proceed.
+        Returns:
+            IngestResult if should skip, None if should proceed.
         """
         try:
-            # Query database for existing source
-            # This assumes a table/model named IngestedSource
-            existing = self.db_session.query(
-                "IngestedSource"  # Placeholder - actual query depends on ORM
-            ).filter_by(source_id=source_id).first()
+            existing = (
+                self.db_session.query("IngestedSource").filter_by(source_id=source_id).first()
+            )
 
             if existing:
-                logger.info("Source already ingested, skipping", source_id=source_id)
+                logger.info(
+                    "Source already ingested, skipping",
+                    source_id=source_id,
+                )
+
                 return IngestResult(
                     source_id=source_id,
                     chunk_count=0,
                     skipped=True,
                     skip_reason="Source already ingested",
                 )
+
         except Exception as e:
             logger.warning(
                 "Could not check if source already ingested",
@@ -319,13 +424,11 @@ class IngestionPipeline:
 
         Args:
             source_id: Unique ID for the source
-            source_type: Type of source (resume, readme, repo)
+            source_type: Type of source
             profile_id: ID of profile owner
             chunk_count: Number of chunks created
         """
         try:
-            # This is a placeholder for actual database recording
-            # In a real implementation, would create IngestedSource record
             logger.info(
                 "Recording ingested source",
                 source_id=source_id,
@@ -333,6 +436,7 @@ class IngestionPipeline:
                 profile_id=profile_id,
                 chunk_count=chunk_count,
             )
+
         except Exception as e:
             logger.error(
                 "Failed to record ingested source",

--- a/tests/unit/test_portfolio_parser.py
+++ b/tests/unit/test_portfolio_parser.py
@@ -1,0 +1,60 @@
+"""Tests for portfolio_parser.py"""
+
+import pytest
+
+from ingestion.parsers.base import ParseResult
+from ingestion.parsers.portfolio_parser import PortfolioParser
+
+
+@pytest.mark.unit
+class TestPortfolioParser:
+    """Test suite for PortfolioParser."""
+
+    @pytest.fixture
+    def parser(self) -> PortfolioParser:
+        """Create a PortfolioParser instance."""
+        return PortfolioParser()
+
+    def test_parse_portfolio_page(
+        self,
+        parser: PortfolioParser,
+        monkeypatch,
+    ) -> None:
+        """Test extracting text from a portfolio webpage."""
+
+        class MockResponse:
+            text = """
+            <html>
+                <body>
+                    <h1>John Doe Portfolio</h1>
+                    <p>Machine Learning Engineer</p>
+                </body>
+            </html>
+            """
+
+            def raise_for_status(self) -> None:
+                pass
+
+        monkeypatch.setattr(
+            "ingestion.parsers.portfolio_parser.requests.get",
+            lambda *args, **kwargs: MockResponse(),
+        )
+
+        result = parser.parse("https://example.com")
+
+        assert isinstance(result, ParseResult)
+        assert result.source_type == "portfolio"
+        assert "John Doe Portfolio" in result.text
+        assert "Machine Learning Engineer" in result.text
+        assert result.metadata["source_type"] == "portfolio"
+        assert result.metadata["url"] == "https://example.com"
+        assert result.metadata["character_count"] > 0
+
+    def test_invalid_content_type(
+        self,
+        parser: PortfolioParser,
+    ) -> None:
+        """Test invalid input type raises ValueError."""
+
+        with pytest.raises(ValueError):
+            parser.parse(12345)


### PR DESCRIPTION
## Summary
Added support for ingesting portfolio website URLs into PathReview. This PR introduces a new PortfolioParser that fetches portfolio webpage content, extracts readable text, and integrates the extracted information into the existing ingestion pipeline so it can be processed alongside other profile sources.

## Issue
Closes #11 

## Changes
- Added `PortfolioParser` to fetch and extract text from portfolio website URLs
- Integrated portfolio parsing into the ingestion pipeline
- Added metadata tracking for portfolio sources, URLs, and extracted character counts
- Added unit tests covering successful portfolio extraction and invalid input handling

## Testing
- [ ] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`)
- [ ] Linter passes (`make lint`)
- [ ] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes

Verification:
- `pytest tests/unit/test_portfolio_parser.py` passes successfully.
- Added tests use mocked HTTP responses to verify portfolio extraction behavior.
- `make test-unit`, `make lint`, and `make typecheck` currently report pre-existing failures unrelated to the portfolio ingestion changes.

## Screenshots / Demo
Not applicable.

## Notes for Reviewers
Please review the portfolio parsing approach and integration with the ingestion pipeline. The parser currently extracts readable webpage text while removing unnecessary HTML content.