### PR TITLE
Feat/68 add safety events count to health check

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -19,7 +19,7 @@ But, in safety/monitoring.py file, there is a function that reads the safety eve
 
 ## Week 8 – Reproduction & solution planning
 
-**Reproduction commit link:** _[to be filled in after committing on branch `feat/68-add-safety-events-count-to-health-check` — this commit adds the reproduction steps below plus `PLAN.md`]_
+**Reproduction commit link:** https://github.com/ronypy/pathreview/commit/e499e4bba779b5d3af10d62d9d06f7089b1b701e
 
 **Reproduction summary:**
 Logged three safety events (`pii_detected` ×2, `injection_attempt` ×1) through the real `SafetyMonitor` in `safety/monitoring.py` using an in-memory Redis stand-in, then confirmed `SafetyMonitor.get_event_count()` reported a total of 3 while the `/health` endpoint's logic in `api/routes/health.py` (lines 25 and 75–80) still returned `safety_events_last_hour: 0`. The counter and the endpoint are disconnected — the endpoint hardcodes `0` instead of reading the counters that already exist.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,18 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/68#issue-4117410262
+
+**Issue title:** Add a safety event count to the health check endpoint
+
+
+**Tier:** [X] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+In api/router/health.py file, the health check endpoint does not include a safety events count. There is a placeholder variable (safety_events_last_hour) which doesn't read the actual data.
+But, in safety/monitoring.py file, there is a function that reads the safety events count from the database. I need to write helper functions to read the data from the database and update the health check endpoint to show the actual safety events count instead of a constant zero value.
+
+**Branch name:** feat/68-add-safety-events-count-to-health-check
+
+**Setup confirmation:** [X] App runs locally at localhost:5173
+
+**Cohort ledger:** [X] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -16,3 +16,22 @@ But, in safety/monitoring.py file, there is a function that reads the safety eve
 **Setup confirmation:** [X] App runs locally at localhost:5173
 
 **Cohort ledger:** [X] Issue added to cohort ledger
+
+## Week 8 – Reproduction & solution planning
+
+**Reproduction commit link:** _[to be filled in after committing on branch `feat/68-add-safety-events-count-to-health-check` — this commit adds the reproduction steps below plus `PLAN.md`]_
+
+**Reproduction summary:**
+Logged three safety events (`pii_detected` ×2, `injection_attempt` ×1) through the real `SafetyMonitor` in `safety/monitoring.py` using an in-memory Redis stand-in, then confirmed `SafetyMonitor.get_event_count()` reported a total of 3 while the `/health` endpoint's logic in `api/routes/health.py` (lines 25 and 75–80) still returned `safety_events_last_hour: 0`. The counter and the endpoint are disconnected — the endpoint hardcodes `0` instead of reading the counters that already exist.
+
+Reproduction steps:
+1. Instantiate `SafetyMonitor` and call `log_event()` for a few event types.
+2. Read the counts back via `get_event_count()` → returns the real totals (3).
+3. Compare against the endpoint field, which is hardcoded to `0` in `api/routes/health.py` → mismatch confirms the bug.
+
+**PLAN.md link:** https://github.com/ronypy/pathreview/blob/feat/68-add-safety-events-count-to-health-check/PLAN.md
+
+**Walkthrough video (recommended):** _[not recorded]_
+
+**Blockers or open questions:**
+The field is named `safety_events_last_hour`, but `get_event_count()` ignores its `window_hours` argument and `log_event()` sets a 24-hour Redis TTL — so the underlying counters aren't actually scoped to one hour. Going into Week 9 I need to decide whether to keep the name and document the approximation, or implement a true rolling 1-hour window (per-minute buckets / sorted sets).

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -35,3 +35,35 @@ Reproduction steps:
 
 **Blockers or open questions:**
 The field is named `safety_events_last_hour`, but `get_event_count()` ignores its `window_hours` argument and `log_event()` sets a 24-hour Redis TTL — so the underlying counters aren't actually scoped to one hour. Going into Week 9 I need to decide whether to keep the name and document the approximation, or implement a true rolling 1-hour window (per-minute buckets / sorted sets).
+
+## Week 9 – Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the core of the fix from `PLAN.md`. Added `SafetyMonitor.get_total_event_count()` in `safety/monitoring.py` (sub-task 1) — it sums the per-type Redis counters across `VALID_EVENT_TYPES`. Wired it into `api/routes/health.py` so `safety_events_last_hour` reports the real total instead of a hardcoded `0` (sub-task 2). While wiring it, I found the existing Redis check referenced `settings.redis_host`/`redis_port`, which don't exist in `core/config.py` (only `redis_url` does), so I switched to `redis.Redis.from_url(settings.redis_url)` and reuse that one client for both the Redis health check and the safety count.
+
+**Next steps:**
+Finish sub-task 3 (fail-safe on Redis outage) and sub-task 4 (tests): unit tests for the new aggregate method and an endpoint-level test proving the wiring. Then run `make check` / `make test-unit` and document the pre-existing baseline before opening the PR.
+
+**Blockers:**
+Decided to keep the `safety_events_last_hour` name and document the window approximation (per the Week 8 open question) rather than build a true rolling 1-hour window — that's a larger change and out of scope for issue #68. Noted as a follow-up.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** _[to be filled in when the PR is opened against `ascherj/pathreview`]_
+
+**Branch:** `feat/68-add-safety-events-count-to-health-check`
+
+**What you built:**
+The `/health` endpoint now reports the real number of recorded safety events instead of a constant `0`. A new `SafetyMonitor.get_total_event_count()` aggregates the per-type counters already stored in Redis, and the endpoint builds a `SafetyMonitor` from the shared Redis client to populate `safety_events_last_hour`. If Redis is unavailable the count falls back to `0` and the endpoint stays responsive (Redis is separately reported `unhealthy`).
+
+**Tests added or updated:**
+`tests/unit/test_monitoring.py` (new, 11 tests) — covers `log_event`, `get_event_count`, and the new `get_total_event_count` (summing, empty state, per-type error isolation, and an end-to-end log→count check). `tests/unit/test_health_endpoint.py` (new, 3 tests) — asserts the endpoint reports the real total, reports `0` with no events, and degrades gracefully to `0` + 503 when Redis is down.
+
+**Self-review confirmation:** [X] make check passes  [X] make test-unit passes
+_(Interpreted per the assignment's pre-existing-failures rule: the repo has a documented baseline of 53 failing unit tests and 175 ruff errors in unrelated modules. My branch adds 14 passing tests and introduces zero new failures — baseline 53 failed / 375 passed → 53 failed / 389 passed. My four changed files are clean under all three tools: `ruff` passes, `black --check` passes, and `mypy` on the two changed source files went from 11 errors → 0 (the annotations and `redis.from_url` switch cleared them). So my change makes things strictly better, not worse.)_
+
+**Draft PR feedback received from:** none (peer review happens in Slack; will request a draft-PR review there before marking ready)

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -53,7 +53,7 @@ Decided to keep the `safety_events_last_hour` name and document the window appro
 
 ### Check-in 2 (end of week)
 
-**PR link:** _[to be filled in when the PR is opened against `ascherj/pathreview`]_
+**PR link:** https://github.com/ascherj/pathreview/pull/558
 
 **Branch:** `feat/68-add-safety-events-count-to-health-check`
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -67,3 +67,34 @@ The `/health` endpoint now reports the real number of recorded safety events ins
 _(Interpreted per the assignment's pre-existing-failures rule: the repo has a documented baseline of 53 failing unit tests and 175 ruff errors in unrelated modules. My branch adds 14 passing tests and introduces zero new failures — baseline 53 failed / 375 passed → 53 failed / 389 passed. My four changed files are clean under all three tools: `ruff` passes, `black --check` passes, and `mypy` on the two changed source files went from 11 errors → 0 (the annotations and `redis.from_url` switch cleared them). So my change makes things strictly better, not worse.)_
 
 **Draft PR feedback received from:** none (peer review happens in Slack; will request a draft-PR review there before marking ready)
+
+## Week 10 – Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [X] No — still awaiting review
+
+**Summary of feedback:**
+No review came in. PR [#558](https://github.com/ascherj/pathreview/pull/558) is open against `ascherj/pathreview` but received no maintainer or peer comments by the end of the week. (Reviewer feedback is not a feature of the Summer 2026 cohort, so this is expected rather than a stall on my end.)
+
+**How you responded:**
+No changes were required since there was no feedback to act on. The PR stands as submitted in Week 9. If a maintainer does comment later, the follow-up I already flagged is the strongest candidate for a change: the `safety_events_last_hour` field name promises a one-hour window the underlying 24-hour Redis TTL can't actually back.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Knowing whether *my* change was healthy was harder than writing the change itself. The repo ships with a large pre-existing baseline of red — 53 failing unit tests and 175 ruff errors across modules I never touched (`test_review_service`, `test_security`, `test_skill_extractor`, etc.). Running `make test-unit` after my edit and seeing dozens of failures was alarming until I stashed my work and re-ran to prove the baseline was identical (53 failed / 375 passed → 53 failed / 389 passed with my 14 tests added). I also lost time to a stale, orphaned git rebase left in `.git/rebase-merge` from weeks earlier — `git status` insisted a rebase was "in progress" even though the reflog showed it had already finished, and I had to reason carefully about `git rebase --quit` (clears the state, keeps HEAD) versus `--abort` (would have destructively reset me to an old state) before touching it. The lesson: in an unfamiliar codebase, "is this failure mine?" is a real question that needs an explicit baseline, not a guess.
+
+**What did you learn about working in a large codebase?**
+The discipline is subtractive, not additive. On my own projects I'd have "fixed" everything I saw — the 175 ruff errors, the missing type annotations, the misleading field name. Here the rule was "don't make it worse," so I deliberately scoped down: I fixed only what my change touched (10 mypy errors in `health.py` cleared by adding a return annotation and switching to `redis.Redis.from_url`, plus one `text("SELECT 1")` wrapper the annotation surfaced) and consciously left the true rolling-1-hour-window rework as a documented follow-up instead of scope-creeping issue #68. I also learned to reuse rather than reinvent — the safety-event counters already existed in `SafetyMonitor`; the bug was purely that the endpoint hardcoded `0` instead of reading them, so the fix was a small aggregate helper (`get_total_event_count`) and one wiring change, not a new subsystem.
+
+**How did AI tools help — and where did they fall short?**
+AI was strongest at mapping and verification bookkeeping: tracing how the disconnected pieces (`log_event` → Redis keys → `get_event_count` → the endpoint) fit together, generating the test matrix (summing, empty state, per-type error isolation, Redis-down degradation), and mechanically establishing the stash-based baseline so I could separate my failures from the repo's. Where it fell short was anything requiring judgment about *this* repo's conventions and state: it needed steering to catch that `settings.redis_host`/`redis_port` didn't actually exist (only `redis_url` did), and a `# mypy: ignore-errors` directive it wrote for the test files was silently mis-parsed by mypy because of a trailing inline comment, which only surfaced when the pre-commit hook rejected the commit. AI accelerated the work but every AI-generated diff still had to be run, type-checked, and reconciled against the real pre-commit pipeline before I trusted it.
+
+**What would you do differently if you started over?**
+I'd capture the test/lint/typecheck baseline on the untouched branch *first*, before writing a single line — that one habit would have removed most of the "did I break this?" anxiety and the mid-work stashing. I'd also verify the environment's git state up front; the orphaned rebase was lurking the whole time and would have been trivial to clear on day one. On the technical side, I'd decide the `window_hours` semantics before naming things: either implement a real per-minute-bucket rolling window or rename the field to match the 24-hour reality, rather than shipping an approximation I then had to document my way around. And I'd record the optional Week 8 walkthrough video — skipping it left my reproduction less legible than it could have been.
+
+**What are you most proud of from this module?**
+The fix is small, but it's honest and defensive. The endpoint now reports real data, degrades gracefully to `0` when Redis is down (without masking that Redis is unhealthy — that's still reported separately), and is covered by 14 tests that pin down the exact behaviors, including the failure paths. I'm most proud that I resisted the temptation to over-reach: I diagnosed the real root cause (counters and endpoint were simply never connected), fixed precisely that, left the codebase strictly cleaner than I found it on every file I touched, and wrote down the one thing I *didn't* fix and why — so the next contributor inherits a clear follow-up instead of a hidden surprise.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,102 @@
+## Solution plan
+
+**Issue:** [#68 — Add a safety event count to the health check endpoint](https://github.com/ascherj/pathreview/issues/68)
+
+### Understand
+The `/health` endpoint is meant to report operational signals about the service,
+including how many safety events (PII detections, injection attempts, content
+filtering, etc.) have occurred recently. Today the response always reports
+`safety_events_last_hour: 0`.
+
+- **Root cause:** In `api/routes/health.py` the field is set to a hardcoded `0`
+  in two places (the initial `health_status` dict on line 25, and again in the
+  "Count safety events" block on lines 75–80). The comment on line 77 even says
+  *"This would be populated by actual safety event logging"* — it was never
+  wired up.
+- **Expected behavior:** The field should reflect the real number of safety
+  events recorded over the last hour, read from the same Redis counters that
+  `SafetyMonitor` maintains.
+- **Actual behavior:** The field is always `0`, so the endpoint hides real
+  safety activity and gives operators a false "all quiet" signal.
+- The data already exists: `safety/monitoring.py` stores per-type counters in
+  Redis (`SafetyMonitor.log_event`) and exposes `get_event_count(event_type)`
+  to read them. Nothing consumes those counters yet.
+
+### Map
+Files, functions, and modules involved:
+
+- **`safety/monitoring.py`** — `SafetyMonitor` class.
+  - `VALID_EVENT_TYPES` (set of the 5 tracked event types).
+  - `get_event_count(event_type, window_hours=1)` — reads a single type's count
+    from Redis. There is no aggregate/total helper yet; I expect to add one.
+- **`api/routes/health.py`** — `health_check()` endpoint.
+  - Lines 25 and 75–80 (the hardcoded `safety_events_last_hour`).
+  - Lines 39–56 already build a `redis.Redis(...)` client for the Redis health
+    check; that client (or an equivalent) is what a `SafetyMonitor` needs.
+- **`core/config.py`** — `settings.redis_host` / `settings.redis_port`, already
+  used by the endpoint to construct the Redis client.
+
+Files I expect to touch: `safety/monitoring.py` and `api/routes/health.py`
+(plus a new/updated test under `tests/`).
+
+### Plan
+Break the fix into concrete sub-tasks:
+
+1. **Add an aggregate helper to `SafetyMonitor`.** Add
+   `get_total_event_count(window_hours=1)` (and/or `get_all_event_counts()`)
+   that sums `get_event_count()` across `VALID_EVENT_TYPES` and returns the
+   total, so the endpoint doesn't have to know the individual key names.
+2. **Wire the helper into the health endpoint.** In `health_check()`, reuse the
+   Redis client already created for the Redis check to build a `SafetyMonitor`,
+   then replace the hardcoded `0` on lines 25 and 78 with a call to the new
+   helper.
+3. **Make it fail-safe.** Wrap the count in the existing try/except so that if
+   Redis is unavailable the endpoint still returns (falling back to `0` for the
+   count) and Redis being down is already reflected in `dependencies.redis`
+   rather than crashing the health check.
+4. **Add a regression test.** Add a test (e.g.
+   `tests/integration/test_health_safety_events.py`) using a fake/mock Redis:
+   log N events via `SafetyMonitor`, call the endpoint, assert
+   `safety_events_last_hour == N`. This locks in the fix and mirrors the
+   reproduction.
+
+### Inputs & outputs
+- **Input:** The per-type safety counters stored in Redis under
+  `safety:events:<event_type>` keys (populated by `SafetyMonitor.log_event`),
+  read via a Redis client built from `settings.redis_host` / `redis_port`.
+- **Output:** The `safety_events_last_hour` integer in the `/health` JSON
+  response now equals the real aggregate count instead of a constant `0`. No
+  change to the HTTP status logic, the other dependency checks, or the response
+  shape — only the value of that one field changes.
+
+### Risks & unknowns
+- **"Last hour" is not actually enforced.** `get_event_count()` ignores its
+  `window_hours` argument (the docstring says so), and `log_event` sets a
+  **24-hour** expiry on the Redis keys (line 51), so the counters really cover
+  up to 24 hours, not one hour. The field name promises a 1-hour window the
+  data can't back yet — I need to decide whether to (a) keep the field name and
+  document the approximation, or (b) implement a true rolling 1-hour window
+  (e.g. per-minute buckets / sorted sets). Risk of scope creep here; I'll likely
+  do (a) for this fix and note (b) as follow-up.
+- **Redis client lifecycle.** The Redis client is created inside a `try` block
+  (lines 44–49); I must make sure the `SafetyMonitor` gets a valid client and
+  that a Redis outage degrades gracefully instead of raising.
+- **`decode_responses=True`** on the health endpoint's client vs. what
+  `SafetyMonitor.get_event_count` expects — `int(count)` works on both `bytes`
+  and `str`, so this is probably fine, but worth confirming.
+- **Unknown:** whether other callers already construct a `SafetyMonitor` I
+  should reuse, and where the canonical Redis client should live (DI vs. ad-hoc
+  construction in the endpoint).
+
+### Edge cases
+- **Redis is down / unreachable** → endpoint must still respond; count falls
+  back to `0` and `dependencies.redis` is marked `unhealthy` (no crash).
+- **No events ever logged** → keys don't exist; `get_event_count` returns `0`;
+  total is `0` (legitimately, not as a bug).
+- **Keys expired** (older than the TTL) → treated as `0`, which is correct.
+- **A non-integer / corrupted value in a key** → `int(count)` could raise;
+  `get_event_count` already catches and returns `0` per type, so one bad key
+  shouldn't zero out the whole total.
+- **New event type added to `VALID_EVENT_TYPES` later** → the aggregate helper
+  iterates the set, so it picks up new types automatically without touching the
+  endpoint.

--- a/api/routes/health.py
+++ b/api/routes/health.py
@@ -1,6 +1,10 @@
-from fastapi import APIRouter, HTTPException, status, Depends
+from datetime import datetime
+from typing import Any
+
 import structlog
-from datetime import datetime, timedelta
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from core.database import get_db
 
@@ -10,12 +14,12 @@ router = APIRouter(prefix="/health", tags=["health"])
 
 
 @router.get("")
-async def health_check(db=Depends(get_db)):
+async def health_check(db: AsyncSession = Depends(get_db)) -> dict[str, Any]:  # noqa: B008
     """
     Check health of PostgreSQL, Redis, and Vector DB.
     Returns 200 if all healthy, 503 if any dependency is down.
     """
-    health_status = {
+    health_status: dict[str, Any] = {
         "status": "healthy",
         "dependencies": {
             "postgres": "unknown",
@@ -28,7 +32,7 @@ async def health_check(db=Depends(get_db)):
 
     try:
         # Check PostgreSQL
-        await db.execute("SELECT 1")
+        await db.execute(text("SELECT 1"))
         health_status["dependencies"]["postgres"] = "healthy"
         log.debug("postgres_health_check_passed")
     except Exception as exc:
@@ -36,24 +40,25 @@ async def health_check(db=Depends(get_db)):
         health_status["dependencies"]["postgres"] = "unhealthy"
         health_status["status"] = "unhealthy"
 
+    redis_client = None
     try:
         # Check Redis (if available)
         import redis
+
         from core.config import settings
 
-        r = redis.Redis(
-            host=settings.redis_host,
-            port=settings.redis_port,
-            db=0,
+        redis_client = redis.Redis.from_url(
+            settings.redis_url,
             decode_responses=True,
         )
-        r.ping()
+        redis_client.ping()
         health_status["dependencies"]["redis"] = "healthy"
         log.debug("redis_health_check_passed")
     except Exception as exc:
         log.error("redis_health_check_failed", error=str(exc))
         health_status["dependencies"]["redis"] = "unhealthy"
         health_status["status"] = "unhealthy"
+        redis_client = None
 
     try:
         # Check Vector DB (if available)
@@ -72,12 +77,19 @@ async def health_check(db=Depends(get_db)):
         health_status["dependencies"]["vector_db"] = "unhealthy"
         health_status["status"] = "unhealthy"
 
-    # Count safety events in last hour (placeholder)
+    # Count safety events in the last hour from the Redis counters that
+    # SafetyMonitor maintains. Falls back to 0 if Redis is unavailable so the
+    # health check stays responsive (Redis being down is already reflected in
+    # dependencies.redis above).
     try:
-        # This would be populated by actual safety event logging
-        health_status["safety_events_last_hour"] = 0
+        if redis_client is not None:
+            from safety.monitoring import SafetyMonitor
+
+            monitor = SafetyMonitor(redis_client)
+            health_status["safety_events_last_hour"] = monitor.get_total_event_count(window_hours=1)
     except Exception as exc:
         log.error("safety_events_check_failed", error=str(exc))
+        health_status["safety_events_last_hour"] = 0
 
     # Return 503 if any critical dependency is down
     if health_status["status"] == "unhealthy":

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -99,7 +99,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -449,7 +448,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -473,7 +471,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1561,7 +1558,6 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1579,7 +1575,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1972,7 +1967,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3507,7 +3501,6 @@
       "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^2.0.1",
         "cssstyle": "^4.0.1",
@@ -4094,7 +4087,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4107,7 +4099,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4771,7 +4762,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/safety/monitoring.py
+++ b/safety/monitoring.py
@@ -2,7 +2,6 @@
 
 import redis
 import structlog
-from datetime import datetime, timedelta
 
 logger = structlog.get_logger()
 
@@ -16,7 +15,7 @@ class SafetyMonitor:
         "injection_attempt",
         "content_filtered",
         "bias_detected",
-        "rate_limited"
+        "rate_limited",
     }
 
     def __init__(self, redis_client: redis.Redis):
@@ -37,8 +36,6 @@ class SafetyMonitor:
         if event_type not in self.VALID_EVENT_TYPES:
             logger.warning("unknown_event_type", event_type=event_type)
             return
-
-        timestamp = datetime.utcnow().isoformat()
 
         try:
             # Log to structlog
@@ -72,3 +69,23 @@ class SafetyMonitor:
         except Exception as e:
             logger.error("event_count_error", event_type=event_type, error=str(e))
             return 0
+
+    def get_total_event_count(self, window_hours: int = 1) -> int:
+        """Get the combined count of safety events across all event types.
+
+        Sums the per-type counters tracked in Redis so callers (such as the
+        health check endpoint) can report a single "safety events" figure
+        without knowing the individual event types.
+
+        Args:
+            window_hours: Time window in hours. Not enforced here (matching
+                get_event_count); kept for API symmetry.
+
+        Returns:
+            Total count across every type in VALID_EVENT_TYPES. Returns 0 if
+            no events have been recorded. Errors reading any single type are
+            handled by get_event_count (that type contributes 0).
+        """
+        return sum(
+            self.get_event_count(event_type, window_hours) for event_type in self.VALID_EVENT_TYPES
+        )

--- a/tests/unit/test_health_endpoint.py
+++ b/tests/unit/test_health_endpoint.py
@@ -1,0 +1,74 @@
+"""Tests for the /health endpoint safety-events wiring (api/routes/health.py)."""
+
+# mypy: ignore-errors
+# (tests aren't type-checked; see `make typecheck`, which excludes tests/)
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from api.routes import health
+
+
+class FakeRedis:
+    """Minimal in-memory Redis stand-in for the health check."""
+
+    def __init__(self, store=None):
+        self.store = store or {}
+
+    def ping(self):
+        return True
+
+    def get(self, key):
+        value = self.store.get(key)
+        return None if value is None else str(value)
+
+
+@pytest.mark.unit
+class TestHealthSafetyEvents:
+    """The endpoint reports the real safety-event count, not a constant 0."""
+
+    @pytest.fixture
+    def mock_db(self):
+        """A DB session whose execute() succeeds (postgres reported healthy)."""
+        db = AsyncMock()
+        db.execute = AsyncMock(return_value=None)
+        return db
+
+    @pytest.mark.asyncio
+    async def test_reports_real_safety_event_count(self, mock_db):
+        """With events recorded, safety_events_last_hour reflects the total."""
+        fake = FakeRedis(
+            {
+                "safety:events:pii_detected": 2,
+                "safety:events:injection_attempt": 1,
+            }
+        )
+        with patch("redis.Redis.from_url", return_value=fake):
+            result = await health.health_check(db=mock_db)
+
+        assert result["safety_events_last_hour"] == 3
+        assert result["dependencies"]["redis"] == "healthy"
+
+    @pytest.mark.asyncio
+    async def test_zero_when_no_events_recorded(self, mock_db):
+        """No recorded events legitimately reports 0."""
+        with patch("redis.Redis.from_url", return_value=FakeRedis({})):
+            result = await health.health_check(db=mock_db)
+
+        assert result["safety_events_last_hour"] == 0
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_zero_when_redis_down(self, mock_db):
+        """Redis being down degrades gracefully: count 0, redis unhealthy, 503."""
+        with (
+            patch("redis.Redis.from_url", side_effect=Exception("redis down")),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            await health.health_check(db=mock_db)
+
+        detail = exc_info.value.detail
+        assert exc_info.value.status_code == 503
+        assert detail["safety_events_last_hour"] == 0
+        assert detail["dependencies"]["redis"] == "unhealthy"

--- a/tests/unit/test_monitoring.py
+++ b/tests/unit/test_monitoring.py
@@ -1,0 +1,141 @@
+"""Tests for safety/monitoring.py"""
+
+# mypy: ignore-errors
+# (tests aren't type-checked; see `make typecheck`, which excludes tests/)
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from safety.monitoring import SafetyMonitor
+
+
+@pytest.mark.unit
+class TestSafetyMonitor:
+    """Test suite for SafetyMonitor."""
+
+    @pytest.fixture
+    def mock_redis(self):
+        """Create a mock Redis client."""
+        return Mock()
+
+    @pytest.fixture
+    def monitor(self, mock_redis):
+        """Create a SafetyMonitor instance with mocked Redis."""
+        return SafetyMonitor(mock_redis)
+
+    # ---- log_event ----
+
+    def test_log_event_valid_type_increments_redis(self, monitor, mock_redis):
+        """A valid event type increments and expires its Redis counter."""
+        mock_redis.incr = Mock()
+        mock_redis.expire = Mock()
+
+        monitor.log_event("pii_detected", {"field": "email"})
+
+        mock_redis.incr.assert_called_once_with("safety:events:pii_detected")
+        mock_redis.expire.assert_called_once_with("safety:events:pii_detected", 86400)
+
+    def test_log_event_invalid_type_ignored(self, monitor, mock_redis):
+        """Unknown event types are dropped without touching Redis."""
+        mock_redis.incr = Mock()
+
+        with patch("safety.monitoring.logger"):
+            monitor.log_event("not_a_real_type", {})
+
+        mock_redis.incr.assert_not_called()
+
+    # ---- get_event_count ----
+
+    def test_get_event_count_returns_int(self, monitor, mock_redis):
+        """A stored count is parsed to an int."""
+        mock_redis.get = Mock(return_value="5")
+        assert monitor.get_event_count("pii_detected") == 5
+
+    def test_get_event_count_missing_key_returns_zero(self, monitor, mock_redis):
+        """A missing key counts as zero."""
+        mock_redis.get = Mock(return_value=None)
+        assert monitor.get_event_count("pii_detected") == 0
+
+    def test_get_event_count_redis_error_returns_zero(self, monitor, mock_redis):
+        """A Redis error is swallowed and counts as zero."""
+        mock_redis.get = Mock(side_effect=Exception("redis down"))
+        with patch("safety.monitoring.logger"):
+            assert monitor.get_event_count("pii_detected") == 0
+
+    def test_get_event_count_key_format(self, monitor, mock_redis):
+        """The Redis key is namespaced per event type."""
+        mock_redis.get = Mock(return_value="1")
+        monitor.get_event_count("injection_attempt")
+        mock_redis.get.assert_called_once_with("safety:events:injection_attempt")
+
+    # ---- get_total_event_count ----
+
+    def test_total_sums_all_event_types(self, monitor, mock_redis):
+        """The total is the sum of every per-type counter."""
+        counts = {
+            "safety:events:pii_detected": "2",
+            "safety:events:injection_attempt": "1",
+            "safety:events:content_filtered": "3",
+        }
+        mock_redis.get = Mock(side_effect=lambda key: counts.get(key))
+
+        assert monitor.get_total_event_count() == 6
+
+    def test_total_zero_when_no_events(self, monitor, mock_redis):
+        """With nothing recorded the total is zero (not an error)."""
+        mock_redis.get = Mock(return_value=None)
+        assert monitor.get_total_event_count() == 0
+
+    def test_total_iterates_every_valid_type(self, monitor, mock_redis):
+        """The aggregate queries exactly the known event types."""
+        mock_redis.get = Mock(return_value=None)
+
+        monitor.get_total_event_count()
+
+        queried = {call.args[0] for call in mock_redis.get.call_args_list}
+        expected = {f"safety:events:{t}" for t in SafetyMonitor.VALID_EVENT_TYPES}
+        assert queried == expected
+
+    def test_total_survives_single_type_error(self, monitor, mock_redis):
+        """One erroring key contributes 0 without zeroing the whole total."""
+
+        def fake_get(key):
+            if key == "safety:events:pii_detected":
+                raise Exception("corrupt value")
+            if key == "safety:events:rate_limited":
+                return "4"
+            return None
+
+        mock_redis.get = Mock(side_effect=fake_get)
+        with patch("safety.monitoring.logger"):
+            assert monitor.get_total_event_count() == 4
+
+    def test_total_reflects_logged_events_end_to_end(self):
+        """Reproduction -> fix: logged events surface in the aggregate count.
+
+        This is the value the /health endpoint now reports instead of a
+        hardcoded 0 (issue #68).
+        """
+
+        class FakeRedis:
+            def __init__(self):
+                self.store = {}
+
+            def incr(self, key):
+                self.store[key] = int(self.store.get(key, 0)) + 1
+                return self.store[key]
+
+            def expire(self, key, ttl):
+                return True
+
+            def get(self, key):
+                value = self.store.get(key)
+                return None if value is None else str(value)
+
+        monitor = SafetyMonitor(FakeRedis())
+        monitor.log_event("pii_detected", {"field": "email"})
+        monitor.log_event("injection_attempt", {"prompt": "ignore previous"})
+        monitor.log_event("pii_detected", {"field": "phone"})
+
+        assert monitor.get_total_event_count() == 3


### PR DESCRIPTION
## Summary
The `/health` endpoint always reported `safety_events_last_hour: 0` because the value was hardcoded — the "would be populated by actual safety event logging" placeholder was never wired up, hiding real safety activity from operators. This PR wires the field to the safety-event counters `SafetyMonitor` already maintains in Redis.

## Issue
Closes #68 

## Changes
<!-- Bullet list of the specific changes made -->
- Add `SafetyMonitor.get_total_event_count()` — sums the per-type Redis counters across `VALID_EVENT_TYPES` into a single figure.
- Wire it into `health_check()`: build a `SafetyMonitor` from the Redis client already created for the Redis health check and report the real total.
- Fail-safe: if Redis is unavailable the count falls back to `0` and the endpoint stays responsive (Redis being down is separately reported in `dependencies.redis`).
- Switch the Redis client to `redis.Redis.from_url(settings.redis_url)` (the old `redis_host`/`redis_port` settings don't exist) and wrap the Postgres check in `sqlalchemy.text()` — together these clear the module's pre-existing mypy errors.
- Add `tests/unit/test_monitoring.py` (11) and `tests/unit/test_health_endpoint.py` (3).

## Testing
<!-- How did you verify your changes? -->
- [x] Unit tests pass (`make test-unit`) — 14 new tests pass; the 53 pre-existing failures are in unrelated modules and are unchanged by this branch (baseline 53 failed/375 passed → 53 failed/389 passed).
- [ ] Integration tests pass (`make test-integration`) — not run (no changes to integration paths).
- [x] Linter passes (`make lint`) — clean on all 4 changed files.
- [x] Type checker passes (`make typecheck`) — mypy on the two changed source files went 11 errors → 0.
- [x] New/updated tests cover the changes

## Screenshots / Demo
<!-- If applicable, add screenshots or a link to a demo video -->
Not Applicable

## Notes for Reviewers
<!-- Anything the reviewer should pay particular attention to -->
Per the "last hour" naming: `get_event_count()` doesn't enforce `window_hours` and `log_event()` sets a 24h Redis TTL, so the counters approximate rather than strictly cover one hour. I kept the field name and documented the approximation (out of scope for #68); a true rolling 1-hour window (per-minute buckets / sorted sets) is a follow-up.