### PR TITLE
Fix/150 ignore vendored build files

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,29 @@
+# PathReview Contribution Journal
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/150
+
+**Issue title:** Tech detector counts vendored and build-output files, skewing language detection
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+PathReview’s technology detector is supposed to ignore dependency and generated-output directories when determining a repository’s programming languages. However, its current skip patterns contain leading slashes, so root-level paths such as `node_modules/package/index.js` and `build/bundle.js` are not excluded. As a result, vendored or generated JavaScript files can affect language detection and cause the repository’s primary language to be reported incorrectly. A successful fix will make the filtering logic work for both root-level and nested directories while passing the existing unit tests.
+
+**Selection notes — “Is this issue right for me?” checklist:**
+
+- The expected behavior and current failure are clearly explained.
+- The issue includes a reproducible example and identifies relevant failing tests.
+- The likely scope is limited to `agent/tools/tech_detector.py` and `tests/unit/test_tech_detector.py`.
+- The issue does not require a database migration, external API integration, or major frontend changes.
+- I have experience with Python, backend development, file-processing logic, and unit testing.
+- I understand the likely cause: root-level paths do not contain the leading slash used by the existing skip patterns.
+- I will verify root-level paths, nested paths, and path separators without changing unrelated detection behavior.
+- This Tier 1 issue has a realistic scope for my first contribution to this repository.
+
+**Branch name:** `fix/150-ignore-vendored-build-files`
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -27,3 +27,73 @@ PathReview’s technology detector is supposed to ignore dependency and generate
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [ ] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/tungnguyenasu/pathreview/commit/41585836d39f3b4ee72b42d29cfb09bf8bff9d6d
+
+**Reproduction summary:**
+I reproduced Issue #150 by running the existing `test_node_modules_excluded`
+and `test_build_directory_excluded` unit tests. Both tests failed because
+root-level `node_modules/` and `build/` paths were not filtered, allowing
+JavaScript files in those directories to make JavaScript the reported primary
+language instead of Python.
+
+**PLAN.md link:** https://github.com/tungnguyenasu/pathreview/blob/fix/150-ignore-vendored-build-files/PLAN.md
+
+**Walkthrough video (recommended):** Not recorded
+
+**Blockers or open questions:**
+I need to verify whether path component comparisons should be case-sensitive.
+I will also confirm that normalizing Windows backslashes does not change
+existing behavior for repository paths that already use forward slashes.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+I reproduced Issue #150, traced the problem to the leading-slash substring
+patterns in `TechDetector._should_skip_file()`, and completed the solution
+plan. I also identified the existing tests that need stronger assertions and
+the edge cases that require regression coverage.
+
+**Next steps:**
+I will normalize path separators, compare exact directory components, add
+regression tests, run the targeted and complete test suites, and open a draft
+pull request for feedback.
+
+**Blockers:**
+None.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [paste final non-draft PR link]
+
+**Branch:** `fix/150-ignore-vendored-build-files`
+
+**What you built:**
+I updated `TechDetector` to normalize repository paths and ignore exact
+dependency, vendor, cache, virtual-environment, and generated-output directory
+components. The fix works for root-level, nested, and Windows-style paths
+without excluding similarly named legitimate directories.
+
+**Tests added or updated:**
+I updated `tests/unit/test_tech_detector.py` to strengthen the existing
+`node_modules`, `vendor`, and `build` tests. I also added regression coverage
+for nested ignored directories, Windows separators, ignored configuration
+files, similarly named valid directories, and inputs where every file is
+excluded. The full `tests/unit/test_tech_detector.py` file passes (32 tests).
+
+**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+
+*Note:* Both boxes are left unchecked because the repository has pre-existing,
+unrelated failures on `main`: `make test-unit` reports 51 failing tests in
+other modules (unchanged by this branch), and `make check` fails on pre-existing
+`ruff`/`black`/`mypy` findings in files this change does not touch. The tests
+specific to Issue #150 all pass, and `mypy` reports no issues on
+`agent/tools/tech_detector.py`.
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -26,7 +26,7 @@ PathReview’s technology detector is supposed to ignore dependency and generate
 
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
-**Cohort ledger:** [ ] Issue added to cohort ledger
+**Cohort ledger:** [x] Issue added to cohort ledger
 
 ## Week 8 — Reproduction & solution planning
 
@@ -97,3 +97,88 @@ specific to Issue #150 all pass, and `mypy` reports no issues on
 `agent/tools/tech_detector.py`.
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No reviewer or maintainer feedback has been received on the pull request. For
+Summer 2026, formal reviewer feedback is not part of the course workflow, so I
+am documenting that the PR is still awaiting review and moving forward with the
+reflection.
+
+**How you responded:**
+No response or additional code changes were required because no reviewer
+feedback was received.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+
+The most difficult part of this contribution was not the final code change
+itself, but getting from an unfamiliar issue to a reliable local development
+and testing workflow. Setting up the project on Windows required working
+through Docker, WSL, Git Bash, Python environments, and the project's `make`
+commands. I also had to distinguish failures caused by my issue from failures
+that already existed elsewhere in the repository. Once I reached the actual
+bug, the code change was relatively small, but proving the root cause and
+testing it carefully took more work than I initially expected.
+
+**What did you learn about working in a large codebase?**
+
+I learned that contributing to an existing codebase requires much more
+attention to scope than building a project from scratch. I could not simply
+change the behavior until my example worked; I had to trace how
+`TechDetector._should_skip_file()` was used, understand the existing test
+patterns, preserve the public output format, and avoid changing unrelated
+behavior. I also learned the importance of separating pre-existing failures
+from failures introduced by my branch. In my own projects I can often change
+multiple related pieces at once, but in an open-source contribution a smaller,
+well-tested change is easier to review and safer to merge.
+
+**How did AI tools help — and where did they fall short?**
+
+AI tools were most useful for navigating the unfamiliar repository, explaining
+error messages, identifying likely files involved in the issue, and helping me
+turn the issue description into a structured reproduction and solution plan.
+They were also useful for suggesting edge cases such as root-level paths,
+nested paths, Windows backslashes, and similarly named directories like
+`rebuild` or `vendor_tools`.
+
+However, I still had to verify the suggestions against the actual PathReview
+code and tests. Some commands depended on whether I was using PowerShell or Git
+Bash, and an AI-generated command that was valid in one shell could fail in the
+other. I also had to run the test suite myself to determine which failures were
+pre-existing. This showed me that AI can accelerate investigation and suggest
+solutions, but it cannot replace checking the repository's real behavior and
+development environment.
+
+**What would you do differently if you started over?**
+
+I would spend more time at the beginning verifying the full development
+environment and the repository's baseline test status before starting the issue
+work. I would also use Git Bash consistently for the project's `make` workflow
+instead of switching between PowerShell and Git Bash. For the contribution
+itself, I would record the baseline `make check` and `make test-unit` results
+immediately so that later I could compare them directly against my branch.
+
+I would still choose a Tier 1 issue for a first contribution because the
+smaller scope allowed me to focus on the contribution workflow instead of
+being overwhelmed by a large feature. After completing one issue like this, I
+would feel more comfortable choosing a higher-tier issue next time.
+
+**What are you most proud of from this module?**
+
+I am most proud that I did more than make the two originally failing tests
+pass. I traced the problem to the path-matching logic and implemented the fix
+in a way that handles root-level paths, nested paths, and Windows-style path
+separators while avoiding false matches on legitimate directories. I also
+expanded the tests to cover those edge cases and confirmed that the complete
+`test_tech_detector.py` suite passes with 32 tests. The process gave me
+experience following an issue from selection and reproduction through planning,
+implementation, testing, and a real pull request.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -70,7 +70,7 @@ None.
 
 ### Check-in 2 (end of week)
 
-**PR link:** [paste final non-draft PR link]
+**PR link:** https://github.com/ascherj/pathreview/pull/585
 
 **Branch:** `fix/150-ignore-vendored-build-files`
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -61,46 +61,58 @@ The input is a list of repository-relative file paths supplied through:
 
 ```python
 TechDetector.execute({"files": files})
+```
 
 Example input:
 
+```python
 [
     "main.py",
     "core/app.py",
     "node_modules/lib/index.js",
     "build/bundle.js",
 ]
+```
 
 Before the fix, JavaScript files inside ignored directories may remain in the
 analysis and produce:
 
+```python
 {
     "primary_language": "JavaScript",
     "all_languages": ["JavaScript", "Python"],
     "frameworks": [],
 }
+```
 
 After the fix, the ignored JavaScript files should not affect detection:
 
+```python
 {
     "primary_language": "Python",
     "all_languages": ["Python"],
     "frameworks": [],
 }
+```
 
-The public output structure of TechDetector should remain unchanged.
+The public output structure of `TechDetector` should remain unchanged.
 
-Risks & unknowns
+### Risks & unknowns
+
 - A broad substring check could incorrectly skip legitimate paths such as
-src/rebuild/parser.py because the directory name contains build. The implementation should compare complete directory components instead.
-- Windows paths may use backslashes while repository APIs commonly return forward slashes. Path normalization must support both.
-- Configuration files inside excluded directories must also be filtered so they do not introduce frameworks such as Node.js.
-- If every supplied file is excluded, the detector should continue returning Unknown instead of raising an exception.
-- The current primary-language selection behavior may have unrelated issues. This fix should remain limited to Issue #150 unless testing proves a broader
-change is required.
+  `src/rebuild/parser.py` because the directory name contains `build`. The
+  implementation should compare complete directory components instead.
+- Windows paths may use backslashes while repository APIs commonly return
+  forward slashes. Path normalization must support both.
+- Configuration files inside excluded directories must also be filtered so they
+  do not introduce frameworks such as Node.js.
+- If every supplied file is excluded, the detector should continue returning
+  `Unknown` instead of raising an exception.
+- The current primary-language selection behavior may have unrelated issues.
+  This fix should remain limited to Issue #150 unless testing proves a broader
+  change is required.
 
-
-Edge cases
+### Edge cases
 
 The implementation and tests should cover:
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,126 @@
+# PathReview Issue #150 Plan
+
+## Solution plan
+
+**Issue:** [Tech detector counts vendored and build-output files, skewing language detection](https://github.com/ascherj/pathreview/issues/150)
+
+### Understand
+
+`TechDetector` receives a list of repository-relative file paths and filters
+out files that should not affect technology detection. The current
+`_should_skip_file()` implementation searches for strings such as
+`/node_modules/` and `/build/`. This works when the ignored directory appears
+below another directory, such as `frontend/node_modules/package/index.js`, but
+it does not work when the ignored directory is at the root of the repository,
+such as `node_modules/package/index.js`.
+
+Because those JavaScript files remain in the filtered file list, JavaScript is
+added to the detected languages. The detector then selects JavaScript as the
+primary language instead of Python. The expected behavior is for dependency,
+vendor, virtual-environment, cache, and generated-output directories to be
+excluded regardless of whether they appear at the repository root or inside
+another directory.
+
+### Map
+
+The main files involved are:
+
+- `agent/tools/tech_detector.py`
+  - `TechDetector._detect_tech()`
+  - `TechDetector._should_skip_file()`
+- `tests/unit/test_tech_detector.py`
+  - `test_node_modules_excluded`
+  - `test_vendor_files_excluded`
+  - `test_build_directory_excluded`
+  - Additional regression tests for nested paths and Windows path separators
+
+`_detect_tech()` calls `_should_skip_file()` before inspecting file extensions
+and configuration filenames. The fix should therefore remain focused on the
+path-filtering stage.
+
+### Plan
+
+1. Normalize each incoming file path so both forward slashes and Windows
+   backslashes can be handled consistently.
+2. Split the normalized path into directory components rather than searching
+   for skip-directory names using leading-slash substrings.
+3. Mark a file as skipped when one of its directory components exactly matches
+   a known ignored directory such as `node_modules`, `vendor`, `dist`, `build`,
+   `.git`, `__pycache__`, `.venv`, or `venv`.
+4. Strengthen the existing unit tests so they verify that languages found only
+   in ignored directories are absent from `all_languages`, not merely that
+   Python happens to be selected as the primary language.
+5. Add regression coverage for root-level ignored directories, nested ignored
+   directories, Windows-style backslash paths, and similarly named legitimate
+   directories. Run the targeted test file and then the complete unit test
+   suite.
+
+### Inputs & outputs
+
+The input is a list of repository-relative file paths supplied through:
+
+```python
+TechDetector.execute({"files": files})
+
+Example input:
+
+[
+    "main.py",
+    "core/app.py",
+    "node_modules/lib/index.js",
+    "build/bundle.js",
+]
+
+Before the fix, JavaScript files inside ignored directories may remain in the
+analysis and produce:
+
+{
+    "primary_language": "JavaScript",
+    "all_languages": ["JavaScript", "Python"],
+    "frameworks": [],
+}
+
+After the fix, the ignored JavaScript files should not affect detection:
+
+{
+    "primary_language": "Python",
+    "all_languages": ["Python"],
+    "frameworks": [],
+}
+
+The public output structure of TechDetector should remain unchanged.
+
+Risks & unknowns
+- A broad substring check could incorrectly skip legitimate paths such as
+src/rebuild/parser.py because the directory name contains build. The implementation should compare complete directory components instead.
+- Windows paths may use backslashes while repository APIs commonly return forward slashes. Path normalization must support both.
+- Configuration files inside excluded directories must also be filtered so they do not introduce frameworks such as Node.js.
+- If every supplied file is excluded, the detector should continue returning Unknown instead of raising an exception.
+- The current primary-language selection behavior may have unrelated issues. This fix should remain limited to Issue #150 unless testing proves a broader
+change is required.
+
+
+Edge cases
+
+The implementation and tests should cover:
+
+- Root-level dependency paths:
+    node_modules/package/index.js
+- Nested dependency paths:
+    frontend/node_modules/package/index.js
+- Root-level build output:
+    build/bundle.js
+    dist/app.js
+- Nested build output:
+    frontend/build/bundle.js
+- Windows-style separators:
+    frontend\node_modules\package\index.js
+- Virtual environments and caches:
+    .venv/Lib/site-packages/library.py
+    src/__pycache__/module.pyc
+- Legitimate similarly named directories that should not be skipped:
+    src/rebuild/parser.py
+    src/vendor_tools/helper.py
+- Configuration files inside ignored directories:
+    node_modules/package/package.json
+- An input where all files are excluded, which should return an unknown language without crashing.

--- a/REPRODUCTION.md
+++ b/REPRODUCTION.md
@@ -18,3 +18,27 @@ python -m pytest `
   tests/unit/test_tech_detector.py::TestTechDetector::test_node_modules_excluded `
   tests/unit/test_tech_detector.py::TestTechDetector::test_build_directory_excluded `
   -v
+```
+
+## Observed behavior
+
+Both targeted tests fail. TechDetector reports JavaScript as the primary
+language even though the JavaScript files are located only inside root-level
+node_modules/ or build/ directories.
+
+The current path filtering uses patterns such as /node_modules/ and
+/build/. Relative repository paths such as node_modules/lib/index.js and
+build/bundle.js do not contain a leading slash, so they remain in the file
+list used for language detection.
+
+## Expected behavior
+
+Files inside dependency, vendor, and generated-output directories should be
+removed before language and framework detection. For the reproduction inputs,
+Python should be the primary language, and JavaScript should not be detected
+from the excluded files.
+
+## Reproduction result
+
+The issue is reproducible locally and appears to originate in
+TechDetector._should_skip_file() in agent/tools/tech_detector.py.

--- a/REPRODUCTION.md
+++ b/REPRODUCTION.md
@@ -1,0 +1,20 @@
+# Issue #150 Reproduction
+
+## Issue
+
+[Tech detector counts vendored and build-output files, skewing language detection](https://github.com/ascherj/pathreview/issues/150)
+
+## Environment
+
+- Operating system: Windows
+- Shell: PowerShell
+- Python environment: Project `.venv`
+- Working branch: `fix/150-ignore-vendored-build-files`
+
+## Reproduction command
+
+```powershell
+python -m pytest `
+  tests/unit/test_tech_detector.py::TestTechDetector::test_node_modules_excluded `
+  tests/unit/test_tech_detector.py::TestTechDetector::test_build_directory_excluded `
+  -v

--- a/agent/tools/tech_detector.py
+++ b/agent/tools/tech_detector.py
@@ -56,6 +56,20 @@ class TechDetector(BaseTool):
         "cmake": ("CMake", "Build"),
     }
 
+    # Directories whose files should never affect tech detection
+    SKIP_DIRECTORIES = frozenset(
+        {
+            ".git",
+            ".venv",
+            "__pycache__",
+            "build",
+            "dist",
+            "node_modules",
+            "vendor",
+            "venv",
+        }
+    )
+
     def execute(self, input_data: dict) -> ToolResult:
         """Detect tech stack from files.
 
@@ -140,25 +154,17 @@ class TechDetector(BaseTool):
             "frameworks": all_frameworks,
         }
 
-    @staticmethod
-    def _should_skip_file(filepath: str) -> bool:
-        """Check if file should be skipped.
+    @classmethod
+    def _should_skip_file(cls, filepath: str) -> bool:
+        """Check whether a file is inside an ignored directory.
 
         Args:
-            filepath: File path
+            filepath: Repository-relative file path.
 
         Returns:
-            True if file should be skipped
+            True if any parent directory should be ignored.
         """
-        skip_patterns = [
-            "/node_modules/",
-            "/vendor/",
-            "/dist/",
-            "/build/",
-            "/.git/",
-            "/__pycache__/",
-            "/.venv/",
-            "/venv/",
-        ]
+        normalized_path = filepath.replace("\\", "/")
+        directory_parts = normalized_path.split("/")[:-1]
 
-        return any(pattern in filepath for pattern in skip_patterns)
+        return any(part in cls.SKIP_DIRECTORIES for part in directory_parts)

--- a/tests/unit/test_tech_detector.py
+++ b/tests/unit/test_tech_detector.py
@@ -64,7 +64,7 @@ class TestTechDetector:
         # .ipynb should be treated as Python, not JSON
 
     def test_node_modules_excluded(self, detector):
-        """Test node_modules/ directory is excluded from counts."""
+        """Test node_modules directory is excluded from detection."""
         files = [
             "src/main.py",
             "node_modules/package1/index.js",
@@ -74,12 +74,13 @@ class TestTechDetector:
 
         result = detector.execute({"files": files})
 
-        data = result.data
-        assert data["primary_language"] == "Python"
-        # node_modules shouldn't dominate
+        assert result.success is True
+        assert result.data["primary_language"] == "Python"
+        assert result.data["all_languages"] == ["Python"]
+        assert result.data["frameworks"] == []
 
     def test_vendor_files_excluded(self, detector):
-        """Test vendor files are excluded."""
+        """Test vendor directory is excluded from detection."""
         files = [
             "src/main.py",
             "vendor/lib.js",
@@ -89,10 +90,12 @@ class TestTechDetector:
 
         result = detector.execute({"files": files})
 
-        # Python should be primary despite vendor files
+        assert result.success is True
+        assert result.data["primary_language"] == "Python"
+        assert result.data["all_languages"] == ["Python"]
 
     def test_build_directory_excluded(self, detector):
-        """Test build directory is excluded."""
+        """Test build directory is excluded from detection."""
         files = [
             "src/main.py",
             "build/generated.js",
@@ -101,8 +104,79 @@ class TestTechDetector:
 
         result = detector.execute({"files": files})
 
-        data = result.data
-        assert data["primary_language"] == "Python"
+        assert result.success is True
+        assert result.data["primary_language"] == "Python"
+        assert result.data["all_languages"] == ["Python"]
+
+    def test_nested_ignored_directories_excluded(self, detector):
+        """Test ignored directories are detected below the repo root."""
+        files = [
+            "src/main.py",
+            "frontend/node_modules/package/index.js",
+            "frontend/dist/generated.ts",
+        ]
+
+        result = detector.execute({"files": files})
+
+        assert result.success is True
+        assert result.data["all_languages"] == ["Python"]
+
+    def test_windows_path_separators_supported(self, detector):
+        """Test ignored directories in Windows-style paths."""
+        files = [
+            "src/main.py",
+            r"frontend\node_modules\package\index.js",
+            r"frontend\build\bundle.ts",
+        ]
+
+        result = detector.execute({"files": files})
+
+        assert result.success is True
+        assert result.data["all_languages"] == ["Python"]
+
+    def test_similarly_named_directories_not_excluded(self, detector):
+        """Test partial directory-name matches are preserved."""
+        files = [
+            "src/main.py",
+            "src/rebuild/parser.js",
+            "src/vendor_tools/helper.ts",
+        ]
+
+        result = detector.execute({"files": files})
+
+        assert result.success is True
+        assert set(result.data["all_languages"]) == {
+            "JavaScript",
+            "Python",
+            "TypeScript",
+        }
+
+    def test_config_files_in_ignored_directories_excluded(self, detector):
+        """Test ignored config files do not introduce frameworks."""
+        files = [
+            "src/main.py",
+            "node_modules/package/package.json",
+        ]
+
+        result = detector.execute({"files": files})
+
+        assert result.success is True
+        assert result.data["all_languages"] == ["Python"]
+        assert result.data["frameworks"] == []
+
+    def test_all_files_excluded_returns_unknown(self, detector):
+        """Test detection when every file belongs to an ignored directory."""
+        files = [
+            "node_modules/package/index.js",
+            "build/bundle.ts",
+        ]
+
+        result = detector.execute({"files": files})
+
+        assert result.success is True
+        assert result.data["primary_language"] == "Unknown"
+        assert result.data["all_languages"] == []
+        assert result.data["frameworks"] == []
 
     def test_config_file_detection(self, detector):
         """Test detection from config files."""


### PR DESCRIPTION
## Summary

- Normalize repository file paths before checking ignored directories.
- Exclude exact dependency, vendor, generated-output, cache, and virtual
  environment directory components.
- Support root-level, nested, and Windows-style paths.
- Add regression tests for ignored and similarly named valid directories.

## Problem

`TechDetector._should_skip_file()` searched for patterns such as
`/node_modules/` and `/build/`. Root-relative paths such as
`node_modules/package/index.js` do not contain a leading slash, so vendored or
generated files remained in the language analysis.

This could cause JavaScript or TypeScript files from ignored directories to
affect the detected languages and primary language.

## Solution

The path is normalized to forward slashes and split into path components.
Only exact parent-directory component matches are excluded. This allows both
root-level and nested ignored directories to be recognized while preserving
legitimate directories such as `rebuild` and `vendor_tools`.

## Testing

- [x] `python -m pytest tests/unit/test_tech_detector.py -v` — 32 passed
- [x] `make check`
- [x] `make test-unit`

## Pre-existing failures

`make check` and `make test-unit` do not pass cleanly on this branch because of
failures that already exist on `main` and are unrelated to this change:

- `make test-unit`: 51 failing tests across 15 unrelated modules (e.g.
  `test_bias_detector`, `test_faithfulness_checker`, `test_pii_scrubber`,
  `test_resume_parser`, `test_review_service`, `test_skill_extractor`,
  `test_readme_parser`, `test_security`, `test_structural_chunker`, …). None are
  touched by this change; the 2 previously-failing `test_tech_detector` cases
  now pass.
- `make check`: fails on pre-existing `ruff`/`black`/`mypy` findings in files
  this change does not modify. `mypy` reports no issues on
  `agent/tools/tech_detector.py`, the only source file changed here.

Closes #150
