### PR TITLE
fix(safety): redact parenthesized US phone numbers in PII scrubber

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -18,7 +18,7 @@ tests for these formats.
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** 1a15bd013ee862097b11fddbdc83fc1e54e0f99a
+**Reproduction commit link:** https://github.com/pablomoreno10/pathreview/commit/1a15bd013ee862097b11fddbdc83fc1e54e0f99a
 
 **Reproduction summary:**
 Reproduced by importing `PIIScrubber` directly and calling `scrub()`/`detect()` on
@@ -27,10 +27,42 @@ an empty list, while an unparenthesized equivalent (`555-123-4567`) was correctl
 Running `pytest tests/unit/test_pii_scrubber.py -v` confirmed 5 existing tests fail against
 this behavior.
 
-**PLAN.md link:** 
+**PLAN.md link:** https://github.com/pablomoreno10/pathreview/blob/fix/146-pii-parenthesized-phone-numbers/PLAN.md
 
 **Blockers or open questions:**
 While reproducing, also found that `test_mixed_pii_and_text` fails for an unrelated reason: the
 `street_address` pattern's `Pl` abbreviation matches the tail of ordinary words like
 "applications" (case-insensitive), corrupting unrelated text. Not in scope for #146, but flagging
 in case it should be filed as a separate issue before Week 9.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Fixed the `phone_us` regex in `safety/pii_scrubber.py` to accept a space as a separator (not just `-`/`.`), plus a related word-boundary fix so parenthesized numbers don't leave a stray `(` behind. Added 2 regression tests. All phone-related test failures from PLAN.md are resolved.
+
+**Next steps:**
+Commit, push, and open the PR.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [link to your submitted pull request]
+
+**Branch:** `fix/146-pii-parenthesized-phone-numbers`
+
+**What you built:**
+Fixed the `phone_us` regex so it correctly redacts parenthesized US phone numbers (e.g. `(555) 123-4567`), which previously passed through unredacted because the separator after the closing parenthesis only allowed `-`/`.`, never a space.
+
+**Tests added or updated:**
+`tests/unit/test_pii_scrubber.py` —> added `test_phone_no_false_positive_on_parenthetical_text` and `test_us_phone_no_stray_parenthesis_after_scrub`; 4 previously-failing tests now pass with no other changes needed.
+
+**Self-review confirmation:**
+
+[X] make check passes (for touched files — repo-wide `make check`/`make test-unit` still show pre-existing, unrelated failures in other files, confirmed identical on `main`)  
+
+[X] make test-unit passes
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -18,7 +18,7 @@ tests for these formats.
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:**
+**Reproduction commit link:** 1a15bd013ee862097b11fddbdc83fc1e54e0f99a
 
 **Reproduction summary:**
 Reproduced by importing `PIIScrubber` directly and calling `scrub()`/`detect()` on

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -49,7 +49,7 @@ Commit, push, and open the PR.
 
 ### Check-in 2 (end of week)
 
-**PR link:** [link to your submitted pull request]
+**PR link:** https://github.com/ascherj/pathreview/pull/575
 
 **Branch:** `fix/146-pii-parenthesized-phone-numbers`
 
@@ -65,4 +65,4 @@ Fixed the `phone_us` regex so it correctly redacts parenthesized US phone number
 
 [X] make test-unit passes
 
-**Draft PR feedback received from:** none
+**Draft PR feedback received from:** none   

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,36 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/146
+
+**Issue title:** PII scrubber fails to redact parenthesized US phone numbers #146
+
+**Tier:** [X] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The PII scrubber in the safety layer (`safety/pii_scrubber.py`) is responsible for redacting personal contact info — like phone numbers — from text before it flows through the review pipeline. Its `phone_us` regex only accepts a hyphen or period as the separator after an optional closing parenthesis, so it silently fails to match common formats like `(555) 123-4567` or `+1 555 123 4567` where a space follows the area code. As a result, real phone numbers in those formats pass through unredacted instead of being replaced with `[REDACTED]`, which is a privacy leak in an app that processes resumes and profile text. A successful fix updates the regex to accept flexible spacing after the parenthesized area code without introducing false positives on unrelated parenthesized text, backed by new regression
+tests for these formats.
+
+**Branch name:** fix/146-pii-parenthesized-phone-numbers
+
+**Setup confirmation:** [X] App runs locally at localhost:5173
+
+**Cohort ledger:** [X] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:**
+
+**Reproduction summary:**
+Reproduced by importing `PIIScrubber` directly and calling `scrub()`/`detect()` on
+`"(555) 123-4567"`: the parenthesized number passed through untouched and `detect()` returned
+an empty list, while an unparenthesized equivalent (`555-123-4567`) was correctly redacted.
+Running `pytest tests/unit/test_pii_scrubber.py -v` confirmed 5 existing tests fail against
+this behavior.
+
+**PLAN.md link:** 
+
+**Blockers or open questions:**
+While reproducing, also found that `test_mixed_pii_and_text` fails for an unrelated reason: the
+`street_address` pattern's `Pl` abbreviation matches the tail of ordinary words like
+"applications" (case-insensitive), corrupting unrelated text. Not in scope for #146, but flagging
+in case it should be filed as a separate issue before Week 9.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -65,4 +65,34 @@ Fixed the `phone_us` regex so it correctly redacts parenthesized US phone number
 
 [X] make test-unit passes
 
-**Draft PR feedback received from:** none   
+**Draft PR feedback received from:** none 
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [X] No — still awaiting review
+
+**Summary of feedback:**
+No review yet.
+
+**How you responded:**
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Navigating all the initial requirements—such as branching and commit naming conventions—alongside exploring the project structure. Overall, the sheer effort required to adapt to an unfamiliar codebase and align with established community standards was greater than I anticipated.
+
+**What did you learn about working in a large codebase?**
+I learned that strict rules and standards are essential for maintaining code quality at scale. Succeeding in a large repository requires patience, energy, and a high degree of adaptability.
+
+**How did AI tools help — and where did they fall short?**
+AI was instrumental in helping me explore the codebase, unpack the problem statement, and formulate a solution plan. It significantly accelerated my workflow and handled many repetitive tasks, though it fell short whenever nuanced, project-specific context was required.
+
+**What would you do differently if you started over?**
+I would make an effort to explore the codebase more broadly. Because I focused heavily on the components directly tied to my specific issue, I missed out on developing a more holistic understanding of the overall system architecture.
+
+**What are you most proud of from this module?**
+My persistence. Despite the steep learning curve, extensive documentation, and strict guidelines, I stayed resilient and pushed through to the finish line.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,14 +1,63 @@
-## Problem Summary Statement
+## Solution plan
 
-**Issue:** #146 — PII scrubber fails to redact parenthesized US phone numbers  
-**Component:** Safety Layer (`safety`)
+**Issue:** PII scrubber fails to redact parenthesized US phone numbers — #146
+https://github.com/ascherj/pathreview/issues/146
 
-### Problem Overview
-The PII (Personally Identifiable Information) scrubbing module in the safety layer currently fails to detect and redact US phone numbers that use parenthesized area codes (e.g., `(123) 456-7890`, `(123)456-7890`, or `+1 (123) 456-7890`). 
+### Understand
+The PII scrubber (`safety/pii_scrubber.py`) redacts phone numbers via a `phone_us` regex:
+`\b(?:\+?1[-.]?)?\(?([0-9]{3})\)?[-.]?([0-9]{3})[-.]?([0-9]{4})\b`. After an optional closing
+parenthesis, it only allows `-` or `.` as the separator — never a space. So formats like
+`(555) 123-4567` or `+1 555 123 4567` never match at all.
 
-Because the existing pattern matcher expects unparenthesized digits separated by standard delimiters (hyphens, dots, or spaces), parenthesized phone numbers pass through the safety pipeline unredacted, exposing raw user contact information.
+Expected: any of these formats gets replaced with `[REDACTED]` (via `scrub()`) and reported by
+`detect()`. 
 
-### Objective
-* Update the phone number pattern matching logic in the safety module to recognize parenthesized area codes and flexible spacing.
-* Ensure the updated pattern avoids false positives on arbitrary parenthesized text.
-* Add dedicated unit tests covering parenthesized phone number formats to prevent regressions.
+Actual: they pass through completely untouched, leaking contact info. Confirmed
+live: `re.search(pattern, "(555) 123-4567")` returns `None`.
+
+### Map
+- `safety/pii_scrubber.py` — `PIIScrubber.PII_PATTERNS["phone_us"]` is the regex to fix.
+- `tests/unit/test_pii_scrubber.py` — existing phone tests to make pass, and where to add new
+  parenthesized-format regression tests (`test_us_phone_number_redaction`,
+  `test_us_phone_formats`, `test_detect_phone_pii`, `test_phone_at_start_of_text`).
+- `PII_PATTERNS["phone_intl"]` and `["street_address"]` — adjacent patterns in the same dict;
+  need to check the new phone regex doesn't start overlapping/double-matching with `phone_intl`.
+
+### Plan
+1. Update the `phone_us` regex so the separator after an optional closing paren (and between
+   all digit groups) accepts a space in addition to `-`/`.`, e.g. `[-.\s]?` instead of `[-.]?`.
+2. Manually verify the updated pattern against all known formats: `555-123-4567`,
+   `(555) 123-4567`, `(555)123-4567`, `555.123.4567`, `+1 555 123 4567`, `+1 (555) 123-4567`.
+3. Run `tests/unit/test_pii_scrubber.py` and fix any remaining failures caused by the phone
+   pattern specifically (the `test_mixed_pii_and_text` failure is a separate, pre-existing
+   `street_address` bug — see Risks below — not necessarily in scope here).
+4. Add new unit tests covering parenthesized formats explicitly, per the issue's stated
+   objective of preventing regressions.
+5. Run `make check && make test-unit` for the full suite to confirm no unrelated regressions.
+
+### Inputs & outputs
+Input: arbitrary free-text strings (resume text, README content, profile fields) that may
+contain zero or more phone numbers in any supported format, mixed with other text/PII.
+Output: `scrub()` returns the same text with every matched phone number replaced by
+`[REDACTED]`; `detect()` returns a list of `{type: "phone_us", value, start, end}` dicts for
+each match, unchanged in shape from today.
+
+### Risks & unknowns
+- Loosening the separator to allow whitespace increases false-positive risk on unrelated
+  digit runs (e.g. arbitrary "555 123 4567"-shaped non-phone numbers, dates, IDs) — needs a
+  quick sanity check against the fixtures already in the test file.
+- `phone_intl` pattern (`\+[0-9]{1,3}[-.]?[0-9]{1,14}`) can already match part of a
+  `+1 555 123 4567` string; adding space-tolerance to `phone_us` may cause both patterns to
+  match overlapping text, which is currently harmless (both just get redacted) but worth
+  confirming doesn't double-count in `detect()`.
+- Separately, `test_mixed_pii_and_text` fails today for an unrelated reason: `street_address`'s
+  abbreviation list includes `Pl` (case-insensitive), which matches the tail of ordinary words
+  like "applications". Not caused by, or necessarily fixed by, this issue — flagging so it isn't
+  confused with the phone regression.
+
+### Edge cases
+- Phone number at the very start or end of a string (no surrounding whitespace/punctuation).
+- Multiple phone numbers in one string, including mixed formats.
+- Phone number adjacent to other PII (email, SSN, address) in the same text.
+- Text with parentheses that aren't a phone number (e.g., "(see notes)") — must not be redacted.
+- No phone number present at all — `scrub()`/`detect()` should be no-ops for that pattern.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,14 @@
+## Problem Summary Statement
+
+**Issue:** #146 — PII scrubber fails to redact parenthesized US phone numbers  
+**Component:** Safety Layer (`safety`)
+
+### Problem Overview
+The PII (Personally Identifiable Information) scrubbing module in the safety layer currently fails to detect and redact US phone numbers that use parenthesized area codes (e.g., `(123) 456-7890`, `(123)456-7890`, or `+1 (123) 456-7890`). 
+
+Because the existing pattern matcher expects unparenthesized digits separated by standard delimiters (hyphens, dots, or spaces), parenthesized phone numbers pass through the safety pipeline unredacted, exposing raw user contact information.
+
+### Objective
+* Update the phone number pattern matching logic in the safety module to recognize parenthesized area codes and flexible spacing.
+* Ensure the updated pattern avoids false positives on arbitrary parenthesized text.
+* Add dedicated unit tests covering parenthesized phone number formats to prevent regressions.

--- a/safety/pii_scrubber.py
+++ b/safety/pii_scrubber.py
@@ -1,6 +1,7 @@
 """PII detection and scrubbing."""
 
 import re
+
 import structlog
 
 logger = structlog.get_logger()
@@ -12,7 +13,7 @@ class PIIScrubber:
     # Regex patterns for common PII
     PII_PATTERNS = {
         "email": r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b",
-        "phone_us": r"\b(?:\+?1[-.]?)?\(?([0-9]{3})\)?[-.]?([0-9]{3})[-.]?([0-9]{4})\b",
+        "phone_us": r"(?<!\w)(?:\+?1[-.\s]?)?\(?([0-9]{3})\)?[-.\s]?([0-9]{3})[-.\s]?([0-9]{4})\b",
         "phone_intl": r"\+[0-9]{1,3}[-.]?[0-9]{1,14}",
         "ssn": r"\b(?!000|666)[0-9]{3}-(?!00)[0-9]{2}-(?!0000)[0-9]{4}\b",
         "street_address": r"\b\d+\s+[A-Za-z\s]+(?:Street|St|Avenue|Ave|Road|Rd|Boulevard|Blvd|Drive|Dr|Lane|Ln|Court|Ct|Circle|Cir|Park|Pl|Plaza|Place|Drive|Dr|Way|Parkway|Pkwy|Point|Pt|Pike|Run|Summit|Summit|Terrace|Ter|Trail|Trl|Tunnel|Turnpike|View|Vista|Vlg|Village|Vly|Valley)",
@@ -47,13 +48,17 @@ class PIIScrubber:
 
         for pii_type, pattern in self.PII_PATTERNS.items():
             for match in re.finditer(pattern, text, flags=re.IGNORECASE):
-                detected.append({
-                    "type": pii_type,
-                    "value": match.group(),
-                    "start": match.start(),
-                    "end": match.end()
-                })
+                detected.append(
+                    {
+                        "type": pii_type,
+                        "value": match.group(),
+                        "start": match.start(),
+                        "end": match.end(),
+                    }
+                )
 
-        logger.info("pii_detected", count=len(detected), types=len(set(d["type"] for d in detected)))
+        logger.info(
+            "pii_detected", count=len(detected), types=len(set(d["type"] for d in detected))
+        )
 
         return detected

--- a/tests/unit/test_pii_scrubber.py
+++ b/tests/unit/test_pii_scrubber.py
@@ -190,6 +190,17 @@ class TestPIIScrubber:
 
         assert "[REDACTED]" in scrubbed
 
+    def test_phone_no_false_positive_on_parenthetical_text(self, scrubber):
+        """Parenthetical text with no digits should not be flagged as a phone number."""
+        text = "Please see the (attached) résumé for details."
+        assert scrubber.detect(text) == []
+
+    def test_us_phone_no_stray_parenthesis_after_scrub(self, scrubber):
+        """Scrubbing a parenthesized phone number must not leave a dangling '('."""
+        scrubbed = scrubber.scrub("Call me at (555) 123-4567")
+        assert "(" not in scrubbed
+        assert "[REDACTED]" in scrubbed
+
     def test_address_variations(self, scrubber):
         """Test various street address formats."""
         addresses = [


### PR DESCRIPTION
## Summary
The PII scrubber's phone regex didn't redact parenthesized US phone numbers like (555) 123-4567, silently leaking contact info causing security issues. This fix updates the regex to accept spaces as a valid separator and corrects a related word-boundary edge case.

## Issue
Closes #146 

## Changes
- Root cause: phone_us's separator only allowed -/. after an optional closing paren, never a space, so parenthesized formats never matched at all.
-  Updated the regex to accept \s alongside -/. as a separator.
- Fixed \b → (?<!\w) at the start of the pattern, which was silently dropping the leading "(" from matches once the space fix was applied.
- Added 2 regression tests covering the fixed formats and a false-positive guard.

## Testing
<!-- How did you verify your changes? -->
- [X] Unit tests pass (make test-unit) — for the file/tests I touched; repo-wide failures are pre-existing
- [ ] Integration tests pass (`make test-integration`) - not applicable 
- [X] Linter passes (`make lint`)
- [X] Type checker passes (`make typecheck`)
- [X] New/updated tests cover the changes

## Screenshots / Demo
backend regex change only - no UI to demo

## Notes for Reviewers

- Manual repro steps for reviewers:
  from safety.pii_scrubber import PIIScrubber
  s = PIIScrubber()
  s.scrub("Call me at (555) 123-4567")  # before: unchanged; after: "Call me at [REDACTED]"
- make check and make test-unit show pre-existing, unrelated failures (182 ruff errors in test_tech_detector.py; ~49 unrelated test failures across test_resume_parser.py, test_review_service.py, etc.) — confirmed identical on main before this branch's changes, not touched here. One remaining failure in test_pii_scrubber.py (test_mixed_pii_and_text) is a separate pre-existing bug in the street_address pattern, also confirmed on main, out of scope for #146.
