### PR TITLE
Fix/158 reviewservice tests fail

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,4 @@ repos:
       - id: mypy
         additional_dependencies: [types-redis]
         args: [--ignore-missing-imports]
+        exclude: ^(tests|scripts|alembic)/

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,24 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/158
+
+**Issue title:** `review_service unit tests misconfigure async mocks — 13 of 19 tests fail` 
+
+**Tier:** [X] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+`review_service` unit tests are misconfigured to use Async mocks for the review `results` object, which leads to 13 tests out of 19 failing trying to call `.first()` on a coroutine (`AttributeError: 'coroutine' object has no attribute 'first'`). A successful fix would use `AsyncMock` for `execute` but use `MagicMock` for the review object, leading to a full passing suite.
+
+**Selection reasoning:**
+
+I chose this Tier 1 issue for several reasons including:
+
+- This is my first time contributing to an open-source project (even if simulated).
+- The fix is limited only to a unit test file `tests/unit/test_review_service.py` and doesn't need me to touch the actual review service itself, so I can get used to navigating the repo's test setup and conventions before tackling an issue that requires more knowledge of the codebase.
+- I have little experience in pytest and I find it really interesting to understand the library and TDD in general.
+
+**Branch name:** `fix/158-reviewservice-tests-fail`
+
+**Setup confirmation:** [X] App runs locally at localhost:5173
+
+**Cohort ledger:** [X] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -36,3 +36,22 @@ I ran `pytest tests/unit/test_review_service.py -v` after `make setup` and saw 1
 
 **Blockers or open questions:**
 No major blockers — root cause and fix are fully scoped in PLAN.md. Going into Week 9, the main thing I want to double check is whether any other test files in the repo have the same `AsyncMock`/`MagicMock` mismatch, so I can flag or fix those too rather than just this one file.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/555
+
+**Branch:** `fix/158-reviewservice-tests-fail`
+
+**What you built:**
+`tests/unit/test_review_service.py` built its DB query-result mock as `AsyncMock()` with no `spec`, so `.scalars()`/`.first()`/`.all()` returned live coroutines instead of their configured return values — only `db.execute()` itself is genuinely async in real SQLAlchemy. Switching `mock_result` to `MagicMock()` across the 13 affected tests fixed the mismatch. I also had to bump `[tool.mypy] python_version` to 3.12 and scope the local pre-commit mypy hook to match CI's, since a pre-existing numpy/mypy version mismatch was blocking any commit that touched a `.py` file at all.
+
+**Tests added or updated:**
+Only `tests/unit/test_review_service.py` — no new tests needed, since the existing 19 already covered `create_review`, `get_review`, and `list_reviews` correctly; they just couldn't run due to the mock misconfiguration. Went from 6/19 to 18/19 passing (the 1 remaining failure is a separate, pre-existing bug out of scope for #158 — documented in the PR).
+
+**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+(Both fail at the full-repo level on pre-existing, unrelated issues — 174 ruff errors, 103 mypy errors, and 41 failing unit tests elsewhere in the repo, none introduced by this PR. Scoped to the files this PR touches, lint/typecheck are clean and `test_review_service.py` is 18/19.)
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -22,3 +22,17 @@ I chose this Tier 1 issue for several reasons including:
 **Setup confirmation:** [X] App runs locally at localhost:5173
 
 **Cohort ledger:** [X] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/rnossair/pathreview/commit/bdff0e3064fbac2d9f9b68533de7104cee48ff71
+
+**Reproduction summary:**
+I ran `pytest tests/unit/test_review_service.py -v` after `make setup` and saw 13 of 19 tests fail with `AttributeError: 'coroutine' object has no attribute 'first'` (or `'all'`), plus a `RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited` — confirming the `mock_result = AsyncMock()` mismatch described in the Week 7 problem summary.
+
+**PLAN.md link:** [PLAN.md](https://github.com/rnossair/pathreview/blob/bdff0e3064fbac2d9f9b68533de7104cee48ff71/PLAN.md)
+
+**Walkthrough video (recommended):** N/A
+
+**Blockers or open questions:**
+No major blockers — root cause and fix are fully scoped in PLAN.md. Going into Week 9, the main thing I want to double check is whether any other test files in the repo have the same `AsyncMock`/`MagicMock` mismatch, so I can flag or fix those too rather than just this one file.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -55,3 +55,34 @@ Only `tests/unit/test_review_service.py` — no new tests needed, since the exis
 (Both fail at the full-repo level on pre-existing, unrelated issues — 174 ruff errors, 103 mypy errors, and 41 failing unit tests elsewhere in the repo, none introduced by this PR. Scoped to the files this PR touches, lint/typecheck are clean and `test_review_service.py` is 18/19.)
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [X] No — still awaiting review
+
+**Summary of feedback:**
+No review came in for the PR so far.
+
+**How you responded:**
+N/A
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The firat part was understanding the unit tests framework in Python as someone who has up until now mostly worked with Ts/Js codebases. Afterwards was understanding the different Mock classes and why choosing the wrong one caused so many tests to fail.
+
+**What did you learn about working in a large codebase?**
+Working in a large codebase means you're held to a pre-existing standard when contributing to it; styling conventions, test coverage expectations, and infrastructure constraints (like pre-commit hooks) shape your work in ways that don't exist in personal projects.
+
+**How did AI tools help — and where did they fall short?**
+AI Assistance was most helpful when understanding new frameworks or understanding how some services functionned, but I oftentimes found myself searching online for more details about some specific classes.
+
+**What would you do differently if you started over?**
+I think if I had more time this summer, I would have liked to choose a Tier 2 issue that would challenge me a bit further. I believe it would have been more beneficial for me if I had the chance to explore the codebase with more details, especially using AI.
+
+**What are you most proud of from this module?**
+I feel like this module gave me the confidence and knowledge to kick-off a first real open-source contribution, and I'm excited to see myself grow more and more adaptable as I navigate new codebases and hope to have a PR merged into a real project.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,34 @@
+## Solution plan
+
+**Issue:** [review_service unit tests misconfigure async mocks — 13 of 19 tests fail](https://github.com/ascherj/pathreview/issues/158)
+
+### Understand
+`tests/unit/test_review_service.py` builds `mock_result = AsyncMock()` to stand in for the object returned by `await db.execute(...)`. In real SQLAlchemy, `execute()` is the only genuinely async step — the `Result` object it resolves to (`.scalars()`, `.first()`, `.all()`) is used synchronously afterward. Because `mock_result` has no `spec`, its child attributes (`.scalars`, `.first`, `.all`) auto-inherit `AsyncMock`, so calling them returns a live coroutine instead of the configured `return_value`. The real `review_service.py` code calls `.scalars().first()`/`.scalars().all()` without `await` (matching real SQLAlchemy), so it ends up doing `coroutine.first()` / `coroutine.all()`, which raises `AttributeError: 'coroutine' object has no attribute 'first'/'all'`.
+
+Expected: all 19 tests in the file pass.
+Actual: 13 of 19 fail with the `AttributeError` above; only the 6 `create_review` tests pass, since they never touch `mock_result`.
+
+### Map
+`tests/unit/test_review_service.py`
+- Import line (currently `from unittest.mock import AsyncMock, Mock, patch`) needs `MagicMock` added.
+- 13 occurrences of `mock_result = AsyncMock()` across the `get_review` and `list_reviews` test methods.
+
+No production code (`core/services/review_service.py`) needs to change — the bug is entirely in the test file's mock setup.
+
+### Plan
+1. Add `MagicMock` to the `unittest.mock` import.
+2. Replace all 13 `mock_result = AsyncMock()` occurrences with `mock_result = MagicMock()`.
+3. Leave `mock_db_session.execute = AsyncMock(return_value=mock_result)` as-is — `execute()` genuinely is async, so this part is already correct.
+4. Run `pytest tests/unit/test_review_service.py -v` and confirm all 19 tests pass.
+5. Spot-check the diff to make sure no `AsyncMock()` was swapped in the 6 already-passing `create_review` tests (they don't use `mock_result`, so should be unaffected).
+
+### Inputs & outputs
+Input: the current (broken) `tests/unit/test_review_service.py`.
+Output: the same file with `mock_result` built as `MagicMock()` instead of `AsyncMock()`, no other logic changed, full test suite green.
+
+### Risks & unknowns
+- Need to double check none of the 13 call sites rely on any part of `mock_result` actually being awaited elsewhere in the same test (a quick grep/read confirms they don't — `mock_result` is only ever accessed via `.scalars().first()`/`.scalars().all()`, both synchronous in real SQLAlchemy).
+- `mock_db_session` itself (from the `mock_db_session` fixture) stays `AsyncMock()` — that's correct and shouldn't be touched, since `commit`/`refresh`/`execute` are all genuinely async in real `AsyncSession`.
+
+### Edge cases
+Not really applicable — this is a test-infrastructure fix, not new behavior. The only thing to verify post-fix is that the previously-passing `create_review` tests (which don't touch `mock_result`) still pass unchanged.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ target-version = ["py311"]
 line-length = 100
 
 [tool.mypy]
-python_version = "3.11"
+python_version = "3.12"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true

--- a/tests/unit/test_review_service.py
+++ b/tests/unit/test_review_service.py
@@ -1,9 +1,9 @@
 """Tests for review_service.py"""
 
-import pytest
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 from uuid import uuid4
-from unittest.mock import AsyncMock, Mock, patch
-import asyncio
+
+import pytest
 
 from core.services.review_service import (
     create_review,
@@ -45,7 +45,9 @@ class TestReviewService:
         return profile
 
     @pytest.mark.asyncio
-    async def test_create_review_returns_review_with_pending_status(self, mock_db_session, mock_review):
+    async def test_create_review_returns_review_with_pending_status(
+        self, mock_db_session, mock_review
+    ):
         """Test create_review returns Review with status='pending'."""
         profile_id = uuid4()
         user_id = uuid4()
@@ -55,18 +57,18 @@ class TestReviewService:
         mock_db_session.commit = AsyncMock()
         mock_db_session.refresh = AsyncMock()
 
-        with patch('core.services.review_service.Review') as MockReview:
-            mock_instance = MockReview.return_value
+        with patch("core.services.review_service.Review") as mock_review_cls:
+            mock_instance = mock_review_cls.return_value
             mock_instance.status = "pending"
             mock_instance.sections = None
             mock_instance.overall_score = None
 
-            result = await create_review(mock_db_session, profile_id, user_id)
+            await create_review(mock_db_session, profile_id, user_id)
 
             # Check that Review was instantiated
-            MockReview.assert_called()
-            call_kwargs = MockReview.call_args[1]
-            assert call_kwargs['status'] == "pending"
+            mock_review_cls.assert_called()
+            call_kwargs = mock_review_cls.call_args[1]
+            assert call_kwargs["status"] == "pending"
 
     @pytest.mark.asyncio
     async def test_get_review_returns_review_for_correct_owner(self, mock_db_session):
@@ -78,7 +80,7 @@ class TestReviewService:
         mock_review.id = review_id
 
         # Setup mock execute to return review
-        mock_result = AsyncMock()
+        mock_result = MagicMock()
         mock_result.scalars.return_value.first.return_value = mock_review
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
@@ -91,11 +93,10 @@ class TestReviewService:
     async def test_get_review_returns_none_for_wrong_user(self, mock_db_session):
         """Test get_review returns None when user_id doesn't match."""
         review_id = uuid4()
-        user_id = uuid4()
         wrong_user_id = uuid4()
 
         # Setup mock to return None
-        mock_result = AsyncMock()
+        mock_result = MagicMock()
         mock_result.scalars.return_value.first.return_value = None
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
@@ -112,7 +113,7 @@ class TestReviewService:
         mock_reviews = [Mock() for _ in range(5)]
 
         # Setup execute mock to return reviews
-        mock_result = AsyncMock()
+        mock_result = MagicMock()
         mock_result.scalars.return_value.all.return_value = mock_reviews
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
@@ -129,13 +130,11 @@ class TestReviewService:
         page_size = 20
 
         # Setup mock
-        mock_result = AsyncMock()
+        mock_result = MagicMock()
         mock_result.scalars.return_value.all.return_value = []
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
-        reviews, total = await list_reviews(
-            mock_db_session, user_id, page=2, page_size=page_size
-        )
+        reviews, total = await list_reviews(mock_db_session, user_id, page=2, page_size=page_size)
 
         # Second call should pass offset for page 2
         calls = mock_db_session.execute.call_args_list
@@ -147,7 +146,7 @@ class TestReviewService:
         """Test list_reviews returns (reviews, total) tuple."""
         user_id = uuid4()
 
-        mock_result = AsyncMock()
+        mock_result = MagicMock()
         mock_result.scalars.return_value.all.return_value = []
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
@@ -165,7 +164,7 @@ class TestReviewService:
         profile_id = uuid4()
         user_id = uuid4()
 
-        with patch('core.services.review_service.Review'):
+        with patch("core.services.review_service.Review"):
             await create_review(mock_db_session, profile_id, user_id)
 
             mock_db_session.add.assert_called_once()
@@ -176,7 +175,7 @@ class TestReviewService:
         profile_id = uuid4()
         user_id = uuid4()
 
-        with patch('core.services.review_service.Review'):
+        with patch("core.services.review_service.Review"):
             await create_review(mock_db_session, profile_id, user_id)
 
             mock_db_session.commit.assert_called_once()
@@ -187,7 +186,7 @@ class TestReviewService:
         profile_id = uuid4()
         user_id = uuid4()
 
-        with patch('core.services.review_service.Review'):
+        with patch("core.services.review_service.Review"):
             await create_review(mock_db_session, profile_id, user_id)
 
             mock_db_session.refresh.assert_called_once()
@@ -198,7 +197,7 @@ class TestReviewService:
         review_id = uuid4()
         user_id = uuid4()
 
-        mock_result = AsyncMock()
+        mock_result = MagicMock()
         mock_result.scalars.return_value.first.return_value = None
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
@@ -212,7 +211,7 @@ class TestReviewService:
         """Test list_reviews uses default pagination."""
         user_id = uuid4()
 
-        mock_result = AsyncMock()
+        mock_result = MagicMock()
         mock_result.scalars.return_value.all.return_value = []
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
@@ -228,7 +227,7 @@ class TestReviewService:
         user_id = uuid4()
         custom_page_size = 50
 
-        mock_result = AsyncMock()
+        mock_result = MagicMock()
         mock_result.scalars.return_value.all.return_value = []
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
@@ -244,13 +243,13 @@ class TestReviewService:
         profile_id = uuid4()
         user_id = uuid4()
 
-        with patch('core.services.review_service.Review') as MockReview:
-            MockReview.return_value = Mock()
+        with patch("core.services.review_service.Review") as mock_review_cls:
+            mock_review_cls.return_value = Mock()
             await create_review(mock_db_session, profile_id, user_id)
 
-            call_kwargs = MockReview.call_args[1]
-            assert 'profile_id' in call_kwargs
-            assert 'status' in call_kwargs
+            call_kwargs = mock_review_cls.call_args[1]
+            assert "profile_id" in call_kwargs
+            assert "status" in call_kwargs
 
     @pytest.mark.asyncio
     async def test_get_review_verifies_ownership(self, mock_db_session):
@@ -258,7 +257,7 @@ class TestReviewService:
         review_id = uuid4()
         user_id = uuid4()
 
-        mock_result = AsyncMock()
+        mock_result = MagicMock()
         mock_result.scalars.return_value.first.return_value = None
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
@@ -273,7 +272,7 @@ class TestReviewService:
         user_id = uuid4()
 
         mock_reviews = [Mock() for _ in range(5)]
-        mock_result = AsyncMock()
+        mock_result = MagicMock()
         mock_result.scalars.return_value.all.return_value = mock_reviews
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
@@ -287,8 +286,8 @@ class TestReviewService:
         """Test list_reviews returns list of Review objects."""
         user_id = uuid4()
 
-        mock_reviews = [Mock(spec=['id', 'status']) for _ in range(3)]
-        mock_result = AsyncMock()
+        mock_reviews = [Mock(spec=["id", "status"]) for _ in range(3)]
+        mock_result = MagicMock()
         mock_result.scalars.return_value.all.return_value = mock_reviews
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
@@ -302,13 +301,13 @@ class TestReviewService:
         profile_id = uuid4()
         user_id = uuid4()
 
-        with patch('core.services.review_service.Review') as MockReview:
-            MockReview.return_value = Mock()
+        with patch("core.services.review_service.Review") as mock_review_cls:
+            mock_review_cls.return_value = Mock()
             await create_review(mock_db_session, profile_id, user_id)
 
-            call_kwargs = MockReview.call_args[1]
-            assert call_kwargs['sections'] is None
-            assert call_kwargs['overall_score'] is None
+            call_kwargs = mock_review_cls.call_args[1]
+            assert call_kwargs["sections"] is None
+            assert call_kwargs["overall_score"] is None
 
     @pytest.mark.asyncio
     async def test_get_review_with_valid_uuid(self, mock_db_session):
@@ -316,7 +315,7 @@ class TestReviewService:
         review_id = uuid4()
         user_id = uuid4()
 
-        mock_result = AsyncMock()
+        mock_result = MagicMock()
         mock_result.scalars.return_value.first.return_value = None
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
@@ -330,7 +329,7 @@ class TestReviewService:
         """Test list_reviews returns results ordered by created_at desc."""
         user_id = uuid4()
 
-        mock_result = AsyncMock()
+        mock_result = MagicMock()
         mock_result.scalars.return_value.all.return_value = []
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 


### PR DESCRIPTION
## Summary
Fixes issue #158: `tests/unit/test_review_service.py` built its DB query-result mock as `AsyncMock()` with no `spec`, so calling `.scalars()`/`.first()`/`.all()` on it returned a live coroutine instead of the configured return value (real SQLAlchemy only awaits `db.execute()` itself — the `Result` object it resolves to is used synchronously). This caused 13 of 19 tests in the file to fail with `AttributeError: 'coroutine' object has no attribute 'first'/'all'`. Fixing it required a small, unrelated mypy config fix first, since a pre-existing numpy/mypy version mismatch was blocking every local commit that touched a `.py` file.

## Issue
Closes #158

## Changes
- Rebuilt `mock_result` as `MagicMock()` instead of `AsyncMock()` across all 13 affected test methods in `tests/unit/test_review_service.py` — only `execute()` is genuinely async in real SQLAlchemy.
- Fixed incidental ruff violations surfaced once the hooks could run cleanly on this file: renamed `MockReview` → `mock_review_cls` (N806), removed two unused local variables (F841).
- Bumped `[tool.mypy] python_version` from `3.11` to `3.12` (`pyproject.toml`) — numpy 2.x's type stubs use PEP 695 `type` statement syntax that mypy can't parse under a 3.11 target. This was blocking every `.py`-touching commit locally, and would hit CI identically since CI installs the same unpinned `numpy>=1.26.0`.
- Added a path exclusion (`tests|scripts|alembic`) to the local mypy pre-commit hook (`.pre-commit-config.yaml`), matching what CI's `typecheck` job already scopes to (`api/ core/ ingestion/ rag/ agent/ safety/`) — without it, the local hook was stricter than CI, flagging `disallow_untyped_defs` across all 19 test methods that CI never checks.

## Testing
- [x] `tests/unit/test_review_service.py` alone: 6/19 → 18/19 passing. The 1 remaining failure (`test_list_reviews_ordered_by_created_at`) is a separate, pre-existing bug (asserts `execute` called once, but `list_reviews` legitimately calls it twice — count query + paginated query) that is out of scope for #158 per the actual issue text.
- [ ] Full-repo `make test-unit` — **not clean**: 41 failed / 387 passed, all pre-existing and unrelated except the 1 above.
- [x] Linter passes on changed files (`ruff check` clean on `tests/unit/test_review_service.py`, `pyproject.toml`, `.pre-commit-config.yaml`).
- [ ] Full-repo `make lint` — **not clean**: 174 pre-existing errors across unrelated files.
- [x] Type checker passes on changed files (mypy hook runs clean/skips correctly post-fix).
- [ ] Full-repo `make typecheck` — **not clean**: 103 pre-existing errors across unrelated files (e.g. `api/routes/profiles.py`, `api/main.py`), none touched by this PR.
- [x] No new tests needed — existing tests now actually exercise the code paths they were written for.

## Screenshots / Demo
N/A — test/config-only change, no user-facing behavior.

## Notes for Reviewers
This repo has widespread pre-existing lint/type/test failures unrelated to this PR. I verified none are introduced by this branch and none overlap with #158's scope — I deliberately did not fix them here to keep this PR focused. The mypy/config commit is a separate, minimal prerequisite fix (not part of #158 itself) required just to get pre-commit hooks passing at all.
