### PR TITLE
fix: wrap PostgreSQL health probe SQL with sqlalchemy.text()

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -66,7 +66,7 @@ The repository contains several pre-existing linting and type-checking issues ac
 
 ### Check-in 2 (end of week)
 
-**PR link:** 
+**PR link:** https://github.com/ascherj/pathreview/pull/582
 
 **Branch:** `fix/154-db-argument-error`
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,26 @@
+## Week 7 — Issue selection
+
+**Issue link:** (https://github.com/ascherj/pathreview/issues/154)
+
+**Issue title:** Health check DB probe passes a raw SQL string, which fails under SQLAlchemy 2.x
+ #154
+
+**Tier:** [yes] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The database health check in api/routes/health.py executes "SELECT 1" as a plain Python string. Under SQLAlchemy 2.x, textual SQL statements must be explicitly wrapped with sqlalchemy.text(), so the current database probe raises an ArgumentError. Because the exception is caught by the health-check logic, the application incorrectly reports the database as unavailable even when PostgreSQL is running normally. A successful fix will wrap the query correctly, allow the probe to execute, and ensure the /health endpoint reports the actual database status.
+
+**Branch name:** fix/154-db-argument-error
+
+**Setup confirmation:** [yes] App runs locally at localhost:5173
+
+**Cohort ledger:** [yes] Issue added to cohort ledger
+
+
+**Setup notes**
+
+I forked the PathReview repository, cloned my fork, and added the original repository as the upstream remote. I created and pushed the working branch fix/154-db-argument-error.
+
+I successfully ran make setup, which installed the Python and frontend dependencies, applied the database migrations, and seeded the development database. I then ran make run and confirmed that the frontend loaded at http://localhost:5173, the API started at http://localhost:8000, and I could log in using the provided test account user1@example.com.
+
+The setup displayed a bcrypt version compatibility warning, but authentication and the rest of the application continued to work. Because that warning is unrelated to issue #154, I will not modify the authentication dependencies as part of this contribution.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -41,3 +41,52 @@ I started the PostgreSQL and Redis services with Docker Compose and confirmed th
 
 **Blockers or open questions:**
 The /health response also reported Redis as unhealthy even though the Redis container was healthy and responded to redis-cli ping with PONG. This appears to be a separate configuration or connectivity issue and is outside the scope of issue #154. I will ensure that my code change is limited to the PostgreSQL probe and does not modify Redis configuration.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+
+I reproduced issue #154 locally and confirmed that the PostgreSQL health probe failed because SQLAlchemy 2.x does not allow raw textual SQL statements to be passed directly to `db.execute()`. I identified the root cause in `api/routes/health.py` and updated the query to use `sqlalchemy.text("SELECT 1")`. After updating the query to await db.execute(text("SELECT 1")) and restarting the application, the /health endpoint correctly reported PostgreSQL as "healthy" instead of "unhealthy", confirming that the SQLAlchemy 2.x compatibility issue was resolved.
+
+**Next steps:**
+
+* Review the final implementation.
+* Update the project documentation.
+* Open a pull request.
+* Request peer or mentor feedback.
+* Address any review comments before marking the PR ready for review.
+
+**Blockers:**
+
+The repository contains several pre-existing linting and type-checking issues across multiple files that are unrelated to issue #154. My implementation only modifies the PostgreSQL health probe and does not introduce any additional linting or type-checking failures.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** 
+
+**Branch:** `fix/154-db-argument-error`
+
+**What you built:**
+
+This change fixes the PostgreSQL health probe so it works correctly with SQLAlchemy 2.x. The health check now wraps the textual SQL query with `sqlalchemy.text()`, allowing the database probe to execute successfully instead of raising an `ArgumentError`. After the fix, PostgreSQL is correctly reported as `"healthy"` when reachable.
+
+**Tests added or updated:**
+
+No new automated tests were added because this fix only changes the SQLAlchemy 2.x syntax used by the PostgreSQL health probe. The fix was verified manually by reproducing the issue before the change and confirming that the /health endpoint reported PostgreSQL as "healthy" after wrapping the query with sqlalchemy.text(). Existing Redis failures were confirmed to be unrelated to this issue.
+
+**Self-review confirmation:**
+
+* [ ] make check passes
+* [ ] make test-unit passes
+make check and make test-unit report pre-existing repository issues unrelated to issue #154. My changes did not introduce any new failures.
+
+The project contains pre-existing linting and typing issues unrelated to this change. My modification did not introduce any additional failures.
+make test-unit reports existing failures unrelated to issue #154. This PR only changes the PostgreSQL health probe and does not introduce additional test failures.
+
+**Draft PR feedback received from:**
+
+None

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -29,7 +29,7 @@ The setup displayed a bcrypt version compatibility warning, but authentication a
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [link to commit documenting the reproduced issue]
+**Reproduction commit link:** (https://github.com/japhet125/pathreview/commit/35cbe6d1a2e091a6769373d5e2de6ac44ec4ddef)
 
 **Reproduction summary:**
 I started the PostgreSQL and Redis services with Docker Compose and confirmed that both containers were healthy. I then called GET http://localhost:8000/health, which returned 503 Service Unavailable and reported PostgreSQL as "unhealthy". The PostgreSQL probe in api/routes/health.py calls await db.execute("SELECT 1") at line 31, causing SQLAlchemy 2.x to reject the raw textual SQL statement even though the PostgreSQL container is reachable.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -24,3 +24,20 @@ I forked the PathReview repository, cloned my fork, and added the original repos
 I successfully ran make setup, which installed the Python and frontend dependencies, applied the database migrations, and seeded the development database. I then ran make run and confirmed that the frontend loaded at http://localhost:5173, the API started at http://localhost:8000, and I could log in using the provided test account user1@example.com.
 
 The setup displayed a bcrypt version compatibility warning, but authentication and the rest of the application continued to work. Because that warning is unrelated to issue #154, I will not modify the authentication dependencies as part of this contribution.
+
+
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [link to commit documenting the reproduced issue]
+
+**Reproduction summary:**
+I started the PostgreSQL and Redis services with Docker Compose and confirmed that both containers were healthy. I then called GET http://localhost:8000/health, which returned 503 Service Unavailable and reported PostgreSQL as "unhealthy". The PostgreSQL probe in api/routes/health.py calls await db.execute("SELECT 1") at line 31, causing SQLAlchemy 2.x to reject the raw textual SQL statement even though the PostgreSQL container is reachable.
+
+
+**PLAN.md link:** (https://github.com/japhet125/pathreview/blob/fix/154-db-argument-error/PLAN.md)
+
+**Walkthrough video (recommended):** [link to your Loom video, ≤2 min — recommended, not graded]
+
+**Blockers or open questions:**
+The /health response also reported Redis as unhealthy even though the Redis container was healthy and responded to redis-cli ping with PONG. This appears to be a separate configuration or connectivity issue and is outside the scope of issue #154. I will ensure that my code change is limited to the PostgreSQL probe and does not modify Redis configuration.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -87,6 +87,40 @@ make check and make test-unit report pre-existing repository issues unrelated to
 The project contains pre-existing linting and typing issues unrelated to this change. My modification did not introduce any additional failures.
 make test-unit reports existing failures unrelated to issue #154. This PR only changes the PostgreSQL health probe and does not introduce additional test failures.
 
-**Draft PR feedback received from:**
+# Week 10 — Iteration & reflection
 
-None
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [X] No — still awaiting review
+
+**Summary of feedback:**
+
+No reviewer feedback has been received yet.
+
+**How you responded:**
+
+No changes were required because I have not received reviewer feedback yet. The pull request remains available for review.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+
+The hardest part was reproducing the bug and confirming its root cause. The actual code change was small, but before making the change I needed to understand how the `/health` endpoint worked, verify that PostgreSQL was running correctly, inspect the application logs, and distinguish the PostgreSQL failure from the separate Redis issue. This taught me that debugging often requires more time to understand and reproduce a problem than to write the final fix.
+
+**What did you learn about working in a large codebase?**
+
+I learned how important it is to understand the scope of an issue before modifying code in a large collaborative project. I also gained experience working with GitHub branches, commits, upstream and origin repositories, pull requests, and contribution requirements. Most importantly, I learned that a good fix should be focused on the reported problem instead of trying to fix every unrelated issue discovered while debugging.
+
+**How did AI tools help — and where did they fall short?**
+
+AI tools helped me understand unfamiliar parts of the codebase, interpret error messages, reproduce the bug, and reason about the SQLAlchemy 2.x error. AI was also useful for reviewing my debugging steps and documentation. However, AI suggestions still required verification. At one point, possible changes to the function signature and other code were considered even though they were outside the scope of issue #154. I compared those suggestions with the issue requirements and the existing code before deciding to keep the implementation focused on wrapping `"SELECT 1"` with `sqlalchemy.text()`.
+
+**What would you do differently if you started over?**
+
+If I started over, I would organize my work around the contribution process from the beginning. I would create and maintain `PLAN.md` and `JOURNAL.md` as I worked instead of updating some documentation afterward. I would also open the draft pull request earlier so there would be more time to request and receive reviewer feedback.
+
+**What are you most proud of from this module?**
+
+I am most proud of learning how to reproduce and debug a real issue in an unfamiliar codebase instead of immediately changing code. I traced the problem to the PostgreSQL health probe, reproduced the SQLAlchemy error, implemented a focused fix, and verified that PostgreSQL changed from `"unhealthy"` to `"healthy"`. I also completed the GitHub contribution workflow by documenting my work and submitting a pull request for review.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,98 @@
+## Solution plan
+
+**Issue:** [Health check DB probe passes a raw SQL string, which fails under SQLAlchemy 2.x — #154](https://github.com/ascherj/pathreview/issues/154)
+
+### Understand
+
+The PostgreSQL health probe in `api/routes/health.py` calls:
+
+```python
+await db.execute("SELECT 1")
+```
+
+SQLAlchemy 2.x does not allow textual SQL to be passed directly as a plain string to `AsyncSession.execute()`. Textual SQL must be explicitly declared using `sqlalchemy.text()`.
+
+The expected behavior is that the health route successfully executes a lightweight `SELECT 1` query and reports PostgreSQL as `"healthy"` when the database is reachable.
+
+The actual behavior is that SQLAlchemy raises an `ArgumentError`, the route catches the exception, PostgreSQL is marked as `"unhealthy"`, and the endpoint returns `503 Service Unavailable`.
+
+### Map
+
+The primary file involved is:
+
+* `api/routes/health.py`
+
+  * `health_check()`
+  * PostgreSQL probe at `await db.execute("SELECT 1")`
+
+Files to investigate for existing testing conventions:
+
+* `tests/`
+* Any existing health-route or API-route test files
+* `core/database.py`, to understand the database session dependency returned by `get_db`
+
+Files I expect to modify:
+
+* `api/routes/health.py`
+* An existing health-check test file, or a new test file under `tests/` if no health-route tests currently exist
+
+Documentation files for Week 8:
+
+* `JOURNAL.md`
+* `PLAN.md`
+
+### Plan
+
+1. Confirm the reproduction by starting the local services, calling `GET http://localhost:8000/health`, and recording that PostgreSQL is reported as `"unhealthy"` even though its Docker container is healthy.
+
+2. Inspect `api/routes/health.py`, `core/database.py`, and the existing test suite to understand how database sessions and FastAPI dependencies are tested in this project.
+
+3. Import `text` from SQLAlchemy and replace the raw SQL execution with:
+
+   ```python
+   await db.execute(text("SELECT 1"))
+   ```
+
+4. Add or update a focused test that verifies the PostgreSQL probe passes a SQLAlchemy textual statement to the database session and reports PostgreSQL as healthy when execution succeeds.
+
+5. Run the relevant test file, then run the broader project checks to confirm that formatting, linting, typing, and existing tests still pass.
+
+6. Call the `/health` endpoint again and verify that the PostgreSQL dependency is no longer marked unhealthy because of the raw SQL string error.
+
+### Inputs & outputs
+
+**Input:**
+
+* An asynchronous SQLAlchemy database session provided by the `get_db` FastAPI dependency
+* A request to `GET /health`
+* A reachable or unreachable PostgreSQL database
+
+**Expected output when PostgreSQL is reachable:**
+
+* The `SELECT 1` probe executes without a SQLAlchemy `ArgumentError`
+* `health_status["dependencies"]["postgres"]` is set to `"healthy"`
+
+**Expected output when PostgreSQL is unavailable:**
+
+* The database exception is caught
+* PostgreSQL is reported as `"unhealthy"`
+* The endpoint returns `503 Service Unavailable`
+
+The change should affect only how the textual PostgreSQL probe is constructed. It should not change Redis, vector database, or safety-event behavior.
+
+### Risks & unknowns
+
+* There may not currently be a dedicated test for the health route, so I may need to determine the project’s preferred location and style for API route tests.
+* Tests may need to override the `get_db` dependency or use an `AsyncMock` database session to avoid requiring a live PostgreSQL connection.
+* The endpoint can still return `503` when Redis or another critical dependency is unhealthy, even after the PostgreSQL probe is fixed. Therefore, validation must inspect the PostgreSQL dependency status rather than relying only on the overall HTTP status.
+* Import ordering and typing rules must continue to satisfy Ruff, Black, and mypy.
+* The Redis health failure observed during reproduction appears separate from issue #154 and should not be included in this fix.
+
+### Edge cases
+
+* PostgreSQL is reachable and the query executes successfully.
+* PostgreSQL is unavailable or the session raises a connection-related exception.
+* The database session raises an unexpected SQLAlchemy exception.
+* PostgreSQL is healthy while Redis is unhealthy; the endpoint may still return `503`, but PostgreSQL should remain marked `"healthy"`.
+* Redis and PostgreSQL are both healthy; the endpoint should report both dependencies accurately.
+* The fix must continue using an asynchronous database session and must not introduce a synchronous database call.

--- a/api/routes/health.py
+++ b/api/routes/health.py
@@ -1,6 +1,8 @@
-from fastapi import APIRouter, HTTPException, status, Depends
+from datetime import datetime
+
 import structlog
-from datetime import datetime, timedelta
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import text
 
 from core.database import get_db
 
@@ -28,7 +30,7 @@ async def health_check(db=Depends(get_db)):
 
     try:
         # Check PostgreSQL
-        await db.execute("SELECT 1")
+        await db.execute(text("SELECT 1"))
         health_status["dependencies"]["postgres"] = "healthy"
         log.debug("postgres_health_check_passed")
     except Exception as exc:
@@ -39,6 +41,7 @@ async def health_check(db=Depends(get_db)):
     try:
         # Check Redis (if available)
         import redis
+
         from core.config import settings
 
         r = redis.Redis(


### PR DESCRIPTION
## Summary

The PostgreSQL probe in `api/routes/health.py` passed `"SELECT 1"` directly to `db.execute()`. SQLAlchemy 2.x rejects raw textual SQL statements, so the health endpoint incorrectly reported PostgreSQL as unavailable even when the database was reachable.

This PR wraps the probe query with `sqlalchemy.text()`, allowing the PostgreSQL health check to execute successfully under SQLAlchemy 2.x.

## Issue

Closes #154

## Changes

Root cause: the PostgreSQL health probe passed a plain Python string to SQLAlchemy’s asynchronous `execute()` method. Under SQLAlchemy 2.x, textual SQL must be explicitly declared with `text()`.

* `api/routes/health.py`

  * Imported `text` from SQLAlchemy
  * Replaced `await db.execute("SELECT 1")` with `await db.execute(text("SELECT 1"))`
  * Kept the existing health-check behavior for PostgreSQL failures, Redis, the vector database, and safety events unchanged

## Testing

**Reproduce the original issue:**

1. Check out the original `main` branch.
2. Start Docker Desktop.
3. Run:

```bash
docker compose up -d
make run
```

4. In another terminal, call:

```bash
curl -i http://localhost:8000/health
```

5. Observe that the logs contain:

```text
postgres_health_check_failed
Textual SQL expression 'SELECT 1' should be explicitly declared as text('SELECT 1')
```

6. Observe that the response reports PostgreSQL as `"unhealthy"` even though the PostgreSQL container is healthy.

**Verify the fix:**

1. Check out `fix/154-db-argument-error`.
2. Start the services and application:

```bash
docker compose up -d
make run
```

3. Call:

```bash
curl -i http://localhost:8000/health
```

4. Confirm that the logs contain:

```text
postgres_health_check_passed
```

5. Confirm that the response reports:

```json
"postgres": "healthy"
```

`make check` and `make test-unit` were also run. They report pre-existing repository failures across files unrelated to this change. The PostgreSQL probe change does not introduce additional observed failures.

## Screenshots / Demo

N/A — this is a backend-only compatibility fix. The observable behavior appears in the `/health` response and application logs.

## Notes for Reviewers

The overall `/health` endpoint can still return `503 Service Unavailable` because the Redis probe raises a separate configuration error: the `Settings` object does not define `redis_host`. That issue is unrelated to #154 and is intentionally outside the scope of this PR.

The repository also contains pre-existing linting, type-checking, and unit-test failures across unrelated modules. This PR is limited to the SQLAlchemy 2.x compatibility fix for the PostgreSQL health probe.
