### PR TITLE
fix(rag): coerce None chunk text to empty string in faithfulness checker

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -25,3 +25,23 @@ longer crashes the whole evaluation run. This affects
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/ateressa/pathreview/commit/f7d5571
+
+**Reproduction summary:**
+Ran `pytest tests/unit/test_faithfulness_checker.py -k test_none_context_chunk_text`,
+an existing test that calls `check()` with `context_chunks = [{"text": None}]`.
+It fails with `TypeError: sequence item 0: expected str instance, NoneType found`,
+raised from the `" ".join(...)` call in `FaithfulnessChecker.check()` — confirming
+`chunk.get("text", "")` doesn't catch an explicit `None` value, only a missing key.
+
+**PLAN.md link:** https://github.com/ateressa/pathreview/blob/fix/153-faithfulness-checker-none-context-text/PLAN.md
+
+**Walkthrough video (recommended):**
+
+**Blockers or open questions:**
+`relevance_scorer.py:32` has the same `chunk.get("text", "")` pattern and may have
+an identical latent crash reachable through `EvalSuite.run()`. Leaving it out of
+this issue's scope but may file a follow-up.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,27 @@
+# Journal
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/153
+
+**Issue title:** Faithfulness checker crashes when a context chunk has text: None
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+`FaithfulnessChecker.check()` builds the context string by calling
+`chunk.get("text", "")` on each retrieved chunk. That default only applies when
+the `"text"` key is missing entirely — if the key exists but is explicitly set
+to `None`, `.get()` returns `None` instead of falling back to `""`. The
+resulting list of chunk texts then gets passed to `" ".join(...)`, which
+raises a `TypeError` because `join` requires every item to be a string. A
+successful fix will coerce a `None` (or otherwise falsy/non-string) `"text"`
+value to an empty string before joining, so a single malformed chunk no
+longer crashes the whole evaluation run. This affects
+`rag/evaluator/faithfulness_checker.py`.
+
+**Branch name:** fix/153-faithfulness-checker-none-context-text
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -39,8 +39,6 @@ raised from the `" ".join(...)` call in `FaithfulnessChecker.check()` — confir
 
 **PLAN.md link:** https://github.com/ateressa/pathreview/blob/fix/153-faithfulness-checker-none-context-text/PLAN.md
 
-**Walkthrough video (recommended):**
-
 **Blockers or open questions:**
 `relevance_scorer.py:32` has the same `chunk.get("text", "")` pattern and may have
 an identical latent crash reachable through `EvalSuite.run()`. Leaving it out of

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -43,3 +43,39 @@ raised from the `" ".join(...)` call in `FaithfulnessChecker.check()` — confir
 `relevance_scorer.py:32` has the same `chunk.get("text", "")` pattern and may have
 an identical latent crash reachable through `EvalSuite.run()`. Leaving it out of
 this issue's scope but may file a follow-up.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the fix from PLAN.md step 1: `rag/evaluator/faithfulness_checker.py`
+now builds `context_text` with `chunk.get("text") or ""` instead of
+`chunk.get("text", "")`, so a chunk with an explicit `"text": None` falls back to
+`""` the same way a missing key already did. `test_none_context_chunk_text` now
+passes, and `test_missing_text_key_in_chunk` (the already-passing case) is
+unaffected. Manually exercised `FaithfulnessChecker.check()` with a
+`[valid_chunk, {"text": None}]` list — returns a normal float (`1.0`) instead of
+crashing.
+
+Also confirmed the PLAN.md risk: `EvalSuite.run()` still crashes on the same
+input, but via `RelevanceScorer.score()` → `_tokenize()` calling `.lower()` on
+`None` (`relevance_scorer.py:32-33`) — a separate, identical bug in a different
+file. Staying out of scope for #153 per the plan; noting it as a likely
+follow-up issue.
+
+Ran `make test-unit` and `make check` before and after the fix (stashing/popping
+the change to diff) to separate pre-existing failures from anything new:
+- `make test-unit`: 53 failed / 375 passed before, 52 failed / 376 passed after
+  — exactly the one target test flipping to passing, no other change.
+- `make check`: 181 pre-existing `ruff` errors, identical count with and without
+  the fix (none in `faithfulness_checker.py`); `black` and `mypy` run clean on
+  the touched file. Pre-existing `black` drift and a `mypy` gap in
+  `eval_suite.py:23` (untouched file) are unrelated to this change.
+
+**Next steps:**
+Update PR description to document the pre-existing failures and the
+`relevance_scorer.py` follow-up, then open the draft PR for peer/mentor review.
+
+**Blockers:**
+None.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -24,4 +24,4 @@ longer crashes the whole evaluation run. This affects
 
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
-**Cohort ledger:** [ ] Issue added to cohort ledger
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -112,3 +112,70 @@ this change introduces no new failures.)*
 **Draft PR feedback received from:** none — posted in Slack for mentor/peer
 review and waited a couple of days with no response. Marking ready for review
 and submitting to meet the hard deadline.
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No feedback arrived. Posted PR #528 in Slack for peer/mentor review in Week 9
+and waited several days before the Week 9 deadline; also checked again this
+week (`gh pr view 528 --repo ascherj/pathreview` shows 0 comments, 0 reviews,
+0 review requests) — still nothing as of this check-in.
+
+**How you responded:**
+N/A — no comments to respond to. No code changes made this week.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The bug itself wasn't hard — I picked a Tier 1 issue, and once the existing
+repro test made the failure obvious, the fix was a one-line change. What I
+didn't expect was how much of the actual effort went into things that weren't
+the fix: this codebase has other developers depending on it, so a change that
+would take five minutes on my own project turned into a slower, more careful
+process. I had to prove the fix didn't break anything for anyone else — run
+the full suite and the lint/type checks before and after, diff the failure
+counts, and document which failures were already there — rather than just
+trusting "the tests I touched look green."
+
+**What did you learn about working in a large codebase?**
+Collaboration is what makes it slow, not the code. On my own project I'd just
+fix the bug and move on. Here, "done" meant provably safe for other people's
+work — existing tests, other contributors' in-flight PRs, mentors who'd
+eventually review it — so I couldn't just eyeball a green checkmark. I had to
+treat "did I break anything" as a question with a rigorous answer: stash the
+fix out, run `make test-unit`/`make check`, stash it back in, and diff the
+exact failure counts, so I could say precisely which failures were pre-existing
+and unrelated instead of just assuming.
+
+**How did AI tools help — and where did they fall short?**
+AI helped me figure out the codebase faster and filled in knowledge gaps I
+didn't have — for example, understanding exactly why `chunk.get(key, default)`
+only falls back for a *missing* key and not an explicit `None`, and catching
+during planning that `relevance_scorer.py` had the same bug pattern before I
+would have thought to check for it. Where it fell short: it can only close
+gaps I know how to ask about. Whether the fix was actually acceptable, and
+whether scoping the `relevance_scorer.py` bug out was the right call, still
+needed a human reviewer's judgment — and that review never came, which is
+exactly the part AI can't substitute for.
+
+**What would you do differently if you started over?**
+I'd get the PR in front of a reviewer earlier in the week instead of near the
+deadline, and follow up directly with a specific mentor or classmate instead
+of posting a link in Slack and waiting. The whole point of the draft-PR step
+was the feedback loop, and that's the one part of the four weeks that never
+actually closed — waiting longer wasn't going to fix that; asking more
+directly might have.
+
+**What are you most proud of?**
+Not the fix itself — it's one line. I'm more proud of the discipline around
+it: instead of assuming the test suite and linter were clean, I stashed the
+change out and back in to get an exact before/after diff on both
+`make test-unit` and `make check`, so the PR could state precisely which of
+the pre-existing failures were unrelated to my change rather than just
+asserting it. That's the habit from this module I'd keep on a real team.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -79,3 +79,36 @@ Update PR description to document the pre-existing failures and the
 
 **Blockers:**
 None.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/528
+
+**Branch:** `fix/153-faithfulness-checker-none-context-text`
+
+**What you built:**
+`FaithfulnessChecker.check()` was crashing with `TypeError` whenever a
+retrieved context chunk had `"text": None` instead of a real string or a
+missing key, because `chunk.get("text", "")` only falls back to `""` for an
+absent key, not an explicit `None`. Changed the lookup to
+`chunk.get("text") or ""` so a `None` value is coerced to empty the same way a
+missing key already was, and a single malformed chunk no longer takes down the
+whole evaluation run.
+
+**Tests added or updated:**
+No new test file — `tests/unit/test_faithfulness_checker.py` already had
+`test_none_context_chunk_text` (previously failing, now passing) and
+`test_missing_text_key_in_chunk` (already passing, confirmed unaffected)
+encoding the expected behavior.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+*(both pass in the sense required for this codebase: 52 pre-existing failures
+in `make test-unit` and 181 pre-existing `ruff` errors in `make check` are
+unchanged with the fix in vs. out — documented in the PR description — and
+this change introduces no new failures.)*
+
+**Draft PR feedback received from:** none — posted in Slack for mentor/peer
+review and waited a couple of days with no response. Marking ready for review
+and submitting to meet the hard deadline.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,49 @@
+## Solution plan
+
+**Issue:** Faithfulness checker crashes when a context chunk has `text: None` ([#153](https://github.com/ascherj/pathreview/issues/153))
+
+### Understand
+`FaithfulnessChecker.check()` builds the context string with
+`chunk.get("text", "") for chunk in context_chunks`. The `.get(key, default)`
+default only applies when `key` is **absent** from the dict — if `"text"` is
+present but explicitly `None`, `.get()` returns `None`. That `None` then
+lands in the list passed to `" ".join(...)`, and `str.join` requires every
+item to be a `str`, so it raises:
+
+```
+TypeError: sequence item 0: expected str instance, NoneType found
+```
+
+- **Expected:** a chunk with `{"text": None}` should be treated like an empty
+  or missing chunk — `check()` still returns a normal `float` in `[0.0, 1.0]`.
+- **Actual:** the whole call crashes, taking down whatever caller invoked it
+  (currently `EvalSuite.run()`), not just the one malformed chunk.
+
+### Map
+- `rag/evaluator/faithfulness_checker.py` — `check()`, the `context_text = " ".join(...)` line (~34-42). This is the only file the fix touches.
+- `tests/unit/test_faithfulness_checker.py` — `test_none_context_chunk_text` (already present, currently failing) and `test_missing_text_key_in_chunk` (already passing) encode the expected behavior; no new test file needed, just make the failing one pass without breaking the passing one.
+- `rag/evaluator/eval_suite.py` — the only current caller of `FaithfulnessChecker.check()` (via `EvalSuite.run()`); confirms the blast radius is a full eval run, not just one chunk.
+- `rag/evaluator/relevance_scorer.py:32` — has the identical `chunk.get("text", "")` pattern. Out of scope for #153 (different file, different issue), but worth a quick look so I don't miss an obviously-related crash while I'm in this area.
+
+### Plan
+1. Replace `chunk.get("text", "")` with something that coerces `None` to `""` too (e.g. `chunk.get("text") or ""`), so both a missing key and an explicit `None` value fall back to an empty string.
+2. Run `pytest tests/unit/test_faithfulness_checker.py -v` and confirm `test_none_context_chunk_text` now passes and every previously-passing test still passes (especially `test_missing_text_key_in_chunk`, to make sure the fix doesn't change that behavior).
+3. Manually exercise `EvalSuite.run()` with a mixed `chunks` list (one chunk with real text, one with `"text": None`) to confirm the score reflects the real chunk instead of crashing or silently zeroing out.
+4. Run the full unit suite (`pytest tests/unit/`) to check for regressions outside this file.
+5. Update `JOURNAL.md` Week 8 (this entry) and open the PR against `fix/153-faithfulness-checker-none-context-text`, scoped only to `faithfulness_checker.py`.
+
+### Inputs & outputs
+- **Input:** `feedback: str`, `context_chunks: list[dict]`, where each dict may have `"text": str`, `"text": None`, or no `"text"` key at all.
+- **Output:** unchanged — a `float` faithfulness score in `[0.0, 1.0]`. The only behavior change is that a `None`/missing `"text"` chunk contributes `""` to the joined context instead of crashing the whole check.
+
+### Risks & unknowns
+- Whether a `None`-text chunk should just be silently treated as empty (matching how a missing key is already handled) or should also log something so a broken upstream retriever is noticeable. Leaning toward silent + consistent with the missing-key path, since that's the existing precedent in this file.
+- `relevance_scorer.py:32` has the same `.get("text", "")` gap and its `_tokenize()` isn't yet confirmed to be `None`-safe — a similar crash may still be reachable via `EvalSuite.run()` through the relevance path even after this fix lands. Flagging as a possible follow-up issue rather than folding it into #153.
+- Haven't traced whether the retrievers (`hybrid.py`, `vector_store.py`) ever legitimately produce `text: None`, or whether this is purely a defensive fix for malformed/adversarial input. Doesn't change the fix, but affects whether this is worth a code comment upstream too.
+
+### Edge cases
+- `{"text": None}` — the reported crash.
+- `{}` (no `"text"` key) — already handled today; must not regress.
+- `{"text": ""}` — already handled today; must not regress.
+- A `context_chunks` list mixing valid, `None`, and missing-key chunks together.
+- Every chunk in the list has `None`/missing text — `context_text` ends up `""`, so every claim should be reported unsupported (score `0.0`), not a crash.

--- a/rag/evaluator/faithfulness_checker.py
+++ b/rag/evaluator/faithfulness_checker.py
@@ -1,6 +1,7 @@
 """Check if generated feedback is supported by retrieved context."""
 
 import re
+
 import structlog
 
 logger = structlog.get_logger()
@@ -20,8 +21,11 @@ class FaithfulnessChecker:
             Faithfulness score 0.0-1.0 (ratio of supported claims)
         """
         if not feedback or not context_chunks:
-            logger.info("faithfulness_empty_input", has_feedback=bool(feedback),
-                       has_chunks=bool(context_chunks))
+            logger.info(
+                "faithfulness_empty_input",
+                has_feedback=bool(feedback),
+                has_chunks=bool(context_chunks),
+            )
             return 0.0
 
         # Extract key claims from feedback (sentences)
@@ -31,9 +35,12 @@ class FaithfulnessChecker:
             return 0.5  # Default to neutral if no extractable claims
 
         # Concatenate context text
-        context_text = " ".join([
-            chunk.get("text", "") for chunk in context_chunks
-        ])
+        # REPRO (#153): chunk.get("text", "") only falls back to "" when the
+        # "text" key is missing, not when it's explicitly None. A chunk like
+        # {"text": None} makes this list comprehension yield None, and
+        # str.join() raises TypeError on a None item. Repro'd by
+        # test_none_context_chunk_text in tests/unit/test_faithfulness_checker.py.
+        context_text = " ".join([chunk.get("text", "") for chunk in context_chunks])
 
         # Check each claim for support
         supported = 0
@@ -43,8 +50,9 @@ class FaithfulnessChecker:
 
         score = supported / len(claims) if claims else 0.0
 
-        logger.info("faithfulness_checked", claims_count=len(claims),
-                   supported_count=supported, score=score)
+        logger.info(
+            "faithfulness_checked", claims_count=len(claims), supported_count=supported, score=score
+        )
 
         return score
 
@@ -59,7 +67,7 @@ class FaithfulnessChecker:
             List of claims (sentences)
         """
         # Split by sentence (simple regex)
-        sentences = re.split(r'[.!?]+', text)
+        sentences = re.split(r"[.!?]+", text)
         claims = [s.strip() for s in sentences if s.strip() and len(s.strip()) > 10]
         return claims[:10]  # Limit to 10 claims for scoring
 
@@ -81,8 +89,25 @@ class FaithfulnessChecker:
         # Require at least some meaningful overlap
         overlap = claim_tokens & context_tokens
         # Filter out common stop words
-        stop_words = {'a', 'an', 'the', 'is', 'are', 'was', 'were', 'be', 'been',
-                     'and', 'or', 'but', 'in', 'of', 'to', 'for', 'that'}
+        stop_words = {
+            "a",
+            "an",
+            "the",
+            "is",
+            "are",
+            "was",
+            "were",
+            "be",
+            "been",
+            "and",
+            "or",
+            "but",
+            "in",
+            "of",
+            "to",
+            "for",
+            "that",
+        }
         meaningful_overlap = overlap - stop_words
 
         return len(meaningful_overlap) >= 2

--- a/rag/evaluator/faithfulness_checker.py
+++ b/rag/evaluator/faithfulness_checker.py
@@ -34,13 +34,9 @@ class FaithfulnessChecker:
             logger.info("faithfulness_no_claims_extracted")
             return 0.5  # Default to neutral if no extractable claims
 
-        # Concatenate context text
-        # REPRO (#153): chunk.get("text", "") only falls back to "" when the
-        # "text" key is missing, not when it's explicitly None. A chunk like
-        # {"text": None} makes this list comprehension yield None, and
-        # str.join() raises TypeError on a None item. Repro'd by
-        # test_none_context_chunk_text in tests/unit/test_faithfulness_checker.py.
-        context_text = " ".join([chunk.get("text", "") for chunk in context_chunks])
+        # Concatenate context text. `or ""` also coerces an explicit
+        # `"text": None` to empty, not just a missing key (#153).
+        context_text = " ".join([chunk.get("text") or "" for chunk in context_chunks])
 
         # Check each claim for support
         supported = 0


### PR DESCRIPTION
## Summary
`FaithfulnessChecker.check()` crashed with `TypeError` when a retrieved context chunk had an explicit `"text": None` instead of a real string or a missing key. `chunk.get("text", "")` only falls back to `""` when the key is absent — an explicit `None` value passes through untouched and breaks `" ".join(...)`. This PR coerces that value with `chunk.get("text") or ""`, matching the already-correct behavior for a missing key.

## Issue
Closes #153

## Changes
- `rag/evaluator/faithfulness_checker.py`: replace `chunk.get("text", "")` with `chunk.get("text") or ""` when building `context_text`, so both a missing `"text"` key and an explicit `None` value fall back to an empty string.

## Testing
- [x] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`)
- [x] Linter passes (`make lint`)
- [x] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes

`tests/unit/test_faithfulness_checker.py::test_none_context_chunk_text` already existed and encoded the expected behavior; it now passes, and `test_missing_text_key_in_chunk` (the already-passing case) is unaffected.

**Pre-existing failures (not introduced by this PR):** the full suite has failures unrelated to this change (bias detector, pii scrubber, resume parser, review service, tech detector, etc.), and `make check` reports 181 pre-existing `ruff` errors plus `black` formatting drift in several files. I confirmed these are unchanged by diffing `make test-unit` / `make check` output with this fix stashed in vs. out:
- `make test-unit`: 53 failed / 375 passed without this fix, 52 failed / 376 passed with it — exactly the one target test flipping, nothing else moves.
- `make check`: identical 181 `ruff` errors with and without the fix; `ruff`, `black`, and `mypy` all run clean on `faithfulness_checker.py` itself.
- Three other pre-existing failures in `test_faithfulness_checker.py` (`test_partial_support_returns_middle_score`, `test_multiple_context_chunks`, `test_multiple_claims_varying_support`) are about the `_is_supported` keyword-overlap threshold, unrelated to the `None`-text bug this PR fixes.

## Notes for Reviewers
- Scope check: `rag/evaluator/relevance_scorer.py:32` has the identical `chunk.get("text", "")` pattern, and `_tokenize()` isn't `None`-safe either — `EvalSuite.run()` still crashes on a `None`-text chunk via that path (confirmed manually), just not through `FaithfulnessChecker`. I left it out of this PR since it's a separate file/bug from #153, but wanted to flag it — happy to file a follow-up issue or fold it in if preferred.