### PR TITLE
feat(rag): consolidate duplicate cross-project feedback (fixes #28)

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -93,7 +93,7 @@ only deduplicates by `section_name`, which is already unique per section.
 
 **PLAN.md link:** https://github.com/aishadeveloper/pathreview/blob/fix/28-generator-duplicates/PLAN.md
 
-**Walkthrough video (recommended):** [to be added]
+**Walkthrough video (recommended):** Not recorded this week.
 
 **Blockers or open questions:**
 - 53 unit tests fail on this branch *before* my changes (verified by running

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -161,5 +161,7 @@ diffed, not counted).
 failures exist and are listed in the PR; my changes introduce no new
 failures, and all touched files pass ruff, black, and mypy.)
 
-**Draft PR feedback received from:** none yet — review requested from an AI
-mentor; will also share the PR in the cohort Slack channel.
+**Draft PR feedback received from:** PR shared in the cohort Slack channel —
+awaiting a peer review (will update with the reviewer's name when received).
+Also requested review from an AI mentor. Gave peer reviews to PRs #183 and
+#182 (issue #34).

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -165,3 +165,128 @@ failures, and all touched files pass ruff, black, and mypy.)
 reviewed the PR on GitHub, pulled the branch and ran the suite locally;
 nothing blocking ("Really clean fix"). Also requested review from an AI
 mentor. Gave peer reviews to PRs #183 and #182 (issue #34).
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [x] Yes  [ ] No — still awaiting review
+
+**Summary of feedback:**
+One review came in, from the instructor Shawn Blackman (@sh4wnbk) on
+https://github.com/ascherj/pathreview/pull/573. It was an approval with no
+requested changes. He called out the merge logic specifically — that
+`_merge_duplicate_skills` normalizes skill names with `casefold()` plus
+whitespace collapsing so "Python " and "python" don't read as two different
+skills, that project lists are unioned in order without duplicates, and that
+it handles both the v2 `projects` list and the legacy singular `project` key.
+He also approved of the JSON parse falling through to returning the section
+unchanged as a safe default, and noted the value of testing both
+`_consolidate_feedback` directly and the end-to-end path through
+`generate_full_review`. He pulled the branch and ran the tests locally (13
+passed), and disclosed that he used Claude while reviewing. He also requested
+a review from an AI mentor; that one hasn't arrived, and no other reviewer or
+maintainer has commented as of the Week 10 deadline. The PR is still open and
+unmerged, which is expected for this course.
+
+**How you responded:**
+Nothing was blocking and no changes were requested, so I made no further code
+changes — I didn't want to churn the diff for its own sake after it had been
+reviewed and run clean. My reply on the PR thanks him and flags the one thing
+his review didn't touch that I still consider open: `_consolidate_feedback`
+merges on exact normalized skill names, so it won't catch genuine paraphrases
+("Python" vs "Python 3", "RAG pipelines" vs "retrieval-augmented generation").
+PLAN.md names embedding-based clustering as the upgrade path if the prompt
+layer isn't enough, and I said I'd rather leave that as a documented follow-up
+than land speculative complexity in a bug-fix PR. If the AI mentor review
+lands after the deadline I'll respond to it on the PR the same way.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The hardest part wasn't the fix — it was establishing what "passing" even
+meant in this repo. 53 unit tests fail on this branch before I touch anything,
+so "the suite is red" carried no signal. I had to run the suite with and
+without my commit and diff the *failure lists*, not the counts, to prove I
+hadn't regressed anything; a count comparison would have silently hidden a
+swap of one failure for another. The second surprise was scope creep from
+below: I went in expecting to rewrite one no-op method, `_consolidate_feedback`,
+and found it couldn't be written at all until the parser stopped destroying
+the data it needed — `_parse_json_output` fanned one response into one section
+per JSON key and `generate_section` kept only `sections[0]`. So a one-method
+bug became a three-file change across `review_generator.py`,
+`output_parser.py`, and `prompt_templates.py`. Third, the repo's pre-commit
+mypy hook runs `disallow_untyped_defs` on whole files, so adding tests to
+legacy test modules meant annotating their existing untyped methods first —
+mechanical, but it padded the diff in a way I had to explain in the PR.
+
+**What did you learn about working in a large codebase?**
+The main shift is that most of what you read, you don't get to change. I spent
+real time in `ingestion/vector_store` and `agent/orchestrator.py` and came away
+with two constraints I had to design *around* rather than fix: `add_chunks`
+persists only `source_id`/`chunk_index`/`section`, dropping the richer
+`primary_language`/`tech_stack` metadata that `repo_analyzer.py` computes,
+which is why `source_id` became my project key; and the orchestrator has a
+`break  # Only process first repo for now`, which is why I couldn't do a live
+end-to-end multi-project reproduction and reproduced in unit tests instead. In
+my own projects I'd have "just fixed" both and blown the scope of the PR. I
+also learned to check consumers before changing a return shape — I'd carried
+"the `sections[0]` truncation might be load-bearing" as the top risk in
+PLAN.md since Week 8, and it dissolved in ten minutes in Week 9 once I actually
+traced it and found `core/services` never calls `ReviewGenerator` at all (its
+RAG step is still a placeholder). And the codebase's own conventions did work
+for me: prompt templates were already versioned, so adding a `v2`
+`skills_feedback` template let me change model behavior without touching `v1`
+or anything depending on it.
+
+**How did AI tools help — and where did they fall short?**
+AI was most useful for orientation and for mechanical volume: tracing which
+modules call `generate_section`, mapping how a chunk flows from
+`vector_store` into `_format_context`, and grinding out the mypy annotations
+on the legacy test files. It was also good at expanding an edge case I'd named
+into a real test — the "same stack, genuinely different observations must not
+merge" case is the one I most wanted covered and least wanted to hand-write.
+Where it fell short was judgment about *how much* to build. Asked how to
+deduplicate near-identical skills, the natural answer is semantic similarity —
+embed the skill names and cluster — and the repo even has an embeddings
+provider sitting in `ingestion/embeddings/provider.py` to make that easy. That
+would have been the wrong PR: nondeterministic, slow, hard to unit test, and
+unjustified until exact-match merging is shown to be insufficient. The
+decision to do prevention in the prompt plus a deterministic exact-match cure,
+and to write down embeddings as a *conditional* follow-up, was mine. Same for
+the small behavioral calls that don't show up in a summary — that a
+single-project review must round-trip byte-identically rather than sprouting
+an "applies to: [one-project]" annotation, and that chunks with no `source_id`
+shouldn't materialize a fake "unknown" project in the attribution list. AI
+also couldn't tell me which of the 53 failures were mine; that needed me to
+run the baseline.
+
+**What would you do differently if you started over?**
+I'd capture the failing-test baseline in Week 7, the day I confirmed setup —
+not in Week 8 when I was already writing code and had to backtrack to work out
+whether I'd broken things. Second, I'd close open risks instead of carrying
+them: the `sections[0]` question sat in PLAN.md for a week and cost me nothing
+to answer once I bothered. The frontend rendering risk I listed there I never
+did resolve — I still haven't checked how `frontend/` renders a section whose
+content is a JSON string with a per-skill `projects` list, and that's the
+weakest spot in the PR. Third, I'd record the Week 8 walkthrough video. I
+skipped it because the orchestrator's first-repo-only `break` made a live
+multi-project demo awkward, but a two-minute screen recording of the xfail
+tests failing and then passing would have made the reproduction legible to a
+reviewer without them pulling the branch. And I'd write the PR description as
+I went rather than reconstructing the pre-existing-failure story at the end.
+
+**What are you most proud of from this module?**
+The reproduction, more than the fix. Writing `xfail(strict=True)` tests in
+Week 8 that fed three same-stack projects' near-identical skill observations
+into `_consolidate_feedback` and asserted consolidation meant the bug was
+pinned down as an executable, failing artifact before I wrote a line of the
+solution — and `strict=True` meant they couldn't quietly pass for the wrong
+reason. Removing those markers in Week 9 and watching them go green is the
+cleanest evidence I have that I fixed the thing I claimed to fix, and it's
+what the reviewer ended up validating when he ran the suite himself. I also
+added a characterization test proving the old method returned its input
+unchanged, so the "before" is documented in the repo and not just in this
+journal.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -161,7 +161,7 @@ diffed, not counted).
 failures exist and are listed in the PR; my changes introduce no new
 failures, and all touched files pass ruff, black, and mypy.)
 
-**Draft PR feedback received from:** PR shared in the cohort Slack channel —
-awaiting a peer review (will update with the reviewer's name when received).
-Also requested review from an AI mentor. Gave peer reviews to PRs #183 and
-#182 (issue #34).
+**Draft PR feedback received from:** Shawn Blackman (instructor, @sh4wnbk) —
+reviewed the PR on GitHub, pulled the branch and ran the suite locally;
+nothing blocking ("Really clean fix"). Also requested review from an AI
+mentor. Gave peer reviews to PRs #183 and #182 (issue #34).

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,79 @@
+## Pathreview: Choose Your Issue
+
+## Issue Selected
+- Issue #28: Generator produces duplicate feedback sections when a user has multiple projects in the same tech stack.
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/28
+
+**Issue title:** Generator produces duplicate feedback sections when a user has multiple projects in the same tech stack
+
+**Tier:** [ ] Tier 1  [ ] Tier 2  [✅] Tier 3
+
+**Problem summary:**
+The generator produces nearly identical "skills" feedback for each project when a user has several projects built with the same technology — for example, three Python RAG projects. Instead of recognizing that the observation is shared and giving one consolidated piece of feedback, it repeats similar feedback for each project, so the review reads as repetitive and padded. A successful fix would make the generator deduplicate and consolidate these cross-project observations — stating a shared skill once and attributing it to all the projects it applies to — so the review feels distinct rather than repetitive. The affected code lives in `rag/generator/review_generator.py` and `rag/generator/output_parser.py`.
+
+**Branch name:** fix/28-generator-duplicates
+
+**Setup confirmation:** [✅] App runs locally at localhost:5173
+
+**Cohort ledger:** [✅] Issue added to cohort ledger
+
+## Is This Issue Right for Me?
+I selected this as a Tier 3 (advanced / AI-system) issue, and I'm comfortable taking it on: I was able to trace the root cause in the codebase before starting, so I know where the fix lives. The scope is well-bounded — the change is contained to two files in the RAG generation layer (`review_generator.py` and `output_parser.py`) rather than rippling across the app — and the core defect is already identified: a `_consolidate_feedback` method that never actually consolidates. The estimated effort (~7–10 hours per the issue) fits the Module 3 timeline. There is one other person working on this issue, but I will be able to implement, test, and submit a PR by the Week 9 deadline, and I don't see any blockers.
+
+## Design Note — Deduplicating cross-project feedback
+
+**Goal (per the issue):** deduplicate and *consolidate* cross-project
+observations — say a shared skill once, attributed to all the projects it
+spans — rather than generating distinct per-project feedback. Consolidation,
+not differentiation.
+
+**Why it happens today.** Reviews are generated per *section*
+(`skills_feedback`, `projects_feedback`, …) in `generate_full_review`, not
+per project. `generate_section` flattens every project's chunks into one
+`{context}` blob and passes only `project_count` (an integer) and
+`github_username` to the prompt. The model sees three similar Python projects
+side by side, with no project boundaries and no instruction to consolidate,
+so it comments on each independently. The existing `_consolidate_feedback`
+method is a no-op: its docstring promises to "merge feedback for the same
+project," but it only deduplicates by `section_name` (which is already
+unique), so it never inspects content or projects.
+
+**What identifiers are available.** At generation time each chunk's metadata
+carries only `source_id`, `chunk_index`, and `section` — the richer
+per-project metadata (`primary_language`, `repo_name`, `tech_stack`) computed
+in `repo_analyzer.py` is dropped by `vector_store.add_chunks`. So `source_id`
+is the reliable project key to group on.
+
+**Approach — prevention plus cure, across the two files:**
+
+Layer 1 (prevention, `review_generator.py`): make the generator
+project-aware. Group retrieved chunks by `source_id` in `_format_context`,
+emit them under explicit `=== Project: <source_id> ===` headers, and pass a
+project inventory into the prompt. Update the `skills_feedback` template so
+each observation is tagged with the projects it applies to
+(`key_skills: list of { skill, evidence, projects: [ids] }`) and instruct the
+model: when a skill applies to multiple projects, emit ONE entry listing all
+of them instead of repeating it per project. This removes most repetition at
+the source.
+
+Layer 2 (cure, `review_generator.py` + `output_parser.py`): implement a real
+`_consolidate_feedback` as a post-processing safety net that merges
+observations describing the same skill and unions their project lists. This
+needs structured input, which is currently blocked in the parser:
+`_parse_json_output` fans one response out into one section per top-level JSON
+key, and `generate_section` then keeps only `sections[0]`, dropping the rest.
+So `output_parser.py` must preserve the structured per-observation shape
+(skill + evidence + projects) for consolidation to operate on. Start with
+normalized exact-match merging on the skill name; upgrade to lexical or
+embedding-based near-duplicate clustering (an embeddings provider already
+exists in `ingestion/embeddings/provider.py`) only if the model still varies
+its phrasing.
+
+**Caveats to note, not fix here:** the orchestrator only analyzes the first
+repo (`break  # Only process first repo for now` in `_build_plan`), and
+`add_chunks` persists only `source_id`/`chunk_index`/`section` — both limit
+how much per-project signal reaches the generator, but neither blocks this
+work.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -106,3 +106,60 @@ only deduplicates by `section_name`, which is already unique per section.
 - A live end-to-end multi-project reproduction is limited by the
   orchestrator's first-repo-only `break`; if I record the walkthrough against
   the running app I'll need seeded multi-project data.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+PLAN.md sub-tasks 1–3 are implemented: `_format_context` now groups chunks
+under `=== Project: <id> ===` headers with a project inventory passed to the
+prompt, a `v2` `skills_feedback` template instructs the model to emit one
+entry per skill with a `projects` list, and `parse_section_output` preserves
+the full structured payload that the old `sections[0]` fan-out was dropping.
+Confirmed before starting that `core/services` never calls `ReviewGenerator`
+(its RAG step is a placeholder), which retired the biggest risk in PLAN.md.
+
+**Next steps:**
+Implement the real `_consolidate_feedback` merge (sub-task 4), flip the Week 8
+xfail reproduction tests and add edge-case coverage (sub-task 5), then
+self-review against docs/CONTRIBUTING.md and open the PR.
+
+**Blockers:**
+The repo's pre-commit mypy hook (`disallow_untyped_defs`) checks whole files,
+so extending the legacy test files requires annotating their existing
+untyped methods — mechanical but it inflates the diff slightly.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/573
+
+**Branch:** `fix/28-generator-duplicates`
+
+**What you built:**
+A two-layer fix for issue #28: the skills prompt now sees explicit project
+boundaries and a consolidation instruction (prevention), and
+`_consolidate_feedback` genuinely merges `key_skills` entries whose
+normalized skill names match, unioning their project lists (cure). A shared
+skill is now stated once and attributed to every project that demonstrates
+it, instead of being repeated per project.
+
+**Tests added or updated:**
+`tests/unit/test_review_generator.py` (Week 8's xfail reproduction tests now
+pass with markers removed, plus new coverage for project grouping, merge
+normalization, different-observations-not-merged, single-project no-op, and
+plaintext fallback), `tests/unit/test_output_parser.py` (new
+`parse_section_output` suite), `tests/unit/test_prompt_templates.py` (v2
+template and version selection). Unit suite: 396 passed; the 53 pre-existing
+failures are byte-identical before and after my changes (failure lists
+diffed, not counted).
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+(both in the documented sense for this codebase: repo-wide pre-existing
+failures exist and are listed in the PR; my changes introduce no new
+failures, and all touched files pass ruff, black, and mypy.)
+
+**Draft PR feedback received from:** none yet — review requested from an AI
+mentor; will also share the PR in the cohort Slack channel.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -77,3 +77,32 @@ repo (`break  # Only process first repo for now` in `_build_plan`), and
 `add_chunks` persists only `source_id`/`chunk_index`/`section` — both limit
 how much per-project signal reaches the generator, but neither blocks this
 work.
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/aishadeveloper/pathreview/commit/5897c749a237e0901142e35673ca3ae377b990a1
+
+**Reproduction summary:**
+I reproduced the issue deterministically with unit tests in
+`tests/unit/test_review_generator.py`: two `xfail(strict=True)` tests feed
+`_consolidate_feedback` (and, via a mocked LLM client, `generate_full_review`)
+near-identical skill observations attributed to three same-stack projects and
+assert they get consolidated — both fail today, and a passing characterization
+test confirms `_consolidate_feedback` returns its input unchanged because it
+only deduplicates by `section_name`, which is already unique per section.
+
+**PLAN.md link:** https://github.com/aishadeveloper/pathreview/blob/fix/28-generator-duplicates/PLAN.md
+
+**Walkthrough video (recommended):** [to be added]
+
+**Blockers or open questions:**
+- 53 unit tests fail on this branch *before* my changes (verified by running
+  the suite with and without my commit — same 53 either way, e.g.
+  `test_json_array_fallback`, `test_tech_detector` exclusions). I'll diff
+  failure lists rather than counts in Week 9 so they don't mask regressions.
+- Before changing the parser's return shape I need to trace who consumes
+  `generate_section`'s output in `core/services` — the `sections[0]`
+  truncation might be load-bearing for non-skills sections.
+- A live end-to-end multi-project reproduction is limited by the
+  orchestrator's first-repo-only `break`; if I record the walkthrough against
+  the running app I'll need seeded multi-project data.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,59 @@
+## Solution plan
+
+**Issue:** [#28 — Generator produces duplicate feedback sections when a user has multiple projects in the same tech stack](https://github.com/ascherj/pathreview/issues/28)
+
+### Understand
+
+**Expected behavior:** when a user has several projects built with the same technology (e.g. three Python RAG projects), a shared observation should be stated once and attributed to all the projects it applies to — "Strong Python/RAG skills, demonstrated across rag-chatbot-alpha, -beta, and -gamma."
+
+**Actual behavior:** the generator repeats a near-identical observation once per project, so the skills feedback reads as repetitive and padded.
+
+**Root cause (verified in code, and reproduced in `tests/unit/test_review_generator.py`):**
+
+1. `generate_section` in `rag/generator/review_generator.py` flattens every project's chunks into one `{context}` blob via `_format_context` and passes only `project_count` (an integer) to the prompt. The model sees three similar projects side by side with no project boundaries and no instruction to consolidate, so it comments on each independently.
+2. The `_consolidate_feedback` safety net is a no-op: its docstring promises to merge feedback about the same project, but it only deduplicates by `section_name` — which `generate_full_review` already guarantees is unique — so it never inspects content. Proven by the xfail tests in the reproduction commit.
+3. Structured output is lost before consolidation could use it: `_parse_json_output` in `rag/generator/output_parser.py` fans one response into one section per top-level JSON key, and `generate_section` keeps only `sections[0]`, dropping the rest.
+
+### Map
+
+Files I expect to touch:
+
+- `rag/generator/review_generator.py` — `_format_context`, `generate_section`, `_consolidate_feedback` (the core of both layers of the fix)
+- `rag/generator/prompt_templates.py` — add a `v2` `skills_feedback` template with per-project context and an explicit consolidation instruction (templates are already versioned, so `v1` stays untouched)
+- `rag/generator/output_parser.py` — preserve the structured per-observation shape (skill + evidence + projects) instead of flattening it, so consolidation has something to operate on
+- `tests/unit/test_review_generator.py` — the reproduction tests flip from xfail to passing (strict xfail forces removing the markers); add tests for the new grouping/merging behavior
+- `tests/unit/test_prompt_templates.py`, `tests/unit/test_output_parser.py` — extend for the v2 template and parser changes
+
+Read-only context: `ingestion/vector_store` `add_chunks` (persists only `source_id`/`chunk_index`/`section` — `source_id` is the reliable project key) and `agent/orchestrator.py` (first-repo-only `break` limits live multi-project data; out of scope).
+
+### Plan
+
+1. **Make context project-aware (prevention).** In `_format_context`, group retrieved chunks by `metadata.source_id` and emit them under explicit `=== Project: <source_id> ===` headers; build a project inventory list and pass it into the prompt alongside `project_count`.
+2. **Add a `v2` skills template.** In `prompt_templates.py`, ask for `key_skills` as a list of `{skill, evidence, projects: [ids]}` and instruct: when a skill applies to multiple projects, emit ONE entry listing all of them. Switch `generate_section` to request `v2` for `skills_feedback`.
+3. **Preserve structure in the parser.** Update `output_parser.py` (and the `sections[0]` handling in `generate_section`) so the per-observation structure survives parsing instead of being flattened to a JSON string blob.
+4. **Implement real consolidation (cure).** Rewrite `_consolidate_feedback` to merge observations whose normalized skill name matches exactly and union their project lists; keep it a pure function so it stays unit-testable.
+5. **Flip the reproduction tests and extend coverage.** Remove the xfail markers, add cases for grouping, merging, and the edge cases below; run `make test-unit` and `make lint`.
+
+If exact-match merging proves too weak against the model's paraphrasing, upgrade to lexical or embedding-based near-duplicate clustering (an embeddings provider already exists in `ingestion/embeddings/provider.py`) — but only if step 2's prompt change doesn't already eliminate most duplication.
+
+### Inputs & outputs
+
+- **Input:** the same retrieved chunks (`{text, score, metadata: {source_id, chunk_index, section}}`) and `profile_data` that the generator receives today — no schema or ingestion changes.
+- **Output:** the same `list[FeedbackSection]` contract, but the skills section contains each shared observation once, with an explicit list of the projects it applies to. Downstream consumers (citations, review service, frontend) keep working because the section shape is unchanged.
+
+### Risks & unknowns
+
+- **Parser fan-out is load-bearing:** other sections' templates (e.g. `projects_feedback`) also return multi-key JSON that flows through `_parse_json_output` → `sections[0]`. Changing that path could alter what non-skills sections contain — I need to trace `generate_section`'s consumers in `core/services` before changing the return shape.
+- **Prompt compliance is probabilistic:** the model may ignore the consolidation instruction or vary skill names ("Python" vs "Python 3"), which is why the deterministic `_consolidate_feedback` layer exists as a backstop — and why it must not depend on the prompt behaving.
+- **Frontend rendering:** the skills section content changes shape (projects list per skill); I haven't yet checked how `frontend/` renders section content — if it renders raw JSON content strings, attribution formatting matters.
+- **Pre-existing suite failures:** 53 unit tests fail on this branch before my changes (verified by running the suite with and without my commit); I must not let those mask new regressions — I'll compare failure lists, not just counts.
+- **Live verification is constrained:** the orchestrator only ingests the first repo (`break` in `agent/orchestrator.py:100`), so an end-to-end multi-project run needs seeded data rather than a real multi-repo ingest.
+
+### Edge cases
+
+- **Single project** — nothing to consolidate; output must be unchanged (no "applies to: [only-project]" noise).
+- **Same stack, genuinely different observations** — three Python projects where the model says something *different* about each must NOT be merged; merging keys on the skill, not the project's tech stack.
+- **Chunks missing `source_id`** — `_format_context` currently defaults to `"unknown"`; grouping must tolerate that without inventing an "unknown" project entry in attributions.
+- **Non-JSON model output** — the plaintext fallback path (`_parse_plaintext_output`) has no structure to consolidate; the fix must degrade gracefully to today's behavior instead of crashing.
+- **Case/whitespace variants of the same skill** — "python" vs "Python " should merge (normalize before matching); "Python" vs "Django" should not.
+- **Empty retrieval** — no chunks retrieved; the project inventory is empty and the prompt must still format without KeyErrors.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -99,7 +99,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -449,7 +448,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -473,7 +471,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1561,7 +1558,6 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1579,7 +1575,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1972,7 +1967,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3507,7 +3501,6 @@
       "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^2.0.1",
         "cssstyle": "^4.0.1",
@@ -4094,7 +4087,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4107,7 +4099,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4771,7 +4762,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/rag/generator/output_parser.py
+++ b/rag/generator/output_parser.py
@@ -8,6 +8,8 @@ import structlog
 
 logger = structlog.get_logger()
 
+_JSON_FENCE_RE = re.compile(r"```(?:json)?\s*\n(.*?)\n```", re.DOTALL)
+
 
 @dataclass
 class FeedbackSection:
@@ -29,7 +31,7 @@ def parse_review_output(raw: str) -> list[FeedbackSection]:
         List of FeedbackSection objects
     """
     # Try JSON in code fence first
-    json_match = re.search(r"```(?:json)?\s*\n(.*?)\n```", raw, re.DOTALL)
+    json_match = _JSON_FENCE_RE.search(raw)
     if json_match:
         json_str = json_match.group(1)
         try:
@@ -47,6 +49,73 @@ def parse_review_output(raw: str) -> list[FeedbackSection]:
 
     # Fallback to plain text parsing
     return _parse_plaintext_output(raw)
+
+
+def parse_section_output(raw: str, section_name: str) -> FeedbackSection:
+    """Parse one section's LLM output, preserving its full structure.
+
+    Unlike parse_review_output, which fans a response out into one section per
+    top-level JSON key (so callers keeping only the first section drop the
+    rest), this returns a single section named after the requested section
+    with the entire structured payload preserved in its content. That intact
+    structure is what downstream consolidation operates on (issue #28).
+
+    Args:
+        raw: Raw LLM output string
+        section_name: Name of the section this output was generated for
+
+    Returns:
+        FeedbackSection named section_name; content is the full JSON payload
+        as a string, or the raw text when the output is not a JSON object
+    """
+    data = _extract_json_dict(raw)
+    if data is None:
+        logger.info("section_output_plaintext", section_name=section_name)
+        return FeedbackSection(
+            section_name=section_name, content=raw, confidence=0.7, suggestions=[]
+        )
+
+    # Unwrap a redundant single top-level key matching the section name
+    payload: dict = data
+    if set(payload.keys()) == {section_name} and isinstance(payload[section_name], dict):
+        payload = payload[section_name]
+
+    suggestions = payload.get("suggestions", [])
+    if not isinstance(suggestions, list):
+        suggestions = []
+
+    logger.info("section_output_parsed", section_name=section_name)
+    return FeedbackSection(
+        section_name=section_name,
+        content=json.dumps(payload),
+        confidence=0.9,
+        suggestions=suggestions,
+    )
+
+
+def _extract_json_dict(raw: str) -> dict | None:
+    """Extract a JSON object from raw LLM output.
+
+    Args:
+        raw: Raw LLM output string, possibly wrapping JSON in a code fence
+
+    Returns:
+        Parsed dict, or None if no JSON object could be extracted
+    """
+    json_match = _JSON_FENCE_RE.search(raw)
+    if json_match:
+        try:
+            data = json.loads(json_match.group(1))
+            if isinstance(data, dict):
+                return data
+        except json.JSONDecodeError:
+            logger.warning("json_parsing_failed_in_fence", json_snippet=json_match.group(1)[:100])
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    return data if isinstance(data, dict) else None
 
 
 def _parse_json_output(data: dict) -> list[FeedbackSection]:

--- a/rag/generator/output_parser.py
+++ b/rag/generator/output_parser.py
@@ -1,8 +1,9 @@
 """Parse LLM output into structured feedback."""
 
-from dataclasses import dataclass
 import json
 import re
+from dataclasses import dataclass
+
 import structlog
 
 logger = structlog.get_logger()
@@ -11,6 +12,7 @@ logger = structlog.get_logger()
 @dataclass
 class FeedbackSection:
     """Structured feedback section."""
+
     section_name: str
     content: str
     confidence: float
@@ -26,8 +28,6 @@ def parse_review_output(raw: str) -> list[FeedbackSection]:
     Returns:
         List of FeedbackSection objects
     """
-    sections = []
-
     # Try JSON in code fence first
     json_match = re.search(r"```(?:json)?\s*\n(.*?)\n```", raw, re.DOTALL)
     if json_match:
@@ -67,15 +67,15 @@ def _parse_json_output(data: dict) -> list[FeedbackSection]:
                 section_name=key,
                 content=json.dumps(value),
                 confidence=0.9,
-                suggestions=value.get("suggestions", [])
-                    if isinstance(value.get("suggestions"), list) else []
+                suggestions=(
+                    value.get("suggestions", [])
+                    if isinstance(value.get("suggestions"), list)
+                    else []
+                ),
             )
         else:
             section = FeedbackSection(
-                section_name=key,
-                content=str(value),
-                confidence=0.85,
-                suggestions=[]
+                section_name=key, content=str(value), confidence=0.85, suggestions=[]
             )
         sections.append(section)
 
@@ -94,10 +94,7 @@ def _parse_plaintext_output(raw: str) -> list[FeedbackSection]:
     """
     # Treat entire text as a single feedback section
     section = FeedbackSection(
-        section_name="general_feedback",
-        content=raw,
-        confidence=0.7,
-        suggestions=[]
+        section_name="general_feedback", content=raw, confidence=0.7, suggestions=[]
     )
 
     logger.info("plaintext_output_parsed", content_length=len(raw))

--- a/rag/generator/prompt_templates.py
+++ b/rag/generator/prompt_templates.py
@@ -26,7 +26,39 @@ Format your response as JSON with these fields:
 - language_proficiency: dict mapping languages to proficiency level
 - framework_expertise: list of mastered frameworks
 - tool_proficiency: list of tools used effectively
-"""
+""",
+        "v2": """Analyze the skills demonstrated in the provided portfolio context.
+
+The portfolio contains {project_count} project(s):
+{project_inventory}
+
+The context below is grouped by project. Each project's evidence appears
+under its own '=== Project: <id> ===' header.
+
+Portfolio Context:
+{context}
+
+GitHub Username: {github_username}
+
+Based on the portfolio evidence above, provide structured feedback on:
+1. Demonstrated technical skills (with specific examples from projects)
+2. Depth of expertise in key areas
+3. Programming language proficiency
+4. Framework and tool mastery
+
+IMPORTANT — consolidate observations across projects: when the same skill is
+demonstrated in more than one project, emit exactly ONE key_skills entry for
+that skill and list every project that demonstrates it in that entry's
+"projects" field. Do not repeat a near-identical observation once per project.
+
+Format your response as JSON with these fields:
+- key_skills: list of objects, each with fields "skill" (short skill name),
+  "evidence" (specific example from the portfolio), and "projects" (list of
+  ids of every project demonstrating this skill)
+- language_proficiency: dict mapping languages to proficiency level
+- framework_expertise: list of mastered frameworks
+- tool_proficiency: list of tools used effectively
+""",
     },
     "projects_feedback": {
         "v1": """Evaluate the quality and presentation of projects in the portfolio.
@@ -110,8 +142,26 @@ Write a concise, professional summary capturing:
 
 Provide only the summary text, no JSON formatting needed.
 """
-    }
+    },
 }
+
+
+# Preferred version per template; templates not listed here use v1.
+CURRENT_TEMPLATE_VERSIONS = {
+    "skills_feedback": "v2",
+}
+
+
+def get_current_version(name: str) -> str:
+    """Return the preferred version for a template.
+
+    Args:
+        name: Template name (skills_feedback, projects_feedback, etc.)
+
+    Returns:
+        Version string to use for this template (defaults to v1)
+    """
+    return CURRENT_TEMPLATE_VERSIONS.get(name, "v1")
 
 
 def get_template(name: str, version: str = "v1") -> str:

--- a/rag/generator/review_generator.py
+++ b/rag/generator/review_generator.py
@@ -1,12 +1,13 @@
 """LLM-based review generation."""
 
+import json
 from dataclasses import dataclass
-from typing import Optional
+
 import openai
 import structlog
 
-from .prompt_templates import get_template
-from .output_parser import parse_review_output, FeedbackSection
+from .output_parser import FeedbackSection, parse_section_output
+from .prompt_templates import get_current_version, get_template
 
 logger = structlog.get_logger()
 
@@ -14,6 +15,7 @@ logger = structlog.get_logger()
 @dataclass
 class ReviewConfig:
     """Configuration for review generation."""
+
     api_key: str
     base_url: str
     model: str
@@ -31,13 +33,11 @@ class ReviewGenerator:
             config: ReviewConfig with API settings
         """
         self.config = config
-        self.client = openai.OpenAI(
-            api_key=config.api_key,
-            base_url=config.base_url
-        )
+        self.client = openai.OpenAI(api_key=config.api_key, base_url=config.base_url)
 
-    def generate_section(self, section_name: str, context_chunks: list[dict],
-                        profile_data: dict) -> FeedbackSection:
+    def generate_section(
+        self, section_name: str, context_chunks: list[dict], profile_data: dict
+    ) -> FeedbackSection:
         """Generate feedback for a specific section.
 
         Args:
@@ -48,18 +48,21 @@ class ReviewGenerator:
         Returns:
             FeedbackSection with generated content
         """
-        # Get template
-        template = get_template(section_name)
+        # Get template (skills_feedback uses the project-aware v2)
+        template = get_template(section_name, get_current_version(section_name))
 
-        # Format context
+        # Format context, grouped by project
         context_text = self._format_context(context_chunks)
+        inventory = self._project_inventory(context_chunks)
         github_username = profile_data.get("github_username", "")
         project_count = len(profile_data.get("projects", []))
 
         prompt = template.format(
             context=context_text,
             github_username=github_username,
-            project_count=project_count
+            project_count=project_count,
+            project_inventory="\n".join(f"- {project}" for project in inventory)
+            or "- (no projects identified)",
         )
 
         # Call LLM
@@ -67,31 +70,20 @@ class ReviewGenerator:
             model=self.config.model,
             messages=[
                 {"role": "system", "content": "You are an expert portfolio reviewer."},
-                {"role": "user", "content": prompt}
+                {"role": "user", "content": prompt},
             ],
             temperature=self.config.temperature,
-            max_tokens=self.config.max_tokens
+            max_tokens=self.config.max_tokens,
         )
 
         content = response.choices[0].message.content
 
-        # Parse output
-        sections = parse_review_output(content)
+        # Parse output, preserving the full structured payload for this section
+        return parse_section_output(content, section_name)
 
-        # Return first section or create default
-        if sections:
-            return sections[0]
-
-        logger.warning("no_sections_parsed", section_name=section_name)
-        return FeedbackSection(
-            section_name=section_name,
-            content=content,
-            confidence=0.6,
-            suggestions=[]
-        )
-
-    def generate_full_review(self, profile_data: dict,
-                            retrieved_chunks: list[dict]) -> list[FeedbackSection]:
+    def generate_full_review(
+        self, profile_data: dict, retrieved_chunks: list[dict]
+    ) -> list[FeedbackSection]:
         """Generate complete review across all sections.
 
         Args:
@@ -106,62 +98,90 @@ class ReviewGenerator:
             "projects_feedback",
             "presentation_feedback",
             "gaps_feedback",
-            "first_impression"
+            "first_impression",
         ]
 
         all_sections = []
 
         for section_name in section_names:
             try:
-                section = self.generate_section(
-                    section_name, retrieved_chunks, profile_data
-                )
-
-                # Add source citations if available
-                section = self._add_citations(section, retrieved_chunks)
-
+                section = self.generate_section(section_name, retrieved_chunks, profile_data)
                 all_sections.append(section)
                 logger.info("section_generated", section=section_name)
 
             except Exception as e:
-                logger.error("section_generation_failed", section=section_name,
-                           error=str(e))
+                logger.error("section_generation_failed", section=section_name, error=str(e))
                 # Continue with remaining sections
-                all_sections.append(FeedbackSection(
-                    section_name=section_name,
-                    content=f"Error generating {section_name}",
-                    confidence=0.0,
-                    suggestions=[]
-                ))
+                all_sections.append(
+                    FeedbackSection(
+                        section_name=section_name,
+                        content=f"Error generating {section_name}",
+                        confidence=0.0,
+                        suggestions=[],
+                    )
+                )
 
         # Consolidate duplicates across similar projects
         all_sections = self._consolidate_feedback(all_sections)
+
+        # Add citations after consolidation, which needs content to still be
+        # parseable JSON
+        all_sections = [self._add_citations(section, retrieved_chunks) for section in all_sections]
 
         logger.info("full_review_generated", section_count=len(all_sections))
         return all_sections
 
     @staticmethod
     def _format_context(chunks: list[dict]) -> str:
-        """Format retrieved chunks into context string.
+        """Format retrieved chunks into a context string grouped by project.
+
+        Chunks are grouped under an explicit '=== Project: <id> ===' header
+        per source project so the model sees project boundaries instead of
+        one flat blob (issue #28).
 
         Args:
             chunks: List of retrieved chunks
 
         Returns:
-            Formatted context string
+            Formatted context string with per-project headers
         """
-        parts = []
-        for i, chunk in enumerate(chunks[:10], 1):  # Limit to 10 chunks
+        grouped: dict[str, list[dict]] = {}
+        for chunk in chunks[:10]:  # Limit to 10 chunks
             source = chunk.get("metadata", {}).get("source_id", "unknown")
-            score = chunk.get("score", 0)
-            text = chunk.get("text", "")
-            parts.append(f"[{i}] (relevance: {score:.2f}) Source: {source}\n{text}")
+            grouped.setdefault(source, []).append(chunk)
+
+        parts = []
+        i = 1
+        for source, source_chunks in grouped.items():
+            parts.append(f"=== Project: {source} ===")
+            for chunk in source_chunks:
+                score = chunk.get("score", 0)
+                text = chunk.get("text", "")
+                parts.append(f"[{i}] (relevance: {score:.2f})\n{text}")
+                i += 1
 
         return "\n\n".join(parts)
 
     @staticmethod
-    def _add_citations(section: FeedbackSection,
-                       retrieved_chunks: list[dict]) -> FeedbackSection:
+    def _project_inventory(chunks: list[dict]) -> list[str]:
+        """List distinct project ids present in the retrieved chunks.
+
+        Args:
+            chunks: List of retrieved chunks
+
+        Returns:
+            Distinct source_id values in retrieval order; chunks without a
+            source_id are skipped rather than reported as a project
+        """
+        inventory: list[str] = []
+        for chunk in chunks:
+            source = chunk.get("metadata", {}).get("source_id")
+            if source and source not in inventory:
+                inventory.append(source)
+        return inventory
+
+    @staticmethod
+    def _add_citations(section: FeedbackSection, retrieved_chunks: list[dict]) -> FeedbackSection:
         """Add source citations to feedback section.
 
         Args:
@@ -187,22 +207,108 @@ class ReviewGenerator:
 
     @staticmethod
     def _consolidate_feedback(sections: list[FeedbackSection]) -> list[FeedbackSection]:
-        """Consolidate duplicate feedback across similar sections.
+        """Consolidate duplicate cross-project observations in each section.
+
+        When several projects share a tech stack, the model may emit one
+        near-identical key_skills entry per project. Entries whose normalized
+        skill name matches are merged into a single entry whose "projects"
+        list is the union of the originals' (issue #28). Sections without
+        structured key_skills data pass through unchanged.
 
         Args:
             sections: List of feedback sections
 
         Returns:
-            Consolidated list of sections
+            Consolidated list of sections, same length and order
         """
-        # Simple consolidation: if two sections mention the same project,
-        # merge the feedback
-        seen = set()
-        consolidated = []
+        return [ReviewGenerator._merge_duplicate_skills(s) for s in sections]
 
-        for section in sections:
-            if section.section_name not in seen:
-                consolidated.append(section)
-                seen.add(section.section_name)
+    @staticmethod
+    def _merge_duplicate_skills(section: FeedbackSection) -> FeedbackSection:
+        """Merge key_skills entries that describe the same skill.
 
-        return consolidated
+        Args:
+            section: Feedback section whose content may be a JSON object
+                with a key_skills list
+
+        Returns:
+            Section with same-skill entries merged and their project lists
+            unioned; the original section if content has no key_skills data
+        """
+        try:
+            data = json.loads(section.content)
+        except (json.JSONDecodeError, TypeError):
+            return section
+        if not isinstance(data, dict) or not isinstance(data.get("key_skills"), list):
+            return section
+
+        merged: dict[str, dict] = {}  # normalized skill name -> merged entry
+        result: list = []
+        for entry in data["key_skills"]:
+            if not isinstance(entry, dict) or not str(entry.get("skill", "")).strip():
+                result.append(entry)  # no skill name to merge on
+                continue
+
+            key = " ".join(str(entry["skill"]).split()).casefold()
+            projects = ReviewGenerator._entry_projects(entry)
+
+            if key not in merged:
+                new_entry = dict(entry)
+                # Normalize to a "projects" list, but only when the entry
+                # carries project info — don't add noise to entries without it
+                if "project" in new_entry or "projects" in new_entry:
+                    new_entry.pop("project", None)
+                    new_entry["projects"] = projects
+                merged[key] = new_entry
+                result.append(new_entry)
+                continue
+
+            # Duplicate skill: union its projects into the first entry
+            existing = merged[key]
+            if projects:
+                existing_projects = existing.setdefault("projects", [])
+                existing.pop("project", None)
+                for project in projects:
+                    if project not in existing_projects:
+                        existing_projects.append(project)
+
+        if len(result) == len(data["key_skills"]) and not any(
+            "project" in e for e in data["key_skills"] if isinstance(e, dict)
+        ):
+            # Nothing merged and nothing renamed: keep the section as-is so
+            # single-project reviews round-trip byte-identically
+            return section
+
+        data["key_skills"] = result
+        logger.info(
+            "duplicate_skills_consolidated",
+            section_name=section.section_name,
+            merged_count=len(data["key_skills"]),
+        )
+        return FeedbackSection(
+            section_name=section.section_name,
+            content=json.dumps(data),
+            confidence=section.confidence,
+            suggestions=section.suggestions,
+        )
+
+    @staticmethod
+    def _entry_projects(entry: dict) -> list[str]:
+        """Extract the project ids a key_skills entry cites.
+
+        Accepts both the v2 "projects" list and a legacy singular "project"
+        string.
+
+        Args:
+            entry: A key_skills entry dict
+
+        Returns:
+            List of project id strings (possibly empty)
+        """
+        projects = entry.get("projects")
+        if isinstance(projects, list):
+            return [str(p) for p in projects if p]
+        project = entry.get("project")
+        if isinstance(project, str) and project:
+            return [project]
+        return []

--- a/tests/unit/test_output_parser.py
+++ b/tests/unit/test_output_parser.py
@@ -1,16 +1,22 @@
 """Tests for output_parser.py"""
 
-import pytest
 import json
 
-from rag.generator.output_parser import parse_review_output, FeedbackSection, _parse_plaintext_output
+import pytest
+
+from rag.generator.output_parser import (
+    FeedbackSection,
+    _parse_plaintext_output,
+    parse_review_output,
+    parse_section_output,
+)
 
 
 @pytest.mark.unit
 class TestOutputParser:
     """Test suite for output_parser module."""
 
-    def test_json_wrapped_in_code_fence(self):
+    def test_json_wrapped_in_code_fence(self) -> None:
         """Test parsing JSON wrapped in code fence."""
         raw_output = """
         ```json
@@ -30,22 +36,26 @@ class TestOutputParser:
         assert len(result) > 0
         assert all(isinstance(s, FeedbackSection) for s in result)
 
-    def test_raw_json_without_fence(self):
+    def test_raw_json_without_fence(self) -> None:
         """Test parsing raw JSON without code fence."""
-        raw_output = json.dumps({
-            "skills": "Advanced Python and JavaScript",
-            "projects": "Strong portfolio of web apps",
-            "recommendations": ["Add DevOps experience", "Write more documentation"]
-        })
+        raw_output = json.dumps(
+            {
+                "skills": "Advanced Python and JavaScript",
+                "projects": "Strong portfolio of web apps",
+                "recommendations": ["Add DevOps experience", "Write more documentation"],
+            }
+        )
 
         result = parse_review_output(raw_output)
 
         assert isinstance(result, list)
         assert len(result) > 0
 
-    def test_plain_text_fallback(self):
+    def test_plain_text_fallback(self) -> None:
         """Test that plain text returns FeedbackSection without crash."""
-        raw_output = "This is plain text feedback about the portfolio. No JSON here. Great work overall!"
+        raw_output = (
+            "This is plain text feedback about the portfolio. No JSON here. Great work overall!"
+        )
 
         result = parse_review_output(raw_output)
 
@@ -56,7 +66,7 @@ class TestOutputParser:
         assert section.section_name == "general_feedback"
         assert "plain text feedback" in section.content
 
-    def test_malformed_json_fallback(self):
+    def test_malformed_json_fallback(self) -> None:
         """Test that malformed JSON gracefully falls back to plaintext."""
         raw_output = """```json
         {
@@ -72,13 +82,13 @@ class TestOutputParser:
         assert isinstance(result, list)
         # May fall back to plaintext or return partial parsing
 
-    def test_feedback_section_has_required_fields(self):
+    def test_feedback_section_has_required_fields(self) -> None:
         """Test that FeedbackSection has all required fields."""
         section = FeedbackSection(
             section_name="skills",
             content="Python, JavaScript expertise",
             confidence=0.95,
-            suggestions=["Learn Rust", "Study DevOps"]
+            suggestions=["Learn Rust", "Study DevOps"],
         )
 
         assert section.section_name == "skills"
@@ -86,22 +96,18 @@ class TestOutputParser:
         assert section.confidence == 0.95
         assert len(section.suggestions) == 2
 
-    def test_json_with_multiple_sections(self):
+    def test_json_with_multiple_sections(self) -> None:
         """Test parsing JSON with multiple sections."""
-        raw_output = json.dumps({
-            "technical_skills": {
-                "languages": ["Python", "JavaScript"],
-                "suggestions": ["Add Rust", "Learn Kubernetes"]
-            },
-            "soft_skills": {
-                "communication": "Good",
-                "suggestions": ["Improve documentation"]
-            },
-            "projects": {
-                "quality": "High",
-                "suggestions": []
+        raw_output = json.dumps(
+            {
+                "technical_skills": {
+                    "languages": ["Python", "JavaScript"],
+                    "suggestions": ["Add Rust", "Learn Kubernetes"],
+                },
+                "soft_skills": {"communication": "Good", "suggestions": ["Improve documentation"]},
+                "projects": {"quality": "High", "suggestions": []},
             }
-        })
+        )
 
         result = parse_review_output(raw_output)
 
@@ -111,12 +117,11 @@ class TestOutputParser:
         assert "technical_skills" in section_names
         assert "soft_skills" in section_names
 
-    def test_confidence_scores_in_sections(self):
+    def test_confidence_scores_in_sections(self) -> None:
         """Test that feedback sections have confidence scores."""
-        raw_output = json.dumps({
-            "skills": "Expert Python developer",
-            "projects": "Impressive portfolio"
-        })
+        raw_output = json.dumps(
+            {"skills": "Expert Python developer", "projects": "Impressive portfolio"}
+        )
 
         result = parse_review_output(raw_output)
 
@@ -125,7 +130,7 @@ class TestOutputParser:
             assert isinstance(section.confidence, float)
             assert 0.0 <= section.confidence <= 1.0
 
-    def test_empty_json_object(self):
+    def test_empty_json_object(self) -> None:
         """Test parsing empty JSON object."""
         raw_output = "{}"
 
@@ -134,19 +139,16 @@ class TestOutputParser:
         # Should return empty list or handle gracefully
         assert isinstance(result, list)
 
-    def test_json_array_fallback(self):
+    def test_json_array_fallback(self) -> None:
         """Test handling of JSON array (not dict)."""
-        raw_output = json.dumps([
-            "First feedback item",
-            "Second feedback item"
-        ])
+        raw_output = json.dumps(["First feedback item", "Second feedback item"])
 
         result = parse_review_output(raw_output)
 
         # May fall back to plaintext or handle specially
         assert isinstance(result, list)
 
-    def test_very_long_plain_text(self):
+    def test_very_long_plain_text(self) -> None:
         """Test parsing very long plain text."""
         raw_output = "This is feedback. " * 500
 
@@ -156,7 +158,7 @@ class TestOutputParser:
         assert isinstance(result[0], FeedbackSection)
         assert len(result[0].content) > 1000
 
-    def test_html_in_feedback(self):
+    def test_html_in_feedback(self) -> None:
         """Test handling of HTML in feedback text."""
         raw_output = "<p>This is HTML feedback</p><p>With multiple tags</p>"
 
@@ -165,7 +167,7 @@ class TestOutputParser:
         assert isinstance(result, list)
         assert len(result) > 0
 
-    def test_code_in_feedback(self):
+    def test_code_in_feedback(self) -> None:
         """Test feedback containing code blocks."""
         raw_output = """
         ```python
@@ -180,14 +182,16 @@ class TestOutputParser:
         assert isinstance(result, list)
         # Should not crash on code blocks
 
-    def test_section_suggestions_extraction(self):
+    def test_section_suggestions_extraction(self) -> None:
         """Test that suggestions are extracted from JSON sections."""
-        raw_output = json.dumps({
-            "skills": {
-                "current": "Python, JavaScript",
-                "suggestions": ["Learn Go", "Master Kubernetes"]
+        raw_output = json.dumps(
+            {
+                "skills": {
+                    "current": "Python, JavaScript",
+                    "suggestions": ["Learn Go", "Master Kubernetes"],
+                }
             }
-        })
+        )
 
         result = parse_review_output(raw_output)
 
@@ -196,7 +200,7 @@ class TestOutputParser:
         if isinstance(section.suggestions, list) and section.suggestions:
             assert "Learn Go" in section.suggestions or len(section.suggestions) > 0
 
-    def test_unicode_characters(self):
+    def test_unicode_characters(self) -> None:
         """Test handling of unicode characters."""
         raw_output = "Portfolio review: Excellent work! 🎉 Skills: Python, JavaScript, Rust™"
 
@@ -205,24 +209,23 @@ class TestOutputParser:
         assert isinstance(result, list)
         assert len(result) > 0
 
-    def test_nested_json_structure(self):
+    def test_nested_json_structure(self) -> None:
         """Test parsing nested JSON structures."""
-        raw_output = json.dumps({
-            "feedback": {
-                "technical": {
-                    "skills": {
-                        "primary": ["Python", "JavaScript"],
-                        "secondary": ["Rust", "Go"]
+        raw_output = json.dumps(
+            {
+                "feedback": {
+                    "technical": {
+                        "skills": {"primary": ["Python", "JavaScript"], "secondary": ["Rust", "Go"]}
                     }
                 }
             }
-        })
+        )
 
         result = parse_review_output(raw_output)
 
         assert isinstance(result, list)
 
-    def test_mixed_content(self):
+    def test_mixed_content(self) -> None:
         """Test output with both code fence and plaintext."""
         raw_output = """
         Some intro text here.
@@ -242,7 +245,7 @@ class TestOutputParser:
         assert isinstance(result, list)
         assert len(result) > 0
 
-    def test_plaintext_output_helper(self):
+    def test_plaintext_output_helper(self) -> None:
         """Test _parse_plaintext_output helper function."""
         text = "This is plaintext feedback with useful information."
 
@@ -254,7 +257,7 @@ class TestOutputParser:
         assert section.content == text
         assert section.confidence == 0.7
 
-    def test_multiple_code_fences(self):
+    def test_multiple_code_fences(self) -> None:
         """Test handling of multiple code fences."""
         raw_output = """
         ```json
@@ -272,15 +275,93 @@ class TestOutputParser:
 
         assert isinstance(result, list)
 
-    def test_no_suggestions_key(self):
+    def test_no_suggestions_key(self) -> None:
         """Test JSON without suggestions key."""
-        raw_output = json.dumps({
-            "skills": "Python expert",
-            "experience": "5 years"
-        })
+        raw_output = json.dumps({"skills": "Python expert", "experience": "5 years"})
 
         result = parse_review_output(raw_output)
 
         assert isinstance(result, list)
         for section in result:
             assert isinstance(section.suggestions, list)
+
+
+@pytest.mark.unit
+class TestParseSectionOutput:
+    """Test suite for parse_section_output (added for issue #28)."""
+
+    def test_multi_key_json_is_preserved_in_one_section(self) -> None:
+        """A multi-key JSON payload stays together in a single section
+        named after the requested section, instead of being fanned out."""
+        raw_output = json.dumps(
+            {
+                "key_skills": [{"skill": "Python", "evidence": "x", "projects": ["p1"]}],
+                "language_proficiency": {"Python": "advanced"},
+                "framework_expertise": ["FastAPI"],
+            }
+        )
+
+        section = parse_section_output(raw_output, "skills_feedback")
+
+        assert isinstance(section, FeedbackSection)
+        assert section.section_name == "skills_feedback"
+        payload = json.loads(section.content)
+        assert set(payload.keys()) == {
+            "key_skills",
+            "language_proficiency",
+            "framework_expertise",
+        }
+
+    def test_single_matching_top_level_key_is_unwrapped(self) -> None:
+        """A redundant {"skills_feedback": {...}} wrapper is unwrapped."""
+        raw_output = json.dumps(
+            {"skills_feedback": {"key_skills": [], "suggestions": ["Add tests"]}}
+        )
+
+        section = parse_section_output(raw_output, "skills_feedback")
+
+        payload = json.loads(section.content)
+        assert "key_skills" in payload
+        assert "skills_feedback" not in payload
+        assert section.suggestions == ["Add tests"]
+
+    def test_json_in_code_fence(self) -> None:
+        """JSON wrapped in a code fence is extracted."""
+        raw_output = """```json
+{"key_skills": [], "suggestions": []}
+```"""
+
+        section = parse_section_output(raw_output, "skills_feedback")
+
+        assert json.loads(section.content) == {"key_skills": [], "suggestions": []}
+        assert section.confidence == 0.9
+
+    def test_plaintext_falls_back_to_raw_content(self) -> None:
+        """Non-JSON output falls back to raw text under the requested
+        section name instead of a generic 'general_feedback' label."""
+        raw_output = "Just plain text feedback, no JSON here."
+
+        section = parse_section_output(raw_output, "first_impression")
+
+        assert section.section_name == "first_impression"
+        assert section.content == raw_output
+        assert section.confidence == 0.7
+        assert section.suggestions == []
+
+    def test_json_array_falls_back_to_plaintext(self) -> None:
+        """A top-level JSON array (not an object) is treated as plaintext
+        rather than crashing."""
+        raw_output = json.dumps(["item one", "item two"])
+
+        section = parse_section_output(raw_output, "skills_feedback")
+
+        assert section.section_name == "skills_feedback"
+        assert section.content == raw_output
+
+    def test_non_list_suggestions_are_dropped(self) -> None:
+        """A non-list suggestions value is normalized to an empty list."""
+        raw_output = json.dumps({"key_skills": [], "suggestions": "not a list"})
+
+        section = parse_section_output(raw_output, "skills_feedback")
+
+        assert section.suggestions == []

--- a/tests/unit/test_prompt_templates.py
+++ b/tests/unit/test_prompt_templates.py
@@ -1,16 +1,21 @@
 """Tests for prompt_templates.py - Snapshot tests"""
 
-import pytest
 import hashlib
 
-from rag.generator.prompt_templates import PROMPT_TEMPLATES, get_template
+import pytest
+
+from rag.generator.prompt_templates import (
+    PROMPT_TEMPLATES,
+    get_current_version,
+    get_template,
+)
 
 
 @pytest.mark.unit
 class TestPromptTemplates:
     """Test suite for prompt templates."""
 
-    def test_all_5_templates_exist(self):
+    def test_all_5_templates_exist(self) -> None:
         """Test all 5 templates exist in PROMPT_TEMPLATES."""
         expected_templates = {
             "skills_feedback",
@@ -23,38 +28,40 @@ class TestPromptTemplates:
         actual_templates = set(PROMPT_TEMPLATES.keys())
         assert actual_templates == expected_templates
 
-    def test_skills_feedback_template_exists(self):
+    def test_skills_feedback_template_exists(self) -> None:
         """Test skills_feedback template exists."""
         assert "skills_feedback" in PROMPT_TEMPLATES
         assert "v1" in PROMPT_TEMPLATES["skills_feedback"]
 
-    def test_projects_feedback_template_exists(self):
+    def test_projects_feedback_template_exists(self) -> None:
         """Test projects_feedback template exists."""
         assert "projects_feedback" in PROMPT_TEMPLATES
         assert "v1" in PROMPT_TEMPLATES["projects_feedback"]
 
-    def test_presentation_feedback_template_exists(self):
+    def test_presentation_feedback_template_exists(self) -> None:
         """Test presentation_feedback template exists."""
         assert "presentation_feedback" in PROMPT_TEMPLATES
         assert "v1" in PROMPT_TEMPLATES["presentation_feedback"]
 
-    def test_gaps_feedback_template_exists(self):
+    def test_gaps_feedback_template_exists(self) -> None:
         """Test gaps_feedback template exists."""
         assert "gaps_feedback" in PROMPT_TEMPLATES
         assert "v1" in PROMPT_TEMPLATES["gaps_feedback"]
 
-    def test_first_impression_template_exists(self):
+    def test_first_impression_template_exists(self) -> None:
         """Test first_impression template exists."""
         assert "first_impression" in PROMPT_TEMPLATES
         assert "v1" in PROMPT_TEMPLATES["first_impression"]
 
-    def test_each_template_contains_context_placeholder(self):
+    def test_each_template_contains_context_placeholder(self) -> None:
         """Test each template contains {context} placeholder."""
         for template_name, versions in PROMPT_TEMPLATES.items():
             for version, template_text in versions.items():
-                assert "{context}" in template_text, f"{template_name} v{version} missing {{context}}"
+                assert (
+                    "{context}" in template_text
+                ), f"{template_name} v{version} missing {{context}}"
 
-    def test_each_template_contains_github_username_placeholder(self):
+    def test_each_template_contains_github_username_placeholder(self) -> None:
         """Test each template contains {github_username} placeholder."""
         for template_name, versions in PROMPT_TEMPLATES.items():
             for version, template_text in versions.items():
@@ -62,7 +69,7 @@ class TestPromptTemplates:
                     "{github_username}" in template_text
                 ), f"{template_name} v{version} missing {{github_username}}"
 
-    def test_each_template_contains_project_count_placeholder(self):
+    def test_each_template_contains_project_count_placeholder(self) -> None:
         """Test each template contains {project_count} placeholder."""
         for template_name, versions in PROMPT_TEMPLATES.items():
             for version, template_text in versions.items():
@@ -70,7 +77,7 @@ class TestPromptTemplates:
                     "{project_count}" in template_text
                 ), f"{template_name} v{version} missing {{project_count}}"
 
-    def test_get_template_returns_correct_template(self):
+    def test_get_template_returns_correct_template(self) -> None:
         """Test get_template() returns correct template."""
         template = get_template("skills_feedback", "v1")
 
@@ -78,101 +85,131 @@ class TestPromptTemplates:
         assert "{context}" in template
         assert "skills" in template.lower()
 
-    def test_get_template_projects_feedback(self):
+    def test_get_template_projects_feedback(self) -> None:
         """Test get_template for projects_feedback."""
         template = get_template("projects_feedback", "v1")
 
         assert isinstance(template, str)
         assert "project" in template.lower()
 
-    def test_get_template_presentation_feedback(self):
+    def test_get_template_presentation_feedback(self) -> None:
         """Test get_template for presentation_feedback."""
         template = get_template("presentation_feedback", "v1")
 
         assert isinstance(template, str)
         assert "presentation" in template.lower() or "readme" in template.lower()
 
-    def test_get_template_gaps_feedback(self):
+    def test_get_template_gaps_feedback(self) -> None:
         """Test get_template for gaps_feedback."""
         template = get_template("gaps_feedback", "v1")
 
         assert isinstance(template, str)
         assert "gap" in template.lower() or "skill" in template.lower()
 
-    def test_get_template_first_impression(self):
+    def test_get_template_first_impression(self) -> None:
         """Test get_template for first_impression."""
         template = get_template("first_impression", "v1")
 
         assert isinstance(template, str)
         assert "impression" in template.lower() or "summary" in template.lower()
 
-    def test_get_template_unknown_name_raises_error(self):
+    def test_get_template_unknown_name_raises_error(self) -> None:
         """Test get_template() raises KeyError/ValueError for unknown template."""
         with pytest.raises((KeyError, ValueError)):
             get_template("nonexistent_template")
 
-    def test_get_template_unknown_version_raises_error(self):
+    def test_get_template_unknown_version_raises_error(self) -> None:
         """Test get_template() raises KeyError/ValueError for unknown version."""
         with pytest.raises((KeyError, ValueError)):
             get_template("skills_feedback", "v999")
 
-    def test_all_templates_have_v1(self):
+    def test_all_templates_have_v1(self) -> None:
         """Test all templates have v1 version."""
-        for template_name in PROMPT_TEMPLATES.keys():
+        for template_name in PROMPT_TEMPLATES:
             assert "v1" in PROMPT_TEMPLATES[template_name]
 
-    def test_templates_are_strings(self):
+    def test_templates_are_strings(self) -> None:
         """Test all templates are strings."""
-        for template_name, versions in PROMPT_TEMPLATES.items():
-            for version, template_text in versions.items():
+        for versions in PROMPT_TEMPLATES.values():
+            for template_text in versions.values():
                 assert isinstance(template_text, str)
                 assert len(template_text) > 0
 
-    def test_templates_have_reasonable_length(self):
+    def test_templates_have_reasonable_length(self) -> None:
         """Test templates have reasonable length."""
         for template_name, versions in PROMPT_TEMPLATES.items():
             for version, template_text in versions.items():
                 # Templates should be at least 100 chars
                 assert len(template_text) > 100, f"{template_name} v{version} too short"
 
-    def test_skills_feedback_mentions_technical_skills(self):
+    def test_skills_feedback_mentions_technical_skills(self) -> None:
         """Test skills_feedback template mentions technical skills."""
         template = PROMPT_TEMPLATES["skills_feedback"]["v1"]
 
         assert "skill" in template.lower()
 
-    def test_projects_feedback_mentions_code_quality(self):
+    def test_projects_feedback_mentions_code_quality(self) -> None:
         """Test projects_feedback template mentions code quality."""
         template = PROMPT_TEMPLATES["projects_feedback"]["v1"]
 
         assert "project" in template.lower() or "quality" in template.lower()
 
-    def test_gaps_feedback_mentions_missing_skills(self):
+    def test_gaps_feedback_mentions_missing_skills(self) -> None:
         """Test gaps_feedback template mentions missing/gap concepts."""
         template = PROMPT_TEMPLATES["gaps_feedback"]["v1"]
 
-        assert "gap" in template.lower() or "missing" in template.lower() or "demand" in template.lower()
+        assert (
+            "gap" in template.lower()
+            or "missing" in template.lower()
+            or "demand" in template.lower()
+        )
 
-    def test_presentation_feedback_mentions_readme(self):
+    def test_presentation_feedback_mentions_readme(self) -> None:
         """Test presentation_feedback template mentions README or presentation."""
         template = PROMPT_TEMPLATES["presentation_feedback"]["v1"]
 
-        assert "readme" in template.lower() or "presentation" in template.lower() or "organization" in template.lower()
+        assert (
+            "readme" in template.lower()
+            or "presentation" in template.lower()
+            or "organization" in template.lower()
+        )
 
-    def test_first_impression_is_concise(self):
+    def test_first_impression_is_concise(self) -> None:
         """Test first_impression template instructs concise output."""
         template = PROMPT_TEMPLATES["first_impression"]["v1"]
 
-        assert "2" in template or "3" in template or "sentence" in template.lower() or "summary" in template.lower()
+        assert (
+            "2" in template
+            or "3" in template
+            or "sentence" in template.lower()
+            or "summary" in template.lower()
+        )
 
-    def test_get_template_default_version(self):
+    def test_skills_feedback_v2_exists_and_consolidates(self) -> None:
+        """Test skills_feedback v2 groups by project and instructs
+        consolidation (issue #28)."""
+        template = get_template("skills_feedback", "v2")
+
+        assert "{project_inventory}" in template
+        assert "=== Project:" in template
+        assert "projects" in template
+        assert "ONE" in template
+
+    def test_get_current_version_prefers_v2_for_skills(self) -> None:
+        """Test get_current_version returns v2 for skills_feedback and v1
+        for everything else."""
+        assert get_current_version("skills_feedback") == "v2"
+        assert get_current_version("projects_feedback") == "v1"
+        assert get_current_version("unknown_template") == "v1"
+
+    def test_get_template_default_version(self) -> None:
         """Test get_template() defaults to v1 when version not specified."""
         template_default = get_template("skills_feedback")
         template_v1 = get_template("skills_feedback", "v1")
 
         assert template_default == template_v1
 
-    def test_template_snapshot_content_hash(self):
+    def test_template_snapshot_content_hash(self) -> None:
         """Snapshot test: verify template content hash."""
         # Create hash of all template content
         template_content = ""
@@ -187,73 +224,78 @@ class TestPromptTemplates:
         assert isinstance(content_hash, str)
         assert len(content_hash) == 32  # MD5 hash length
 
-    def test_skills_feedback_requests_json_format(self):
+    def test_skills_feedback_requests_json_format(self) -> None:
         """Test skills_feedback requests JSON output."""
         template = PROMPT_TEMPLATES["skills_feedback"]["v1"]
 
         assert "json" in template.lower()
 
-    def test_projects_feedback_requests_json_format(self):
+    def test_projects_feedback_requests_json_format(self) -> None:
         """Test projects_feedback requests JSON output."""
         template = PROMPT_TEMPLATES["projects_feedback"]["v1"]
 
         assert "json" in template.lower()
 
-    def test_presentation_feedback_requests_json_format(self):
+    def test_presentation_feedback_requests_json_format(self) -> None:
         """Test presentation_feedback requests JSON output."""
         template = PROMPT_TEMPLATES["presentation_feedback"]["v1"]
 
         assert "json" in template.lower()
 
-    def test_gaps_feedback_requests_json_format(self):
+    def test_gaps_feedback_requests_json_format(self) -> None:
         """Test gaps_feedback requests JSON output."""
         template = PROMPT_TEMPLATES["gaps_feedback"]["v1"]
 
         assert "json" in template.lower()
 
-    def test_first_impression_plain_text(self):
+    def test_first_impression_plain_text(self) -> None:
         """Test first_impression may request plain text."""
         template = PROMPT_TEMPLATES["first_impression"]["v1"]
 
         # Should specify format (JSON or plain text)
-        assert "json" in template.lower() or "text" in template.lower() or "summary" in template.lower()
+        assert (
+            "json" in template.lower()
+            or "text" in template.lower()
+            or "summary" in template.lower()
+        )
 
-    def test_templates_have_portfolio_context(self):
+    def test_templates_have_portfolio_context(self) -> None:
         """Test templates mention portfolio or context."""
-        for name in PROMPT_TEMPLATES.keys():
+        for name in PROMPT_TEMPLATES:
             template = PROMPT_TEMPLATES[name]["v1"]
             # All should have context mention or portfolio mention
             assert "{context}" in template or "portfolio" in template.lower()
 
-    def test_template_get_logs_retrieval(self):
+    def test_template_get_logs_retrieval(self) -> None:
         """Test that get_template logs retrieval."""
-        # Import logger to verify it's used
-        with pytest.MonkeyPatch.context() as mp:
-            from unittest.mock import patch
-            with patch('rag.generator.prompt_templates.logger') as mock_logger:
-                get_template("skills_feedback")
-                # Should log template retrieval
+        from unittest.mock import patch
 
-    def test_each_template_name_is_valid_identifier(self):
+        with patch("rag.generator.prompt_templates.logger") as mock_logger:
+            get_template("skills_feedback")
+
+        # Should log template retrieval
+        assert mock_logger.info.called
+
+    def test_each_template_name_is_valid_identifier(self) -> None:
         """Test template names are valid Python identifiers."""
-        for name in PROMPT_TEMPLATES.keys():
+        for name in PROMPT_TEMPLATES:
             assert name.isidentifier()
             assert "_" in name  # Should use snake_case
 
-    def test_template_versions_are_strings(self):
+    def test_template_versions_are_strings(self) -> None:
         """Test template version keys are strings."""
-        for template_name, versions in PROMPT_TEMPLATES.items():
+        for versions in PROMPT_TEMPLATES.values():
             assert isinstance(versions, dict)
-            for version_key in versions.keys():
+            for version_key in versions:
                 assert isinstance(version_key, str)
                 assert version_key.startswith("v")
 
-    def test_no_hardcoded_usernames_in_templates(self):
+    def test_no_hardcoded_usernames_in_templates(self) -> None:
         """Test templates don't contain hardcoded test usernames."""
         forbidden = ["john", "jane", "test", "demo"]
 
-        for name, versions in PROMPT_TEMPLATES.items():
-            for version, template_text in versions.items():
+        for versions in PROMPT_TEMPLATES.values():
+            for template_text in versions.values():
                 for forbidden_word in forbidden:
                     # Should use {github_username} placeholder instead
                     assert not (
@@ -261,13 +303,14 @@ class TestPromptTemplates:
                         and "{github_username}" not in template_text
                     )
 
-    def test_templates_use_consistent_placeholders(self):
+    def test_templates_use_consistent_placeholders(self) -> None:
         """Test all templates use consistent placeholder syntax."""
-        for name, versions in PROMPT_TEMPLATES.items():
-            for version, template_text in versions.items():
+        for versions in PROMPT_TEMPLATES.values():
+            for template_text in versions.values():
                 # All placeholders should use {name} syntax
                 import re
-                placeholders = re.findall(r'\{(\w+)\}', template_text)
+
+                placeholders = re.findall(r"\{(\w+)\}", template_text)
                 assert "context" in placeholders
                 assert "github_username" in placeholders
                 assert "project_count" in placeholders

--- a/tests/unit/test_review_generator.py
+++ b/tests/unit/test_review_generator.py
@@ -1,0 +1,160 @@
+"""Tests for review_generator.py
+
+Reproduction for issue #28: the generator produces duplicate feedback
+sections when a user has multiple projects in the same tech stack.
+
+The two xfail tests below encode the *expected* behavior — consolidating a
+shared observation into one entry attributed to all projects it applies to.
+They fail today because `_consolidate_feedback` only deduplicates by
+`section_name` (which is already unique per section), so near-identical
+cross-project observations pass through untouched. They are marked
+`xfail(strict=True)` so they document the bug now and will flip to a hard
+failure (XPASS) once the fix lands, forcing the markers to be removed.
+"""
+
+import json
+from unittest.mock import Mock
+
+import pytest
+
+from rag.generator.output_parser import FeedbackSection
+from rag.generator.review_generator import ReviewConfig, ReviewGenerator
+
+XFAIL_REASON = (
+    "Issue #28: _consolidate_feedback deduplicates by section_name only, "
+    "so duplicate cross-project observations are never merged"
+)
+
+
+def _mock_completion(content: str) -> Mock:
+    """Build a mock chat completion response with the given content."""
+    choice = Mock()
+    choice.message.content = content
+    completion = Mock()
+    completion.choices = [choice]
+    return completion
+
+
+def _make_generator(responses: list[str]) -> ReviewGenerator:
+    """Create a ReviewGenerator whose LLM client returns canned responses."""
+    config = ReviewConfig(
+        api_key="test-key",
+        base_url="http://localhost:9999/v1",
+        model="test-model",
+    )
+    generator = ReviewGenerator(config)
+    generator.client = Mock()
+    generator.client.chat.completions.create.side_effect = [_mock_completion(r) for r in responses]
+    return generator
+
+
+@pytest.mark.unit
+class TestConsolidateFeedback:
+    """Reproduction tests for issue #28 (duplicate cross-project feedback)."""
+
+    @pytest.mark.xfail(reason=XFAIL_REASON, strict=True)
+    def test_consolidate_merges_same_observation_across_projects(self) -> None:
+        """A skill observation repeated for three same-stack projects should
+        be consolidated into a single entry attributed to all three."""
+        observation = "Built a RAG pipeline with embeddings and vector search"
+        skills_content = json.dumps(
+            {
+                "key_skills": [
+                    {
+                        "skill": "Python / RAG",
+                        "evidence": f"{observation} in rag-chatbot-alpha",
+                        "project": "rag-chatbot-alpha",
+                    },
+                    {
+                        "skill": "Python / RAG",
+                        "evidence": f"{observation} in rag-chatbot-beta",
+                        "project": "rag-chatbot-beta",
+                    },
+                    {
+                        "skill": "Python / RAG",
+                        "evidence": f"{observation} in rag-chatbot-gamma",
+                        "project": "rag-chatbot-gamma",
+                    },
+                ]
+            }
+        )
+        sections = [
+            FeedbackSection(
+                section_name="skills_feedback",
+                content=skills_content,
+                confidence=0.9,
+                suggestions=[],
+            )
+        ]
+
+        result = ReviewGenerator._consolidate_feedback(sections)
+
+        # The shared skill should be stated once, not once per project.
+        combined = " ".join(s.content for s in result)
+        assert combined.count("Python / RAG") == 1
+
+    @pytest.mark.xfail(reason=XFAIL_REASON, strict=True)
+    def test_full_review_does_not_repeat_feedback_per_same_stack_project(self) -> None:
+        """generate_full_review should not repeat a near-identical observation
+        once per project when the projects share a tech stack."""
+        repeated_phrase = "solid Python and vector-database skills"
+        skills_response = json.dumps(
+            {
+                "skills_feedback": {
+                    "observations": [
+                        f"Demonstrates {repeated_phrase} in rag-chatbot-alpha.",
+                        f"Demonstrates {repeated_phrase} in rag-chatbot-beta.",
+                        f"Demonstrates {repeated_phrase} in rag-chatbot-gamma.",
+                    ],
+                    "suggestions": ["Add integration tests"],
+                }
+            }
+        )
+        other_response = json.dumps(
+            {"feedback": {"observations": ["Looks fine."], "suggestions": []}}
+        )
+        # generate_full_review generates 5 sections; skills_feedback is first.
+        generator = _make_generator([skills_response] + [other_response] * 4)
+
+        profile_data = {
+            "github_username": "janedoe",
+            "projects": [
+                {"github_repo": "rag-chatbot-alpha"},
+                {"github_repo": "rag-chatbot-beta"},
+                {"github_repo": "rag-chatbot-gamma"},
+            ],
+        }
+        chunks = [
+            {
+                "text": f"README for {repo}: a Python RAG chatbot using embeddings.",
+                "score": 0.9,
+                "metadata": {"source_id": repo, "chunk_index": 0, "section": "readme"},
+            }
+            for repo in ["rag-chatbot-alpha", "rag-chatbot-beta", "rag-chatbot-gamma"]
+        ]
+
+        sections = generator.generate_full_review(profile_data, chunks)
+
+        # The shared observation should survive as ONE consolidated statement
+        # attributed to all three projects — not repeated three times.
+        combined = " ".join(s.content for s in sections)
+        assert combined.count(repeated_phrase) == 1
+
+
+@pytest.mark.unit
+class TestConsolidateFeedbackCurrentBehavior:
+    """Characterization of what _consolidate_feedback does today: it only
+    deduplicates by section_name, which generate_full_review already
+    guarantees to be unique — so it never changes its input."""
+
+    def test_sections_with_unique_names_pass_through_unchanged(self) -> None:
+        """With unique section names (the only real-world input), the
+        'consolidation' returns its input untouched."""
+        sections = [
+            FeedbackSection("skills_feedback", "duplicate text A", 0.9, []),
+            FeedbackSection("projects_feedback", "duplicate text A", 0.9, []),
+        ]
+
+        result = ReviewGenerator._consolidate_feedback(sections)
+
+        assert result == sections

--- a/tests/unit/test_review_generator.py
+++ b/tests/unit/test_review_generator.py
@@ -1,15 +1,10 @@
 """Tests for review_generator.py
 
-Reproduction for issue #28: the generator produces duplicate feedback
-sections when a user has multiple projects in the same tech stack.
-
-The two xfail tests below encode the *expected* behavior — consolidating a
-shared observation into one entry attributed to all projects it applies to.
-They fail today because `_consolidate_feedback` only deduplicates by
-`section_name` (which is already unique per section), so near-identical
-cross-project observations pass through untouched. They are marked
-`xfail(strict=True)` so they document the bug now and will flip to a hard
-failure (XPASS) once the fix lands, forcing the markers to be removed.
+Covers the fix for issue #28: the generator produced duplicate feedback
+when a user has multiple projects in the same tech stack. The tests in
+TestConsolidateFeedback started life as the xfail reproduction for the bug
+and now assert the fixed behavior: a shared observation is stated once and
+attributed to every project it applies to.
 """
 
 import json
@@ -19,11 +14,6 @@ import pytest
 
 from rag.generator.output_parser import FeedbackSection
 from rag.generator.review_generator import ReviewConfig, ReviewGenerator
-
-XFAIL_REASON = (
-    "Issue #28: _consolidate_feedback deduplicates by section_name only, "
-    "so duplicate cross-project observations are never merged"
-)
 
 
 def _mock_completion(content: str) -> Mock:
@@ -48,18 +38,27 @@ def _make_generator(responses: list[str]) -> ReviewGenerator:
     return generator
 
 
+def _skills_section(key_skills: list) -> FeedbackSection:
+    """Build a skills_feedback section holding the given key_skills."""
+    return FeedbackSection(
+        section_name="skills_feedback",
+        content=json.dumps({"key_skills": key_skills}),
+        confidence=0.9,
+        suggestions=[],
+    )
+
+
 @pytest.mark.unit
 class TestConsolidateFeedback:
-    """Reproduction tests for issue #28 (duplicate cross-project feedback)."""
+    """Consolidation of duplicate cross-project observations (issue #28)."""
 
-    @pytest.mark.xfail(reason=XFAIL_REASON, strict=True)
     def test_consolidate_merges_same_observation_across_projects(self) -> None:
-        """A skill observation repeated for three same-stack projects should
-        be consolidated into a single entry attributed to all three."""
+        """A skill observation repeated for three same-stack projects is
+        consolidated into a single entry attributed to all three."""
         observation = "Built a RAG pipeline with embeddings and vector search"
-        skills_content = json.dumps(
-            {
-                "key_skills": [
+        sections = [
+            _skills_section(
+                [
                     {
                         "skill": "Python / RAG",
                         "evidence": f"{observation} in rag-chatbot-alpha",
@@ -76,14 +75,6 @@ class TestConsolidateFeedback:
                         "project": "rag-chatbot-gamma",
                     },
                 ]
-            }
-        )
-        sections = [
-            FeedbackSection(
-                section_name="skills_feedback",
-                content=skills_content,
-                confidence=0.9,
-                suggestions=[],
             )
         ]
 
@@ -93,21 +84,34 @@ class TestConsolidateFeedback:
         combined = " ".join(s.content for s in result)
         assert combined.count("Python / RAG") == 1
 
-    @pytest.mark.xfail(reason=XFAIL_REASON, strict=True)
+        # ...and attributed to every project that demonstrated it.
+        merged = json.loads(result[0].content)["key_skills"]
+        assert len(merged) == 1
+        assert merged[0]["projects"] == [
+            "rag-chatbot-alpha",
+            "rag-chatbot-beta",
+            "rag-chatbot-gamma",
+        ]
+
     def test_full_review_does_not_repeat_feedback_per_same_stack_project(self) -> None:
-        """generate_full_review should not repeat a near-identical observation
-        once per project when the projects share a tech stack."""
+        """generate_full_review consolidates near-identical entries even when
+        the model ignores the prompt and emits one entry per project."""
         repeated_phrase = "solid Python and vector-database skills"
         skills_response = json.dumps(
             {
-                "skills_feedback": {
-                    "observations": [
-                        f"Demonstrates {repeated_phrase} in rag-chatbot-alpha.",
-                        f"Demonstrates {repeated_phrase} in rag-chatbot-beta.",
-                        f"Demonstrates {repeated_phrase} in rag-chatbot-gamma.",
-                    ],
-                    "suggestions": ["Add integration tests"],
-                }
+                "key_skills": [
+                    {
+                        "skill": "Python / vector databases",
+                        "evidence": f"Demonstrates {repeated_phrase} in {repo}.",
+                        "projects": [repo],
+                    }
+                    for repo in [
+                        "rag-chatbot-alpha",
+                        "rag-chatbot-beta",
+                        "rag-chatbot-gamma",
+                    ]
+                ],
+                "language_proficiency": {"Python": "advanced"},
             }
         )
         other_response = json.dumps(
@@ -135,26 +139,177 @@ class TestConsolidateFeedback:
 
         sections = generator.generate_full_review(profile_data, chunks)
 
-        # The shared observation should survive as ONE consolidated statement
+        # The shared observation survives as ONE consolidated statement
         # attributed to all three projects — not repeated three times.
         combined = " ".join(s.content for s in sections)
         assert combined.count(repeated_phrase) == 1
+        payload = json.loads(sections[0].content.split("\nSources:")[0])
+        assert [e["projects"] for e in payload["key_skills"]] == [
+            ["rag-chatbot-alpha", "rag-chatbot-beta", "rag-chatbot-gamma"]
+        ]
 
-
-@pytest.mark.unit
-class TestConsolidateFeedbackCurrentBehavior:
-    """Characterization of what _consolidate_feedback does today: it only
-    deduplicates by section_name, which generate_full_review already
-    guarantees to be unique — so it never changes its input."""
-
-    def test_sections_with_unique_names_pass_through_unchanged(self) -> None:
-        """With unique section names (the only real-world input), the
-        'consolidation' returns its input untouched."""
+    def test_case_and_whitespace_variants_of_a_skill_merge(self) -> None:
+        """'python' and ' Python ' are the same skill; 'Django' is not."""
         sections = [
-            FeedbackSection("skills_feedback", "duplicate text A", 0.9, []),
-            FeedbackSection("projects_feedback", "duplicate text A", 0.9, []),
+            _skills_section(
+                [
+                    {"skill": "python", "evidence": "a", "projects": ["p1"]},
+                    {"skill": " Python ", "evidence": "b", "projects": ["p2"]},
+                    {"skill": "Django", "evidence": "c", "projects": ["p1"]},
+                ]
+            )
+        ]
+
+        result = ReviewGenerator._consolidate_feedback(sections)
+
+        merged = json.loads(result[0].content)["key_skills"]
+        assert len(merged) == 2
+        assert merged[0]["skill"] == "python"  # first-seen form is kept
+        assert merged[0]["projects"] == ["p1", "p2"]
+        assert merged[1]["skill"] == "Django"
+
+    def test_different_observations_for_same_stack_are_not_merged(self) -> None:
+        """Three same-stack projects with genuinely different observations
+        keep all three entries — merging keys on the skill, not the stack."""
+        sections = [
+            _skills_section(
+                [
+                    {"skill": "API design", "evidence": "a", "projects": ["p1"]},
+                    {"skill": "Testing", "evidence": "b", "projects": ["p2"]},
+                    {"skill": "Deployment", "evidence": "c", "projects": ["p3"]},
+                ]
+            )
+        ]
+
+        result = ReviewGenerator._consolidate_feedback(sections)
+
+        merged = json.loads(result[0].content)["key_skills"]
+        assert len(merged) == 3
+
+    def test_single_project_entry_without_project_info_is_untouched(self) -> None:
+        """A lone entry with no project attribution gains no 'projects' noise
+        — single-project reviews round-trip unchanged."""
+        section = _skills_section([{"skill": "Python", "evidence": "Built one solid project"}])
+
+        result = ReviewGenerator._consolidate_feedback([section])
+
+        assert result[0] == section
+
+    def test_non_json_content_passes_through_unchanged(self) -> None:
+        """Sections whose content is not JSON (the plaintext fallback path)
+        pass through consolidation untouched."""
+        sections = [
+            FeedbackSection("skills_feedback", "plain text feedback", 0.7, []),
+            FeedbackSection("projects_feedback", "plain text feedback", 0.7, []),
         ]
 
         result = ReviewGenerator._consolidate_feedback(sections)
 
         assert result == sections
+
+    def test_entries_without_skill_name_are_preserved(self) -> None:
+        """Malformed entries (no skill name, or not a dict) are kept as-is
+        rather than dropped or crashed on."""
+        sections = [
+            _skills_section(
+                [
+                    {"skill": "Python", "evidence": "a", "projects": ["p1"]},
+                    {"skill": "Python", "evidence": "b", "projects": ["p2"]},
+                    {"evidence": "no skill name"},
+                    "just a string",
+                ]
+            )
+        ]
+
+        result = ReviewGenerator._consolidate_feedback(sections)
+
+        merged = json.loads(result[0].content)["key_skills"]
+        assert len(merged) == 3
+        assert {"evidence": "no skill name"} in merged
+        assert "just a string" in merged
+
+
+@pytest.mark.unit
+class TestProjectAwareContext:
+    """Project grouping in _format_context and _project_inventory."""
+
+    def _chunk(self, source_id: str | None, text: str = "chunk text", score: float = 0.5) -> dict:
+        metadata = {"chunk_index": 0, "section": "readme"}
+        if source_id is not None:
+            metadata["source_id"] = source_id
+        return {"text": text, "score": score, "metadata": metadata}
+
+    def test_format_context_groups_chunks_by_project(self) -> None:
+        """Interleaved chunks from two projects are grouped under one header
+        per project."""
+        chunks = [
+            self._chunk("proj-a", "a1"),
+            self._chunk("proj-b", "b1"),
+            self._chunk("proj-a", "a2"),
+        ]
+
+        context = ReviewGenerator._format_context(chunks)
+
+        assert context.count("=== Project: proj-a ===") == 1
+        assert context.count("=== Project: proj-b ===") == 1
+        # proj-a's chunks appear together, before proj-b's header
+        assert context.index("a1") < context.index("a2") < context.index("b1")
+
+    def test_format_context_limits_to_ten_chunks(self) -> None:
+        """The 10-chunk context limit is preserved."""
+        chunks = [self._chunk("proj-a", f"text-{i}") for i in range(15)]
+
+        context = ReviewGenerator._format_context(chunks)
+
+        assert "text-9" in context
+        assert "text-10" not in context
+
+    def test_project_inventory_lists_distinct_projects_in_order(self) -> None:
+        chunks = [
+            self._chunk("proj-a"),
+            self._chunk("proj-b"),
+            self._chunk("proj-a"),
+        ]
+
+        assert ReviewGenerator._project_inventory(chunks) == ["proj-a", "proj-b"]
+
+    def test_project_inventory_skips_chunks_without_source_id(self) -> None:
+        """Chunks missing source_id don't become a phantom 'unknown' project."""
+        chunks = [self._chunk("proj-a"), self._chunk(None)]
+
+        assert ReviewGenerator._project_inventory(chunks) == ["proj-a"]
+
+    def test_generate_section_passes_project_inventory_to_prompt(self) -> None:
+        """The skills prompt receives the project inventory and grouped
+        context."""
+        generator = _make_generator([json.dumps({"key_skills": []})])
+        chunks = [self._chunk("proj-a"), self._chunk("proj-b")]
+
+        generator.generate_section("skills_feedback", chunks, {"projects": []})
+
+        prompt = generator.client.chat.completions.create.call_args.kwargs["messages"][1]["content"]
+        assert "- proj-a" in prompt
+        assert "- proj-b" in prompt
+        assert "=== Project: proj-a ===" in prompt
+
+    def test_citations_are_added_after_consolidation(self) -> None:
+        """Sections still get source citations, appended after consolidation
+        so consolidation sees parseable JSON."""
+        skills_response = json.dumps(
+            {
+                "key_skills": [
+                    {"skill": "Python", "evidence": "a", "projects": ["proj-a"]},
+                    {"skill": "Python", "evidence": "b", "projects": ["proj-b"]},
+                ]
+            }
+        )
+        generator = _make_generator([skills_response] * 5)
+        chunks = [self._chunk("proj-a"), self._chunk("proj-b")]
+
+        sections = generator.generate_full_review({"projects": []}, chunks)
+
+        skills = sections[0]
+        assert "Sources: proj-a, proj-b" in skills.content
+        # Consolidation worked despite the citation suffix
+        payload = json.loads(skills.content.split("\nSources:")[0])
+        assert len(payload["key_skills"]) == 1


### PR DESCRIPTION
## Summary
When a user has multiple projects in the same tech stack (e.g. three Python RAG projects), the review generator repeated a near-identical skills observation once per project, so reviews read as repetitive and padded. This PR makes the generator consolidate cross-project observations: a shared skill is stated once and attributed to every project that demonstrates it. The fix works in two layers â€” the prompt now shows the model explicit project boundaries and instructs consolidation (prevention), and `_consolidate_feedback` genuinely merges duplicate entries as a deterministic backstop (cure).

## Issue
Closes #28

## Changes
- **`rag/generator/review_generator.py`**
  - `_format_context` groups retrieved chunks under `=== Project: <id> ===` headers instead of one flat blob; new `_project_inventory` helper lists the distinct projects for the prompt.
  - `_consolidate_feedback` â€” previously a no-op that deduplicated by `section_name`, which `generate_full_review` already guarantees is unique â€” now merges `key_skills` entries whose normalized skill names match (casefold + whitespace collapse) and unions their `projects` lists. Sections without structured skill data (plaintext fallback, other section templates) pass through unchanged.
  - Source citations are appended **after** consolidation, so section content is still parseable JSON when consolidation runs.
- **`rag/generator/prompt_templates.py`** â€” new `v2` `skills_feedback` template (v1 untouched, using the existing versioning scheme) that presents the project inventory, and instructs: when a skill applies to multiple projects, emit ONE `key_skills` entry with all of them in its `projects` field. `get_current_version` selects v2 for skills only; all other sections stay on v1.
- **`rag/generator/output_parser.py`** â€” new `parse_section_output` preserves the full structured payload under the requested section name. The old path (`parse_review_output` fan-out + callers keeping `sections[0]`) dropped everything after the first top-level JSON key, which left consolidation nothing to operate on. `parse_review_output` itself is unchanged for backwards compatibility.
- **Tests** â€” the issue #28 reproduction tests (added in the Week 8 reproduction commit as `xfail(strict=True)`) flip to passing with markers removed; new coverage for project grouping, merge normalization, "different observations are not merged", single-project no-op, and plaintext fallback (`tests/unit/test_review_generator.py`, `tests/unit/test_output_parser.py`, `tests/unit/test_prompt_templates.py`).

## Testing
- [x] Unit tests pass (`make test-unit`) â€” see pre-existing failures note below
- [ ] Integration tests pass (`make test-integration`) â€” not run; requires Docker services
- [x] Linter passes (`make lint`) â€” on all touched files, see note below
- [x] Type checker passes (`make typecheck`) â€” on all touched files, see note below
- [x] New/updated tests cover the changes

**Pre-existing failures (documented per course guidance):** 53 unit tests fail on this branch *before* these changes (e.g. `test_review_service.py` async-mock errors, `test_bias_detector.py`, `test_pii_scrubber.py` â€” they correspond to other tracked issues in the repo). I captured the failure list before starting and verified it is **byte-identical** after my changes: no new failures; passing tests went from 376 to 396. Likewise `make lint`/`make typecheck` report pre-existing errors repo-wide; every file touched by this PR passes ruff, black, and mypy via the repo's pre-commit hooks, which also required adding type annotations and lint fixes to the two legacy test files this PR extends.

### How to verify (no API key needed)
1. `pytest tests/unit/test_review_generator.py -v` — the two `TestConsolidateFeedback` tests (formerly the Week 8 xfail reproduction) assert that a skill repeated across three same-stack projects collapses to ONE entry attributed to all three.
2. Reproduce the merge directly in a REPL:
```python
import json
from rag.generator.output_parser import FeedbackSection
from rag.generator.review_generator import ReviewGenerator

dup = [{"skill": "Python / RAG", "evidence": "Built a RAG pipeline", "project": p}
       for p in ("proj-a", "proj-b", "proj-c")]
section = FeedbackSection("skills_feedback", json.dumps({"key_skills": dup}), 0.9, [])
print(ReviewGenerator._consolidate_feedback([section])[0].content)
# -> one "Python / RAG" entry with "projects": ["proj-a", "proj-b", "proj-c"]
```
3. Inspect the prompt-side change: `python -c "from rag.generator.prompt_templates import get_template; print(get_template('skills_feedback', 'v2'))"` — note the project inventory block, the `=== Project: <id> ===` grouping contract, and the consolidate-across-projects instruction.
4. Regression check: `make test-unit` — same 53 pre-existing failures as before this PR (documented below), 396 passing.

## Screenshots / Demo
N/A â€” the behavior change is demonstrated deterministically by unit tests (`pytest tests/unit/test_review_generator.py -v`): the former reproduction tests assert that a skill observation repeated across three same-stack projects is emitted once with all three projects attributed.

## Notes for Reviewers
- The merge keys on **normalized exact skill-name match**. Lexical/embedding near-duplicate clustering (an embeddings provider exists in `ingestion/embeddings/provider.py`) was considered and deferred until there's evidence the v2 prompt still lets paraphrased duplicates through â€” see PLAN.md in the fork for the full decision trail.
- On merge, the first entry's `evidence` is kept and project attributions are unioned in first-seen order; legacy singular `"project"` keys are accepted and normalized to `"projects"`.
- Known limitation, out of scope here: the agent orchestrator only ingests the first repo (`break` in `agent/orchestrator.py` `_build_plan`), which limits live multi-project runs end-to-end; the generator fix is fully exercised via the retrieval layer regardless.
