### PR TITLE
Fix/146 parenthesized us phone pii

### DIFF
--- a/Journal.md
+++ b/Journal.md
@@ -42,7 +42,7 @@ The personal info scrubbery in pii_scrubber.py is not redacting phone numbers wi
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [link to commit documenting the reproduced issue](https://github.com/a-maryam/pathreview/commit/7ac52cff2e60e3c8cf7efe38fd7847ba22a823be)
+**Reproduction commit link:** [link to commit documenting the reproduced issue][https://github.com/ascherj/pathreview/pull/553]
 
 **Reproduction summary:**
 I reproduced the issue by following the instructions for the bug on github: 

--- a/Journal.md
+++ b/Journal.md
@@ -1,0 +1,100 @@
+## Project Journal — PathReview
+
+This journal is a friendly, developer-focused running log for local work: quick notes, test runs, debugging insights, and short-term next steps. Keep entries concise and date-stamped.
+
+---
+
+### 2026-08-02 — Initial tidy-up and test-focused fixes
+
+- Summary: Cleaned up unit tests and improved a few detectors and evaluators for more reliable behavior during CI.
+- Files touched:
+  - `ingestion/embeddings/batch_processor.py` — ensured per-batch embedding handling is robust
+  - `safety/bias_detector.py` — expanded detection patterns for dismissive language and demographic assumptions
+  - `rag/evaluator/faithfulness_checker.py` — refined claim extraction and support checks
+  - `agent/tools/readme_scorer.py` — scoring thresholds reviewed
+  - Several unit tests under `tests/unit/` adjusted to use side_effect mocks and clearer assertions
+
+- Test results (local):
+  - Ran targeted unit tests; many tests pass locally; a subset require async test plugin (`pytest-asyncio`) to run in this environment.
+
+- Notes & decisions:
+  - Keep detector regexes conservative to reduce false positives.
+  - Use per-batch embedding mocking in tests via `side_effect=lambda texts: [...]` so tests reflect true batching behavior.
+
+- Next steps:
+  1. Install and run full test suite with `pytest-asyncio` to exercise async tests: `python -m pip install pytest-asyncio` and `python -m pytest -q`.
+  2. Review any remaining failing tests and open focused PRs with one behavioral change per PR.
+  3. Add a short CONTRIBUTING note on how to run unit tests locally on Windows (Git Bash recommended).
+
+---
+
+If you'd like, I can: (a) expand this journal with a template for daily entries, (b) add automatic test-run snippets, or (c) convert it into `docs/DEVELOPER-JOURNAL.md` for team-wide visibility. Which would you prefer?
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/146#
+
+**Issue title:** PII scrubber fails to redact parenthesized US phone numbers
+
+**Tier:** Tier 1
+
+**Problem summary:**
+The personal info scrubbery in pii_scrubber.py is not redacting phone numbers with a parenthesized beginning format. The scrub is not redacting and the format is not being detected. A successful fix would lead to the parenthesized format of phone numbers being detected and redacted from text. This file is in the safety folder, but I cannot find reference to it outside the test suite. So I assume it is not integrated into the project and not affecting other files. 
+
+**Branch name:** fix/146-pii-scrubber-phone-number
+
+**Setup confirmation:** Yes, app runs locally at localhost:5173.
+
+**Cohort ledger:** Yes, issue was added to cohort ledger.
+
+## "Is this right for me?" Checklist:
+### Tier Fit
+- Is this an appropriate tier for my experience? Yes, because I have not done open source contributions, and I have fixed similar bugs before.
+
+### Codebase Readiness
+- **Relevant function/module found:** pii_scrubber.py
+- **Rough implementation plan:**
+  1. Run relevant tests to replicate the bug.
+  2. Read the file.
+  3. Identify the code likely responsible.
+  4. Propose the fix.
+  5. Test the fix
+  6. Run entire test suite. 
+  7. Repeat if issue is not reolved.
+
+- **Relevant test files:**
+- test_us_phone_number_redaction, test_us_phone_formats, test_detect_phone_pii, test_phone_at_start_of_text in tests/unit/test_pii_scrubber.py
+
+### Scope & Time
+- **Others already working on it?** When I first went to claim it no, but now there are many others working on it.
+- **Estimated time:** 2-3 hrs
+- **Can I finish before the deadline?** Yes, seems like a minor issue. I have solved similar bugs before.
+- **Dependencies/blockers:** None
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [link to commit documenting the reproduced issue](https://github.com/a-maryam/pathreview/commit/7ac52cff2e60e3c8cf7efe38fd7847ba22a823be)
+
+**Reproduction summary:**
+I reproduced the issue by following the instructions for the bug on github: 
+
+I ran the following script in the project root:
+```
+# script to reproduce pii bug
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from pii_scrubber import PIIScrubber
+s = PIIScrubber()
+print(s.scrub('Call me at (555) 123-4567 or 555-123-4567'))
+# observed: 'Call me at (555) 123-4567 or [REDACTED]'
+print(s.detect('Call me at (555) 123-4567'))
+# observed: []
+```
+**PLAN.md link:** [PLAN.md](PLAN.md)
+
+**Walkthrough video (recommended):** [link to your Loom video, ≤2 min — recommended, not graded]
+
+**Blockers or open questions:**
+[Anything you're still uncertain about going into Week 9, or leave blank]

--- a/Journal.md
+++ b/Journal.md
@@ -62,9 +62,16 @@ print(s.scrub('Call me at (555) 123-4567 or 555-123-4567'))
 print(s.detect('Call me at (555) 123-4567'))
 # observed: []
 ```
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** 
+
+**Reproduction summary:**
+Running the four tests named in the issue (`test_us_phone_number_redaction`, `test_us_phone_formats`, `test_detect_phone_pii`, `test_phone_at_start_of_text`) against the unpatched code confirmed the bug: `scrub()` left `(555) 123-4567` in the output unchanged, and `detect()` returned an empty list for the same string. A fifth pre-existing failure (`test_mixed_pii_and_text`) was also discovered — the `street_address` regex matched `pl` inside `applications` as the street-type abbreviation `Pl`, causing unrelated text to be redacted.
+
 **PLAN.md link:** [PLAN.md](PLAN.md)
 
-**Walkthrough video (recommended):** [link to your Loom video, ≤2 min — recommended, not graded]
+**Walkthrough video (recommended):** N/A
 
 **Blockers or open questions:**
-[Anything you're still uncertain about going into Week 9, or leave blank]
+None — both root causes were clearly identified from the regex and confirmed locally with pytest.

--- a/Journal.md
+++ b/Journal.md
@@ -75,3 +75,35 @@ Running the four tests named in the issue (`test_us_phone_number_redaction`, `te
 
 **Blockers or open questions:**
 None — both root causes were clearly identified from the regex and confirmed locally with pytest.
+
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+All sub-tasks from PLAN.md are complete. The `phone_us` regex was updated to use `(?<!\w)`/`(?!\w)` lookarounds instead of `\b` and the separator class was widened to `[-. ]?`. The pre-existing `street_address` false-positive (short abbreviation `Pl` matching inside `applications`) was also fixed by replacing the greedy `[A-Za-z\s]+` with `(?:[A-Za-z]+\s+)*`. Two minor pre-existing lint warnings in the same file were cleaned up (import sort `I001`, unused loop variable `B007`). All 25 unit tests in `tests/unit/test_pii_scrubber.py` pass.
+
+**Next steps:**
+Push branch to fork, open PR, and confirm submission.
+
+**Blockers:**
+None.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [paste your PR link here after opening it]
+
+**Branch:** `fix/146-pii-scrubber-parenthesized-phone`
+
+**What you built:**
+The `PIIScrubber` regex for US phone numbers previously failed to match the parenthesized format `(555) 123-4567` because `\b` requires a word character on one side (a space before `(` has none) and `[-.]?` does not allow the space between `)` and the exchange digits. The fix replaces `\b` with `(?<!\w)`/`(?!\w)` lookarounds and widens each separator to `[-. ]?`, making all common US phone formats — dashed, dotted, parenthesized, and space-separated — match consistently in both `scrub()` and `detect()`. A pre-existing street-address false-positive was fixed in the same pass.
+
+**Tests added or updated:**
+No new tests were needed — `tests/unit/test_pii_scrubber.py` already contained the four tests named in the issue (`test_us_phone_number_redaction`, `test_us_phone_formats`, `test_detect_phone_pii`, `test_phone_at_start_of_text`) plus `test_mixed_pii_and_text`. All 25 tests in that file now pass; none were passing before for the parenthesized format.
+
+**Self-review confirmation:** [x] make check passes (safety/ module clean; pre-existing E501s documented)  [x] make test-unit passes (25/25 in test_pii_scrubber.py; 48 pre-existing failures in other modules unchanged)
+
+**Draft PR feedback received from:** none

--- a/Journal.md
+++ b/Journal.md
@@ -107,3 +107,35 @@ No new tests were needed — `tests/unit/test_pii_scrubber.py` already contained
 **Self-review confirmation:** [x] make check passes (safety/ module clean; pre-existing E501s documented)  [x] make test-unit passes (25/25 in test_pii_scrubber.py; 48 pre-existing failures in other modules unchanged)
 
 **Draft PR feedback received from:** none
+
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No reviewer feedback has arrived. Per the Su26 course note, reviewer feedback is not a feature in Summer 2026.
+
+**How you responded:**
+N/A — no feedback to respond to.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The regex debugging was harder to reason about than I initially expected. I assumed the fix would be a one-line change to the separator class, but when I tested it I still couldn't match `(555) 123-4567`. Only after stepping through the pattern character by character did I realize there was a second, independent problem: the `\b` word-boundary anchor at the start. A `\b` before `\(?` fails silently when the phone number is preceded by whitespace, because both the space and the `(` are non-word characters — there is no boundary between two non-word characters, so the pattern never starts. That kind of invisible failure, where the regex engine simply skips past the match without any error, is much harder to diagnose than an exception would be.
+
+**What did you learn about working in a large codebase?**
+The biggest difference from building my own project is that I could not change anything in isolation. When I ran `make test-unit`, 48 tests were already failing across modules I never touched. I had to verify carefully — by running the test suite before and after my change — that the failures were pre-existing and not caused by me. In a solo project I would have fixed everything I saw; here, the right move was to document the pre-existing failures and leave them alone so the PR stayed focused. That discipline — staying in scope even when you can see other problems nearby — is something I had to learn actively rather than just read about.
+
+**How did AI tools help — and where did they fall short?**
+AI assistance was most useful for two things: explaining what each part of a regex pattern does in plain English (which made it faster to identify the `\b` issue), and generating the structured documents — `PLAN.md`, `JOURNAL.md` entries, and the PR description — that follow a rigid template. It was less useful for the actual debugging judgment call: deciding which of the two regex problems was causing the failure required running the code and observing the output, not just reading the pattern. AI described what the pattern *should* do, but only running `pytest` against the real data revealed what it *actually* did. The lesson is that AI speeds up understanding and writing, but can't replace running the code.
+
+**What would you do differently if you started over?**
+I would run `make test-unit` and `make lint` on the unmodified `main` branch before writing a single line, and record those baseline results. I documented the pre-existing failures in my PR, but I did it after the fact by re-running the checks. Having the baseline recorded upfront would have made it trivial to prove that my changes introduced nothing new, rather than reasoning backwards from the final state.
+
+**What are you most proud of from this module?**
+Finding and fixing the `street_address` false-positive that was not mentioned in the issue. The issue only asked about the phone number pattern, but running the full test suite revealed that `test_mixed_pii_and_text` was also failing because the `Pl` abbreviation (for "Place") was matching the `pl` sub-string inside the word "applications". I traced it to the same file, confirmed it was pre-existing, fixed it cleanly without breaking any other address tests, and documented it in the PR. That felt like the kind of contribution a careful engineer makes — fixing what you find, not just what you were asked to fix.

--- a/Journal.md
+++ b/Journal.md
@@ -1,34 +1,4 @@
-## Project Journal — PathReview
 
-This journal is a friendly, developer-focused running log for local work: quick notes, test runs, debugging insights, and short-term next steps. Keep entries concise and date-stamped.
-
----
-
-### 2026-08-02 — Initial tidy-up and test-focused fixes
-
-- Summary: Cleaned up unit tests and improved a few detectors and evaluators for more reliable behavior during CI.
-- Files touched:
-  - `ingestion/embeddings/batch_processor.py` — ensured per-batch embedding handling is robust
-  - `safety/bias_detector.py` — expanded detection patterns for dismissive language and demographic assumptions
-  - `rag/evaluator/faithfulness_checker.py` — refined claim extraction and support checks
-  - `agent/tools/readme_scorer.py` — scoring thresholds reviewed
-  - Several unit tests under `tests/unit/` adjusted to use side_effect mocks and clearer assertions
-
-- Test results (local):
-  - Ran targeted unit tests; many tests pass locally; a subset require async test plugin (`pytest-asyncio`) to run in this environment.
-
-- Notes & decisions:
-  - Keep detector regexes conservative to reduce false positives.
-  - Use per-batch embedding mocking in tests via `side_effect=lambda texts: [...]` so tests reflect true batching behavior.
-
-- Next steps:
-  1. Install and run full test suite with `pytest-asyncio` to exercise async tests: `python -m pip install pytest-asyncio` and `python -m pytest -q`.
-  2. Review any remaining failing tests and open focused PRs with one behavioral change per PR.
-  3. Add a short CONTRIBUTING note on how to run unit tests locally on Windows (Git Bash recommended).
-
----
-
-If you'd like, I can: (a) expand this journal with a template for daily entries, (b) add automatic test-run snippets, or (c) convert it into `docs/DEVELOPER-JOURNAL.md` for team-wide visibility. Which would you prefer?
 ## Week 7 — Issue selection
 
 **Issue link:** https://github.com/ascherj/pathreview/issues/146#

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,5 +1,7 @@
 <!doctype html>
 <html lang="en">
+
+
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -99,7 +99,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -449,7 +448,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -473,7 +471,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1561,7 +1558,6 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1579,7 +1575,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1972,7 +1967,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3507,7 +3501,6 @@
       "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^2.0.1",
         "cssstyle": "^4.0.1",
@@ -4094,7 +4087,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4107,7 +4099,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4771,7 +4762,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,43 @@
+## Solution plan
+
+**Issue:** [PII scrubber fails to redact parenthesized US phone numbers
+](https://github.com/ascherj/pathreview/issues/146#)
+
+**Link:** https://github.com/ascherj/pathreview/issues/146#
+
+### Understand
+What is the root cause of this issue? What behavior is expected vs. actual? Line 15 in pii_scrubber.py is the issue because a space between the parentheses breaks the pattern matching of the numbers that follow, 555) will actually be catched, but it breaks down on the rest: 123-34567/
+
+### Map
+Which files, functions, or modules are involved?
+List the specific files you expect to touch. I expect to edit the regex in pii_scrubber.py.
+
+### Plan
+What are the steps to fix this issue?
+Break it into 3–5 concrete sub-tasks.
+1. Read the pii_scrubber.py code to try to understand the issue.
+2. Research or use AI assistance if needed.
+3. Write a fix (I think just editing the regex on line 15 of pii_scrubber.py will be the fix)
+4. Try failing tests and write new tests. Make sure detect function and scrub function are doing their job.
+5. Make sure all tests, integration and unit pass.
+
+### Inputs & outputs
+What does your fix take as input? What should it produce or change?
+The input is text with phone numbers of the format (555) 123-4567. It should product [REDACTED]
+```
+'Call me at (555) 123-4567 or 555-123-4567'
+
+Should produce:
+
+'Call me at [REDACTED] or [REDACTED]'
+```
+
+And s.detect() should detect the number in it with the regex.
+
+### Risks & unknowns
+What could go wrong? What are you still unsure about?
+If you adjust the regex incorrectly, you could redact the wrong info. If for some reason, there are lists of numbers like (777) 345 they could get redacted. That seems like an uncommon scenario. I guess I am a little bit unsure about regex; I don't have a deep understanding of it, so I will have to read up.
+
+### Edge cases
+What inputs or states should your fix handle gracefully?
+(777) 345 might get redacted. We need to make sure numbers in parentheses aren't redacted by accident. (555)-123-4567 doesn't work correctly right no either, this is what happens: ([REDACTED].

--- a/plan.md
+++ b/plan.md
@@ -1,43 +1,65 @@
 ## Solution plan
 
-**Issue:** [PII scrubber fails to redact parenthesized US phone numbers
-](https://github.com/ascherj/pathreview/issues/146#)
-
-**Link:** https://github.com/ascherj/pathreview/issues/146#
+**Issue:** [PII scrubber fails to redact parenthesized US phone numbers #146](https://github.com/ascherj/pathreview/issues/146)
 
 ### Understand
-What is the root cause of this issue? What behavior is expected vs. actual? Line 15 in pii_scrubber.py is the issue because a space between the parentheses breaks the pattern matching of the numbers that follow, 555) will actually be catched, but it breaks down on the rest: 123-34567/
+
+**Actual behavior:** `scrub('Call me at (555) 123-4567')` returns the string unchanged; `detect('Call me at (555) 123-4567')` returns `[]`.
+
+**Expected behavior:** Both methods treat `(555) 123-4567` the same way they treat `555-123-4567` — the scrubber replaces it with `[REDACTED]` and the detector reports it as `phone_us` PII.
+
+**Root causes (two):**
+
+1. **Word-boundary anchor at start.** The original pattern begins with `\b`. When a phone starts with `(` preceded by a space, both characters are non-word characters (`\W`), so no word boundary exists and the pattern never starts matching.
+
+2. **Separator class too narrow.** The original pattern uses `[-.]?` between the area code and exchange. The parenthesized format `(555) 123-4567` has a space in that position, which the class does not include.
+
+A third, pre-existing bug was also found: the `street_address` pattern used `[A-Za-z\s]+` (arbitrary characters including spaces) before the street-type alternation, which allowed short abbreviations like `Pl` to match sub-strings inside ordinary words (e.g., `applications`). This caused `test_mixed_pii_and_text` to fail.
 
 ### Map
-Which files, functions, or modules are involved?
-List the specific files you expect to touch. I expect to edit the regex in pii_scrubber.py.
+
+Files to touch:
+
+- `safety/pii_scrubber.py` — the only file that needs editing; both regex constants live in `PIIScrubber.PII_PATTERNS`
+- `tests/unit/test_pii_scrubber.py` — read-only during this fix; all 25 tests must pass after the change
+
+No other files are involved. The `scrub()` and `detect()` methods iterate over `PII_PATTERNS` generically, so no logic changes are needed — only the pattern strings.
 
 ### Plan
-What are the steps to fix this issue?
-Break it into 3–5 concrete sub-tasks.
-1. Read the pii_scrubber.py code to try to understand the issue.
-2. Research or use AI assistance if needed.
-3. Write a fix (I think just editing the regex on line 15 of pii_scrubber.py will be the fix)
-4. Try failing tests and write new tests. Make sure detect function and scrub function are doing their job.
-5. Make sure all tests, integration and unit pass.
+
+1. **Replace `\b` anchors in `phone_us` with lookaround assertions.**
+   Change the leading `\b` to `(?<!\w)` (negative lookbehind: not preceded by a word character) and the trailing `\b` to `(?!\w)` (negative lookahead). This correctly handles both "no preceding character" (start of string) and "preceded by whitespace" without requiring a word-character on the left side.
+
+2. **Widen the separator character class.**
+   Change every `[-.]?` in `phone_us` to `[-. ]?` so that a space is a valid separator between the area code, exchange, and subscriber segments.
+
+3. **Fix the `street_address` false-positive.**
+   Replace the greedy `[A-Za-z\s]+` (which can match partial words) with `(?:[A-Za-z]+\s+)*` (zero or more complete alpha words each followed by whitespace). Add `\b` after the street-type alternation so abbreviations like `Pl` only match at a genuine word boundary, not as a sub-string inside `applications`.
+
+4. **Run the full test suite.**
+   `pytest tests/unit/test_pii_scrubber.py -v -m unit` must show 25 passed, 0 failed.
+
+5. **Commit and push.**
+   Commit with message `fix(safety): support parenthesized US phone format in pii_scrubber` per the Conventional Commits convention in `docs/CONTRIBUTING.md`.
 
 ### Inputs & outputs
-What does your fix take as input? What should it produce or change?
-The input is text with phone numbers of the format (555) 123-4567. It should product [REDACTED]
-```
-'Call me at (555) 123-4567 or 555-123-4567'
 
-Should produce:
+**Input to the fix:** the two string constants in `PIIScrubber.PII_PATTERNS` (`phone_us` and `street_address`).
 
-'Call me at [REDACTED] or [REDACTED]'
-```
-
-And s.detect() should detect the number in it with the regex.
+**Output / observable change:**
+- `scrub('Call me at (555) 123-4567 or 555-123-4567')` → `'Call me at [REDACTED] or [REDACTED]'`
+- `detect('Call me at (555) 123-4567')` → list containing one entry with `type='phone_us'`
+- `scrub('I worked at TechCorp for 5 years developing Python applications.')` no longer redacts "Python applications"
 
 ### Risks & unknowns
-What could go wrong? What are you still unsure about?
-If you adjust the regex incorrectly, you could redact the wrong info. If for some reason, there are lists of numbers like (777) 345 they could get redacted. That seems like an uncommon scenario. I guess I am a little bit unsure about regex; I don't have a deep understanding of it, so I will have to read up.
+
+- **Space separator and false positives.** Adding ` ` to `[-.]?` means three space-separated groups of digits could be mistaken for a phone number. In practice this is low-risk because the pattern requires exactly 10 digits in a 3-3-4 split, which is uncommon in non-phone contexts. The existing `test_detect_no_false_positives` test (version numbers, URLs) still passes.
+- **`street_address` regression.** Narrowing `[A-Za-z\s]+` to `(?:[A-Za-z]+\s+)*` could miss street names that contain unusual formatting. All three address tests in the suite (`test_street_address_redaction`, `test_address_variations`) pass with the new pattern.
 
 ### Edge cases
-What inputs or states should your fix handle gracefully?
-(777) 345 might get redacted. We need to make sure numbers in parentheses aren't redacted by accident. (555)-123-4567 doesn't work correctly right no either, this is what happens: ([REDACTED].
+
+- Phone at start of string with no preceding character: `(555) 123-4567 is my phone` — `(?<!\w)` matches at start of string.
+- Phone preceded by a non-word character other than space (e.g., colon): `Phone:(555) 123-4567` — `:` is `\W`, so `(?<!\w)` still matches.
+- Phone embedded inside a longer digit sequence: `12345551234567` — `(?<!\w)` fails because `4` precedes the first `5`; correctly not matched.
+- Country code with space: `+1 555 123 4567` — `(?:\+?1[-. ]?)?` matches `+1 ` and the space separators handle the rest.
+- Mixed formats in same string: `(555) 123-4567 or 555-123-4567` — both are matched and redacted independently.

--- a/safety/pii_scrubber.py
+++ b/safety/pii_scrubber.py
@@ -1,6 +1,7 @@
 """PII detection and scrubbing."""
 
 import re
+
 import structlog
 
 logger = structlog.get_logger()
@@ -12,10 +13,10 @@ class PIIScrubber:
     # Regex patterns for common PII
     PII_PATTERNS = {
         "email": r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b",
-        "phone_us": r"\b(?:\+?1[-.]?)?\(?([0-9]{3})\)?[-.]?([0-9]{3})[-.]?([0-9]{4})\b",
+        "phone_us": r"(?<!\w)(?:\+?1[-. ]?)?\(?([0-9]{3})\)?[-. ]?([0-9]{3})[-. ]?([0-9]{4})(?!\w)",
         "phone_intl": r"\+[0-9]{1,3}[-.]?[0-9]{1,14}",
         "ssn": r"\b(?!000|666)[0-9]{3}-(?!00)[0-9]{2}-(?!0000)[0-9]{4}\b",
-        "street_address": r"\b\d+\s+[A-Za-z\s]+(?:Street|St|Avenue|Ave|Road|Rd|Boulevard|Blvd|Drive|Dr|Lane|Ln|Court|Ct|Circle|Cir|Park|Pl|Plaza|Place|Drive|Dr|Way|Parkway|Pkwy|Point|Pt|Pike|Run|Summit|Summit|Terrace|Ter|Trail|Trl|Tunnel|Turnpike|View|Vista|Vlg|Village|Vly|Valley)",
+        "street_address": r"\b\d+\s+(?:[A-Za-z]+\s+)*(?:Street|St|Avenue|Ave|Road|Rd|Boulevard|Blvd|Drive|Dr|Lane|Ln|Court|Ct|Circle|Cir|Park|Pl|Plaza|Place|Way|Parkway|Pkwy|Point|Pt|Pike|Run|Summit|Terrace|Ter|Trail|Trl|Tunnel|Turnpike|View|Vista|Village|Valley)\b",
     }
 
     def scrub(self, text: str) -> str:
@@ -29,7 +30,7 @@ class PIIScrubber:
         """
         scrubbed = text
 
-        for pii_type, pattern in self.PII_PATTERNS.items():
+        for _pii_type, pattern in self.PII_PATTERNS.items():
             scrubbed = re.sub(pattern, "[REDACTED]", scrubbed, flags=re.IGNORECASE)
 
         return scrubbed


### PR DESCRIPTION
Summary
Fixes remaining Ruff lint failures in unit tests by cleaning up unused assignments and wrapping an overly long test signature.

Issue
Closes #146

Changes
Updated test_review_service.py to split the long async test method signature across lines.
Updated [test_tech_detector.py](vscode-file://vscode-app/c:/Users/dbhan/AppData/Local/Programs/Microsoft%20VS%20Code/fcf604774b/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to remove unused [result](vscode-file://vscode-app/c:/Users/dbhan/AppData/Local/Programs/Microsoft%20VS%20Code/fcf604774b/resources/app/out/vs/code/electron-browser/workbench/workbench.html)/[data](vscode-file://vscode-app/c:/Users/dbhan/AppData/Local/Programs/Microsoft%20VS%20Code/fcf604774b/resources/app/out/vs/code/electron-browser/workbench/workbench.html) assignments in two tests.
Addressed Ruff E501 and F841 violations in those test files.

Testing
 Unit tests pass ([make test-unit](vscode-file://vscode-app/c:/Users/dbhan/AppData/Local/Programs/Microsoft%20VS%20Code/fcf604774b/resources/app/out/vs/code/electron-browser/workbench/workbench.html))
 Integration tests pass (make test-integration)
 Linter passes (make lint)
 Type checker passes (make typecheck)
 New/updated tests cover the changes