### PR TITLE
feat(rag): add offline eval runner for benchmark portfolios (#40)

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,16 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/40
+
+**Issue title:** Implement an offline eval runner that measures review quality across a benchmark portfolio set
+
+**Tier:** [ ] Tier 1  [ ] Tier 2  [x] Tier 3
+
+**Problem summary:**
+Right now, PathReview's eval suite only runs inline as part of live API requests, which means there's no way to check review quality across a broad set of portfolios without triggering real requests each time. This issue asks for a standalone script (`scripts/run_evals.py`) that runs the full RAG pipeline offline against a curated benchmark set of portfolios and writes out a JSON report of quality scores. The work touches the RAG evaluation logic in `rag/evaluator/eval_suite.py`, which will likely need to be refactored or reused so it can run outside the API request path. A successful fix gives the team a repeatable, on-demand way to measure review quality without needing to hit the live API.
+
+**Branch name:** feat/40-offline-eval-runner
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -17,7 +17,7 @@ Right now, PathReview's eval suite only runs inline as part of live API requests
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** (added after commit — see below)
+**Reproduction commit link:** https://github.com/SumaiaAlhemyari/pathreview/commit/a0507e9
 
 **Reproduction summary:**
 Ran scripts/run_evals.py and confirmed it is a stub. It prints success messages but never creates eval_results.json. Also found that EvalSuite, RelevanceScorer, and FaithfulnessChecker are not called anywhere in api/, only in their own tests.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -7,7 +7,7 @@
 **Tier:** [ ] Tier 1  [ ] Tier 2  [x] Tier 3
 
 **Problem summary:**
-Right now, PathReview's eval suite only runs inline as part of live API requests, which means there's no way to check review quality across a broad set of portfolios without triggering real requests each time. This issue asks for a standalone script (`scripts/run_evals.py`) that runs the full RAG pipeline offline against a curated benchmark set of portfolios and writes out a JSON report of quality scores. The work touches the RAG evaluation logic in `rag/evaluator/eval_suite.py`, which will likely need to be refactored or reused so it can run outside the API request path. A successful fix gives the team a repeatable, on-demand way to measure review quality without needing to hit the live API.
+Right now, PathReview only checks review quality during a real request. There is no way to test many portfolios at once without making real requests each time. This issue asks for a new script, `scripts/run_evals.py`, that runs the full pipeline by itself, using a set of sample portfolios, and saves the scores to a JSON file. This work uses the code in `rag/evaluator/eval_suite.py`, which may need changes so it can run outside of a live request. Once finished, there will be an easy way to check review quality anytime, without needing to make real API calls.
 
 **Branch name:** feat/40-offline-eval-runner
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -14,3 +14,17 @@ Right now, PathReview's eval suite only runs inline as part of live API requests
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** (added after commit — see below)
+
+**Reproduction summary:**
+Ran scripts/run_evals.py and confirmed it is a stub. It prints success messages but never creates eval_results.json. Also found that EvalSuite, RelevanceScorer, and FaithfulnessChecker are not called anywhere in api/, only in their own tests.
+
+**PLAN.md link:** https://github.com/SumaiaAlhemyari/pathreview/blob/feat/40-offline-eval-runner/PLAN.md
+
+**Walkthrough video (recommended):** Not recorded
+
+**Blockers or open questions:**
+No mock version of the review generator exists yet, and there are no sample benchmark portfolios yet. Both need to be created before the real eval runner can work end to end.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -28,3 +28,36 @@ Ran scripts/run_evals.py and confirmed it is a stub. It prints success messages 
 
 **Blockers or open questions:**
 No mock version of the review generator exists yet, and there are no sample benchmark portfolios yet. Both need to be created before the real eval runner can work end to end.
+
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+All five sub-tasks from PLAN.md are done. Added sample benchmark portfolios in tests/fixtures/sample_profiles/. Added a mock review generator in rag/generator/mock_generator.py so the script runs without a real API key. Rewrote scripts/run_evals.py to actually run retrieval, generation, and evaluation, and write eval_results.json. Added tests/unit/test_mock_generator.py and tests/unit/test_run_evals.py.
+
+**Next steps:**
+Open the pull request and get feedback on it before marking it ready for review.
+
+**Blockers:**
+Found that VectorStore.add_chunks was dead code with a broken interface. Worked around it instead of fixing it, since fixing it is outside the scope of this issue.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/554
+
+**Branch:** feat/40-offline-eval-runner
+
+**What you built:**
+A real offline eval runner that loads sample portfolios, runs them through search and review generation, scores the results, and writes real scores to eval_results.json. Before this, the script only printed messages and never actually ran anything.
+
+**Tests added or updated:**
+Added tests/unit/test_mock_generator.py, which covers the mock review generator returning correct fields, staying consistent for the same input, and working without any real API calls. Added tests/unit/test_run_evals.py, which covers loading the sample portfolios, running one portfolio through the full pipeline, handling a portfolio with no chunks without crashing, and running the whole script end to end to confirm it writes a valid report.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+(Both pass in the sense that no new failures were introduced. The codebase already had 182 lint errors and 53 failing tests before this change, confirmed by checking before starting. My new files are lint-clean, and all new tests pass.)
+
+**Draft PR feedback received from:** none yet

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -61,3 +61,34 @@ Added tests/unit/test_mock_generator.py, which covers the mock review generator 
 (Both pass in the sense that no new failures were introduced. The codebase already had 182 lint errors and 53 failing tests before this change, confirmed by checking before starting. My new files are lint-clean, and all new tests pass.)
 
 **Draft PR feedback received from:** none yet
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No review comments came in on the pull request before the course ended.
+
+**How you responded:**
+Not applicable, since no feedback arrived.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Getting a working local environment was harder than the actual coding. I hit a real bug in a pinned Docker image, where ChromaDB and numpy were incompatible with each other. I also tried running Docker inside a Docker container, which does not work because of how overlay filesystems stack. I had to switch to a real virtual machine before I could even start on the issue itself.
+
+**What did you learn about working in a large codebase?**
+The issue description did not fully match the real code. It said the eval logic ran during live requests, but when I checked, that code was never called anywhere except its own tests. I also found a second bug on my own: a class that was never used anywhere and had a broken interface. Working in someone else's codebase means checking what the code actually does, not just trusting what the issue says.
+
+**How did AI tools help — and where did they fall short?**
+AI was useful for reading through unfamiliar files quickly and for writing repetitive test code. It fell short on judgment calls, like deciding what counted as in scope for the issue, and on tooling problems that needed real trial and error, like the Docker setup and a mypy version mismatch. Those needed actual investigation, not just a generated answer.
+
+**What would you do differently if you started over?**
+I would confirm the local environment setup actually works end to end before assuming a plan will work, instead of discovering problems partway through setup. I would also read the actual code the issue points to before trusting the issue's own description of the problem.
+
+**What are you most proud of from this module?**
+Finding that the eval code the issue described as already running live was actually never connected to anything. That was not something the issue told me. I found it myself by checking the real code.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -49,6 +49,40 @@ Found that VectorStore.add_chunks was dead code with a broken interface. Worked 
 
 **PR link:** https://github.com/ascherj/pathreview/pull/554
 
+**PR description (copied here for reference):**
+
+## Summary
+Before this change, `scripts/run_evals.py` was an empty stub. It printed messages saying the evaluation was complete, but it did not actually run anything, and it never created `eval_results.json`. This PR replaces it with a script that loads a set of sample portfolios, runs each one through retrieval and generation, scores the results, and writes a real JSON report. A new deterministic mock review generator lets the whole pipeline run offline, with no real API key or network access needed.
+
+## Issue
+Closes #40
+
+## Changes
+- Replaced the stub in `scripts/run_evals.py` with a full pipeline: load fixtures, embed and index chunks, retrieve, generate, evaluate, write JSON report
+- Added `rag/generator/mock_generator.py`, a deterministic mock review generator that mirrors the existing `MockEmbeddingProvider` pattern
+- Added three sample benchmark portfolios in `tests/fixtures/sample_profiles/`
+- Added `scripts/__init__.py` so the script can be imported cleanly in tests
+- Added `tests/unit/test_mock_generator.py` and `tests/unit/test_run_evals.py`
+
+## Testing
+- Unit tests pass (make test-unit) — new tests pass; 53 pre-existing failures unrelated to this change remain, unchanged from before this PR
+- Integration tests pass (make test-integration) — not run, no integration tests touch this code path
+- Linter passes (make lint) — new files are lint-clean; 182 pre-existing lint errors in unrelated files remain, unchanged from before this PR
+- Type checker passes (make typecheck) — new files are clean under the project's .venv mypy; pre-commit's isolated mypy hook (a different, older mypy version) surfaces unrelated pre-existing annotation gaps in files this PR does not touch
+- New/updated tests cover the changes
+
+Manual verification steps:
+1. .venv/bin/python scripts/run_evals.py
+2. Confirm it prints "Evaluation complete. Results written to eval_results.json"
+3. cat eval_results.json
+4. Confirm the file exists and contains real scores for three sample profiles (bench_fullstack_01, bench_junior_02, bench_datascience_03), each with relevance_score, faithfulness_score, and overall_score
+
+## Notes for Reviewers
+`VectorStore.add_chunks()` is dead code with a mismatched interface (expects `Chunk` objects with attributes that don't exist on the actual `Chunk` dataclass). This PR bypasses it and inserts chunks directly via the collection API instead of fixing that unrelated bug, to stay in scope for #40.
+
+The mock generator's scores are intentionally low (faithfulness near 0), since its placeholder text doesn't reference real chunk content. This is expected and shows the pipeline works correctly end to end, not a bug in the eval logic itself.
+
+
 **Branch:** feat/40-offline-eval-runner
 
 **What you built:**

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,37 @@
+## Solution plan
+
+**Issue:** Implement an offline eval runner that measures review quality across a benchmark portfolio set. [#40](https://github.com/ascherj/pathreview/issues/40)
+
+### Understand
+`scripts/run_evals.py` only has placeholder code right now. It prints fake success messages but does not do any real work. I ran it and confirmed this: no `eval_results.json` file gets created. The issue says the eval logic runs inline during API requests, but that is not true in the current code. `EvalSuite`, `RelevanceScorer`, and `FaithfulnessChecker` are only used in their own tests. They are not connected to the API at all. So there are two problems to fix: there is no standalone runner, and the eval code is not hooked up to the real pipeline either. What should happen: running `python3 scripts/run_evals.py` should run retrieval, then generation, then evaluation, across a set of sample portfolios, and save real scores to `eval_results.json`. What happens now: it prints two lines and stops.
+
+### Map
+- `scripts/run_evals.py`: replace the placeholder code with real logic
+- `rag/evaluator/eval_suite.py`: already works, just needs to be called
+- `rag/retriever/hybrid.py`, `rag/retriever/vector_store.py`, `rag/retriever/keyword_search.py`: handles retrieval
+- `rag/generator/review_generator.py`: handles generation, but currently only works with a real API, not a mock one
+- `ingestion/embeddings/provider.py`: already has a mock embedding option we can use
+- `core/config.py`: loads settings from `.env`
+- `tests/benchmarks/`: this folder is empty right now. We need to add sample portfolio files here, or in `tests/fixtures/sample_profiles/` as the placeholder code suggests
+
+### Plan
+1. Add a small set of sample portfolios to test with, since none exist yet.
+2. Add a mock version of the review generator, similar to the mock embedding provider already in the code, so the script can run without needing a real API key.
+3. Update `scripts/run_evals.py` to load the sample portfolios, run retrieval, run generation using the mock version, then run evaluation.
+4. Combine the results from all portfolios into one JSON report, with an average score and a score for each portfolio, and save it to `eval_results.json`.
+5. Add a test that checks the script creates a proper report from start to finish using the mock versions.
+
+### Inputs & outputs
+- Input: sample portfolio files, and settings from `.env` (uses mock mode by default)
+- Output: `eval_results.json` with scores for each portfolio and an overall average
+
+### Risks & unknowns
+- There is no mock version of the review generator yet. Building one is more work than just connecting existing pieces.
+- There are no sample portfolios yet. I will need to decide how many to create and what should be in them.
+- The eval code is not connected to the API at all right now. It is unclear if this issue also wants that fixed, or just the standalone script. The issue only asks for the standalone script, so I will stick to that.
+- The retriever needs data already loaded into the vector database for each portfolio. The sample portfolios will need to be loaded in first, which is an extra step.
+
+### Edge cases
+- A sample portfolio file that is empty or missing data
+- A portfolio that gets no matching results back from search
+- If one portfolio fails, the whole run should not stop. It should still finish and report results for the portfolios that worked

--- a/rag/generator/mock_generator.py
+++ b/rag/generator/mock_generator.py
@@ -1,0 +1,78 @@
+"""Deterministic mock review generator for offline evaluation.
+
+Mirrors MockEmbeddingProvider: no real API calls, same input always
+produces the same output. Used by scripts/run_evals.py so the eval
+runner can execute without an API key or network access.
+"""
+
+import hashlib
+
+import structlog
+
+from rag.generator.output_parser import FeedbackSection
+
+logger = structlog.get_logger()
+
+SECTION_NAMES = [
+    "skills_feedback",
+    "projects_feedback",
+    "presentation_feedback",
+    "gaps_feedback",
+    "first_impression",
+]
+
+
+class MockReviewGenerator:
+    """Generate deterministic fake review sections without calling an LLM."""
+
+    def generate_section(
+        self, section_name: str, context_chunks: list[dict], profile_data: dict
+    ) -> FeedbackSection:
+        """Generate one deterministic feedback section.
+
+        Args:
+            section_name: Section name (skills_feedback, projects_feedback, etc.)
+            context_chunks: Retrieved context chunks
+            profile_data: Profile metadata
+
+        Returns:
+            FeedbackSection with deterministic fake content
+        """
+        github_username = profile_data.get("github_username", "unknown")
+        chunk_count = len(context_chunks)
+
+        # Deterministic confidence derived from a hash, same pattern as
+        # MockEmbeddingProvider's deterministic seed.
+        seed_text = f"{section_name}:{github_username}:{chunk_count}"
+        digest = hashlib.sha256(seed_text.encode()).hexdigest()
+        confidence = 0.5 + (int(digest[:4], 16) % 50) / 100
+
+        content = (
+            f"Mock {section_name.replace('_', ' ')} for {github_username}. "
+            f"Based on {chunk_count} retrieved chunks."
+        )
+
+        return FeedbackSection(
+            section_name=section_name,
+            content=content,
+            confidence=round(confidence, 2),
+            suggestions=[f"Mock suggestion for {section_name}"],
+        )
+
+    def generate_full_review(
+        self, profile_data: dict, retrieved_chunks: list[dict]
+    ) -> list[FeedbackSection]:
+        """Generate a complete deterministic review across all sections.
+
+        Args:
+            profile_data: Profile metadata and projects
+            retrieved_chunks: Context chunks from retrieval
+
+        Returns:
+            List of FeedbackSections for all review areas
+        """
+        sections = [
+            self.generate_section(name, retrieved_chunks, profile_data) for name in SECTION_NAMES
+        ]
+        logger.info("mock_full_review_generated", section_count=len(sections))
+        return sections

--- a/scripts/run_evals.py
+++ b/scripts/run_evals.py
@@ -4,6 +4,10 @@
 def main() -> None:
     """Execute the full evaluation pipeline and output results."""
     print("Running RAG evaluation suite...")
+    # REPRODUCTION (Week 8): confirmed this script is a stub.
+    # Running it prints success messages but writes no eval_results.json.
+    # EvalSuite, RelevanceScorer, and FaithfulnessChecker exist in
+    # rag/evaluator/ but are not called here or anywhere in api/.
     # TODO: Implement eval runner
     # 1. Load benchmark portfolios from tests/fixtures/sample_profiles/
     # 2. Run each through the full RAG pipeline with mock LLM

--- a/scripts/run_evals.py
+++ b/scripts/run_evals.py
@@ -1,19 +1,174 @@
-"""Run the RAG evaluation suite against benchmark portfolios."""
+"""Run the RAG evaluation suite against benchmark portfolios.
+
+Loads a set of benchmark portfolios from tests/fixtures/sample_profiles/,
+runs each through the full RAG pipeline (retrieval, generation, evaluation)
+using mock providers so it runs offline with no API key or network access,
+and writes a JSON report of quality scores to eval_results.json.
+"""
+
+import json
+import sys
+import tempfile
+from datetime import UTC, datetime
+from pathlib import Path
+
+import structlog
+
+from core.config import settings
+from ingestion.embeddings.provider import EmbeddingProvider, get_embedding_provider
+from rag.evaluator.eval_suite import EvalSuite
+from rag.generator.mock_generator import MockReviewGenerator
+from rag.retriever.hybrid import HybridRetriever
+from rag.retriever.keyword_search import KeywordSearcher
+from rag.retriever.vector_store import VectorStore
+
+logger = structlog.get_logger()
+
+FIXTURES_DIR = Path(__file__).parent.parent / "tests" / "fixtures" / "sample_profiles"
+OUTPUT_PATH = Path(__file__).parent.parent / "eval_results.json"
+
+# Mock embeddings are random per-text vectors, not semantically meaningful,
+# so a real similarity threshold would filter out valid results. Use 0.0
+# for offline eval so retrieval always returns chunks.
+MOCK_MIN_SCORE = 0.0
+
+
+def load_fixtures() -> list[dict]:
+    """Load all benchmark portfolio fixtures.
+
+    Returns:
+        List of fixture dicts, one per benchmark portfolio
+    """
+    fixtures = []
+    for path in sorted(FIXTURES_DIR.glob("*.json")):
+        with open(path) as f:
+            fixtures.append(json.load(f))
+    return fixtures
+
+
+def index_fixture(
+    fixture: dict, vector_store: VectorStore, embedding_provider: EmbeddingProvider
+) -> tuple[KeywordSearcher, list[float]]:
+    """Embed and index a fixture's chunks into the vector store and a keyword index.
+
+    Args:
+        fixture: Fixture dict with profile_id, query, and chunks
+        vector_store: VectorStore to insert chunks into
+        embedding_provider: Provider used to embed chunk text and the query
+
+    Returns:
+        Tuple of (indexed KeywordSearcher, query embedding)
+    """
+    profile_id = fixture["profile_id"]
+    chunks = fixture["chunks"]
+    texts = [c["text"] for c in chunks]
+
+    embeddings = embedding_provider.embed(texts)
+    query_embedding = embedding_provider.embed([fixture["query"]])[0]
+
+    ids = [f"{profile_id}_{i}" for i in range(len(chunks))]
+    metadatas = [
+        {"source_id": c["source_id"], "chunk_index": i, "section": c.get("section", "")}
+        for i, c in enumerate(chunks)
+    ]
+
+    # Insert directly via the collection rather than VectorStore.add_chunks,
+    # which expects Chunk objects with attributes (chunk.id, chunk.source_id)
+    # that don't match the actual Chunk dataclass (text, metadata only).
+    # See PLAN.md risks: add_chunks is dead code and not used here.
+    collection = vector_store.get_collection(f"profile_{profile_id}")
+    collection.upsert(ids=ids, embeddings=embeddings, documents=texts, metadatas=metadatas)
+
+    keyword_chunks = [
+        {"id": ids[i], "text": texts[i], "metadata": metadatas[i]} for i in range(len(chunks))
+    ]
+    keyword_searcher = KeywordSearcher()
+    keyword_searcher.index(keyword_chunks)
+
+    return keyword_searcher, query_embedding
+
+
+def evaluate_fixture(fixture: dict, vector_store: VectorStore, embedding_provider: EmbeddingProvider) -> dict:
+    """Run one fixture through retrieval, generation, and evaluation.
+
+    Args:
+        fixture: Fixture dict with profile_id, query, github_username, projects, chunks
+        vector_store: Shared VectorStore instance
+        embedding_provider: Shared embedding provider
+
+    Returns:
+        Dict with profile_id and eval scores, or an error entry on failure
+    """
+    profile_id = fixture["profile_id"]
+    try:
+        keyword_searcher, query_embedding = index_fixture(fixture, vector_store, embedding_provider)
+        retriever = HybridRetriever(vector_store, keyword_searcher)
+        retrieved_chunks = retriever.retrieve(
+            query=fixture["query"],
+            profile_id=profile_id,
+            query_embedding=query_embedding,
+            max_chunks=10,
+            min_score=MOCK_MIN_SCORE,
+        )
+
+        profile_data = {
+            "github_username": fixture.get("github_username", ""),
+            "projects": fixture.get("projects", []),
+        }
+        generator = MockReviewGenerator()
+        sections = generator.generate_full_review(profile_data, retrieved_chunks)
+        feedback_text = "\n".join(s.content for s in sections)
+
+        eval_suite = EvalSuite()
+        result = eval_suite.run(fixture["query"], retrieved_chunks, feedback_text)
+
+        return {
+            "profile_id": profile_id,
+            "relevance_score": result.relevance_score,
+            "faithfulness_score": result.faithfulness_score,
+            "overall_score": result.overall_score,
+            "chunks_retrieved": len(retrieved_chunks),
+            "sections_generated": len(sections),
+        }
+    except Exception as e:
+        # A single bad fixture should not stop the whole run.
+        logger.error("fixture_evaluation_failed", profile_id=profile_id, error=str(e))
+        return {"profile_id": profile_id, "error": str(e)}
 
 
 def main() -> None:
     """Execute the full evaluation pipeline and output results."""
     print("Running RAG evaluation suite...")
-    # REPRODUCTION (Week 8): confirmed this script is a stub.
-    # Running it prints success messages but writes no eval_results.json.
-    # EvalSuite, RelevanceScorer, and FaithfulnessChecker exist in
-    # rag/evaluator/ but are not called here or anywhere in api/.
-    # TODO: Implement eval runner
-    # 1. Load benchmark portfolios from tests/fixtures/sample_profiles/
-    # 2. Run each through the full RAG pipeline with mock LLM
-    # 3. Score retrieval relevance, faithfulness, and actionability
-    # 4. Output JSON report to eval_results.json
-    print("Evaluation complete. Results written to eval_results.json")
+
+    fixtures = load_fixtures()
+    if not fixtures:
+        print(f"No fixtures found in {FIXTURES_DIR}")
+        sys.exit(1)
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        vector_store = VectorStore(persist_dir=tmp_dir)
+        embedding_provider = get_embedding_provider(settings.llm_provider)
+
+        results = [
+            evaluate_fixture(fixture, vector_store, embedding_provider) for fixture in fixtures
+        ]
+
+    scored = [r for r in results if "overall_score" in r]
+    failed = [r for r in results if "error" in r]
+    average_overall_score = sum(r["overall_score"] for r in scored) / len(scored) if scored else 0.0
+
+    report = {
+        "generated_at": datetime.now(UTC).isoformat(),
+        "profiles_evaluated": len(scored),
+        "profiles_failed": len(failed),
+        "average_overall_score": round(average_overall_score, 4),
+        "results": results,
+    }
+
+    with open(OUTPUT_PATH, "w") as f:
+        json.dump(report, f, indent=2)
+
+    print(f"Evaluation complete. Results written to {OUTPUT_PATH}")
 
 
 if __name__ == "__main__":

--- a/tests/fixtures/sample_profiles/profile_01_fullstack.json
+++ b/tests/fixtures/sample_profiles/profile_01_fullstack.json
@@ -1,0 +1,11 @@
+{
+  "profile_id": "bench_fullstack_01",
+  "github_username": "sample-dev-01",
+  "projects": ["task-tracker-api", "react-dashboard", "cli-tool"],
+  "query": "How is this candidate's overall portfolio?",
+  "chunks": [
+    {"source_id": "readme_task_tracker", "section": "overview", "text": "task-tracker-api is a REST API built with FastAPI and PostgreSQL for managing project tasks. Includes JWT authentication and full test coverage."},
+    {"source_id": "readme_react_dashboard", "section": "overview", "text": "react-dashboard is a React and TypeScript frontend that visualizes analytics data using Recharts. Deployed on Vercel."},
+    {"source_id": "resume", "section": "experience", "text": "Backend developer with 2 years of experience building APIs in Python. Familiar with Docker and CI pipelines."}
+  ]
+}

--- a/tests/fixtures/sample_profiles/profile_02_junior.json
+++ b/tests/fixtures/sample_profiles/profile_02_junior.json
@@ -1,0 +1,11 @@
+{
+  "profile_id": "bench_junior_02",
+  "github_username": "sample-dev-02",
+  "projects": ["todo-app", "weather-widget"],
+  "query": "How is this candidate's overall portfolio?",
+  "chunks": [
+    {"source_id": "readme_todo_app", "section": "overview", "text": "todo-app is a simple to-do list built with vanilla JavaScript and localStorage. No tests included."},
+    {"source_id": "readme_weather_widget", "section": "overview", "text": "weather-widget fetches weather data from a public API and displays it. Built as a learning project."},
+    {"source_id": "resume", "section": "experience", "text": "Recent bootcamp graduate with no professional experience. Comfortable with HTML, CSS, and JavaScript basics."}
+  ]
+}

--- a/tests/fixtures/sample_profiles/profile_03_datascience.json
+++ b/tests/fixtures/sample_profiles/profile_03_datascience.json
@@ -1,0 +1,11 @@
+{
+  "profile_id": "bench_datascience_03",
+  "github_username": "sample-dev-03",
+  "projects": ["churn-prediction-model", "data-pipeline"],
+  "query": "How is this candidate's overall portfolio?",
+  "chunks": [
+    {"source_id": "readme_churn_model", "section": "overview", "text": "churn-prediction-model uses scikit-learn to predict customer churn from historical data. Includes a Jupyter notebook with exploratory analysis and model evaluation."},
+    {"source_id": "readme_data_pipeline", "section": "overview", "text": "data-pipeline is an Airflow-based ETL pipeline that ingests data from S3 into a data warehouse. Includes unit tests for transformation logic."},
+    {"source_id": "resume", "section": "experience", "text": "Data scientist with 3 years of experience in machine learning and data engineering. Proficient in Python, SQL, and pandas."}
+  ]
+}

--- a/tests/unit/test_mock_generator.py
+++ b/tests/unit/test_mock_generator.py
@@ -1,0 +1,87 @@
+"""Tests for mock_generator.py"""
+
+import pytest
+
+from rag.generator.mock_generator import SECTION_NAMES, MockReviewGenerator
+
+
+@pytest.mark.unit
+class TestMockReviewGenerator:
+    """Test suite for MockReviewGenerator."""
+
+    @pytest.fixture
+    def generator(self) -> MockReviewGenerator:
+        """Create a MockReviewGenerator instance."""
+        return MockReviewGenerator()
+
+    def test_generate_section_returns_feedback_section(
+        self, generator: MockReviewGenerator
+    ) -> None:
+        """Test generate_section returns a FeedbackSection with expected fields."""
+        section = generator.generate_section(
+            "skills_feedback", [], {"github_username": "testuser"}
+        )
+
+        assert section.section_name == "skills_feedback"
+        assert "testuser" in section.content
+        assert 0.0 <= section.confidence <= 1.0
+        assert isinstance(section.suggestions, list)
+        assert len(section.suggestions) > 0
+
+    def test_generate_section_is_deterministic(
+        self, generator: MockReviewGenerator
+    ) -> None:
+        """Test the same input always produces the same output."""
+        profile_data = {"github_username": "sameuser"}
+        chunks: list[dict] = [{"text": "some chunk"}]
+
+        section1 = generator.generate_section("skills_feedback", chunks, profile_data)
+        section2 = generator.generate_section("skills_feedback", chunks, profile_data)
+
+        assert section1.content == section2.content
+        assert section1.confidence == section2.confidence
+
+    def test_generate_section_varies_with_chunk_count(
+        self, generator: MockReviewGenerator
+    ) -> None:
+        """Test confidence and content reflect the number of chunks passed in."""
+        profile_data = {"github_username": "testuser"}
+
+        section_no_chunks = generator.generate_section("skills_feedback", [], profile_data)
+        section_with_chunks = generator.generate_section(
+            "skills_feedback", [{"text": "a"}, {"text": "b"}], profile_data
+        )
+
+        assert section_no_chunks.content != section_with_chunks.content
+
+    def test_generate_full_review_returns_all_sections(
+        self, generator: MockReviewGenerator
+    ) -> None:
+        """Test generate_full_review returns one section per known section name."""
+        sections = generator.generate_full_review({"github_username": "testuser"}, [])
+
+        assert len(sections) == len(SECTION_NAMES)
+        returned_names = {s.section_name for s in sections}
+        assert returned_names == set(SECTION_NAMES)
+
+    def test_generate_full_review_handles_missing_username(
+        self, generator: MockReviewGenerator
+    ) -> None:
+        """Test generate_full_review does not crash when github_username is missing."""
+        sections = generator.generate_full_review({}, [])
+
+        assert len(sections) == len(SECTION_NAMES)
+        for section in sections:
+            assert "unknown" in section.content
+
+    def test_no_network_or_api_calls(self, generator: MockReviewGenerator) -> None:
+        """Test the generator works with no API key or network access configured.
+
+        This is the core requirement for offline evaluation: MockReviewGenerator
+        must never attempt a real API call.
+        """
+        sections = generator.generate_full_review(
+            {"github_username": "offline-user"}, [{"text": "chunk text"}]
+        )
+
+        assert len(sections) == len(SECTION_NAMES)

--- a/tests/unit/test_run_evals.py
+++ b/tests/unit/test_run_evals.py
@@ -1,0 +1,111 @@
+"""Tests for scripts/run_evals.py"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+import scripts.run_evals as run_evals
+from ingestion.embeddings.provider import EmbeddingProvider, get_embedding_provider
+from rag.retriever.vector_store import VectorStore
+
+
+@pytest.mark.unit
+class TestRunEvals:
+    """Test suite for the offline eval runner."""
+
+    @pytest.fixture
+    def sample_fixture(self) -> dict:
+        """A minimal valid benchmark fixture."""
+        return {
+            "profile_id": "test_profile_01",
+            "github_username": "test-user",
+            "projects": ["some-project"],
+            "query": "How is this candidate's portfolio?",
+            "chunks": [
+                {
+                    "source_id": "readme",
+                    "section": "overview",
+                    "text": "some-project is a Python tool.",
+                },
+            ],
+        }
+
+    def test_load_fixtures_finds_real_fixtures(self) -> None:
+        """Test load_fixtures reads the real benchmark fixture files."""
+        fixtures = run_evals.load_fixtures()
+
+        assert len(fixtures) >= 1
+        for fixture in fixtures:
+            assert "profile_id" in fixture
+            assert "query" in fixture
+            assert "chunks" in fixture
+
+    def test_evaluate_fixture_returns_scores(
+        self, tmp_path: Path, sample_fixture: dict
+    ) -> None:
+        """Test evaluate_fixture runs the full pipeline and returns scores."""
+        vector_store = VectorStore(persist_dir=str(tmp_path))
+        embedding_provider: EmbeddingProvider = get_embedding_provider("mock")
+
+        result = run_evals.evaluate_fixture(sample_fixture, vector_store, embedding_provider)
+
+        assert result["profile_id"] == "test_profile_01"
+        assert "error" not in result
+        assert 0.0 <= result["relevance_score"] <= 1.0
+        assert 0.0 <= result["faithfulness_score"] <= 1.0
+        assert 0.0 <= result["overall_score"] <= 1.0
+        assert result["chunks_retrieved"] >= 1
+        assert result["sections_generated"] == 5
+
+    def test_evaluate_fixture_handles_empty_chunks_gracefully(self, tmp_path: Path) -> None:
+        """Test a fixture with no chunks does not crash the run."""
+        vector_store = VectorStore(persist_dir=str(tmp_path))
+        embedding_provider: EmbeddingProvider = get_embedding_provider("mock")
+
+        empty_fixture = {
+            "profile_id": "empty_profile",
+            "github_username": "nobody",
+            "projects": [],
+            "query": "How is this portfolio?",
+            "chunks": [],
+        }
+
+        result = run_evals.evaluate_fixture(empty_fixture, vector_store, embedding_provider)
+
+        assert result["profile_id"] == "empty_profile"
+
+    def test_main_writes_valid_json_report(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, sample_fixture: dict
+    ) -> None:
+        """Test main() end to end writes a well-formed eval_results.json."""
+        fixtures_dir = tmp_path / "fixtures"
+        fixtures_dir.mkdir()
+        (fixtures_dir / "profile_01.json").write_text(json.dumps(sample_fixture))
+
+        output_path = tmp_path / "eval_results.json"
+
+        monkeypatch.setattr(run_evals, "FIXTURES_DIR", fixtures_dir)
+        monkeypatch.setattr(run_evals, "OUTPUT_PATH", output_path)
+
+        run_evals.main()
+
+        assert output_path.exists()
+        report = json.loads(output_path.read_text())
+
+        assert report["profiles_evaluated"] == 1
+        assert report["profiles_failed"] == 0
+        assert 0.0 <= report["average_overall_score"] <= 1.0
+        assert len(report["results"]) == 1
+
+    def test_main_exits_when_no_fixtures_found(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test main() exits cleanly if the fixtures directory is empty."""
+        empty_dir = tmp_path / "empty_fixtures"
+        empty_dir.mkdir()
+
+        monkeypatch.setattr(run_evals, "FIXTURES_DIR", empty_dir)
+
+        with pytest.raises(SystemExit):
+            run_evals.main()


### PR DESCRIPTION
## Summary
Before this change, `scripts/run_evals.py` was an empty stub. It printed messages saying the evaluation was complete, but it did not actually run anything, and it never created `eval_results.json`. This PR replaces it with a script that loads a set of sample portfolios, runs each one through retrieval and generation, scores the results, and writes a real JSON report. A new deterministic mock review generator lets the whole pipeline run offline, with no real API key or network access needed.

## Issue
Closes #40

## Changes
- Replaced the stub in `scripts/run_evals.py` with a full pipeline: load fixtures, embed and index chunks, retrieve, generate, evaluate, write JSON report
- Added `rag/generator/mock_generator.py`, a deterministic mock review generator that mirrors the existing `MockEmbeddingProvider` pattern
- Added three sample benchmark portfolios in `tests/fixtures/sample_profiles/`
- Added `scripts/__init__.py` so the script can be imported cleanly in tests
- Added `tests/unit/test_mock_generator.py` and `tests/unit/test_run_evals.py`

## Testing
- [x] Unit tests pass (`make test-unit`) — new tests pass; 53 pre-existing failures unrelated to this change remain, unchanged from before this PR
- [x] Integration tests pass (`make test-integration`) — not run, no integration tests touch this code path
- [x] Linter passes (`make lint`) — new files are lint-clean; 182 pre-existing lint errors in unrelated files remain, unchanged from before this PR
- [x] Type checker passes (`make typecheck`) — new files are clean under the project's `.venv` mypy; pre-commit's isolated mypy hook (a different, older mypy version) surfaces unrelated pre-existing annotation gaps in files this PR does not touch
- [x] New/updated tests cover the changes

Manual verification steps:
1. `.venv/bin/python scripts/run_evals.py`
2. Confirm it prints "Evaluation complete. Results written to eval_results.json"
3. `cat eval_results.json`
4. Confirm the file exists and contains real scores for three sample profiles (`bench_fullstack_01`, `bench_junior_02`, `bench_datascience_03`), each with `relevance_score`, `faithfulness_score`, and `overall_score`

## Notes for Reviewers
`VectorStore.add_chunks()` is dead code with a mismatched interface (expects `Chunk` objects with attributes that don't exist on the actual `Chunk` dataclass). This PR bypasses it and inserts chunks directly via the collection API instead of fixing that unrelated bug, to stay in scope for #40.

The mock generator's scores are intentionally low (faithfulness near 0), since its placeholder text doesn't reference real chunk content. This is expected and shows the pipeline works correctly end to end, not a bug in the eval logic itself.