### PR TITLE
feat(api): reuse cached reviews for identical profiles

### DIFF
--- a/alembic/versions/003_add_content_hash_to_reviews.py
+++ b/alembic/versions/003_add_content_hash_to_reviews.py
@@ -1,0 +1,28 @@
+"""Add content_hash column to reviews table.
+
+Revision ID: 003
+Revises: 002
+Create Date: 2026-08-02 00:00:00.000000
+"""
+
+import sqlalchemy as sa
+
+from alembic import op  # type: ignore[attr-defined]
+
+revision = "003"
+down_revision = "002"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "reviews",
+        sa.Column("content_hash", sa.String(length=64), nullable=True),
+    )
+    op.create_index("ix_reviews_content_hash", "reviews", ["content_hash"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_reviews_content_hash", table_name="reviews")
+    op.drop_column("reviews", "content_hash")

--- a/api/routes/reviews.py
+++ b/api/routes/reviews.py
@@ -1,12 +1,14 @@
-from fastapi import APIRouter, Depends, HTTPException, status, BackgroundTasks
+from typing import Annotated, Any
 from uuid import UUID
-import structlog
 
-from api.schemas.review import ReviewCreate, ReviewResponse, ReviewListResponse
+import structlog
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from api.middleware.auth import get_current_user
-from core.models.user import User
-from core.models.review import Review
+from api.schemas.review import ReviewCreate, ReviewListResponse, ReviewResponse
 from core.database import get_db
+from core.models.user import User
 from core.services.review_service import (
     create_review,
     get_review,
@@ -17,37 +19,45 @@ from core.services.review_service import (
 log = structlog.get_logger()
 
 router = APIRouter(prefix="/reviews", tags=["reviews"])
+CurrentUserDep = Annotated[User, Depends(get_current_user)]
+DbSessionDep = Annotated[AsyncSession, Depends(get_db)]
 
 
 @router.post("", response_model=ReviewResponse)
 async def create_review_endpoint(
     data: ReviewCreate,
     background_tasks: BackgroundTasks,
-    current_user: User = Depends(get_current_user),
-    db=Depends(get_db),
-):
+    current_user: CurrentUserDep,
+    db: DbSessionDep,
+) -> ReviewResponse:
     """
     Create a new review for a profile.
     Triggers ingestion pipeline and agent orchestration asynchronously.
     Returns review with status="pending" immediately.
     """
     try:
-        # Create review with status="pending"
-        review = await create_review(
+        # Create review with status="pending" or reuse a cached completed review.
+        review, created = await create_review(
             db=db,
             profile_id=data.profile_id,
             user_id=current_user.id,
         )
 
-        # Add background task for processing
-        background_tasks.add_task(process_review, db, review.id, data.profile_id)
-
-        log.info(
-            "review_created",
-            review_id=str(review.id),
-            profile_id=str(data.profile_id),
-            user_id=str(current_user.id),
-        )
+        if created:
+            background_tasks.add_task(process_review, db, review.id, data.profile_id)
+            log.info(
+                "review_created",
+                review_id=str(review.id),
+                profile_id=str(data.profile_id),
+                user_id=str(current_user.id),
+            )
+        else:
+            log.info(
+                "review_reused_from_cache",
+                review_id=str(review.id),
+                profile_id=str(data.profile_id),
+                user_id=str(current_user.id),
+            )
 
         return ReviewResponse.model_validate(review)
 
@@ -59,15 +69,15 @@ async def create_review_endpoint(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to create review",
-        )
+        ) from exc
 
 
 @router.get("/{review_id}", response_model=ReviewResponse)
 async def get_review_endpoint(
     review_id: UUID,
-    current_user: User = Depends(get_current_user),
-    db=Depends(get_db),
-):
+    current_user: CurrentUserDep,
+    db: DbSessionDep,
+) -> ReviewResponse:
     """
     Get a review by ID.
     Returns 404 if not found or not owned by current user.
@@ -95,16 +105,16 @@ async def get_review_endpoint(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to retrieve review",
-        )
+        ) from exc
 
 
 @router.get("", response_model=ReviewListResponse)
 async def list_reviews_endpoint(
+    current_user: CurrentUserDep,
+    db: DbSessionDep,
     page: int = 1,
     page_size: int = 20,
-    current_user: User = Depends(get_current_user),
-    db=Depends(get_db),
-):
+) -> ReviewListResponse:
     """
     List reviews for current user with pagination.
     """
@@ -133,15 +143,15 @@ async def list_reviews_endpoint(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to list reviews",
-        )
+        ) from exc
 
 
 @router.get("/{review_id}/status")
 async def get_review_status(
     review_id: UUID,
-    current_user: User = Depends(get_current_user),
-    db=Depends(get_db),
-):
+    current_user: CurrentUserDep,
+    db: DbSessionDep,
+) -> dict[str, Any]:
     """
     Get review status and progress.
     Returns {review_id, status, progress_pct}
@@ -173,4 +183,4 @@ async def get_review_status(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to retrieve review status",
-        )
+        ) from exc

--- a/core/models/review.py
+++ b/core/models/review.py
@@ -33,6 +33,7 @@ class Review(Base):
     )  # "pending", "processing", "complete", "failed"
     sections: Mapped[dict | None] = mapped_column(JSON, nullable=True)  # Structured review output
     overall_score: Mapped[float | None] = mapped_column(Float, nullable=True)
+    content_hash: Mapped[str | None] = mapped_column(String(64), nullable=True)
     error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, default=datetime.utcnow
@@ -47,6 +48,7 @@ class Review(Base):
     __table_args__ = (
         Index("ix_reviews_profile_id", "profile_id"),
         Index("ix_reviews_status", "status"),
+        Index("ix_reviews_content_hash", "content_hash"),
         Index("ix_reviews_created_at", "created_at"),
     )
 

--- a/core/services/review_service.py
+++ b/core/services/review_service.py
@@ -1,54 +1,108 @@
-from uuid import UUID
-import structlog
+import hashlib
 import json
 from datetime import datetime
-from sqlalchemy import select, and_
+from typing import Any, cast
+from uuid import UUID
 
-from core.models.review import Review
-from core.models.profile import Profile
-from core.models.ingested_source import IngestedSource
+import structlog
+from fastapi import HTTPException, status
+from sqlalchemy import and_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from api.schemas.review import FeedbackSection
+from core.models.ingested_source import IngestedSource
+from core.models.profile import Profile
+from core.models.review import Review
 
 log = structlog.get_logger()
 
 
+def _normalize_hash_value(value: str | None) -> str:
+    """Normalize optional profile values before hashing."""
+    return (value or "").strip()
+
+
+def _build_review_content_hash(profile: Profile) -> str:
+    """Build a deterministic hash for the review-relevant profile inputs."""
+    hash_input = "||".join(
+        [
+            _normalize_hash_value(profile.github_username),
+            _normalize_hash_value(profile.portfolio_url),
+            _normalize_hash_value(profile.resume_text),
+        ]
+    )
+    return hashlib.sha256(hash_input.encode("utf-8")).hexdigest()
+
+
 async def create_review(
-    db,
+    db: AsyncSession,
     profile_id: UUID,
     user_id: UUID,
-) -> Review:
+) -> tuple[Review, bool]:
     """
-    Create a new review with status="pending".
+    Create a new review with status="pending" or reuse a cached completed review.
+
+    Returns a tuple of (review, created_new_review).
     """
+    profile_stmt = select(Profile).where(and_(Profile.id == profile_id, Profile.user_id == user_id))
+    profile_result = await db.execute(profile_stmt)
+    profile = profile_result.scalars().first()
+
+    if not profile:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Profile not found",
+        )
+
+    content_hash = _build_review_content_hash(profile)
+
+    cached_stmt = (
+        select(Review)
+        .where(
+            and_(
+                Review.profile_id == profile_id,
+                Review.status == "complete",
+                Review.content_hash == content_hash,
+            )
+        )
+        .order_by(Review.updated_at.desc())
+    )
+    cached_result = await db.execute(cached_stmt)
+    cached_review = cached_result.scalars().first()
+
+    if cached_review:
+        return cached_review, False
+
     review = Review(
         profile_id=profile_id,
         status="pending",
         sections=None,
         overall_score=None,
+        content_hash=content_hash,
     )
     db.add(review)
     await db.commit()
     await db.refresh(review)
-    return review
+    return review, True
 
 
 async def get_review(
-    db,
+    db: AsyncSession,
     review_id: UUID,
     user_id: UUID,
 ) -> Review | None:
     """
     Get a review by ID, checking that it belongs to the user's profile.
     """
-    stmt = select(Review).join(Profile).where(
-        and_(Review.id == review_id, Profile.user_id == user_id)
+    stmt = (
+        select(Review).join(Profile).where(and_(Review.id == review_id, Profile.user_id == user_id))
     )
     result = await db.execute(stmt)
-    return result.scalars().first()
+    return cast("Review | None", result.scalars().first())
 
 
 async def list_reviews(
-    db,
+    db: AsyncSession,
     user_id: UUID,
     page: int = 1,
     page_size: int = 20,
@@ -62,7 +116,7 @@ async def list_reviews(
     # Get total count
     count_stmt = select(Review).join(Profile).where(Profile.user_id == user_id)
     count_result = await db.execute(count_stmt)
-    total = len(count_result.scalars().all())
+    total = len(cast("list[Review]", count_result.scalars().all()))
 
     # Get paginated results
     stmt = (
@@ -74,13 +128,13 @@ async def list_reviews(
         .limit(page_size)
     )
     result = await db.execute(stmt)
-    reviews = result.scalars().all()
+    reviews = cast("list[Review]", result.scalars().all())
 
     return reviews, total
 
 
 async def process_review(
-    db,
+    db: AsyncSession,
     review_id: UUID,
     profile_id: UUID,
 ) -> None:
@@ -194,12 +248,15 @@ async def process_review(
             log.error("review_status_update_failed", review_id=str(review_id), error=str(e))
 
 
-async def _run_ingestion_pipeline(db, profile: Profile) -> list[dict]:
+async def _run_ingestion_pipeline(
+    db: AsyncSession,
+    profile: Profile,
+) -> list[dict[str, Any]]:
     """
     Run ingestion pipeline to extract data from profile sources.
     Returns list of ingested source data.
     """
-    sources = []
+    sources: list[dict[str, Any]] = []
 
     # Ingest from GitHub if available
     if profile.github_username:
@@ -279,7 +336,10 @@ async def _run_ingestion_pipeline(db, profile: Profile) -> list[dict]:
     return sources
 
 
-async def _run_agent_orchestration(profile: Profile, ingestion_results: list[dict]) -> dict:
+async def _run_agent_orchestration(
+    profile: Profile,
+    ingestion_results: list[dict[str, Any]],
+) -> dict[str, Any]:
     """
     Run agent orchestration to analyze ingested data.
     Returns agent output with initial analysis.
@@ -306,9 +366,9 @@ async def _run_agent_orchestration(profile: Profile, ingestion_results: list[dic
 
 async def _run_rag_retrieval_generation(
     profile: Profile,
-    ingestion_results: list[dict],
-    agent_output: dict,
-) -> dict:
+    ingestion_results: list[dict[str, Any]],
+    agent_output: dict[str, Any],
+) -> dict[str, Any]:
     """
     Run RAG retrieval and generation to create detailed feedback.
     Returns enhanced review output.
@@ -354,7 +414,7 @@ async def _run_rag_retrieval_generation(
     }
 
 
-async def _run_safety_checks(output: dict) -> bool:
+async def _run_safety_checks(output: dict[str, Any]) -> bool:
     """
     Run safety checks on the review output.
     Returns True if all checks pass, False otherwise.

--- a/tests/unit/test_review_service.py
+++ b/tests/unit/test_review_service.py
@@ -9,6 +9,7 @@ import pytest
 from fastapi import HTTPException
 
 from core.services.review_service import (
+    _build_review_content_hash,
     create_review,
     get_review,
     list_reviews,
@@ -388,6 +389,19 @@ class TestReviewService:
         mock_db_session.add.assert_not_called()
         mock_db_session.commit.assert_not_called()
         mock_db_session.refresh.assert_not_called()
+
+    def test_review_content_hash_changes_when_profile_content_changes(self):
+        """Test the cache fingerprint changes when review-relevant profile content changes."""
+        original_profile = _build_mock_profile()
+        updated_profile = _build_mock_profile()
+        updated_profile.github_username = original_profile.github_username
+        updated_profile.portfolio_url = original_profile.portfolio_url
+        updated_profile.resume_text = "Updated resume text"
+
+        original_hash = _build_review_content_hash(original_profile)
+        updated_hash = _build_review_content_hash(updated_profile)
+
+        assert original_hash != updated_hash
 
     @pytest.mark.asyncio
     async def test_create_review_raises_not_found_for_wrong_owner(self, mock_db_session):

--- a/tests/unit/test_review_service.py
+++ b/tests/unit/test_review_service.py
@@ -1,15 +1,39 @@
+# mypy: disable-error-code=no-untyped-def
+
 """Tests for review_service.py"""
 
-import pytest
+from unittest.mock import AsyncMock, Mock
 from uuid import uuid4
-from unittest.mock import AsyncMock, Mock, patch
-import asyncio
+
+import pytest
+from fastapi import HTTPException
 
 from core.services.review_service import (
     create_review,
     get_review,
     list_reviews,
 )
+
+
+def _mock_execute_result(first=None, all_values=None):
+    """Build a simple async execute result mock."""
+    result = Mock()
+    scalars = Mock()
+    scalars.first.return_value = first
+    scalars.all.return_value = all_values if all_values is not None else []
+    result.scalars.return_value = scalars
+    return result
+
+
+def _build_mock_profile():
+    """Create a mock profile object for create_review tests."""
+    profile = Mock()
+    profile.id = uuid4()
+    profile.user_id = uuid4()
+    profile.github_username = "octocat"
+    profile.portfolio_url = "https://example.com"
+    profile.resume_text = "Sample resume text"
+    return profile
 
 
 @pytest.mark.unit
@@ -42,31 +66,35 @@ class TestReviewService:
         profile = Mock()
         profile.id = uuid4()
         profile.user_id = uuid4()
+        profile.github_username = "octocat"
+        profile.portfolio_url = "https://example.com"
+        profile.resume_text = "Sample resume text"
         return profile
 
     @pytest.mark.asyncio
-    async def test_create_review_returns_review_with_pending_status(self, mock_db_session, mock_review):
+    async def test_create_review_returns_review_with_pending_status(
+        self, mock_db_session, mock_review
+    ):
         """Test create_review returns Review with status='pending'."""
-        profile_id = uuid4()
-        user_id = uuid4()
+        profile = _build_mock_profile()
 
         # Setup mock
         mock_db_session.add = Mock()
         mock_db_session.commit = AsyncMock()
         mock_db_session.refresh = AsyncMock()
+        mock_db_session.execute = AsyncMock(
+            side_effect=[
+                _mock_execute_result(first=profile),
+                _mock_execute_result(first=None),
+            ]
+        )
 
-        with patch('core.services.review_service.Review') as MockReview:
-            mock_instance = MockReview.return_value
-            mock_instance.status = "pending"
-            mock_instance.sections = None
-            mock_instance.overall_score = None
+        result, created = await create_review(mock_db_session, profile.id, profile.user_id)
 
-            result = await create_review(mock_db_session, profile_id, user_id)
-
-            # Check that Review was instantiated
-            MockReview.assert_called()
-            call_kwargs = MockReview.call_args[1]
-            assert call_kwargs['status'] == "pending"
+        assert result.status == "pending"
+        assert result.sections is None
+        assert result.overall_score is None
+        assert created is True
 
     @pytest.mark.asyncio
     async def test_get_review_returns_review_for_correct_owner(self, mock_db_session):
@@ -78,9 +106,7 @@ class TestReviewService:
         mock_review.id = review_id
 
         # Setup mock execute to return review
-        mock_result = AsyncMock()
-        mock_result.scalars.return_value.first.return_value = mock_review
-        mock_db_session.execute = AsyncMock(return_value=mock_result)
+        mock_db_session.execute = AsyncMock(return_value=_mock_execute_result(first=mock_review))
 
         result = await get_review(mock_db_session, review_id, user_id)
 
@@ -91,13 +117,10 @@ class TestReviewService:
     async def test_get_review_returns_none_for_wrong_user(self, mock_db_session):
         """Test get_review returns None when user_id doesn't match."""
         review_id = uuid4()
-        user_id = uuid4()
         wrong_user_id = uuid4()
 
         # Setup mock to return None
-        mock_result = AsyncMock()
-        mock_result.scalars.return_value.first.return_value = None
-        mock_db_session.execute = AsyncMock(return_value=mock_result)
+        mock_db_session.execute = AsyncMock(return_value=_mock_execute_result(first=None))
 
         result = await get_review(mock_db_session, review_id, wrong_user_id)
 
@@ -112,9 +135,12 @@ class TestReviewService:
         mock_reviews = [Mock() for _ in range(5)]
 
         # Setup execute mock to return reviews
-        mock_result = AsyncMock()
-        mock_result.scalars.return_value.all.return_value = mock_reviews
-        mock_db_session.execute = AsyncMock(return_value=mock_result)
+        mock_db_session.execute = AsyncMock(
+            side_effect=[
+                _mock_execute_result(all_values=mock_reviews),
+                _mock_execute_result(all_values=mock_reviews),
+            ]
+        )
 
         reviews, total = await list_reviews(mock_db_session, user_id, page=1, page_size=20)
 
@@ -129,13 +155,14 @@ class TestReviewService:
         page_size = 20
 
         # Setup mock
-        mock_result = AsyncMock()
-        mock_result.scalars.return_value.all.return_value = []
-        mock_db_session.execute = AsyncMock(return_value=mock_result)
-
-        reviews, total = await list_reviews(
-            mock_db_session, user_id, page=2, page_size=page_size
+        mock_db_session.execute = AsyncMock(
+            side_effect=[
+                _mock_execute_result(all_values=[]),
+                _mock_execute_result(all_values=[]),
+            ]
         )
+
+        reviews, total = await list_reviews(mock_db_session, user_id, page=2, page_size=page_size)
 
         # Second call should pass offset for page 2
         calls = mock_db_session.execute.call_args_list
@@ -147,9 +174,12 @@ class TestReviewService:
         """Test list_reviews returns (reviews, total) tuple."""
         user_id = uuid4()
 
-        mock_result = AsyncMock()
-        mock_result.scalars.return_value.all.return_value = []
-        mock_db_session.execute = AsyncMock(return_value=mock_result)
+        mock_db_session.execute = AsyncMock(
+            side_effect=[
+                _mock_execute_result(all_values=[]),
+                _mock_execute_result(all_values=[]),
+            ]
+        )
 
         result = await list_reviews(mock_db_session, user_id)
 
@@ -162,35 +192,47 @@ class TestReviewService:
     @pytest.mark.asyncio
     async def test_create_review_calls_db_add(self, mock_db_session):
         """Test create_review calls db.add()."""
-        profile_id = uuid4()
-        user_id = uuid4()
+        profile = _build_mock_profile()
+        mock_db_session.execute = AsyncMock(
+            side_effect=[
+                _mock_execute_result(first=profile),
+                _mock_execute_result(first=None),
+            ]
+        )
 
-        with patch('core.services.review_service.Review'):
-            await create_review(mock_db_session, profile_id, user_id)
+        await create_review(mock_db_session, profile.id, profile.user_id)
 
-            mock_db_session.add.assert_called_once()
+        mock_db_session.add.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_create_review_calls_db_commit(self, mock_db_session):
         """Test create_review calls db.commit()."""
-        profile_id = uuid4()
-        user_id = uuid4()
+        profile = _build_mock_profile()
+        mock_db_session.execute = AsyncMock(
+            side_effect=[
+                _mock_execute_result(first=profile),
+                _mock_execute_result(first=None),
+            ]
+        )
 
-        with patch('core.services.review_service.Review'):
-            await create_review(mock_db_session, profile_id, user_id)
+        await create_review(mock_db_session, profile.id, profile.user_id)
 
-            mock_db_session.commit.assert_called_once()
+        mock_db_session.commit.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_create_review_calls_db_refresh(self, mock_db_session):
         """Test create_review calls db.refresh()."""
-        profile_id = uuid4()
-        user_id = uuid4()
+        profile = _build_mock_profile()
+        mock_db_session.execute = AsyncMock(
+            side_effect=[
+                _mock_execute_result(first=profile),
+                _mock_execute_result(first=None),
+            ]
+        )
 
-        with patch('core.services.review_service.Review'):
-            await create_review(mock_db_session, profile_id, user_id)
+        await create_review(mock_db_session, profile.id, profile.user_id)
 
-            mock_db_session.refresh.assert_called_once()
+        mock_db_session.refresh.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_get_review_uses_select_and_join(self, mock_db_session):
@@ -198,9 +240,7 @@ class TestReviewService:
         review_id = uuid4()
         user_id = uuid4()
 
-        mock_result = AsyncMock()
-        mock_result.scalars.return_value.first.return_value = None
-        mock_db_session.execute = AsyncMock(return_value=mock_result)
+        mock_db_session.execute = AsyncMock(return_value=_mock_execute_result(first=None))
 
         await get_review(mock_db_session, review_id, user_id)
 
@@ -212,9 +252,12 @@ class TestReviewService:
         """Test list_reviews uses default pagination."""
         user_id = uuid4()
 
-        mock_result = AsyncMock()
-        mock_result.scalars.return_value.all.return_value = []
-        mock_db_session.execute = AsyncMock(return_value=mock_result)
+        mock_db_session.execute = AsyncMock(
+            side_effect=[
+                _mock_execute_result(all_values=[]),
+                _mock_execute_result(all_values=[]),
+            ]
+        )
 
         reviews, total = await list_reviews(mock_db_session, user_id)
 
@@ -228,9 +271,12 @@ class TestReviewService:
         user_id = uuid4()
         custom_page_size = 50
 
-        mock_result = AsyncMock()
-        mock_result.scalars.return_value.all.return_value = []
-        mock_db_session.execute = AsyncMock(return_value=mock_result)
+        mock_db_session.execute = AsyncMock(
+            side_effect=[
+                _mock_execute_result(all_values=[]),
+                _mock_execute_result(all_values=[]),
+            ]
+        )
 
         reviews, total = await list_reviews(
             mock_db_session, user_id, page=1, page_size=custom_page_size
@@ -241,16 +287,19 @@ class TestReviewService:
     @pytest.mark.asyncio
     async def test_create_review_with_uuid_ids(self, mock_db_session):
         """Test create_review handles UUID objects correctly."""
-        profile_id = uuid4()
-        user_id = uuid4()
+        profile = _build_mock_profile()
+        mock_db_session.execute = AsyncMock(
+            side_effect=[
+                _mock_execute_result(first=profile),
+                _mock_execute_result(first=None),
+            ]
+        )
 
-        with patch('core.services.review_service.Review') as MockReview:
-            MockReview.return_value = Mock()
-            await create_review(mock_db_session, profile_id, user_id)
+        review, created = await create_review(mock_db_session, profile.id, profile.user_id)
 
-            call_kwargs = MockReview.call_args[1]
-            assert 'profile_id' in call_kwargs
-            assert 'status' in call_kwargs
+        assert review.profile_id == profile.id
+        assert review.status == "pending"
+        assert created is True
 
     @pytest.mark.asyncio
     async def test_get_review_verifies_ownership(self, mock_db_session):
@@ -258,9 +307,7 @@ class TestReviewService:
         review_id = uuid4()
         user_id = uuid4()
 
-        mock_result = AsyncMock()
-        mock_result.scalars.return_value.first.return_value = None
-        mock_db_session.execute = AsyncMock(return_value=mock_result)
+        mock_db_session.execute = AsyncMock(return_value=_mock_execute_result(first=None))
 
         await get_review(mock_db_session, review_id, user_id)
 
@@ -273,9 +320,12 @@ class TestReviewService:
         user_id = uuid4()
 
         mock_reviews = [Mock() for _ in range(5)]
-        mock_result = AsyncMock()
-        mock_result.scalars.return_value.all.return_value = mock_reviews
-        mock_db_session.execute = AsyncMock(return_value=mock_result)
+        mock_db_session.execute = AsyncMock(
+            side_effect=[
+                _mock_execute_result(all_values=mock_reviews),
+                _mock_execute_result(all_values=mock_reviews),
+            ]
+        )
 
         reviews, total = await list_reviews(mock_db_session, user_id)
 
@@ -287,10 +337,13 @@ class TestReviewService:
         """Test list_reviews returns list of Review objects."""
         user_id = uuid4()
 
-        mock_reviews = [Mock(spec=['id', 'status']) for _ in range(3)]
-        mock_result = AsyncMock()
-        mock_result.scalars.return_value.all.return_value = mock_reviews
-        mock_db_session.execute = AsyncMock(return_value=mock_result)
+        mock_reviews = [Mock(spec=["id", "status"]) for _ in range(3)]
+        mock_db_session.execute = AsyncMock(
+            side_effect=[
+                _mock_execute_result(all_values=mock_reviews),
+                _mock_execute_result(all_values=mock_reviews),
+            ]
+        )
 
         reviews, total = await list_reviews(mock_db_session, user_id)
 
@@ -299,16 +352,54 @@ class TestReviewService:
     @pytest.mark.asyncio
     async def test_review_sections_and_score_initially_none(self, mock_db_session):
         """Test review has None for sections and overall_score initially."""
+        profile = _build_mock_profile()
+        mock_db_session.execute = AsyncMock(
+            side_effect=[
+                _mock_execute_result(first=profile),
+                _mock_execute_result(first=None),
+            ]
+        )
+
+        review, created = await create_review(mock_db_session, profile.id, profile.user_id)
+
+        assert review.sections is None
+        assert review.overall_score is None
+        assert created is True
+
+    @pytest.mark.asyncio
+    async def test_create_review_reuses_cached_completed_review(self, mock_db_session):
+        """Test create_review returns a cached completed review for identical content."""
+        profile = _build_mock_profile()
+        cached_review = Mock()
+        cached_review.id = uuid4()
+        cached_review.status = "complete"
+
+        mock_db_session.execute = AsyncMock(
+            side_effect=[
+                _mock_execute_result(first=profile),
+                _mock_execute_result(first=cached_review),
+            ]
+        )
+
+        review, created = await create_review(mock_db_session, profile.id, profile.user_id)
+
+        assert review == cached_review
+        assert created is False
+        mock_db_session.add.assert_not_called()
+        mock_db_session.commit.assert_not_called()
+        mock_db_session.refresh.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_create_review_raises_not_found_for_wrong_owner(self, mock_db_session):
+        """Test create_review raises 404 when the profile is not owned by the user."""
         profile_id = uuid4()
         user_id = uuid4()
+        mock_db_session.execute = AsyncMock(side_effect=[_mock_execute_result(first=None)])
 
-        with patch('core.services.review_service.Review') as MockReview:
-            MockReview.return_value = Mock()
+        with pytest.raises(HTTPException) as exc_info:
             await create_review(mock_db_session, profile_id, user_id)
 
-            call_kwargs = MockReview.call_args[1]
-            assert call_kwargs['sections'] is None
-            assert call_kwargs['overall_score'] is None
+        assert exc_info.value.status_code == 404
 
     @pytest.mark.asyncio
     async def test_get_review_with_valid_uuid(self, mock_db_session):
@@ -316,9 +407,7 @@ class TestReviewService:
         review_id = uuid4()
         user_id = uuid4()
 
-        mock_result = AsyncMock()
-        mock_result.scalars.return_value.first.return_value = None
-        mock_db_session.execute = AsyncMock(return_value=mock_result)
+        mock_db_session.execute = AsyncMock(return_value=_mock_execute_result(first=None))
 
         # Should not raise
         result = await get_review(mock_db_session, review_id, user_id)
@@ -330,11 +419,14 @@ class TestReviewService:
         """Test list_reviews returns results ordered by created_at desc."""
         user_id = uuid4()
 
-        mock_result = AsyncMock()
-        mock_result.scalars.return_value.all.return_value = []
-        mock_db_session.execute = AsyncMock(return_value=mock_result)
+        mock_db_session.execute = AsyncMock(
+            side_effect=[
+                _mock_execute_result(all_values=[]),
+                _mock_execute_result(all_values=[]),
+            ]
+        )
 
         reviews, total = await list_reviews(mock_db_session, user_id)
 
         # Should order by created_at descending
-        mock_db_session.execute.assert_called_once()
+        assert mock_db_session.execute.call_count == 2


### PR DESCRIPTION
## Summary
Adds review-level caching for identical profile submissions so the API can reuse an existing completed review instead of creating and processing a duplicate request.

## Issue
Closes #32

## Changes
- add a review `content_hash` column with an Alembic migration
- compute a deterministic hash from GitHub username, portfolio URL, and resume text
- reuse an existing completed review when the incoming profile content matches a prior completed review
- skip background processing on cache hits
- update review service unit tests to cover cache hits, cache misses, missing profiles, and changed-content fingerprints

## Testing
- [x] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`)
- [x] Linter passes (`make lint`)
- [ ] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes

## Screenshots / Demo
N/A

## Notes for Reviewers
`make check` and `make test-unit` still report pre-existing unrelated failures elsewhere in the repository. For this change, the updated tests in `tests/unit/test_review_service.py` pass, and the touched files did not introduce new failures in the repo-wide checks. I also validated the API flow locally by confirming that a second identical review request returns the same completed review instead of creating a duplicate review record.
