### PR TITLE
Feat/50 add has tests to repo analysis

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -116,3 +116,34 @@ https://www.loom.com/share/a85ab29d2c694b70992cfcabf61f98fd
 - Need to confirm the best approach for detecting tests using GitHub API repository tree data while minimizing additional API requests.
 - Need to determine the expected fallback behavior if GitHub API calls fail due to rate limits, permissions, or network errors.
 - Need to validate whether `has_tests` detection should support only common patterns (`tests/`, `test/`, `pytest.ini`, `test_*.py`) or include additional conventions such as `spec/` and `__tests__/`.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+
+- Implemented the `_get_repo_tree()` helper in `agent/tools/github_tool.py` to retrieve repository file structure using the GitHub Tree API with a single request.
+- Added the `_has_tests()` helper method to detect common test indicators:
+  - `tests/` and `test/` directories
+  - `test_*.py` and `*_test.py` file patterns
+  - pytest configuration files
+- Integrated the new `has_tests` boolean field into the repository metadata output in `_fetch_repo_metadata()`.
+- Followed the existing `_has_readme()` pattern by adding error handling and returning `False` safely when GitHub API requests fail.
+- Updated `tests/unit/test_github_tool.py` with tests covering:
+  - repositories containing tests
+  - repositories without tests
+  - API failure fallback behavior
+
+
+**Next steps:**
+- Run validation commands:
+  - `make check`
+  - `make test-unit`
+- Review the implementation for edge cases such as empty repositories and large repository tree responses.
+- Update PR description with implementation details, testing instructions, and reviewer notes.
+- Submit the pull request and verify that the PR template is fully completed.
+
+**Blockers:**
+- None.
+---

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -82,3 +82,37 @@ No. This issue has no known blockers or dependencies. The change can be complete
 ## Verdict
 
 I am ready to claim this issue. It is a good fit because it is a focused Tier 1 change that improves the repository analysis output without requiring broad codebase changes. I have identified the affected code, understand the expected behavior, and can complete the implementation within the available timeframe.
+
+## Week 8 — Reproduction & Solution Planning
+
+**Reproduction commit link**
+
+https://github.com/Sangeetha229/pathreview/commit/5bc6b6940c171679afb3db09b49867c620e76955
+
+---
+
+**Reproduction summary**
+
+The issue was reproduced locally by adding a unit test in `tests/unit/test_github_tool.py` that validates the repository metadata output from `GitHubTool`.
+
+The test confirmed that the current implementation does not include the expected `has_tests` boolean field in the repository analysis metadata. The existing metadata response contains fields such as `name`, `description`, `primary_language`, and `has_readme`, but test detection information is missing.
+
+---
+
+**PLAN.md link**
+
+https://github.com/Sangeetha229/pathreview/blob/feat/50-add-has-tests-to-repo-analysis/PLAN.md
+
+---
+
+**Walkthrough video (recommended)**
+
+https://www.loom.com/share/a85ab29d2c694b70992cfcabf61f98fd
+
+---
+
+**Blockers or open questions**
+
+- Need to confirm the best approach for detecting tests using GitHub API repository tree data while minimizing additional API requests.
+- Need to determine the expected fallback behavior if GitHub API calls fail due to rate limits, permissions, or network errors.
+- Need to validate whether `has_tests` detection should support only common patterns (`tests/`, `test/`, `pytest.ini`, `test_*.py`) or include additional conventions such as `spec/` and `__tests__/`.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -147,3 +147,29 @@ https://www.loom.com/share/a85ab29d2c694b70992cfcabf61f98fd
 **Blockers:**
 - None.
 ---
+
+### Check-in 2 (end of week)
+
+**PR link:**  
+
+(https://github.com/ascherj/pathreview/pull/547)
+
+**Branch:**  
+
+feat/50-add-has-tests-to-repo-analysis
+
+**What you built:**  
+Completed the implementation of the `has_tests` boolean field in the GitHub repository metadata analysis. The solution uses the GitHub Tree API to inspect repository contents and detect common testing indicators such as test directories, Python test files, and pytest configuration files, while handling API failures safely.
+
+**Tests added or updated:**  
+Updated `tests/unit/test_github_tool.py` to include test cases for:
+- repositories containing test files or directories (`has_tests = True`)
+- repositories without test indicators (`has_tests = False`)
+- GitHub API failure fallback behavior
+
+**Self-review confirmation:**  
+ [x] make check passes (pre-existing failures unrelated to this PR)  
+ [x] make test-unit passes (pre-existing failures unrelated to this PR) 
+
+**Draft PR feedback received from:**  
+none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,84 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/50
+
+**Issue title:** Add a has_tests boolean to the repo analysis output
+ #50
+
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+
+The repository analysis tool currently provides metadata such as language, stars, forks, README availability, and topics, but it does not identify whether a repository contains automated tests. This missing capability prevents the analysis output from highlighting an important code quality indicator: test coverage presence. The fix will add detection logic in the repository analysis component to check for common testing indicators, including `tests/` or `test/` directories, `pytest.ini`, and Python test files matching the `test_*.py` pattern. The analysis output will expose this information through a new boolean field, `has_tests`, allowing users to quickly identify whether a repository includes tests.
+
+
+**Branch name:** [feat/50-add-has-tests-to-repo-analysis]
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger
+
+## Is This Issue Right for Me?
+
+### Part 1 — Understanding the Issue
+
+**Can I explain what this issue is asking for in my own words?**
+
+Yes. This issue requires adding test detection capability to the GitHub repository metadata analysis tool. Currently, the `GitHubTool` collects repository information such as language, stars, forks, README availability, and topics, but it does not indicate whether a repository contains automated tests. The expected behavior is to add a new `has_tests` boolean field in the analysis output that identifies whether the repository contains common testing indicators such as a `tests/` or `test/` directory, a `pytest.ini` configuration file, or Python test files matching the `test_*.py` pattern.
+
+**Do I understand which part of the app is affected?**
+
+Yes. The affected code is located in the GitHub repository metadata tool. The main file I identified is the `GitHubTool` implementation, where repository metadata is collected in the `_fetch_repo_metadata()` method. The new detection logic will be added within this tool so that the analysis response includes the additional `has_tests` field.
+
+**Do I understand what "done" looks like?**
+
+Yes. Before the fix, the repository analysis output does not provide any information about testing support. After the fix, the output will include a `has_tests` boolean value:
+- `true` when the repository contains test directories, pytest configuration, or matching test files.
+- `false` when no test indicators are found.
+
+---
+
+### Part 2 — Tier Fit
+
+**Is the tier a realistic match for where I am right now?**
+
+Yes. This issue is a **Tier 1** issue because it is a localized change within a single tool file. The implementation does not require changes to multiple modules, database models, APIs, or system architecture. The scope is appropriate because it involves adding a small piece of repository metadata detection logic and exposing it in the existing analysis output.
+
+---
+
+### Part 3 — Codebase Readiness
+
+**Can I find the relevant code?**
+
+Yes. I located and reviewed the `agent/tools/github_tool.py`. The relevant section is the `_fetch_repo_metadata()` method, where the repository metadata dictionary is created and returned as the analysis output.
+
+**Do I understand the surrounding code well enough to change it safely?**
+
+Yes. The tool already follows a pattern where additional repository checks, such as `_has_readme()`, are implemented as helper methods and included in the metadata response. I can follow the same approach by adding a `_has_tests()` helper method and including its result in the metadata dictionary without affecting existing functionality.
+
+**Have I read the relevant test file?**
+
+There is currently no existing test file specifically covering the `GitHubTool` module. I have reviewed the implementation directly and understand the expected behavior. If tests are required, I will add coverage for the new `has_tests` detection logic separately.
+
+---
+
+### Part 4 — Scope and Time
+
+**How many others are already working on this issue?**
+
+I have checked the issue comments and tracker claims. I am comfortable proceeding with this issue.
+
+**Is the scope realistic for Weeks 8–9?**
+
+Yes. This is a Tier 1 feature addition with a limited scope. The expected work includes implementing the detection logic, updating the metadata output, and validating the behavior. The estimated effort is within the expected timeframe for a Tier 1 issue.
+
+**Are there any blockers or dependencies?**
+
+No. This issue has no known blockers or dependencies. The change can be completed within the existing GitHub metadata tool.
+
+---
+
+## Verdict
+
+I am ready to claim this issue. It is a good fit because it is a focused Tier 1 change that improves the repository analysis output without requiring broad codebase changes. I have identified the affected code, understand the expected behavior, and can complete the implementation within the available timeframe.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -173,3 +173,34 @@ Updated `tests/unit/test_github_tool.py` to include test cases for:
 
 **Draft PR feedback received from:**  
 none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No 
+
+**Summary of feedback:**
+No formal reviewer feedback was received before submission. I monitored the pull request but did not receive comments or requested changes.
+
+**How you responded:**
+N/A
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+One of the hardest parts was identifying whether test failures were caused by my changes or were already present in the repository. When running `make test-unit`, several tests failed, and I initially assumed my implementation in `agent/tools/github_tool.py` was incorrect. After investigating, I realized these were pre-existing failures unrelated to my `has_tests` feature, which required extra time to verify and isolate my changes.
+
+**What did you learn about working in a large codebase?**
+I learned that working in a large codebase requires following existing patterns rather than creating new structures. For example, I modeled `_has_tests()` after the existing `_has_readme()` method to ensure consistency in error handling and API usage. I also realized that even small changes, like adding a field in `_fetch_repo_metadata()`, require understanding how different parts of the system interact.
+
+**How did AI tools help — and where did they fall short?**
+AI tools helped me structure my implementation, especially in designing helper methods like `_get_repo_tree()` and improving my PR documentation and journal entries. However, AI could not determine whether failing tests were pre-existing or caused by my changes. I had to manually run targeted tests (`pytest tests/unit/test_github_tool.py`) and validate outputs to confirm my implementation was correct.
+
+**What would you do differently if you started over?**
+If I started over, I would run `make check` and `make test-unit` at the very beginning before writing any code. This would help me identify pre-existing issues early and avoid confusion later when debugging failures. I would also spend more time initially exploring the test files and understanding how the GitHubTool is used across the project.
+
+**What are you most proud of from this module?**
+I am most proud of successfully adding the `has_tests` feature to an existing codebase while maintaining code quality and consistency. Specifically, I implemented `_get_repo_tree()` to efficiently fetch repository data and ensured my solution minimized API calls. I also clearly documented my work in the PR, including manual verification steps and handling of pre-existing issues, which reflects a professional development workflow.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,492 @@
+## Solution Plan
+
+**Issue:** Add `has_tests` boolean to repository analysis output
+
+---
+
+### Understand
+
+The root cause is that the current `GitHubTool` only fetches basic repository metadata (e.g., stars, forks, README) but does not analyze repository contents to detect the presence of tests.
+
+This issue was **confirmed via a failing unit test**, which demonstrated that the `has_tests` field is currently missing from the metadata output.
+
+The expected behavior is to include a `has_tests` boolean field indicating whether a repository contains common testing indicators such as:
+- `tests/` or `test/` directories  
+- `pytest.ini` file  
+- files matching `test_*.py`  
+
+Currently, this information is not included in the output.
+
+---
+
+### Map
+
+**Relevant files and components:**
+
+- `agent/tools/github_tool.py`
+  - `_fetch_repo_metadata()` → assembles repository metadata
+  - `_has_readme()` → reference pattern for helper methods
+
+**Tests**
+
+ `tests/unit/test_github_tool.py`
+
+Used to validate:
+
+- Metadata includes `has_tests`
+- Repositories containing tests return `True`
+- Repositories without tests return `False`
+
+---
+
+**External dependencies:**
+- GitHub API endpoints:
+  - `/repos/{owner}/{repo}`
+  - `/repos/{owner}/{repo}/git/trees/{branch}`
+
+---
+
+### Plan
+
+**Step 1: Reproduce the Current Failure**
+
+Actions:
+
+- Add a failing unit test in:
+
+```
+tests/unit/test_github_tool.py
+```
+
+- Verify that metadata does not currently contain:
+
+```json
+"has_tests": true
+```
+
+Run:
+
+```bash
+pytest tests/unit/test_github_tool.py -v
+```
+
+Expected failure:
+
+```
+AssertionError: Expected 'has_tests' field is missing
+```
+
+---
+
+**Step 2: Implement Test Detection Helper**
+
+Actions:
+
+Create a new helper method in:
+
+```
+agent/tools/github_tool.py
+```
+
+Function:
+
+```python
+_has_tests(owner, repo)
+```
+
+The helper should inspect repository contents and return:
+
+```python
+True
+```
+
+when any supported test indicator exists:
+
+- `tests/` directory
+- `test/` directory
+- `pytest.ini`
+- files matching:
+
+```
+test_*.py
+```
+
+Otherwise return:
+
+```python
+False
+```
+
+---
+
+**Step 3: Integrate `has_tests` Into Repository Metadata**
+
+Update:
+
+```
+_fetch_repo_metadata()
+```
+
+Add the new metadata field:
+
+```python
+metadata = {
+    "name": repo_json.get("name", ""),
+    "description": repo_json.get("description") or "",
+    "primary_language": repo_json.get("language") or "Unknown",
+    "star_count": repo_json.get("stargazers_count", 0),
+    "fork_count": repo_json.get("forks_count", 0),
+    "open_issues_count": repo_json.get("open_issues_count", 0),
+    "last_commit_date": repo_json.get("pushed_at", ""),
+    "has_readme": self._has_readme(username, repo_name),
+    "has_tests": self._has_tests(username, repo_name),
+    "topics": repo_json.get("topics", []),
+    "homepage": repo_json.get("homepage") or "",
+}
+```
+
+---
+
+**Step 4: Add Test Coverage**
+
+Update:
+
+```
+tests/unit/test_github_tool.py
+```
+
+Add test cases for:
+
+1. Repository containing tests:
+
+Expected:
+
+```json
+{
+  "has_tests": true
+}
+```
+
+2. Repository without tests:
+
+Expected:
+
+```json
+{
+  "has_tests": false
+}
+```
+
+3. Repository with only configuration indicator:
+
+Example:
+
+```
+pytest.ini
+```
+
+Expected:
+
+```json
+{
+  "has_tests": true
+}
+```
+
+---
+
+**Step 5: Validate the Fix**
+
+Run:
+
+```bash
+pytest tests/unit/test_github_tool.py -v
+```
+
+Confirm:
+
+- Existing tests pass
+- New `has_tests` tests pass
+- Metadata output contains the new field
+
+---
+
+### Inputs and Outputs
+
+**Input**
+
+The repository analysis receives:
+
+```text
+github_username
+repo_name
+```
+
+The implementation uses GitHub repository information and repository tree contents.
+
+---
+
+**Output Before**
+
+Current metadata response:
+
+```json
+{
+  "name": "example-repo",
+  "description": "Sample repository",
+  "primary_language": "Python",
+  "star_count": 120,
+  "fork_count": 25,
+  "open_issues_count": 8,
+  "last_commit_date": "2026-07-20T10:30:00Z",
+  "has_readme": true,
+  "topics": [
+    "machine-learning",
+    "python"
+  ],
+  "homepage": "https://example.com"
+}
+```
+
+---
+
+**Output After**
+
+Updated metadata response:
+
+```json
+{
+  "name": "example-repo",
+  "description": "Sample repository",
+  "primary_language": "Python",
+  "star_count": 120,
+  "fork_count": 25,
+  "open_issues_count": 8,
+  "last_commit_date": "2026-07-20T10:30:00Z",
+  "has_readme": true,
+  "has_tests": true,
+  "topics": [
+    "machine-learning",
+    "python"
+  ],
+  "homepage": "https://example.com"
+}
+```
+
+---
+
+### Risks and Unknowns
+
+**GitHub API Rate Limits**
+
+Risk:
+
+`_has_tests()` may require additional GitHub API requests.
+
+Investigation area:
+
+```
+agent/tools/github_tool.py
+```
+
+Consider minimizing API calls by using existing repository tree data when available.
+
+---
+
+**Incomplete Test Detection**
+
+Risk:
+
+Some repositories may use different testing conventions:
+
+Examples:
+
+```
+spec/
+__tests__/
+custom_test_folder/
+```
+
+These may produce false negatives.
+
+---
+
+**Performance Impact**
+
+Risk:
+
+Scanning repository trees may increase execution time.
+
+Investigation area:
+
+```
+_has_tests()
+```
+
+The implementation should avoid unnecessary API calls.
+
+---
+
+**GitHub API Failures**
+
+Risk:
+
+Network errors, permission issues, or rate limits may prevent test detection.
+
+Expected behavior:
+
+`has_tests` should safely default to:
+
+```json
+false
+```
+
+without breaking repository analysis.
+
+---
+
+**Default Branch Handling**
+
+Risk:
+
+Repositories may use branches other than:
+
+```
+main
+master
+```
+
+Investigation area:
+
+Use the repository default branch from GitHub metadata instead of assuming a branch name.
+
+---
+
+**Large Repository Handling**
+
+Risk:
+
+Large repositories may contain thousands of files.
+
+The implementation should avoid downloading the complete repository contents.
+
+---
+
+### Edge Cases
+
+The implementation should handle:
+
+**Repository With No Tests**
+
+Example:
+
+```
+src/
+README.md
+requirements.txt
+```
+
+Expected:
+
+```json
+{
+  "has_tests": false
+}
+```
+
+---
+
+**Repository With Only pytest.ini**
+
+Example:
+
+```
+pytest.ini
+src/
+```
+
+Expected:
+
+```json
+{
+  "has_tests": true
+}
+```
+
+---
+
+**Empty Repository**
+
+Example:
+
+```
+(no files)
+```
+
+Expected:
+
+```json
+{
+  "has_tests": false
+}
+```
+
+---
+
+**Case Variations**
+
+Examples:
+
+```
+Tests/
+TEST/
+test_example.PY
+```
+
+The detection logic should handle case differences where possible.
+
+---
+
+**Private or Inaccessible Repository**
+
+Expected:
+
+- No crash
+- Return safe default:
+
+```json
+{
+  "has_tests": false
+}
+```
+
+---
+
+**Test Directory as a File**
+
+Example:
+
+```
+test
+```
+
+exists as a file instead of a directory.
+
+Expected:
+
+- Do not incorrectly classify it as a test directory.
+
+---
+
+**Completion Criteria**
+
+The issue is complete when:
+
+- `GitHubTool` returns a `has_tests` boolean field.
+- Test repositories return `has_tests: true`.
+- Non-test repositories return `has_tests: false`.
+- Unit tests pass.
+- Existing repository metadata behavior remains unchanged.
+
+
+

--- a/agent/tools/github_tool.py
+++ b/agent/tools/github_tool.py
@@ -92,6 +92,7 @@ class GitHubTool(BaseTool):
             "open_issues_count": repo_json.get("open_issues_count", 0),
             "last_commit_date": repo_json.get("pushed_at", ""),
             "has_readme": self._has_readme(username, repo_name),
+            "has_tests": self._has_tests(username, repo_name),
             "topics": repo_json.get("topics", []),
             "homepage": repo_json.get("homepage") or "",
         }
@@ -125,5 +126,55 @@ class GitHubTool(BaseTool):
         try:
             response = httpx.head(url, headers=headers, timeout=5.0)
             return bool(response.status_code == 200)
+        except Exception:
+            return False
+
+    def _get_repo_tree(self, username: str, repo_name: str) -> list[dict]:
+        """Fetch repository file tree using GitHub Tree API.
+
+        Uses a single API call to reduce request overhead.
+        """
+
+        url = f"{self.base_url}/repos/{username}/{repo_name}/git/trees/HEAD?recursive=1"
+
+        headers = {}
+        if self.api_token:
+            headers["Authorization"] = f"token {self.api_token}"
+
+        try:
+            response = httpx.get(url, headers=headers, timeout=10.0)
+            response.raise_for_status()
+
+            data = response.json()
+
+            # Avoid incorrect detection on incomplete responses
+            if data.get("truncated"):
+                return []
+
+            tree: list[dict] = data.get("tree", [])
+            return tree
+
+        except Exception:
+            return []
+
+    def _has_tests(self, username: str, repo_name: str) -> bool:
+        """Check whether repository contains tests."""
+
+        try:
+            tree = self._get_repo_tree(username, repo_name)
+
+            for item in tree:
+                path = item.get("path", "").lower()
+
+                if (
+                    path.startswith("tests/")
+                    or path.startswith("test/")
+                    or path.endswith("pytest.ini")
+                    or path.split("/")[-1].startswith("test_")
+                    or path.endswith("_test.py")
+                ):
+                    return True
+
+            return False
         except Exception:
             return False

--- a/agent/tools/github_tool.py
+++ b/agent/tools/github_tool.py
@@ -2,6 +2,7 @@
 
 import httpx
 import structlog
+
 from .base import BaseTool, ToolResult
 
 logger = structlog.get_logger()
@@ -35,44 +36,30 @@ class GitHubTool(BaseTool):
         repo_name = input_data.get("repo_name")
 
         if not username or not repo_name:
-            return ToolResult(
-                success=False,
-                data={},
-                error="Missing github_username or repo_name"
-            )
+            return ToolResult(success=False, data={}, error="Missing github_username or repo_name")
 
         try:
             repo_data = self._fetch_repo_metadata(username, repo_name)
             return ToolResult(success=True, data=repo_data)
 
         except httpx.HTTPStatusError as e:
-            logger.error("github_request_failed", status=e.response.status_code,
-                        username=username, repo=repo_name)
+            logger.error(
+                "github_request_failed",
+                status=e.response.status_code,
+                username=username,
+                repo=repo_name,
+            )
             if e.response.status_code == 404:
-                return ToolResult(
-                    success=False,
-                    data={},
-                    error="Repository not found"
-                )
+                return ToolResult(success=False, data={}, error="Repository not found")
             elif e.response.status_code == 403:
-                return ToolResult(
-                    success=False,
-                    data={},
-                    error="Rate limited or access denied"
-                )
+                return ToolResult(success=False, data={}, error="Rate limited or access denied")
             return ToolResult(
-                success=False,
-                data={},
-                error=f"GitHub API error: {e.response.status_code}"
+                success=False, data={}, error=f"GitHub API error: {e.response.status_code}"
             )
 
         except Exception as e:
             logger.error("github_tool_error", error=str(e))
-            return ToolResult(
-                success=False,
-                data={},
-                error=str(e)
-            )
+            return ToolResult(success=False, data={}, error=str(e))
 
     def _fetch_repo_metadata(self, username: str, repo_name: str) -> dict:
         """Fetch repository metadata from GitHub API.
@@ -109,8 +96,13 @@ class GitHubTool(BaseTool):
             "homepage": repo_json.get("homepage") or "",
         }
 
-        logger.info("github_repo_fetched", username=username, repo=repo_name,
-                   language=metadata["primary_language"], stars=metadata["star_count"])
+        logger.info(
+            "github_repo_fetched",
+            username=username,
+            repo=repo_name,
+            language=metadata["primary_language"],
+            stars=metadata["star_count"],
+        )
 
         return metadata
 
@@ -132,6 +124,6 @@ class GitHubTool(BaseTool):
 
         try:
             response = httpx.head(url, headers=headers, timeout=5.0)
-            return response.status_code == 200
+            return bool(response.status_code == 200)
         except Exception:
             return False

--- a/tests/unit/test_github_tool.py
+++ b/tests/unit/test_github_tool.py
@@ -1,0 +1,15 @@
+from agent.tools.github_tool import GitHubTool
+
+
+def test_repo_metadata_contains_has_tests() -> None:
+    """
+    Reproduction test:
+    Confirms that repository metadata is missing the expected
+    has_tests field in the current implementation.
+    """
+
+    tool = GitHubTool()
+
+    result = tool._fetch_repo_metadata("psf", "requests")
+
+    assert "has_tests" in result, "Expected 'has_tests' field is missing"

--- a/tests/unit/test_github_tool.py
+++ b/tests/unit/test_github_tool.py
@@ -3,13 +3,83 @@ from agent.tools.github_tool import GitHubTool
 
 def test_repo_metadata_contains_has_tests() -> None:
     """
-    Reproduction test:
-    Confirms that repository metadata is missing the expected
-    has_tests field in the current implementation.
+    Verify repository metadata includes the has_tests field.
     """
 
     tool = GitHubTool()
 
+    # Mock test detection to avoid making GitHub API calls
+    tool._has_tests = lambda username, repo_name: True  # type: ignore[method-assign]
+
     result = tool._fetch_repo_metadata("psf", "requests")
 
-    assert "has_tests" in result, "Expected 'has_tests' field is missing"
+    assert "has_tests" in result
+    assert result["has_tests"] is True
+
+
+def test_has_tests_returns_true_when_tests_exist() -> None:
+    """
+    Repository containing test files should return True.
+    """
+
+    tool = GitHubTool()
+
+    tool._get_repo_tree = lambda username, repo_name: [  # type: ignore[method-assign]
+        {"path": "src/main.py"},
+        {"path": "tests/test_example.py"},
+    ]
+
+    result = tool._has_tests("owner", "repo")
+
+    assert result is True
+
+
+def test_has_tests_returns_true_for_pytest_configuration() -> None:
+    """
+    Repository containing pytest.ini should return True.
+    """
+
+    tool = GitHubTool()
+
+    tool._get_repo_tree = lambda username, repo_name: [  # type: ignore[method-assign]
+        {"path": "pytest.ini"},
+        {"path": "src/main.py"},
+    ]
+
+    result = tool._has_tests("owner", "repo")
+
+    assert result is True
+
+
+def test_has_tests_returns_false_when_tests_are_missing() -> None:
+    """
+    Repository without test indicators should return False.
+    """
+
+    tool = GitHubTool()
+
+    tool._get_repo_tree = lambda username, repo_name: [  # type: ignore[method-assign]
+        {"path": "src/main.py"},
+        {"path": "README.md"},
+    ]
+
+    result = tool._has_tests("owner", "repo")
+
+    assert result is False
+
+
+def test_has_tests_returns_false_when_api_fails() -> None:
+    """
+    GitHub API failures should safely return False.
+    """
+
+    tool = GitHubTool()
+
+    def raise_error(username: str, repo_name: str) -> list[dict]:
+        raise Exception("GitHub API unavailable")
+
+    tool._get_repo_tree = raise_error  # type: ignore[method-assign]
+
+    result = tool._has_tests("owner", "repo")
+
+    assert result is False


### PR DESCRIPTION
## Summary

This PR adds a new `has_tests` boolean field to the GitHub repository metadata analysis output. The feature detects whether a repository contains automated tests by analyzing repository tree contents through the GitHub Tree API. This improves repository analysis by exposing test presence as an additional code quality indicator.


## Issue
Closes #50

## Changes
- Added `_get_repo_tree()` helper method in `agent/tools/github_tool.py` to retrieve repository file structure using the GitHub Tree API with a single request.
- Added `_has_tests()` helper method to detect common testing indicators:
  - `tests/` directories
  - `test/` directories
  - `test_*.py` files
  - `*_test.py` files
  - `pytest.ini` configuration files
- Added the `has_tests` boolean field to the repository metadata returned by `_fetch_repo_metadata()`.
- Followed the existing `_has_readme()` pattern by handling GitHub API failures safely and returning `False` as the fallback behavior.
- Added unit tests covering:
  - repositories containing tests
  - repositories without test indicators
  - GitHub API failure fallback behavior
- Reduced unnecessary API calls by using repository tree inspection through a single GitHub Tree API request.


## Testing
- [x] New/updated tests cover the changes
- [x] Linter passes (`make lint`)
- [x] Type checker passes (`make typecheck`)
- [x] Unit tests for the changed functionality pass
- [ ] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`)

### Validation performed

Feature-specific unit tests:

```bash
pytest tests/unit/test_github_tool.py -v

The has_tests implementation passes feature-specific tests and does not introduce new failures.

Manual Verification Steps

The following steps verify the has_tests behavior manually.

1. Open Git Bash and go to the repository
cd pathreview

2. Checkout the feature branch
git checkout feat/50-add-has-tests-to-repo-analysis

3. Activate the virtual environment
Windows Git Bash:
source .venv/Scripts/activate

4. Install dependencies (if required)
pip install -r requirements.txt

5. Run the GitHubTool unit tests

pytest tests/unit/test_github_tool.py -v

Expected:

PASSED

The tests verify:

Repository with test files returns:
{
  "has_tests": true
}
Repository without test indicators returns:
{
  "has_tests": false
}
GitHub API failures safely return:
{
  "has_tests": false
}
7. Manually verify repository metadata output

Run:

python -c "from agent.tools.github_tool import GitHubTool; print(GitHubTool()._fetch_repo_metadata('psf','requests')['has_tests'])"

Expected output:

True

Run with a repository without test indicators:

python -c "from agent.tools.github_tool import GitHubTool; print(GitHubTool()._fetch_repo_metadata('octocat','Hello-World')['has_tests'])"

Expected output:

False

8. Run validation checks on modified files
ruff check agent/tools/github_tool.py tests/unit/test_github_tool.py

black --check agent/tools/github_tool.py tests/unit/test_github_tool.py

mypy agent/tools/github_tool.py tests/unit/test_github_tool.py

Expected:

No errors found


##Validation Notes

make check and make test-unit were executed during validation.
Any initial failures observed from these commands were investigated and confirmed to be pre-existing repository issues unrelated to this PR.

## Screenshots / Demo

https://www.loom.com/share/6924b80a9ffe426b99be1f89550b3287

## Notes for Reviewers

The implementation uses the GitHub Tree API to inspect repository contents while minimizing additional API requests.
The test detection logic is isolated inside _has_tests() to keep repository metadata generation clean and maintainable.
Error handling follows the existing _has_readme() pattern by safely returning False when GitHub API requests fail.
The implementation avoids downloading repository contents and only inspects repository tree metadata.

