### PR TITLE
fix(api): build Redis health probe from settings.redis_url

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -67,3 +67,29 @@ AttributeError: 'Settings' object has no attribute 'redis_host'
   backend (uvicorn :8000) + Vite dev server (:5173). Confirmed the app is served at
   http://localhost:5173 (title "PathReview - AI Portfolio Review Assistant") and that the
   `/api` proxy reaches the backend.
+
+---
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/chaoyi09/pathreview/commit/f2fe872
+<!-- This commit adds tests/unit/test_health_route.py, whose
+     test_health_does_not_reference_removed_redis_host_fields asserts the Settings
+     model has no redis_host/redis_port. The Week 7 commit (b73de11) also documents the
+     reproduction steps under "Reproduction (local)" above. -->
+
+**Reproduction summary:**
+Importing the config and reading the field the health check relies on
+(`python -c "from core.config import settings; settings.redis_host"`) raises
+`AttributeError: 'Settings' object has no attribute 'redis_host'`, and hitting `GET /health`
+surfaces the same failure in the Redis probe — confirming the bug is real and lives in
+`api/routes/health.py` reading a field that `core/config.py` never defines.
+
+**PLAN.md link:** https://github.com/chaoyi09/pathreview/blob/fix/155-health-redis-host/PLAN.md
+
+**Walkthrough video (recommended):** [optional — add Loom link here if I record one]
+
+**Blockers or open questions:**
+None blocking. Note: `GET /health` also returns 503 because of a *separate* SQLAlchemy 2.x
+bug (`db.execute("SELECT 1")` needs `text(...)`), which is out of scope for #155 — I verify
+my Redis fix by checking the `redis` sub-status, not the overall status.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -147,3 +147,123 @@ this branch (the 3 extra passes are the new tests). Documented in the PR
 description.
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [x] Yes  [ ] No — still awaiting review
+
+**Summary of feedback:**
+
+sh4wnbk reviewed PR #541 on Aug 2, after I requested review in the cohort Slack
+channel. Rather than taking the PR description at face value, he checked the fix
+independently against `core/config.py` and confirmed that `redis_url` is defined on
+`Settings` while `redis_host` / `redis_port` are not. He read all three tests
+individually and agreed that mocking Redis and overriding `get_db` was the right way
+to keep them independent of live services. He also said that explicitly flagging the
+SQLAlchemy `text()` issue (#154) as out of scope was a good call, and that #160
+lacking regression tests is a fair reason to prefer my scoping.
+
+Two items were actionable:
+
+1. **Optional suggestion.** Add an assertion verifying that a URL such as
+   `redis://:pass@host:6379/2` is parsed correctly, since `from_url` honours auth and
+   a non-default db index where the old hardcoded `db=0` client did not. He explicitly
+   framed this as a nice-to-have rather than a necessity.
+2. **Answer to my open question.** In my PR description I had offered to drop
+   `test_health_does_not_reference_removed_redis_host_fields` if a maintainer would
+   rather not constrain the `Settings` surface. He argued for keeping it — constraining
+   that surface is the point of the fix, and the assertion is low-cost insurance.
+
+**How you responded:**
+
+I replied on the PR the same week.
+
+On the regression guard I agreed and kept the test.
+
+On the URL-parsing assertion I declined to add it in this PR and explained why: the
+entire argument for preferring my PR over #160 is that mine is scoped to a single
+issue and ships regression tests. Widening the diff after the fact would have quietly
+undercut the position I had already taken publicly. I logged it as a follow-up and
+offered to add it here instead if a maintainer would prefer the coverage in one place.
+I also matched his AI-use disclosure with my own.
+
+No maintainer review has come in. The PR still shows "Review required" and merging is
+blocked pending someone with write access, which is outside my control.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+
+Verifying the fix, not writing it. The code change is four lines out and two lines in,
+and it was straightforward once I found `redis_url` in `core/config.py`. What I did not
+expect was having no reliable signal to check it against.
+
+Two things caused that. First, `/health` is broken twice. Separately from #155, the DB
+probe passes a raw SQL string that SQLAlchemy 2.x rejects (#154), so `GET /health` still
+returns 503 even with my fix in place. The obvious verification — hit the endpoint, read
+the status code — told me nothing. Second, `CONTRIBUTING.md` says to run `make check` and
+`make test-unit` before opening a PR, but both already fail on `main`: 182 ruff errors and
+53 failing tests before I touched anything. The PR template has a "linter passes" checkbox
+I could not honestly tick.
+
+The whole contribution came to about six hours of actual work. The code change was a
+small fraction of that. The rest went into reproducing the bug, writing the endpoint's
+first tests, establishing a baseline I could compare against, and writing the PR up so
+that comparison was legible to someone else. I spent more time working out what
+"working" meant here than making it work.
+
+**What did you learn about working in a large codebase?**
+
+That the burden is on the contributor to make a change *verifiable*, not just correct. In
+my own projects the suite is green, so "still green" is the entire proof. Here I had to
+construct the proof myself: record a baseline on `main` (182 lint errors, 53 failed / 375
+passed), run the identical commands on my branch (182 errors, 53 failed / 378 passed), and
+put that comparison in the PR description so a reviewer can see at a glance that the only
+delta is three new passing tests. Nobody asked me for that table. Without it, "tests pass"
+would have been either false or meaningless.
+
+The second lesson is that scope is an argument, not a preference. #160 already proposed
+fixing #155 and #154 together. My PR only stands as a distinct contribution because it is
+narrower and adds regression tests. Once I made that argument in public, it also
+constrained me — when a reviewer later offered a small optional assertion, accepting it
+would have contradicted the position I had taken.
+
+**How did AI tools help — and where did they fall short?**
+
+Most useful for orientation and mechanics: locating where `Settings` is defined in a repo
+I had never seen, confirming `redis.Redis.from_url` semantics for auth and db index, and
+getting the async `get_db` dependency override right in the tests, which is fiddly and
+easy to get subtly wrong.
+
+It fell short on every judgment call that depended on the state of this specific repo. No
+tool could tell me whether 53 failing tests on `main` were pre-existing or mine — I had to
+check out `main`, run the suite, and record the numbers. Nothing could decide whether to
+fold #154 into the fix, whether to continue after finding #160, or whether to accept a
+reviewer's optional suggestion when accepting it would weaken my own scoping argument. AI
+shortened the "how do I do X" loop considerably and did nothing for the "should I do X"
+loop — which is where the four weeks actually went.
+
+**What would you do differently if you started over?**
+
+Search for existing PRs before writing code, not after. I found #160 when my
+implementation was already finished, which meant my scoping rationale was built to justify
+work I had already done rather than to decide what work to do. It happens to be a
+defensible rationale, but I would rather have reached it deliberately at the start — and
+possibly asked in the issue thread which approach the maintainer preferred, given that
+#155 had over forty people claiming it.
+
+I would also record the `main` baseline before starting rather than at PR time. Knowing
+up front which failures already belong to the repo turns the test suite from noise into
+something you can actually read your own work against.
+
+**What are you most proud of?**
+
+The baseline comparison table. It isn't code, and it isn't what I was graded on building,
+but it is the thing that makes the PR reviewable — it converts "trust me, I didn't break anything" into
+something a stranger can check in five seconds. The reviewer's first move was to verify my
+claims independently against `core/config.py`, and I think the PR invited that because it
+showed its work instead of asserting a conclusion.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -93,3 +93,57 @@ surfaces the same failure in the Redis probe — confirming the bug is real and 
 None blocking. Note: `GET /health` also returns 503 because of a *separate* SQLAlchemy 2.x
 bug (`db.execute("SELECT 1")` needs `text(...)`), which is out of scope for #155 — I verify
 my Redis fix by checking the `redis` sub-status, not the overall status.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Sub-tasks 1–3 from PLAN.md are done: reproduced the AttributeError locally,
+replaced the Redis probe in `api/routes/health.py` with
+`redis.Redis.from_url(settings.redis_url, decode_responses=True)`, and added
+three unit tests in `tests/unit/test_health_route.py` covering the healthy path,
+a failing ping, and a guard against the removed Settings fields.
+
+**Next steps:**
+Sub-task 4 — run `make check` and `make test-unit`, record a baseline for the
+codebase's pre-existing failures, then open the PR against `ascherj/pathreview`.
+
+**Blockers:**
+None. The endpoint's separate SQLAlchemy 2.x bug (#154) is out of scope; the
+unit tests mock the DB session so it doesn't interfere.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/541
+
+**Branch:** `fix/155-health-redis-host`
+
+**What you built:**
+The `/health` endpoint's Redis probe read `settings.redis_host` and
+`settings.redis_port`, which are not defined on the `Settings` model, so the
+probe raised `AttributeError` before it could report Redis status. The fix
+builds the client with `redis.Redis.from_url(settings.redis_url)`, reusing the
+`redis_url` field that already exists — which also means auth credentials and a
+non-default db index in the URL are now honoured, where the old hardcoded
+`db=0` client ignored them.
+
+**Tests added or updated:**
+`tests/unit/test_health_route.py` (new, 3 tests). Covers: (1) reachable Redis →
+200 with `redis: "healthy"`, constructed via `from_url`; (2) failing `ping()` →
+`redis: "unhealthy"` and HTTP 503; (3) a regression guard asserting `Settings`
+has no `redis_host`/`redis_port` and does have `redis_url`. Redis is mocked and
+the `get_db` dependency is overridden, so no live services are needed.
+
+**Self-review confirmation:** [x] make check passes [x] make test-unit passes
+
+Both commands fail on `main` before my changes, so "passes" here means no new
+failures. Baseline recorded and verified:
+`make lint` — 182 errors on `main`, 182 on this branch.
+`make test-unit` — 53 failed / 375 passed on `main`, 53 failed / 378 passed on
+this branch (the 3 extra passes are the new tests). Documented in the PR
+description.
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,69 @@
+# PathReview — Module 3 Journal
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/155
+
+**Issue title:** Health check references `settings.redis_host`, which does not exist on Settings
+
+**Tier:** [x] Tier 1 [ ] Tier 2 [ ] Tier 3
+
+**Problem summary:**
+The `/health` endpoint is supposed to report the status of PostgreSQL, Redis, and the
+vector DB, but its Redis probe reads `settings.redis_host` and `settings.redis_port`.
+Those two fields were never defined on the `Settings` model in `core/config.py` — the
+config only exposes a single `redis_url` field. As a result, as soon as the request
+reaches the Redis check in `api/routes/health.py`, Python raises
+`AttributeError: 'Settings' object has no attribute 'redis_host'`, so the endpoint can
+never actually report Redis health. A successful fix makes `/health` build its Redis
+client from the existing `redis_url` setting so the probe runs, returns a real
+healthy/unhealthy status, and no longer crashes.
+
+**Branch name:** fix/155-health-redis-host
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger
+<!-- Note: I don't currently have edit access to the cohort issue ledger.
+     I've asked about access in the class Slack channel and will add my entry
+     (Name / GitHub username `chaoyi09` / Issue #155) as soon as I can edit it. -->
+
+
+---
+
+### "Is this right for me?" — checklist notes
+
+- **Do I understand the problem?** Yes. The bug is a missing config field: `health.py`
+  references `settings.redis_host` / `settings.redis_port`, which don't exist on
+  `Settings`. I reproduced the exact `AttributeError` locally.
+- **Is the scope contained?** Yes. The root cause lives in two files
+  (`api/routes/health.py` and `core/config.py`) and the fix is a few lines — use the
+  existing `redis_url` instead of the nonexistent host/port fields. No schema changes,
+  migrations, or cross-module refactors needed.
+- **Can I reproduce it?** Yes — running `python -c "from core.config import settings;
+  settings.redis_host"` raises the AttributeError, and `grep redis_host core/config.py`
+  confirms the field is absent.
+- **Do I have the skills?** Yes. It's Python / FastAPI / Pydantic Settings — reading
+  config and a Redis client constructor, which I'm comfortable with.
+- **Is there test coverage to add?** The `/health` route currently has no tests, so this
+  issue is also a good chance to add the first regression test for the endpoint.
+
+### Reproduction (local)
+
+```text
+$ python -c "from core.config import settings; print(settings.redis_host)"
+AttributeError: 'Settings' object has no attribute 'redis_host'
+```
+
+### Environment setup notes
+
+- Cloned my fork (`origin` = my fork, `upstream` = ascherj/pathreview).
+- Created `.env` from `.env.example`.
+- Started backend services with `docker compose up -d` (Postgres on 5433, Redis on 6379).
+- Created `.venv` and installed dependencies with `pip install -e ".[dev]"`.
+- Ran `alembic upgrade head` to apply migrations.
+- Reproduced the AttributeError and confirmed `redis_url` is the field that does exist.
+- Installed frontend deps (`cd frontend && npm install`) and started the app with the
+  backend (uvicorn :8000) + Vite dev server (:5173). Confirmed the app is served at
+  http://localhost:5173 (title "PathReview - AI Portfolio Review Assistant") and that the
+  `/api` proxy reaches the backend.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,83 @@
+## Solution plan
+
+**Issue:** Health check references `settings.redis_host`, which does not exist on Settings —
+https://github.com/ascherj/pathreview/issues/155
+
+### Understand
+
+The `/health` endpoint reports the status of PostgreSQL, Redis, and the vector DB. Its Redis
+probe constructs a client with `redis.Redis(host=settings.redis_host, port=settings.redis_port,
+...)`. Neither `redis_host` nor `redis_port` is defined on the `Settings` model in
+`core/config.py` — the only Redis-related field is `redis_url`.
+
+- **Expected:** `GET /health` runs the Redis probe, pings Redis, and reports
+  `redis: "healthy"` (or `"unhealthy"` if the ping fails).
+- **Actual:** As soon as execution reaches the Redis block, Python raises
+  `AttributeError: 'Settings' object has no attribute 'redis_host'`, so the Redis status is
+  never determined and the request errors out.
+
+Root cause: the health check reads config fields that were never added to `Settings`. The
+existing, correct field is `settings.redis_url`.
+
+### Map
+
+Files involved:
+
+- `api/routes/health.py` — the endpoint; the Redis probe (the buggy lines) lives here.
+- `core/config.py` — the `Settings` model; confirms `redis_url` exists and `redis_host`/
+  `redis_port` do not.
+- `tests/unit/test_health_route.py` — new test file for the endpoint (no `/health` tests
+  exist today).
+
+Files I expect to touch: `api/routes/health.py` (the fix) and `tests/unit/test_health_route.py`
+(new tests). `core/config.py` is read-only reference — no change needed, because I am reusing
+the existing `redis_url` rather than adding new host/port fields.
+
+### Plan
+
+1. **Reproduce** the AttributeError locally: `python -c "from core.config import settings;
+   settings.redis_host"` and by hitting `GET /health`, confirming the Redis block is where it
+   fails.
+2. **Fix the probe** in `api/routes/health.py`: replace
+   `redis.Redis(host=settings.redis_host, port=settings.redis_port, db=0, decode_responses=True)`
+   with `redis.Redis.from_url(settings.redis_url, decode_responses=True)`, which parses host,
+   port, and db index straight from `redis_url`.
+3. **Add tests** in `tests/unit/test_health_route.py`: (a) reachable Redis → `/health` returns
+   200 with `redis: "healthy"` and the client is built from `redis_url`; (b) failing `ping()` →
+   `redis: "unhealthy"` and HTTP 503; (c) a guard asserting `Settings` has no `redis_host`/
+   `redis_port` and does have `redis_url`.
+4. **Verify** with `pytest tests/unit/test_health_route.py -m unit`, plus `ruff`/`black` on the
+   changed files, and confirm no new lint/type errors are introduced.
+
+### Inputs & outputs
+
+- **Input:** `settings.redis_url` (e.g. `redis://localhost:6379/0`).
+- **Output / change:** the Redis probe no longer raises `AttributeError`; `GET /health` returns
+  a JSON body whose `dependencies.redis` is `"healthy"` when the ping succeeds and `"unhealthy"`
+  (with overall status `"unhealthy"` → HTTP 503) when it fails. No config schema change; no
+  change to any other dependency check.
+
+### Risks & unknowns
+
+- **Other unrelated failure in the same endpoint:** `api/routes/health.py` also runs
+  `db.execute("SELECT 1")`, which fails under SQLAlchemy 2.x with "Textual SQL expression ...
+  should be explicitly declared as text('SELECT 1')". This is a *separate* bug (out of scope for
+  #155) but it makes `GET /health` return 503 overall, so I must assert on the `redis`
+  sub-status specifically, not the top-level status, when verifying my fix.
+- **`from_url` semantics:** need to confirm `redis.Redis.from_url` honors a `/0` db index and
+  any auth in the URL the same way the old host/port client did — verified against the `redis`
+  package (`redis>=5.0`, `types-redis` in dev deps).
+- **Tests hitting real services:** the unit tests must not require a live Redis/DB, so I mock
+  `redis.Redis.from_url` and override the `get_db` FastAPI dependency; risk is getting the async
+  dependency override right.
+
+### Edge cases
+
+- **Redis down / unreachable:** `ping()` raises `ConnectionError` → probe must catch it and
+  report `redis: "unhealthy"` (→ 503), not crash.
+- **Malformed or empty `redis_url`:** `from_url` may raise on a bad URL → handled by the existing
+  `try/except` around the Redis block, reported as `unhealthy`.
+- **`redis_url` with auth or non-default db** (e.g. `redis://:pass@host:6379/2`): `from_url`
+  should parse these; the old host/port approach silently ignored them.
+- **Redis healthy but Postgres/vector unhealthy:** overall status still degrades to unhealthy —
+  the Redis fix must not mask other dependency failures.

--- a/api/routes/health.py
+++ b/api/routes/health.py
@@ -41,10 +41,8 @@ async def health_check(db=Depends(get_db)):
         import redis
         from core.config import settings
 
-        r = redis.Redis(
-            host=settings.redis_host,
-            port=settings.redis_port,
-            db=0,
+        r = redis.Redis.from_url(
+            settings.redis_url,
             decode_responses=True,
         )
         r.ping()

--- a/tests/unit/test_health_route.py
+++ b/tests/unit/test_health_route.py
@@ -1,0 +1,81 @@
+"""Unit tests for the /health endpoint.
+
+Regression coverage for issue #155: the Redis probe previously read
+``settings.redis_host`` / ``settings.redis_port``, which do not exist on the
+Settings model, raising ``AttributeError``. The probe now uses the existing
+``settings.redis_url`` field via ``redis.Redis.from_url``.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.main import app
+from core.database import get_db
+
+
+@pytest.fixture
+def fake_db():
+    """A database session whose ``execute`` succeeds (postgres healthy)."""
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=None)
+    return db
+
+
+@pytest.fixture
+def client(fake_db):
+    """TestClient with the DB dependency overridden so no real DB is needed."""
+
+    async def _override_get_db():
+        yield fake_db
+
+    app.dependency_overrides[get_db] = _override_get_db
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+@pytest.mark.unit
+def test_health_uses_redis_url_and_reports_healthy(client):
+    """With a reachable Redis, /health returns 200 and redis is healthy.
+
+    This is the core regression test for issue #155: reaching the Redis probe
+    must not raise AttributeError, and Redis must be built from redis_url.
+    """
+    fake_redis = MagicMock()
+    fake_redis.ping.return_value = True
+
+    with patch("redis.Redis.from_url", return_value=fake_redis) as from_url:
+        response = client.get("/health")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "healthy"
+    assert body["dependencies"]["redis"] == "healthy"
+    # The probe must be constructed from the existing redis_url setting.
+    from_url.assert_called_once()
+
+
+@pytest.mark.unit
+def test_health_reports_redis_unhealthy_when_ping_fails(client):
+    """A failing Redis ping degrades status to unhealthy and returns 503."""
+    fake_redis = MagicMock()
+    fake_redis.ping.side_effect = ConnectionError("redis down")
+
+    with patch("redis.Redis.from_url", return_value=fake_redis):
+        response = client.get("/health")
+
+    assert response.status_code == 503
+    detail = response.json()["detail"]
+    assert detail["dependencies"]["redis"] == "unhealthy"
+    assert detail["status"] == "unhealthy"
+
+
+@pytest.mark.unit
+def test_health_does_not_reference_removed_redis_host_fields():
+    """Guard against reintroducing the nonexistent redis_host/redis_port fields."""
+    from core.config import settings
+
+    assert not hasattr(settings, "redis_host")
+    assert not hasattr(settings, "redis_port")
+    assert settings.redis_url  # the field the probe should use


### PR DESCRIPTION
## Summary

The `/health` endpoint's Redis probe read `settings.redis_host` and
`settings.redis_port`, neither of which is defined on the `Settings` model in
`core/config.py`. The probe raised `AttributeError` before it could report Redis
status, so `/health` failed even when Redis was reachable. This PR builds the
client with `redis.Redis.from_url(settings.redis_url)`, using the `redis_url`
field that already exists on `Settings`, and adds regression tests for the
endpoint.

## Issue
Closes #155

## Changes

- `api/routes/health.py` — construct the Redis client via
  `redis.Redis.from_url(settings.redis_url, decode_responses=True)` instead of
  the nonexistent `redis_host` / `redis_port` fields. `from_url` parses host,
  port, and db index from the URL, so a `redis_url` carrying auth credentials or
  a non-default db index (e.g. `redis://:pass@host:6379/2`) is now honoured; the
  previous hardcoded `db=0` client silently ignored both.
- `tests/unit/test_health_route.py` (new) — regression coverage for this issue.
- `JOURNAL.md`, `PLAN.md` — coursework artifacts required by the AI201
  contribution exercise; unrelated to the fix itself.

## Testing

- [x] Unit tests pass (`make test-unit`) — no new failures; see note below
- [ ] Integration tests pass (`make test-integration`) — not run
- [ ] Linter passes (`make lint`) — pre-existing failures; see note below
- [ ] Type checker passes (`make typecheck`) — not run separately
- [x] New/updated tests cover the changes

Three unit tests, all mocking Redis and overriding the `get_db` dependency so no
live services are required:

1. `test_health_uses_redis_url_and_reports_healthy` — the probe no longer raises
   `AttributeError`, `/health` returns 200, and the client is constructed via
   `from_url`.
2. `test_health_reports_redis_unhealthy_when_ping_fails` — a failing ping
   degrades overall status and returns 503.
3. `test_health_does_not_reference_removed_redis_host_fields` — guards against
   reintroducing `redis_host` / `redis_port`.

**Pre-existing failures.** Both `make lint` and `make test-unit` already fail on
`main` before any of my changes, so I recorded a baseline and confirmed my
changes introduce nothing new:

| | `main` | this branch |
|---|---|---|
| `make lint` (ruff) | 182 errors | 182 errors |
| `make test-unit` | 53 failed / 375 passed | 53 failed / 378 passed |

The three additional passes are the new tests. The lint errors are import
ordering, unused imports/variables, and line length across `agent/`, `rag/`,
`safety/`, `ingestion/`, and existing test files; the test failures are spread
across `test_bias_detector.py`, `test_review_service.py`, `test_resume_parser.py`,
`test_pii_scrubber.py`, and others. None are in `tests/unit/test_health_route.py`,
which is clean under both tools.

The four ruff errors reported in `api/routes/health.py` (I001 on the module and
function-level import blocks, F401 on an unused `timedelta`, B008 on `Depends`)
are all on lines this PR does not touch, and I left them alone to keep the diff
scoped to #155.

## Screenshots / Demo

N/A — no user-facing changes.

## Notes for Reviewers

- Scope is limited to #155. The DB probe's raw-SQL issue (#154) is a separate
  bug and is untouched here; the tests mock the DB session, so that path is not
  exercised.
- #160 also proposes a fix covering #155 alongside #154. This PR is scoped to
  the single issue and adds regression tests, which #160 does not include.
- `test_health_does_not_reference_removed_redis_host_fields` asserts the absence
  of `redis_host` / `redis_port` on `Settings`. This is intentional as a
  regression guard, but happy to drop it if you'd rather not constrain the
  Settings surface.
