### PR TITLE
fix(ingestion): prevent duplicate embeddings on repository re-ingestion

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,19 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/6
+
+**Issue title:** Duplicate embeddings generated when re-ingesting the same repository
+
+**Tier:** [ ] Tier 1  [x] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The ingestion pipeline currently processes a repository again even when that same repository has already been ingested. This creates duplicate vector embeddings for identical source content, which can cause retrieval results to contain repeated chunks and artificially inflated relevance scores. The problem primarily affects `ingestion/pipeline.py` and the ingested-source tracking model in `core/models/ingested_source.py`. A successful fix would detect an existing ingestion before generating embeddings and prevent duplicate vector entries while preserving legitimate re-ingestion behavior when appropriate.
+
+**Selection notes:**
+I reviewed the issue description, relevant files, and estimated effort. The issue requires understanding how the ingestion pipeline checks persisted source records before generating and storing embeddings. The scope is limited to the ingestion workflow and associated tests rather than requiring a major application redesign. I should be able to reproduce the duplicate-ingestion behavior locally and verify that repeated ingestion no longer creates duplicate vector entries.
+
+**Branch name:** fix/6-prevent-duplicate-embeddings
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -31,3 +31,17 @@ I reproduced the issue with a focused unit test that ingests identical repositor
 
 **Blockers or open questions:**
 I still need to confirm whether changed content from the same repository should create a new ingestion or replace the previous repository vectors. I also need to verify all callers before converting the pipeline’s database operations to use the project’s asynchronous SQLAlchemy session.
+
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+I implemented persistent ingestion deduplication using a unique source identifier stored in the `ingested_sources` table. I replaced the placeholder duplicate lookup and recording logic with asynchronous SQLAlchemy operations, normalized repository metadata so volatile metrics do not trigger re-ingestion, and converted the Week 8 reproduction into regression tests.
+
+**Next steps:**
+I will run the project-wide checks, document any pre-existing failures, open a draft pull request, and request feedback from a peer or mentor. After addressing relevant feedback, I will mark the pull request ready for review and complete Check-in 2.
+
+**Blockers:**
+The repository contains pre-existing type-checking failures outside the files changed for issue #6. I am validating the affected files independently and confirming that this contribution does not introduce additional failures.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -61,3 +61,34 @@ I added `tests/unit/test_ingestion_pipeline_deduplication.py`, which covers iden
 **Self-review confirmation:** [x] make check introduces no new failures  [x] make test-unit introduces no new failures
 
 **Draft PR feedback received from:** N/A
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [x] Yes  [ ] No — still awaiting review
+
+**Summary of feedback:**
+A reviewer asked how I derived my implementation because it was similar to another design for the same issue.
+
+**How you responded:**
+I explained that I traced the existing ingestion pipeline, found the mismatch between the asynchronous database session and the synchronous duplicate-check logic, and found that successful ingestions were not actually being persisted. I also explained why I used stable repository fields for deduplication and how I tested the behavior.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Understanding how one change affected multiple parts of the codebase was harder than I expected. Fixing the duplicate check was not just changing one query. I also had to understand the async SQLAlchemy session, how ingestion records were stored, how source IDs were generated, and how the tests needed to change after the pipeline became asynchronous.
+
+**What did you learn about working in a large codebase?**
+I learned that a change that looks small from an issue description can affect several connected files. I had to inspect the database model, ingestion pipeline, migrations, and tests before making the fix. I also learned to keep my PR focused and check the diff carefully so unrelated file changes do not get included.
+
+**How did AI tools help — and where did they fall short?**
+AI was most useful for helping me trace unfamiliar code, understand the async database flow, debug test and lint errors, and think through edge cases for deduplication. However, I still needed to verify the suggestions against the actual repository. AI could suggest an implementation quickly, but it could not replace understanding the existing architecture or checking whether the final changes really fit the project.
+
+**What would you do differently if you started over?**
+I would spend more time mapping all callers and related database code before beginning implementation. I would also check `git diff` more frequently so unrelated changes are caught earlier, and I would establish the exact deduplication rules before writing the final implementation.
+
+**What are you most proud of from this module?**
+I am most proud that I went from reproducing the bug with a failing test to implementing a fix with regression tests that cover both duplicates and legitimate repository changes. I understand the ingestion workflow much better now than when I selected the issue.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -17,3 +17,17 @@ I reviewed the issue description, relevant files, and estimated effort. The issu
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/SingLZ/pathreview/commit/6af19678b07fbc7a7d6189a0de65fcd473d79b00
+
+**Reproduction summary:**
+I reproduced the issue with a focused unit test that ingests identical repository metadata twice for the same profile. The embedding processor was invoked twice instead of once, and the second result was not marked as skipped.
+
+**PLAN.md link:** https://github.com/SingLZ/pathreview/blob/fix/6-prevent-duplicate-embeddings/PLAN.md
+
+**Walkthrough video (recommended):** Not recorded.
+
+**Blockers or open questions:**
+I still need to confirm whether changed content from the same repository should create a new ingestion or replace the previous repository vectors. I also need to verify all callers before converting the pipeline’s database operations to use the project’s asynchronous SQLAlchemy session.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -45,3 +45,19 @@ I will run the project-wide checks, document any pre-existing failures, open a d
 
 **Blockers:**
 The repository contains pre-existing type-checking failures outside the files changed for issue #6. I am validating the affected files independently and confirming that this contribution does not introduce additional failures.
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/576
+
+**Branch:** `fix/6-prevent-duplicate-embeddings`
+
+**What you built:**
+I implemented persistent deduplication for repository ingestion. The pipeline now checks a stable source ID before generating embeddings and ignores changes to volatile repository metrics.
+
+**Tests added or updated:**
+I added `tests/unit/test_ingestion_pipeline_deduplication.py`, which covers identical repository ingestion, changed star counts, and meaningful repository content changes.
+
+**Self-review confirmation:** [x] make check introduces no new failures  [x] make test-unit introduces no new failures
+
+**Draft PR feedback received from:** N/A

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,113 @@
+## Solution plan
+
+**Issue:** [Duplicate embeddings generated when re-ingesting the same repository](https://github.com/ascherj/pathreview/issues/6)
+
+### Understand
+
+The repository ingestion pipeline calculates a deterministic source identifier from the profile ID, repository name, and repository metadata. It then calls `_check_skip()` before parsing and embedding the repository. However, `_check_skip()` attempts to query the literal string `"IngestedSource"` through a synchronous SQLAlchemy-style `.query()` call, while the application database layer provides an asynchronous `AsyncSession`. The resulting exception is caught and converted into a warning, so ingestion continues instead of being skipped.
+
+The pipeline also calls `_record_ingested_source()` after generating embeddings, but that method currently only writes a log message and does not create an `IngestedSource` database record. Therefore, the second ingestion has no persisted record to find even if the lookup were corrected.
+
+The expected behavior is that ingesting identical repository data for the same profile a second time should return an `IngestResult` with `skipped=True` and should not parse, chunk, generate, or store embeddings again. The current behavior processes both requests and invokes the embedding processor twice, creating duplicate vector entries or attempting to store the same logical chunks again.
+
+### Map
+
+Files expected to be modified:
+
+* `ingestion/pipeline.py`
+
+  * `IngestionPipeline.ingest_repo_metadata()`
+  * Potentially `ingest_resume()` and `ingest_readme()` because they use the same broken deduplication helpers
+  * `_check_skip()`
+  * `_record_ingested_source()`
+  * `_hash_content()`, if the full content hash must be retained separately from the vector source identifier
+
+* `core/models/ingested_source.py`
+
+  * Confirm the fields used to identify duplicate sources
+  * Potentially add a composite uniqueness constraint for profile, source type, and content hash
+
+* `alembic/versions/<new_migration>.py`
+
+  * Add a database uniqueness constraint if model-level uniqueness is part of the selected solution
+
+* `tests/unit/test_ingestion_pipeline_deduplication.py`
+
+  * Convert the reproduction into passing regression tests
+  * Add cases covering legitimate non-duplicate ingestion
+
+Additional files to inspect before implementation:
+
+* `core/database.py`
+
+  * Confirm the intended `AsyncSession` transaction pattern
+
+* Any API route, service, or background task that constructs or calls `IngestionPipeline`
+
+  * Determine whether changing ingestion methods to `async` affects existing callers
+
+### Plan
+
+1. **Define the duplicate identity.**
+   Use the existing `IngestedSource` fields to identify an exact duplicate by `profile_id`, `source_type`, and the full SHA-256 `content_hash`. Keep the generated `source_id` for vector chunk identifiers, but do not query a nonexistent `source_id` database column.
+
+2. **Implement a real database lookup.**
+   Import the `IngestedSource` model and use SQLAlchemy 2.x `select()` with the project’s `AsyncSession`. Update the ingestion flow to await the lookup before parsing, chunking, or embedding content.
+
+3. **Persist successful ingestion records.**
+   Replace the placeholder `_record_ingested_source()` implementation with creation of an `IngestedSource` row containing the profile ID, source type, content hash, source URL or filename when available, and chunk count. Flush or commit through the established transaction convention.
+
+4. **Protect against database duplicates.**
+   Evaluate adding a composite unique constraint over `profile_id`, `source_type`, and `content_hash`. If added, create an Alembic migration and handle `IntegrityError` so concurrent duplicate requests do not create multiple database records.
+
+5. **Complete focused regression tests.**
+   Update the reproduction test so identical repository input is processed once and skipped on the second call. Add tests showing that changed repository content, a different profile, or a different source type is not incorrectly skipped.
+
+### Inputs & outputs
+
+Inputs:
+
+* `profile_id`: identifies the owner of the repository data
+* `repo_data`: repository metadata passed to `ingest_repo_metadata()`
+* `source_type`: `"repo"` for repository ingestion
+* Derived full SHA-256 content hash
+* Optional repository URL extracted from `repo_data`
+
+Expected first-ingestion output:
+
+* `IngestResult.skipped` is `False`
+* Repository content is parsed and chunked
+* Embeddings are generated and stored once
+* One matching `IngestedSource` row is persisted
+* `IngestResult.chunk_count` contains the number of stored chunks
+
+Expected duplicate-ingestion output:
+
+* `IngestResult.skipped` is `True`
+* `skip_reason` explains that the source was already ingested
+* Parsing, chunking, and embedding are not invoked
+* No additional vector entries or database records are created
+* `chunk_count` remains `0` for the skipped operation
+
+### Risks & unknowns
+
+* `IngestionPipeline` currently exposes synchronous methods, but the database layer uses `AsyncSession`. Converting the pipeline methods to asynchronous methods may require changes to callers that are not identified in the issue description.
+* The model stores `content_hash`, while the pipeline currently constructs a separate truncated `source_id`. The implementation must avoid confusing these two identifiers.
+* It is not yet confirmed whether updated metadata from the same repository should create a new ingestion, replace the previous vectors, or be skipped based only on repository URL.
+* A database record written only after vector storage leaves a concurrency window in which two requests can both generate embeddings. A uniqueness constraint prevents duplicate rows but may not prevent duplicate vector processing by itself.
+* If embedding storage succeeds but the database write fails, the vector database and relational database can become inconsistent. The implementation should define appropriate cleanup or retry behavior.
+* Existing `IngestedSource` rows may already contain duplicate combinations. A uniqueness migration could fail unless existing data is checked or cleaned first.
+
+### Edge cases
+
+* The exact same repository data is ingested twice for the same profile.
+* The same repository data is ingested for two different profiles.
+* Repository data changes and therefore produces a different content hash.
+* Dictionary ordering or serialization differences produce logically identical repository metadata.
+* Repository data has no `name`, URL, description, or language.
+* The database lookup raises a temporary error.
+* The database insert encounters a concurrent uniqueness conflict.
+* Embedding generation fails before the ingestion record is written.
+* The database write fails after embeddings have already been stored.
+* The source produces zero chunks.
+* Resume and README ingestion continue to work because they share the same skip and record helpers.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+issue 6 tier 2
 # PathReview
 
 **AI-powered portfolio review assistant** that helps early-career developers strengthen their professional portfolios.

--- a/alembic/versions/003_add_source_id_to_ingested_sources.py
+++ b/alembic/versions/003_add_source_id_to_ingested_sources.py
@@ -1,0 +1,38 @@
+"""Add source_id deduplication key to ingested_sources.
+
+Revision ID: 003
+Revises: 002
+Create Date: 2026-07-28 00:00:00.000000
+"""
+
+import sqlalchemy as sa
+
+from alembic import op  # type: ignore[attr-defined]
+
+revision = "003"
+down_revision = "002"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Add the nullable, unique ingestion source identifier."""
+    op.add_column(
+        "ingested_sources",
+        sa.Column("source_id", sa.String(255), nullable=True),
+    )
+    op.create_index(
+        "ix_ingested_sources_source_id",
+        "ingested_sources",
+        ["source_id"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    """Remove the ingestion source identifier."""
+    op.drop_index(
+        "ix_ingested_sources_source_id",
+        table_name="ingested_sources",
+    )
+    op.drop_column("ingested_sources", "source_id")

--- a/core/models/ingested_source.py
+++ b/core/models/ingested_source.py
@@ -31,6 +31,13 @@ class IngestedSource(Base):
     source_type: Mapped[str] = mapped_column(
         String(50), nullable=False
     )  # "resume", "readme", "repo", "web"
+
+    source_id: Mapped[str | None] = mapped_column(
+        String(255),
+        nullable=True,
+        unique=True,
+        index=True,
+    )
     source_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
     filename: Mapped[str | None] = mapped_column(String(255), nullable=True)
     content_hash: Mapped[str | None] = mapped_column(

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -99,7 +99,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -449,7 +448,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -473,7 +471,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1561,7 +1558,6 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1579,7 +1575,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1972,7 +1967,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3507,7 +3501,6 @@
       "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^2.0.1",
         "cssstyle": "^4.0.1",
@@ -4094,7 +4087,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4107,7 +4099,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4771,7 +4762,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/ingestion/pipeline.py
+++ b/ingestion/pipeline.py
@@ -1,8 +1,14 @@
 import hashlib
+import json
 from dataclasses import dataclass
-from typing import Optional
+from typing import Any
 
 import structlog
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from core.models.ingested_source import IngestedSource
 
 from .chunking.strategy_selector import StrategySelector
 from .embeddings.batch_processor import BatchEmbeddingProcessor
@@ -11,17 +17,42 @@ from .parsers.readme_parser import ReadmeParser
 from .parsers.repo_analyzer import RepoAnalyzer
 from .parsers.resume_parser import ResumeParser
 
-
 logger = structlog.get_logger()
+
+REPO_DEDUP_FIELDS = (
+    "name",
+    "description",
+    "language",
+    "languages",
+    "topics",
+    "html_url",
+    "file_structure",
+)
+
+
+def _is_unique_violation(error: IntegrityError) -> bool:
+    """Return whether an integrity error is a duplicate-key violation."""
+    original_error = getattr(error, "orig", None)
+    sqlstate = getattr(original_error, "sqlstate", None) or getattr(
+        original_error,
+        "pgcode",
+        None,
+    )
+
+    if sqlstate is not None:
+        return str(sqlstate) == "23505"
+
+    return "unique" in type(original_error).__name__.lower()
 
 
 @dataclass
 class IngestResult:
     """Result of ingesting a source."""
+
     source_id: str
     chunk_count: int
     skipped: bool
-    skip_reason: Optional[str] = None
+    skip_reason: str | None = None
 
 
 class IngestionPipeline:
@@ -29,10 +60,10 @@ class IngestionPipeline:
 
     def __init__(
         self,
-        vector_db,
-        db_session,
+        vector_db: Any,
+        db_session: AsyncSession,
         embedding_provider: EmbeddingProvider,
-    ):
+    ) -> None:
         """
         Initialize the ingestion pipeline.
 
@@ -52,7 +83,7 @@ class IngestionPipeline:
         self.readme_parser = ReadmeParser()
         self.repo_analyzer = RepoAnalyzer()
 
-    def ingest_resume(
+    async def ingest_resume(
         self,
         profile_id: str,
         content: str | bytes,
@@ -69,7 +100,8 @@ class IngestionPipeline:
         Returns:
             IngestResult with ingestion status
         """
-        source_id = f"resume_{profile_id}_{self._hash_content(content)}"
+        content_hash = self._content_digest(content)
+        source_id = f"resume_{profile_id}_{content_hash[:16]}"
 
         logger.info(
             "Starting resume ingestion",
@@ -79,23 +111,28 @@ class IngestionPipeline:
         )
 
         # Check if already ingested
-        skip_result = self._check_skip(source_id, "resume")
+        skip_result = await self._check_skip(source_id, "resume")
         if skip_result:
             return skip_result
 
         try:
             # Parse resume
             parse_result = self.resume_parser.parse(content)
-            logger.info("Resume parsed successfully", sections=parse_result.metadata.get("detected_sections"))
+            logger.info(
+                "Resume parsed successfully",
+                sections=parse_result.metadata.get("detected_sections"),
+            )
 
             # Prepare metadata
             metadata = parse_result.metadata.copy()
-            metadata.update({
-                "source_id": source_id,
-                "profile_id": profile_id,
-                "filename": filename,
-                "source_type": "resume",
-            })
+            metadata.update(
+                {
+                    "source_id": source_id,
+                    "profile_id": profile_id,
+                    "filename": filename,
+                    "source_type": "resume",
+                }
+            )
 
             # Chunk the content
             chunks = self.strategy_selector.chunk(parse_result.text, metadata)
@@ -106,7 +143,14 @@ class IngestionPipeline:
             logger.info("Resume embeddings stored", chunk_count=len(chunks))
 
             # Record in database
-            self._record_ingested_source(source_id, "resume", profile_id, len(chunks))
+            await self._record_ingested_source(
+                source_id=source_id,
+                source_type="resume",
+                profile_id=profile_id,
+                chunk_count=len(chunks),
+                content_hash=content_hash,
+                filename=filename,
+            )
 
             return IngestResult(
                 source_id=source_id,
@@ -123,7 +167,7 @@ class IngestionPipeline:
             )
             raise
 
-    def ingest_readme(
+    async def ingest_readme(
         self,
         profile_id: str,
         repo_name: str,
@@ -140,7 +184,8 @@ class IngestionPipeline:
         Returns:
             IngestResult with ingestion status
         """
-        source_id = f"readme_{profile_id}_{repo_name}_{self._hash_content(content)}"
+        content_hash = self._content_digest(content)
+        source_id = f"readme_{profile_id}_{repo_name}_{content_hash[:16]}"
 
         logger.info(
             "Starting README ingestion",
@@ -150,7 +195,7 @@ class IngestionPipeline:
         )
 
         # Check if already ingested
-        skip_result = self._check_skip(source_id, "readme")
+        skip_result = await self._check_skip(source_id, "readme")
         if skip_result:
             return skip_result
 
@@ -165,12 +210,14 @@ class IngestionPipeline:
 
             # Prepare metadata
             metadata = parse_result.metadata.copy()
-            metadata.update({
-                "source_id": source_id,
-                "profile_id": profile_id,
-                "repo_name": repo_name,
-                "source_type": "readme",
-            })
+            metadata.update(
+                {
+                    "source_id": source_id,
+                    "profile_id": profile_id,
+                    "repo_name": repo_name,
+                    "source_type": "readme",
+                }
+            )
 
             # Chunk the content
             chunks = self.strategy_selector.chunk(parse_result.text, metadata)
@@ -181,7 +228,13 @@ class IngestionPipeline:
             logger.info("README embeddings stored", chunk_count=len(chunks))
 
             # Record in database
-            self._record_ingested_source(source_id, "readme", profile_id, len(chunks))
+            await self._record_ingested_source(
+                source_id=source_id,
+                source_type="readme",
+                profile_id=profile_id,
+                chunk_count=len(chunks),
+                content_hash=content_hash,
+            )
 
             return IngestResult(
                 source_id=source_id,
@@ -198,10 +251,10 @@ class IngestionPipeline:
             )
             raise
 
-    def ingest_repo_metadata(
+    async def ingest_repo_metadata(
         self,
         profile_id: str,
-        repo_data: dict,
+        repo_data: dict[str, Any],
     ) -> IngestResult:
         """
         Ingest repository metadata.
@@ -214,7 +267,8 @@ class IngestionPipeline:
             IngestResult with ingestion status
         """
         repo_name = repo_data.get("name", "unknown")
-        source_id = f"repo_{profile_id}_{repo_name}_{self._hash_content(str(repo_data))}"
+        content_hash = self._content_digest(self._repo_dedup_payload(repo_data))
+        source_id = f"repo_{profile_id}_{repo_name}_{content_hash[:16]}"
 
         logger.info(
             "Starting repo metadata ingestion",
@@ -224,7 +278,7 @@ class IngestionPipeline:
         )
 
         # Check if already ingested
-        skip_result = self._check_skip(source_id, "repo")
+        skip_result = await self._check_skip(source_id, "repo")
         if skip_result:
             return skip_result
 
@@ -239,11 +293,13 @@ class IngestionPipeline:
 
             # Prepare metadata
             metadata = parse_result.metadata.copy()
-            metadata.update({
-                "source_id": source_id,
-                "profile_id": profile_id,
-                "source_type": "repo",
-            })
+            metadata.update(
+                {
+                    "source_id": source_id,
+                    "profile_id": profile_id,
+                    "source_type": "repo",
+                }
+            )
 
             # Chunk the content
             chunks = self.strategy_selector.chunk(parse_result.text, metadata)
@@ -254,7 +310,14 @@ class IngestionPipeline:
             logger.info("Repository embeddings stored", chunk_count=len(chunks))
 
             # Record in database
-            self._record_ingested_source(source_id, "repo", profile_id, len(chunks))
+            await self._record_ingested_source(
+                source_id=source_id,
+                source_type="repo",
+                profile_id=profile_id,
+                chunk_count=len(chunks),
+                content_hash=content_hash,
+                source_url=repo_data.get("html_url"),
+            )
 
             return IngestResult(
                 source_id=source_id,
@@ -271,71 +334,124 @@ class IngestionPipeline:
             )
             raise
 
-    def _hash_content(self, content: str | bytes) -> str:
-        """Generate a hash of content for deduplication."""
+    def _content_digest(self, content: str | bytes) -> str:
+        """Generate the full SHA-256 hexadecimal digest of content."""
         if isinstance(content, str):
-            content = content.encode()
-        return hashlib.sha256(content).hexdigest()[:16]
+            content = content.encode("utf-8")
 
-    def _check_skip(self, source_id: str, source_type: str) -> Optional[IngestResult]:
-        """
-        Check if source has already been ingested.
+        return hashlib.sha256(content).hexdigest()
 
-        Returns IngestResult if should skip, None if should proceed.
-        """
+    def _hash_content(self, content: str | bytes) -> str:
+        """Generate the shortened digest used inside vector source identifiers."""
+        return self._content_digest(content)[:16]
+
+    def _repo_dedup_payload(self, repo_data: dict[str, Any]) -> str:
+        """Build stable repository content for deduplication."""
+        stable_data = {
+            field: repo_data.get(field) for field in REPO_DEDUP_FIELDS if field in repo_data
+        }
+        stable_data["has_readme"] = bool(repo_data.get("readme_content"))
+
+        return json.dumps(
+            stable_data,
+            sort_keys=True,
+            separators=(",", ":"),
+            default=str,
+        )
+
+    async def _check_skip(
+        self,
+        source_id: str,
+        source_type: str,
+    ) -> IngestResult | None:
+        """Return a skipped result when the source already exists."""
         try:
-            # Query database for existing source
-            # This assumes a table/model named IngestedSource
-            existing = self.db_session.query(
-                "IngestedSource"  # Placeholder - actual query depends on ORM
-            ).filter_by(source_id=source_id).first()
-
-            if existing:
-                logger.info("Source already ingested, skipping", source_id=source_id)
-                return IngestResult(
-                    source_id=source_id,
-                    chunk_count=0,
-                    skipped=True,
-                    skip_reason="Source already ingested",
+            result = await self.db_session.execute(
+                select(IngestedSource).where(
+                    IngestedSource.source_id == source_id,
                 )
-        except Exception as e:
-            logger.warning(
-                "Could not check if source already ingested",
-                source_id=source_id,
-                error=str(e),
             )
+            existing_source = result.scalar_one_or_none()
+        except SQLAlchemyError as error:
+            logger.error(
+                "Could not check ingestion state",
+                source_id=source_id,
+                source_type=source_type,
+                error=str(error),
+            )
+            raise
 
-        return None
+        if existing_source is None:
+            return None
 
-    def _record_ingested_source(
+        logger.info(
+            "Source already ingested, skipping",
+            source_id=source_id,
+            source_type=source_type,
+        )
+
+        return IngestResult(
+            source_id=source_id,
+            chunk_count=0,
+            skipped=True,
+            skip_reason="Source already ingested",
+        )
+
+    async def _record_ingested_source(
         self,
         source_id: str,
         source_type: str,
         profile_id: str,
         chunk_count: int,
+        *,
+        content_hash: str | None = None,
+        filename: str | None = None,
+        source_url: str | None = None,
     ) -> None:
-        """
-        Record that a source has been ingested.
+        """Persist successful ingestion bookkeeping."""
+        record = IngestedSource(
+            profile_id=profile_id,
+            source_type=source_type,
+            source_id=source_id,
+            content_hash=content_hash,
+            filename=filename,
+            source_url=source_url,
+            chunk_count=chunk_count,
+        )
 
-        Args:
-            source_id: Unique ID for the source
-            source_type: Type of source (resume, readme, repo)
-            profile_id: ID of profile owner
-            chunk_count: Number of chunks created
-        """
         try:
-            # This is a placeholder for actual database recording
-            # In a real implementation, would create IngestedSource record
-            logger.info(
-                "Recording ingested source",
-                source_id=source_id,
-                source_type=source_type,
-                profile_id=profile_id,
-                chunk_count=chunk_count,
-            )
-        except Exception as e:
+            self.db_session.add(record)
+            await self.db_session.commit()
+        except IntegrityError as error:
+            await self.db_session.rollback()
+
+            if _is_unique_violation(error):
+                logger.info(
+                    "Source was recorded by a concurrent ingestion",
+                    source_id=source_id,
+                    source_type=source_type,
+                )
+                return
+
             logger.error(
                 "Failed to record ingested source",
                 source_id=source_id,
-                error=str(e),
+                error=str(error),
             )
+            raise
+        except SQLAlchemyError as error:
+            await self.db_session.rollback()
+            logger.error(
+                "Failed to record ingested source",
+                source_id=source_id,
+                error=str(error),
+            )
+            raise
+
+        logger.info(
+            "Recorded ingested source",
+            source_id=source_id,
+            source_type=source_type,
+            profile_id=profile_id,
+            chunk_count=chunk_count,
+        )

--- a/tests/unit/test_ingestion_pipeline_deduplication.py
+++ b/tests/unit/test_ingestion_pipeline_deduplication.py
@@ -1,0 +1,75 @@
+from unittest.mock import MagicMock, patch
+
+from ingestion.chunking.base import Chunk
+from ingestion.parsers.base import ParseResult
+from ingestion.pipeline import IngestionPipeline
+
+
+def test_reingesting_identical_repository_does_not_generate_embeddings_twice() -> None:
+    """Reproduce issue #6: identical repository ingestion is not skipped."""
+    pipeline = IngestionPipeline(
+        vector_db=MagicMock(),
+        db_session=object(),
+        embedding_provider=MagicMock(),
+    )
+
+    repo_data = {
+        "name": "sample-repository",
+        "url": "https://github.com/example/sample-repository",
+        "description": "Repository used to reproduce duplicate ingestion.",
+        "language": "Python",
+    }
+
+    with (
+        patch.object(
+            pipeline.repo_analyzer,
+            "parse",
+            return_value=ParseResult(
+                text="Sample repository metadata",
+                metadata={
+                    "primary_language": "Python",
+                    "tech_stack": ["Python"],
+                },
+                source_type="repo",
+            ),
+        ),
+        patch.object(
+            pipeline.strategy_selector,
+            "chunk",
+            return_value=[
+                Chunk(
+                    text="Sample repository metadata",
+                    metadata={"chunk_index": 0},
+                )
+            ],
+        ),
+        patch.object(
+            pipeline.batch_processor,
+            "process",
+            return_value=[],
+        ) as process_mock,
+    ):
+        pipeline.ingest_repo_metadata(
+            "00000000-0000-0000-0000-000000000001",
+            repo_data,
+        )
+        second_result = pipeline.ingest_repo_metadata(
+            "00000000-0000-0000-0000-000000000001",
+            repo_data,
+        )
+
+    assert (
+        process_mock.call_count == 1
+    ), "Re-ingesting identical repository data generated embeddings twice"
+    assert second_result.skipped is True
+
+    pipeline.ingest_repo_metadata("00000000-0000-0000-0000-000000000001", repo_data)
+    second_result = pipeline.ingest_repo_metadata(
+        "00000000-0000-0000-0000-000000000001",
+        repo_data,
+    )
+
+    assert (
+        process_mock.call_count == 1
+    ), "Re-ingesting identical repository data generated embeddings twice"
+    assert second_result.skipped is True

--- a/tests/unit/test_ingestion_pipeline_deduplication.py
+++ b/tests/unit/test_ingestion_pipeline_deduplication.py
@@ -1,22 +1,93 @@
+from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
+import pytest
+
+from core.models.ingested_source import IngestedSource
 from ingestion.chunking.base import Chunk
 from ingestion.parsers.base import ParseResult
 from ingestion.pipeline import IngestionPipeline
 
 
-def test_reingesting_identical_repository_does_not_generate_embeddings_twice() -> None:
-    """Reproduce issue #6: identical repository ingestion is not skipped."""
-    pipeline = IngestionPipeline(
+class _ScalarResult:
+    """Minimal SQLAlchemy result substitute for pipeline unit tests."""
+
+    def __init__(self, value: IngestedSource | None) -> None:
+        self._value = value
+
+    def scalar_one_or_none(self) -> IngestedSource | None:
+        return self._value
+
+
+class _FakeAsyncSession:
+    """In-memory AsyncSession substitute that persists sources by source_id."""
+
+    def __init__(self) -> None:
+        self.records: dict[str, IngestedSource] = {}
+        self._pending: IngestedSource | None = None
+
+    async def execute(self, statement: Any) -> _ScalarResult:
+        parameters = statement.compile().params
+        source_id = next(value for key, value in parameters.items() if "source_id" in key)
+        return _ScalarResult(self.records.get(str(source_id)))
+
+    def add(self, record: IngestedSource) -> None:
+        self._pending = record
+
+    async def commit(self) -> None:
+        if self._pending is None:
+            return
+
+        if self._pending.source_id is None:
+            raise AssertionError("Test record must have a source_id")
+
+        self.records[self._pending.source_id] = self._pending
+        self._pending = None
+
+    async def rollback(self) -> None:
+        self._pending = None
+
+
+def _create_pipeline(
+    session: _FakeAsyncSession,
+) -> IngestionPipeline:
+    return IngestionPipeline(
         vector_db=MagicMock(),
-        db_session=object(),
-        embedding_provider=MagicMock(),
+        db_session=cast(Any, session),
+        embedding_provider=cast(Any, MagicMock()),
     )
+
+
+def _parse_result() -> ParseResult:
+    return ParseResult(
+        text="Sample repository metadata",
+        metadata={
+            "primary_language": "Python",
+            "tech_stack": ["Python"],
+        },
+        source_type="repo",
+    )
+
+
+def _chunks() -> list[Chunk]:
+    return [
+        Chunk(
+            text="Sample repository metadata",
+            metadata={"chunk_index": 0},
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_reingesting_identical_repository_skips_embeddings() -> None:
+    """Identical repository data should only be embedded once."""
+    session = _FakeAsyncSession()
+    pipeline = _create_pipeline(session)
 
     repo_data = {
         "name": "sample-repository",
-        "url": "https://github.com/example/sample-repository",
-        "description": "Repository used to reproduce duplicate ingestion.",
+        "html_url": "https://github.com/example/sample-repository",
+        "description": "Sample project",
         "language": "Python",
     }
 
@@ -24,24 +95,12 @@ def test_reingesting_identical_repository_does_not_generate_embeddings_twice() -
         patch.object(
             pipeline.repo_analyzer,
             "parse",
-            return_value=ParseResult(
-                text="Sample repository metadata",
-                metadata={
-                    "primary_language": "Python",
-                    "tech_stack": ["Python"],
-                },
-                source_type="repo",
-            ),
+            return_value=_parse_result(),
         ),
         patch.object(
             pipeline.strategy_selector,
             "chunk",
-            return_value=[
-                Chunk(
-                    text="Sample repository metadata",
-                    metadata={"chunk_index": 0},
-                )
-            ],
+            return_value=_chunks(),
         ),
         patch.object(
             pipeline.batch_processor,
@@ -49,27 +108,113 @@ def test_reingesting_identical_repository_does_not_generate_embeddings_twice() -
             return_value=[],
         ) as process_mock,
     ):
-        pipeline.ingest_repo_metadata(
+        first_result = await pipeline.ingest_repo_metadata(
             "00000000-0000-0000-0000-000000000001",
             repo_data,
         )
-        second_result = pipeline.ingest_repo_metadata(
+        second_result = await pipeline.ingest_repo_metadata(
             "00000000-0000-0000-0000-000000000001",
             repo_data,
         )
 
-    assert (
-        process_mock.call_count == 1
-    ), "Re-ingesting identical repository data generated embeddings twice"
+    assert first_result.skipped is False
     assert second_result.skipped is True
+    assert process_mock.call_count == 1
+    assert len(session.records) == 1
 
-    pipeline.ingest_repo_metadata("00000000-0000-0000-0000-000000000001", repo_data)
-    second_result = pipeline.ingest_repo_metadata(
-        "00000000-0000-0000-0000-000000000001",
-        repo_data,
-    )
 
-    assert (
-        process_mock.call_count == 1
-    ), "Re-ingesting identical repository data generated embeddings twice"
+@pytest.mark.asyncio
+async def test_volatile_repo_metrics_do_not_trigger_reingestion() -> None:
+    """Changing star counts should not change repository identity."""
+    session = _FakeAsyncSession()
+    pipeline = _create_pipeline(session)
+
+    initial_data = {
+        "name": "sample-repository",
+        "html_url": "https://github.com/example/sample-repository",
+        "description": "Sample project",
+        "language": "Python",
+        "stargazers_count": 10,
+    }
+    refreshed_data = {
+        **initial_data,
+        "stargazers_count": 11,
+    }
+
+    with (
+        patch.object(
+            pipeline.repo_analyzer,
+            "parse",
+            return_value=_parse_result(),
+        ),
+        patch.object(
+            pipeline.strategy_selector,
+            "chunk",
+            return_value=_chunks(),
+        ),
+        patch.object(
+            pipeline.batch_processor,
+            "process",
+            return_value=[],
+        ) as process_mock,
+    ):
+        await pipeline.ingest_repo_metadata(
+            "00000000-0000-0000-0000-000000000001",
+            initial_data,
+        )
+        second_result = await pipeline.ingest_repo_metadata(
+            "00000000-0000-0000-0000-000000000001",
+            refreshed_data,
+        )
+
     assert second_result.skipped is True
+    assert process_mock.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_meaningful_repo_change_triggers_new_ingestion() -> None:
+    """Changing repository content should produce a new ingestion."""
+    session = _FakeAsyncSession()
+    pipeline = _create_pipeline(session)
+
+    initial_data = {
+        "name": "sample-repository",
+        "html_url": "https://github.com/example/sample-repository",
+        "description": "Initial description",
+        "language": "Python",
+    }
+    changed_data = {
+        **initial_data,
+        "description": "Updated description",
+    }
+
+    with (
+        patch.object(
+            pipeline.repo_analyzer,
+            "parse",
+            return_value=_parse_result(),
+        ),
+        patch.object(
+            pipeline.strategy_selector,
+            "chunk",
+            return_value=_chunks(),
+        ),
+        patch.object(
+            pipeline.batch_processor,
+            "process",
+            return_value=[],
+        ) as process_mock,
+    ):
+        first_result = await pipeline.ingest_repo_metadata(
+            "00000000-0000-0000-0000-000000000001",
+            initial_data,
+        )
+        second_result = await pipeline.ingest_repo_metadata(
+            "00000000-0000-0000-0000-000000000001",
+            changed_data,
+        )
+
+    assert first_result.skipped is False
+    assert second_result.skipped is False
+    assert process_mock.call_count == 2
+    assert len(session.records) == 2


### PR DESCRIPTION
## Summary

Prevents duplicate embeddings when the same repository is ingested again by storing and checking a stable source ID before generating embeddings.

## Issue

Closes #6

## Changes

* Added a unique `source_id` to `IngestedSource`
* Added an Alembic migration
* Replaced placeholder deduplication logic with async SQLAlchemy queries
* Normalized repository metadata before hashing
* Added regression tests for duplicate and changed repository data

## Testing

* [ ] Unit tests pass (`make test-unit`)
* [ ] Integration tests pass (`make test-integration`)
* [ ] Linter passes (`make lint`)
* [ ] Type checker passes (`make typecheck`)
* [x] New/updated tests cover the changes

Focused test:

```bash
pytest tests/unit/test_ingestion_pipeline_deduplication.py -q
```

Result: `3 passed`

Project-wide checks still report pre-existing failures unrelated to this PR.


