### PR TITLE
test/88-reviews-no-documents-test

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -67,3 +67,47 @@ I created an endpoint-level test for `POST /reviews` when the submitted profile 
 - There were previous tests that were not passing, but my changes do not touch any other files.
 
 **Draft PR feedback received from:** None
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [X] No — still awaiting review
+
+**Summary of feedback:**
+[What did reviewers comment on? Or note that no review came in.]
+No review came in yet for this PR.
+
+**How you responded:**
+[What changes did you make, or what did you reply? If no feedback,
+leave blank.]
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+[Be specific — what part of the process, codebase, or workflow
+surprised you?]
+- The process of understanding the codebase and how components in it connect was surprisingly harder than expected. Even after having an initial plan after exploring the codebase, there were things that I missed and didn't account for, specifically to make a unit test case for the endpoint. This could be due to the fact that I wasn't fully familiar with `pytest` and mocking yet and that was my first time making an endpoint test case.
+
+**What did you learn about working in a large codebase?**
+[What's different about contributing to someone else's production code
+vs. building your own project?]
+- Working on my own project, I would have the full context and understanding of how everything works and connects. I'm the one who made decisions to make the project. However, with working in a large production codebase that was made without me, I was thrown into it without any knowledge or context and it was up to me to build an understanding of it. This really taught me how read through a codebase by starting small and building my understanding outwards. I had to focus on only components that affect the issue I was working on. If I had tried to understand every single bit of the codebase, I would've been burnt out or overwhelmed by it. 
+
+**How did AI tools help — and where did they fall short?**
+[Where was AI assistance most useful this module? Where did you need
+to go beyond what AI could give you?]
+- AI tools help speed up my process in learning about the codebase. AI can scan and understand a large codebase than I ever could from just manually scanning. After doing my initial exploration for files and code relating to my issue, I consulted AI to tell me if I missed anything and help me understand how they connect or why it is relevant. An example of this was the AI tool telling me to review the profile endpoint and services as they are somewhat relevant to the reviews endpoint. This helped me understand what kind of information a profile holds and how I could create or mock a profile without any ingested content/documents.
+- AI tools also helped me understand how `pytest` works, teaching me the basics so I could understand the codebase's current patterns and uses of `pytest` to maintain consistency. I've never used `pytest` extensively before, so AI being a quick guide really helped.
+
+**What would you do differently if you started over?**
+[Issue selection, planning, implementation, or process — anything
+you'd change?]
+- I'd say the planning part of the process is what I could've improved on. As stated before, during the implementation phase, I remember having to review even more parts or components of the codebase that I had not initially reviewed beforehand. If I had been more thorough in my exploration and leveraged AI to validate or walk through my through process, the implementation could've been more smooth sailing.
+- I'd also say I could've explored `pytest` and mocking more deeply. It was quite frustrating as these were relatively new to me and I did have a time restriction for the assignment milestones. If I had the opportunity to explore these topics more and understand how the codebase uses them, implementation of the test case would've been quicker and maybe with more confidence.
+
+**What are you most proud of from this module?**
+[One thing — it doesn't have to be the PR itself.]
+- I'm proud of now understanding the process of contributing to large codebases or open source projects. I've always wanted to explore open source projects and contribute to projects to maybe join a community of other developers, but it always felt intimidating. I didn't want to just try to fix easy bugs/issues such as fixing typos or anything, but I realized this is how I can get my foot in the door and how I could start to learn about the codebase itself. From this module, I realized that any issue is a good starting point as long as I take the time and effort to intentionally learn about what I need to work on. 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -51,9 +51,9 @@ I reproduced the issue by sending `curl` requests to the `POST auth/register` an
 
 ### Check-in 2 (end of week)
 
-**PR link:** [link to your submitted pull request]
+**PR link:** [https://github.com/ascherj/pathreview/pull/549](https://github.com/ascherj/pathreview/pull/549)
 
-**Branch:** [the branch name you worked on, e.g. `fix/123-short-description`]
+**Branch:** `test/88-reviews-no-documents-test`
 
 **What you built:**
 I created an endpoint-level test for `POST /reviews` when the submitted profile has no data source or ingested content. The test uses FastAPI `TestClient` with mocked auth and db dependencies. I have the current test marked as `xfail` because the current behavior doesn't align with the expected behavior written in the issue writeup. The expected behavior was for the endpoint to return an appropriate error such as `400`, but it instead processes successfully and creates/commits new reviews to the database.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,69 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/88
+
+**Issue title:** ``POST /reviews`` endpoint has no test for when the profile has no ingested documents
+
+
+**Tier:** Tier 1
+
+**Problem summary:**
+There are currently many unit tests (at ``tests/unit``) in this project, but there aren't any that covers testing the ``/reviews`` endpoint (there is one for the review service layer). The specific issue is that there isn't a test for the edge case of ``POST /reviews`` when a profile exists without any associated/ingested documents. This endpoint is meant to create a new review for the profile, triggering the ingestion pipeline with a profile's documents. There needs to be a test to ensure the endpoint doesn't break and returns an appropriate error instead of crashing when hitting the endpoint with a profile that has no ingested documents.
+
+I chose this issue because this is my first time committing to a large codebase that I'm unfamiliar with. I think a tier 1 problem would be a good fit for me to familiarize myself to starting open source contributions. I was also very interested in writing test cases in the previous projects so I decided on an issue where I would test functionality. This also gives me a different view on what could be considered a "contribution", which can be anything that is asked for by a maintainer rather than always being a new feature to add or bug to fix.
+
+**Branch name:** 
+- https://github.com/AndyNguwin/pathreview/tree/test/88-reviews-no-documents-test
+- test/88-reviews-no-documents-test
+
+**Setup confirmation:** [X] App runs locally at localhost:5173
+
+**Cohort ledger:** [X] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:**
+- [Link specifically for issue reproduction](https://github.com/AndyNguwin/pathreview/commit/3dabbfb311adb973316a183374d59544c3ae23c0)
+
+**Reproduction summary:**
+I reproduced the issue by sending `curl` requests to the `POST auth/register` and `POST auth/login` endpoints to create an account, `POST /profiles` to create a profile with no data or content since the default for those fields are `None`, and then `POST /reviews` and `POST /reviews/{reviewID}` to create the review and check its status. From what I observed, the system allows for the review to be made rather than rejecting it or raising an error to handle and it eventually switches from `status: pending` to `status: complete` with a generic analysis/review. View the reproduction steps and results in the [`REPRODUCE_ISSUE.md`](REPRODUCE_ISSUE.md)
+
+**PLAN.md link:** [https://github.com/AndyNguwin/pathreview/blob/test/88-reviews-no-documents-test/PLAN.md](https://github.com/AndyNguwin/pathreview/blob/test/88-reviews-no-documents-test/PLAN.md)
+
+**Blockers or open questions:**
+- What exactly is the expected behavior for this edge case? Should there be an error response JSON? Is there a specific error message or status code it should have?
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+- I have reviewed the test files in `tests/unit/` to understand their structure and patterns using `pytest`. I see patterns such as naming conventions starting with "test" and then description of what's being tested, `@pytest.mark.unit` to tag test classes as unit tests and then `@pytest.fixture` for anything reusable for the test cases in a file, using mocks, etc.
+- I have started working on creating the fixtures and understanding how mocks are used and implemented in `test_review_routes.py`
+
+**Next steps:**
+- Continue setting up the test file, specifically the test cases that will use the fixtures of the client, database, user, and profile.
+
+**Blockers:**
+- Just new to learning about mocks, fixtures, and syntax.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [link to your submitted pull request]
+
+**Branch:** [the branch name you worked on, e.g. `fix/123-short-description`]
+
+**What you built:**
+I created an endpoint-level test for `POST /reviews` when the submitted profile has no data source or ingested content. The test uses FastAPI `TestClient` with mocked auth and db dependencies. I have the current test marked as `xfail` because the current behavior doesn't align with the expected behavior written in the issue writeup. The expected behavior was for the endpoint to return an appropriate error such as `400`, but it instead processes successfully and creates/commits new reviews to the database.
+
+**Tests added or updated:**
+`tests/unit/test_review_routes.py`
+
+**Self-review confirmation:** 
+- [X] make check passes
+- [X] make test-unit passes
+- There were previous tests that were not passing, but my changes do not touch any other files.
+
+**Draft PR feedback received from:** None

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,39 @@
+## Solution plan
+
+**Issue:** [``POST /reviews`` endpoint has no test for when the profile has no ingested documents](https://github.com/ascherj/pathreview/issues/88)
+
+### Understand
+What is the root cause of this issue? What behavior is expected vs. actual?
+- The root cause is just that there is no unit test for this specific endpoint with that input yet. The expected behavior for this endpoint-level test is that the endpoint should handle this edge case gracefully by not creating a review with no ingested sources and returning an appropriate error response. The current actual behavior is that the request is accepted, a review is still created even with no documents or sources and completes the review with generic analysis.
+
+### Map
+Which files, functions, or modules are involved?
+List the specific files you expect to touch.
+1. `tests/unit/test_review_routes.py`: creating a separate file for this endpoint-level testing
+2. `api/routes/reviews.py`: where the `POST /reviews` request routes to that needs to be tested
+3. `core/services/review_service.py`: contains backend functions and processes that are called when a request is accepted by `POST /reviews`
+4. `tests/unit/`: contains all of the existing testing files to follow similar structure
+
+### Plan
+What are the steps to fix this issue?
+Break it into 3–5 concrete sub-tasks.
+1. Review the current existing tests in the `tests/unit/` folder to understand and match the structure of the pytest patterns and fixtures.
+2. Set up a test user and a profile that has no data sources (Github, Resume, Portfolio) and ingested documents yet.
+3. Send a ``POST /reviews`` request with the empty profile's ID.
+4. Assert that the endpoint handles a request with a profile that no sources gracefully with the expected error response.
+4. Run the pytest to ensure the test case runs properly (fixing the feature if the test case fails is outside of the scope.)
+
+### Inputs & outputs
+What does your fix take as input? What should it produce or change?
+- Input: an authenticated (using login token and profile ID) `POST /reviews` request for a profile that has no Github username, resume, nor portfolio.
+- Output: A new pytest test case file that covers this edge case at the endpoint level, verifying that the endpoint handles it gracefully.
+
+### Risks & unknowns
+What could go wrong? What are you still unsure about?
+- The expected behavior for this edge case doesn't seem to be defined yet. Is the endpoint supposed to return an error response? If so, what status code or message will it have?
+- 
+
+### Edge cases
+What inputs or states should your fix handle gracefully?
+- A profile that has no Github username, portfolio URL, nor uploaded resume associated to it.
+- A profile that has the source fields, but ingestion produces no documents to create a review from.

--- a/REPRODUCE_ISSUE.md
+++ b/REPRODUCE_ISSUE.md
@@ -1,0 +1,82 @@
+# Reproduce: POST /reviews With No Ingested Documents
+
+These commands assume the backend is running at `http://localhost:8000` and using Bash to run commands.
+
+## 0. Create A Test Account (Optional)
+- Create an account to use for the reproduction. Adjust the email if this account already exists.
+- **NOTE**: A test account isn't needed, can use one of the example or existing accounts as reviews create separate profiles.
+
+```bash
+curl -s -X POST http://localhost:8000/auth/register \
+  -H "Content-Type: application/json" \
+  -d '{"email": "empty-profile@example.com", "password": "password1"}'
+```
+
+## 1. Log In And Capture Token
+- Using the test account `empty-profile@example.com` with password `password1`. Adjust if using another account for testing.
+- Login to an account to get the access token to use for creating a profile and a review.
+
+```bash
+LOGIN_RESPONSE=$(curl -s -X POST http://localhost:8000/auth/login \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "username=empty-profile@example.com" \
+  -d "password=password1")
+
+TOKEN=$(python -c "import json,sys; print(json.load(sys.stdin)['access_token'])" <<< "$LOGIN_RESPONSE")
+echo "$TOKEN"
+```
+
+**Result**:
+- Echoed the login/account token.
+- `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmMGZhM2Q1OS1lOGE2LTQ3NjUtYmUzMS03N2Q0NWRmY2JiMzEiLCJleHAiOjE3ODUwNDQzMTV9.ck5bZ_YHIRjYEOpr8eM8z4zMo-qVelFyXL75I5JI3TY`
+
+## 2. Create A Profile With No Ingested Data
+- `POST /profiles` accepts `github_username`, `portfolio_url`, and `resume_file`, but they default to `None`, so send no form fields. (view [`api/routes/profiles.py`](api\routes\profiles.py) )
+- Expected profile fields should include null/empty source fields, such as no GitHub username, no portfolio URL, and no resume filename.
+- Save the profile id of that profile to use for creating a review.
+
+```bash
+PROFILE_RESPONSE=$(curl -s -X POST http://localhost:8000/profiles \
+  -H "Authorization: Bearer $TOKEN")
+
+PROFILE_ID=$(python -c "import json,sys; print(json.load(sys.stdin)['id'])" <<< "$PROFILE_RESPONSE")
+echo "$PROFILE_RESPONSE"
+echo "$PROFILE_ID"
+```
+**Result**:
+- Echoed the response JSON from the profile request and the profile id:
+  - `{"id":"b3f81e27-21ac-4787-996b-bbe15997d630","user_id":"f0fa3d59-e8a6-4765-be31-77d45dfcbb31","github_username":null,"portfolio_url":null,"created_at":"2026-07-26T11:39:32.325062Z","resume_filename":null}`
+  - `b3f81e27-21ac-4787-996b-bbe15997d630`
+
+
+## 3. Create A Review For The Empty Profile
+- Using the saved login token and profile id, create a review using the `POST /reviews` endpoint for the profile with no ingested content.
+
+```bash
+REVIEW_RESPONSE=$(curl -s -X POST http://localhost:8000/reviews \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "{\"profile_id\": \"$PROFILE_ID\"}")
+
+REVIEW_ID=$(python -c "import json,sys; print(json.load(sys.stdin)['id'])" <<< "$REVIEW_RESPONSE")
+echo "$REVIEW_RESPONSE"
+echo "$REVIEW_ID"
+```
+
+**Result**:
+- Echoed the response JSON from the review request and the profile id:
+  - `{"id":"4d62f114-1246-4bf1-af19-6c509e59d242","profile_id":"b3f81e27-21ac-4787-996b-bbe15997d630","status":"pending","sections":null,"overall_score":null,"error_message":null,"created_at":"2026-07-26T11:39:58.507387Z","updated_at":"2026-07-26T11:39:58.507387Z"}`
+  - `4d62f114-1246-4bf1-af19-6c509e59d242`
+- Response JSON from the review request suggests that it successfully processed the review rather than rejecting or raising an error to handle.
+
+## 4. Check Review Status
+
+```bash
+curl -s -X GET "http://localhost:8000/reviews/$REVIEW_ID" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+**Result**:
+- Response JSON: 
+  - `{"id":"d4c254ff-bf5b-4ac6-9200-a3427e1a44d8","profile_id":"29e71ffd-62aa-4f19-a303-09d580dda50f","status":"complete","sections":[{"section_name":"Technical Skills","content":"Detailed feedback on technical skills based on portfolio analysis","confidence":0.85,"suggestions":["Add more detail on AI/ML experience","Include specific technologies and frameworks"]},{"section_name":"Project Experience","content":"Detailed feedback on project experience and impact","confidence":0.8,"suggestions":["Include measurable impact metrics","Add links to project repositories"]},{"section_name":"Career Growth","content":"Feedback on career progression and development","confidence":0.78,"suggestions":["Document learning from each role","Highlight growth in responsibilities"]}],"overall_score":0.81,"error_message":null,"created_at":"2026-07-26T11:21:16.384891Z","updated_at":"2026-07-26T11:21:16.414575Z"}`
+- Review's status becomes "complete" for this profile.

--- a/tests/unit/test_review_routes.py
+++ b/tests/unit/test_review_routes.py
@@ -1,0 +1,101 @@
+"""Tests for api/routes/reviews.py"""
+
+from collections.abc import AsyncGenerator, Generator
+from datetime import datetime
+from importlib import import_module
+from typing import Any
+from unittest.mock import AsyncMock, Mock
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def review_routes_module() -> Any:
+    return import_module("api.routes.reviews")
+
+
+@pytest.fixture
+def test_app(review_routes_module: Any) -> FastAPI:
+    app = FastAPI()
+    app.include_router(review_routes_module.router)
+    return app
+
+
+@pytest.fixture
+def test_user() -> Mock:
+    user = Mock()
+    user.id = uuid4()
+    user.email = "test@example.com"
+    return user
+
+
+@pytest.fixture
+def empty_profile(test_user: Mock) -> Mock:
+    profile = Mock()
+    profile.id = uuid4()
+    profile.user_id = test_user.id
+    profile.github_username = None
+    profile.portfolio_url = None
+    profile.resume_text = None
+    profile.resume_filename = None
+    return profile
+
+
+@pytest.fixture
+def test_db() -> AsyncMock:
+    db = AsyncMock()
+    db.add = Mock()
+
+    async def refresh(review: Any) -> None:
+        review.id = str(uuid4())
+        review.created_at = datetime.utcnow()
+        review.updated_at = datetime.utcnow()
+
+    db.refresh = AsyncMock(side_effect=refresh)
+    return db
+
+
+@pytest.fixture
+def test_client(
+    test_app: FastAPI,
+    test_user: Mock,
+    test_db: AsyncMock,
+    review_routes_module: Any,
+) -> Generator[TestClient, None, None]:
+    # Endpoint relies on user and db, so I have to override them with mocks
+    test_app.dependency_overrides[review_routes_module.get_current_user] = lambda: test_user
+
+    async def override_get_db() -> AsyncGenerator[AsyncMock, None]:
+        yield test_db
+
+    test_app.dependency_overrides[review_routes_module.get_db] = override_get_db
+
+    try:
+        yield TestClient(test_app)
+    finally:
+        test_app.dependency_overrides.clear()
+
+
+@pytest.mark.xfail(reason="POST /reviews currently accepts empty profiles instead of returning 400")
+def test_post_with_empty_profile(
+    test_client: TestClient,
+    empty_profile: Mock,
+    test_db: AsyncMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("api.routes.reviews.process_review", AsyncMock())
+
+    response = test_client.post(
+        "/reviews",
+        json={"profile_id": str(empty_profile.id)},
+    )
+
+    # Assert that an appropriate error is returned instead of creating a review.
+    assert response.status_code == 400
+    # The db should not be modified because no review should be made.
+    test_db.add.assert_not_called()
+    test_db.commit.assert_not_awaited()
+    test_db.refresh.assert_not_awaited()


### PR DESCRIPTION
## Summary
<!-- One paragraph describing what this PR does and why -->
This PR adds endpoint-level coverage for issue 88, which identified that POST /reviews was not tested when the requested profile has no ingested content. It documents the reproduction flow through the created markdown files and adds a test for an empty-profile review request, asserting that the endpoint should return an appropriate error and avoid creating or committing a review to the database. This helps capture the current behavior gap so the backend can be fixed against a clear regression test.

## Issue
Closes #88  

## Changes
<!-- Bullet list of the specific changes made -->
- Added `tests/unit/test_review_routes.py` with an endpoint-level POST /reviews test for an empty profile.
- Added mocked FastAPI auth and database dependencies for the route test.
- Marked the test as `xfail` to document the current known behavior gap.
- Asserted that the endpoint should return 400 and avoid database writes.

## Testing
<!-- How did you verify your changes? -->
- [X] Unit tests pass (`make test-unit`)
- [X] Integration tests pass (`make test-integration`)
- [X] Linter passes (`make lint`)
- [X] Type checker passes (`make typecheck`)
- [X] New/updated tests cover the changes
- There are previous tests that weren't passing, but are unrelated to the scope nor were they touched or affected.

## Screenshots / Demo
<!-- If applicable, add screenshots or a link to a demo video -->

## Notes for Reviewers
<!-- Anything the reviewer should pay particular attention to -->
- To re-emphasize, the test case is marked as `xfail` to show that the current system behavior of this process does not match the intended/expected behavior as stated in the issue writeup.
- Commits were rewritten to match commit message conventions, which removed my commits that showed incremental progress