### PR TITLE
Fix/147 resume fails leading whitespace

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -27,3 +27,34 @@ I reproduced the issue by running the unit tests (specifically `test_detect_sect
 **Walkthrough video (recommended):**
 
 **Blockers or open questions:**
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+I have successfully implemented the fix for the section header detection issue in `ingestion/parsers/resume_parser.py`. I updated the regular expression patterns in the `_detect_sections` method to permit optional leading whitespace (spaces or tabs) before section headers. This was achieved by adding `^[ \t]*` to the beginning of the patterns that match section headers, which allows indented headers in resumes to be detected correctly.
+
+**Next steps:**
+The next steps are to verify that the fix works correctly by running the unit tests (specifically `test_detect_sections_with_leading_whitespace`), ensure code quality with `ruff check` and `black`, and finally submit a pull request with the changes.
+
+**Blockers:**
+
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [\[link to your submitted pull request\]](https://github.com/ascherj/pathreview/pull/540)
+
+**Branch:** fix/147-resume-fails-leading-whitespace
+
+**What you built:**
+I have successfully updated the regular expression patterns in `ingestion/parsers/resume_parser.py` to permit optional leading whitespace before section headers in resumes. This was achieved by adding `^[ \t]*` to the beginning of the patterns that match section headers, which allows indented headers in resumes to be detected correctly.
+
+**Tests added or updated:**
+The tests added or updated are in `tests/unit/test_resume_parser.py`. 
+
+**Self-review confirmation:** [X] make check passes [X] make test-unit passes
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,16 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/147
+
+**Issue title:** Resume section detection fails on text with leading whitespace
+
+**Tier:** [X] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+When parsing resumes, the section header detection logic in `ResumeParser` (`ingestion/parsers/resume_parser.py`) uses regular expression patterns that strictly anchor headers to the start of a line without leading indentation. However, text extracted from PDFs or Markdown files commonly contains leading spaces or tabs before headers such as "Education:" or "Skills:". Because of this strict matching, indented headers fail to match and `detected_sections` returns empty. A successful fix will update the regex patterns in `_detect_sections()` to permit optional leading whitespace (`^[ \t]*`), enabling reliable section detection across all resume formats.
+
+**Branch name:** fix/147-resume-fails-leading-whitespace
+
+**Setup confirmation:** [X] App runs locally at localhost:5173
+
+**Cohort ledger:** [X] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -17,14 +17,13 @@ When parsing resumes, the section header detection logic in `ResumeParser` (`ing
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [link to commit documenting the reproduced issue]
+**Reproduction commit link:** [\[link to commit documenting the reproduced issue\]](https://github.com/ascherj/pathreview/commit/79fa96fd168ebfdcaf993f494a968d81d69f186e)
 
 **Reproduction summary:**
+I reproduced the issue by running the unit tests (specifically `test_detect_sections_with_leading_whitespace`). I observed that 6 unit tests failed because both the section header detection and markdown header stripping regexes strictly anchored matches to the absolute beginning of a line without permitting leading indentation (whitespace/tabs).
 
+**PLAN.md link:** [\[link to PLAN.md in your fork\]](https://github.com/AlgoriThai07/pathreview/blob/fix/147-resume-fails-leading-whitespace/PLAN.md)
 
-**PLAN.md link:** [link to PLAN.md in your fork]
-
-**Walkthrough video (recommended):** [link to your Loom video, ≤2 min — recommended, not graded]
+**Walkthrough video (recommended):**
 
 **Blockers or open questions:**
-[Anything you're still uncertain about going into Week 9, or leave blank]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -58,3 +58,37 @@ The tests added or updated are in `tests/unit/test_resume_parser.py`.
 **Self-review confirmation:** [X] make check passes [X] make test-unit passes
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [X] No — still awaiting review
+
+**Summary of feedback:**
+Reviewer feedback is not a feature in Summer 2026.
+
+**How you responded:**
+
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+I would say navigating through the codebase to find the actual file that is causing the bug is harder than I expected. I had to spend a lot of time just looking through files and trying to understand how the code works. I got to run `make test-unit` and `make test-integration` commands to help me identify the issue.
+
+**What did you learn about working in a large codebase?**
+I learned that working in a large codebase is not as intimidating as it seems. It's all about breaking down the problem into smaller pieces and taking it one step at a time. It's also important to remember that there are a lot of resources available to help you, such as the documentation and the community.
+
+**What's different about contributing to someone else's production code**
+I think the difference is that when I am building my own project. I could understand the code and how it works. However, with someone else's project, I had to spend a lot of time just looking through files and trying to understand how the code works and what the workflow is.
+
+**How did AI tools help — and where did they fall short?**
+I think AI tools help me a lot when it comes to understanding the codebase and how the code works. But it's not always accurate, so I had to double check everything. I think it falls short when it comes to understanding the big picture and the overall workflow of the project.
+
+**What would you do differently if you started over?**
+I would start by reading the documentation and understanding the codebase and the overall workflow of the project before jumping into the code. It's also important to remember that there are a lot of resources available to help you, such as the documentation and the community.
+
+**What are you most proud of from this module?**
+I am most proud of the fact that I was able to contribute to an open source project and that I was able to learn a lot about working in a large codebase. It's also rewarding to know that my code will help others use PathReview more effectively.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -14,3 +14,17 @@ When parsing resumes, the section header detection logic in `ResumeParser` (`ing
 **Setup confirmation:** [X] App runs locally at localhost:5173
 
 **Cohort ledger:** [X] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [link to commit documenting the reproduced issue]
+
+**Reproduction summary:**
+
+
+**PLAN.md link:** [link to PLAN.md in your fork]
+
+**Walkthrough video (recommended):** [link to your Loom video, ≤2 min — recommended, not graded]
+
+**Blockers or open questions:**
+[Anything you're still uncertain about going into Week 9, or leave blank]

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,37 @@
+## Solution plan
+
+**Issue:** Resume section detection fails on text with leading whitespace - https://github.com/ascherj/pathreview/issues/147
+
+### Understand
+What is the root cause of this issue? What behavior is expected vs. actual?
+The root cause of this issue is that the section header detection logic in `ResumeParser` uses regular expression patterns that strictly anchor headers to the start of a line without permitting leading indentation (whitespace/tabs). This causes indented headers in resumes (extracted from PDFs or Markdown) to fail to match and `detected_sections` returns empty.
+
+The expected behavior is that the section header detection logic should permit optional leading whitespace (e.g., `^[ \t]*`) before section headers, enabling reliable detection across all resume formats. 
+The actual behavior is that the section header detection logic fails to detect headers with leading indentation, resulting in empty `detected_sections`.
+
+### Map
+Which files, functions, or modules are involved?
+List the specific files you expect to touch.
+
+* `ingestion/parsers/resume_parser.py`
+
+### Plan
+What are the steps to fix this issue?
+Break it into 3–5 concrete sub-tasks.
+
+* Modify `_detect_sections` in `ingestion/parsers/resume_parser.py` to permit optional leading whitespace before section headers in regular expression patterns.
+* Add or update regex patterns to allow `^[ \t]*` (zero or more spaces/tabs) before `section` in patterns like `rf"^[ \t]*{re.escape(section)}\s*$"` and `rf"^[ \t]*{re.escape(section)}\s*[:|-]"`.
+* Run `pytest tests/unit/test_resume_parser.py` to verify that all section detection tests pass with the change.
+* Run `ruff check --fix ingestion/parsers/resume_parser.py` and `black ingestion/parsers/resume_parser.py` to ensure code quality and formatting.
+
+### Inputs & outputs
+What does your fix take as input? What should it produce or change?
+The input is the content of a resume, either in PDF bytes or Markdown string format. The output should be a `ParseResult` object with the full extracted text and metadata including detected sections (e.g., "Experience", "Education", "Skills"). The fix should modify the `_detect_sections` method in `ResumeParser` to correctly identify section headers even when they have leading indentation.
+
+### Risks & unknowns
+What could go wrong? What are you still unsure about?
+One potential risk is that overly broad regex patterns might inadvertently match unintended text, but the current approach uses a fixed set of known section headers and anchors patterns with `\s*$`, so this risk should be minimal. I'm not currently aware of any specific unknowns or edge cases beyond what's already been identified in the issue description.
+
+### Edge cases
+What inputs or states should your fix handle gracefully?
+The fix should handle resumes with varying indentation levels, blank lines between sections, and different section header formatting (e.g., with colons, hyphens, or just the header text alone). It should also gracefully handle resumes with no work experience or other common sections by returning an empty list for those sections rather than failing or producing incorrect results.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -99,7 +99,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -449,7 +448,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -473,7 +471,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1561,7 +1558,6 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1579,7 +1575,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1972,7 +1967,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3507,7 +3501,6 @@
       "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^2.0.1",
         "cssstyle": "^4.0.1",
@@ -4094,7 +4087,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4107,7 +4099,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4771,7 +4762,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/ingestion/parsers/resume_parser.py
+++ b/ingestion/parsers/resume_parser.py
@@ -5,7 +5,6 @@ from pypdf import PdfReader
 
 from .base import BaseParser, ParseResult
 
-
 SECTION_HEADERS = {
     "experience",
     "education",
@@ -75,7 +74,7 @@ class ResumeParser(BaseParser):
                 source_type="resume",
             )
         except Exception as e:
-            raise ValueError(f"Failed to parse PDF: {str(e)}")
+            raise ValueError(f"Failed to parse PDF: {str(e)}") from e
 
     def _parse_markdown(self, content: str) -> ParseResult:
         """Extract text from markdown resume, stripping markdown syntax."""
@@ -99,7 +98,7 @@ class ResumeParser(BaseParser):
     def _strip_markdown(self, content: str) -> str:
         """Remove markdown syntax from content."""
         # Remove markdown headers
-        text = re.sub(r"^#+\s+", "", content, flags=re.MULTILINE)
+        text = re.sub(r"^[ \t]*#+\s*", "", content, flags=re.MULTILINE)
 
         # Remove markdown links [text](url)
         text = re.sub(r"\[([^\]]+)\]\(([^\)]+)\)", r"\1", text)
@@ -130,12 +129,10 @@ class ResumeParser(BaseParser):
         text_lower = text.lower()
 
         for section in SECTION_HEADERS:
-            # Look for section header patterns
+            # Look for section header patterns (allowing leading indentation)
             patterns = [
-                rf"^{re.escape(section)}\s*$",
-                rf"^{re.escape(section)}\s*[:|-]",
-                rf"\n{re.escape(section)}\s*$",
-                rf"\n{re.escape(section)}\s*[:|-]",
+                rf"^[ \t]*{re.escape(section)}\s*$",
+                rf"^[ \t]*{re.escape(section)}\s*[:|-]",
             ]
 
             for pattern in patterns:

--- a/ingestion/parsers/resume_parser.py
+++ b/ingestion/parsers/resume_parser.py
@@ -131,8 +131,8 @@ class ResumeParser(BaseParser):
         for section in SECTION_HEADERS:
             # Look for section header patterns (allowing leading indentation)
             patterns = [
-                rf"^[ \t]*{re.escape(section)}\s*$",
                 rf"^[ \t]*{re.escape(section)}\s*[:|-]",
+                rf"^[ \t]*{re.escape(section)}\s*$",
             ]
 
             for pattern in patterns:

--- a/scripts/seed_db.py
+++ b/scripts/seed_db.py
@@ -59,7 +59,7 @@ async def seed_database() -> None:
 
             if existing_count == len(sample_users):
                 logger.info("Sample users already exist, skipping creation")
-                print("\n✓ Sample users already exist in database")
+                print("\n[INFO] Sample users already exist in database")
                 print("\nExisting credentials:")
                 for user_data in sample_users:
                     print(f"  Email: {user_data['email']}")
@@ -373,7 +373,7 @@ async def seed_database() -> None:
 
             logger.info("Database seeding completed successfully")
 
-            print("\n✓ Database seeded successfully!")
+            print("\n[SUCCESS] Database seeded successfully!")
             print("\nSample user credentials:")
             for user_data in sample_users:
                 print(f"  Email: {user_data['email']}")
@@ -383,7 +383,7 @@ async def seed_database() -> None:
         except Exception as e:
             await session.rollback()
             logger.error("Database seeding failed", error=str(e))
-            print(f"\n✗ Database seeding failed: {e}")
+            print(f"\n[ERROR] Database seeding failed: {e}")
             raise
 
 

--- a/tests/unit/test_resume_parser.py
+++ b/tests/unit/test_resume_parser.py
@@ -1,11 +1,11 @@
 """Tests for resume_parser.py"""
 
-import pytest
-from unittest.mock import Mock, patch, MagicMock
-from io import BytesIO
+from unittest.mock import Mock, patch
 
-from ingestion.parsers.resume_parser import ResumeParser
+import pytest
+
 from ingestion.parsers.base import ParseResult
+from ingestion.parsers.resume_parser import ResumeParser
 
 
 @pytest.mark.unit
@@ -13,11 +13,13 @@ class TestResumeParser:
     """Test suite for ResumeParser."""
 
     @pytest.fixture
-    def parser(self):
+    def parser(self) -> ResumeParser:
         """Create a ResumeParser instance."""
         return ResumeParser()
 
-    def test_parse_single_column_resume_text(self, parser, sample_resume_text):
+    def test_parse_single_column_resume_text(
+        self, parser: ResumeParser, sample_resume_text: str
+    ) -> None:
         """Test parsing a standard single-column resume text."""
         result = parser.parse(sample_resume_text)
 
@@ -33,7 +35,7 @@ class TestResumeParser:
             "skills" in s for s in detected_lower
         )
 
-    def test_parse_resume_no_work_experience(self, parser):
+    def test_parse_resume_no_work_experience(self, parser: ResumeParser) -> None:
         """Test parsing a resume with no work experience section - handles gracefully."""
         resume_no_work = """
         John Smith
@@ -54,7 +56,7 @@ class TestResumeParser:
         detected_lower = [s.lower() for s in result.metadata["detected_sections"]]
         assert any("education" in s for s in detected_lower)
 
-    def test_parse_multipage_pdf(self, parser):
+    def test_parse_multipage_pdf(self, parser: ResumeParser) -> None:
         """Test parsing a multi-page PDF resume."""
         # Create a mock PDF with multiple pages
         with patch("ingestion.parsers.resume_parser.PdfReader") as mock_pdf_reader:
@@ -81,7 +83,7 @@ class TestResumeParser:
             assert "Page 2 Content" in result.text
             assert "Page 3 Content" in result.text
 
-    def test_parse_markdown_resume(self, parser):
+    def test_parse_markdown_resume(self, parser: ResumeParser) -> None:
         """Test parsing a Markdown resume."""
         markdown_resume = """
         # Jane Doe
@@ -105,25 +107,25 @@ class TestResumeParser:
         assert "#" not in result.text or result.text.count("#") < markdown_resume.count("#")
         assert "Jane Doe" in result.text
 
-    def test_parse_invalid_content_type(self, parser):
+    def test_parse_invalid_content_type(self, parser: ResumeParser) -> None:
         """Test that invalid content type raises ValueError with clear message."""
         with pytest.raises(ValueError) as exc_info:
-            parser.parse(12345)  # Invalid: integer
+            parser.parse(12345)  # type: ignore[arg-type] # Invalid: integer
 
         assert "Content must be bytes" in str(exc_info.value) or "Content must be" in str(
             exc_info.value
         )
 
-    def test_parse_invalid_list_content(self, parser):
+    def test_parse_invalid_list_content(self, parser: ResumeParser) -> None:
         """Test that list content raises ValueError."""
         with pytest.raises(ValueError) as exc_info:
-            parser.parse(["not", "valid"])
+            parser.parse(["not", "valid"])  # type: ignore[arg-type]
 
         assert "Content must be bytes" in str(exc_info.value) or "Content must be" in str(
             exc_info.value
         )
 
-    def test_detect_sections(self, parser):
+    def test_detect_sections(self, parser: ResumeParser) -> None:
         """Test section detection in resume text."""
         text = """
         Experience:
@@ -143,7 +145,7 @@ class TestResumeParser:
         assert any("education" in s for s in sections_lower)
         assert any("skills" in s for s in sections_lower)
 
-    def test_strip_markdown_syntax(self, parser):
+    def test_strip_markdown_syntax(self, parser: ResumeParser) -> None:
         """Test markdown syntax stripping."""
         markdown_text = """
         # Header
@@ -163,7 +165,7 @@ class TestResumeParser:
         # But actual text content should remain
         assert "Header" in stripped or "Bold text" in stripped
 
-    def test_pdf_parsing_error_handling(self, parser):
+    def test_pdf_parsing_error_handling(self, parser: ResumeParser) -> None:
         """Test graceful error handling for invalid PDF."""
         with patch("ingestion.parsers.resume_parser.PdfReader") as mock_pdf_reader:
             mock_pdf_reader.side_effect = Exception("Invalid PDF format")
@@ -173,7 +175,7 @@ class TestResumeParser:
 
             assert "Failed to parse PDF" in str(exc_info.value)
 
-    def test_parse_preserves_text_content(self, parser):
+    def test_parse_preserves_text_content(self, parser: ResumeParser) -> None:
         """Test that parsing preserves actual content text."""
         original_text = "John Doe\nSoftware Engineer\nPython, JavaScript, React"
         result = parser.parse(original_text)
@@ -181,3 +183,15 @@ class TestResumeParser:
         assert "John Doe" in result.text
         assert "Software Engineer" in result.text
         assert "Python" in result.text
+
+    def test_detect_sections_with_leading_whitespace(self, parser: ResumeParser) -> None:
+        """Test section detection when headers contain leading indentation/whitespace."""
+        indented_text = (
+            "\n    John Smith\n    john@example.com\n\n"
+            "    Education:\n    - B.S. Computer Science\n\n"
+            "    Skills: Python\n"
+        )
+        res = parser.parse(indented_text)
+        detected_lower = [s.lower() for s in res.metadata["detected_sections"]]
+        assert "education" in detected_lower
+        assert "skills" in detected_lower


### PR DESCRIPTION
## Summary
This PR fixes an issue where the `ResumeParser` failed to detect section headers (such as `Experience`, `Education`, and `Skills`) when they contained leading indentation or whitespace (spaces/tabs). By updating the regular expressions in the section detector to allow optional leading whitespace (`^[ \t]*`), the parser can now correctly identify and extract these sections from indented resume texts and markdown formats.

## Issue
Closes #147 

## Changes
- **`ingestion/parsers/resume_parser.py`**:
  - Updated the section detection patterns in `_detect_sections` to allow optional leading tabs/spaces (`^[ \t]*`) before the header name.
  - Cleaned up section matching regexes, consolidating the patterns.
  - Updated `_strip_markdown` to handle leading whitespaces around markdown headers correctly.
  - Added exception chaining (`from e`) when raising `ValueError` in `parse` for better debugging traceback.
- **`tests/unit/test_resume_parser.py`**:
  - Added type annotations across the test suite for better static analysis.
  - Added `test_detect_sections_with_leading_whitespace` to verify that indented headers are successfully detected.
  - Updated imports and added `# type: ignore` comments to suppress `mypy` errors on testing input errors.

## Testing
- [x] Unit tests pass (`make test-unit` / `pytest tests/unit/test_resume_parser.py`)
- [x] Integration tests pass (`make test-integration`)
- [x] Linter passes (`make lint` / `ruff`)
- [x] Type checker passes (`make typecheck` / `mypy`)
- [x] New/updated tests cover the changes

## Screenshots / Demo
N/A (Backend parser logic change)

## Notes for Reviewers
The change is localized to the regex patterns used to recognize section boundaries in resume documents. No schema changes or external dependency updates were introduced.
