### PR TITLE
fix(ingestion): preserve documents without headings

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -136,3 +136,40 @@ the first Markdown heading (confirmed during this week's investigation — the
 preamble was dropped from the returned chunks). I am keeping that behavior
 outside the narrow issue #149 plan unless maintainers confirm it should be
 addressed in the same change.
+
+## Week 9 — Implementation & verification
+
+**Fix commit link:**
+`https://github.com/techmilano/pathreview/commit/d5a6a906ab54f061e5fd83900625472541bb73df`
+
+**Fix summary:**
+I implemented the plan from `PLAN.md`. In
+`StructuralChunker._extract_sections()` (`ingestion/chunking/structural_chunker.py`),
+after the existing final-section save, I added a narrow fallback: when a
+nonempty document produced no heading-based sections, it now returns a single
+untitled section `{"content": text.strip(), "path": [], "level": 0}`. The
+existing `chunk()` loop then emits one chunk with `heading_path=""`,
+`heading_level=0`, and reuses the 800-token threshold so large heading-less
+documents still delegate to `SemanticChunker`. The guard only fires when **no**
+heading sections were produced, so documents with headings — including the
+preamble-before-first-heading case — are unaffected and stay out of scope.
+
+**Verification:**
+The previously failing `test_document_with_no_headings` now passes; I
+strengthened it to also assert content preservation, caller-metadata survival,
+and the `heading_path=""` / `heading_level=0` defaults. I added
+`test_large_document_with_no_headings_sub_chunked` to cover the semantic
+sub-chunking path and sequential `chunk_index` values. All 16 structural
+chunker tests and all 16 semantic chunker tests pass (32 total). The Week 8
+reproduction script now reports `Chunks returned: 1` with the expected
+metadata, confirming the silent data loss is resolved. Post-fix evidence is
+recorded in `reproduction/README.md`; the Week 7 static investigation is
+reconciled with runtime results in `docs/contributions/149/INVESTIGATION.md`.
+
+**Walkthrough video (recommended):**
+`Not recorded.`
+
+**Blockers or open questions:**
+None blocking. The preamble-before-first-heading behavior remains a known,
+related limitation that is intentionally left out of scope for issue #149; it
+can be raised separately with maintainers.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -166,6 +166,14 @@ metadata, confirming the silent data loss is resolved. Post-fix evidence is
 recorded in `reproduction/README.md`; the Week 7 static investigation is
 reconciled with runtime results in `docs/contributions/149/INVESTIGATION.md`.
 
+**Self-review confirmation:** [x] make check — no new failures introduced
+[x] make test-unit — no new failures introduced
+
+**Baseline note:** The full commands remain red because the repository baseline
+contains 182 pre-existing Ruff errors and 52 unrelated test failures. The files
+changed for Issue #149 add no new lint errors, and all 32 relevant chunker tests pass.
+That matches the assignment's explicit rule that, with documented pre-existing failures, "passes" means your contribution does not make the baseline worse.
+
 **Walkthrough video (recommended):**
 `Not recorded.`
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -106,3 +106,33 @@ During Week 8, I will:
 4. Confirm the root cause.
 5. Determine the expected behavior using existing project patterns.
 6. Write a structured solution plan before modifying production code.
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:**
+`https://github.com/techmilano/pathreview/commit/dbcbe5d8f68c3baf116fb043fc0d833b012abd02`
+
+**Reproduction summary:**
+I reproduced issue #149 by running the existing `test_document_with_no_headings`
+unit test and a standalone script (`reproduction/reproduce_issue_149.py`) that
+passes a nonempty plain-text document to `StructuralChunker.chunk()`. The unit
+test failed with `assert 0 >= 1`, and the script reported `Chunks returned: 0`
+deterministically across two runs, confirming that heading-less content is
+silently discarded. The 14 other structural chunker tests continue to pass, so
+the failure is isolated to the no-heading case. I traced the root cause to the
+content-collection guard in `StructuralChunker._extract_sections()`
+(`ingestion/chunking/structural_chunker.py`), which never collects lines when no
+heading has been seen. Full evidence is captured in `reproduction/README.md`.
+
+**PLAN.md link:**
+`https://github.com/techmilano/pathreview/blob/fix/149-handle-documents-without-headings/PLAN.md`
+
+**Walkthrough video (recommended):**
+`[INSERT LOOM LINK OR WRITE "Not recorded"]`
+
+**Blockers or open questions:**
+The same `_extract_sections()` guard also discards introductory content before
+the first Markdown heading (confirmed during this week's investigation — the
+preamble was dropped from the returned chunks). I am keeping that behavior
+outside the narrow issue #149 plan unless maintainers confirm it should be
+addressed in the same change.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -128,7 +128,7 @@ heading has been seen. Full evidence is captured in `reproduction/README.md`.
 `https://github.com/techmilano/pathreview/blob/fix/149-handle-documents-without-headings/PLAN.md`
 
 **Walkthrough video (recommended):**
-`[INSERT LOOM LINK OR WRITE "Not recorded"]`
+`Not recorded.`
 
 **Blockers or open questions:**
 The same `_extract_sections()` guard also discards introductory content before

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -16,19 +16,13 @@ Milano Hyacinthe
 
 ### Problem Summary
 
-The PathReview structural chunker currently depends on Markdown headings to
-identify document sections. When a valid document contains plain text but no
-headings, the chunker returns an empty list instead of producing one or more
-chunks.
-
-Because the ingestion pipeline receives no chunks, the document may be silently
-excluded from the RAG index. This means the document's content will not be
-available during retrieval even though the source document itself is valid and
-contains usable text.
-
-At this stage, I have not implemented a solution. The expected behavior and the
-correct fallback approach will be confirmed by inspecting the chunking
-interfaces, related implementations, existing tests, and project conventions.
+PathReview's structural chunker uses Markdown headings to identify document
+sections. When a valid plain-text document contains no headings, the chunker
+returns an empty list instead of producing usable chunks. This silently
+excludes the document from the ingestion and RAG pipeline, making its content
+unavailable during retrieval. A successful fix will ensure that non-empty
+documents without headings still produce appropriate chunks while preserving
+the project's existing chunking and metadata conventions.
 
 ### Why I Selected This Issue
 
@@ -90,6 +84,12 @@ The initial investigation will focus on:
 ### Working Branch
 
 `fix/149-handle-documents-without-headings`
+
+### Week 7 Completion Confirmation
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger
 
 ### Week 7 Commits
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,108 @@
+# PathReview Contribution Journal
+
+## Contributor
+
+Milano Hyacinthe
+
+## Week 7: Issue Selection and Codebase Orientation
+
+### Selected Issue
+
+- Issue number: #149
+- Issue title: Structural chunker silently drops documents that contain no headings
+- Issue link: https://github.com/ascherj/pathreview/issues/149
+- Tier: Tier 1
+- Area: Ingestion and document chunking
+
+### Problem Summary
+
+The PathReview structural chunker currently depends on Markdown headings to
+identify document sections. When a valid document contains plain text but no
+headings, the chunker returns an empty list instead of producing one or more
+chunks.
+
+Because the ingestion pipeline receives no chunks, the document may be silently
+excluded from the RAG index. This means the document's content will not be
+available during retrieval even though the source document itself is valid and
+contains usable text.
+
+At this stage, I have not implemented a solution. The expected behavior and the
+correct fallback approach will be confirmed by inspecting the chunking
+interfaces, related implementations, existing tests, and project conventions.
+
+### Why I Selected This Issue
+
+I selected this issue because it has a clear and limited scope, is categorized
+as Tier 1, includes a reproducible failure case, and appears to affect a focused
+part of the ingestion subsystem.
+
+The issue also connects to my previous experience building a RAG application,
+where document chunking directly affected retrieval quality. I expect the issue
+to be achievable within the Week 7–9 timeline without requiring a major
+architectural change.
+
+### Issue-Fit Evaluation
+
+- The problem can be explained in my own words: Yes
+- The affected subsystem is identifiable: Yes
+- The issue includes a reproduction example: Yes
+- The issue identifies a relevant test: Yes
+- The scope appears appropriate for one pull request: Yes
+- The work appears achievable by the end of Week 9: Yes
+- The issue appears to require an architectural redesign: No
+- I understand the final implementation already: No; further investigation is
+  required before planning the solution
+
+### Codebase Areas to Investigate
+
+The initial investigation will focus on:
+
+- `ingestion/chunking/structural_chunker.py`
+- Other chunking implementations under `ingestion/chunking/`
+- Shared chunk and document models
+- The ingestion pipeline
+- Unit tests for the structural chunker
+- Metadata requirements for generated chunks
+- The project's error-handling and fallback patterns
+
+### Initial Questions
+
+1. What behavior is expected when a document has no headings?
+2. Should the entire document become one chunk?
+3. Should the structural chunker delegate to another chunking strategy?
+4. How should maximum chunk size be handled?
+5. What metadata must be preserved?
+6. How is empty input distinguished from valid heading-free input?
+7. Are there similar fallback patterns elsewhere in the repository?
+
+### Repository Setup
+
+- Fork created under my GitHub account
+- Repository cloned locally
+- Original repository added as the `upstream` remote
+- Local `main` synchronized with `upstream/main`
+- Issue-specific branch created
+- Environment file created from `.env.example`
+- Supporting Docker services started
+- Project setup command completed
+- Baseline checks initiated
+
+### Working Branch
+
+`fix/149-handle-documents-without-headings`
+
+### Week 7 Commits
+
+1. `docs(ingestion): add week 7 issue journal`
+2. `chore(dev): verify local project setup`
+
+### Week 8 Next Steps
+
+During Week 8, I will:
+
+1. Reproduce the reported failure locally.
+2. Run the relevant unit test.
+3. Trace the execution path through the chunking and ingestion code.
+4. Confirm the root cause.
+5. Determine the expected behavior using existing project patterns.
+6. Write a structured solution plan before modifying production code.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -181,3 +181,35 @@ That matches the assignment's explicit rule that, with documented pre-existing f
 None blocking. The preamble-before-first-heading behavior remains a known,
 related limitation that is intentionally left out of scope for issue #149; it
 can be raised separately with maintainers.
+
+## Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/545
+
+**Branch:** `fix/149-handle-documents-without-headings`
+
+**What you built:**
+Updated `StructuralChunker` so nonempty documents without recognized Markdown
+headings are preserved as an untitled section instead of being silently
+discarded. The fix preserves caller metadata and continues using the existing
+semantic sub-chunking path for documents that exceed the 800-token section
+limit.
+
+**Tests added or updated:**
+Updated `tests/unit/test_structural_chunker.py` to verify short heading-less
+documents, large heading-less documents, content preservation, caller-metadata
+preservation, default heading metadata, semantic sub-chunking, and sequential
+chunk indexes. All 16 structural chunker tests and all 16 semantic chunker tests
+pass, for a total of 32 relevant passing tests.
+
+**Self-review confirmation:** [x] make check — no new failures introduced
+[x] make test-unit — no new failures introduced
+
+**Baseline note:** The full repository commands remain red because the
+pre-existing baseline contains 182 Ruff errors and 52 unrelated unit-test
+failures. The files changed for Issue #149 introduce no new lint errors, and all
+32 relevant chunker tests pass.
+
+**Draft PR feedback received from:** Christopher Paladines
+
+**Feedback addressed:** No changes were requested.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -212,4 +212,90 @@ failures. The files changed for Issue #149 introduce no new lint errors, and all
 
 **Draft PR feedback received from:** Christopher Paladines
 
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No formal reviewer or maintainer feedback has been posted on PR #545. During
+Week 9, Christopher Paladines reviewed the draft contribution with me and did
+not request any changes. Because Summer 2026 does not include formal reviewer
+feedback, no additional changes were required for Week 10.
+
+**How you responded:**
+
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+
+The hardest part was determining how narrowly to fix the problem without
+changing related behavior outside Issue #149. The same condition that caused
+heading-less documents to be discarded also affects introductory text that
+appears before the first Markdown heading. I had to distinguish the reported
+failure from that related preamble behavior and design a fallback that activates
+only when no structural sections are produced.
+
+Verification was also more complicated than expected because the repository
+baseline contained 182 existing Ruff errors and 52 unrelated unit-test failures.
+Instead of treating the full repository failures as failures caused by my work,
+I compared my results with the baseline, checked the modified files separately,
+and demonstrated that all 32 relevant structural and semantic chunker tests
+passed.
+
+**What did you learn about working in a large codebase?**
+
+I learned that a small production change can depend on behavior across several
+parts of a large codebase. Although the final implementation changed only a
+small section of `StructuralChunker._extract_sections()`, I needed to inspect
+the structural chunker, semantic chunker, ingestion pipeline, metadata model,
+embedding ID generation, and existing unit tests before deciding where the
+fallback belonged.
+
+I also learned the importance of following existing architecture instead of
+creating a separate solution path. Returning an untitled section allowed the
+existing chunking loop to preserve metadata, enforce the 800-token threshold,
+delegate oversized content to `SemanticChunker`, and assign sequential chunk
+indexes. Careful scope control was just as important as writing the code.
+
+**How did AI tools help — and where did they fall short?**
+
+AI tools helped me navigate unfamiliar files, explain the chunking flow,
+identify edge cases, compare possible implementation approaches, strengthen
+the tests, and organize the reproduction evidence, solution plan, pull-request
+description, and journal entries.
+
+AI suggestions still had to be verified against the actual repository. AI
+could propose that the document become one fallback section, but it could not
+prove that metadata would survive, large documents would use semantic
+sub-chunking, or existing heading behavior would remain unchanged. I needed to
+read the implementation, run the reproduction script, execute the relevant
+tests, compare repository-wide failures with the baseline, and decide manually
+that the related preamble behavior should remain outside this pull request.
+
+**What would you do differently if you started over?**
+
+I would record the complete repository baseline earlier, including the existing
+Ruff errors and unrelated test failures. That would make it easier to separate
+pre-existing problems from regressions introduced by my contribution.
+
+I would also investigate the preamble-before-first-heading behavior during the
+initial issue-selection stage and document it immediately as a related but
+separate limitation. This would make the Week 8 scope decision and Week 9
+implementation more direct. I would still keep the final fix narrowly focused
+on documents containing no headings.
+
+**What are you most proud of from this module?**
+
+I am most proud that the final fix resolves silent document loss while remaining
+small and consistent with the existing architecture. A valid heading-less
+document now produces usable chunks, caller metadata is preserved, large
+documents continue through semantic sub-chunking, and existing heading-based
+behavior remains unchanged. The original failing test now passes, and all 32
+relevant structural and semantic chunker tests pass.
+
 **Feedback addressed:** No changes were requested.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,265 @@
+# Solution plan
+
+**Issue:** [Structural chunker silently drops documents that contain no headings](https://github.com/ascherj/pathreview/issues/149)
+
+**Branch:** `fix/149-handle-documents-without-headings`
+
+## Understand
+
+`StructuralChunker.chunk()` returns an empty list when given a valid, nonempty
+document that contains no Markdown headings.
+
+The expected behavior is that the document produces at least one `Chunk`. Short
+documents should become one chunk. Large documents should continue to use the
+existing semantic sub-chunking behavior (sections over 800 tokens delegate to
+`SemanticChunker`).
+
+The actual behavior is that `_extract_sections()` discards every content line
+because non-heading lines are only collected when `heading_stack` or
+`current_section_lines` is already nonempty. For a document without headings,
+both values remain empty, no section is created, `chunk()` returns an empty
+list, and the ingestion pipeline continues without storing any chunks or
+embeddings (silent data loss, no exception).
+
+The issue was reproduced at runtime using:
+
+* the existing `test_document_with_no_headings` unit test — **FAILED**
+  (`assert 0 >= 1`);
+* `reproduction/reproduce_issue_149.py` — `Chunks returned: 0`, deterministic
+  across two runs;
+* a direct diagnostic call to `_extract_sections()` returning `[]`.
+
+See `reproduction/README.md` for full evidence.
+
+## Map
+
+### `ingestion/chunking/structural_chunker.py`
+
+Functions:
+
+```text
+StructuralChunker.chunk()
+StructuralChunker._extract_sections()
+```
+
+Expected change:
+
+* Make `_extract_sections()` return one default untitled section when the input
+  is nonempty but no heading-based sections were found.
+
+### `tests/unit/test_structural_chunker.py`
+
+Tests involved:
+
+```text
+test_document_with_no_headings
+test_empty_input_returns_empty_list
+test_whitespace_only_input
+test_large_section_sub_chunked
+test_preserve_source_metadata
+```
+
+Expected change:
+
+* Strengthen the existing heading-less regression test.
+* Add a large heading-less document test.
+* Confirm metadata defaults and caller-metadata preservation.
+
+### `ingestion/chunking/semantic_chunker.py`
+
+Expected production change: **none currently expected.** `StructuralChunker`
+already delegates oversized sections to `SemanticChunker`; this file should be
+reviewed and tested but likely does not need modification.
+
+### `tests/unit/test_semantic_chunker.py`
+
+Expected production change: **none currently expected.** Run these tests to
+confirm the fallback path remains compatible.
+
+### `reproduction/README.md`
+
+Expected Week 9 update: add post-fix verification results confirming the
+original reproduction now produces chunks.
+
+### `docs/contributions/149/INVESTIGATION.md`
+
+Expected Week 9 update: record the verified runtime result and the final
+implementation decision.
+
+## Plan
+
+1. Strengthen `test_document_with_no_headings` in
+   `tests/unit/test_structural_chunker.py` so it verifies:
+   * one or more chunks are returned;
+   * the original text is preserved;
+   * caller metadata survives;
+   * `heading_path` is an empty string;
+   * `heading_level` is zero.
+2. Add a test for a heading-less document larger than 800 tokens to verify the
+   existing semantic sub-chunking path is used and produces valid sequential
+   chunk metadata (unique `chunk_index`).
+3. Update `StructuralChunker._extract_sections()` so that a nonempty document
+   producing no heading-based sections is returned as one untitled section:
+
+   ```python
+   {
+       "content": text.strip(),
+       "path": [],
+       "level": 0,
+   }
+   ```
+
+   The existing `chunk()` loop then yields `heading_path = ""`,
+   `heading_level = 0`, and either one chunk (short) or semantic sub-chunks
+   (large), reusing current metadata construction and the 800-token threshold.
+4. Run the focused regression test, all structural chunker tests, the semantic
+   chunker tests, related unit tests, linting (`ruff`), formatting (`black`),
+   and the direct reproduction script.
+5. Update `reproduction/README.md` and `docs/contributions/149/INVESTIGATION.md`
+   with post-fix results before preparing the final contribution.
+
+## Inputs & outputs
+
+### Input
+
+The fix accepts the same inputs as the existing public interface:
+
+```python
+StructuralChunker.chunk(text: str, metadata: dict)
+```
+
+Relevant input cases: a short heading-less document; a large heading-less
+document; an empty string; whitespace-only content; Markdown with one or more
+headings; caller metadata such as `source`, `source_id`, `source_type`,
+`filename`, `profile_id`, or `repo_name`.
+
+### Expected output for a short heading-less document
+
+A list containing one `Chunk`, with metadata:
+
+```text
+heading_path = ""
+heading_level = 0
+chunk_index = 0
+char_start = 0
+char_end = document length
+```
+
+Caller-provided metadata must be preserved.
+
+### Expected output for a large heading-less document
+
+A list containing multiple semantic sub-chunks when the text exceeds the
+existing 800-token section threshold. Each chunk must contain nonempty text,
+caller metadata, valid sequential chunk indexes, and heading-context defaults
+appropriate for a heading-less document.
+
+### Expected output for empty or whitespace-only content
+
+```python
+[]
+```
+
+This existing behavior must remain unchanged.
+
+## Risks & unknowns
+
+### Risk: existing heading-hierarchy regressions
+
+Changing `_extract_sections()` could affect Markdown documents containing nested
+headings.
+
+Mitigation: run all tests in `tests/unit/test_structural_chunker.py`, paying
+particular attention to nested headings, breadcrumbs, multiple H1 headings,
+heading levels, and source metadata. (Current baseline: 14 pass.)
+
+### Risk: preamble behavior expands unintentionally
+
+The same guard that drops heading-less documents also drops text before the
+first heading (confirmed in the Week 8 investigation).
+
+Mitigation: use a narrow fallback that triggers **only when no structural
+sections were produced.** Do not change general preamble handling unless
+maintainers confirm it is in scope.
+
+### Risk: large heading-less documents become one oversized chunk
+
+A naïve fallback could bypass the existing 800-token section limit.
+
+Mitigation: return the document as a normal default section so the existing size
+check in `chunk()` still delegates large content to `SemanticChunker`.
+
+### Risk: metadata inconsistency
+
+A separate fallback implemented directly in `chunk()` could create metadata that
+differs from normal structural chunks.
+
+Mitigation: reuse the existing section loop and metadata-building logic.
+
+### Risk: semantic sub-chunk indexes / embedding-id collisions
+
+The large-document path must preserve valid sequential chunk indexes.
+`ingestion/embeddings/batch_processor.py` builds embedding ids as
+`"{source_id}_chunk_{chunk_index}"`, so duplicate indexes would collide.
+
+Investigation path:
+
+```text
+ingestion/chunking/semantic_chunker.py
+ingestion/embeddings/batch_processor.py
+tests/unit/test_semantic_chunker.py
+```
+
+### Unknown: preamble content scope
+
+It is not yet confirmed whether introductory content before the first heading
+should be included in issue #149. This question is not blocking for the narrow
+no-heading fix.
+
+## Edge cases
+
+### Empty string
+
+Input: `""` → Expected: `[]`
+
+### Whitespace-only document
+
+Input: `"   \n\n   "` → Expected: `[]`
+
+### One-line heading-less document
+
+Input: `"A short README with no heading."` → Expected: one nonempty `Chunk`.
+
+### Multiline heading-less document
+
+Expected: all nonempty content preserved in one or more chunks.
+
+### Large heading-less document
+
+Expected: divided through the existing semantic sub-chunking path.
+
+### Caller metadata
+
+Input metadata may contain `source`, `source_id`, `source_type`, `filename`,
+`profile_id`, `repo_name`, `version`. Expected: all caller metadata survives on
+every returned `Chunk`.
+
+### Markdown headings
+
+Documents with H1/H2/H3 headings must continue to preserve section boundaries,
+heading breadcrumbs, heading levels, and multiple top-level sections.
+
+### Content before the first heading
+
+Expected Week 8 scope: investigate and document, but do not include in the
+production fix unless scope is confirmed by maintainers.
+
+### Heading with no body content
+
+The fallback must not create misleading blank chunks or change existing behavior
+for empty heading sections.
+
+---
+
+This file is a living plan, not a fixed contract. It will be updated in Week 9
+if the implementation reveals new information.

--- a/docs/contributions/149/INVESTIGATION.md
+++ b/docs/contributions/149/INVESTIGATION.md
@@ -140,4 +140,29 @@ Behavioral invariants a fix must not break:
 - The exact chosen fix (fallback to semantic chunker vs. synthesize a default
   section vs. other) — that decision and its `PLAN.md` belong to Week 8.
 - Whether the preamble-before-first-heading sub-observation is in scope for #149.
-</content>
+
+## 8. Week 9 resolution (runtime-confirmed)
+
+The open items from §7 are now resolved against running code (fix commit
+`d5a6a906ab54f061e5fd83900625472541bb73df`):
+
+- **`test_document_with_no_headings` did fail at runtime** (`assert 0 >= 1`),
+  confirming the Week 7 static tension in §3. It now passes after the fix and was
+  strengthened to assert content preservation, caller-metadata survival, and the
+  `heading_path=""` / `heading_level=0` defaults.
+- **Chosen fix:** synthesize a single default section rather than call
+  `SemanticChunker` directly from `_extract_sections`. When a nonempty document
+  produces no heading-based sections, `_extract_sections` appends
+  `{"content": text.strip(), "path": [], "level": 0}`. This keeps the section
+  seam intact, so the existing `chunk()` loop still applies the 800-token
+  threshold and delegates oversized heading-less documents to `SemanticChunker` —
+  reusing the one fallback path noted in §5 without adding a second entry point.
+- **Preamble-before-first-heading remains out of scope for #149.** The fix guard
+  (`if not sections and text.strip()`) only fires when *no* heading sections were
+  produced, so documents that contain headings — including any preamble above the
+  first one — are untouched. The metadata invariants in §6 all hold: empty and
+  whitespace input still return `[]`, caller metadata survives, and `chunk_index`
+  stays sequential (verified by `test_large_document_with_no_headings_sub_chunked`).
+
+All 16 structural and 16 semantic chunker tests pass. Post-fix reproduction
+evidence is captured in `reproduction/README.md`.

--- a/docs/contributions/149/INVESTIGATION.md
+++ b/docs/contributions/149/INVESTIGATION.md
@@ -1,0 +1,143 @@
+# Investigation — Issue #149: Structural chunker drops heading-less documents
+
+> Week 7 investigation. All conclusions below are drawn from **static reading**
+> of the source. Runtime reproduction is deferred to Week 8.
+
+## 1. Likely execution path
+
+For a README with content but **no `#`-style headings**:
+
+```
+IngestionPipeline.ingest_readme(...)          ingestion/pipeline.py:126
+  └─ ReadmeParser.parse(content)              ingestion/parsers/readme_parser.py:9
+       → ParseResult(text=content, metadata={heading_count: 0, ...})
+  └─ StrategySelector.chunk(text, metadata)   ingestion/chunking/strategy_selector.py:34
+       → select_chunker("readme") → StructuralChunker
+  └─ StructuralChunker.chunk(text, metadata)  ingestion/chunking/structural_chunker.py:24
+       └─ _extract_sections(text)             ingestion/chunking/structural_chunker.py:72
+            → returns []   ← content is never collected (see §4)
+       → chunk() returns []
+  └─ BatchEmbeddingProcessor.process([])      ingestion/embeddings/batch_processor.py:26
+       → logs warning "Empty chunks list...", returns []  (no exception)
+  └─ _record_ingested_source(..., chunk_count=0)
+  └─ returns IngestResult(chunk_count=0, skipped=False)   ← "success" with 0 chunks
+```
+
+Net effect: the pipeline reports success, records the source as ingested, and
+stores **zero embeddings** — the document is silently unretrievable.
+
+## 2. Relevant implementation files
+
+| File | Relevance |
+|---|---|
+| `ingestion/chunking/structural_chunker.py` | **Primary.** `_extract_sections` is where content is dropped. |
+| `ingestion/chunking/base.py` | Defines the `Chunk` dataclass (`text`, `metadata`) and `BaseChunker` interface. |
+| `ingestion/chunking/semantic_chunker.py` | Existing plain-text chunker; the structural chunker already delegates to it for oversized sections. Likely reusable for the heading-less fallback. |
+| `ingestion/chunking/strategy_selector.py` | Routes `readme` → `StructuralChunker`. |
+| `ingestion/pipeline.py` | Consumes chunks; treats `[]` as success (`ingest_readme`, lines 126–199). |
+| `ingestion/embeddings/batch_processor.py` | Confirms `[]` is a warning, not an error (line 39). |
+| `ingestion/parsers/readme_parser.py` | Produces `heading_count` metadata; `0` is the trigger condition for the bug. |
+
+## 3. Relevant tests
+
+- `tests/unit/test_structural_chunker.py`
+  - **`test_document_with_no_headings` (lines 28–35)** — asserts a heading-less
+    document returns `len(result) >= 1` (a single chunk). This encodes the
+    **expected** post-fix behavior.
+  - `test_empty_input_returns_empty_list`, `test_whitespace_only_input` — a fix
+    must keep returning `[]` for genuinely empty/whitespace input.
+  - `test_large_section_sub_chunked` — confirms the >800-token sub-chunking path.
+  - `test_preserve_source_metadata` — caller metadata must survive chunking.
+- `tests/unit/test_semantic_chunker.py` — reference for the fallback chunker's
+  behavior/metadata if the fix delegates to it.
+
+> Observation (code-supported, not yet runtime-verified): the existing test
+> `test_document_with_no_headings` asserts `>= 1` chunk, whereas the current
+> `_extract_sections` logic (§4) yields no sections for a heading-less input.
+> These appear to be in direct tension. Whether the test currently **fails**
+> (vs. is skipped/xfail/otherwise) will be confirmed by reproduction in Week 8;
+> it is not asserted here.
+
+## 4. Root cause (directly supported by the code)
+
+In `_extract_sections` (`structural_chunker.py:72`), non-heading lines are only
+collected when a guard is already satisfied:
+
+```python
+else:
+    # Regular content line
+    if heading_stack or current_section_lines:  # line 111
+        current_section_lines.append(line)
+```
+
+- `heading_stack` is only populated when a heading line is matched (line 106).
+- `current_section_lines` only grows **inside** this same block.
+
+So for a document with no headings, both are empty on the first content line,
+the guard is `False`, and the line is skipped — permanently. `current_section_lines`
+never becomes non-empty, so nothing is ever appended.
+
+Two save points then both fail their guards:
+
+- Mid-loop save requires `heading_stack` (line 90) — never true here.
+- Final save requires `current_section_lines and heading_stack` (line 115) —
+  both false.
+
+Result: `sections == []` → `chunk()` returns `[]`.
+
+**This is a directly code-supported root cause**, not a hypothesis: the guard
+on line 111 combined with the guard on line 115 makes it impossible for a
+heading-less document to produce any section.
+
+### Related sub-observation (same guard)
+
+The same guard also drops **preamble content that appears before the first
+heading** in documents that *do* have headings (e.g. an intro paragraph above
+the first `#`). This is caused by the identical condition and may be worth
+addressing in the same fix. To be confirmed with reproduction in Week 8 — noted
+here, not asserted as in-scope.
+
+## 5. Existing chunker patterns (to reuse / stay consistent with)
+
+- **Empty-guard idiom:** both chunkers start with
+  `if not text or not text.strip(): return []` — a fix should preserve this so
+  truly empty input still yields `[]`.
+- **Delegation for oversized sections:** `StructuralChunker` already calls
+  `self.semantic_chunker.chunk(section_text, section_metadata)` when a section
+  exceeds `SECTION_TOKEN_LIMIT = 800` (lines 49–57). A natural fix is to route
+  heading-less documents through the same `SemanticChunker`, keeping one
+  fallback path.
+- **Metadata via copy-and-update:** every chunk is built as
+  `metadata.copy()` then `.update({...})`, never by mutating the caller's dict.
+- **Token counting:** `tiktoken.get_encoding("cl100k_base")` in both chunkers.
+
+## 6. Metadata / interface contract a future fix MUST preserve
+
+The `Chunk` dataclass is `text: str` + `metadata: dict`. Downstream consumers
+depend on specific metadata keys:
+
+| Key | Set by | Consumed by | Notes |
+|---|---|---|---|
+| `source_id` | pipeline | `batch_processor._store_embedding` (line 106) | Part of the embedding ID. |
+| `chunk_index` | chunkers | `batch_processor._store_embedding` (line 107) | Forms `"{source_id}_chunk_{chunk_index}"`; must be unique/sequential per source or embedding IDs collide. |
+| `heading_path` | structural chunker | tests + retrieval context | For heading-less docs there is no path; a fix must choose a sensible value (e.g. `""`) and stay type-consistent (`str`). |
+| `heading_level` | structural chunker | `test_chunk_metadata_includes_heading_level` | `int`; pick a defined default (e.g. `0`) for no-heading chunks. |
+| `char_start` / `char_end` | chunkers | metadata / offsets | Present on non-sub-chunked sections and semantic chunks. |
+| caller keys (`source_type`, `profile_id`, `repo_name`, `filename`, README parser fields…) | pipeline / parser | retrieval + storage | Must be **preserved** (see `test_preserve_source_metadata`). |
+
+Behavioral invariants a fix must not break:
+
+1. Empty/whitespace input still returns `[]`.
+2. Existing heading-based tests continue to pass (nesting, breadcrumb,
+   multi-H1, sub-chunking, metadata structure).
+3. All caller-supplied metadata keys survive onto every emitted chunk.
+4. `chunk_index` remains unique per source (so embedding IDs don't collide).
+
+## 7. What is explicitly NOT concluded yet
+
+- Whether `test_document_with_no_headings` currently passes/fails at runtime
+  (Week 8 reproduction).
+- The exact chosen fix (fallback to semantic chunker vs. synthesize a default
+  section vs. other) — that decision and its `PLAN.md` belong to Week 8.
+- Whether the preamble-before-first-heading sub-observation is in scope for #149.
+</content>

--- a/docs/contributions/149/WEEK7.md
+++ b/docs/contributions/149/WEEK7.md
@@ -1,0 +1,93 @@
+# Week 7 — Issue #149: Structural chunker silently drops documents that contain no headings
+
+## Issue
+
+- **Link:** https://github.com/ascherj/pathreview/issues/149
+- **Title:** Structural chunker silently drops documents that contain no headings
+- **Type:** `fix`
+- **Subsystem / scope:** `ingestion` (chunking)
+
+## Problem summary
+
+The `StructuralChunker` (used for READMEs) splits markdown on heading
+boundaries. When a document contains **no markdown headings at all**, the
+chunker returns an **empty list** instead of chunking the plain text. Because
+the ingestion pipeline treats an empty chunk list as a successful (non-error)
+outcome, the document is recorded as "ingested" with `chunk_count = 0`, no
+embeddings are stored, and the content becomes silently unretrievable — no
+exception, no user-visible warning.
+
+This matters for READMEs, which are routed to the `StructuralChunker` by the
+strategy selector. A heading-less README (common for small projects) would be
+accepted by the pipeline yet contribute nothing to retrieval.
+
+## Week 7 deliverables checklist
+
+| Deliverable | Status | Evidence |
+|---|---|---|
+| Issue link | ✅ | See above |
+| Concise problem summary | ✅ | See above |
+| Forked repository | ✅ | `origin` → `https://github.com/techmilano/pathreview.git` |
+| Configured upstream remote | ✅ | `upstream` → `https://github.com/ascherj/pathreview.git` |
+| Issue-specific branch | ✅ | `fix/149-handle-documents-without-headings` (see below) |
+| Meaningful setup / documentation commits | ⏳ | This week's docs commit (proposed below) |
+
+## Branch-name verification
+
+`docs/CONTRIBUTING.md` requires: `<type>/<issue-number>-<short-description>`
+with types `fix`, `feat`, `test`, `docs`, `refactor`, `perf`, `chore`.
+
+Current branch: **`fix/149-handle-documents-without-headings`**
+
+- `<type>` = `fix` ✅ (valid type)
+- `<issue-number>` = `149` ✅ (matches issue)
+- `<short-description>` = `handle-documents-without-headings` ✅ (kebab-case)
+
+**Verdict:** Compliant.
+
+## Repository subsystems (per `README.md` / observed layout)
+
+| Subsystem | Directory | Role |
+|---|---|---|
+| API Layer | `api/` | FastAPI REST API |
+| Ingestion Pipeline | `ingestion/` | Parsing, **chunking**, embeddings |
+| RAG System | `rag/` | Retrieval, generation, evaluation |
+| Agent System | `agent/` | Multi-tool orchestration |
+| Safety Layer | `safety/` | Filtering, bias/PII, prompt defense |
+| Frontend | `frontend/` | React + TypeScript (Vite) |
+| Core | `core/` | Config + shared models |
+| Tests | `tests/` | Unit tests + fixtures |
+
+Issue #149 lives entirely in the **Ingestion Pipeline → chunking** area.
+
+## Scope guardrails for this week
+
+- No production code or tests modified (documentation only).
+- Root cause is described from static reading of the code; **reproduction and a
+  `PLAN.md` are deferred to Week 8**.
+- No push, PR, or GitHub issue changes.
+
+## Detailed findings
+
+See [`INVESTIGATION.md`](INVESTIGATION.md) for the execution path, implicated
+files, existing patterns, and the metadata contract a future fix must preserve.
+
+## Proposed Conventional Commit (documentation only)
+
+```
+docs(ingestion): add week 7 investigation notes for issue #149
+
+Document the structural chunker's silent-drop behavior for heading-less
+documents: execution path, implicated files, existing chunker patterns,
+and the chunk metadata contract a future fix must preserve. No production
+code or tests changed.
+
+Refs #149
+```
+
+> Scope note: `docs/CONTRIBUTING.md` lists `ingestion` among the valid scopes.
+> `docs(ingestion)` ties the documentation to the affected subsystem. A plain
+> `docs: ...` (no scope) is also acceptable per the spec if a scopeless subject
+> is preferred.
+</content>
+</invoke>

--- a/ingestion/chunking/structural_chunker.py
+++ b/ingestion/chunking/structural_chunker.py
@@ -119,4 +119,14 @@ class StructuralChunker(BaseChunker):
                 "level": heading_stack[-1][0] if heading_stack else 0,
             })
 
+        # Fallback: a nonempty document that produced no heading-based sections
+        # (i.e. it contains no Markdown headings) is returned as a single
+        # untitled section so its content is not silently dropped (issue #149).
+        if not sections and text.strip():
+            sections.append({
+                "content": text.strip(),
+                "path": [],
+                "level": 0,
+            })
+
         return sections

--- a/reproduction/README.md
+++ b/reproduction/README.md
@@ -1,0 +1,188 @@
+# Issue #149 Reproduction
+
+## Issue
+
+* **Repository:** `ascherj/pathreview`
+* **Fork:** `techmilano/pathreview`
+* **Issue:** `#149`
+* **Title:** Structural chunker silently drops documents that contain no headings
+* **Branch:** `fix/149-handle-documents-without-headings`
+* **Commit tested:** `c6b7d7994205596f7486b1028fb3bc4a3c16ba17`
+
+## Reproduction Status
+
+**Confirmed**
+
+`StructuralChunker.chunk()` returns an empty list when it receives a valid,
+nonempty document without Markdown headings.
+
+## Environment
+
+* **Operating system:** Ubuntu 24.04.4 LTS (Linux 6.17.0-20-generic)
+* **Python version:** 3.12.3
+* **Pytest version:** 9.1.1
+* **tiktoken version:** 0.13.0
+* **Git commit:** `c6b7d7994205596f7486b1028fb3bc4a3c16ba17`
+
+> Note: reproduction was run in a lightweight virtual environment containing
+> only `pytest` and `tiktoken` (the sole runtime import of
+> `structural_chunker.py`). The direct script was executed from the repository
+> root with `PYTHONPATH=.` so the `ingestion` package resolves the same way it
+> would after `pip install -e .`.
+
+## Automated Test Reproduction
+
+Command:
+
+```bash
+pytest \
+  tests/unit/test_structural_chunker.py::TestStructuralChunker::test_document_with_no_headings \
+  -v
+```
+
+Expected:
+
+```text
+The nonempty heading-less document returns at least one Chunk.
+```
+
+Actual:
+
+```text
+The chunker returns an empty list and the test fails with `assert 0 >= 1`.
+```
+
+Evidence:
+
+```text
+reproduction/failing_test_output.txt
+```
+
+## Direct Runtime Reproduction
+
+Command:
+
+```bash
+PYTHONPATH=. python reproduction/reproduce_issue_149.py
+```
+
+Expected:
+
+```text
+Chunks returned: at least 1
+```
+
+Actual:
+
+```text
+Input characters: 1000
+Chunks returned: 0
+Expected chunks: at least 1
+Actual chunks: []
+```
+
+The script was run twice and produced byte-identical output, confirming the
+failure is deterministic.
+
+Evidence:
+
+```text
+reproduction/direct_reproduction_output.txt
+```
+
+## Root Cause
+
+The issue occurs in:
+
+```text
+ingestion/chunking/structural_chunker.py
+```
+
+`_extract_sections()` collects non-heading lines only after a heading or
+existing section content is already present:
+
+```python
+else:
+    # Regular content line
+    if heading_stack or current_section_lines:  # never true without a heading
+        current_section_lines.append(line)
+```
+
+A heading-less document never satisfies that guard, so every content line is
+discarded, the final save condition `if current_section_lines and heading_stack`
+also stays false, and `_extract_sections()` returns `[]`. `chunk()` then loops
+over zero sections and returns `[]`. Downstream, the pipeline treats an empty
+chunk list as success and stores no embeddings — silent data loss, no
+exception.
+
+## Related Preamble Investigation
+
+Command:
+
+```bash
+PYTHONPATH=. python - <<'PY'
+from ingestion.chunking.structural_chunker import StructuralChunker
+text = """Introductory content before the first heading.
+
+# Installation
+
+Installation instructions.
+"""
+chunks = StructuralChunker().chunk(text, {"source": "week-8-preamble-check"})
+print(f"Chunks returned: {len(chunks)}")
+for i, c in enumerate(chunks):
+    print(i, c.metadata.get("heading_path"), repr(c.text))
+PY
+```
+
+Result:
+
+```text
+Chunks returned: 1
+Chunk 0 -> heading_path "Installation", text "Installation instructions."
+Introductory content present in any chunk? NO — the preamble was dropped.
+```
+
+The introductory content before the first heading does **not** appear in any
+returned chunk. This is caused by the same guard in `_extract_sections()`.
+
+Scope decision:
+
+```text
+Preamble-before-heading behavior is related but is not included in the narrow
+issue #149 fix unless maintainers confirm that it belongs in scope.
+```
+
+## Existing Behavior Baseline
+
+Command:
+
+```bash
+pytest tests/unit/test_structural_chunker.py \
+  -k "not test_document_with_no_headings" \
+  -v
+```
+
+Result:
+
+```text
+14 passed, 1 deselected in 0.17s
+```
+
+All non-target structural chunker tests pass (empty/whitespace input returns
+`[]`, nested heading paths, breadcrumbs, large-section sub-chunking, heading
+levels, caller metadata, multiple H1 headings, chunk text content). These
+behaviors must remain unchanged by the Week 9 fix.
+
+Evidence:
+
+```text
+reproduction/related_tests_output.txt
+```
+
+## Week 8 Scope
+
+This commit documents the broken behavior and where it occurs.
+
+It does **not** implement the production fix. The fix is planned in the
+root-level `PLAN.md` and will be implemented in Week 9.

--- a/reproduction/README.md
+++ b/reproduction/README.md
@@ -186,3 +186,74 @@ This commit documents the broken behavior and where it occurs.
 
 It does **not** implement the production fix. The fix is planned in the
 root-level `PLAN.md` and will be implemented in Week 9.
+
+## Week 9 Post-Fix Verification
+
+The fix was implemented in commit
+`d5a6a906ab54f061e5fd83900625472541bb73df` (see the root-level `PLAN.md` for the
+plan it follows). The reproduction commands above were re-run against the fixed
+code; each now shows the corrected behavior.
+
+### Automated test
+
+Command:
+
+```bash
+pytest \
+  tests/unit/test_structural_chunker.py::TestStructuralChunker::test_document_with_no_headings \
+  -v
+```
+
+Result:
+
+```text
+PASSED
+```
+
+The test was strengthened to also assert that the original content is preserved,
+that caller-supplied metadata survives, and that the heading defaults are
+`heading_path=""` and `heading_level=0`.
+
+### Direct runtime reproduction
+
+Command:
+
+```bash
+PYTHONPATH=. python reproduction/reproduce_issue_149.py
+```
+
+Result:
+
+```text
+Input characters: 1000
+Chunks returned: 1
+Expected chunks: at least 1
+```
+
+The single returned chunk carries `heading_path=""`, `heading_level=0`,
+`chunk_index=0`, and the caller's `source` / `source_type` metadata — the
+heading-less document is no longer silently discarded.
+
+### Full chunker suite
+
+Command:
+
+```bash
+pytest tests/unit/test_structural_chunker.py tests/unit/test_semantic_chunker.py -q
+```
+
+Result:
+
+```text
+32 passed
+```
+
+All 16 structural chunker tests (including the new
+`test_large_document_with_no_headings_sub_chunked`, which covers the >800-token
+`SemanticChunker` delegation path) and all 16 semantic chunker tests pass, so the
+fix resolves issue #149 without regressing existing behavior.
+
+### Scope note
+
+The related preamble-before-first-heading behavior documented above is
+**unchanged** by this fix and remains out of scope for issue #149.

--- a/reproduction/direct_reproduction_output.txt
+++ b/reproduction/direct_reproduction_output.txt
@@ -1,0 +1,4 @@
+Input characters: 1000
+Chunks returned: 0
+Expected chunks: at least 1
+Actual chunks: []

--- a/reproduction/failing_test_output.txt
+++ b/reproduction/failing_test_output.txt
@@ -1,0 +1,28 @@
+============================= test session starts ==============================
+platform linux -- Python 3.12.3, pytest-9.1.1, pluggy-1.6.0 -- /home/devmilano/git/pathreview/.venv/bin/python
+cachedir: .pytest_cache
+rootdir: /home/devmilano/git/pathreview
+configfile: pyproject.toml
+collecting ... collected 1 item
+
+tests/unit/test_structural_chunker.py::TestStructuralChunker::test_document_with_no_headings FAILED [100%]
+
+=================================== FAILURES ===================================
+_____________ TestStructuralChunker.test_document_with_no_headings _____________
+
+self = <tests.unit.test_structural_chunker.TestStructuralChunker object at 0x7b50a2e637a0>
+chunker = <ingestion.chunking.structural_chunker.StructuralChunker object at 0x7b50a3030980>
+
+    def test_document_with_no_headings(self, chunker):
+        """Test document with no headings returns single chunk."""
+        text = "This is plain text without any markdown headings. " * 20
+        result = chunker.chunk(text, {"source": "test"})
+    
+>       assert len(result) >= 1
+E       assert 0 >= 1
+E        +  where 0 = len([])
+
+tests/unit/test_structural_chunker.py:33: AssertionError
+=========================== short test summary info ============================
+FAILED tests/unit/test_structural_chunker.py::TestStructuralChunker::test_document_with_no_headings
+============================== 1 failed in 0.17s ===============================

--- a/reproduction/related_tests_output.txt
+++ b/reproduction/related_tests_output.txt
@@ -1,0 +1,23 @@
+============================= test session starts ==============================
+platform linux -- Python 3.12.3, pytest-9.1.1, pluggy-1.6.0 -- /home/devmilano/git/pathreview/.venv/bin/python
+cachedir: .pytest_cache
+rootdir: /home/devmilano/git/pathreview
+configfile: pyproject.toml
+collecting ... collected 15 items / 1 deselected / 14 selected
+
+tests/unit/test_structural_chunker.py::TestStructuralChunker::test_empty_input_returns_empty_list PASSED [  7%]
+tests/unit/test_structural_chunker.py::TestStructuralChunker::test_whitespace_only_input PASSED [ 14%]
+tests/unit/test_structural_chunker.py::TestStructuralChunker::test_document_with_nested_headings PASSED [ 21%]
+tests/unit/test_structural_chunker.py::TestStructuralChunker::test_heading_path_format PASSED [ 28%]
+tests/unit/test_structural_chunker.py::TestStructuralChunker::test_large_section_sub_chunked PASSED [ 35%]
+tests/unit/test_structural_chunker.py::TestStructuralChunker::test_chunk_metadata_includes_heading_level PASSED [ 42%]
+tests/unit/test_structural_chunker.py::TestStructuralChunker::test_chunk_metadata_structure PASSED [ 50%]
+tests/unit/test_structural_chunker.py::TestStructuralChunker::test_preserve_source_metadata PASSED [ 57%]
+tests/unit/test_structural_chunker.py::TestStructuralChunker::test_multiple_h1_headings PASSED [ 64%]
+tests/unit/test_structural_chunker.py::TestStructuralChunker::test_heading_path_breadcrumb PASSED [ 71%]
+tests/unit/test_structural_chunker.py::TestStructuralChunker::test_chunks_have_text_content PASSED [ 78%]
+tests/unit/test_structural_chunker.py::TestStructuralChunker::test_section_extraction_with_multiple_levels PASSED [ 85%]
+tests/unit/test_structural_chunker.py::TestStructuralChunker::test_heading_not_in_middle_of_content PASSED [ 92%]
+tests/unit/test_structural_chunker.py::TestStructuralChunker::test_empty_sections_handled PASSED [100%]
+
+======================= 14 passed, 1 deselected in 0.17s =======================

--- a/reproduction/reproduce_issue_149.py
+++ b/reproduction/reproduce_issue_149.py
@@ -1,0 +1,33 @@
+"""Minimal runtime reproduction for PathReview issue #149.
+
+Issue: Structural chunker silently drops documents that contain no headings.
+https://github.com/ascherj/pathreview/issues/149
+
+Running this script passes a valid, nonempty, heading-less document to
+``StructuralChunker.chunk()`` and prints the number of chunks it returns.
+Expected (post-fix): at least one chunk. Actual (current): zero chunks.
+"""
+
+from ingestion.chunking.structural_chunker import StructuralChunker
+
+
+def main() -> None:
+    """Show that a nonempty heading-less document returns no chunks."""
+    text = "This is a plain document with no headings at all. " * 20
+
+    metadata = {
+        "source": "week-8-reproduction",
+        "source_type": "readme",
+    }
+
+    chunker = StructuralChunker()
+    chunks = chunker.chunk(text, metadata)
+
+    print(f"Input characters: {len(text)}")
+    print(f"Chunks returned: {len(chunks)}")
+    print("Expected chunks: at least 1")
+    print(f"Actual chunks: {chunks}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_structural_chunker.py
+++ b/tests/unit/test_structural_chunker.py
@@ -26,13 +26,49 @@ class TestStructuralChunker:
         assert result == []
 
     def test_document_with_no_headings(self, chunker):
-        """Test document with no headings returns single chunk."""
+        """Test document with no headings returns a single usable chunk."""
         text = "This is plain text without any markdown headings. " * 20
         result = chunker.chunk(text, {"source": "test"})
 
+        # Content must not be silently dropped (issue #149).
         assert len(result) >= 1
-        assert isinstance(result[0], Chunk)
         assert all(isinstance(c, Chunk) for c in result)
+
+        # A short heading-less document fits in one chunk.
+        assert len(result) == 1
+        chunk = result[0]
+
+        # The original text is preserved.
+        assert chunk.text == text.strip()
+
+        # Caller metadata survives.
+        assert chunk.metadata["source"] == "test"
+
+        # Heading context defaults for an untitled document.
+        assert chunk.metadata["heading_path"] == ""
+        assert chunk.metadata["heading_level"] == 0
+
+    def test_large_document_with_no_headings_sub_chunked(self, chunker):
+        """Test a large heading-less document is sub-chunked, not dropped."""
+        # Exceed the 800-token section threshold so the semantic sub-chunking
+        # path is exercised for a document that contains no headings.
+        text = "This is a paragraph with plenty of content to embed. " * 200
+        result = chunker.chunk(text, {"source": "large-doc"})
+
+        # Should produce multiple sub-chunks rather than a single oversized one.
+        assert len(result) > 1
+        assert all(isinstance(c, Chunk) for c in result)
+
+        # Every sub-chunk carries text, caller metadata, and heading defaults.
+        for chunk in result:
+            assert chunk.text.strip()
+            assert chunk.metadata["source"] == "large-doc"
+            assert chunk.metadata.get("heading_path", "") == ""
+            assert chunk.metadata.get("heading_level", 0) == 0
+
+        # Chunk indexes are sequential and unique (embedding-id safety).
+        indexes = [c.metadata["chunk_index"] for c in result]
+        assert indexes == list(range(len(result)))
 
     def test_document_with_nested_headings(self, chunker):
         """Test document with nested headings preserves heading_path."""


### PR DESCRIPTION
## Summary

Fixes Issue #149 by updating `StructuralChunker` so nonempty documents without Markdown headings are preserved instead of silently producing zero chunks.

When `_extract_sections()` finds no heading-based sections, it now creates one untitled fallback section using the original document content. The existing chunking flow then handles metadata, token limits, chunk indexes, and semantic sub-chunking normally.

Fixes #149.

## Problem

`StructuralChunker._extract_sections()` previously collected content only after a recognized Markdown heading had been encountered.

As a result, a valid document containing meaningful text but no Markdown headings produced an empty section list. The `chunk()` method then returned zero chunks, silently dropping the entire document from the ingestion pipeline.

This behavior was reproduced with both:

* The existing `test_document_with_no_headings` unit test
* A direct reproduction script using a nonempty headingless document

Before the fix, the regression test failed because zero chunks were returned.

## Changes Made

Updated:

```text
ingestion/chunking/structural_chunker.py
```

The section extraction logic now adds a fallback section when:

* No heading-based sections were produced
* The input contains meaningful non-whitespace text

The fallback section uses:

```python
{
    "content": text.strip(),
    "path": [],
    "level": 0,
}
```

This approach keeps the existing section-processing flow intact.

The existing `chunk()` method continues to:

* Preserve caller-supplied metadata
* Set `heading_path` to an empty string
* Set `heading_level` to `0`
* Assign sequential chunk indexes
* Apply the existing 800-token section limit
* Delegate large headingless documents to `SemanticChunker`

Documents that already contain recognized Markdown headings continue through the existing heading-based behavior unchanged.

## Why This Approach

The fix creates a normal fallback section instead of adding a separate chunking path for headingless documents.

This was chosen because it:

* Preserves the existing `StructuralChunker` design
* Reuses the existing metadata logic
* Reuses the current token-threshold behavior
* Reuses semantic sub-chunking for oversized documents
* Avoids duplicating chunk-generation logic
* Limits the production change to the behavior described in Issue #149

## Tests Added or Updated

Updated:

```text
tests/unit/test_structural_chunker.py
```

### Short headingless document

The existing regression test was strengthened to verify that:

* At least one chunk is returned
* Exactly one chunk is returned for a short document
* The returned object is a `Chunk`
* The original document content is preserved
* Caller-provided metadata is preserved
* `heading_path` is an empty string
* `heading_level` is `0`

### Large headingless document

Added coverage verifying that a headingless document exceeding the structural chunker’s 800-token section threshold:

* Produces multiple chunks
* Uses the existing semantic sub-chunking path
* Preserves caller-provided metadata
* Preserves the default heading metadata
* Produces nonempty chunk content
* Assigns sequential and unique chunk indexes

### Existing behavior

The existing tests continue to cover:

* Empty input
* Whitespace-only input
* Nested Markdown headings
* Heading hierarchy and breadcrumb metadata
* Multiple top-level headings
* Large headed sections
* Source metadata preservation
* Empty headed sections

## Verification Results

### Targeted chunker tests

Command:

```bash
pytest \
  tests/unit/test_structural_chunker.py \
  tests/unit/test_semantic_chunker.py \
  -q
```

Result:

```text
32 passed
```

This includes:

* 16 structural chunker tests
* 16 semantic chunker tests

### Direct reproduction

Command:

```bash
PYTHONPATH=. python reproduction/reproduce_issue_149.py
```

Result after the fix:

```text
Input characters: 1000
Chunks returned: 1
Expected chunks: at least 1
```

The returned chunk includes:

```text
heading_path=""
heading_level=0
chunk_index=0
```

Caller-provided source metadata is also preserved.

## Repository Baseline Validation

The repository currently contains pre-existing validation failures unrelated to Issue #149.

### `make check`

The full command reports:

```text
182 pre-existing Ruff errors
```

These errors existed in the repository baseline before the Issue #149 implementation.

The files changed for this fix introduce no new lint or formatting errors:

```text
ingestion/chunking/structural_chunker.py
tests/unit/test_structural_chunker.py
```

### `make test-unit`

The full command reports:

```text
52 pre-existing unrelated test failures
```

These failures are outside the structural and semantic chunker components modified by this pull request and existed before the Issue #149 implementation.

The relevant test scope for this contribution passes completely:

```text
32 passed
```

This pull request intentionally leaves the repository-wide baseline unchanged and does not attempt to fix unrelated lint errors or failing tests.

## Manual Review

The implementation, test coverage, documentation, and scope were manually reviewed with the team before PR submission.

## Documentation Updated

The following documentation was updated with the investigation, implementation decision, and post-fix verification results:

```text
JOURNAL.md
docs/contributions/149/INVESTIGATION.md
reproduction/README.md
```

The documentation includes:

* The original failure
* The confirmed root cause
* The selected fallback design
* The successful regression test
* Direct reproduction output
* Targeted test results
* The known related limitation
* The reason unrelated repository failures were not addressed

## Scope and Known Limitation

This pull request addresses documents that contain no recognized Markdown headings.

A related behavior remains unchanged: introductory content appearing before the first heading in a document that later contains headings may still be omitted by the existing parser logic.

That case is intentionally outside the narrow scope of Issue #149 and should be discussed or tracked separately rather than expanding this contribution.

## AI Assistance

AI tools were used to help:

* Navigate the relevant code paths
* Compare the implementation with existing test patterns
* Identify edge cases
* Review the proposed test coverage
* Improve the implementation and verification documentation

All AI-assisted suggestions were manually reviewed. The implementation and test results were validated against the actual repository code.

## Checklist

* [x] The change addresses Issue #149.
* [x] The implementation follows the existing chunker architecture.
* [x] Relevant unit tests were added or strengthened.
* [x] The original regression test now passes.
* [x] Short headingless documents are covered.
* [x] Large headingless documents are covered.
* [x] Caller-provided metadata is preserved.
* [x] Existing heading-based behavior remains unchanged.
* [x] Empty and whitespace-only input behavior remains unchanged.
* [x] Targeted structural and semantic chunker tests pass.
* [x] The modified files introduce no new lint errors.
* [x] Repository-wide pre-existing failures are documented.
* [x] Documentation was updated.
* [x] The change was manually reviewed with the team.
* [x] The pull request remains scoped to Issue #149.
