### PR TITLE
fix(rag): score short and partially grounded claims in faithfulness checker

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,4 +1,4 @@
-# PathReview — Module 3 Journal
+# PathReview: Module 3 Journal
 
 ## Week 7 — Issue selection
 
@@ -17,8 +17,8 @@ which only counts a claim as supported when it shares at least two meaningful
 "Knows Python." share just one meaningful token with a context that plainly
 supports them, so they are always marked unsupported and the overall score
 collapses to 0.0. A successful fix makes the support check scale to the length of
-the claim — so a genuinely covered one-keyword claim can still count as supported
-— while still rejecting claims the context does not actually back up, which
+the claim, so a genuinely covered one-keyword claim can still count as supported
+while still rejecting claims the context does not actually back up, which
 restores an accurate faithfulness score and makes the three related tests in
 `tests/unit/test_faithfulness_checker.py` pass.
 
@@ -28,7 +28,7 @@ restores an accurate faithfulness score and makes the three related tests in
 
 **Cohort ledger:** [x] Issue added to cohort ledger
 
-### Selection notes — "Is this right for me?" reasoning
+### Selection notes: "Is this right for me?" reasoning
 
 - **Scope is contained:** The fix is limited to a single function (`_is_supported()`)
   in one file (`rag/evaluator/faithfulness_checker.py`). No cross-module or
@@ -38,11 +38,11 @@ restores an accurate faithfulness score and makes the three related tests in
   `test_multiple_context_chunks`, `test_multiple_claims_varying_support`), so I have
   an objective definition of "done."
 - **No heavy external dependencies:** The checker and its tests run purely in
-  Python via `make test-unit` — they do not need the LLM provider or the ChromaDB
+  Python via `make test-unit`, so they do not need the LLM provider or the ChromaDB
   vector service, so a fully green vector DB isn't a blocker for this issue.
 - **Right difficulty level:** It's a Tier 1 bug, but it's a real logic fix (not a
   test-fixture tweak or one-line crash guard), so it forces me to understand how a
-  RAG system verifies that feedback is grounded in evidence — good learning value
+  RAG system verifies that feedback is grounded in evidence, which is good learning value
   for a first contribution.
 - **Risk / unknowns:** The main judgment call is choosing the right supported-ness
   rule (e.g. scaling required overlap to claim length) so that short valid claims
@@ -118,7 +118,7 @@ short claim needs just one meaningful match), and `check()` averages the per-cla
 scores, so short and partially grounded feedback is scored fairly instead of 0.0.
 
 **Tests added or updated:**
-`tests/unit/test_issue_152_reproduction.py` — four regression tests covering the
+`tests/unit/test_issue_152_reproduction.py` has four regression tests covering the
 issue snippet, a single-keyword short claim, a partially grounded claim scoring
 mid-range, and comma-separated skills matching despite punctuation. The repo's
 existing `tests/unit/test_faithfulness_checker.py` tests for this module now pass

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,55 @@
+# PathReview — Module 3 Journal
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/152
+
+**Issue title:** Faithfulness checker can never mark short claims as supported
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The RAG faithfulness evaluator (`rag/evaluator/faithfulness_checker.py`) scores
+generated feedback by checking how many of its individual claims are actually
+"supported" by the retrieved context chunks. The bug lives in `_is_supported()`,
+which only counts a claim as supported when it shares at least two meaningful
+(non-stopword) tokens with the context. Short but fully grounded claims such as
+"Knows Python." share just one meaningful token with a context that plainly
+supports them, so they are always marked unsupported and the overall score
+collapses to 0.0. A successful fix makes the support check scale to the length of
+the claim — so a genuinely covered one-keyword claim can still count as supported
+— while still rejecting claims the context does not actually back up, which
+restores an accurate faithfulness score and makes the three related tests in
+`tests/unit/test_faithfulness_checker.py` pass.
+
+**Branch name:** fix/152-faithfulness-short-claim-support
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger
+
+### Selection notes — "Is this right for me?" reasoning
+
+- **Scope is contained:** The fix is limited to a single function (`_is_supported()`)
+  in one file (`rag/evaluator/faithfulness_checker.py`). No cross-module or
+  database/API changes are required.
+- **Clearly reproducible:** The issue provides an exact repro snippet and names the
+  three failing unit tests (`test_partial_support_returns_middle_score`,
+  `test_multiple_context_chunks`, `test_multiple_claims_varying_support`), so I have
+  an objective definition of "done."
+- **No heavy external dependencies:** The checker and its tests run purely in
+  Python via `make test-unit` — they do not need the LLM provider or the ChromaDB
+  vector service, so a fully green vector DB isn't a blocker for this issue.
+- **Right difficulty level:** It's a Tier 1 bug, but it's a real logic fix (not a
+  test-fixture tweak or one-line crash guard), so it forces me to understand how a
+  RAG system verifies that feedback is grounded in evidence — good learning value
+  for a first contribution.
+- **Risk / unknowns:** The main judgment call is choosing the right supported-ness
+  rule (e.g. scaling required overlap to claim length) so that short valid claims
+  pass without making unrelated claims pass too. I'll validate that balance against
+  the full `test_faithfulness_checker.py` suite before opening a PR.
+
+**Environment status:** `make setup` and `make run` succeed; frontend confirmed
+returning HTTP 200 at http://localhost:5173/ with the backend on :8000. (Note: the
+`chromadb/chroma:0.4.22` container currently crashes on NumPy 2.0; not required for
+issue #152 and can be addressed separately.)

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -26,7 +26,7 @@ restores an accurate faithfulness score and makes the three related tests in
 
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
-**Cohort ledger:** [ ] Issue added to cohort ledger
+**Cohort ledger:** [x] Issue added to cohort ledger
 
 ### Selection notes — "Is this right for me?" reasoning
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -134,3 +134,76 @@ tests I fixed with no new failures. My changed files pass `ruff`, `black`, and
 no new failures.)
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No review or comments arrived on PR #526 by the end of the week. As of this
+entry the PR is still open with zero reviews and zero inline or conversation
+comments. (Per the Summer 2026 cohort note, reviewer feedback is not provided
+this term, so this is expected.)
+
+**How you responded:**
+There was nothing to respond to. If a review does come in later, I plan to read
+every comment first, sort them into clear fixes vs. points that need discussion,
+reply to each thread, and push follow-up commits rather than force-pushing over
+the existing diff.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The hard part was not writing the fix but making one scoring rule satisfy two
+sets of tests that pulled in opposite directions. The direct `_is_supported()`
+tests wanted a clean True/False, while the `check()` tests wanted a single
+partially grounded claim (like "The developer shows Python expertise and
+Kubernetes knowledge") to land between 0.2 and 0.8, which a plain
+supported/unsupported flag can never produce. I ended up working out the token
+counts for the failing cases by hand, and that is how I found that a length
+scaled threshold, `max(1, (len + 1) // 2)`, combined with averaging graded
+per-claim scores, was what threaded both needles at once.
+
+**What did you learn about working in a large codebase?**
+The biggest shift was realizing the tests were the real specification. The issue
+described the symptom, but the exact expected behavior lived in
+`tests/unit/test_faithfulness_checker.py`, and reading those assertions is what
+showed me the bug was actually three stacked problems: the `>= 2` overlap
+threshold, punctuation-blind tokenization (so "Python," never matched "python"),
+and binary per-claim scoring. I also learned to expect a messy baseline.
+`make test-unit` reported 55 failing tests before I changed anything, so
+"passing" meant "introduce no new failures," not a fully green suite. That is
+very different from my own projects, where I control the whole state.
+
+**How did AI tools help — and where did they fall short?**
+AI was most useful for orienting quickly: tracing the only caller of `check()` in
+`rag/evaluator/eval_suite.py` to confirm I would not break it, drafting PLAN.md
+and the PR description, and running the suite iteratively while I tuned the logic.
+Where it fell short was the precise threshold math. I could not just trust a
+generated formula, because a plain overlap ratio gave 0.167 for the partial
+support case and would have failed the 0.2 lower bound, so I had to reason
+through the specific token overlaps myself. AI also had no knowledge of the 55
+pre-existing failures, so establishing and documenting that baseline was on me.
+
+**What would you do differently if you started over?**
+I would open the PR as a draft earlier in the week instead of close to the
+deadline, so there was more room for feedback even in a term where reviews are
+rare. During issue selection I would also read the module's test file before
+committing to the issue, because the interdependence between the
+`_is_supported()` tests and the `check()` score-range tests was the real
+difficulty, and I only fully saw it in Week 9. I would still choose #152 again;
+it taught me more than a one-line crash fix would have.
+
+**What are you most proud of from this module?**
+I am most proud that the fix is principled rather than reverse-engineered from
+the tests. The graded `_support_score()` with a length-aware threshold is a real
+answer to "how well does the context support this claim," and it makes short
+claims like "Knows Python" score correctly without letting unrelated claims slip
+through. I am also proud of keeping the change honest and in scope: I left the
+`test_none_context_chunk_text` crash alone because it belongs to issue #153, and
+I documented the 55-to-50 failure baseline so a reviewer can trust exactly what
+my change did and did not touch.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -53,3 +53,29 @@ restores an accurate faithfulness score and makes the three related tests in
 returning HTTP 200 at http://localhost:5173/ with the backend on :8000. (Note: the
 `chromadb/chroma:0.4.22` container currently crashes on NumPy 2.0; not required for
 issue #152 and can be addressed separately.)
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/aryamanm24/pathreview/commit/ef14e1fdee20304b99cb82b03f78dbe6abde58c4
+
+**Reproduction summary:**
+I reproduced the bug two ways. Running the issue's own snippet,
+`check("Knows Python. Knows SQL.", [{"text": "python expert"}, {"text": "sql expert"}])`
+returns `0.0` and `_is_supported("Knows Python", "python expert")` returns
+`False`, even though both short claims are fully backed by the context. Running
+`pytest tests/unit/test_faithfulness_checker.py` confirms the three tests named
+in the issue fail (`test_partial_support_returns_middle_score`,
+`test_multiple_context_chunks`, `test_multiple_claims_varying_support`), and I
+added `tests/unit/test_issue_152_reproduction.py` with two failing tests that
+capture the exact scenario.
+
+**PLAN.md link:** https://github.com/aryamanm24/pathreview/blob/fix/152-faithfulness-short-claim-support/PLAN.md
+
+**Walkthrough video (recommended):** (not recorded)
+
+**Blockers or open questions:**
+The main open question is tuning a single support rule that satisfies both the
+direct `_is_supported()` True/False tests and the `check()` mid-range score tests
+at the same time. Separately, `test_none_context_chunk_text` also fails, but that
+is the `text: None` crash tracked under issue #153, so I'm treating it as out of
+scope for this #152 fix.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -79,3 +79,58 @@ direct `_is_supported()` True/False tests and the `check()` mid-range score test
 at the same time. Separately, `test_none_context_chunk_text` also fails, but that
 is the `text: None` crash tracked under issue #153, so I'm treating it as out of
 scope for this #152 fix.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the fix in `rag/evaluator/faithfulness_checker.py`, working through
+the PLAN.md sub-tasks: (1) added a `_tokenize()` helper that strips punctuation
+so `"Python,"` matches `python`; (2) replaced the fixed `>= 2` overlap rule with
+a graded `_support_score()` whose required matches scale with claim length; and
+(3) made `check()` average the per-claim scores so partially grounded feedback
+lands in the middle of the range. The three issue tests plus my reproduction
+tests now pass.
+
+**Next steps:**
+Finish reconciling `_is_supported()` (kept as a `>= 0.5` threshold over the new
+graded score), run the full `make check` / `make test-unit` to confirm no new
+failures, open the PR, and request peer feedback.
+
+**Blockers:**
+None. `test_none_context_chunk_text` still fails, but that is issue #153 (a
+separate `text: None` crash), not #152.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/526
+
+**Branch:** `fix/152-faithfulness-short-claim-support`
+
+**What you built:**
+The faithfulness checker now grades each feedback claim by how much of it the
+retrieved context supports, instead of requiring at least two overlapping words.
+Tokenization strips punctuation, the support bar scales with claim length (a very
+short claim needs just one meaningful match), and `check()` averages the per-claim
+scores, so short and partially grounded feedback is scored fairly instead of 0.0.
+
+**Tests added or updated:**
+`tests/unit/test_issue_152_reproduction.py` — four regression tests covering the
+issue snippet, a single-keyword short claim, a partially grounded claim scoring
+mid-range, and comma-separated skills matching despite punctuation. The repo's
+existing `tests/unit/test_faithfulness_checker.py` tests for this module now pass
+unchanged.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+(Note on pre-existing failures: this repo ships many unrelated failing tests and
+lint errors from other curated issues. Baseline before my change was 55 failing
+unit tests; after my change it is 50, and the diff is exactly the 5 faithfulness
+tests I fixed with no new failures. My changed files pass `ruff`, `black`, and
+`mypy`. Per the assignment's guidance, "passes" here means my change introduces
+no new failures.)
+
+**Draft PR feedback received from:** none

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,109 @@
+# Solution plan
+
+**Issue:** Faithfulness checker can never mark short claims as supported —
+https://github.com/ascherj/pathreview/issues/152
+
+### Understand
+
+The faithfulness checker scores generated feedback by splitting it into claims
+(sentences) and measuring how many are "supported" by the retrieved context.
+Reproduced locally against commit `ef14e1f`:
+
+- `check("Knows Python. Knows SQL.", [{"text": "python expert"}, {"text": "sql expert"}])`
+  returns `0.0`, even though both claims are fully backed by the context.
+- `_is_supported("Knows Python", "python expert")` returns `False`.
+- `pytest tests/unit/test_faithfulness_checker.py` shows the three tests named
+  in the issue failing: `test_partial_support_returns_middle_score`,
+  `test_multiple_context_chunks`, `test_multiple_claims_varying_support`.
+
+There are three root causes, all in `_is_supported()` / `check()`:
+
+1. **Rigid threshold.** `_is_supported()` returns `True` only when a claim and
+   the context share **at least two** non-stopword tokens
+   (`len(meaningful_overlap) >= 2`). Short or single-keyword claims can share at
+   most one meaningful token with their support, so they are always unsupported.
+2. **Punctuation-blind tokenization.** Tokens come from `claim.lower().split()`,
+   which keeps punctuation. `"Python,"` and `"JavaScript,"` never match the
+   context's `python` / `javascript`, so even multi-skill claims under-count
+   their overlap.
+3. **Binary, not graded, scoring.** `check()` counts each claim as fully
+   supported or not, so a single claim that is partially grounded (e.g. Python
+   supported but Kubernetes not) can only score `0.0` or `1.0`, never the
+   mid-range value the tests expect.
+
+**Expected vs. actual:** a short, grounded claim should count as supported and
+partially grounded feedback should produce a mid-range score. Actual output is
+`0.0` for these cases.
+
+### Map
+
+Files I expect to touch:
+
+- `rag/evaluator/faithfulness_checker.py` — primary fix. Specifically
+  `FaithfulnessChecker._is_supported()` (threshold + tokenization) and
+  `FaithfulnessChecker.check()` (graded per-claim scoring). May add a small
+  private tokenizer helper (e.g. `_tokenize()`) and reuse it in both places.
+- `tests/unit/test_faithfulness_checker.py` — verify the three target tests pass;
+  possibly add a couple of cases for short-claim support and comma-separated
+  skills.
+- `tests/unit/test_issue_152_reproduction.py` — reproduction tests added this
+  week; they should go green once the fix lands.
+
+Not in scope: `test_none_context_chunk_text` fails too, but that is the
+`text: None` crash tracked separately as issue #153, not #152.
+
+### Plan
+
+1. **Normalize tokenization.** Add a helper that lowercases and extracts word
+   tokens with a regex (`re.findall(r"[a-z0-9]+", text)`), then removes
+   stopwords. Use it for both claim and context so `"Python,"` matches `python`.
+2. **Make support length-aware.** Replace the fixed `>= 2` rule in
+   `_is_supported()` with a rule that scales to claim length — a claim counts as
+   supported when a sufficient share of its meaningful tokens appear in the
+   context, with a floor so a 1–2 keyword claim can still be supported. Keep the
+   `bool` return type for direct callers.
+3. **Grade the score in `check()`.** Compute a per-claim support ratio (fraction
+   of meaningful claim tokens found in the context) and average across claims, so
+   partially grounded feedback lands in the middle of the range instead of
+   snapping to 0.0/1.0.
+4. **Reconcile the two paths.** Tune the threshold and ratio so both the direct
+   `_is_supported()` True/False tests and the `check()` score-range tests pass
+   together, then run `make test-unit` and `make check` (ruff + black + mypy).
+
+### Inputs & outputs
+
+- **Input:** `check(feedback: str, context_chunks: list[dict])` where each chunk
+  has a `"text"` string; `_is_supported(claim: str, context: str)`.
+- **Output:** `check()` returns a `float` faithfulness score in `[0.0, 1.0]`
+  (ratio of supported/grounded claims). `_is_supported()` returns `bool`.
+- **Change:** internal scoring/threshold logic only. No public signatures change,
+  no new dependencies, no API/DB changes.
+
+### Risks & unknowns
+
+- **Threshold tension.** The direct `_is_supported()` tests constrain the
+  threshold (e.g. `test_specialized_technical_terms` must be `True`,
+  `test_is_supported_without_keywords` must be `False`) while the `check()`
+  range tests constrain the graded scoring (a single partially-grounded claim
+  must land in `0.2–0.8`). Finding one formula that satisfies both is the main
+  unknown; I'll iterate against the full test file.
+- **Regression risk from tokenization.** Stripping punctuation changes overlap
+  counts for currently passing tests (e.g. `test_feedback_fully_supported_by_context`,
+  `test_common_words_filtered_in_overlap`); I must re-run the whole file, not
+  just the three targets.
+- **Stopword list.** The current stopword set is small; comma-joined lists and
+  words like "has"/"with" may need handling to avoid inflating overlap.
+- **Scope boundary.** Whether to also add a one-line `None` guard for the #153
+  crash or leave it to that issue's owner — leaning toward leaving it out to keep
+  the PR focused on #152.
+
+### Edge cases
+
+- Short claims with a single meaningful token ("Knows Python.").
+- Comma/"and"-separated skills ("Python, JavaScript, and Docker experience").
+- Fully unsupported feedback — must stay near `0.0` (don't over-credit).
+- Fully supported feedback — must stay near `1.0` (don't under-credit).
+- Case-insensitive matching and repeated tokens.
+- Empty feedback or empty context — keep returning `0.0`.
+- Context chunk missing the `"text"` key — keep handling gracefully.
+- Very long feedback/context — keep runtime reasonable (set-based overlap).

--- a/rag/evaluator/faithfulness_checker.py
+++ b/rag/evaluator/faithfulness_checker.py
@@ -1,9 +1,37 @@
 """Check if generated feedback is supported by retrieved context."""
 
 import re
+
 import structlog
 
 logger = structlog.get_logger()
+
+# Common words that carry no evidence value when matching a claim against
+# context. Kept small on purpose: only true function words, so domain terms
+# such as "python" or "docker" are always treated as meaningful.
+STOP_WORDS = {
+    "a",
+    "an",
+    "the",
+    "is",
+    "are",
+    "was",
+    "were",
+    "be",
+    "been",
+    "and",
+    "or",
+    "but",
+    "in",
+    "of",
+    "to",
+    "for",
+    "that",
+}
+
+# Token pattern: alphanumeric runs, so trailing punctuation (e.g. "Python,")
+# does not prevent a match against "python".
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
 
 
 class FaithfulnessChecker:
@@ -13,15 +41,18 @@ class FaithfulnessChecker:
         """Check faithfulness of feedback to context.
 
         Args:
-            feedback: Generated feedback text
-            context_chunks: Retrieved context chunks
+            feedback: Generated feedback text.
+            context_chunks: Retrieved context chunks.
 
         Returns:
-            Faithfulness score 0.0-1.0 (ratio of supported claims)
+            Faithfulness score 0.0-1.0 (mean per-claim support across claims).
         """
         if not feedback or not context_chunks:
-            logger.info("faithfulness_empty_input", has_feedback=bool(feedback),
-                       has_chunks=bool(context_chunks))
+            logger.info(
+                "faithfulness_empty_input",
+                has_feedback=bool(feedback),
+                has_chunks=bool(context_chunks),
+            )
             return 0.0
 
         # Extract key claims from feedback (sentences)
@@ -31,20 +62,24 @@ class FaithfulnessChecker:
             return 0.5  # Default to neutral if no extractable claims
 
         # Concatenate context text
-        context_text = " ".join([
-            chunk.get("text", "") for chunk in context_chunks
-        ])
+        context_text = " ".join([chunk.get("text", "") for chunk in context_chunks])
 
-        # Check each claim for support
+        # Score each claim on how well the context supports it, then average.
+        # Grading each claim (instead of a hard supported/unsupported flag)
+        # lets partially grounded feedback land in the middle of the range.
+        total_support = 0.0
         supported = 0
         for claim in claims:
-            if self._is_supported(claim, context_text):
+            claim_support = self._support_score(claim, context_text)
+            total_support += claim_support
+            if claim_support >= 0.5:
                 supported += 1
 
-        score = supported / len(claims) if claims else 0.0
+        score = total_support / len(claims)
 
-        logger.info("faithfulness_checked", claims_count=len(claims),
-                   supported_count=supported, score=score)
+        logger.info(
+            "faithfulness_checked", claims_count=len(claims), supported_count=supported, score=score
+        )
 
         return score
 
@@ -53,36 +88,68 @@ class FaithfulnessChecker:
         """Extract key claims from feedback text.
 
         Args:
-            text: Feedback text
+            text: Feedback text.
 
         Returns:
-            List of claims (sentences)
+            List of claims (sentences).
         """
         # Split by sentence (simple regex)
-        sentences = re.split(r'[.!?]+', text)
+        sentences = re.split(r"[.!?]+", text)
         claims = [s.strip() for s in sentences if s.strip() and len(s.strip()) > 10]
         return claims[:10]  # Limit to 10 claims for scoring
 
     @staticmethod
-    def _is_supported(claim: str, context: str) -> bool:
+    def _tokenize(text: str) -> set[str]:
+        """Tokenize text into meaningful lowercase tokens.
+
+        Splits on non-alphanumeric characters (so punctuation is stripped) and
+        removes stop words.
+
+        Args:
+            text: Text to tokenize.
+
+        Returns:
+            Set of meaningful tokens.
+        """
+        tokens = _TOKEN_RE.findall(text.lower())
+        return {token for token in tokens if token not in STOP_WORDS}
+
+    def _support_score(self, claim: str, context: str) -> float:
+        """Grade how well the context supports a single claim.
+
+        A claim is fully supported (1.0) once at least half of its meaningful
+        tokens appear in the context, so short claims are not penalized for
+        having few tokens to match. A claim with no meaningful overlap scores
+        0.0, and partial overlap scores in between.
+
+        Args:
+            claim: Claim text.
+            context: Context text.
+
+        Returns:
+            Support score between 0.0 and 1.0.
+        """
+        claim_tokens = self._tokenize(claim)
+        if not claim_tokens:
+            return 0.0
+
+        context_tokens = self._tokenize(context)
+        overlap = claim_tokens & context_tokens
+
+        # Number of matches that counts as full support. Scales with claim
+        # length (about half its tokens) but never requires more than one match
+        # for a very short claim.
+        needed = max(1, (len(claim_tokens) + 1) // 2)
+        return min(1.0, len(overlap) / needed)
+
+    def _is_supported(self, claim: str, context: str) -> bool:
         """Check if a claim is supported by context.
 
         Args:
-            claim: Claim text
-            context: Context text
+            claim: Claim text.
+            context: Context text.
 
         Returns:
-            True if claim is supported
+            True if the claim's support score reaches the support threshold.
         """
-        # Tokenize and check for keyword overlap
-        claim_tokens = set(claim.lower().split())
-        context_tokens = set(context.lower().split())
-
-        # Require at least some meaningful overlap
-        overlap = claim_tokens & context_tokens
-        # Filter out common stop words
-        stop_words = {'a', 'an', 'the', 'is', 'are', 'was', 'were', 'be', 'been',
-                     'and', 'or', 'but', 'in', 'of', 'to', 'for', 'that'}
-        meaningful_overlap = overlap - stop_words
-
-        return len(meaningful_overlap) >= 2
+        return self._support_score(claim, context) >= 0.5

--- a/tests/unit/test_issue_152_reproduction.py
+++ b/tests/unit/test_issue_152_reproduction.py
@@ -42,3 +42,27 @@ class TestIssue152Reproduction:
         as supported, but the >=2 meaningful-overlap rule rejects it today.
         """
         assert checker._is_supported("Knows Python", "python expert") is True
+
+    def test_partially_grounded_claim_scores_in_the_middle(
+        self, checker: FaithfulnessChecker
+    ) -> None:
+        """Feedback where the context supports some keywords but not others
+        should land between fully supported and fully unsupported.
+        """
+        score = checker.check(
+            "The developer shows Python expertise and Kubernetes knowledge.",
+            [{"text": "Strong Python programming skills demonstrated in projects."}],
+        )
+        assert 0.2 < score < 0.8
+
+    def test_comma_separated_skills_are_matched(self, checker: FaithfulnessChecker) -> None:
+        """Skills written as a comma-separated list must still match the
+        context; trailing punctuation should not block token overlap.
+        """
+        assert (
+            checker._is_supported(
+                "Python, JavaScript, and Docker",
+                "python and javascript and docker experience",
+            )
+            is True
+        )

--- a/tests/unit/test_issue_152_reproduction.py
+++ b/tests/unit/test_issue_152_reproduction.py
@@ -1,0 +1,44 @@
+"""Reproduction for issue #152 — faithfulness checker can never mark short
+claims as supported.
+
+Issue: https://github.com/ascherj/pathreview/issues/152
+
+These tests capture the reported bug in
+``rag/evaluator/faithfulness_checker.py``. They assert the *correct* behavior,
+so they currently FAIL against the buggy implementation and will pass once the
+fix from Week 9 lands. Run just this file with:
+
+    .venv/bin/pytest tests/unit/test_issue_152_reproduction.py -v
+"""
+
+import pytest
+
+from rag.evaluator.faithfulness_checker import FaithfulnessChecker
+
+
+@pytest.mark.unit
+class TestIssue152Reproduction:
+    """Short, fully-grounded claims must not score 0.0."""
+
+    @pytest.fixture
+    def checker(self) -> FaithfulnessChecker:
+        return FaithfulnessChecker()
+
+    def test_short_supported_claims_are_not_zero(self, checker: FaithfulnessChecker) -> None:
+        """Exact snippet from the issue: two short claims, each fully supported
+        by a context chunk, currently scores 0.0.
+        """
+        score = checker.check(
+            "Knows Python. Knows SQL.",
+            [{"text": "python expert"}, {"text": "sql expert"}],
+        )
+        # Both claims are supported by the context, so the score should be high.
+        assert score > 0.5
+
+    def test_single_meaningful_token_can_support_a_short_claim(
+        self, checker: FaithfulnessChecker
+    ) -> None:
+        """A one-keyword claim that the context clearly backs up should count
+        as supported, but the >=2 meaningful-overlap rule rejects it today.
+        """
+        assert checker._is_supported("Knows Python", "python expert") is True


### PR DESCRIPTION
## Summary
`FaithfulnessChecker` scored feedback by counting claims that shared at least two meaningful words with the retrieved context, so short but fully grounded claims like "Knows Python." were always marked unsupported and honest feedback could score 0.0. This PR grades each claim by how much of it the context supports, so short and partially grounded feedback is scored fairly.

## Issue
Closes #152

## Changes
Root cause: `_is_supported()` required `len(meaningful_overlap) >= 2`. A short claim shares at most one meaningful token with its supporting context, so it could never clear the bar, and `check()` then counted it unsupported and the score collapsed to 0.0. Tokenizing with `str.split()` also kept punctuation, so `"Python,"` never matched `python`.

- `rag/evaluator/faithfulness_checker.py`:
  - Added `_tokenize()` (regex word tokens, lowercased, stop words removed) so punctuation no longer blocks matches.
  - Added `_support_score()` that grades a claim by overlap, with the number of matches required scaling to claim length (`max(1, (len + 1) // 2)`), so a very short claim needs only one meaningful match.
  - `check()` now averages per-claim support scores instead of counting a hard supported/unsupported flag, so partially grounded feedback lands mid-range.
  - `_is_supported()` kept as a bool (`_support_score >= 0.5`) for backwards compatibility.
- No signature or dependency changes; `rag/evaluator/eval_suite.py` (the only caller of `check()`) is unaffected.

## Testing
- [x] Unit tests pass (`make test-unit`) — see Notes on pre-existing failures
- [ ] Integration tests pass (`make test-integration`) — not run; unrelated
- [x] Linter passes (`make lint`) — on changed files
- [x] Type checker passes (`make typecheck`) — on `rag/`
- [x] New/updated tests cover the changes

**Reproduce the bug (on `main`):**
```
python -c "from rag.evaluator.faithfulness_checker import FaithfulnessChecker as F; print(F().check('Knows Python. Knows SQL.', [{'text':'python expert'},{'text':'sql expert'}]))"
# prints 0.0
```
**Verify the fix (this branch):** the same command returns a high score, and `pytest tests/unit/test_faithfulness_checker.py tests/unit/test_issue_152_reproduction.py` passes except the unrelated #153 case.

## Screenshots / Demo
N/A — internal scoring change; the observable behavior is the faithfulness score returned by `FaithfulnessChecker.check()`, shown in the testing steps.

## Notes for Reviewers
This repo has many pre-existing failures unrelated to this change. Baseline on `main`: 55 failing unit tests plus ruff errors across other modules. After this change: 50 failing unit tests — the diff is exactly the 5 faithfulness tests this PR fixes, with no new failures. My changed files pass `ruff`, `black`, and `mypy`. One test, `test_none_context_chunk_text`, still fails: that is the separate `text: None` crash tracked as #153, intentionally left out of scope.
