### PR TITLE
Feat/101 review copy link

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -51,3 +51,34 @@ I reproduced the issue by following the user workflow to "share" the link they p
 
 **Blockers or open questions:**
 How to handle link regeneration + privacy? 
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+I implemented the entire changes defined in PLAN.md, making new API endpoints and editing the database schema, creating a new share page accessible by any user, and implemented tests to ensure link expiration.
+
+**Next steps:**
+I'm working on doing a PR review through Slack and getting ready for submission!
+
+**Blockers:**
+[Anything slowing you down? Or leave blank.]
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [link to your submitted pull request]
+
+**Branch:** [the branch name you worked on, e.g. `fix/123-short-description`]
+
+**What you built:**
+[1–3 sentences summarizing what your fix does and how it works]
+
+**Tests added or updated:**
+[Which test files did you touch? What do they cover?]
+
+**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+
+**Draft PR feedback received from:** [name or Slack handle, or "none"]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -39,10 +39,12 @@ I would need to write a new test case to check for the 30-day deletion system, a
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [link to commit documenting the reproduced issue]
+**Reproduction commit link:** https://github.com/anthonyle1/pathreview/commit/eb3dd4fc8da32c4244912066f22102dcf492f4ec
 
 **Reproduction summary:**
 [1–2 sentences: How did you reproduce the issue? What did you observe?]
+I reproduced the issue by following the user workflow to "share" the link they provided. The link is able to be shared, but when opening the link to an incognito tab that is signed out, the user is prompted to log-in instead of viewing the shared review page.
+
 
 **PLAN.md link:** [link to PLAN.md in your fork]
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,38 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/101
+
+**Issue title:** Add a "Copy link" button to share a public review summary
+
+**Tier:** [ ] Tier 1  [x] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+
+The issue asks to implement a system where users are able to share a read-only view of their review summary. The link should be accessible without the need to login and expires after 30 days. Even though `frontend/src/services/shareService.ts ` does not exist, there are exisiting APIs I can use to help build the frontend-backend connection to populate the page. A share button exists, but the link generation, public view and expiration needs to be implemented. A successful fix would have the previously stated features implemented.
+
+**Branch name:** feat/101-review-copy-link
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger
+
+** Is this Issue Right for Me?*
+
+*Part 1*: The issue asks to implement a feature where the user can share the results of pathreview. I need to implement methods to handle link generation, expiration, and privacy. Additionally, I need to ensure there are API endpoints exist for the data provided.
+
+The relevant files are listed by the issue:
+*`frontend/src/pages/ReviewPage.tsx`
+*`frontend/src/services/shareService.ts`
+*`api/routes/reviews.py`
+
+However, `frontend/src/services/shareService.ts` does not exist, so I would need to look into `frontend/src/services/api.ts`.
+
+The "done" should allow the user to physically generate a link and open it to see a summary of their review from the reviews API route. On the summary page, the page should include how much time left does the page have until expiration (or when the page expires). Additionally, the link should be accessible by any user.
+
+*Part 2*: I chose a Tier 2 issue since I've worked on open-source style projects in the past, especially as a technical lead for a project at my university. I've worked on a few development teams also! I'm also fairly familiar with front-end development (especially in React) and would like to expand my knowledge through working thorugh this issue.
+
+*Part 3* The relevant code is found in the relevant files above. The button is found in `frontend/src/pages/ReviewPage.tsx` I will be using the `get_review_endpoint` endpoint found in `api/routes/reviews.py`.
+
+I would need to write a new test case to check for the 30-day deletion system, and unique link generation, which would be found in `tests/unit/test_review_service.py` or `frontend/src/test/setup.ts`.
+
+*Part 4* The issue provides an estimate of 5-8 hours for completing this issue, which should be ample time for Weeks 8-9. The only major thing I'm doing is working on a game jam and contributing towards other projects. Only 1 student within my section is already working on the issue. There are no open blockers or dependencies for issue #101 also.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -82,3 +82,44 @@ In `tests\unit\test_review_service.py`, I added test cases to check functionalit
 **Self-review confirmation:** [x] make check passes  [x] make test-unit passes
 
 **Draft PR feedback received from:** [Shawn Blackman](https://github.com/sh4wnbk) 
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [x] Yes  [ ] No — still awaiting review
+
+**Summary of feedback:**
+The reviewer commented on both pros and cons of my solution. He mentioned that it was a good idea to use uuid4 to prevent links to be guessable. Additionally, he mentioned that he appreciated including the is_public column to have expire links die at the endpoint. He mentioned that it may have been a good idea to have a seperate table for shared links rather than to include them in the review table, as an extra layer of protection since both private and public endpoints pull from the same database table. 
+
+**How you responded:**
+Since I was running low on time when submitting, I didn't have much time to address the database change. He also mentioned how I left parts of my notebook blank, so I corrected that.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+
+I didn't anticipate the level of scope the issue handeled. I didn't really expect to change a lot of the existing API endpoints due to changes made in the database schema and building logic for new data endpoints. 
+
+
+**What did you learn about working in a large codebase?**
+
+I think it was difficult overall to be working with a lot more restrictions in place. For this project, it was the first time I was working with a test suite in a full-stack project, so some things such as checking test cases before starting to code was something I was not used to. Additionally, the review stages can add some extra time to ensure consistency with the entire project. When working on personal projects, often you're the only person or in a small group working on the code. This leads to more leniency on code style.
+
+**How did AI tools help — and where did they fall short?**
+[Where was AI assistance most useful this module? Where did you need
+to go beyond what AI could give you?]
+
+AI was really helpful with being able to identify where the issue was and what relevant parts of the code are isolated with this feature. Since I forgot to check my test cases initially, I asked Claude to compare the test suite from before and after the committed code made on my PR request. I didn't really need much help beyond what AI gave me, but having the extra oversight from the PR review was helpful.
+
+**What would you do differently if you started over?**
+
+With this issue specifically, I should've had a seperate table that was linked to the Reviews table through a foreign key. I think this would have saved on storage space long term and also helps prevent pages that do not have an existing public link to not be showcased. It also would have allowed for proper deletion of the link.
+
+With the overall process, I need to be more aware of testing and implement it more into my code to better understand how I'm isolating my code to the specific issue.
+
+**What are you most proud of from this module?**
+
+I got to work on something beyond a frontend issue! Even though the issue itself was labeled as a frontend issue, I ended up working on features beyond frontend, especially on building new API endpoints to handle sharing logic.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -69,16 +69,16 @@ I'm working on doing a PR review through Slack and getting ready for submission!
 
 ### Check-in 2 (end of week)
 
-**PR link:** [link to your submitted pull request]
+**PR link:** https://github.com/ascherj/pathreview/pull/537
 
-**Branch:** [the branch name you worked on, e.g. `fix/123-short-description`]
+**Branch:** Add a "Copy link" button to share a public review summary
 
 **What you built:**
-[1–3 sentences summarizing what your fix does and how it works]
+I adjusted the Reviews database schema to include a public/private column and a date expiration column. Additionally, I created a new SharePage page as a place to display ReviewPage information. I handled link expiry after 30 days also. 
 
 **Tests added or updated:**
-[Which test files did you touch? What do they cover?]
+In `tests\unit\test_review_service.py`, I added test cases to check functionality for `share_review` and `get_shared_review` functions. It covers link generation on first share, expiry-trigger regeneration, and public-access checks.
 
-**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
 
-**Draft PR feedback received from:** [name or Slack handle, or "none"]
+**Draft PR feedback received from:** [Shawn Blackman](https://github.com/sh4wnbk) 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -42,13 +42,12 @@ I would need to write a new test case to check for the 30-day deletion system, a
 **Reproduction commit link:** https://github.com/anthonyle1/pathreview/commit/eb3dd4fc8da32c4244912066f22102dcf492f4ec
 
 **Reproduction summary:**
-[1–2 sentences: How did you reproduce the issue? What did you observe?]
 I reproduced the issue by following the user workflow to "share" the link they provided. The link is able to be shared, but when opening the link to an incognito tab that is signed out, the user is prompted to log-in instead of viewing the shared review page.
 
 
-**PLAN.md link:** [link to PLAN.md in your fork]
+**PLAN.md link:** https://github.com/anthonyle1/pathreview/blob/feat/101-review-copy-link/PLAN.md
 
 **Walkthrough video (recommended):** [link to your Loom video, ≤2 min — recommended, not graded]
 
 **Blockers or open questions:**
-[Anything you're still uncertain about going into Week 9, or leave blank]
+How to handle link regeneration + privacy? 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -36,3 +36,17 @@ The "done" should allow the user to physically generate a link and open it to se
 I would need to write a new test case to check for the 30-day deletion system, and unique link generation, which would be found in `tests/unit/test_review_service.py` or `frontend/src/test/setup.ts`.
 
 *Part 4* The issue provides an estimate of 5-8 hours for completing this issue, which should be ample time for Weeks 8-9. The only major thing I'm doing is working on a game jam and contributing towards other projects. Only 1 student within my section is already working on the issue. There are no open blockers or dependencies for issue #101 also.
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [link to commit documenting the reproduced issue]
+
+**Reproduction summary:**
+[1–2 sentences: How did you reproduce the issue? What did you observe?]
+
+**PLAN.md link:** [link to PLAN.md in your fork]
+
+**Walkthrough video (recommended):** [link to your Loom video, ≤2 min — recommended, not graded]
+
+**Blockers or open questions:**
+[Anything you're still uncertain about going into Week 9, or leave blank]

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,41 @@
+## Solution plan
+
+**Issue:** Add a "Copy link" button to share a public review summary
+https://github.com/ascherj/pathreview/issues/101
+
+### Understand
+What is the root cause of this issue? What behavior is expected vs. actual?
+
+The main feature of the issue is not implemented. The share button's link should be publicly viewable and should generate a link that expires. As of right now, the link is not publicly viewable as the user needs to be signed in to at least view a review page. Additionally, there is not any logic that handles link expiry. The link should be different than the href link as the main user still needs to be able to access after expiration.
+
+### Map
+Which files, functions, or modules are involved?
+List the specific files you expect to touch.
+
+reviews.py -- need to implement public/private setting and removing expiring links
+ReviewPage.tsx -- link is already generated, but needs to handle privacy
+App.tsx -- need to be able to handle user privacy. ie user needs to login to view review page
+
+### Plan
+What are the steps to fix this issue?
+Break it into 3–5 concrete sub-tasks.
+
+1. Implement public sharable link by adding privacy row to review table, with expiration date (30 days)
+2. Ensure page is viewable by any user (not logged in)
+3. Write test cases and ensure that link is properly destroyed.
+4. Ensure original user is able to view the page. (review is not entirely destroyed)
+
+### Inputs & outputs
+What does your fix take as input? What should it produce or change?
+
+The fix takes the user's input to the share button of the current review as the input. This should change the review schema's privacy row to public and generate an expiry date. When the page has expired and any user attempts to view the page, the expiry date will be checked and the privacy setting will be set to false. The generated link will be destroyed as a result.
+
+### Risks & unknowns
+What could go wrong? What are you still unsure about?
+
+The link needs to be unique, thus there needs to be checks to ensure links are not duplicated between href and the generated links. I'm unsure about if generating a new link is neccesary. I'm also unsure about how to handle the privacy issue. The time stamps need to be standardized at ONE time zone I think also to help eliminate time-related issues. 
+
+### Edge cases
+What inputs or states should your fix handle gracefully?
+
+The current date needs to be handled gracefully. The privacy setting should also be handled also. Additionally, when the user re-prompts to share the link, the link should stay the same and a new link should not be regenerated.

--- a/alembic/versions/003_add_sharing_to_reviews.py
+++ b/alembic/versions/003_add_sharing_to_reviews.py
@@ -1,0 +1,31 @@
+"""Add is_public and share_expires_at columns to reviews table.
+
+Revision ID: 003
+Revises: 002
+Create Date: 2026-08-01 00:00:00.000000
+"""
+
+import sqlalchemy as sa
+
+from alembic import op  # type: ignore[attr-defined]
+
+revision = "003"
+down_revision = "002"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "reviews",
+        sa.Column("is_public", sa.Boolean(), nullable=False, server_default="false"),
+    )
+    op.add_column(
+        "reviews",
+        sa.Column("share_expires_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("reviews", "share_expires_at")
+    op.drop_column("reviews", "is_public")

--- a/api/routes/reviews.py
+++ b/api/routes/reviews.py
@@ -1,17 +1,26 @@
-from fastapi import APIRouter, Depends, HTTPException, status, BackgroundTasks
+from typing import Annotated
 from uuid import UUID
-import structlog
 
-from api.schemas.review import ReviewCreate, ReviewResponse, ReviewListResponse
+import structlog
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from api.middleware.auth import get_current_user
-from core.models.user import User
-from core.models.review import Review
+from api.schemas.review import (
+    ReviewCreate,
+    ReviewListResponse,
+    ReviewResponse,
+    ShareLinkResponse,
+)
 from core.database import get_db
+from core.models.user import User
 from core.services.review_service import (
     create_review,
     get_review,
+    get_shared_review,
     list_reviews,
     process_review,
+    share_review,
 )
 
 log = structlog.get_logger()
@@ -23,9 +32,9 @@ router = APIRouter(prefix="/reviews", tags=["reviews"])
 async def create_review_endpoint(
     data: ReviewCreate,
     background_tasks: BackgroundTasks,
-    current_user: User = Depends(get_current_user),
-    db=Depends(get_db),
-):
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> ReviewResponse:
     """
     Create a new review for a profile.
     Triggers ingestion pipeline and agent orchestration asynchronously.
@@ -36,11 +45,11 @@ async def create_review_endpoint(
         review = await create_review(
             db=db,
             profile_id=data.profile_id,
-            user_id=current_user.id,
+            user_id=UUID(current_user.id),
         )
 
         # Add background task for processing
-        background_tasks.add_task(process_review, db, review.id, data.profile_id)
+        background_tasks.add_task(process_review, db, UUID(review.id), data.profile_id)
 
         log.info(
             "review_created",
@@ -49,7 +58,8 @@ async def create_review_endpoint(
             user_id=str(current_user.id),
         )
 
-        return ReviewResponse.model_validate(review)
+        response: ReviewResponse = ReviewResponse.model_validate(review)
+        return response
 
     except HTTPException:
         raise
@@ -59,21 +69,21 @@ async def create_review_endpoint(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to create review",
-        )
+        ) from exc
 
 
 @router.get("/{review_id}", response_model=ReviewResponse)
 async def get_review_endpoint(
     review_id: UUID,
-    current_user: User = Depends(get_current_user),
-    db=Depends(get_db),
-):
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> ReviewResponse:
     """
     Get a review by ID.
     Returns 404 if not found or not owned by current user.
     """
     try:
-        review = await get_review(db=db, review_id=review_id, user_id=current_user.id)
+        review = await get_review(db=db, review_id=review_id, user_id=UUID(current_user.id))
 
         if not review:
             log.warning(
@@ -86,7 +96,8 @@ async def get_review_endpoint(
                 detail="Review not found",
             )
 
-        return ReviewResponse.model_validate(review)
+        response: ReviewResponse = ReviewResponse.model_validate(review)
+        return response
 
     except HTTPException:
         raise
@@ -95,16 +106,16 @@ async def get_review_endpoint(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to retrieve review",
-        )
+        ) from exc
 
 
 @router.get("", response_model=ReviewListResponse)
 async def list_reviews_endpoint(
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
     page: int = 1,
     page_size: int = 20,
-    current_user: User = Depends(get_current_user),
-    db=Depends(get_db),
-):
+) -> ReviewListResponse:
     """
     List reviews for current user with pagination.
     """
@@ -116,7 +127,7 @@ async def list_reviews_endpoint(
 
         reviews, total = await list_reviews(
             db=db,
-            user_id=current_user.id,
+            user_id=UUID(current_user.id),
             page=page,
             page_size=page_size,
         )
@@ -133,21 +144,93 @@ async def list_reviews_endpoint(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to list reviews",
+        ) from exc
+
+
+@router.post("/{review_id}/share", response_model=ShareLinkResponse)
+async def share_review_endpoint(
+    review_id: UUID,
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> ShareLinkResponse:
+    """
+    Enable public sharing for a review owned by the current user.
+    Idempotent: if a valid share link already exists, it is returned
+    unchanged instead of being regenerated.
+    """
+    try:
+        review = await share_review(db=db, review_id=review_id, user_id=UUID(current_user.id))
+
+        if not review:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Review not found",
+            )
+
+        # share_review always sets share_expires_at when it returns a review
+        assert review.share_expires_at is not None
+
+        return ShareLinkResponse(
+            review_id=UUID(review.id),
+            is_public=review.is_public,
+            share_url=f"/shared/{review.id}",
+            expires_at=review.share_expires_at,
         )
+
+    except HTTPException:
+        raise
+    except Exception as exc:
+        log.error("share_review_error", error=str(exc))
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to share review",
+        ) from exc
+
+
+@router.get("/{review_id}/shared", response_model=ReviewResponse)
+async def get_shared_review_endpoint(
+    review_id: UUID,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> ReviewResponse:
+    """
+    Get a publicly shared review by ID. No authentication required.
+    Returns 404 if the review doesn't exist, isn't public, or its share
+    link has expired.
+    """
+    try:
+        review = await get_shared_review(db=db, review_id=review_id)
+
+        if not review:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Shared review not found or expired",
+            )
+
+        response: ReviewResponse = ReviewResponse.model_validate(review)
+        return response
+
+    except HTTPException:
+        raise
+    except Exception as exc:
+        log.error("get_shared_review_error", error=str(exc))
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to retrieve shared review",
+        ) from exc
 
 
 @router.get("/{review_id}/status")
 async def get_review_status(
     review_id: UUID,
-    current_user: User = Depends(get_current_user),
-    db=Depends(get_db),
-):
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> dict[str, str | int]:
     """
     Get review status and progress.
     Returns {review_id, status, progress_pct}
     """
     try:
-        review = await get_review(db=db, review_id=review_id, user_id=current_user.id)
+        review = await get_review(db=db, review_id=review_id, user_id=UUID(current_user.id))
 
         if not review:
             log.warning(
@@ -173,4 +256,4 @@ async def get_review_status(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to retrieve review status",
-        )
+        ) from exc

--- a/api/schemas/review.py
+++ b/api/schemas/review.py
@@ -22,6 +22,8 @@ class ReviewResponse(BaseModel):
     sections: list[FeedbackSection] | None
     overall_score: float | None
     error_message: str | None = None
+    is_public: bool
+    share_expires_at: datetime | None = None
     created_at: datetime
     updated_at: datetime
 
@@ -33,3 +35,10 @@ class ReviewListResponse(BaseModel):
     total: int
     page: int
     page_size: int
+
+
+class ShareLinkResponse(BaseModel):
+    review_id: UUID
+    is_public: bool
+    share_url: str
+    expires_at: datetime

--- a/core/models/review.py
+++ b/core/models/review.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING
 from uuid import uuid4
 
-from sqlalchemy import JSON, DateTime, Float, ForeignKey, Index, String, Text
+from sqlalchemy import JSON, Boolean, DateTime, Float, ForeignKey, Index, String, Text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -34,6 +34,10 @@ class Review(Base):
     sections: Mapped[dict | None] = mapped_column(JSON, nullable=True)  # Structured review output
     overall_score: Mapped[float | None] = mapped_column(Float, nullable=True)
     error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
+    is_public: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    share_expires_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, default=datetime.utcnow
     )

--- a/core/services/review_service.py
+++ b/core/services/review_service.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from uuid import UUID
 
 import structlog
@@ -99,7 +99,7 @@ async def share_review(
     if not review:
         return None
 
-    now = datetime.utcnow()
+    now = datetime.now(UTC)
     if review.is_public and review.share_expires_at and review.share_expires_at > now:
         return review
 
@@ -127,7 +127,7 @@ async def get_shared_review(
     if not review or not review.is_public:
         return None
 
-    if review.share_expires_at and review.share_expires_at <= datetime.utcnow():
+    if review.share_expires_at and review.share_expires_at <= datetime.now(UTC):
         review.is_public = False
         db.add(review)
         await db.commit()

--- a/core/services/review_service.py
+++ b/core/services/review_service.py
@@ -1,19 +1,23 @@
-from uuid import UUID
-import structlog
 import json
-from datetime import datetime
-from sqlalchemy import select, and_
+from datetime import datetime, timedelta
+from uuid import UUID
 
-from core.models.review import Review
-from core.models.profile import Profile
-from core.models.ingested_source import IngestedSource
+import structlog
+from sqlalchemy import and_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from api.schemas.review import FeedbackSection
+from core.models.ingested_source import IngestedSource
+from core.models.profile import Profile
+from core.models.review import Review
 
 log = structlog.get_logger()
 
+SHARE_LINK_TTL_DAYS = 30
+
 
 async def create_review(
-    db,
+    db: AsyncSession,
     profile_id: UUID,
     user_id: UUID,
 ) -> Review:
@@ -33,22 +37,23 @@ async def create_review(
 
 
 async def get_review(
-    db,
+    db: AsyncSession,
     review_id: UUID,
     user_id: UUID,
 ) -> Review | None:
     """
     Get a review by ID, checking that it belongs to the user's profile.
     """
-    stmt = select(Review).join(Profile).where(
-        and_(Review.id == review_id, Profile.user_id == user_id)
+    stmt = (
+        select(Review).join(Profile).where(and_(Review.id == review_id, Profile.user_id == user_id))
     )
     result = await db.execute(stmt)
-    return result.scalars().first()
+    review: Review | None = result.scalars().first()
+    return review
 
 
 async def list_reviews(
-    db,
+    db: AsyncSession,
     user_id: UUID,
     page: int = 1,
     page_size: int = 20,
@@ -74,13 +79,65 @@ async def list_reviews(
         .limit(page_size)
     )
     result = await db.execute(stmt)
-    reviews = result.scalars().all()
+    reviews = list(result.scalars().all())
 
     return reviews, total
 
 
+async def share_review(
+    db: AsyncSession,
+    review_id: UUID,
+    user_id: UUID,
+) -> Review | None:
+    """
+    Make a review publicly viewable for 30 days, owned-user only.
+    Idempotent: if the review is already public with a share link that
+    hasn't expired yet, that same link is returned unchanged rather than
+    generating a new one.
+    """
+    review = await get_review(db=db, review_id=review_id, user_id=user_id)
+    if not review:
+        return None
+
+    now = datetime.utcnow()
+    if review.is_public and review.share_expires_at and review.share_expires_at > now:
+        return review
+
+    review.is_public = True
+    review.share_expires_at = now + timedelta(days=SHARE_LINK_TTL_DAYS)
+    db.add(review)
+    await db.commit()
+    await db.refresh(review)
+    return review
+
+
+async def get_shared_review(
+    db: AsyncSession,
+    review_id: UUID,
+) -> Review | None:
+    """
+    Get a review by ID for unauthenticated public access.
+    Returns None if the review doesn't exist, isn't public, or its share
+    link has expired. An expired link also flips is_public back to False.
+    """
+    stmt = select(Review).where(Review.id == review_id)
+    result = await db.execute(stmt)
+    review: Review | None = result.scalars().first()
+
+    if not review or not review.is_public:
+        return None
+
+    if review.share_expires_at and review.share_expires_at <= datetime.utcnow():
+        review.is_public = False
+        db.add(review)
+        await db.commit()
+        return None
+
+    return review
+
+
 async def process_review(
-    db,
+    db: AsyncSession,
     review_id: UUID,
     profile_id: UUID,
 ) -> None:
@@ -166,7 +223,7 @@ async def process_review(
         ]
 
         review.status = "complete"
-        review.sections = [s.model_dump() for s in sections]
+        review.sections = [s.model_dump() for s in sections]  # type: ignore[assignment]
         review.overall_score = rag_output.get("overall_score", None)
         review.updated_at = datetime.utcnow()
 
@@ -194,12 +251,12 @@ async def process_review(
             log.error("review_status_update_failed", review_id=str(review_id), error=str(e))
 
 
-async def _run_ingestion_pipeline(db, profile: Profile) -> list[dict]:
+async def _run_ingestion_pipeline(db: AsyncSession, profile: Profile) -> list[dict]:
     """
     Run ingestion pipeline to extract data from profile sources.
     Returns list of ingested source data.
     """
-    sources = []
+    sources: list[dict] = []
 
     # Ingest from GitHub if available
     if profile.github_username:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -99,7 +99,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -449,7 +448,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -473,7 +471,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1561,7 +1558,6 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1579,7 +1575,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1972,7 +1967,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3507,7 +3501,6 @@
       "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^2.0.1",
         "cssstyle": "^4.0.1",
@@ -4094,7 +4087,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4107,7 +4099,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4771,7 +4762,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import { DashboardPage } from './pages/DashboardPage'
 import { NewProfilePage } from './pages/NewProfilePage'
 import { ReviewPage } from './pages/ReviewPage'
 import { ReviewHistoryPage } from './pages/ReviewHistoryPage'
+import { SharedReviewPage } from './pages/SharedReviewPage'
 
 const ProtectedRoute: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const { user, isLoading } = useAuth()
@@ -77,9 +78,6 @@ function App() {
           }
         />
         <Route
-
-        // TODO: HANDLE PUBLIC VIEW
-
           path="/reviews/:reviewId"
           element={
             <ProtectedRoute>
@@ -87,6 +85,7 @@ function App() {
             </ProtectedRoute>
           }
         />
+        <Route path="/shared/:reviewId" element={<SharedReviewPage />} />
       </Routes>
     </>
   )

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -77,6 +77,9 @@ function App() {
           }
         />
         <Route
+
+        // TODO: HANDLE PUBLIC VIEW
+
           path="/reviews/:reviewId"
           element={
             <ProtectedRoute>

--- a/frontend/src/pages/ReviewPage.tsx
+++ b/frontend/src/pages/ReviewPage.tsx
@@ -29,14 +29,18 @@ export const ReviewPage: React.FC = () => {
 
   const currentReview = fullReview || statusReview
 
-  const handleShare = () => {
+  const handleShare = async () => {
+    if (!reviewId) return
 
-    // TODO: GENERATE UNIQUE LINK TO PUBLICLY SHARE
-
-    const url = window.location.href // need to generate NEW link
-    navigator.clipboard.writeText(url).then(() => {
-      alert('Review link copied to clipboard!')
-    })
+    try {
+      const { share_url, expires_at } = await apiClient.shareReview(reviewId)
+      const url = `${window.location.origin}${share_url}`
+      await navigator.clipboard.writeText(url)
+      const expiresDate = new Date(expires_at).toLocaleDateString()
+      alert(`Review link copied to clipboard! Link expires on ${expiresDate}.`)
+    } catch (err) {
+      alert(err instanceof Error ? err.message : 'Failed to generate share link')
+    }
   }
 
   const handleExport = () => {
@@ -114,9 +118,6 @@ ${section.suggestions.map((s) => `- ${s}`).join('\n')}
             <div className="mb-8 flex items-center justify-between">
               <h1 className="text-3xl font-bold text-gray-900">Portfolio Review</h1>
               <div className="flex items-center gap-3">
-
-              # Button to trigger new link
-
                 <button
                   onClick={handleShare}
                   className="inline-flex items-center gap-2 px-4 py-2 border border-gray-300 hover:bg-gray-50 text-gray-700 font-medium rounded-lg transition-colors"

--- a/frontend/src/pages/ReviewPage.tsx
+++ b/frontend/src/pages/ReviewPage.tsx
@@ -33,7 +33,7 @@ export const ReviewPage: React.FC = () => {
 
     // TODO: GENERATE UNIQUE LINK TO PUBLICLY SHARE
 
-    const url = window.location.href // random link is already generated
+    const url = window.location.href // need to generate NEW link
     navigator.clipboard.writeText(url).then(() => {
       alert('Review link copied to clipboard!')
     })

--- a/frontend/src/pages/ReviewPage.tsx
+++ b/frontend/src/pages/ReviewPage.tsx
@@ -30,7 +30,10 @@ export const ReviewPage: React.FC = () => {
   const currentReview = fullReview || statusReview
 
   const handleShare = () => {
-    const url = window.location.href
+
+    // TODO: GENERATE UNIQUE LINK TO PUBLICLY SHARE
+
+    const url = window.location.href // random link is already generated
     navigator.clipboard.writeText(url).then(() => {
       alert('Review link copied to clipboard!')
     })
@@ -111,6 +114,9 @@ ${section.suggestions.map((s) => `- ${s}`).join('\n')}
             <div className="mb-8 flex items-center justify-between">
               <h1 className="text-3xl font-bold text-gray-900">Portfolio Review</h1>
               <div className="flex items-center gap-3">
+
+              # Button to trigger new link
+
                 <button
                   onClick={handleShare}
                   className="inline-flex items-center gap-2 px-4 py-2 border border-gray-300 hover:bg-gray-50 text-gray-700 font-medium rounded-lg transition-colors"

--- a/frontend/src/pages/SharedReviewPage.tsx
+++ b/frontend/src/pages/SharedReviewPage.tsx
@@ -1,0 +1,103 @@
+import React, { useEffect, useState } from 'react'
+import { useParams } from 'react-router-dom'
+import { Loader, Clock } from 'lucide-react'
+import { ReviewSection } from '../components/ReviewSection'
+import { apiClient } from '../services/api'
+import { Review } from '../types'
+
+export const SharedReviewPage: React.FC = () => {
+  const { reviewId } = useParams<{ reviewId: string }>()
+  const [review, setReview] = useState<Review | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    if (!reviewId) return
+
+    const fetchSharedReview = async () => {
+      try {
+        const data = await apiClient.getSharedReview(reviewId)
+        setReview(data)
+      } catch (err) {
+        setError(
+          err instanceof Error ? err.message : 'This review is private or the link has expired'
+        )
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    fetchSharedReview()
+  }, [reviewId])
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        {isLoading && (
+          <div className="mb-12 p-8 bg-white rounded-lg shadow text-center">
+            <Loader className="w-8 h-8 animate-spin text-blue-600 mx-auto mb-4" />
+            <p className="text-gray-900 font-semibold">Loading shared review...</p>
+          </div>
+        )}
+
+        {!isLoading && error && (
+          <div className="p-8 bg-red-50 border border-red-200 rounded-lg text-center">
+            <p className="text-red-800 font-semibold">Review Unavailable</p>
+            <p className="text-red-600 text-sm mt-2">{error}</p>
+          </div>
+        )}
+
+        {!isLoading && review && (
+          <>
+            <div className="mb-6">
+              <h1 className="text-3xl font-bold text-gray-900">Portfolio Review</h1>
+              {review.share_expires_at && (
+                <p className="mt-2 flex items-center gap-2 text-sm text-gray-500">
+                  <Clock className="w-4 h-4" />
+                  Shared link expires on {new Date(review.share_expires_at).toLocaleDateString()}
+                </p>
+              )}
+            </div>
+
+            {review.status === 'failed' && (
+              <div className="mb-12 p-8 bg-red-50 border border-red-200 rounded-lg text-center">
+                <p className="text-red-800 font-semibold">Review Failed</p>
+                <p className="text-red-600 text-sm mt-2">{review.error_message || 'An error occurred'}</p>
+              </div>
+            )}
+
+            {review.status === 'complete' && (
+              <>
+                {review.overall_score !== undefined && (
+                  <div className="mb-8 bg-white rounded-lg shadow p-8">
+                    <h2 className="text-lg font-semibold text-gray-900 mb-4">Overall Score</h2>
+                    <div className="w-full bg-gray-200 rounded-full h-4 overflow-hidden">
+                      <div
+                        className="h-full bg-blue-600 transition-all"
+                        style={{ width: `${review.overall_score * 100}%` }}
+                      ></div>
+                    </div>
+                    <p className="mt-2 text-2xl font-bold text-blue-600">
+                      {Math.round(review.overall_score * 100)}/100
+                    </p>
+                  </div>
+                )}
+
+                <div className="space-y-6">
+                  <h2 className="text-2xl font-bold text-gray-900">Feedback</h2>
+                  {review.sections && review.sections.length > 0 ? (
+                    review.sections.map((section, index) => (
+                      <ReviewSection key={index} section={section} />
+                    ))
+                  ) : (
+                    <p className="text-gray-600">No feedback sections available</p>
+                  )}
+                </div>
+              </>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,4 +1,4 @@
-import { AuthResponse, Profile, Review, ReviewListResponse } from '../types'
+import { AuthResponse, Profile, Review, ReviewListResponse, ShareLinkResponse } from '../types'
 
 const API_BASE = '/api'
 
@@ -105,6 +105,10 @@ class ApiClient {
 
   async getReviewStatus(id: string): Promise<Review> {
     return this.request(`/reviews/${id}/status`)
+  }
+
+  async shareReview(id: string): Promise<ShareLinkResponse> {
+    return this.request(`/reviews/${id}/share`, { method: 'POST' })
   }
 
   async listReviews(page: number = 1, pageSize: number = 10): Promise<ReviewListResponse> {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -111,6 +111,10 @@ class ApiClient {
     return this.request(`/reviews/${id}/share`, { method: 'POST' })
   }
 
+  async getSharedReview(id: string): Promise<Review> {
+    return this.request(`/reviews/${id}/shared`)
+  }
+
   async listReviews(page: number = 1, pageSize: number = 10): Promise<ReviewListResponse> {
     return this.request(`/reviews?page=${page}&page_size=${pageSize}`)
   }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -26,8 +26,17 @@ export interface Review {
   overall_score?: number
   sections?: FeedbackSection[]
   error_message?: string
+  is_public: boolean
+  share_expires_at?: string | null
   created_at: string
   updated_at: string
+}
+
+export interface ShareLinkResponse {
+  review_id: string
+  is_public: boolean
+  share_url: string
+  expires_at: string
 }
 
 export interface ReviewListResponse {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,9 @@ select = ["E", "F", "I", "N", "W", "UP", "B", "SIM", "TCH"]
 "scripts/*.py" = ["E501"]
 "alembic/versions/*.py" = ["E501"]
 
+[tool.ruff.lint.flake8-bugbear]
+extend-immutable-calls = ["fastapi.Depends", "fastapi.Query", "fastapi.Body"]
+
 [tool.black]
 target-version = ["py311"]
 line-length = 100

--- a/tests/unit/test_review_service.py
+++ b/tests/unit/test_review_service.py
@@ -1,14 +1,17 @@
 """Tests for review_service.py"""
 
-import pytest
-from uuid import uuid4
+from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, Mock, patch
-import asyncio
+from uuid import UUID, uuid4
+
+import pytest
 
 from core.services.review_service import (
     create_review,
     get_review,
+    get_shared_review,
     list_reviews,
+    share_review,
 )
 
 
@@ -17,7 +20,7 @@ class TestReviewService:
     """Test suite for review_service module."""
 
     @pytest.fixture
-    def mock_db_session(self):
+    def mock_db_session(self) -> AsyncMock:
         """Create a mock async database session."""
         session = AsyncMock()
         session.add = Mock()
@@ -27,7 +30,7 @@ class TestReviewService:
         return session
 
     @pytest.fixture
-    def mock_review(self):
+    def mock_review(self) -> Mock:
         """Create a mock Review object."""
         review = Mock()
         review.id = uuid4()
@@ -37,7 +40,7 @@ class TestReviewService:
         return review
 
     @pytest.fixture
-    def mock_profile(self):
+    def mock_profile(self) -> Mock:
         """Create a mock Profile object."""
         profile = Mock()
         profile.id = uuid4()
@@ -45,7 +48,9 @@ class TestReviewService:
         return profile
 
     @pytest.mark.asyncio
-    async def test_create_review_returns_review_with_pending_status(self, mock_db_session, mock_review):
+    async def test_create_review_returns_review_with_pending_status(
+        self, mock_db_session: AsyncMock, mock_review: Mock
+    ) -> None:
         """Test create_review returns Review with status='pending'."""
         profile_id = uuid4()
         user_id = uuid4()
@@ -55,21 +60,23 @@ class TestReviewService:
         mock_db_session.commit = AsyncMock()
         mock_db_session.refresh = AsyncMock()
 
-        with patch('core.services.review_service.Review') as MockReview:
-            mock_instance = MockReview.return_value
+        with patch("core.services.review_service.Review") as mock_review_cls:
+            mock_instance = mock_review_cls.return_value
             mock_instance.status = "pending"
             mock_instance.sections = None
             mock_instance.overall_score = None
 
-            result = await create_review(mock_db_session, profile_id, user_id)
+            await create_review(mock_db_session, profile_id, user_id)
 
             # Check that Review was instantiated
-            MockReview.assert_called()
-            call_kwargs = MockReview.call_args[1]
-            assert call_kwargs['status'] == "pending"
+            mock_review_cls.assert_called()
+            call_kwargs = mock_review_cls.call_args[1]
+            assert call_kwargs["status"] == "pending"
 
     @pytest.mark.asyncio
-    async def test_get_review_returns_review_for_correct_owner(self, mock_db_session):
+    async def test_get_review_returns_review_for_correct_owner(
+        self, mock_db_session: AsyncMock
+    ) -> None:
         """Test get_review returns review when user_id matches."""
         review_id = uuid4()
         user_id = uuid4()
@@ -88,10 +95,9 @@ class TestReviewService:
         mock_db_session.execute.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_get_review_returns_none_for_wrong_user(self, mock_db_session):
+    async def test_get_review_returns_none_for_wrong_user(self, mock_db_session: AsyncMock) -> None:
         """Test get_review returns None when user_id doesn't match."""
         review_id = uuid4()
-        user_id = uuid4()
         wrong_user_id = uuid4()
 
         # Setup mock to return None
@@ -104,7 +110,7 @@ class TestReviewService:
         assert result is None
 
     @pytest.mark.asyncio
-    async def test_list_reviews_returns_paginated_results(self, mock_db_session):
+    async def test_list_reviews_returns_paginated_results(self, mock_db_session: AsyncMock) -> None:
         """Test list_reviews returns paginated results."""
         user_id = uuid4()
 
@@ -123,7 +129,9 @@ class TestReviewService:
         assert total >= 0
 
     @pytest.mark.asyncio
-    async def test_list_reviews_page_2_returns_correct_offset(self, mock_db_session):
+    async def test_list_reviews_page_2_returns_correct_offset(
+        self, mock_db_session: AsyncMock
+    ) -> None:
         """Test list_reviews page 2 returns correct offset."""
         user_id = uuid4()
         page_size = 20
@@ -133,9 +141,7 @@ class TestReviewService:
         mock_result.scalars.return_value.all.return_value = []
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
-        reviews, total = await list_reviews(
-            mock_db_session, user_id, page=2, page_size=page_size
-        )
+        await list_reviews(mock_db_session, user_id, page=2, page_size=page_size)
 
         # Second call should pass offset for page 2
         calls = mock_db_session.execute.call_args_list
@@ -143,7 +149,7 @@ class TestReviewService:
         assert len(calls) > 0
 
     @pytest.mark.asyncio
-    async def test_list_reviews_returns_tuple(self, mock_db_session):
+    async def test_list_reviews_returns_tuple(self, mock_db_session: AsyncMock) -> None:
         """Test list_reviews returns (reviews, total) tuple."""
         user_id = uuid4()
 
@@ -160,40 +166,40 @@ class TestReviewService:
         assert isinstance(total, int)
 
     @pytest.mark.asyncio
-    async def test_create_review_calls_db_add(self, mock_db_session):
+    async def test_create_review_calls_db_add(self, mock_db_session: AsyncMock) -> None:
         """Test create_review calls db.add()."""
         profile_id = uuid4()
         user_id = uuid4()
 
-        with patch('core.services.review_service.Review'):
+        with patch("core.services.review_service.Review"):
             await create_review(mock_db_session, profile_id, user_id)
 
             mock_db_session.add.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_create_review_calls_db_commit(self, mock_db_session):
+    async def test_create_review_calls_db_commit(self, mock_db_session: AsyncMock) -> None:
         """Test create_review calls db.commit()."""
         profile_id = uuid4()
         user_id = uuid4()
 
-        with patch('core.services.review_service.Review'):
+        with patch("core.services.review_service.Review"):
             await create_review(mock_db_session, profile_id, user_id)
 
             mock_db_session.commit.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_create_review_calls_db_refresh(self, mock_db_session):
+    async def test_create_review_calls_db_refresh(self, mock_db_session: AsyncMock) -> None:
         """Test create_review calls db.refresh()."""
         profile_id = uuid4()
         user_id = uuid4()
 
-        with patch('core.services.review_service.Review'):
+        with patch("core.services.review_service.Review"):
             await create_review(mock_db_session, profile_id, user_id)
 
             mock_db_session.refresh.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_get_review_uses_select_and_join(self, mock_db_session):
+    async def test_get_review_uses_select_and_join(self, mock_db_session: AsyncMock) -> None:
         """Test get_review constructs proper SQL with join."""
         review_id = uuid4()
         user_id = uuid4()
@@ -208,7 +214,7 @@ class TestReviewService:
         mock_db_session.execute.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_list_reviews_default_pagination(self, mock_db_session):
+    async def test_list_reviews_default_pagination(self, mock_db_session: AsyncMock) -> None:
         """Test list_reviews uses default pagination."""
         user_id = uuid4()
 
@@ -223,7 +229,7 @@ class TestReviewService:
         assert isinstance(total, int)
 
     @pytest.mark.asyncio
-    async def test_list_reviews_custom_page_size(self, mock_db_session):
+    async def test_list_reviews_custom_page_size(self, mock_db_session: AsyncMock) -> None:
         """Test list_reviews with custom page size."""
         user_id = uuid4()
         custom_page_size = 50
@@ -232,28 +238,28 @@ class TestReviewService:
         mock_result.scalars.return_value.all.return_value = []
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
-        reviews, total = await list_reviews(
+        reviews, _total = await list_reviews(
             mock_db_session, user_id, page=1, page_size=custom_page_size
         )
 
         assert isinstance(reviews, list)
 
     @pytest.mark.asyncio
-    async def test_create_review_with_uuid_ids(self, mock_db_session):
+    async def test_create_review_with_uuid_ids(self, mock_db_session: AsyncMock) -> None:
         """Test create_review handles UUID objects correctly."""
         profile_id = uuid4()
         user_id = uuid4()
 
-        with patch('core.services.review_service.Review') as MockReview:
-            MockReview.return_value = Mock()
+        with patch("core.services.review_service.Review") as mock_review_cls:
+            mock_review_cls.return_value = Mock()
             await create_review(mock_db_session, profile_id, user_id)
 
-            call_kwargs = MockReview.call_args[1]
-            assert 'profile_id' in call_kwargs
-            assert 'status' in call_kwargs
+            call_kwargs = mock_review_cls.call_args[1]
+            assert "profile_id" in call_kwargs
+            assert "status" in call_kwargs
 
     @pytest.mark.asyncio
-    async def test_get_review_verifies_ownership(self, mock_db_session):
+    async def test_get_review_verifies_ownership(self, mock_db_session: AsyncMock) -> None:
         """Test get_review checks Profile.user_id matches."""
         review_id = uuid4()
         user_id = uuid4()
@@ -268,7 +274,7 @@ class TestReviewService:
         mock_db_session.execute.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_list_reviews_counts_total(self, mock_db_session):
+    async def test_list_reviews_counts_total(self, mock_db_session: AsyncMock) -> None:
         """Test list_reviews calculates total count."""
         user_id = uuid4()
 
@@ -277,41 +283,43 @@ class TestReviewService:
         mock_result.scalars.return_value.all.return_value = mock_reviews
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
-        reviews, total = await list_reviews(mock_db_session, user_id)
+        _reviews, total = await list_reviews(mock_db_session, user_id)
 
         # Total should be counted
         assert isinstance(total, int)
 
     @pytest.mark.asyncio
-    async def test_list_reviews_returns_reviews_list(self, mock_db_session):
+    async def test_list_reviews_returns_reviews_list(self, mock_db_session: AsyncMock) -> None:
         """Test list_reviews returns list of Review objects."""
         user_id = uuid4()
 
-        mock_reviews = [Mock(spec=['id', 'status']) for _ in range(3)]
+        mock_reviews = [Mock(spec=["id", "status"]) for _ in range(3)]
         mock_result = AsyncMock()
         mock_result.scalars.return_value.all.return_value = mock_reviews
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
-        reviews, total = await list_reviews(mock_db_session, user_id)
+        reviews, _total = await list_reviews(mock_db_session, user_id)
 
         assert isinstance(reviews, list)
 
     @pytest.mark.asyncio
-    async def test_review_sections_and_score_initially_none(self, mock_db_session):
+    async def test_review_sections_and_score_initially_none(
+        self, mock_db_session: AsyncMock
+    ) -> None:
         """Test review has None for sections and overall_score initially."""
         profile_id = uuid4()
         user_id = uuid4()
 
-        with patch('core.services.review_service.Review') as MockReview:
-            MockReview.return_value = Mock()
+        with patch("core.services.review_service.Review") as mock_review_cls:
+            mock_review_cls.return_value = Mock()
             await create_review(mock_db_session, profile_id, user_id)
 
-            call_kwargs = MockReview.call_args[1]
-            assert call_kwargs['sections'] is None
-            assert call_kwargs['overall_score'] is None
+            call_kwargs = mock_review_cls.call_args[1]
+            assert call_kwargs["sections"] is None
+            assert call_kwargs["overall_score"] is None
 
     @pytest.mark.asyncio
-    async def test_get_review_with_valid_uuid(self, mock_db_session):
+    async def test_get_review_with_valid_uuid(self, mock_db_session: AsyncMock) -> None:
         """Test get_review handles valid UUID parameters."""
         review_id = uuid4()
         user_id = uuid4()
@@ -326,7 +334,7 @@ class TestReviewService:
         assert result is None or result is not None  # Just verify no exception
 
     @pytest.mark.asyncio
-    async def test_list_reviews_ordered_by_created_at(self, mock_db_session):
+    async def test_list_reviews_ordered_by_created_at(self, mock_db_session: AsyncMock) -> None:
         """Test list_reviews returns results ordered by created_at desc."""
         user_id = uuid4()
 
@@ -334,7 +342,178 @@ class TestReviewService:
         mock_result.scalars.return_value.all.return_value = []
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
-        reviews, total = await list_reviews(mock_db_session, user_id)
+        await list_reviews(mock_db_session, user_id)
 
         # Should order by created_at descending
         mock_db_session.execute.assert_called_once()
+
+
+@pytest.mark.unit
+class TestReviewSharing:
+    """Test suite for share_review and get_shared_review in review_service."""
+
+    @pytest.fixture
+    def mock_db_session(self) -> AsyncMock:
+        """Create a mock async database session."""
+        session = AsyncMock()
+        session.add = Mock()
+        session.commit = AsyncMock()
+        session.refresh = AsyncMock()
+        session.execute = AsyncMock()
+        return session
+
+    @staticmethod
+    def _make_review(
+        review_id: UUID | None = None,
+        is_public: bool = False,
+        share_expires_at: datetime | None = None,
+    ) -> Mock:
+        review = Mock()
+        review.id = review_id or uuid4()
+        review.is_public = is_public
+        review.share_expires_at = share_expires_at
+        return review
+
+    @pytest.mark.asyncio
+    async def test_share_review_returns_none_when_review_not_found(
+        self, mock_db_session: AsyncMock
+    ) -> None:
+        """share_review returns None when the review doesn't exist or isn't owned by the user."""
+        with patch("core.services.review_service.get_review", new=AsyncMock(return_value=None)):
+            result = await share_review(mock_db_session, uuid4(), uuid4())
+
+        assert result is None
+        mock_db_session.commit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_share_review_activates_sharing_for_unshared_review(
+        self, mock_db_session: AsyncMock
+    ) -> None:
+        """Sharing a review for the first time makes it public with a 30-day expiry."""
+        review = self._make_review(is_public=False, share_expires_at=None)
+
+        with patch("core.services.review_service.get_review", new=AsyncMock(return_value=review)):
+            result = await share_review(mock_db_session, review.id, uuid4())
+
+        assert result is review
+        assert review.is_public is True
+        assert review.share_expires_at is not None
+
+        expected_expiry = datetime.utcnow() + timedelta(days=30)
+        assert abs((review.share_expires_at - expected_expiry).total_seconds()) < 5
+        mock_db_session.commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_share_review_generates_distinct_links_for_distinct_reviews(
+        self, mock_db_session: AsyncMock
+    ) -> None:
+        """Each review's public link is derived from its own unique ID."""
+        review_a = self._make_review(is_public=False)
+        review_b = self._make_review(is_public=False)
+
+        with patch("core.services.review_service.get_review", new=AsyncMock(return_value=review_a)):
+            result_a = await share_review(mock_db_session, review_a.id, uuid4())
+        with patch("core.services.review_service.get_review", new=AsyncMock(return_value=review_b)):
+            result_b = await share_review(mock_db_session, review_b.id, uuid4())
+
+        assert result_a is not None
+        assert result_b is not None
+        assert result_a.id != result_b.id
+
+    @pytest.mark.asyncio
+    async def test_share_review_link_is_idempotent_while_still_valid(
+        self, mock_db_session: AsyncMock
+    ) -> None:
+        """Re-sharing an already-public, non-expired review must not regenerate the link."""
+        original_expiry = datetime.utcnow() + timedelta(days=10)
+        review = self._make_review(is_public=True, share_expires_at=original_expiry)
+
+        with patch("core.services.review_service.get_review", new=AsyncMock(return_value=review)):
+            result = await share_review(mock_db_session, review.id, uuid4())
+
+        assert result is review
+        assert review.share_expires_at == original_expiry
+        mock_db_session.commit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_share_review_regenerates_expiry_once_link_has_expired(
+        self, mock_db_session: AsyncMock
+    ) -> None:
+        """Re-sharing after expiry re-activates the same link with a fresh 30-day expiry."""
+        expired_at = datetime.utcnow() - timedelta(days=1)
+        review = self._make_review(is_public=True, share_expires_at=expired_at)
+
+        with patch("core.services.review_service.get_review", new=AsyncMock(return_value=review)):
+            result = await share_review(mock_db_session, review.id, uuid4())
+
+        assert result is review
+        assert review.is_public is True
+        assert review.share_expires_at > datetime.utcnow()
+        mock_db_session.commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_get_shared_review_returns_review_when_public_and_not_expired(
+        self, mock_db_session: AsyncMock
+    ) -> None:
+        """A valid, unexpired public link resolves to the review."""
+        review = self._make_review(
+            is_public=True, share_expires_at=datetime.utcnow() + timedelta(days=5)
+        )
+
+        mock_result = Mock()
+        mock_result.scalars.return_value.first.return_value = review
+        mock_db_session.execute = AsyncMock(return_value=mock_result)
+
+        result = await get_shared_review(mock_db_session, review.id)
+
+        assert result is review
+        mock_db_session.commit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_get_shared_review_returns_none_when_review_missing(
+        self, mock_db_session: AsyncMock
+    ) -> None:
+        """An unknown review ID resolves to no shared review."""
+        mock_result = Mock()
+        mock_result.scalars.return_value.first.return_value = None
+        mock_db_session.execute = AsyncMock(return_value=mock_result)
+
+        result = await get_shared_review(mock_db_session, uuid4())
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_get_shared_review_returns_none_when_not_public(
+        self, mock_db_session: AsyncMock
+    ) -> None:
+        """A review that exists but was never shared is not accessible publicly."""
+        review = self._make_review(
+            is_public=False, share_expires_at=datetime.utcnow() + timedelta(days=5)
+        )
+
+        mock_result = Mock()
+        mock_result.scalars.return_value.first.return_value = review
+        mock_db_session.execute = AsyncMock(return_value=mock_result)
+
+        result = await get_shared_review(mock_db_session, review.id)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_get_shared_review_expires_link_and_returns_none(
+        self, mock_db_session: AsyncMock
+    ) -> None:
+        """Accessing an expired shared link flips is_public back to False and denies access."""
+        review = self._make_review(
+            is_public=True, share_expires_at=datetime.utcnow() - timedelta(days=1)
+        )
+
+        mock_result = Mock()
+        mock_result.scalars.return_value.first.return_value = review
+        mock_db_session.execute = AsyncMock(return_value=mock_result)
+
+        result = await get_shared_review(mock_db_session, review.id)
+
+        assert result is None
+        assert review.is_public is False
+        mock_db_session.commit.assert_called_once()

--- a/tests/unit/test_review_service.py
+++ b/tests/unit/test_review_service.py
@@ -1,6 +1,6 @@
 """Tests for review_service.py"""
 
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, Mock, patch
 from uuid import UUID, uuid4
 
@@ -399,7 +399,7 @@ class TestReviewSharing:
         assert review.is_public is True
         assert review.share_expires_at is not None
 
-        expected_expiry = datetime.utcnow() + timedelta(days=30)
+        expected_expiry = datetime.now(UTC) + timedelta(days=30)
         assert abs((review.share_expires_at - expected_expiry).total_seconds()) < 5
         mock_db_session.commit.assert_called_once()
 
@@ -425,7 +425,7 @@ class TestReviewSharing:
         self, mock_db_session: AsyncMock
     ) -> None:
         """Re-sharing an already-public, non-expired review must not regenerate the link."""
-        original_expiry = datetime.utcnow() + timedelta(days=10)
+        original_expiry = datetime.now(UTC) + timedelta(days=10)
         review = self._make_review(is_public=True, share_expires_at=original_expiry)
 
         with patch("core.services.review_service.get_review", new=AsyncMock(return_value=review)):
@@ -440,7 +440,7 @@ class TestReviewSharing:
         self, mock_db_session: AsyncMock
     ) -> None:
         """Re-sharing after expiry re-activates the same link with a fresh 30-day expiry."""
-        expired_at = datetime.utcnow() - timedelta(days=1)
+        expired_at = datetime.now(UTC) - timedelta(days=1)
         review = self._make_review(is_public=True, share_expires_at=expired_at)
 
         with patch("core.services.review_service.get_review", new=AsyncMock(return_value=review)):
@@ -448,7 +448,7 @@ class TestReviewSharing:
 
         assert result is review
         assert review.is_public is True
-        assert review.share_expires_at > datetime.utcnow()
+        assert review.share_expires_at > datetime.now(UTC)
         mock_db_session.commit.assert_called_once()
 
     @pytest.mark.asyncio
@@ -457,7 +457,7 @@ class TestReviewSharing:
     ) -> None:
         """A valid, unexpired public link resolves to the review."""
         review = self._make_review(
-            is_public=True, share_expires_at=datetime.utcnow() + timedelta(days=5)
+            is_public=True, share_expires_at=datetime.now(UTC) + timedelta(days=5)
         )
 
         mock_result = Mock()
@@ -488,7 +488,7 @@ class TestReviewSharing:
     ) -> None:
         """A review that exists but was never shared is not accessible publicly."""
         review = self._make_review(
-            is_public=False, share_expires_at=datetime.utcnow() + timedelta(days=5)
+            is_public=False, share_expires_at=datetime.now(UTC) + timedelta(days=5)
         )
 
         mock_result = Mock()
@@ -505,7 +505,7 @@ class TestReviewSharing:
     ) -> None:
         """Accessing an expired shared link flips is_public back to False and denies access."""
         review = self._make_review(
-            is_public=True, share_expires_at=datetime.utcnow() - timedelta(days=1)
+            is_public=True, share_expires_at=datetime.now(UTC) - timedelta(days=1)
         )
 
         mock_result = Mock()


### PR DESCRIPTION
## Summary
This PR introduces changes to resolve issue #101. It implements the ability to allow users to share pathreview's review of their resume and other parts publicly using a temporary link. Additionally, new test cases are generated to be able to test link generation and expiration, as new columns are introduced for the Review table. 

## Issue
Closes #101 

## Changes
<!-- Bullet list of the specific changes made -->
- Edited database schema to include `is_public` and generated `expiration date` columns
- Implemented new API endpoints specific for sharing pages, specifically for link generation and link expiration
- Connected new API endpoints to frontend share button in review page tab
- Built new SharePage (using components from ReviewPage) viewable by any user until link expiration

## Testing
<!-- How did you verify your changes? -->
- [x] Unit tests pass (`make test-unit`)
- [x] Integration tests pass (`make test-integration`)
- [x] Linter passes (`make lint`)
- [x] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes

## Screenshots / Demo
https://imgur.com/a/kxXCX2e

## Notes for Reviewers
<!-- Anything the reviewer should pay particular attention to -->
