### PR TITLE
fix(agent): ignore vendored and build files in tech detector

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -71,3 +71,80 @@ I added `tests/unit/test_tech_detector_path_edge_cases.py` with regression tests
 **Self-review confirmation:** [x] make check passes  [x] focused TechDetector unit tests pass; repository-wide unit suite has documented pre-existing unrelated failures
 
 **Draft PR feedback received from:** none
+
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No reviewer or maintainer feedback has been provided on my pull request.
+As noted in the Summer 2026 course instructions, reviewer feedback is not
+provided for this cohort, so I am documenting that no review was received.
+
+**How you responded:**
+No response or additional changes were required because I did not receive
+reviewer feedback.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+
+The hardest part was not the final code change itself, but understanding the
+existing repository workflow and making sure my contribution met all of the
+project's standards. I had to reproduce Issue #150, trace the behavior to
+`agent/tools/tech_detector.py`, understand the existing tests, and work
+through formatting, linting, type-checking, and Git requirements. I also
+learned that having a working fix is only one part of completing an
+open-source contribution; tests, documentation, commits, and the pull
+request process are equally important.
+
+**What did you learn about working in a large codebase?**
+
+I learned to make focused changes instead of trying to understand or modify
+the entire repository. For Issue #150, I concentrated on
+`agent/tools/tech_detector.py` and the related unit tests, reproduced the
+failure first, and then changed only the path-filtering behavior responsible
+for the bug. I also learned that existing tests and contribution guidelines
+are important sources of information because they show the behavior and
+standards that maintainers expect. This is different from my own projects,
+where I control the architecture and can change several parts of the system
+without coordinating with an existing codebase.
+
+**How did AI tools help — and where did they fall short?**
+
+AI tools were useful for helping me interpret test failures, understand the
+TechDetector logic, plan the fix, and troubleshoot Git, pytest, formatting,
+and type-checking errors. They also helped me think about edge cases such as
+Windows-style paths and nested vendored directories. However, I learned that
+I could not rely on AI output without verifying it against the repository.
+At one point, changes to the test file introduced linting and type-checking
+problems, so I had to use the actual pytest, Ruff, Black, mypy, Git, and
+repository results to determine what was correct. The biggest lesson was
+that AI can accelerate investigation and debugging, but the codebase,
+tests, and contribution requirements remain the source of truth.
+
+**What would you do differently if you started over?**
+
+I would read the complete grading rubric and `CONTRIBUTING.md` before making
+my first change and maintain a checklist for every required deliverable. I
+would also add my own edge-case tests earlier instead of relying initially
+on only the existing regression tests. Most importantly, I would verify the
+final GitHub branch, `JOURNAL.md`, test commits, PR description, and PR status
+against the rubric before submitting. This would have helped me avoid the
+documentation and submission problems I encountered during Week 9.
+
+**What are you most proud of from this module?**
+
+I am most proud that I worked through a real bug from reproduction to a
+tested implementation rather than stopping once the two original failing
+tests passed. My final TechDetector change handles vendored and generated
+directories while accounting for both Unix and Windows path separators, and
+I added regression coverage for additional path edge cases. More broadly,
+I am proud that I became more comfortable navigating an unfamiliar
+repository, diagnosing failures, using Git branches and commits, and
+preparing a contribution for review.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,19 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/150
+
+**Issue title:** Tech detector counts vendored and build-output files, skewing language detection
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The technology detector currently counts files inside directories such as `node_modules/` and `build/` when deciding a repository’s primary programming language. These files are usually third-party dependencies or generated build artifacts rather than code written by the repository owner. As a result, a mostly Python project can incorrectly be classified as JavaScript when vendored JavaScript files outnumber the real source files. A successful fix would filter out these paths before counting languages so the detector reflects the repository’s actual source code.
+
+**Issue selection reasoning:**
+I chose this issue because it is a Tier 1 bug with a clear reproduction example, a narrow scope, and existing failing tests. The relevant implementation and test files are identified in the issue, so I can trace the problem without needing to understand the entire codebase. The expected behavior is also specific: files inside `node_modules/` and `build/` should not affect primary-language detection. This makes the issue realistic for my current experience while still requiring me to understand and test an existing module.
+
+**Branch name:** fix/150-ignore-vendored-build-files
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -50,3 +50,6 @@ I will open a draft pull request, request peer or mentor feedback, review the re
 
 **Blockers:**
 The full unit-test suite currently has 51 pre-existing failures in unrelated modules. My focused TechDetector tests pass, and my changes do not touch the failing modules.
+
+**Tests added or updated:**
+Updated the TechDetector test coverage by adding regression tests for Windows-style paths, deeply nested vendored/build directories, and filenames that resemble skipped directory names. Verified that all TechDetector unit tests pass.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -35,3 +35,18 @@ I reproduced Issue #150 by running the existing `test_node_modules_excluded` and
 
 **Blockers or open questions:**
 I still need to confirm how file paths are normalized inside `TechDetector` and whether nested or Windows-style paths require additional handling.
+
+
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+I implemented the fix for Issue #150 in `agent/tools/tech_detector.py`. The detector now normalizes file paths and excludes files located inside vendored or generated directories before performing language detection. The existing `test_node_modules_excluded` and `test_build_directory_excluded` regression tests now pass, and all 27 tests in `tests/unit/test_tech_detector.py` pass.
+
+**Next steps:**
+I will open a draft pull request, request peer or mentor feedback, review the repository contribution checklist, and document the repository-wide pre-existing test failures. After addressing any relevant feedback, I will mark the pull request ready for review and complete Check-in 2.
+
+**Blockers:**
+The full unit-test suite currently has 51 pre-existing failures in unrelated modules. My focused TechDetector tests pass, and my changes do not touch the failing modules.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -22,12 +22,14 @@ I chose this issue because it is a Tier 1 bug with a clear reproduction example,
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [Add after pushing the reproduction commit]
+
+**Reproduction commit link:** https://github.com/iadamib7/pathreview/commit/2df3497
 
 **Reproduction summary:**
 I reproduced Issue #150 by running the existing `test_node_modules_excluded` and `test_build_directory_excluded` tests in `tests/unit/test_tech_detector.py`. Both tests failed because `TechDetector` counted JavaScript files inside `node_modules/` and `build/`, causing it to report JavaScript instead of the expected Python primary language.
 
-**PLAN.md link:** [Add after pushing the branch]
+
+**PLAN.md link:** https://github.com/iadamib7/pathreview/blob/fix/150-ignore-vendored-build-files/PLAN.md
 
 **Walkthrough video (recommended):** Not recorded
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -53,3 +53,21 @@ The full unit-test suite currently has 51 pre-existing failures in unrelated mod
 
 **Tests added or updated:**
 Updated the TechDetector test coverage by adding regression tests for Windows-style paths, deeply nested vendored/build directories, and filenames that resemble skipped directory names. Verified that all TechDetector unit tests pass.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/551
+
+**Branch:** `fix/150-ignore-vendored-build-files`
+
+**What you built:**
+I updated `TechDetector` so files inside vendored dependency and generated build directories do not affect primary-language detection. The implementation normalizes Windows and Unix path separators, checks only directory components, and excludes paths inside directories such as `node_modules`, `build`, `dist`, `vendor`, `.git`, `.venv`, `venv`, and `__pycache__`.
+
+**Tests added or updated:**
+I added `tests/unit/test_tech_detector_path_edge_cases.py` with regression tests for Windows-style backslash paths, deeply nested `node_modules` and `build` directories, and valid source files named `node_modules.py` and `build.py`. I also verified that the 27 existing tests in `tests/unit/test_tech_detector.py` and the 3 new edge-case tests all pass.
+
+**Self-review confirmation:** [x] make check passes  [x] focused TechDetector unit tests pass; repository-wide unit suite has documented pre-existing unrelated failures
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -17,3 +17,19 @@ I chose this issue because it is a Tier 1 bug with a clear reproduction example,
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [Add after pushing the reproduction commit]
+
+**Reproduction summary:**
+I reproduced Issue #150 by running the existing `test_node_modules_excluded` and `test_build_directory_excluded` tests in `tests/unit/test_tech_detector.py`. Both tests failed because `TechDetector` counted JavaScript files inside `node_modules/` and `build/`, causing it to report JavaScript instead of the expected Python primary language.
+
+**PLAN.md link:** [Add after pushing the branch]
+
+**Walkthrough video (recommended):** Not recorded
+
+**Blockers or open questions:**
+I still need to confirm how file paths are normalized inside `TechDetector` and whether nested or Windows-style paths require additional handling.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,44 @@
+## Solution plan
+
+**Issue:** [Tech detector counts vendored and build-output files, skewing language detection](https://github.com/ascherj/pathreview/issues/150)
+
+### Understand
+
+The `TechDetector` currently counts every file extension in the provided file list when determining the primary programming language. It does not filter out files located inside dependency or generated-output directories such as `node_modules/` and `build/`. As a result, third-party JavaScript files or generated bundles can outnumber the repository's real source files and cause the detector to return JavaScript as the primary language even when the project itself is primarily Python.
+
+The expected behavior is for vendored dependencies and build artifacts to be ignored before language counts are calculated. The actual behavior is that those files are included in the counts.
+
+### Map
+
+The main files involved are:
+
+- `agent/tools/tech_detector.py`
+  - Contains the `TechDetector` implementation.
+  - Responsible for analyzing file paths and determining language counts.
+- `tests/unit/test_tech_detector.py`
+  - Contains the failing tests:
+    - `test_node_modules_excluded`
+    - `test_build_directory_excluded`
+
+I expect the implementation change to be limited mainly to `agent/tools/tech_detector.py`. The tests may only need to be reviewed or expanded if additional edge cases are discovered.
+
+### Plan
+
+1. Inspect the file-processing loop in `TechDetector.execute()` to identify where file paths are counted by extension.
+2. Add a path-filtering check that excludes files located inside known vendored or generated directories such as `node_modules/` and `build/`.
+3. Ensure the filtering works for relative paths and does not exclude normal source files whose filenames merely contain similar text.
+4. Run the two failing unit tests to verify that Python becomes the primary language after excluded paths are removed.
+5. Run the complete `tests/unit/test_tech_detector.py` test file to confirm the change does not break existing language or framework detection behavior.
+
+### Inputs & outputs
+
+The input is a dictionary containing a list of repository file paths, for example:
+
+```python
+{
+    "files": [
+        "src/main.py",
+        "node_modules/package/index.js",
+        "build/bundle.js"
+    ]
+}

--- a/agent/tools/tech_detector.py
+++ b/agent/tools/tech_detector.py
@@ -1,6 +1,7 @@
 """Technology stack detector tool."""
 
 import structlog
+
 from .base import BaseTool, ToolResult
 
 logger = structlog.get_logger()
@@ -60,10 +61,10 @@ class TechDetector(BaseTool):
         """Detect tech stack from files.
 
         Args:
-            input_data: Must contain 'files' (list of file paths)
+            input_data: Must contain 'files' (list of file paths).
 
         Returns:
-            ToolResult with detected technologies
+            ToolResult with detected technologies.
         """
         files = input_data.get("files", [])
 
@@ -75,90 +76,100 @@ class TechDetector(BaseTool):
                     "primary_language": "Unknown",
                     "all_languages": [],
                     "frameworks": [],
-                }
+                },
             )
 
         try:
             result = self._detect_tech(files)
             return ToolResult(success=True, data=result)
 
-        except Exception as e:
-            logger.error("tech_detector_error", error=str(e))
+        except Exception as error:
+            logger.error("tech_detector_error", error=str(error))
             return ToolResult(
                 success=False,
                 data={},
-                error=str(e)
+                error=str(error),
             )
 
     def _detect_tech(self, files: list[str]) -> dict:
-        """Detect technologies from file list.
+        """Detect technologies from a file list.
 
         Args:
-            files: List of file paths
+            files: List of file paths.
 
         Returns:
-            Dict with detected languages and frameworks
+            Dictionary with detected languages and frameworks.
         """
-        # Filter out vendor/build directories
-        filtered_files = [
-            f for f in files
-            if not self._should_skip_file(f)
-        ]
+        filtered_files = [filepath for filepath in files if not self._should_skip_file(filepath)]
 
         languages = set()
         frameworks = set()
 
-        # Detect by file extension
+        # Detect languages by file extension.
         for filepath in filtered_files:
-            for ext, lang in self.EXT_TO_LANG.items():
-                if filepath.endswith(ext):
-                    languages.add(lang)
+            for extension, language in self.EXT_TO_LANG.items():
+                if filepath.endswith(extension):
+                    languages.add(language)
 
-        # Detect by config files
+        # Detect languages and frameworks by configuration files.
         for filepath in filtered_files:
-            for config_file, (framework, lang) in self.CONFIG_INDICATORS.items():
+            for config_file, (framework, language) in self.CONFIG_INDICATORS.items():
                 if filepath.endswith(config_file):
-                    languages.add(lang)
-                    if framework not in ("Docker", "Infrastructure", "CI/CD", "Build"):
+                    languages.add(language)
+
+                    if framework not in (
+                        "Docker",
+                        "Infrastructure",
+                        "CI/CD",
+                        "Build",
+                    ):
                         frameworks.add(framework)
 
-        # Determine primary language (most common)
-        primary = "Unknown"
+        primary_language = "Unknown"
+
         if languages:
-            lang_list = sorted(languages)
-            primary = lang_list[0]
+            primary_language = sorted(languages)[0]
 
         all_languages = sorted(languages)
         all_frameworks = sorted(frameworks)
 
-        logger.info("tech_detected", primary_lang=primary,
-                   languages_count=len(all_languages), frameworks_count=len(all_frameworks))
+        logger.info(
+            "tech_detected",
+            primary_lang=primary_language,
+            languages_count=len(all_languages),
+            frameworks_count=len(all_frameworks),
+        )
 
         return {
-            "primary_language": primary,
+            "primary_language": primary_language,
             "all_languages": all_languages,
             "frameworks": all_frameworks,
         }
 
     @staticmethod
     def _should_skip_file(filepath: str) -> bool:
-        """Check if file should be skipped.
+        """Check whether a file is inside a vendored or generated directory.
 
         Args:
-            filepath: File path
+            filepath: Repository-relative or absolute file path.
 
         Returns:
-            True if file should be skipped
+            True if the file should be excluded from technology detection.
         """
-        skip_patterns = [
-            "/node_modules/",
-            "/vendor/",
-            "/dist/",
-            "/build/",
-            "/.git/",
-            "/__pycache__/",
-            "/.venv/",
-            "/venv/",
-        ]
+        skip_directories = {
+            "node_modules",
+            "vendor",
+            "dist",
+            "build",
+            ".git",
+            "__pycache__",
+            ".venv",
+            "venv",
+        }
 
-        return any(pattern in filepath for pattern in skip_patterns)
+        normalized_path = filepath.replace("\\", "/")
+        path_parts = [part for part in normalized_path.split("/") if part]
+
+        directory_parts = path_parts[:-1]
+
+        return any(part in skip_directories for part in directory_parts)

--- a/tests/unit/test_tech_detector_path_edge_cases.py
+++ b/tests/unit/test_tech_detector_path_edge_cases.py
@@ -1,0 +1,55 @@
+"""Edge-case tests for TechDetector path filtering."""
+
+import pytest
+
+from agent.tools.tech_detector import TechDetector
+
+
+@pytest.mark.unit
+class TestTechDetectorPathEdgeCases:
+    """Test vendored and generated directory path handling."""
+
+    def test_windows_style_paths_are_excluded(self) -> None:
+        """Exclude vendored and build directories using Windows separators."""
+        detector = TechDetector()
+        files = [
+            r"src\main.py",
+            r"frontend\node_modules\package\index.js",
+            r"frontend\build\bundle.js",
+        ]
+
+        result = detector.execute({"files": files})
+
+        assert result.success is True
+        assert result.data["primary_language"] == "Python"
+        assert result.data["all_languages"] == ["Python"]
+
+    def test_deeply_nested_vendored_paths_are_excluded(self) -> None:
+        """Exclude deeply nested dependency and build-output paths."""
+        detector = TechDetector()
+        files = [
+            "src/main.py",
+            "src/node_modules/pkg/sub/file.js",
+            "frontend/build/assets/vendor.js",
+        ]
+
+        result = detector.execute({"files": files})
+
+        assert result.success is True
+        assert result.data["primary_language"] == "Python"
+        assert result.data["all_languages"] == ["Python"]
+
+    def test_filename_matching_directory_name_is_not_excluded(self) -> None:
+        """Keep normal source files whose names resemble skipped directories."""
+        detector = TechDetector()
+        files = [
+            "src/main.py",
+            "src/node_modules.py",
+            "src/build.py",
+        ]
+
+        result = detector.execute({"files": files})
+
+        assert result.success is True
+        assert result.data["primary_language"] == "Python"
+        assert result.data["all_languages"] == ["Python"]


### PR DESCRIPTION
## Summary

This PR fixes Issue #150 by preventing vendored dependencies and generated build files from affecting primary-language detection.

The TechDetector now normalizes file paths and ignores files located inside directories such as:

- `node_modules`
- `vendor`
- `dist`
- `build`
- `.git`
- `__pycache__`
- `.venv`
- `venv`

This prevents third-party or generated JavaScript files from incorrectly causing a Python repository to be classified as JavaScript.

## Testing

- `python -m pytest tests/unit/test_tech_detector.py -v`
  - 27 passed
- `ruff`
  - passed
- `black`
  - passed
- `mypy`
  - passed

The repository-wide unit-test suite still has unrelated pre-existing failures in other modules. My changes do not touch those modules and did not introduce new TechDetector failures.

Closes #150
