### PR TITLE
feat(agent): add repository test detection

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -88,3 +88,25 @@ There are no blockers specific to issue #50. The repository still contains unrel
 https://github.com/ascherj/pathreview/pull/527
 
 **PR status:** Open and ready for review
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/527
+
+**Branch:** `feat/50-add-has-tests`
+
+**What you built:**
+
+I added a `has_tests` Boolean to the GitHub repository analysis output. `GitHubTool` now retrieves the repository tree from the default branch and detects `tests/`, `test/`, `pytest.ini`, and Python files named `test_*.py`.
+
+**Tests added or updated:**
+
+I added `tests/unit/test_github_tool.py` with 9 focused tests covering positive and negative detection cases, repository-tree retrieval, metadata integration, and empty repositories. All 9 focused tests pass.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+The full checks still contain documented pre-existing failures, but this contribution introduced no new failures. The focused files pass Ruff, Black, and Mypy.
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -42,3 +42,43 @@ I ran `GitHubTool` against the PathReview repository, which contains automated t
 **Blockers or open questions:**
 
 I still need to determine the best GitHub API endpoint for retrieving the repository file tree and whether the existing test-detection logic in `ingestion/parsers/repo_analyzer.py` can be reused.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1
+
+**Current progress:**
+
+I implemented repository test detection in `GitHubTool`. The tool now retrieves the repository tree from GitHub using the repository's default branch and adds a `has_tests` Boolean to the metadata output.
+
+The detection returns `true` when it finds:
+
+- a `tests/` directory
+- a `test/` directory
+- a `pytest.ini` file
+- a Python file named `test_*.py`
+
+It returns `false` when none of these indicators are present.
+
+**Testing completed:**
+
+- Added 9 focused unit tests in `tests/unit/test_github_tool.py`
+- All 9 focused tests pass
+- Ruff passes for both changed files
+- Black passes for both changed files
+- Mypy passes for both changed files
+- A real GitHub smoke test against the PathReview repository returned `has_tests: True`
+- Full unit suite result: 384 passed and 53 pre-existing failures
+- Project lint result: 181 pre-existing errors, with no errors in the two files changed for this issue
+
+**Implementation commit:**
+
+https://github.com/morishbhayani/pathreview/commit/dfb7294
+
+**Edge-case test commit:**
+
+https://github.com/morishbhayani/pathreview/commit/5bd128f
+
+**Current blockers:**
+
+There are no blockers specific to issue #50. The repository still contains unrelated pre-existing unit-test and lint failures.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -82,3 +82,9 @@ https://github.com/morishbhayani/pathreview/commit/5bd128f
 **Current blockers:**
 
 There are no blockers specific to issue #50. The repository still contains unrelated pre-existing unit-test and lint failures.
+
+**Pull request:**
+
+https://github.com/ascherj/pathreview/pull/527
+
+**PR status:** Open and ready for review

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -29,13 +29,13 @@ PathReview analyzes GitHub repositories, but it currently does not report whethe
 - It will help me learn how an existing codebase analyzes repositories and returns structured results.
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [will add after creating the commit]
+**Reproduction commit link:**  https://github.com/morishbhayani/pathreview/commit/ea215fe
 
 **Reproduction summary:**
 
 I ran `GitHubTool` against the PathReview repository, which contains automated tests. The tool successfully returned repository metadata including `has_readme`, but the returned data did not contain a `has_tests` field.
 
-**PLAN.md link:** [will add after creating PLAN.md]
+**PLAN.md link:** https://github.com/morishbhayani/pathreview/blob/feat/50-add-has-tests/PLAN.md
 
 **Walkthrough video (recommended):** Not recorded
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -27,3 +27,18 @@ PathReview analyzes GitHub repositories, but it currently does not report whethe
 - The implementation mainly uses Python and GitHub repository file information.
 - The issue is small enough to understand without changing the entire application.
 - It will help me learn how an existing codebase analyzes repositories and returns structured results.
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [will add after creating the commit]
+
+**Reproduction summary:**
+
+I ran `GitHubTool` against the PathReview repository, which contains automated tests. The tool successfully returned repository metadata including `has_readme`, but the returned data did not contain a `has_tests` field.
+
+**PLAN.md link:** [will add after creating PLAN.md]
+
+**Walkthrough video (recommended):** Not recorded
+
+**Blockers or open questions:**
+
+I still need to determine the best GitHub API endpoint for retrieving the repository file tree and whether the existing test-detection logic in `ingestion/parsers/repo_analyzer.py` can be reused.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,29 @@
+# Module 3 Journal
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/50
+
+**Issue title:** Add a `has_tests` boolean to the repo analysis output
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+
+PathReview analyzes GitHub repositories, but it currently does not report whether a repository contains automated tests. This issue adds a `has_tests` Boolean field to the repository analysis output. The value should be `true` when the repository contains common testing indicators such as a `tests/` folder, a `test/` folder, `pytest.ini`, or files named like `test_*.py`. Otherwise, the value should be `false`.
+
+**Branch name:** `feat/50-add-has-tests`
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger
+
+---
+
+### Is this issue right for me?
+
+- The issue is labeled Tier 1 and is suitable for a first contribution.
+- The task has a clear expected output: `has_tests` should be either `true` or `false`.
+- The implementation mainly uses Python and GitHub repository file information.
+- The issue is small enough to understand without changing the entire application.
+- It will help me learn how an existing codebase analyzes repositories and returns structured results.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -110,3 +110,43 @@ I added `tests/unit/test_github_tool.py` with 9 focused tests covering positive 
 The full checks still contain documented pre-existing failures, but this contribution introduced no new failures. The focused files pass Ruff, Black, and Mypy.
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+
+No reviewer or maintainer feedback has been received on PR #527. The Summer 2026 course notes explain that formal reviewer feedback is not being provided, so I documented the current status and continued with my reflection.
+
+**How you responded:**
+
+No response or code changes were required because no reviewer feedback was received.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+
+The hardest part was understanding how a small feature fit into an unfamiliar codebase. Adding a Boolean sounded simple, but I first had to trace how `GitHubTool` collected repository metadata, determine how to retrieve the repository file tree, and decide where the detection logic belonged. I also had to separate problems caused by my changes from pre-existing repository failures. The full unit suite already had 53 failures, and the lint check had more than 180 errors, so I had to compare before-and-after results instead of assuming every failure was caused by my implementation. I also encountered a local Mypy and NumPy compatibility issue because the project targets Python 3.11 while my environment used Python 3.12.
+
+**What did you learn about working in a large codebase?**
+
+I learned that contributing to someone else's code requires more investigation and discipline than building a project from scratch. I had to read `CONTRIBUTING.md`, follow existing naming and commit conventions, study nearby code, and match the repository's test patterns. I also learned the importance of keeping the scope narrow. Even though I found many unrelated test and lint failures, fixing them would have made the pull request harder to review and moved it away from issue #50. A production contribution is not only about making code work; it is also about making the change understandable, testable, and safe for maintainers to review.
+
+**How did AI tools help — and where did they fall short?**
+
+AI assistance was most useful for helping me navigate the unfamiliar repository, explain Git and GitHub concepts, create a step-by-step implementation plan, draft focused tests, interpret command output, and prepare the pull request description. It also helped me understand why the local Mypy command failed while the project's pre-commit Mypy hook passed.
+
+AI output still required careful review. Some early guidance was incomplete, including an initially incomplete `PLAN.md`, and generated code had to be checked with Ruff, Black, Mypy, unit tests, and a real GitHub smoke test. AI could suggest commands and implementation ideas, but it could not replace reading the contribution guide, examining the actual codebase, checking the real command output, or deciding whether failures were related to my change.
+
+**What would you do differently if you started over?**
+
+I would read `CONTRIBUTING.md`, inspect the relevant production file, and examine existing test patterns before writing the initial plan. I would also record the complete baseline results for `make check` and `make test-unit` immediately, which would make later regression comparisons easier. I would open the draft pull request earlier instead of waiting until most of the implementation was complete. Finally, I would plan edge cases such as an empty repository and both `test/` and `tests/` directories at the beginning rather than adding those tests later in separate steps.
+
+**What are you most proud of from this module?**
+
+I am most proud that I completed a real open-source contribution workflow from issue selection through implementation and pull-request submission. I added repository test detection, wrote nine focused tests, verified the feature against a real GitHub repository, documented unrelated failures honestly, and submitted a mergeable PR with a clear commit history. More importantly, I now understand how to investigate, test, document, and submit a focused change inside a codebase I did not create.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,15 +1,122 @@
+cat > PLAN.md <<'EOF'
 ## Solution plan
 
-**Issue:** Add a `has_tests` boolean to the repo analysis output  
-https://github.com/ascherj/pathreview/issues/50
+**Issue:** [Add a `has_tests` boolean to the repo analysis output](https://github.com/ascherj/pathreview/issues/50)
 
 ### Understand
 
-`GitHubTool` returns information about a repository, such as its name, language, stars, and whether it has a README.
+`GitHubTool` in `agent/tools/github_tool.py` fetches information about a GitHub repository and returns metadata such as the repository name, primary language, star count, fork count, open issue count, and whether the repository contains a README.
 
-The problem is that it does not return a `has_tests` field.
+The root cause is that `GitHubTool._fetch_repo_metadata()` only requests the basic repository information and checks for a README. It does not inspect the repository file tree, so it cannot determine whether test files or test folders exist. Its returned metadata dictionary also does not contain a `has_tests` key.
 
-Expected:
+I reproduced the gap by running `GitHubTool.execute()` against the PathReview repository. The request succeeded and returned `has_readme: True`, but checking `"has_tests" in result.data` returned `False`.
 
-```python
-"has_tests": True
+Expected behaviour:
+
+- Return `has_tests: True` when the repository contains recognised test indicators.
+- Return `has_tests: False` when no recognised test indicators are found.
+
+Actual behaviour:
+
+- The `has_tests` field is missing entirely from the metadata returned by `GitHubTool`.
+
+There is already similar test-detection logic in `ingestion/parsers/repo_analyzer.py`, but that parser is separate from the agent GitHub tool. The GitHub tool still needs access to repository file paths and must include the Boolean result in its own output.
+
+### Map
+
+The following codebase parts are involved:
+
+- `agent/tools/github_tool.py`
+  - `GitHubTool.execute()`
+  - `GitHubTool._fetch_repo_metadata()`
+  - `GitHubTool._has_readme()`
+  - A new `_has_tests()` helper will likely be added.
+  - A separate helper for fetching the repository tree may also be added.
+
+- `ingestion/parsers/repo_analyzer.py`
+  - `RepoAnalyzer._detect_tests()`
+  - This existing method provides a useful reference for recognised test indicators.
+  - This file may not need to be modified because it belongs to a different analysis path.
+
+- `tests/unit/test_github_tool.py`
+  - This will be a new unit test file.
+  - It will test the new test-detection behaviour without making real GitHub network requests.
+
+The GitHub API paths involved will likely include:
+
+- `/repos/{username}/{repo_name}` for repository metadata and the default branch.
+- `/repos/{username}/{repo_name}/git/trees/{branch}?recursive=1` for repository file paths.
+
+### Plan
+
+1. Update `GitHubTool._fetch_repo_metadata()` to read the repository's `default_branch` from the basic GitHub repository response instead of assuming the branch is named `main`.
+
+2. Add a helper that requests the repository tree from GitHub using the default branch and extracts the returned file and folder paths.
+
+3. Add a private `_has_tests()` helper that examines the repository paths and returns `True` when it finds one of the required indicators:
+   - a `tests/` directory
+   - a `test/` directory
+   - a `pytest.ini` file
+   - a Python file whose filename matches `test_*.py`
+
+4. Call `_has_tests()` from `_fetch_repo_metadata()` and add the result to the returned dictionary using the key `"has_tests"`.
+
+5. Create `tests/unit/test_github_tool.py` and mock the GitHub API responses. Add tests for repositories with tests, repositories without tests, nested test directories, different default branches, and GitHub request failures.
+
+### Inputs & outputs
+
+Inputs to `GitHubTool.execute()`:
+
+- `github_username`
+- `repo_name`
+
+Additional data used internally:
+
+- Repository metadata returned by GitHub
+- The repository's default branch
+- Repository file and folder paths returned by the GitHub tree API
+- An optional GitHub API token already supported by `GitHubTool`
+
+Output:
+
+`GitHubTool.execute()` should continue returning a `ToolResult`. Its `data` dictionary should contain all existing metadata fields and one additional Boolean field:
+
+- `"has_tests": True` when recognised tests are found
+- `"has_tests": False` when recognised tests are not found
+
+The change should not remove or rename existing metadata fields such as `has_readme`, `primary_language`, or `star_count`.
+
+### Risks & unknowns
+
+- The GitHub recursive tree API may return `"truncated": true` for very large repositories. In that case, some test files may not appear in the response.
+
+- Fetching the repository tree requires an additional GitHub API request. Unauthenticated requests have stricter rate limits, so repeated repository analysis may receive a `403` response.
+
+- Repositories may use default branches such as `master`, `develop`, or another custom name. The implementation must use the `default_branch` value returned by GitHub rather than assuming `main`.
+
+- Private repositories may not be accessible without a valid API token.
+
+- Returning `False` when the GitHub tree request fails could make “unable to inspect” look the same as “no tests found.” I need to confirm whether this is acceptable or whether the failure should be logged separately while preserving the existing `ToolResult` behaviour.
+
+- Test-detection logic already exists in `ingestion/parsers/repo_analyzer.py`. Duplicating similar matching rules in `GitHubTool` could cause the two implementations to behave differently later. I need to decide whether the logic can be shared safely without creating unnecessary coupling between the agent and ingestion modules.
+
+- A broad search for the text `test_` could create false positives. Detection should examine complete path segments or filenames instead of matching unrelated words anywhere in a path.
+
+### Edge cases
+
+- A repository containing a root-level `tests/` directory
+- A repository containing a root-level `test/` directory
+- A nested test directory such as `backend/tests/`
+- A root-level `pytest.ini` file
+- A nested Python test file such as `src/tests/test_api.py`
+- A root-level Python test file such as `test_app.py`
+- A repository containing no test files or folders
+- An empty repository
+- A repository whose default branch is not `main`
+- A repository tree response marked as truncated
+- A private or unavailable repository
+- A GitHub `403` rate-limit response
+- A GitHub `404` response
+- A request timeout or network failure
+- Unrelated filenames such as `latest_update.py`, `contest_results.py`, or `testing_notes.md`, which should not automatically count as test files
+EOF

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,15 @@
+## Solution plan
+
+**Issue:** Add a `has_tests` boolean to the repo analysis output  
+https://github.com/ascherj/pathreview/issues/50
+
+### Understand
+
+`GitHubTool` returns information about a repository, such as its name, language, stars, and whether it has a README.
+
+The problem is that it does not return a `has_tests` field.
+
+Expected:
+
+```python
+"has_tests": True

--- a/agent/tools/github_tool.py
+++ b/agent/tools/github_tool.py
@@ -2,6 +2,7 @@
 
 import httpx
 import structlog
+
 from .base import BaseTool, ToolResult
 
 logger = structlog.get_logger()
@@ -35,44 +36,30 @@ class GitHubTool(BaseTool):
         repo_name = input_data.get("repo_name")
 
         if not username or not repo_name:
-            return ToolResult(
-                success=False,
-                data={},
-                error="Missing github_username or repo_name"
-            )
+            return ToolResult(success=False, data={}, error="Missing github_username or repo_name")
 
         try:
             repo_data = self._fetch_repo_metadata(username, repo_name)
             return ToolResult(success=True, data=repo_data)
 
         except httpx.HTTPStatusError as e:
-            logger.error("github_request_failed", status=e.response.status_code,
-                        username=username, repo=repo_name)
+            logger.error(
+                "github_request_failed",
+                status=e.response.status_code,
+                username=username,
+                repo=repo_name,
+            )
             if e.response.status_code == 404:
-                return ToolResult(
-                    success=False,
-                    data={},
-                    error="Repository not found"
-                )
+                return ToolResult(success=False, data={}, error="Repository not found")
             elif e.response.status_code == 403:
-                return ToolResult(
-                    success=False,
-                    data={},
-                    error="Rate limited or access denied"
-                )
+                return ToolResult(success=False, data={}, error="Rate limited or access denied")
             return ToolResult(
-                success=False,
-                data={},
-                error=f"GitHub API error: {e.response.status_code}"
+                success=False, data={}, error=f"GitHub API error: {e.response.status_code}"
             )
 
         except Exception as e:
             logger.error("github_tool_error", error=str(e))
-            return ToolResult(
-                success=False,
-                data={},
-                error=str(e)
-            )
+            return ToolResult(success=False, data={}, error=str(e))
 
     def _fetch_repo_metadata(self, username: str, repo_name: str) -> dict:
         """Fetch repository metadata from GitHub API.
@@ -95,6 +82,13 @@ class GitHubTool(BaseTool):
 
         repo_json = response.json()
 
+        default_branch = repo_json.get("default_branch", "main")
+        repo_paths = self._fetch_repo_tree(
+            username,
+            repo_name,
+            default_branch,
+        )
+
         # Extract metadata, handling null values
         metadata = {
             "name": repo_json.get("name", ""),
@@ -105,12 +99,18 @@ class GitHubTool(BaseTool):
             "open_issues_count": repo_json.get("open_issues_count", 0),
             "last_commit_date": repo_json.get("pushed_at", ""),
             "has_readme": self._has_readme(username, repo_name),
+            "has_tests": self._has_tests(repo_paths),
             "topics": repo_json.get("topics", []),
             "homepage": repo_json.get("homepage") or "",
         }
 
-        logger.info("github_repo_fetched", username=username, repo=repo_name,
-                   language=metadata["primary_language"], stars=metadata["star_count"])
+        logger.info(
+            "github_repo_fetched",
+            username=username,
+            repo=repo_name,
+            language=metadata["primary_language"],
+            stars=metadata["star_count"],
+        )
 
         return metadata
 
@@ -132,6 +132,73 @@ class GitHubTool(BaseTool):
 
         try:
             response = httpx.head(url, headers=headers, timeout=5.0)
-            return response.status_code == 200
+            return bool(response.status_code == 200)
         except Exception:
             return False
+
+    def _has_tests(self, paths: list[str]) -> bool:
+        """Check whether repository paths contain common test indicators.
+
+        Args:
+            paths: Repository file and directory paths.
+
+        Returns:
+            True if recognized tests are present, otherwise False.
+        """
+        for path in paths:
+            normalized_path = path.strip("/").lower()
+            parts = normalized_path.split("/")
+            filename = parts[-1]
+
+            if "tests" in parts or "test" in parts:
+                return True
+
+            if filename == "pytest.ini":
+                return True
+
+            if filename.startswith("test_") and filename.endswith(".py"):
+                return True
+
+        return False
+
+    def _fetch_repo_tree(
+        self,
+        username: str,
+        repo_name: str,
+        branch: str,
+    ) -> list[str]:
+        """Fetch repository file and directory paths from GitHub.
+
+        Args:
+            username: GitHub username.
+            repo_name: Repository name.
+            branch: Repository branch to inspect.
+
+        Returns:
+            Repository file and directory paths.
+        """
+        url = f"{self.base_url}/repos/{username}/{repo_name}" f"/git/trees/{branch}"
+
+        headers = {}
+        if self.api_token:
+            headers["Authorization"] = f"token {self.api_token}"
+
+        response = httpx.get(
+            url,
+            headers=headers,
+            params={"recursive": "1"},
+            timeout=10.0,
+        )
+        response.raise_for_status()
+
+        tree_json = response.json()
+
+        if tree_json.get("truncated", False):
+            logger.warning(
+                "github_tree_truncated",
+                username=username,
+                repo=repo_name,
+                branch=branch,
+            )
+
+        return [item["path"] for item in tree_json.get("tree", []) if item.get("path")]

--- a/tests/unit/test_github_tool.py
+++ b/tests/unit/test_github_tool.py
@@ -133,3 +133,7 @@ class TestGitHubTool:
         tree_request = mock_get.call_args_list[1]
         assert "/git/trees/develop" in tree_request.args[0]
         assert metadata["has_tests"] is True
+
+    def test_has_tests_returns_false_for_empty_repository(self, tool: GitHubTool) -> None:
+        """Return False when the repository contains no paths."""
+        assert tool._has_tests([]) is False

--- a/tests/unit/test_github_tool.py
+++ b/tests/unit/test_github_tool.py
@@ -1,0 +1,135 @@
+"""Tests for github_tool.py."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from agent.tools.github_tool import GitHubTool
+
+
+@pytest.mark.unit
+class TestGitHubTool:
+    """Test suite for GitHubTool."""
+
+    @pytest.fixture
+    def tool(self) -> GitHubTool:
+        """Create a GitHubTool instance."""
+        return GitHubTool()
+
+    def test_has_tests_detects_tests_directory(self, tool: GitHubTool) -> None:
+        """Return True when the repository contains a tests directory."""
+        paths = [
+            "README.md",
+            "src/app.py",
+            "tests/test_app.py",
+        ]
+
+        assert tool._has_tests(paths) is True
+
+    def test_has_tests_returns_false_without_test_indicators(self, tool: GitHubTool) -> None:
+        """Return False when the repository contains no recognized tests."""
+        paths = [
+            "README.md",
+            "src/app.py",
+            "requirements.txt",
+        ]
+
+        assert tool._has_tests(paths) is False
+
+    def test_has_tests_detects_python_test_file(self, tool: GitHubTool) -> None:
+        """Return True when a test_*.py file exists."""
+        paths = [
+            "README.md",
+            "src/app.py",
+            "test_app.py",
+        ]
+
+        assert tool._has_tests(paths) is True
+
+    def test_has_tests_detects_pytest_config(self, tool: GitHubTool) -> None:
+        """Return True when pytest.ini exists."""
+        paths = [
+            "README.md",
+            "src/app.py",
+            "pytest.ini",
+        ]
+
+        assert tool._has_tests(paths) is True
+
+    def test_has_tests_ignores_unrelated_filenames(self, tool: GitHubTool) -> None:
+        """Return False for filenames that only contain similar text."""
+        paths = [
+            "README.md",
+            "latest_update.py",
+            "contest_results.py",
+            "testing_notes.md",
+        ]
+
+        assert tool._has_tests(paths) is False
+
+    @patch("agent.tools.github_tool.httpx.get")
+    def test_fetch_repo_tree_returns_repository_paths(
+        self, mock_get: Mock, tool: GitHubTool
+    ) -> None:
+        """Return repository paths from the GitHub tree response."""
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "tree": [
+                {"path": "README.md", "type": "blob"},
+                {"path": "src", "type": "tree"},
+                {"path": "src/app.py", "type": "blob"},
+                {"path": "tests/test_app.py", "type": "blob"},
+            ],
+            "truncated": False,
+        }
+        mock_get.return_value = mock_response
+
+        paths = tool._fetch_repo_tree("octocat", "sample-repo", "main")
+
+        assert paths == [
+            "README.md",
+            "src",
+            "src/app.py",
+            "tests/test_app.py",
+        ]
+
+    @patch("agent.tools.github_tool.httpx.head")
+    @patch("agent.tools.github_tool.httpx.get")
+    def test_repo_metadata_includes_has_tests(
+        self,
+        mock_get: Mock,
+        mock_head: Mock,
+        tool: GitHubTool,
+    ) -> None:
+        """Include has_tests in repository metadata."""
+        repo_response = Mock()
+        repo_response.json.return_value = {
+            "name": "sample-repo",
+            "description": "Sample repository",
+            "language": "Python",
+            "stargazers_count": 5,
+            "forks_count": 2,
+            "open_issues_count": 1,
+            "pushed_at": "2026-07-30T12:00:00Z",
+            "default_branch": "develop",
+            "topics": [],
+            "homepage": None,
+        }
+
+        tree_response = Mock()
+        tree_response.json.return_value = {
+            "tree": [
+                {"path": "README.md", "type": "blob"},
+                {"path": "tests/test_app.py", "type": "blob"},
+            ],
+            "truncated": False,
+        }
+
+        mock_get.side_effect = [repo_response, tree_response]
+        mock_head.return_value.status_code = 200
+
+        metadata = tool._fetch_repo_metadata("octocat", "sample-repo")
+
+        tree_request = mock_get.call_args_list[1]
+        assert "/git/trees/develop" in tree_request.args[0]
+        assert metadata["has_tests"] is True

--- a/tests/unit/test_github_tool.py
+++ b/tests/unit/test_github_tool.py
@@ -137,3 +137,9 @@ class TestGitHubTool:
     def test_has_tests_returns_false_for_empty_repository(self, tool: GitHubTool) -> None:
         """Return False when the repository contains no paths."""
         assert tool._has_tests([]) is False
+
+    def test_has_tests_detects_test_directory(self, tool: GitHubTool) -> None:
+        """Return True when a singular test directory is present."""
+        paths = ["src/app.py", "test/test_app.py"]
+
+        assert tool._has_tests(paths) is True


### PR DESCRIPTION
## Summary

Adds a `has_tests` Boolean to the GitHub repository analysis output.

The GitHub tool now:

- fetches the repository tree from the default branch
- detects `tests/` directories
- detects `test/` directories
- detects `pytest.ini`
- detects Python files named `test_*.py`
- returns `has_tests: true` when any test indicator is found
- returns `has_tests: false` otherwise

Closes #50

## Changes

- Added repository-tree retrieval to `GitHubTool`
- Added `_has_tests()` detection logic
- Included `has_tests` in repository metadata
- Added focused unit tests for positive, negative, metadata, tree-fetching, and empty-repository cases

## Testing

- `pytest tests/unit/test_github_tool.py -v`
  - 9 passed
- Ruff passed for both changed files
- Black passed for both changed files
- Mypy passed for both changed files
- Real GitHub smoke test against `ascherj/pathreview`
  - `Success: True`
  - `Has tests: True`
  - `Error: None`

## Existing repository issues

The full unit suite currently reports:

- 384 passed
- 53 pre-existing failures

The project-wide lint check currently reports 181 pre-existing errors. Neither changed file appears in the lint errors, and this contribution introduced no new test failures.