### PR TITLE
fix(rag): handle None text values in faithfulness checker context chunks

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,27 @@
+# Contribution Journal
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/153
+
+**Issue title:** Faithfulness checker crashes when a context chunk has `text: None`
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The `FaithfulnessChecker` in the RAG evaluator (`rag/evaluator/faithfulness_checker.py`)
+is supposed to score how well generated feedback is supported by the retrieved context
+chunks. When one of those chunks has a `text` key whose value is `None`, the `check()`
+method crashes with a `TypeError` instead of returning a score, because
+`chunk.get("text", "")` only substitutes the default when the key is *missing* — not
+when it is present with a `None` value — so `" ".join(...)` receives a `None`. Any
+evaluation run that includes such a chunk breaks entirely rather than degrading
+gracefully. A successful fix treats `None` text as an empty string so `check()` skips
+the empty chunk and still returns a normal 0.0–1.0 faithfulness score, which is exactly
+what the existing `test_none_context_chunk_text` unit test expects.
+
+**Branch name:** fix/153-faithfulness-checker-none-text
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -32,3 +32,21 @@ test and confirming `check()` returns a score instead of raising `TypeError`.
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** TBD after committing this Week 8 documentation
+
+**Reproduction summary:**
+I reproduced the issue against the `main` version of `rag/evaluator/faithfulness_checker.py`
+by running `FaithfulnessChecker().check("Knows Python.", [{"text": None}])`. The observed
+failure was `TypeError: sequence item 0: expected str instance, NoneType found` from the
+`" ".join(...)` call that receives `None` from `chunk.get("text", "")`.
+
+**PLAN.md link:** https://github.com/wzltmp/pathreview/blob/fix/153-faithfulness-checker-none-text/PLAN.md
+
+**Walkthrough video (recommended):** Not recorded yet
+
+**Blockers or open questions:**
+No current blockers. Before opening the PR, I still need to run the full required checks:
+`make check` and `make test-unit`.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -20,6 +20,13 @@ gracefully. A successful fix treats `None` text as an empty string so `check()` 
 the empty chunk and still returns a normal 0.0–1.0 faithfulness score, which is exactly
 what the existing `test_none_context_chunk_text` unit test expects.
 
+**Selection notes ("Is this right for me?"):**
+This Tier 1 issue has a clear reproduction, a localized root cause in one evaluator,
+and an existing regression test that defines success. It fits my scope because the fix
+requires no API, schema, dependency, or architectural changes—only safe handling of a
+nullable dictionary value. I can verify it by running the focused faithfulness checker
+test and confirming `check()` returns a score instead of raising `TypeError`.
+
 **Branch name:** fix/153-faithfulness-checker-none-text
 
 **Setup confirmation:** [x] App runs locally at localhost:5173

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -35,7 +35,7 @@ test and confirming `check()` returns a score instead of raising `TypeError`.
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** TBD after committing this Week 8 documentation
+**Reproduction commit link:** https://github.com/wzltmp/pathreview/commit/7b62494
 
 **Reproduction summary:**
 I reproduced the issue against the `main` version of `rag/evaluator/faithfulness_checker.py`

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -35,7 +35,7 @@ test and confirming `check()` returns a score instead of raising `TypeError`.
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** https://github.com/wzltmp/pathreview/commit/7b62494
+**Reproduction commit link:** https://github.com/wzltmp/pathreview/commit/a4420c8
 
 **Reproduction summary:**
 I reproduced the issue against the `main` version of `rag/evaluator/faithfulness_checker.py`
@@ -50,3 +50,77 @@ failure was `TypeError: sequence item 0: expected str instance, NoneType found` 
 **Blockers or open questions:**
 No current blockers. Before opening the PR, I still need to run the full required checks:
 `make check` and `make test-unit`.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+PLAN.md steps 1–4 are done. The fix is implemented in
+`rag/evaluator/faithfulness_checker.py`: `check()` now builds `context_text` with
+`chunk.get("text") or ""` instead of `chunk.get("text", "")`, so a chunk with an explicit
+`"text": None` falls back to `""` exactly as a missing key already did. The existing
+`test_none_context_chunk_text` now passes, and `test_missing_text_key_in_chunk` is
+unaffected. I also audited the branch against `docs/CONTRIBUTING.md`: branch name matches
+`<type>/<issue-number>-<short-description>`, all commits are Conventional Commits with the
+`rag` scope, and there are no merge commits.
+
+**Next steps:**
+PLAN.md step 5 — establish validation evidence. This repo has many pre-existing `make
+check` and `make test-unit` failures, so I need to measure ruff, mypy, and pytest against
+a clean `upstream/main` checkout *before* and *after* my change to prove I introduce no
+new ones. I also want to strengthen test coverage: the existing regression test only
+asserts a bounded float for a lone `None` chunk, so it would still pass if the crash were
+"fixed" by discarding the whole context. Then rebase onto `upstream/main`, self-review the
+full diff, and open the PR.
+
+**Blockers:**
+None.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/548
+
+**Branch:** `fix/153-faithfulness-checker-none-text`
+
+**What you built:**
+`FaithfulnessChecker.check()` crashed with `TypeError` whenever a retrieved context chunk
+had `"text": None`, because `dict.get()` only substitutes its default when the key is
+*absent*, not when it is present and `None` — so `" ".join(...)` received a `None`. The
+fix coerces a `None` chunk text to `""` before joining, so the malformed chunk is skipped
+and `check()` returns a normal 0.0–1.0 score instead of taking down the whole evaluation
+run. I also updated the `check()` docstring to document the nullable-text behavior.
+
+**Tests added or updated:**
+`tests/unit/test_faithfulness_checker.py` — added
+`test_none_chunk_text_does_not_discard_valid_chunks`, which passes a `None` chunk
+*alongside* a valid chunk and asserts the valid one is still scored (`score > 0.5`). This
+covers a gap the existing `test_none_context_chunk_text` could not catch: that test only
+asserts a bounded float for a lone `None` chunk, so it would still pass if the crash were
+avoided by throwing away the entire context. I verified the new test is a genuine
+regression test by reverting the one-line fix and confirming it fails, then restoring it.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+Both boxes use the documented meaning for a codebase with pre-existing failures: my
+changes introduce **no new failures**. Measured against a clean `upstream/main` worktree
+before and after:
+
+| Check | `main` (baseline) | This branch | Delta |
+|---|---|---|---|
+| `make test-unit` | 53 failed / 375 passed | 52 failed / 377 passed | −1 failure, 0 new |
+| `ruff` | 182 errors | 181 errors | −1, 0 new |
+| `mypy` (`make typecheck` scope) | 5 errors | 5 errors | identical output |
+
+I diffed the sorted lists of `FAILED` test IDs between `main` and this branch: the only
+difference is `test_none_context_chunk_text` flipping from failing to passing. Nothing
+that passed on `main` fails here. The 3 still-failing tests in
+`test_faithfulness_checker.py` are pre-existing `_is_supported()` scoring-threshold bugs,
+a separate concern I deliberately kept out of scope. All of this is documented in the PR's
+Notes for Reviewers section.
+
+**Draft PR feedback received from:** none — opened directly as ready for review. Peer
+review requested in the cohort Slack channel; I will address any feedback in follow-up
+commits on this branch.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -132,9 +132,9 @@ commits on this branch.
 **Feedback received:** [ ] Yes  [x] No — still awaiting review
 
 **Summary of feedback:**
-As of August 4, 2026, [PR #548](https://github.com/ascherj/pathreview/pull/548) is open
-and marked as requiring review, with no reviews or comments. No review came in before I
-completed this reflection.
+As of August 14, 2026, [PR #548](https://github.com/ascherj/pathreview/pull/548) is open
+and marked as requiring review, with no reviews or comments. Reviewer feedback is not
+provided in Summer 2026, so no review came in by the end of the week.
 
 **How you responded:**
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -129,15 +129,20 @@ commits on this branch.
 
 ### Reviewer feedback
 
-**Did you receive reviewer feedback?** [ ] Yes  [x] No — still awaiting review
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
 
+**Summary of feedback:**
 As of August 4, 2026, [PR #548](https://github.com/ascherj/pathreview/pull/548) is open
-and marked as requiring review, with no reviews or comments. There is therefore no
-reviewer-requested change to make or response to document yet. If feedback arrives, I
-will respond on the PR and add any resulting commit here rather than treating the lack of
-a review as a reason to delay this reflection.
+and marked as requiring review, with no reviews or comments. No review came in before I
+completed this reflection.
 
-### What was harder than expected?
+**How you responded:**
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
 
 The code change was only one expression, but proving that it was safe was much harder
 than writing it. I chose issue #153 because it had a narrow failure: `dict.get("text",
@@ -155,7 +160,7 @@ validation in a repository whose default branch already had 53 failing unit test
 ruff errors, and 5 mypy errors. I used a clean `upstream/main` worktree and compared
 sorted failure IDs, not just totals, to show that my branch introduced no regressions.
 
-### What did you learn from working in a large codebase?
+**What did you learn about working in a large codebase?**
 
 I learned that contributing to someone else's codebase is as much about respecting its
 boundaries as changing its code. I needed to follow the repository's branch and commit
@@ -172,7 +177,7 @@ was in the file would have mixed two bugs in one review and risked overlapping a
 contributor. In my own project I might clean up everything nearby; in a shared project,
 a focused change with explicit evidence is easier to review and safer to merge.
 
-### How did AI tools help, and where did they fall short?
+**How did AI tools help — and where did they fall short?**
 
 AI tools helped me trace the failure to the difference between a missing dictionary key
 and an explicit `None`, find the nearby tests, enumerate edge cases, and turn raw command
@@ -189,7 +194,7 @@ such as `{"text": 123}` still raises the same `TypeError`. That case was outside
 reported issue, so I did not expand this PR, but it showed me that generated suggestions
 are hypotheses to test, not evidence.
 
-### What would you do differently next time?
+**What would you do differently if you started over?**
 
 I would write the journal entries when the work happens instead of reconstructing both
 Week 9 check-ins near the deadline. I would also open a draft PR earlier so a peer could
@@ -199,7 +204,7 @@ and I would establish the repository's baseline before running the full suite on
 branch. Finally, I would examine the whole input contract up front, including truthy
 non-string values, even if I ultimately documented them as out of scope.
 
-### What are you most proud of?
+**What are you most proud of from this module?**
 
 I am most proud of not stopping at the one-line fix. The additional regression test
 captures the behavior users need: one malformed context chunk must not erase the useful

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -124,3 +124,87 @@ Notes for Reviewers section.
 **Draft PR feedback received from:** none — opened directly as ready for review. Peer
 review requested in the cohort Slack channel; I will address any feedback in follow-up
 commits on this branch.
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Did you receive reviewer feedback?** [ ] Yes  [x] No — still awaiting review
+
+As of August 4, 2026, [PR #548](https://github.com/ascherj/pathreview/pull/548) is open
+and marked as requiring review, with no reviews or comments. There is therefore no
+reviewer-requested change to make or response to document yet. If feedback arrives, I
+will respond on the PR and add any resulting commit here rather than treating the lack of
+a review as a reason to delay this reflection.
+
+### What was harder than expected?
+
+The code change was only one expression, but proving that it was safe was much harder
+than writing it. I chose issue #153 because it had a narrow failure: `dict.get("text",
+"")` returns `None` when the key exists with that value, and `" ".join(...)` then raises
+a `TypeError`. Changing it to `chunk.get("text") or ""` stopped the crash. The existing
+`test_none_context_chunk_text` also turned green, but it only checked that the result was
+a bounded float. It would still pass if the implementation silently discarded all
+context and always returned `0.0`.
+
+I had to define the intended behavior more precisely and add
+`test_none_chunk_text_does_not_discard_valid_chunks`, which combines a `None` chunk with
+valid context and asserts that the valid text is still scored. I then reverted the fix,
+confirmed that this test failed, and restored it. The other unexpected difficulty was
+validation in a repository whose default branch already had 53 failing unit tests, 182
+ruff errors, and 5 mypy errors. I used a clean `upstream/main` worktree and compared
+sorted failure IDs, not just totals, to show that my branch introduced no regressions.
+
+### What did you learn from working in a large codebase?
+
+I learned that contributing to someone else's codebase is as much about respecting its
+boundaries as changing its code. I needed to follow the repository's branch and commit
+conventions, understand the evaluator's existing behavior, and separate my failures from
+the baseline before making any claim about validation. I also found that project tooling
+can disagree with itself: the pre-commit mypy hook checks staged tests, while `make
+typecheck` excludes them, so touching a test exposes about 25 pre-existing
+`no-untyped-def` errors. I ran the individual checks manually and compared the same hook
+against `upstream/main` rather than hiding or "fixing" unrelated failures.
+
+The most important scope decision was leaving three failing `_is_supported()` tests
+alone. They belong to issue #152 and were already failing on `main`. Fixing them while I
+was in the file would have mixed two bugs in one review and risked overlapping another
+contributor. In my own project I might clean up everything nearby; in a shared project,
+a focused change with explicit evidence is easier to review and safer to merge.
+
+### How did AI tools help, and where did they fall short?
+
+AI tools helped me trace the failure to the difference between a missing dictionary key
+and an explicit `None`, find the nearby tests, enumerate edge cases, and turn raw command
+output into a baseline-versus-branch comparison. They were also useful for reviewing the
+written explanation from a maintainer's perspective: what behavior changed, why the new
+test mattered, and which failures were unrelated.
+
+They did not remove the need to verify anything. A plausible answer was available as soon
+as the existing test passed, but that answer did not prove valid chunks were preserved.
+I had to inspect the assertion, strengthen it, and deliberately revert the production
+change to prove the regression test could fail. AI-assisted edge-case analysis also
+stopped too early at falsy values; only later did I notice that a truthy non-string value
+such as `{"text": 123}` still raises the same `TypeError`. That case was outside the
+reported issue, so I did not expand this PR, but it showed me that generated suggestions
+are hypotheses to test, not evidence.
+
+### What would you do differently next time?
+
+I would write the journal entries when the work happens instead of reconstructing both
+Week 9 check-ins near the deadline. I would also open a draft PR earlier so a peer could
+challenge the behavior and test before I marked it ready for review. Technically, I would
+start with the stronger behavioral test—`None` beside a valid chunk—then make it pass,
+and I would establish the repository's baseline before running the full suite on my
+branch. Finally, I would examine the whole input contract up front, including truthy
+non-string values, even if I ultimately documented them as out of scope.
+
+### What are you most proud of?
+
+I am most proud of not stopping at the one-line fix. The additional regression test
+captures the behavior users need: one malformed context chunk must not erase the useful
+chunks around it. Confirming that the test failed when I reverted the fix made it real
+evidence rather than a green checkbox. I am also proud that I handled a noisy codebase
+without either claiming the suite was clean or widening the PR to repair unrelated
+problems. The final contribution is small, but its scope, test, validation record, and PR
+explanation make it something a maintainer can evaluate with confidence.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,110 @@
+# Solution plan
+
+**Issue:** [#153 — Faithfulness checker crashes when a context chunk has `text: None`](https://github.com/ascherj/pathreview/issues/153)
+
+## Understand
+
+`FaithfulnessChecker.check()` builds one context string from retrieved chunks with:
+
+```python
+" ".join([chunk.get("text", "") for chunk in context_chunks])
+```
+
+That handles a missing `text` key, but not a present key whose value is `None`.
+For `{"text": None}`, `dict.get()` returns `None`, so `" ".join(...)` raises
+`TypeError: sequence item 0: expected str instance, NoneType found`.
+
+Expected behavior: `check()` should treat `None` chunk text the same way it treats
+missing text, skip that empty chunk contribution, and return a normal faithfulness
+score between `0.0` and `1.0`.
+
+Root cause: missing normalization of nullable chunk text in
+`rag/evaluator/faithfulness_checker.py`.
+
+## Map
+
+Files involved:
+
+- `rag/evaluator/faithfulness_checker.py` — `FaithfulnessChecker.check()` concatenates
+  chunk text before scoring claims.
+- `tests/unit/test_faithfulness_checker.py` —
+  `TestFaithfulnessChecker.test_none_context_chunk_text` is the regression test named
+  in the issue.
+- `JOURNAL.md` — Week 8 reproduction notes and links for the course deliverable.
+
+Expected code touch:
+
+- `rag/evaluator/faithfulness_checker.py`
+
+No API, database, frontend, migration, or dependency changes are needed.
+
+## Plan
+
+1. Reproduce the issue from the `main` version by running:
+   ```python
+   from rag.evaluator.faithfulness_checker import FaithfulnessChecker
+   FaithfulnessChecker().check("Knows Python.", [{"text": None}])
+   ```
+   Confirm it raises the `TypeError` from `" ".join(...)`.
+2. In `FaithfulnessChecker.check()`, normalize each chunk text while building
+   `context_text`:
+   ```python
+   context_text = " ".join([chunk.get("text") or "" for chunk in context_chunks])
+   ```
+3. Keep the existing behavior for missing `text` keys, empty context chunks, and normal
+   text chunks unchanged.
+4. Run the focused regression test:
+   ```bash
+   .venv/bin/pytest tests/unit/test_faithfulness_checker.py::TestFaithfulnessChecker::test_none_context_chunk_text -q
+   ```
+5. Before opening the PR, run the project checks required by `docs/CONTRIBUTING.md`:
+   ```bash
+   make check
+   make test-unit
+   ```
+
+## Inputs & outputs
+
+Function being fixed:
+
+```python
+FaithfulnessChecker.check(feedback: str, context_chunks: list[dict]) -> float
+```
+
+Input that currently fails on `main`:
+
+```python
+feedback = "Knows Python."
+context_chunks = [{"text": None}]
+```
+
+Expected output after the fix:
+
+- No exception.
+- Returns a `float`.
+- Score remains within `0.0 <= score <= 1.0`.
+- `None` chunk text contributes no context text.
+
+Existing happy path remains unchanged:
+
+- `{"text": "Python portfolio content"}` is included in `context_text`.
+- Missing `text` key is treated as empty text.
+
+## Risks & unknowns
+
+- `rag/evaluator/faithfulness_checker.py`: using `or ""` also treats other falsey values
+  such as `0` or `False` as empty text. That is acceptable here because chunk text should
+  be a string, and non-string values are already invalid context for text scoring.
+- `tests/unit/test_faithfulness_checker.py`: the existing regression test only asserts
+  that the method returns a bounded float, not an exact score. That matches the evaluator's
+  current loose scoring tests, so I will not add stricter assertions unless reviewers ask.
+- Full validation still depends on running `make check` and `make test-unit` before the PR,
+  because the codebase uses ruff, black, mypy, and pytest per `docs/CONTRIBUTING.md`.
+
+## Edge cases
+
+- Context chunk has `{"text": None}`: should not crash; treat as empty text.
+- Context chunk is missing `text`: should keep existing graceful behavior.
+- Mixed chunks, e.g. one `None` text and one valid text string: should score against the
+  valid text chunk.
+- Empty `feedback` or empty `context_chunks`: should keep returning `0.0`.

--- a/rag/evaluator/faithfulness_checker.py
+++ b/rag/evaluator/faithfulness_checker.py
@@ -15,7 +15,8 @@ class FaithfulnessChecker:
 
         Args:
             feedback: Generated feedback text
-            context_chunks: Retrieved context chunks
+            context_chunks: Retrieved context chunks. A chunk whose "text" key is
+                missing or set to None contributes no text to the context.
 
         Returns:
             Faithfulness score 0.0-1.0 (ratio of supported claims)

--- a/rag/evaluator/faithfulness_checker.py
+++ b/rag/evaluator/faithfulness_checker.py
@@ -1,6 +1,7 @@
 """Check if generated feedback is supported by retrieved context."""
 
 import re
+
 import structlog
 
 logger = structlog.get_logger()
@@ -20,8 +21,11 @@ class FaithfulnessChecker:
             Faithfulness score 0.0-1.0 (ratio of supported claims)
         """
         if not feedback or not context_chunks:
-            logger.info("faithfulness_empty_input", has_feedback=bool(feedback),
-                       has_chunks=bool(context_chunks))
+            logger.info(
+                "faithfulness_empty_input",
+                has_feedback=bool(feedback),
+                has_chunks=bool(context_chunks),
+            )
             return 0.0
 
         # Extract key claims from feedback (sentences)
@@ -31,9 +35,7 @@ class FaithfulnessChecker:
             return 0.5  # Default to neutral if no extractable claims
 
         # Concatenate context text
-        context_text = " ".join([
-            chunk.get("text", "") for chunk in context_chunks
-        ])
+        context_text = " ".join([chunk.get("text") or "" for chunk in context_chunks])
 
         # Check each claim for support
         supported = 0
@@ -43,8 +45,9 @@ class FaithfulnessChecker:
 
         score = supported / len(claims) if claims else 0.0
 
-        logger.info("faithfulness_checked", claims_count=len(claims),
-                   supported_count=supported, score=score)
+        logger.info(
+            "faithfulness_checked", claims_count=len(claims), supported_count=supported, score=score
+        )
 
         return score
 
@@ -59,7 +62,7 @@ class FaithfulnessChecker:
             List of claims (sentences)
         """
         # Split by sentence (simple regex)
-        sentences = re.split(r'[.!?]+', text)
+        sentences = re.split(r"[.!?]+", text)
         claims = [s.strip() for s in sentences if s.strip() and len(s.strip()) > 10]
         return claims[:10]  # Limit to 10 claims for scoring
 
@@ -81,8 +84,25 @@ class FaithfulnessChecker:
         # Require at least some meaningful overlap
         overlap = claim_tokens & context_tokens
         # Filter out common stop words
-        stop_words = {'a', 'an', 'the', 'is', 'are', 'was', 'were', 'be', 'been',
-                     'and', 'or', 'but', 'in', 'of', 'to', 'for', 'that'}
+        stop_words = {
+            "a",
+            "an",
+            "the",
+            "is",
+            "are",
+            "was",
+            "were",
+            "be",
+            "been",
+            "and",
+            "or",
+            "but",
+            "in",
+            "of",
+            "to",
+            "for",
+            "that",
+        }
         meaningful_overlap = overlap - stop_words
 
         return len(meaningful_overlap) >= 2

--- a/tests/unit/test_faithfulness_checker.py
+++ b/tests/unit/test_faithfulness_checker.py
@@ -18,9 +18,7 @@ class TestFaithfulnessChecker:
         """Test feedback fully supported by context returns score close to 1.0."""
         feedback = "The developer has strong Python skills and experience with Django."
         context_chunks = [
-            {
-                "text": "The portfolio shows Python expertise and Django framework experience."
-            },
+            {"text": "The portfolio shows Python expertise and Django framework experience."},
         ]
 
         score = checker.check(feedback, context_chunks)
@@ -34,9 +32,7 @@ class TestFaithfulnessChecker:
         """Test feedback with no support in context returns score close to 0.0."""
         feedback = "This developer is an expert in Rust systems programming."
         context_chunks = [
-            {
-                "text": "The developer has Python and JavaScript experience."
-            },
+            {"text": "The developer has Python and JavaScript experience."},
         ]
 
         score = checker.check(feedback, context_chunks)
@@ -48,9 +44,7 @@ class TestFaithfulnessChecker:
         """Test partial support returns score between 0 and 1."""
         feedback = "The developer shows Python expertise and Kubernetes knowledge."
         context_chunks = [
-            {
-                "text": "Strong Python programming skills demonstrated in projects."
-            },
+            {"text": "Strong Python programming skills demonstrated in projects."},
         ]
 
         score = checker.check(feedback, context_chunks)
@@ -63,9 +57,7 @@ class TestFaithfulnessChecker:
     def test_empty_feedback_returns_zero(self, checker):
         """Test empty feedback returns 0.0."""
         feedback = ""
-        context_chunks = [
-            {"text": "Some context"}
-        ]
+        context_chunks = [{"text": "Some context"}]
 
         score = checker.check(feedback, context_chunks)
 
@@ -155,15 +147,11 @@ class TestFaithfulnessChecker:
         """Test that score varies with input, never hardcoded 1.0 or 0.0."""
         # First test: fully supported
         score1 = checker.check(
-            "Python and JavaScript skills",
-            [{"text": "Expert in Python and JavaScript"}]
+            "Python and JavaScript skills", [{"text": "Expert in Python and JavaScript"}]
         )
 
         # Second test: no support
-        score2 = checker.check(
-            "Rust expertise",
-            [{"text": "Java programming background"}]
-        )
+        score2 = checker.check("Rust expertise", [{"text": "Java programming background"}])
 
         # Scores should be different
         assert score1 != score2
@@ -173,9 +161,7 @@ class TestFaithfulnessChecker:
     def test_multiple_claims_varying_support(self, checker):
         """Test scoring with multiple claims of varying support."""
         feedback = "Python expert. Knows Rust. Skilled with Docker."
-        context_chunks = [
-            {"text": "Python and Docker expertise shown in projects."}
-        ]
+        context_chunks = [{"text": "Python and Docker expertise shown in projects."}]
 
         score = checker.check(feedback, context_chunks)
 
@@ -186,9 +172,7 @@ class TestFaithfulnessChecker:
     def test_very_long_feedback(self, checker):
         """Test handling of very long feedback text."""
         feedback = "The developer. " * 100
-        context_chunks = [
-            {"text": "Developer portfolio content"}
-        ]
+        context_chunks = [{"text": "Developer portfolio content"}]
 
         score = checker.check(feedback, context_chunks)
 
@@ -198,9 +182,7 @@ class TestFaithfulnessChecker:
     def test_very_long_context(self, checker):
         """Test handling of very long context."""
         feedback = "The developer has Python skills."
-        context_chunks = [
-            {"text": "Python " * 1000}
-        ]
+        context_chunks = [{"text": "Python " * 1000}]
 
         score = checker.check(feedback, context_chunks)
 
@@ -231,9 +213,7 @@ class TestFaithfulnessChecker:
     def test_none_context_chunk_text(self, checker):
         """Test handling of None in context chunk text."""
         feedback = "Has Python skills"
-        context_chunks = [
-            {"text": None}
-        ]
+        context_chunks = [{"text": None}]
 
         score = checker.check(feedback, context_chunks)
 
@@ -241,12 +221,31 @@ class TestFaithfulnessChecker:
         assert isinstance(score, float)
         assert 0.0 <= score <= 1.0
 
+    def test_none_chunk_text_does_not_discard_valid_chunks(
+        self, checker: FaithfulnessChecker
+    ) -> None:
+        """Test a None chunk text is skipped without dropping valid chunk context.
+
+        Guards against "fixing" the crash by discarding the whole context: the
+        remaining chunk must still support the claim and produce a high score.
+        """
+        feedback = "The developer has strong Python skills and experience with Django."
+        context_chunks: list[dict] = [
+            {"text": None},
+            {"text": "The portfolio shows Python expertise and Django framework experience."},
+        ]
+
+        score = checker.check(feedback, context_chunks)
+
+        assert isinstance(score, float)
+        assert 0.0 <= score <= 1.0
+        # The valid chunk must still be scored, not thrown away with the None one
+        assert score > 0.5
+
     def test_missing_text_key_in_chunk(self, checker):
         """Test handling of missing 'text' key in context chunk."""
         feedback = "Has Python skills"
-        context_chunks = [
-            {"content": "Python skills"}  # Wrong key
-        ]
+        context_chunks = [{"content": "Python skills"}]  # Wrong key
 
         score = checker.check(feedback, context_chunks)
 


### PR DESCRIPTION
## Summary

`FaithfulnessChecker.check()` in `rag/evaluator/faithfulness_checker.py` raised a
`TypeError` and aborted the whole evaluation run whenever a retrieved context chunk
carried `"text": None`. It now treats a `None` chunk text the same way it already
treated a missing `text` key — as empty text — so the chunk contributes nothing and
`check()` returns a normal `0.0`–`1.0` faithfulness score instead of crashing.

## Issue

Closes #153

## Changes

**Root cause:** `check()` built its context string with `chunk.get("text", "")`. The
second argument to `dict.get()` is only substituted when the key is *absent*. When the
key is present but explicitly set to `None` — which is what the retriever produces for a
chunk with no extracted text — `.get()` returns `None`, and the following
`" ".join(...)` raises `TypeError: sequence item 0: expected str instance, NoneType
found`. A single malformed chunk therefore took down the entire evaluation run rather
than being skipped. The missing-key path was already safe, so the two cases were
inconsistent.

- `rag/evaluator/faithfulness_checker.py` — `check()` now builds `context_text` with
  `chunk.get("text") or ""` instead of `chunk.get("text", "")`, coercing a `None` (or
  otherwise falsy) chunk text to `""` before the join. Chunk text is expected to be a
  string, so treating any falsy value as empty is the correct behavior here.
- `rag/evaluator/faithfulness_checker.py` — updated the `check()` docstring so the
  `context_chunks` argument documents that a missing-or-`None` `"text"` contributes no
  text to the context.
- `tests/unit/test_faithfulness_checker.py` — added
  `test_none_chunk_text_does_not_discard_valid_chunks`.
- No API, schema, migration, dependency, or frontend changes.

**Note on formatting churn in `faithfulness_checker.py`:** the repo's own
`.pre-commit-config.yaml` runs `black` on committed files, and this file is not
black-clean on `main`. Committing the one-line fix therefore reformatted the surrounding
`logger.info(...)` calls, the `stop_words` set, and one regex literal. Those hunks are
formatter output, not hand edits — the only behavioral change is the single
`context_text` line.

## Testing

- [x] Unit tests pass (`make test-unit`) — **no new failures**; see the before/after
      table in Notes for Reviewers. This repo has 53 pre-existing unit-test failures on
      `main`, so "passes" here means my change introduces none and fixes one.
- [ ] Integration tests pass (`make test-integration`) — not run; requires the Docker
      Postgres/Redis services, and this change touches no I/O, API, or database path.
- [x] Linter passes (`make lint`) — **no new ruff errors**; my change removes one
      (`faithfulness_checker.py: I001`). 182 pre-existing errors remain repo-wide.
- [x] Type checker passes (`make typecheck`) — **zero new mypy errors**; output is
      byte-identical to `main` (5 pre-existing missing-stub errors, none in the files
      touched here).
- [x] New/updated tests cover the changes

**Reproduce the original bug (on `main`):**

1. `git checkout main`
2. Run the failing case directly:
   ```bash
   python -c "from rag.evaluator.faithfulness_checker import FaithfulnessChecker; \
   print(FaithfulnessChecker().check('Knows Python.', [{'text': None}]))"
   ```
   Observe: `TypeError: sequence item 0: expected str instance, NoneType found`
3. Or run the existing regression test, which fails on `main`:
   ```bash
   pytest tests/unit/test_faithfulness_checker.py::TestFaithfulnessChecker::test_none_context_chunk_text -v
   ```

**Verify the fix (on this branch):**

1. `git checkout fix/153-faithfulness-checker-none-text`
2. Re-run the same one-liner from step 2 above. Expected: it prints a float
   (`0.0`) instead of raising.
3. Run the affected test file:
   ```bash
   pytest tests/unit/test_faithfulness_checker.py -v
   ```
   Expected: `test_none_context_chunk_text` and the new
   `test_none_chunk_text_does_not_discard_valid_chunks` both pass. The 3 remaining
   failures in this file are pre-existing scoring bugs tracked separately (see below).

**Why the new test:** the pre-existing `test_none_context_chunk_text` only asserts that
`check()` returns a bounded float for a lone `{"text": None}` chunk, so it would still
pass if someone "fixed" the crash by discarding the entire context. The new test passes
a `None` chunk *alongside* a valid one and asserts the valid chunk is still scored
(`score > 0.5`). I verified it is a real regression test by reverting the one-line fix
and confirming it fails, then restoring it.

## Screenshots / Demo

N/A — backend-only change with no UI surface. The observable change is
`FaithfulnessChecker.check()` returning a float instead of raising `TypeError`,
demonstrated by the command-line steps above.

## Notes for Reviewers

This repository has substantial pre-existing `make check` and `make test-unit` failures
that are unrelated to this change. I measured every check against a clean `upstream/main`
worktree before and after, so the deltas below are exact:

| Check | `main` (baseline) | This branch | Delta |
|---|---|---|---|
| `make test-unit` | 53 failed / 375 passed | 52 failed / 377 passed | −1 failure, 0 new |
| `ruff` | 182 errors | 181 errors | −1, 0 new |
| `mypy` (`make typecheck` scope) | 5 errors | 5 errors | identical output |

- **Unit tests:** I diffed the sorted lists of `FAILED` test IDs between `main` and this
  branch. The only difference is `test_none_context_chunk_text` moving from failing to
  passing. No test that passed on `main` fails here.
- **Remaining failures in `tests/unit/test_faithfulness_checker.py`:**
  `test_partial_support_returns_middle_score`, `test_multiple_context_chunks`, and
  `test_multiple_claims_varying_support` fail on `main` and still fail here. They are
  scoring-threshold bugs in `_is_supported()`, a separate concern from this crash, so I
  deliberately left them out of scope rather than widen this PR.
- **Ruff:** my change *removes* one pre-existing error (`I001`, unsorted imports in
  `faithfulness_checker.py`) because pre-commit's ruff hook fixed it on commit. It adds
  none.
- **One deviation from the surrounding test style, flagged deliberately:** my new test
  function carries type annotations (`checker: FaithfulnessChecker`, `-> None`) while the
  21 existing tests in the file do not. Without them, pre-commit's mypy hook reports one
  additional `no-untyped-def` error. Annotating keeps my mypy delta at exactly zero. Note
  that `make typecheck` deliberately excludes `tests/`, so this only affects the
  pre-commit hook. Happy to drop the annotations for consistency if you'd prefer the test
  match its neighbours.
- `PLAN.md` and `JOURNAL.md` are CodePath coursework deliverables required on the
  contributor's branch, consistent with other cohort PRs. Let me know if you'd rather I
  drop them from this PR.
