### PR TITLE
feat(api): add rate limit headers to responses

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -41,6 +41,59 @@ in the tracker is 3–5 hours, which matches a middleware-plus-tests task.
 
 **Reproduction summary:** I sent 65 in-process requests from the same test client to the dependency-free `/` API route, exceeding the configured 60-request limit. Every request returned `200`, the final response had no `X-RateLimit-Limit` or `X-RateLimit-Remaining` header, and `X-Request-ID` was present; separately, all 19 existing `RateLimiter` unit tests passed, confirming that the gap is missing API wiring rather than the limiter algorithm.
 
+At the reproduction commit (`ec0a927276011808879f5f6a021152a25ebb6f4c`), I ran:
+
+```powershell
+.\.venv\Scripts\python.exe -c @'
+from fastapi.testclient import TestClient
+from api.main import app
+
+client = TestClient(app)
+responses = [client.get('/') for _ in range(65)]
+last = responses[-1]
+
+print('request_count=', len(responses))
+print('status_codes=', sorted({response.status_code for response in responses}))
+print('429_count=', sum(response.status_code == 429 for response in responses))
+print('X-RateLimit-Limit=', last.headers.get('X-RateLimit-Limit'))
+print('X-RateLimit-Remaining=', last.headers.get('X-RateLimit-Remaining'))
+print('X-Request-ID-present=', 'X-Request-ID' in last.headers)
+'@
+```
+
 **PLAN.md link:** https://github.com/isomer04/pathreview/blob/feat/86-ratelimit-headers/PLAN.md
 
 **Blockers or open questions:** Confirm whether trusted proxy configuration is available before using forwarded IP headers; otherwise use `request.client.host`. Middleware order and Redis fail-open header semantics need to be covered explicitly by the implementation tests.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented every code sub-task in `PLAN.md`: added the rate-limit middleware, connected it to the existing Redis-backed limiter, registered it in the API, exposed the headers through CORS, and added HTTP-level unit tests. The middleware uses `request.client.host`, enforces the configured per-minute limit, returns `429` after exhaustion, and adds quota headers to allowed, denied, and handled error responses.
+
+**Next steps:**
+Request peer or mentor feedback, address any agreed changes, commit and push the implementation, open the PR, and replace the pending PR link below before submission.
+
+**Blockers:**
+No draft PR or peer review is available yet. The implementation was intentionally left uncommitted, so it cannot be pushed or used to open a PR until committing is authorized.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** Pending — the changes have not been committed or pushed, so no PR exists yet.
+
+**Branch:** `feat/86-ratelimit-headers`
+
+**What you built:**
+Added API middleware that checks the existing Redis rolling-window limiter by client IP, reports `X-RateLimit-Limit` and `X-RateLimit-Remaining` on responses, and returns a JSON `429` when the quota is exhausted. Middleware ordering preserves request IDs and CORS headers on rejected requests, and the synchronous Redis call runs in a worker thread instead of blocking the async request loop.
+
+**Tests added or updated:**
+Added `tests/unit/test_rate_limit_middleware.py` with eight tests covering allowed responses, the last allowed and first denied requests, route short-circuiting, independent client IPs, missing client metadata, Redis fail-open semantics, handled route errors, and request-ID/CORS behavior on `429` responses. The focused rate-limit suite passes all 27 tests.
+
+**Self-review confirmation:** [x] make check introduces no new failures  [x] make test-unit introduces no new failures
+
+Pre-existing failures were recorded before implementation and compared afterward. Ruff reported 182 findings before and 181 afterward; Black reported 52 files needing formatting before and 51 afterward; the new middleware passes targeted Ruff, Black, and mypy checks. The full unit suite had 53 failures and 375 passes before the change; after adding all eight focused tests, the same 53 unrelated tests fail and the pass count increases to 383.
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -73,16 +73,16 @@ print('X-Request-ID-present=', 'X-Request-ID' in last.headers)
 Implemented every code sub-task in `PLAN.md`: added the rate-limit middleware, connected it to the existing Redis-backed limiter, registered it in the API, exposed the headers through CORS, and added HTTP-level unit tests. The middleware uses `request.client.host`, enforces the configured per-minute limit, returns `429` after exhaustion, and adds quota headers to allowed, denied, and handled error responses.
 
 **Next steps:**
-Request peer or mentor feedback, address any agreed changes, commit and push the implementation, open the PR, and replace the pending PR link below before submission.
+Monitor CI and reviewer feedback, address any required changes, and keep the PR ready for final submission.
 
 **Blockers:**
-No draft PR or peer review is available yet. The implementation was intentionally left uncommitted, so it cannot be pushed or used to open a PR until committing is authorized.
+None currently.
 
 ---
 
 ### Check-in 2 (end of week)
 
-**PR link:** Pending — the changes have not been committed or pushed, so no PR exists yet.
+**PR link:** https://github.com/ascherj/pathreview/pull/563
 
 **Branch:** `feat/86-ratelimit-headers`
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -37,7 +37,7 @@ in the tracker is 3–5 hours, which matches a middleware-plus-tests task.
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** Pending — add after the reproduction commit is created and approved.
+**Reproduction commit link:** https://github.com/isomer04/pathreview/commit/ec0a927276011808879f5f6a021152a25ebb6f4c
 
 **Reproduction summary:** I sent 65 in-process requests from the same test client to the dependency-free `/` API route, exceeding the configured 60-request limit. Every request returned `200`, the final response had no `X-RateLimit-Limit` or `X-RateLimit-Remaining` header, and `X-Request-ID` was present; separately, all 19 existing `RateLimiter` unit tests passed, confirming that the gap is missing API wiring rather than the limiter algorithm.
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -34,3 +34,13 @@ in the tracker is 3–5 hours, which matches a middleware-plus-tests task.
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** Pending — add after the reproduction commit is created and approved.
+
+**Reproduction summary:** I sent 65 in-process requests from the same test client to the dependency-free `/` API route, exceeding the configured 60-request limit. Every request returned `200`, the final response had no `X-RateLimit-Limit` or `X-RateLimit-Remaining` header, and `X-Request-ID` was present; separately, all 19 existing `RateLimiter` unit tests passed, confirming that the gap is missing API wiring rather than the limiter algorithm.
+
+**PLAN.md link:** https://github.com/isomer04/pathreview/blob/feat/86-ratelimit-headers/PLAN.md
+
+**Blockers or open questions:** Confirm whether trusted proxy configuration is available before using forwarded IP headers; otherwise use `request.client.host`. Middleware order and Redis fail-open header semantics need to be covered explicitly by the implementation tests.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,36 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/86
+
+**Issue title:** Add an API rate limiting header (`X-RateLimit-Remaining`) to responses
+
+**Tier:** [ ] Tier 1  [x] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+Right now API clients get no advance warning about how close they are to the rate
+limit — they only find out by being blocked with a 429. In fact, the project ships a
+working `RateLimiter` class in `safety/rate_limiter.py`, but nothing in the request
+path ever calls it, so no limit is actually enforced and no rate-limit information
+reaches clients. The fix adds middleware in the `api/` layer (following the existing
+`RequestIDMiddleware` pattern) that runs the limiter on each request and attaches
+standard `X-RateLimit-Limit` and `X-RateLimit-Remaining` headers to every response,
+returning a 429 with those same headers when the limit is exceeded. A successful fix
+means clients can read their remaining quota from any response and back off before
+they ever hit a hard block.
+
+**"Is this right for me?" — scope reasoning:**
+Reasonable Tier 2 fit. The limiter logic already exists and is unit-tested, so the
+core algorithm isn't the work — but this isn't purely cosmetic either: it means adding
+new middleware to the live request path, deciding how to key the limit (client IP),
+handling the 429-with-headers case, and reasoning about Redis failure/fail-open
+behavior, which is more than a one-line change. The change stays contained to
+`api/middleware/rate_limit.py`, `api/main.py`, and a new test file, and doesn't touch
+the database, LLM, or frontend. The design decisions — enforce vs. headers-only and
+which identity to key on — are already settled (enforce + client IP). Estimated effort
+in the tracker is 3–5 hours, which matches a middleware-plus-tests task.
+
+**Branch name:** `feat/86-ratelimit-headers`
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -97,3 +97,60 @@ Added `tests/unit/test_rate_limit_middleware.py` with eight tests covering allow
 Pre-existing failures were recorded before implementation and compared afterward. Ruff reported 182 findings before and 181 afterward; Black reported 52 files needing formatting before and 51 afterward; the new middleware passes targeted Ruff, Black, and mypy checks. The full unit suite had 53 failures and 375 passes before the change; after adding all eight focused tests, the same 53 unrelated tests fail and the pass count increases to 383.
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No feedback arrived by the end of the week. Per the Su26 course note, reviewer
+feedback is not a feature this term, so no review was expected.
+
+**How you responded:**
+N/A — no feedback was received.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Reproducing the actual bug in Week 8 was harder than expected. The RateLimiter
+class already existed, was unit-tested, and looked correct in isolation — the
+real challenge was proving that it was never invoked in the request path, which
+took constructing a targeted TestClient script that fired enough requests to
+show the limit was never enforced and the headers were simply absent, rather
+than debugging faulty limiter logic.
+
+**What did you learn about working in a large codebase?**
+Existing conventions matter more than they seem to at first glance. Rather than
+designing a new middleware pattern, the working solution was to follow the
+existing `RequestIDMiddleware` pattern already in `api/`, which kept the change
+consistent with how the rest of the request pipeline is structured. It was also
+a reminder that "large codebase gaps" aren't always missing code — sometimes,
+as with the RateLimiter here, the logic is fully built and tested but simply
+never wired in, and finding that requires tracing the actual request path
+rather than trusting that tested code is active code.
+
+**How did AI tools help — and where did they fall short?**
+AI tools were most useful for planning — drafting PLAN.md, breaking the fix
+into concrete sub-tasks, and scaffolding the middleware and test structure
+quickly. They fell short on edge cases: things like Redis fail-open semantics,
+preserving CORS and X-Request-ID headers on 429 responses, and making sure the
+synchronous Redis call didn't block the async request loop needed manual
+reasoning and testing to get right rather than something AI surfaced
+proactively.
+
+**What would you do differently if you started over?**
+Spend more time on reproduction upfront. Since confirming the actual gap (an
+unenforced, unwired limiter) took longer than expected, investing more time in
+Week 8 to nail down a clean, minimal reproduction before writing PLAN.md would
+have made the implementation phase more confident and left less to discover
+mid-build.
+
+**What are you most proud of from this module?**
+The clean middleware integration — threading the synchronous Redis-backed
+limiter call into a worker thread so it doesn't block the async request loop,
+while still preserving request ID and CORS headers on both allowed and
+rejected (429) responses.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,33 @@
+## Solution plan
+
+**Issue:** [Add an API rate limiting header (`X-RateLimit-Remaining`) to responses](https://github.com/ascherj/pathreview/issues/86)
+
+### Understand
+The existing `RateLimiter` in `safety/rate_limiter.py` implements and unit-tests a Redis-backed rolling window, but no production API code imports or calls it. Requests currently pass through CORS and `RequestIDMiddleware` to the route, so even 65 same-client requests all return `200` and include no `X-RateLimit-Limit` or `X-RateLimit-Remaining` headers. Expected behavior is to limit requests by client IP, report the configured limit and remaining quota on responses, and return `429` with the same headers after the quota is exhausted.
+
+### Map
+- Add `api/middleware/rate_limit.py`: adapt `RateLimiter` to the HTTP request/response lifecycle.
+- Update `api/main.py`: construct/register the middleware and expose the custom headers through CORS if browser clients must read them.
+- Add `tests/unit/test_rate_limit_middleware.py`: verify allowed, exhausted, and Redis-failure request paths at the HTTP boundary.
+- Reuse `safety/rate_limiter.py`: existing rolling-window logic; no algorithm change is currently expected.
+- Reuse `core/config.py`: `settings.redis_url` and `settings.rate_limit_per_minute` provide configuration.
+
+### Plan
+1. Create `RateLimitMiddleware`, following `RequestIDMiddleware`'s `BaseHTTPMiddleware` pattern, and derive a stable limiter identifier from `request.client.host`.
+2. Call `RateLimiter.check_rate_limit()` with the configured per-minute limit before forwarding an allowed request; short-circuit denied requests with a JSON `429` response.
+3. Add `X-RateLimit-Limit` and `X-RateLimit-Remaining` to both normal and `429` responses, and configure CORS exposure so frontend JavaScript can read them.
+4. Register the middleware in `api/main.py` with a Redis client created from `settings.redis_url`, checking middleware order so request IDs and CORS headers remain present on rejected requests.
+5. Add focused HTTP-level tests with a fake or mocked limiter for decrementing quota, the first denied request, independent client IPs, and fail-open behavior; then run the targeted and full relevant test suites.
+
+### Inputs & outputs
+Input is each HTTP request's client IP plus `settings.rate_limit_per_minute`; Redis stores request timestamps for that identifier. An allowed request continues to its route and returns the two quota headers. An exhausted identifier receives HTTP `429` with `X-RateLimit-Limit` set to the configured limit and `X-RateLimit-Remaining: 0`. A Redis error preserves the existing fail-open policy rather than making the API unavailable.
+
+### Risks & unknowns
+- `request.client.host` may identify a reverse proxy rather than the real client; trusting `X-Forwarded-For` without trusted-proxy configuration would allow spoofing, so proxy-aware identity is out of scope unless deployment settings establish trust.
+- Starlette middleware registration order can cause early `429` responses to miss `X-Request-ID` or CORS processing; tests must pin down the intended order.
+- The Redis client and limiter are synchronous, so direct calls in async middleware may block under load; confirm whether this project accepts the existing client model or needs thread offloading.
+- `RateLimiter` fails open with a full remaining count on Redis errors, which may be misleading; preserve it for compatibility but document/test the chosen header behavior.
+- “Every response” may include CORS preflight, docs, validation errors, and unhandled errors; confirm the expected exclusions before broadening scope.
+
+### Edge cases
+Handle a missing `request.client`, exactly the last allowed request (`remaining = 0`), the next request returning `429`, separate IPs receiving separate quotas, Redis being unavailable, and route-generated error responses. Ensure rate headers are non-negative integers and that denied responses retain expected request-ID/CORS headers.

--- a/api/main.py
+++ b/api/main.py
@@ -1,12 +1,16 @@
+import redis
+import structlog
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import JSONResponse
 from fastapi.openapi.utils import get_openapi
-import structlog
+from fastapi.responses import JSONResponse
 
+from api.middleware.rate_limit import RateLimitMiddleware
 from api.middleware.request_id import RequestIDMiddleware
-from api.routes import auth, profiles, reviews, health
+from api.routes import auth, health, profiles, reviews
+from core.config import settings
 from core.database import init_db
+from safety.rate_limiter import RateLimiter
 
 log = structlog.get_logger()
 
@@ -30,9 +34,7 @@ def custom_openapi():
         routes=app.routes,
     )
 
-    openapi_schema["info"]["x-logo"] = {
-        "url": "https://pathreview.example.com/logo.png"
-    }
+    openapi_schema["info"]["x-logo"] = {"url": "https://pathreview.example.com/logo.png"}
 
     app.openapi_schema = openapi_schema
     return app.openapi_schema
@@ -41,6 +43,14 @@ def custom_openapi():
 app.openapi = custom_openapi
 
 
+# Add rate limit middleware first so CORS and request IDs wrap rejected responses
+rate_limiter = RateLimiter(redis.Redis.from_url(settings.redis_url))
+app.add_middleware(
+    RateLimitMiddleware,
+    rate_limiter=rate_limiter,
+    limit=settings.rate_limit_per_minute,
+)
+
 # Add CORS middleware
 app.add_middleware(
     CORSMiddleware,
@@ -48,6 +58,7 @@ app.add_middleware(
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
+    expose_headers=["X-RateLimit-Limit", "X-RateLimit-Remaining"],
 )
 
 # Add request ID middleware

--- a/api/middleware/rate_limit.py
+++ b/api/middleware/rate_limit.py
@@ -1,0 +1,50 @@
+"""HTTP middleware for API rate limiting."""
+
+from fastapi import Request
+from starlette.concurrency import run_in_threadpool
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.responses import JSONResponse, Response
+from starlette.types import ASGIApp
+
+from safety.rate_limiter import RateLimiter
+
+
+class RateLimitMiddleware(BaseHTTPMiddleware):
+    """Enforce a per-client request limit and report the remaining quota."""
+
+    def __init__(self, app: ASGIApp, rate_limiter: RateLimiter, limit: int) -> None:
+        """Initialize the middleware.
+
+        Args:
+            app: Downstream ASGI application.
+            rate_limiter: Limiter used to check each client identifier.
+            limit: Maximum requests allowed per minute.
+        """
+        super().__init__(app)
+        self.rate_limiter = rate_limiter
+        self.limit = limit
+
+    async def dispatch(
+        self,
+        request: Request,
+        call_next: RequestResponseEndpoint,
+    ) -> Response:
+        """Check the client quota and attach rate-limit headers to the response."""
+        identifier = request.client.host if request.client is not None else "unknown"
+        allowed, remaining = await run_in_threadpool(
+            self.rate_limiter.check_rate_limit,
+            identifier,
+            self.limit,
+        )
+
+        if allowed:
+            response = await call_next(request)
+        else:
+            response = JSONResponse(
+                status_code=429,
+                content={"detail": "Rate limit exceeded"},
+            )
+
+        response.headers["X-RateLimit-Limit"] = str(self.limit)
+        response.headers["X-RateLimit-Remaining"] = str(max(0, remaining))
+        return response

--- a/tests/unit/test_rate_limit_middleware.py
+++ b/tests/unit/test_rate_limit_middleware.py
@@ -1,0 +1,184 @@
+"""Tests for API rate-limit middleware."""
+
+from unittest.mock import Mock, call
+
+import pytest
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.testclient import TestClient
+from starlette.responses import JSONResponse, Response
+
+from api.middleware.rate_limit import RateLimitMiddleware
+from api.middleware.request_id import RequestIDMiddleware
+from safety.rate_limiter import RateLimiter
+
+
+def create_test_app(
+    limiter: Mock,
+    *,
+    limit: int = 3,
+    outer_middleware: bool = False,
+) -> tuple[FastAPI, dict[str, int]]:
+    """Create a small application with rate limiting enabled."""
+    app = FastAPI()
+    route_calls = {"count": 0}
+
+    app.add_middleware(
+        RateLimitMiddleware,
+        rate_limiter=limiter,
+        limit=limit,
+    )
+
+    if outer_middleware:
+        app.add_middleware(
+            CORSMiddleware,
+            allow_origins=["http://localhost:5173"],
+            allow_methods=["*"],
+            allow_headers=["*"],
+            expose_headers=["X-RateLimit-Limit", "X-RateLimit-Remaining"],
+        )
+        app.add_middleware(RequestIDMiddleware)
+
+    @app.get("/limited")
+    async def limited_route() -> dict[str, str]:
+        route_calls["count"] += 1
+        return {"status": "ok"}
+
+    @app.get("/teapot")
+    async def teapot_route() -> None:
+        raise HTTPException(status_code=418, detail="teapot")
+
+    return app, route_calls
+
+
+@pytest.mark.unit
+class TestRateLimitMiddleware:
+    """Test rate limiting at the HTTP boundary."""
+
+    @pytest.fixture
+    def limiter(self) -> Mock:
+        """Create a mocked rate limiter."""
+        return Mock(spec=RateLimiter)
+
+    def test_allowed_response_includes_limit_headers(self, limiter: Mock) -> None:
+        """An allowed request reports its configured and remaining quota."""
+        limiter.check_rate_limit.return_value = (True, 2)
+        app, _ = create_test_app(limiter)
+        client = TestClient(app, client=("192.0.2.10", 50000))
+
+        response = client.get("/limited")
+
+        assert response.status_code == 200
+        assert response.headers["X-RateLimit-Limit"] == "3"
+        assert response.headers["X-RateLimit-Remaining"] == "2"
+        limiter.check_rate_limit.assert_called_once_with("192.0.2.10", 3)
+
+    def test_exhausted_client_receives_429_without_calling_route(self, limiter: Mock) -> None:
+        """An exhausted client is rejected before route handling."""
+        limiter.check_rate_limit.return_value = (False, 0)
+        app, route_calls = create_test_app(limiter)
+
+        response = TestClient(app).get("/limited")
+
+        assert response.status_code == 429
+        assert response.json() == {"detail": "Rate limit exceeded"}
+        assert response.headers["X-RateLimit-Limit"] == "3"
+        assert response.headers["X-RateLimit-Remaining"] == "0"
+        assert route_calls["count"] == 0
+
+    def test_last_allowed_request_precedes_first_denied_request(self, limiter: Mock) -> None:
+        """Remaining zero is allowed until the following request is denied."""
+        limiter.check_rate_limit.side_effect = [(True, 0), (False, 0)]
+        app, route_calls = create_test_app(limiter)
+        client = TestClient(app)
+
+        last_allowed = client.get("/limited")
+        first_denied = client.get("/limited")
+
+        assert last_allowed.status_code == 200
+        assert last_allowed.headers["X-RateLimit-Remaining"] == "0"
+        assert first_denied.status_code == 429
+        assert first_denied.headers["X-RateLimit-Remaining"] == "0"
+        assert route_calls["count"] == 1
+
+    def test_different_client_ips_use_independent_identifiers(self, limiter: Mock) -> None:
+        """Each client address is passed to the limiter separately."""
+        limiter.check_rate_limit.return_value = (True, 2)
+        app, _ = create_test_app(limiter)
+
+        TestClient(app, client=("192.0.2.11", 50000)).get("/limited")
+        TestClient(app, client=("192.0.2.12", 50000)).get("/limited")
+
+        assert limiter.check_rate_limit.call_args_list == [
+            call("192.0.2.11", 3),
+            call("192.0.2.12", 3),
+        ]
+
+    def test_fail_open_result_preserves_service_and_full_quota(self, limiter: Mock) -> None:
+        """The limiter's Redis fail-open result remains an allowed response."""
+        limiter.check_rate_limit.return_value = (True, 3)
+        app, route_calls = create_test_app(limiter)
+
+        response = TestClient(app).get("/limited")
+
+        assert response.status_code == 200
+        assert response.headers["X-RateLimit-Remaining"] == "3"
+        assert route_calls["count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_missing_client_uses_stable_fallback_identifier(self, limiter: Mock) -> None:
+        """A request without client metadata uses a stable fallback key."""
+        limiter.check_rate_limit.return_value = (True, 2)
+        middleware = RateLimitMiddleware(FastAPI(), rate_limiter=limiter, limit=3)
+        request = Request(
+            {
+                "type": "http",
+                "asgi": {"version": "3.0"},
+                "http_version": "1.1",
+                "method": "GET",
+                "scheme": "http",
+                "path": "/limited",
+                "raw_path": b"/limited",
+                "query_string": b"",
+                "headers": [],
+                "client": None,
+                "server": ("testserver", 80),
+                "root_path": "",
+            }
+        )
+
+        async def call_next(_request: Request) -> Response:
+            return JSONResponse({"status": "ok"})
+
+        response = await middleware.dispatch(request, call_next)
+
+        assert response.headers["X-RateLimit-Remaining"] == "2"
+        limiter.check_rate_limit.assert_called_once_with("unknown", 3)
+
+    def test_route_generated_error_includes_limit_headers(self, limiter: Mock) -> None:
+        """Handled application errors retain rate-limit metadata."""
+        limiter.check_rate_limit.return_value = (True, 1)
+        app, _ = create_test_app(limiter)
+
+        response = TestClient(app).get("/teapot")
+
+        assert response.status_code == 418
+        assert response.headers["X-RateLimit-Limit"] == "3"
+        assert response.headers["X-RateLimit-Remaining"] == "1"
+
+    def test_rejected_response_retains_request_id_and_cors_headers(self, limiter: Mock) -> None:
+        """Outer request-ID and CORS middleware process rejected responses."""
+        limiter.check_rate_limit.return_value = (False, 0)
+        app, _ = create_test_app(limiter, outer_middleware=True)
+
+        response = TestClient(app).get(
+            "/limited",
+            headers={"Origin": "http://localhost:5173"},
+        )
+
+        exposed_headers = response.headers["Access-Control-Expose-Headers"]
+        assert response.status_code == 429
+        assert response.headers["X-Request-ID"]
+        assert response.headers["Access-Control-Allow-Origin"] == "http://localhost:5173"
+        assert "X-RateLimit-Limit" in exposed_headers
+        assert "X-RateLimit-Remaining" in exposed_headers


### PR DESCRIPTION
## Summary

Adds API middleware that connects the existing Redis-backed rate limiter to the request path. Responses now report `X-RateLimit-Limit` and `X-RateLimit-Remaining`, while requests exceeding the configured per-minute quota receive a JSON `429` response with the same headers.

## Issue

Closes #86

## Changes

- Add `RateLimitMiddleware` using the existing Redis rolling-window limiter.
- Identify clients using `request.client.host`.
- Run synchronous Redis checks in a worker thread to avoid blocking the async event loop.
- Return rate-limit headers on allowed, denied, and handled error responses.
- Preserve CORS and `X-Request-ID` headers on rejected requests through middleware ordering.
- Expose the rate-limit headers to browser clients through CORS.
- Add focused HTTP-level middleware tests.
- Document implementation progress and verification results in `JOURNAL.md`.

## Testing

- [x] Unit tests introduce no new failures (`make test-unit`)
  - Focused rate-limit suite: 27 passed.
  - Full suite before: 53 failed, 375 passed.
  - Full suite after: 53 failed, 383 passed.
- [ ] Integration tests pass (`make test-integration`)
  - Not run; this request path is covered by HTTP-level unit tests.
- [x] Linter introduces no new failures (`make lint`)
  - Ruff findings decreased from 182 to 181.
  - All changed Python files pass targeted Ruff checks.
- [x] Type checker introduces no new failures (`make typecheck`)
  - The new middleware passes targeted mypy validation.
  - The full repository has documented pre-existing mypy failures.
- [x] New and updated tests cover the changes.
- [x] All changed Python files pass Black formatting checks.

## Screenshots / Demo

Not applicable; this is an API middleware change.

## Notes for Reviewers

Please pay particular attention to:

- Using `request.client.host` rather than trusting forwarded-IP headers without trusted-proxy configuration.
- Middleware ordering for CORS and request-ID headers on `429` responses.
- Redis fail-open behavior, which allows requests and reports the full quota if Redis is unavailable.
- The worker-thread boundary around the existing synchronous Redis limiter.

The global lint, formatting, type-checking, and unit-test failures existed before this contribution. Before-and-after runs confirm that this change does not introduce additional failures.