### PR TITLE
fix: wrap raw SQL in text() for health check DB

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -70,3 +70,34 @@ Added `tests/unit/test_health.py` since no tests existed for this route before, 
 **Self-review confirmation:** [x] make check passes  [x] make test-unit passes
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [x] Yes  [ ] No
+
+**Summary of feedback:**
+Github Copilot commented on my PR. It flagged that my tests mock `db.execute()` without verifying it was called with a wrapped `sqlalchemy.text()` statement, which meant that if someone regressed the fix back to a raw string, my tests would still pass. It suggested asserting on the actual call argument's `.text` value.
+
+**How you responded:**
+The AI assistant suggested to assert that `db.execute()` was actually called with a `text("SELECT 1")` statement, not just any argument, plus a `type: ignore` for mypy. I accepted that suggested fix.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Definitely getting my local environment stable. I ran into a leftover `uvicorn` process from an earlier session that was still running old code and made it look like my fix caused a new error, when it hadn't. Moreover, I also needed to make sure not to modify the existing `health_check()` function too much, since it was already a bit messy and I didn't want to introduce new bugs.
+
+**What did you learn about working in a large codebase?**
+There's already a lot of unrelated bugs sitting in the same files I was touching. I learned that my job wasn't to fix all of that, but to focus on the specific issue at hand. I needed to make sure my specific change didn't add to it, and to be upfront in my PR about what already existed before I got there.
+
+**How did AI tools help — and where did they fall short?**
+AI was most useful for explaining why the bug happened. Actually it helped me reproduce it without needing the full Docker stack running. Where it fell short was writing tests that were more advanced than I could confidently explain myself, so I had to ask for a simpler version so I actually understood the solution, instead of just accepting AI output at face value.
+
+**What would you do differently if you started over?**
+I'd check for old leftover processes earlier instead of assuming my code was broken when I got an unexpected error. I'd also decide on my test strategy once and stick with it, instead of writing a stricter test, simplifying it, then getting feedback asking for the stricter version back.
+
+**What are you most proud of from this module?**
+Figuring out I could reproduce the bug without the need of Docker by pointing SQLAlchemy at a fake connection string, so I got a fast way to prove the bug existed and later confirm the fix worked.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -39,3 +39,17 @@ I reproduced the bug by running the app locally in Docker using `make run` and t
 
 **Blockers or open questions:**
 Still need to confirm the fix works against a real Postgres connection in Docker (not just my isolated reproduction script), and I'm deciding whether to add a new test file (tests/unit/test_health.py) before opening the PR, since one doesn't currently exist for this route.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+I was able to implement the the fix from my plan which was the wrapping of the raw SQL string in `sqlalchemy.text()` (`api/routes/health.py`). Then, I ran the reproduction script again and confirmed the `ArgumentError` is gone. And finally, I added `tests/unit/test_health.py` with two tests covering the healthy and unhealthy cases for the Postgres probe.
+
+**Next steps:**
+Now i need to make sure the fix works (not just mocks), run a full self-review comparing `make check` and `make test-unit` before/after my change, and open the PR.
+
+**Blockers:**
+None.
+

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -9,6 +9,9 @@
 **Problem summary:**
 In this case, the /health endpoint should verify the app and its DB connection are working. It uses SQL to test the DB as "SELECT 1", but the version of SQLAlchemy here does not allow the direct use of raw strings for queries. Because of this, the DB check throws an error every time as it always shows the DB as “down”, even when is running fine. The part of the codebase that this exists is in api/routes/health.py in the DB probe portion of the health check logic. An ideal solution will make the DB check run successfully and return the actual running status of the DB connection.
 
+**Selection reasoning:**
+I chose Tier 1 because this is my first time working in a large and unfamiliar codebase. Moreover, this particular issue is relatively easy to fix since it is isolated to one file (api/routes/health.py) with a clear cause, so I could describe the before/after without much digging. Given the 3 to 6 hours estimate for Tier 1 work, I'm confident this fits comfortably within the Week 8–9 timeline.
+
 **Branch name:** fix/154-health-check-sql-text
 
 **Setup confirmation:** [x] App runs locally at localhost:5173

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -53,3 +53,20 @@ Now i need to make sure the fix works (not just mocks), run a full self-review c
 **Blockers:**
 None.
 
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/523
+
+**Branch:** fix/154-health-check-sql-text
+
+**What you built:**
+Fixed the `/health` endpoint's Postgres probe by wrapping the raw SQL string in `sqlalchemy.text()`. SQLAlchemy 2.x rejects raw strings unless wrapped in `sqlalchemy.text()`. The change made was `text("SELECT 1")`, rather than "SELECT 1". I also added type annotations to `health_check()` (a return type and an explicit type for the `health_status` dict) since the pre-commit `mypy` hook was blocking my commit on pre-existing untyped code in this same function.
+
+**Tests added or updated:**
+Added `tests/unit/test_health.py` since no tests existed for this route before, with two tests: one confirming Postgres reports "healthy" when the query succeeds, and one confirming it reports "unhealthy" with a 503 when the query raises.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,16 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/154
+
+**Issue title:** Health check DB probe passes a raw SQL string, which fails under SQLAlchemy 2.x
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+In this case, the /health endpoint should verify the app and its DB connection are working. It uses SQL to test the DB as "SELECT 1", but the version of SQLAlchemy here does not allow the direct use of raw strings for queries. Because of this, the DB check throws an error every time as it always shows the DB as “down”, even when is running fine. The part of the codebase that this exists is in api/routes/health.py in the DB probe portion of the health check logic. An ideal solution will make the DB check run successfully and return the actual running status of the DB connection.
+
+**Branch name:** fix/154-health-check-sql-text
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -4,7 +4,7 @@
 
 **Issue title:** Health check DB probe passes a raw SQL string, which fails under SQLAlchemy 2.x
 
-**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+**Tier:** [x] Tier 1 [ ] Tier 2 [ ] Tier 3
 
 **Problem summary:**
 In this case, the /health endpoint should verify the app and its DB connection are working. It uses SQL to test the DB as "SELECT 1", but the version of SQLAlchemy here does not allow the direct use of raw strings for queries. Because of this, the DB check throws an error every time as it always shows the DB as “down”, even when is running fine. The part of the codebase that this exists is in api/routes/health.py in the DB probe portion of the health check logic. An ideal solution will make the DB check run successfully and return the actual running status of the DB connection.
@@ -17,3 +17,23 @@ I chose Tier 1 because this is my first time working in a large and unfamiliar c
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning — Issue #154
+
+**Reproduction summary:**
+I reproduced the bug by running the app locally in Docker using `make run` and then, calling `GET /health` (`curl http://localhost:8000/health` as per the SETUP.md). Postgres was healthy in the container, but the endpoint still returned a 503 with `postgres: "unhealthy"` in the `dependencies` object, confirming the raw SQL string issue described in the issue. In this case, this is the exact output:
+
+```json
+{"detail":
+    {"status":"unhealthy","dependencies":
+        {
+            "postgres":"unhealthy","redis":"unhealthy","vector_db":"healthy"
+        },
+    "safety_events_last_hour":0,"timestamp":"2026-07-24T21:04:44.544803"}
+}
+```
+
+**PLAN.md link:** https://github.com/Andresc06/pathreview/blob/fix/154-health-check-sql-text/PLAN.md
+
+**Blockers or open questions:**
+Still need to confirm the fix works against a real Postgres connection in Docker (not just my isolated reproduction script), and I'm deciding whether to add a new test file (tests/unit/test_health.py) before opening the PR, since one doesn't currently exist for this route.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -20,6 +20,8 @@ I chose Tier 1 because this is my first time working in a large and unfamiliar c
 
 ## Week 8 — Reproduction & solution planning — Issue #154
 
+**Reproduction commit link:** https://github.com/Andresc06/pathreview/commit/5a097c5
+
 **Reproduction summary:**
 I reproduced the bug by running the app locally in Docker using `make run` and then, calling `GET /health` (`curl http://localhost:8000/health` as per the SETUP.md). Postgres was healthy in the container, but the endpoint still returned a 503 with `postgres: "unhealthy"` in the `dependencies` object, confirming the raw SQL string issue described in the issue. In this case, this is the exact output:
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,47 @@
+## Solution plan
+
+**Issue:** #154 — Health check DB probe passes a raw SQL string, which fails under SQLAlchemy 2.x https://github.com/ascherj/pathreview/issues/154
+
+### Understand
+What is the root cause of this issue? What behavior is expected vs. actual?
+In this case, the behavior expected was that api/routes/health.py runs await db.execute("SELECT 1") to check whether Postgres is reachable, which would return a successful message saying that the db connection is healthy. However, it does not behave that way, the root cause is that the health check's Postgres probe uses a raw SQL string (`"SELECT 1"`) on line 31, but the version of SQLAlchemy used in this project requires raw SQL to be wrapped in `sqlalchemy.text()`. This mismatch makes the query to fail, raising an ArgumentError, which then marks postgres: "unhealthy" even when Postgres is fine.
+
+
+
+### Map
+Which files, functions, or modules are involved?
+Files i expect to be involved:
+- api/routes/health.py: inside health_check() function, specifically in line 31. This line is the only line that needs to change for the actual fix.
+- core/database.py: this file likely contains the database session setup and might need to be checked for compatibility with the new text() usage.
+
+### Plan
+What are the steps to fix this issue?
+1. Confirm the exact import needed: from sqlalchemy import text.
+2. Change line 31 from await db.execute("SELECT 1") to await db.execute(text("SELECT 1")).
+3. Run my earlier reproduction script again, this time confirming the ArgumentError is gone and the call succeeds.
+4. Manually verify by running the app in Docker (`make run`) and calling `GET /health` again, confirming `postgres` now reports "healthy".
+5. Run make test-unit to confirm nothing else breaks.
+6. Run make check (lint/format/typecheck) before opening the PR.
+
+### Inputs & outputs
+What does your fix take as input? What should it produce or change?
+- Function I'm changing: health_check(db=Depends(get_db)) in api/routes/health.py.
+Buggy behavior:
+- Input: any call to GET /health with a working Postgres connection
+- Output: 503, postgres: "unhealthy" (wrong — should be healthy)
+Fixed behavior:
+- Input: same — working Postgres connection
+- Output: 200, postgres: "healthy"
+
+### Risks & unknowns
+What could go wrong? What are you still unsure about?
+- I'm not 100% sure text("SELECT 1") is sufficient to fix the error, or if db.execute() needs any additional handling of the result. I'll check by running it against a real Postgres instance in Docker.
+- The Redis check right below mine (line 44-45) references settings.redis_host, which doesn't exist on Settings. Since that's a separate AttributeError unrelated to my fix, I need to make sure my PR doesn't accidentally "fix" that since it's issue #155's scope.
+- I'm not writing a new test for this fix right now since it's a single-line change I can verify manually, but after reading the contributing guide, I realize it expects tests for any change. My plan is to add a new test file, tests/unit/test_health.py (none currently exists for this route), before opening the PR, mocking the DB session the way tests/unit/test_review_service.py does.
+
+
+### Edge cases
+What inputs or states should your fix handle gracefully?
+- Postgres reachable and query succeeds: should report "healthy".
+- Postgres unreachable: should still correctly report "unhealthy" and in this case, my fix must not accidentally mask real failures, only stop false positives from the wrapping bug.
+- Redis/Vector DB checks remain broken/unrelated: overall status may still show "unhealthy" due to #155 until that's fixed separately — worth noting in my PR description so a reviewer doesn't think my fix is incomplete.

--- a/api/routes/health.py
+++ b/api/routes/health.py
@@ -1,6 +1,10 @@
-from fastapi import APIRouter, HTTPException, status, Depends
+from datetime import datetime
+from typing import Any
+
 import structlog
-from datetime import datetime, timedelta
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from core.database import get_db
 
@@ -10,12 +14,12 @@ router = APIRouter(prefix="/health", tags=["health"])
 
 
 @router.get("")
-async def health_check(db=Depends(get_db)):
+async def health_check(db: AsyncSession = Depends(get_db)) -> dict[str, Any]:
     """
     Check health of PostgreSQL, Redis, and Vector DB.
     Returns 200 if all healthy, 503 if any dependency is down.
     """
-    health_status = {
+    health_status: dict[str, Any] = {
         "status": "healthy",
         "dependencies": {
             "postgres": "unknown",
@@ -28,7 +32,7 @@ async def health_check(db=Depends(get_db)):
 
     try:
         # Check PostgreSQL
-        await db.execute("SELECT 1")
+        await db.execute(text("SELECT 1"))
         health_status["dependencies"]["postgres"] = "healthy"
         log.debug("postgres_health_check_passed")
     except Exception as exc:
@@ -39,6 +43,7 @@ async def health_check(db=Depends(get_db)):
     try:
         # Check Redis (if available)
         import redis
+
         from core.config import settings
 
         r = redis.Redis(

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -1,0 +1,46 @@
+"""Tests for api/routes/health.py"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException
+
+from api.routes.health import health_check
+
+
+@pytest.mark.unit
+class TestHealthCheck:
+    """Test suite for the /health endpoint's Postgres probe."""
+
+    @pytest.fixture
+    def mock_db_session(self) -> AsyncMock:
+        """Create a mock async database session."""
+        session = AsyncMock()
+        session.execute = AsyncMock()
+        return session
+
+    @pytest.mark.asyncio
+    async def test_postgres_reports_healthy_when_query_succeeds(
+        self, mock_db_session: AsyncMock
+    ) -> None:
+        """When db.execute succeeds, postgres should be reported as healthy."""
+        try:
+            result = await health_check(db=mock_db_session)
+        except HTTPException as exc:
+            result = exc.detail
+
+        assert result["dependencies"]["postgres"] == "healthy"
+
+    @pytest.mark.asyncio
+    async def test_postgres_reports_unhealthy_when_query_raises(
+        self, mock_db_session: AsyncMock
+    ) -> None:
+        """When db.execute raises, postgres should be reported as unhealthy
+        and the endpoint should raise HTTPException with a 503 status."""
+        mock_db_session.execute.side_effect = Exception("connection refused")
+
+        with pytest.raises(HTTPException) as exc_info:
+            await health_check(db=mock_db_session)
+
+        assert exc_info.value.status_code == 503
+        assert exc_info.value.detail["dependencies"]["postgres"] == "unhealthy"

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -25,9 +25,13 @@ class TestHealthCheck:
     ) -> None:
         """When db.execute succeeds, postgres should be reported as healthy."""
         try:
-            result = await health_check(db=mock_db_session)
+            result = await health_check(db=mock_db_session)  # type: ignore[arg-type]
         except HTTPException as exc:
             result = exc.detail
+
+        mock_db_session.execute.assert_awaited_once()
+        stmt = mock_db_session.execute.call_args.args[0]
+        assert getattr(stmt, "text", None) == "SELECT 1"
 
         assert result["dependencies"]["postgres"] == "healthy"
 


### PR DESCRIPTION
## Summary
The problem was that the health check of the DB always reported Postgres as down, even when it was working. This was due to the use of raw SQL strings in the query (which SQLAlchemy 2.x rejected). That being said, this PR wraps the query into `sqlalchemy.text()` and fixes the issue so the probe runs correctly.

## Issue
Closes #154

## Changes
Root cause: SQLAlchemy 2.x requires literal SQL passed to `execute()` to be explicitly wrapped in `text()`. The use of a bare string raises `ArgumentError` before any connection attempt. The existing code in `api/routes/health.py` didn't do this, so the `try/except` always caught the `ArgumentError` and marked postgres as "unhealthy", flipping the whole response to unhealthy/503.

- `api/routes/health.py`: health_check(): changed `await db.execute("SELECT 1")` to `await db.execute(text("SELECT 1"))`, and added the `from sqlalchemy import text` import
- `api/routes/health.py`: also added type annotations to health_check() (return type `dict[str, Any]`. This was needed to satisfy the project's pre-commit `mypy` hook, which was failing on pre-existing code
- `tests/unit/test_health.py`: new file added to test the health check with two tests covering the healthy/unhealthy cases for the Postgres probe

## Testing
- [x] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`)
- [ ] Linter passes (`make lint`)
- [ ] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the change

### Reproduce the original bug (before the fix):
1. Run `docker compose up -d` then `make run`
2. Call `GET /health`, which is `curl http://localhost:8000/health`
3. Observe: response is `503`, with `"postgres": "unhealthy"` in `dependencies`.

### Verify the fix:
1. Run `docker compose up -d` then `make run`
2. Call `GET /health` again
3. Expected: `"postgres": "healthy"` in the response. (Note: the overall response may still show `"status": "unhealthy"` due to a unrelated bug in the Redis check.)

## Screenshots / Demo
N/A. backend-only change. The observable difference is the `postgres` field in the `/health` JSON response.

## Notes for Reviewers
Before this change, `make check` and `make test-unit` already showed issues unrelated to this fix:
- `ruff check .`: 182 pre-existing errors repo-wide before my change.
- `black --check .`: 52 files already needed reformatting before and after.
- `mypy` on `api/routes/health.py`: 8 pre-existing errors before my change; after adding type annotations, 3 remain, all inside the unrelated Redis check block.
- `make test-unit`: 53 pre-existing test failures across other modules before and after (unrelated tracked issues)

I also want to mention that I noticed a second bug in the same file where the Redis check references `settings.redis_host`, which doesn't exist on `Settings` (separate issue).
