### PR TITLE
PR Test/157 relevance scorer test overlap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,67 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+PathReview is an AI-powered portfolio review assistant for early-career developers. It ingests GitHub profiles, resumes, and repos, then uses a RAG pipeline and a multi-tool agent to generate structured, evidence-based portfolio feedback, guarded by a safety layer.
+
+Stack: FastAPI + SQLAlchemy/Postgres backend (Python 3.11), React + TypeScript + Vite frontend, Redis, ChromaDB for vector storage, Alembic for migrations.
+
+## Commands
+
+Backend commands run through `.venv` (created by `make setup`); prefix manual invocations with `.venv/bin/` if not activated.
+
+```bash
+make setup           # first-time setup: venv, deps, migrations, seed data, frontend install
+make run              # start backend (uvicorn, :8000) + frontend (vite, :5173) concurrently
+make test-unit        # pytest tests/unit -v -m unit (~30s, no external deps)
+make test-integration # pytest tests/integration -v -m integration (requires Docker services)
+make test-all         # full pytest suite
+make lint             # ruff check .
+make format           # black .
+make typecheck        # mypy api/ core/ ingestion/ rag/ agent/ safety/
+make check            # lint + format + typecheck
+make migrate          # alembic upgrade head
+make seed             # re-seed database
+make reset-db         # drop, recreate, migrate, and reseed the dev database
+make eval             # run the RAG evaluation suite (scripts/run_evals.py)
+```
+
+Single test file/case: `.venv/bin/pytest tests/unit/test_relevance_scorer.py -v` or `-k test_name`.
+
+Frontend (from `frontend/`): `npm run dev`, `npm test` (vitest), `npm run build` (tsc + vite build).
+
+Docker services (Postgres + Redis) must be running (`docker compose up -d`) before `make setup` or `make test-integration`.
+
+## Architecture
+
+Five subsystems, roughly following this data flow: **API → Ingestion → Agent → RAG → Safety → Review Output**.
+
+- **`api/`** — FastAPI app. Routes (`api/routes/`) handle JWT auth, validation, rate limiting, and delegate business logic to `core/services/`. Don't put business logic directly in route handlers.
+- **`core/`** — Shared foundation: SQLAlchemy models (`core/models/`), service layer (`core/services/`), config, database session, security, logging. This is the dependency root other subsystems build on.
+- **`ingestion/`** — Turns uploaded resumes/READMEs/repos into embeddings. Flow: `parsers/` (implement `BaseParser`, return `ParseResult`) → `chunking/` (`semantic_chunker.py` vs `structural_chunker.py`, selected via `strategy_selector.py`) → `embeddings/` (batched provider calls) → stored via `pipeline.py`, which orchestrates the whole parse→chunk→embed→store sequence and is where new parsers get registered.
+- **`agent/`** — Plan-execute orchestrator (`orchestrator.py`) coordinating analysis tools in `agent/tools/` (github_tool, skill_extractor, readme_scorer, market_analyzer, tech_detector), each implementing `BaseTool` (`name`, `description`, `execute()`). Tools are registered in the orchestrator, which handles retries/timeouts and synthesizes results. `agent/memory/` manages session state and context across the agent run.
+- **`rag/`** — `retriever/hybrid.py` combines vector similarity (`vector_store.py`, ChromaDB) with BM25 keyword search (`keyword_search.py`). `generator/` builds prompts (`prompt_templates.py`), calls the LLM (`review_generator.py`), and parses structured output (`output_parser.py`). `evaluator/` scores retrieval relevance (`relevance_scorer.py`) and generation faithfulness (`faithfulness_checker.py`) — this is what `make eval` exercises.
+- **`safety/`** — Sequential middleware wrapping generation: prompt injection defense → content filter → bias detector → PII scrubber, plus rate limiting and monitoring. All safety events are logged with structured metadata.
+- **`frontend/`** — React + TypeScript dashboard (Vite, react-router). Tests in `frontend/src/test/` via vitest + testing-library + jest-axe (accessibility).
+
+See `docs/ARCHITECTURE.md` for the full diagram and `docs/adr/` for rationale on chunking strategy, embedding model choice, and agent orchestration design.
+
+## Adding to the codebase
+
+**New ingestion parser**: implement `BaseParser` in `ingestion/parsers/`, register in `ingestion/pipeline.py`, add tests in `tests/unit/test_<parser_name>.py`.
+
+**New agent tool**: implement `BaseTool` in `agent/tools/`, register in `agent/orchestrator.py`, add tests in `tests/unit/test_<tool_name>.py` (mock external API calls).
+
+## Conventions
+
+- **Branch naming**: `<type>/<issue-number>-<short-description>` (e.g. `fix/124-resume-parser-index-error`). Types: `fix`, `feat`, `test`, `docs`, `refactor`, `perf`, `chore`.
+- **Commits**: Conventional Commits — `<type>(<scope>): <description>`. Scopes: `ingestion`, `rag`, `agent`, `safety`, `api`, `frontend`.
+- **Python style**: black-formatted, ruff-linted (rules: E, F, I, N, W, UP, B, SIM, TCH), line length 100. mypy runs with `disallow_untyped_defs` and `check_untyped_defs` — new functions need full type annotations.
+- **Docstrings**: Google-style, required on public functions/classes.
+- Before opening a PR: `make check && make test-unit` must pass.
+
+## Test markers
+
+pytest markers (`pyproject.toml`): `unit` (fast, no external deps), `integration` (requires Docker services), `benchmark` (performance), `security` (red-team tests). Test suite lives under `tests/unit/`, `tests/integration/`, `tests/security/`, `tests/benchmarks/`.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -40,3 +40,35 @@ None currently — the fix is confined to rewriting one chunk-text fixture. The 
 **Setup confirmation:** [X] App runs locally at localhost:5173
 
 **Cohort ledger:** [X] Issue added to cohort ledger
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the PLAN.md fix: rewrote the chunk text in `test_query_with_partial_overlap` (`tests/unit/test_relevance_scorer.py`) so it genuinely omits two of the four query tokens (`python`, `framework`), producing a partial-overlap score of 0.5 instead of the full-overlap 1.0 that was causing the failure. Steps 1–3 from PLAN.md are done: fixture rewritten, overlap ratio hand-verified before running, and the targeted test confirmed passing (`test_query_with_partial_overlap` PASSED, all 19 tests in the file pass).
+
+**Next steps:**
+Run the full unit suite and `make check` to confirm no regressions elsewhere, then commit and open the PR (PLAN.md steps 4–5).
+
+**Blockers:**
+None on the fix itself. Discovered along the way that `make test-unit`, `make lint`, and `make typecheck` all have pre-existing, unrelated failures repo-wide (52 failing unit tests, 182 ruff errors, 5 mypy errors from missing stubs and a numpy/mypy version mismatch) — confirmed via `git stash` that these predate this branch and aren't caused by this change, so they're out of scope for #157.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/557
+
+**Branch:** `test/157-relevance-scorer-test-overlap`
+
+**What you built:**
+Fixed the fixture bug in `test_query_with_partial_overlap`: the chunk text previously contained every query token, so the scorer correctly returned a full-overlap score of 1.0 and the `0.3 < score < 0.9` assertion failed. The chunk text now genuinely omits some query terms, so the test exercises the intended partial-match path (score = 0.5). No production code in `rag/evaluator/relevance_scorer.py` changed — the scorer's logic was already correct.
+
+**Tests added or updated:**
+Only `tests/unit/test_relevance_scorer.py` — updated the `test_query_with_partial_overlap` fixture text and comment, and added missing type annotations across all 19 test methods (plus one `chunks: list[dict]` var annotation) so the file satisfies the mypy pre-commit hook. No new test files were added; all 19 existing tests in this file cover the scorer's behavior and now pass.
+
+**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+> Both commands exit with errors when run repo-wide, but neither failure is related to this change: `make test-unit` goes from 53 failed/375 passed (pre-fix) to 52 failed/376 passed (post-fix) — exactly the targeted test flipped, nothing else changed. `make check` fails on 182 pre-existing ruff errors and 5 pre-existing mypy errors elsewhere in the repo; `ruff check tests/unit/test_relevance_scorer.py` and the mypy pre-commit hook both pass cleanly on the file I touched.
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,29 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/157
+
+**Issue title:** Relevance scorer “partial overlap” test fixture actually has full query overlap
+
+**Tier:** [X] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The relevance scorer test suite has a test named `test_query_with_partial_overlap` that is supposed to validate how the scorer handles queries where only some terms appear in a chunk, but the test fixture actually includes all of the query terms ("Python", "Django", "web", "framework") inside the chunk text. Because the scorer correctly returns 1.0 for full keyword coverage, the assertion `score < 0.9` fails even though the scorer itself is working correctly. This is a test-quality bug in the backend relevance scoring tests: the fixture description says "partial overlap" but the data represents full overlap. A successful fix would update the chunk text so that it genuinely omits one or more query terms, making the test actually exercise the partial-match code path and allowing the assertion to pass against correct scorer behavior.
+
+**Issue-selection Reasoning:**
+- **Understanding:** I can describe the problem and the correct behavior without looking at the issue again. The test fixture uses a chunk that contains every term from the query, so the scorer returns `1.0` even though the test is designed to measure partial overlap.
+- **Affected code:** I found and read `test_query_with_partial_overlap` in `tests/unit/test_relevance_scorer.py` and traced the scoring logic through the `score` and `_tokenize` methods in `rag/evaluator/relevance_scorer.py`.
+- **Definition of done:** Currently, all query terms are present in the chunk and the scorer returns `1.0`, which causes the `score < 0.9` assertion to fail. After the fix, the chunk should contain only a subset of the query terms, resulting in a score in the `0.3`–`0.9` range and a passing test.
+- **Tier fit:** This is a Tier 1 issue and is a good first contribution because the fix is confined to a single test fixture and requires no changes to production code or other modules.
+- **Codebase readiness:** I read the full test file and the scorer implementation to understand how keyword overlap is computed before selecting this issue.
+- **Testing:** I ran `pytest tests/unit/test_relevance_scorer.py -q` and confirmed the reported failure: 1 failed, 18 passed, with the failing assertion showing the actual score was `1.0`.
+- **Rough plan:** I will revise the test fixture so only some of the query terms appear in the chunk, rerun the unit tests to confirm they pass, and verify that no changes are needed in the scorer itself.
+- **Claims:** I reviewed the issue activity and the cohort ledger and understand that claims are non-exclusive. I am fine working on this issue alongside other contributors.
+- **Time and scope:** The change is small and self-contained, so it fits comfortably within the Week 9 deadline.
+- **Dependencies:** I did not find any open blockers or prerequisite issues that need to be resolved before this fix can be made.
+
+
+**Branch name:** test/157/relevance-scorer-test-overlap
+
+**Setup confirmation:** [X] App runs locally at localhost:5173
+
+**Cohort ledger:** [X] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -16,7 +16,7 @@ The relevance scorer test suite has a test named `test_query_with_partial_overla
 - **Tier fit:** This is a Tier 1 issue and is a good first contribution because the fix is confined to a single test fixture and requires no changes to production code or other modules.
 - **Codebase readiness:** I read the full test file and the scorer implementation to understand how keyword overlap is computed before selecting this issue.
 - **Testing:** I ran `pytest tests/unit/test_relevance_scorer.py -q` and confirmed the reported failure: 1 failed, 18 passed, with the failing assertion showing the actual score was `1.0`.
-- **Rough plan:** I will revise the test fixture so only some of the query terms appear in the chunk, rerun the unit tests to confirm they pass, and verify that no changes are needed in the scorer itself.
+- **Rough plan:** I will revise the test fixture so only some of the query terms appear in the chunk, rerun the unit tests to confirm they pass, and then verify that no changes are needed in the scorer itself.
 - **Claims:** I reviewed the issue activity and the cohort ledger and understand that claims are non-exclusive. I am fine working on this issue alongside other contributors.
 - **Time and scope:** The change is small and self-contained, so it fits comfortably within the Week 9 deadline.
 - **Dependencies:** I did not find any open blockers or prerequisite issues that need to be resolved before this fix can be made.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -21,8 +21,21 @@ The relevance scorer test suite has a test named `test_query_with_partial_overla
 - **Time and scope:** The change is small and self-contained, so it fits comfortably within the Week 9 deadline.
 - **Dependencies:** I did not find any open blockers or prerequisite issues that need to be resolved before this fix can be made.
 
+## Week 8 — Reproduction & solution planning
 
-**Branch name:** test/157/relevance-scorer-test-overlap
+**Reproduction commit link:** https://github.com/carlostorres18/pathreview/commit/c2369955b4fcf4d446d76cc4792006232e00ef04
+
+**Reproduction summary:**
+Ran `.venv/bin/pytest tests/unit/test_relevance_scorer.py -q` and observed `1 failed, 18 passed`. The failure is `test_query_with_partial_overlap`, which asserts `0.3 < score < 0.9` but got `score == 1.0` — the logged output shows `avg_score=1.0` because the chunk fixture text contains every token from the query, so the scorer correctly reports full overlap instead of the partial overlap the test name implies.
+
+**PLAN.md link:** [PLAN.md](./PLAN.md) (this repo, root of branch `test/157-relevance-scorer-test-overlap`)
+
+**Walkthrough video (recommended):** [Issue #157 Loom Video](https://www.loom.com/share/5d978a143ea84e559868a6b9d4fa0d74)
+
+**Blockers or open questions:**
+None currently — the fix is confined to rewriting one chunk-text fixture. The only thing to double-check while implementing is that the replacement text lands the overlap ratio inside `(0.3, 0.9)` and doesn't accidentally hit the zero-overlap or full-overlap paths instead, since `RelevanceScorer._tokenize` does a naive `.lower().split()` with no punctuation stripping or stemming.
+
+**Branch name:** test/157-relevance-scorer-test-overlap
 
 **Setup confirmation:** [X] App runs locally at localhost:5173
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -72,3 +72,34 @@ Only `tests/unit/test_relevance_scorer.py` — updated the `test_query_with_part
 > Both commands exit with errors when run repo-wide, but neither failure is related to this change: `make test-unit` goes from 53 failed/375 passed (pre-fix) to 52 failed/376 passed (post-fix) — exactly the targeted test flipped, nothing else changed. `make check` fails on 182 pre-existing ruff errors and 5 pre-existing mypy errors elsewhere in the repo; `ruff check tests/unit/test_relevance_scorer.py` and the mypy pre-commit hook both pass cleanly on the file I touched.
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No review has come in yet on PR #557 as of this writing.
+
+**How you responded:**
+N/A — nothing to respond to yet. If review comments come in before the module closes, I'll update this section with what was raised and how I addressed it.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The fix itself — a one-line fixture change — was straightforward once I traced the scoring logic. What surprised me was how much friction showed up *after* the fix was written. `make check` and `make test-unit` only run mypy/ruff against `api/`, `core/`, `ingestion/`, `rag/`, `agent/`, and `safety/` — they never touch `tests/` — so both commands looked clean locally. But the repo's `pre-commit` hook runs `mypy` against whatever files are actually staged, `tests/` included, and it rejected my commit over 21 pre-existing missing type annotations elsewhere in `test_relevance_scorer.py` that had nothing to do with my change. I had to diff the mypy scope in `Makefile` against `.pre-commit-config.yaml` to even understand why a "passing" file was blocking a commit, then add annotations across the whole file to get past the hook. I also learned to distrust "182 lint errors" and "52 failing tests" as signals about *my* change specifically — I used `git stash` to diff pass/fail counts before and after my edit, which was the only way to prove those failures were pre-existing and not something I'd introduced.
+
+**What did you learn about working in a large codebase?**
+Contributing to someone else's codebase means the safety net (CI config, lint rules, test markers, Makefile targets) was written by people who understood tradeoffs I didn't have visibility into yet — like why `make typecheck` deliberately excludes `tests/`. Instead of assuming a failing check means my code is wrong, I learned to first ask "is this pre-existing, and is it in scope for the issue I'm fixing?" before touching anything outside the files the issue actually calls for. I leaned on AI to quickly read across files I hadn't touched yet — the scorer implementation, the Makefile, the pre-commit config — so I could reason about *why* a check was failing instead of just reacting to red text in the terminal.
+
+**How did AI tools help — and where did they fall short?**
+AI was most useful for fast comprehension: tracing how `RelevanceScorer.score()` tokenizes and compares query/chunk text, confirming my replacement fixture would land the overlap ratio inside the asserted range before I ran anything, and explaining *why* the pre-commit hook disagreed with `make check`. It also caught that the whole test file was pre-existing tech debt (see this exact issue class) rather than something to work around case by case. Where it fell short — or rather, where it needed me to make the call — was scope: deciding whether to add type annotations across the whole file (arguably out-of-scope for #157) versus bypassing the hook was a judgment call about tradeoffs the AI could lay out but shouldn't make unilaterally, so I decided explicitly rather than letting it just push through.
+
+**What would you do differently if you started over?**
+I'd run the actual `pre-commit` hooks locally right after writing the fix — not just `make check` — so I'd hit the annotation issue during implementation instead of at commit time. I'd also skim `.pre-commit-config.yaml` alongside the `Makefile` during issue selection, so I know upfront which checks are enforced at commit-time versus CI-time before I've already written the fix.
+
+**What are you most proud of from this module?**
+Tackling a Tier 1 issue end-to-end — reproducing it, tracing root cause instead of just silencing the assertion, and verifying with before/after test counts that my fix didn't mask or introduce anything — gave me a repeatable process I trust for picking up the next issue faster. It's also good preparation heading into AI301 in Fall 2026, since a lot of this module was really about learning to read a codebase's own conventions before changing it.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,63 @@
+## Solution plan
+
+**Issue:** [#157 — Relevance scorer "partial overlap" test fixture actually has full query overlap](https://github.com/ascherj/pathreview/issues/157)
+
+### Bug replication
+
+1. Run `.venv/bin/pytest tests/unit/test_relevance_scorer.py -q`
+2. Observe: `1 failed, 18 passed` — failure is `TestRelevanceScorer::test_query_with_partial_overlap`
+3. Assertion failure: `assert 1.0 < 0.9` at `tests/unit/test_relevance_scorer.py:60`, with logged `avg_score=1.0`
+
+Confirmed locally (2026-07-21).
+
+### Understand
+
+`RelevanceScorer.score()` (`rag/evaluator/relevance_scorer.py`) computes relevance as keyword-overlap ratio: `overlap / len(query_tokens)`, where overlap is the set intersection of lowercased, whitespace-tokenized words from the query and the chunk text.
+
+`test_query_with_partial_overlap` intends to exercise the case where only *some* query terms appear in a chunk, asserting the resulting score lands in `0.3 < score < 0.9`. But the fixture data is wrong:
+
+- Query: `"Python Django web framework"` → tokens `{python, django, web, framework}`
+- Chunk: `"Django is a Python web framework for rapid development"` → contains all 4 query tokens
+
+Every query token is present in the chunk, so overlap is 4/4 = 1.0 (full match), not partial. The scorer is behaving correctly per its own logic (full overlap → 1.0); the test fixture just doesn't represent "partial overlap" as its name and docstring claim. This is a test-fixture bug, not a scorer bug — no production code in `rag/evaluator/relevance_scorer.py` needs to change.
+
+**Expected vs. actual:**
+- Expected: chunk text omits at least one query term, so the assertion validates the partial-overlap code path (some but not all tokens matching).
+- Actual: chunk contains every query term, so the assertion accidentally checks the full-overlap path and fails.
+
+### Map
+
+Files expected to touch:
+
+- `tests/unit/test_relevance_scorer.py` — only file requiring a change. Specifically the `chunks` fixture text (line 52) inside `test_query_with_partial_overlap` (lines 47–60).
+
+Files read/verified but NOT expected to change:
+
+- `rag/evaluator/relevance_scorer.py` — confirmed scorer logic is correct as-is; no fix needed here.
+
+### Plan
+
+1. Edit the chunk text in `test_query_with_partial_overlap` so it contains some but not all query terms — e.g. drop "Django" and/or "framework" from the chunk so only a subset of `{python, django, web, framework}` is present.
+2. Manually compute the expected overlap ratio for the new fixture to confirm it lands inside `0.3 < score < 0.9` before running the test (so the assertion range doesn't need adjusting too).
+3. Run `.venv/bin/pytest tests/unit/test_relevance_scorer.py -v` and confirm `test_query_with_partial_overlap` now passes and all other 18 tests still pass (no regressions from the edit, since only one fixture changes).
+4. Run the full unit suite (`make test-unit`) to confirm no other test depends on this fixture's current text.
+5. Update `JOURNAL.md` / commit with a Conventional Commit message, e.g. `test(rag): fix partial-overlap fixture in relevance scorer tests`.
+
+### Inputs & outputs
+
+- **Input:** the `query` string and `chunks` list literals inside the single test function.
+- **Output:** a chunk text string that genuinely omits ≥1 query token, causing `scorer.score()` to return a value strictly between 0.3 and 0.9, so the existing assertions pass without weakening them.
+
+### Risks & unknowns
+
+- Need to pick chunk wording that lands the score comfortably inside `(0.3, 0.9)`, not just barely over/under a boundary — a token count that's too sparse could drop below 0.3, or still include too many terms and stay near 1.0. Will hand-verify the overlap ratio before running.
+- The `RelevanceScorer._tokenize` implementation is a naive `.lower().split()` — no punctuation stripping — so wording like "Django," or "framework." would tokenize as `django,`/`framework.` and silently fail to match. Need to keep the omitted/kept terms as clean whitespace-delimited words.
+- Should confirm no other test or non-test code (e.g. `rag/evaluator/eval_suite.py`, `scripts/run_evals.py`) imports or relies on this specific fixture string — a quick grep for the chunk text confirms it's local to this one test.
+- Low risk overall: change is isolated to one test fixture, no production code or public API changes, so blast radius is minimal.
+
+### Edge cases
+
+Not applicable in the traditional sense — this is a test-fixture-only fix, not new production logic. The main "edge case" to guard against is picking replacement fixture text that:
+- still contains ≥1 but not all 4 query tokens (must genuinely be "partial"),
+- doesn't accidentally match 0 tokens (would test the zero-overlap path instead),
+- doesn't rely on substring/stemming behavior the tokenizer doesn't implement (e.g. "frameworks" ≠ "framework" under naive `.split()`).

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -99,7 +99,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -449,7 +448,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -473,7 +471,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1561,7 +1558,6 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1579,7 +1575,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1972,7 +1967,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3507,7 +3501,6 @@
       "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^2.0.1",
         "cssstyle": "^4.0.1",
@@ -4094,7 +4087,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4107,7 +4099,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4771,7 +4762,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/tests/unit/test_relevance_scorer.py
+++ b/tests/unit/test_relevance_scorer.py
@@ -10,17 +10,15 @@ class TestRelevanceScorer:
     """Test suite for RelevanceScorer."""
 
     @pytest.fixture
-    def scorer(self):
+    def scorer(self) -> RelevanceScorer:
         """Create a RelevanceScorer instance."""
         return RelevanceScorer()
 
-    def test_query_with_perfect_keyword_match(self, scorer):
+    def test_query_with_perfect_keyword_match(self, scorer: RelevanceScorer) -> None:
         """Test query with perfect keyword match in chunks returns score close to 1.0."""
         query = "Python development framework"
         chunks = [
-            {
-                "text": "Python is a great development language for building frameworks"
-            },
+            {"text": "Python is a great development language for building frameworks"},
         ]
 
         score = scorer.score(query, chunks)
@@ -30,13 +28,11 @@ class TestRelevanceScorer:
         # Should be high score due to keyword overlap
         assert score > 0.5
 
-    def test_query_with_zero_keyword_overlap(self, scorer):
+    def test_query_with_zero_keyword_overlap(self, scorer: RelevanceScorer) -> None:
         """Test query with zero keyword overlap returns score close to 0.0."""
         query = "Rust Kubernetes microservices"
         chunks = [
-            {
-                "text": "Python is dynamically typed and interpreted language"
-            },
+            {"text": "Python is dynamically typed and interpreted language"},
         ]
 
         score = scorer.score(query, chunks)
@@ -44,13 +40,14 @@ class TestRelevanceScorer:
         assert isinstance(score, float)
         assert score < 0.5  # Should be low score
 
-    def test_query_with_partial_overlap(self, scorer):
+    def test_query_with_partial_overlap(self, scorer: RelevanceScorer) -> None:
         """Test query with partial overlap returns score between 0 and 1."""
         query = "Python Django web framework"
         chunks = [
-            {
-                "text": "Django is a Python web framework for rapid development"
-            },
+            # Deliberately omits "python" and "framework" so only half of the
+            # query tokens (django, web) are present, exercising the
+            # partial-match path instead of full overlap.
+            {"text": "Django is a popular web application toolkit for rapid development"},
         ]
 
         score = scorer.score(query, chunks)
@@ -59,27 +56,25 @@ class TestRelevanceScorer:
         assert 0.0 <= score <= 1.0
         assert 0.3 < score < 0.9  # Partial overlap should be in middle range
 
-    def test_empty_chunks_list_returns_zero(self, scorer):
+    def test_empty_chunks_list_returns_zero(self, scorer: RelevanceScorer) -> None:
         """Test empty chunks list returns 0.0."""
         query = "Some query"
-        chunks = []
+        chunks: list[dict] = []
 
         score = scorer.score(query, chunks)
 
         assert score == 0.0
 
-    def test_empty_query_returns_zero(self, scorer):
+    def test_empty_query_returns_zero(self, scorer: RelevanceScorer) -> None:
         """Test empty query returns 0.0."""
         query = ""
-        chunks = [
-            {"text": "Some content"}
-        ]
+        chunks = [{"text": "Some content"}]
 
         score = scorer.score(query, chunks)
 
         assert score == 0.0
 
-    def test_multiple_chunks_aggregated(self, scorer):
+    def test_multiple_chunks_aggregated(self, scorer: RelevanceScorer) -> None:
         """Test that score aggregates multiple chunks."""
         query = "Python programming"
         chunks = [
@@ -93,19 +88,17 @@ class TestRelevanceScorer:
         assert isinstance(score, float)
         assert 0.0 <= score <= 1.0
 
-    def test_case_insensitive_matching(self, scorer):
+    def test_case_insensitive_matching(self, scorer: RelevanceScorer) -> None:
         """Test that keyword matching is case insensitive."""
         query = "PYTHON PROGRAMMING"
-        chunks = [
-            {"text": "python programming is fun"}
-        ]
+        chunks = [{"text": "python programming is fun"}]
 
         score = scorer.score(query, chunks)
 
         # Should match despite different cases
         assert score > 0.5
 
-    def test_tokenization(self, scorer):
+    def test_tokenization(self, scorer: RelevanceScorer) -> None:
         """Test that tokenization works correctly."""
         tokens = scorer._tokenize("Python web development framework")
 
@@ -114,82 +107,67 @@ class TestRelevanceScorer:
         assert all(isinstance(t, str) for t in tokens)
         assert "python" in tokens  # Should be lowercase
 
-    def test_empty_text_in_chunk(self, scorer):
+    def test_empty_text_in_chunk(self, scorer: RelevanceScorer) -> None:
         """Test handling of empty text in chunk."""
         query = "Python"
-        chunks = [
-            {"text": ""},
-            {"text": "Python programming"}
-        ]
+        chunks = [{"text": ""}, {"text": "Python programming"}]
 
         score = scorer.score(query, chunks)
 
         assert isinstance(score, float)
         assert 0.0 <= score <= 1.0
 
-    def test_very_long_query(self, scorer):
+    def test_very_long_query(self, scorer: RelevanceScorer) -> None:
         """Test handling of very long query."""
         query = "Python " * 100
-        chunks = [
-            {"text": "Python is a programming language"}
-        ]
+        chunks = [{"text": "Python is a programming language"}]
 
         score = scorer.score(query, chunks)
 
         assert isinstance(score, float)
         assert 0.0 <= score <= 1.0
 
-    def test_very_long_chunk(self, scorer):
+    def test_very_long_chunk(self, scorer: RelevanceScorer) -> None:
         """Test handling of very long chunk."""
         query = "Python"
-        chunks = [
-            {"text": "Python " * 1000 + "is a great language"}
-        ]
+        chunks = [{"text": "Python " * 1000 + "is a great language"}]
 
         score = scorer.score(query, chunks)
 
         assert isinstance(score, float)
         assert 0.0 <= score <= 1.0
 
-    def test_special_characters_ignored(self, scorer):
+    def test_special_characters_ignored(self, scorer: RelevanceScorer) -> None:
         """Test that special characters are handled."""
         query = "Python c++ golang"
-        chunks = [
-            {"text": "c++ is a systems programming language"}
-        ]
+        chunks = [{"text": "c++ is a systems programming language"}]
 
         score = scorer.score(query, chunks)
 
         # Should handle special characters in tokenization
         assert isinstance(score, float)
 
-    def test_multiple_keyword_matches(self, scorer):
+    def test_multiple_keyword_matches(self, scorer: RelevanceScorer) -> None:
         """Test scoring improves with multiple keyword matches."""
         query = "Python framework development tools"
-        chunks = [
-            {"text": "Python django flask development framework tools"}
-        ]
+        chunks = [{"text": "Python django flask development framework tools"}]
 
         score = scorer.score(query, chunks)
 
         # Multiple matches should yield higher score
         assert score > 0.6
 
-    def test_single_word_chunks(self, scorer):
+    def test_single_word_chunks(self, scorer: RelevanceScorer) -> None:
         """Test handling of single-word chunks."""
         query = "Python development"
-        chunks = [
-            {"text": "Python"},
-            {"text": "development"},
-            {"text": "framework"}
-        ]
+        chunks = [{"text": "Python"}, {"text": "development"}, {"text": "framework"}]
 
         score = scorer.score(query, chunks)
 
         assert isinstance(score, float)
         assert score > 0.0  # Should find matches
 
-    def test_score_ranges_from_zero_to_one(self, scorer):
+    def test_score_ranges_from_zero_to_one(self, scorer: RelevanceScorer) -> None:
         """Test that score is always between 0 and 1."""
         test_cases = [
             ("Python", [{"text": "Java"}]),  # No match
@@ -201,24 +179,20 @@ class TestRelevanceScorer:
             score = scorer.score(query, chunks)
             assert 0.0 <= score <= 1.0
 
-    def test_common_words_not_preventing_scoring(self, scorer):
+    def test_common_words_not_preventing_scoring(self, scorer: RelevanceScorer) -> None:
         """Test that common words don't prevent scoring."""
         query = "the best Python framework"
-        chunks = [
-            {"text": "Django is the best Python web framework"}
-        ]
+        chunks = [{"text": "Django is the best Python web framework"}]
 
         score = scorer.score(query, chunks)
 
         # Despite common words, should still score relevantly
         assert score > 0.3
 
-    def test_chunk_without_text_key(self, scorer):
+    def test_chunk_without_text_key(self, scorer: RelevanceScorer) -> None:
         """Test handling of chunk missing 'text' key."""
         query = "Python"
-        chunks = [
-            {"content": "Python programming"}  # Wrong key
-        ]
+        chunks = [{"content": "Python programming"}]  # Wrong key
 
         score = scorer.score(query, chunks)
 
@@ -226,25 +200,22 @@ class TestRelevanceScorer:
         assert isinstance(score, float)
         assert 0.0 <= score <= 1.0
 
-    def test_whitespace_only_in_chunks(self, scorer):
+    def test_whitespace_only_in_chunks(self, scorer: RelevanceScorer) -> None:
         """Test chunks with only whitespace."""
         query = "Python"
-        chunks = [
-            {"text": "   "},
-            {"text": "\n\t"}
-        ]
+        chunks = [{"text": "   "}, {"text": "\n\t"}]
 
         score = scorer.score(query, chunks)
 
         assert score == 0.0
 
-    def test_average_relevance_calculation(self, scorer):
+    def test_average_relevance_calculation(self, scorer: RelevanceScorer) -> None:
         """Test that multiple chunks' scores are averaged."""
         query = "Python"
         chunks = [
             {"text": "Python is great"},
             {"text": "Python programming"},
-            {"text": "Java is different"}
+            {"text": "Java is different"},
         ]
 
         score = scorer.score(query, chunks)


### PR DESCRIPTION
## Summary
<!-- One paragraph describing what this PR does and why -->
The relevance_scorer unit test suite had a fixture bug in test_query_with_partial_overlap: the chunk text contained every token from the query, so RelevanceScorer.score() correctly returned a full-overlap score of 1.0, causing the test's 0.3 < score < 0.9 assertion to fail even though the scorer itself was behaving correctly. This PR rewrites the fixture so the chunk genuinely omits some query terms, exercising the intended partial-match code path. No production code in rag/evaluator/relevance_scorer.py was changed.

## Issue
Closes #157 

## Changes
<!-- Bullet list of the specific changes made -->
- Rewrote the chunk text in test_query_with_partial_overlap (tests/unit/test_relevance_scorer.py) so it omits 2 of the 4 query tokens (python, framework), giving a genuine partial-overlap score of 0.5 instead of a full-overlap score of 1.0.
- Added a short comment explaining why the fixture is shaped that way.
- Added missing type annotations (-> None, scorer: RelevanceScorer, chunks: list[dict]) across all test methods in the file so it passes the mypy pre-commit hook, which checks staged test files (unlike make typecheck, which excludes tests/).

## Testing
<!-- How did you verify your changes? -->
- [x] Unit tests pass (make test-unit) — ran full suite; result was 52 failed / 376 passed. Confirmed via git stash that all 52 failures are pre-existing on this branch's base and unrelated to this change (53 failed / 375 passed before the fix — exactly the one targeted test flipped from fail to pass, nothing else changed).
- [x] Integration tests pass (make test-integration) — not run (requires Docker services, no integration tests touch this scorer).
- [x] Linter passes (make lint) — repo-wide ruff check . reports 182 pre-existing errors unrelated to this change; ruff check tests/unit/test_relevance_scorer.py on this file alone passes cleanly.
- [x] Type checker passes (make typecheck) — repo-wide mypy reports 5 pre-existing errors (missing stubs for PyPDF2/jose/passlib/rank_bm25, plus a numpy/mypy version incompatibility), none related to this file; the mypy pre-commit hook (which actually runs against this file) passes.
- [x] New/updated tests cover the changes — no new tests added; existing test_query_with_partial_overlap now correctly exercises the partial-overlap path, and all 19 tests in tests/unit/test_relevance_scorer.py pass.

## Screenshots / Demo
<!-- If applicable, add screenshots or a link to a demo video -->
N/A — test-only change, no user-facing behavior.

## Notes for Reviewers
<!-- Anything the reviewer should pay particular attention to -->
- No production code changed — rag/evaluator/relevance_scorer.py's scoring logic is correct as-is; this was purely a test-fixture bug.
- The 52 pre-existing make test-unit failures and the make lint/make typecheck repo-wide failures are all unrelated to this PR and predate this branch — flagged here for transparency rather than left unmentioned, but out of scope to fix as part of #157.
