### PR TITLE
test(rag): add full RAG pipeline integration test

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -27,7 +27,7 @@ The issue has a specific expected outcome: one integration test should exercise 
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** https://github.com/drmitte7/pathreview/commit/078560a9f44f23893eea3a848d7f160ff83b5648
+**Reproduction commit link:** https://github.com/drmitte7/pathreview/commit/14d7862ee37839ad64fa147b7c73ddee71905d19
 
 **Reproduction summary:**
 I reproduced the issue by confirming that the `tests/integration` directory contains only `__init__.py` and that `tests/integration/test_rag_pipeline.py` is missing. I also confirmed that PathReview has separate unit tests for RAG components but no integration test that runs retrieval, reranking, generation, and response parsing as one complete workflow.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -50,28 +50,20 @@ I will run `make check` and `make test-unit`, compare the results with the failu
 **Blockers:**
 The targeted integration test has no current blockers. Mypy reports three pre-existing type errors in `rag/retriever/vector_store.py`, `rag/retriever/keyword_search.py`, and `rag/generator/output_parser.py`. These files were not modified by this contribution.
 
-### Check-in 2 (final)
+### Check-in 2 (end of week)
 
-**Pull request:**
-https://github.com/ascherj/pathreview/pull/586
+**PR link:** https://github.com/ascherj/pathreview/pull/586
 
-**Branch:**
-`test/38-rag-pipeline-integration-test`
+**Branch:** `test/38-rag-pipeline-integration-test`
 
-**Implementation completed:**
+**What you built:**
 I added `tests/integration/test_rag_pipeline.py`, which tests the full RAG workflow from retrieval and hybrid reranking through mocked LLM generation and structured output parsing.
 
-**Testing results:**
-- Targeted integration test: 1 passed
-- Ruff check on the new test file: passed
-- Black check on the new test file: passed
-- Full repository Ruff check: 182 pre-existing errors
-- Full unit-test suite: 375 passed and 53 pre-existing failures
-- The same full-suite results were reproduced on `upstream/main`, confirming that this branch introduces no new failures.
+**Tests added or updated:**
+I added `tests/integration/test_rag_pipeline.py`. It verifies vector and BM25 retrieval, hybrid reranking, mocked LLM generation, prompt context, and structured output parsing. The targeted integration test passes.
 
-**Peer or mentor feedback:**
-I requested review through the pull request, but no peer or mentor review was received before the submission deadline.
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
 
-**Self-review:**
-- [x] I reviewed the complete pull-request diff.
-- [x] My contribution introduces no new test or lint failures.
+The full repository checks contain 182 pre-existing Ruff errors and 53 pre-existing unit-test failures. I reproduced the same results on `upstream/main`, confirming that this branch introduces no new failures.
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -24,3 +24,15 @@ The issue has a specific expected outcome: one integration test should exercise 
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/drmitte7/pathreview/commit/078560a9f44f23893eea3a848d7f160ff83b5648
+
+**Reproduction summary:**
+I reproduced the issue by confirming that the `tests/integration` directory contains only `__init__.py` and that `tests/integration/test_rag_pipeline.py` is missing. I also confirmed that PathReview has separate unit tests for RAG components but no integration test that runs retrieval, reranking, generation, and response parsing as one complete workflow.
+
+**PLAN.md link:** https://github.com/drmitte7/pathreview/blob/test/38-rag-pipeline-integration-test/PLAN.md
+
+**Blockers or open questions:**
+I still need to confirm whether “reranking” in issue #38 refers to the score blending performed by `HybridRetriever`, the separate `RelevanceScorer`, or both. I also need to confirm whether the expected mock LLM approach uses an existing provider abstraction or patches the OpenAI-compatible client call in `ReviewGenerator`.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,26 @@
+# PathReview Contribution Journal
+
+## Week 7 — Issue selection
+
+**Issue link:** [Issue #38 — Add an integration test that runs the full RAG pipeline against a mock LLM](https://github.com/ascherj/pathreview/issues/38)
+
+**Issue title:** Add an integration test that runs the full RAG pipeline against a mock LLM
+
+**Tier:** [ ] Tier 1  [x] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+PathReview currently has unit tests for individual RAG components, but it does not have an integration test proving that the components work together as one complete pipeline. This means a problem in the connection between retrieval, reranking, generation, and output parsing might not be detected by the existing tests. The proposed test will send a representative query through the full RAG workflow while using the mock LLM provider instead of making a real external LLM request. A successful implementation will verify that every stage receives the expected input, produces the expected output, and returns a correctly parsed final result.
+
+**Issue fit and selection reasoning:**
+I selected this Tier 2 issue because it requires understanding how several RAG modules connect rather than changing only one isolated function. This is more challenging than a Tier 1 issue, but the scope is still manageable because the issue identifies one primary test file, `tests/integration/test_rag_pipeline.py`, and provides an estimated effort of four to six hours. Using the mock LLM provider should allow the test to run predictably without depending on an external API or consuming API credits. I am comfortable working with Python and pytest, and this issue will help me build experience tracing data across multiple modules in a larger codebase.
+
+**“Is this issue right for me?” selection notes:**
+The issue has a specific expected outcome: one integration test should exercise the complete RAG flow from retrieval through final parsing. The main deliverable is limited to the integration-test area, although I will need to read existing retriever, reranker, generator, parser, mock-provider, fixture, and unit-test code before implementing it. The issue does not require a production LLM connection because the mock provider will make the test deterministic and suitable for continuous integration. The four-to-six-hour estimate fits the Module 3 timeline, and I understand that the Tier 2 label reflects the need for cross-module investigation.
+
+**Expected implementation file:** `tests/integration/test_rag_pipeline.py`
+
+**Branch name:** `test/38-rag-pipeline-integration-test`
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -67,3 +67,34 @@ I added `tests/integration/test_rag_pipeline.py`. It verifies vector and BM25 re
 The full repository checks contain 182 pre-existing Ruff errors and 53 pre-existing unit-test failures. I reproduced the same results on `upstream/main`, confirming that this branch introduces no new failures.
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No reviewer or maintainer feedback was received on my pull request before completing this reflection. My PR remains open and ready for review, but no additional changes were requested.
+
+**How you responded:**
+Since no reviewer feedback was received, I did not need to make any additional code changes or responses. I left the pull request open and ready for future review.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The hardest part was not writing the integration test itself, but understanding how all of the existing RAG components connect together. For issue #38, I had to work with `VectorStore`, `KeywordSearcher`, `HybridRetriever`, `ReviewGenerator`, and the output parser so that `tests/integration/test_rag_pipeline.py` exercised retrieval, reranking, generation, and parsing as one workflow. Another challenge was distinguishing problems caused by my code from existing repository problems, especially when `make check` reported 182 Ruff errors and `make test-unit` reported 53 failing tests.
+
+**What did you learn about working in a large codebase?**
+I learned that contributing to an existing codebase requires much more attention to scope than working on my own project. Instead of fixing every problem I found, I needed to stay focused on issue #38 and avoid modifying unrelated production files just because they contained lint, type, or test failures. I also learned how important it is to understand the repository's Git workflow, including working on a dedicated branch, rebasing onto `upstream/main`, force-pushing safely with `--force-with-lease`, and keeping the pull request focused.
+
+**How did AI tools help — and where did they fall short?**
+AI tools helped me understand unfamiliar parts of the RAG pipeline, plan the integration test, interpret pytest and Git output, and work through commands for rebasing, committing, and preparing the pull request. AI was also useful for helping me structure the mocked LLM response so the test could run without making a real OpenAI API request. However, I learned that AI suggestions still have to be verified against the actual repository because assumptions about function signatures, existing tests, or project behavior may not always match the current code, so running the code and checking the real test output was essential.
+
+**What would you do differently if you started over?**
+If I started again, I would open the draft pull request earlier so there would be more time for peer or maintainer feedback before the deadline. I would also inspect the interfaces between `HybridRetriever`, `ReviewGenerator`, and the output parser earlier in the process before writing the integration test, which would make implementation more direct. I would continue using a before-and-after testing baseline because comparing my branch with `upstream/main` was very useful for proving that the existing 182 Ruff errors and 53 unit-test failures were not introduced by my contribution.
+
+**What are you most proud of from this module?**
+I am most proud that I completed a real open-source-style contribution from issue selection through planning, implementation, testing, documentation, and pull request submission. My integration test in `tests/integration/test_rag_pipeline.py` successfully exercises the RAG pipeline end to end using deterministic data and a mocked LLM, and the targeted test passes without requiring an external API call. I also became much more comfortable working with Git branches, upstream repositories, rebasing, test failures, and documenting technical decisions in a professional pull request.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -36,3 +36,16 @@ I reproduced the issue by confirming that the `tests/integration` directory cont
 
 **Blockers or open questions:**
 I still need to confirm whether “reranking” in issue #38 refers to the score blending performed by `HybridRetriever`, the separate `RelevanceScorer`, or both. I also need to confirm whether the expected mock LLM approach uses an existing provider abstraction or patches the OpenAI-compatible client call in `ReviewGenerator`.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+I created `tests/integration/test_rag_pipeline.py` and implemented the main workflow from my solution plan. The test creates deterministic document chunks, indexes them for vector and keyword retrieval, runs a representative query through `HybridRetriever`, and verifies that the relevant result ranks first. It also replaces the external LLM request with a deterministic mock, confirms that retrieved context reaches the generation prompt, and verifies that the response is parsed into structured feedback. The targeted integration test passed successfully on repeated runs.
+
+**Next steps:**
+I will run `make check` and `make test-unit`, compare the results with the failures observed before implementation, and confirm that my change introduces no new failures. I will then open a draft pull request, request peer or mentor feedback, address relevant feedback, and complete Check-in 2 with the final PR link and verification results.
+
+**Blockers:**
+The targeted integration test has no current blockers. Mypy reports three pre-existing type errors in `rag/retriever/vector_store.py`, `rag/retriever/keyword_search.py`, and `rag/generator/output_parser.py`. These files were not modified by this contribution.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -49,3 +49,29 @@ I will run `make check` and `make test-unit`, compare the results with the failu
 
 **Blockers:**
 The targeted integration test has no current blockers. Mypy reports three pre-existing type errors in `rag/retriever/vector_store.py`, `rag/retriever/keyword_search.py`, and `rag/generator/output_parser.py`. These files were not modified by this contribution.
+
+### Check-in 2 (final)
+
+**Pull request:**
+https://github.com/ascherj/pathreview/pull/586
+
+**Branch:**
+`test/38-rag-pipeline-integration-test`
+
+**Implementation completed:**
+I added `tests/integration/test_rag_pipeline.py`, which tests the full RAG workflow from retrieval and hybrid reranking through mocked LLM generation and structured output parsing.
+
+**Testing results:**
+- Targeted integration test: 1 passed
+- Ruff check on the new test file: passed
+- Black check on the new test file: passed
+- Full repository Ruff check: 182 pre-existing errors
+- Full unit-test suite: 375 passed and 53 pre-existing failures
+- The same full-suite results were reproduced on `upstream/main`, confirming that this branch introduces no new failures.
+
+**Peer or mentor feedback:**
+I requested review through the pull request, but no peer or mentor review was received before the submission deadline.
+
+**Self-review:**
+- [x] I reviewed the complete pull-request diff.
+- [x] My contribution introduces no new test or lint failures.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,128 @@
+# Issue #38 Solution Plan
+
+## Solution plan
+
+**Issue:** [Add an integration test that runs the full RAG pipeline against a mock LLM](https://github.com/ascherj/pathreview/issues/38)
+
+### Understand
+
+PathReview has unit tests for individual RAG components, but it does not currently have an integration test that verifies the components work together as one complete workflow. The missing test should run a representative query through retrieval, result ordering or reranking, LLM generation, and response parsing.
+
+The expected behavior is for the full RAG pipeline to return predictable structured feedback while using a mock LLM provider. The test must not contact a real external LLM service or require a real API key.
+
+The actual behavior is that `tests/integration/test_rag_pipeline.py` does not exist. The `tests/integration` directory currently contains only `__init__.py`, so pytest cannot collect a complete RAG pipeline integration test.
+
+### Map
+
+The primary file I expect to create is:
+
+* `tests/integration/test_rag_pipeline.py` — new integration test for the complete RAG workflow.
+
+The following files and modules are likely involved:
+
+* `rag/retriever/hybrid.py` — combines vector and keyword retrieval results and orders them.
+* `rag/retriever/vector_store.py` — stores and retrieves document chunks using vector similarity.
+* `rag/retriever/keyword_search.py` — indexes chunks and performs keyword retrieval.
+* `rag/evaluator/relevance_scorer.py` — calculates how relevant retrieved content is to the query.
+* `rag/generator/review_generator.py` — builds the prompt, calls the LLM client, and sends the response to the parser.
+* `rag/generator/output_parser.py` — converts the generated response into structured feedback.
+* `tests/conftest.py` — may contain reusable pytest fixtures.
+* `tests/unit/test_keyword_search.py` — examples for indexing and retrieving deterministic test documents.
+* `tests/unit/test_relevance_scorer.py` — examples for relevance-score assertions.
+* `tests/unit/test_output_parser.py` — examples of valid mock LLM output and parser assertions.
+* `tests/unit/test_llm_provider_contract.py` — should be inspected for existing mock LLM patterns.
+
+I do not currently expect to change production code. I will first attempt to implement the integration test using existing public interfaces, pytest fixtures, and mocking.
+
+### Plan
+
+1. **Trace the RAG component interfaces.**
+   Read the constructors and public methods in the retriever, scorer, generator, and parser modules. Determine the exact input and output types passed between retrieval, reranking, generation, and parsing.
+
+2. **Locate the existing mock LLM pattern.**
+   Search the test suite and provider modules for the mock LLM provider mentioned in issue #38. Determine whether the integration test should instantiate an existing mock provider or patch the OpenAI-compatible client used by `ReviewGenerator`.
+
+3. **Create deterministic test data.**
+   Define a representative query and several document chunks, including at least one relevant chunk and one irrelevant chunk. Give the chunks stable identifiers and metadata so the expected retrieval order is predictable.
+
+4. **Configure isolated retrieval components.**
+   Use a temporary vector-store directory and a unique collection name so the test does not depend on or modify local development data. Index the deterministic chunks in both the vector and keyword retrieval components.
+
+5. **Run retrieval and reranking.**
+   Send the query through the retrieval pipeline and confirm that the relevant chunk is returned and ranked above the irrelevant chunk. Verify that the retrieved result contains the fields required by the generation stage.
+
+6. **Mock the LLM response.**
+   Configure the mock LLM to return fixed, valid structured review output. Assert that no real network request is made and that the prompt passed to the mock contains content from the retrieved chunk.
+
+7. **Verify generation and parsing.**
+   Run the generation and parsing stages and assert that the final structured result contains the expected feedback section, summary, strengths, improvements, evidence, and score.
+
+8. **Run the tests and check regressions.**
+   Run the new integration test by itself, followed by the relevant RAG unit tests. Confirm that the test is deterministic and does not require an API key, internet connection, or existing database state.
+
+### Inputs & outputs
+
+#### Inputs
+
+The integration test will use:
+
+* A representative user query.
+* A small collection of deterministic document chunks.
+* At least one relevant and one irrelevant chunk.
+* Stable chunk identifiers and metadata.
+* Mock or deterministic embeddings.
+* A temporary vector-store location.
+* A unique test collection name.
+* Any profile or configuration object required by `ReviewGenerator`.
+* A fixed mock LLM response containing valid structured JSON.
+
+#### Outputs
+
+The retrieval stage should produce a nonempty ordered list of results containing document text, metadata, and scores.
+
+The reranking or score-ordering stage should place the most relevant chunk ahead of unrelated chunks.
+
+The generation stage should receive a prompt containing the retrieved context and return the fixed mock response.
+
+The parsing stage should produce structured feedback objects with specific expected values.
+
+The completed integration test should pass locally and in CI without:
+
+* A real LLM API key.
+* An external network request.
+* Pre-existing vector-store data.
+* Manual application startup.
+
+### Risks & unknowns
+
+* **Meaning of reranking:** `rag/retriever/hybrid.py` appears to combine vector and keyword scores, while `rag/evaluator/relevance_scorer.py` performs separate relevance scoring. I need to determine whether issue #38 expects one or both of these operations in the test.
+
+* **Mock LLM location:** The issue refers to a mock LLM provider, but I still need to identify its exact implementation. I will search the provider modules and `tests/unit/test_llm_provider_contract.py` before creating a new mock.
+
+* **Generator client interface:** `rag/generator/review_generator.py` may expect an OpenAI-compatible response object with nested choices and message content. The mock must match the exact attributes accessed by the generator.
+
+* **Persistent vector-store state:** `rag/retriever/vector_store.py` may use persistent ChromaDB storage. Using the default development collection could make the test depend on previous runs, so the test should use pytest's `tmp_path` fixture and a unique collection.
+
+* **Keyword index setup:** `KeywordSearcher` must be indexed before searching. An empty index currently raises an error in an existing unit test, so the integration test must populate the index with valid chunks before executing the query.
+
+* **Existing unrelated failures:** Some current unit tests fail for reasons outside issue #38. I must avoid changing those components unless a change is required specifically for the new integration test.
+
+* **Production orchestration:** I need to determine whether an existing service function already connects the complete RAG pipeline. If no orchestration entry point exists, the integration test may need to assemble the existing components directly.
+
+### Edge cases
+
+* The query retrieves no documents because all results are below the minimum score. The pipeline should handle an empty context predictably and should not make an uncontrolled external request.
+
+* Vector and keyword retrieval return tied or nearly tied scores. The test should avoid brittle assertions unless the implementation defines a deterministic tie-breaking rule.
+
+* The mock LLM returns valid JSON wrapped in a Markdown code fence. The parser should still produce structured feedback.
+
+* The mock LLM returns malformed JSON. The parser should follow its documented fallback behavior rather than crashing unexpectedly.
+
+* A retrieved chunk is missing optional metadata. Prompt construction should either handle the missing field gracefully or produce a clear expected error.
+
+* The vector store contains stale information from an earlier test. Using an isolated temporary directory and unique collection should prevent cross-test contamination.
+
+* The mock is applied incorrectly and the generator attempts a real network request. The test should patch or inject the mock before generation and must not depend on an API key.
+
+* Retrieval returns the correct document but in a different score order because of floating-point differences. Assertions should focus on meaningful ranking and content rather than unnecessary exact score equality.

--- a/REPRODUCTION.md
+++ b/REPRODUCTION.md
@@ -1,0 +1,86 @@
+# Issue #38 Reproduction
+
+**Issue:** [Add an integration test that runs the full RAG pipeline against a mock LLM](https://github.com/ascherj/pathreview/issues/38)
+
+**Branch:** `test/38-rag-pipeline-integration-test`
+
+## Reproduction goal
+
+Issue #38 describes a missing integration test rather than an application crash. The reproduction goal is to confirm that PathReview has tests for individual RAG components but does not have a test that runs one query through retrieval, reranking, generation, and output parsing as a complete workflow.
+
+## Reproduction steps
+
+From the root of the repository, I inspected the integration-test directory:
+
+```bash
+ls -la tests/integration
+```
+
+The directory contained only:
+
+```text
+__init__.py
+```
+
+I then checked whether the test file requested by issue #38 exists:
+
+```bash
+if [ -f tests/integration/test_rag_pipeline.py ]; then
+  echo "test_rag_pipeline.py EXISTS"
+else
+  echo "REPRODUCED: test_rag_pipeline.py is MISSING"
+fi
+```
+
+The command returned:
+
+```text
+REPRODUCED: test_rag_pipeline.py is MISSING
+```
+
+I also ran the integration-test directory:
+
+```bash
+.venv/Scripts/python -m pytest tests/integration -v
+```
+
+Finally, I ran related unit tests for keyword retrieval, relevance scoring, and output parsing:
+
+```bash
+.venv/Scripts/python -m pytest \
+  tests/unit/test_keyword_search.py \
+  tests/unit/test_relevance_scorer.py \
+  tests/unit/test_output_parser.py \
+  -v
+```
+
+## Observed behavior
+
+The `tests/integration` directory contains only `__init__.py`, and the requested `tests/integration/test_rag_pipeline.py` file is missing. Therefore, pytest cannot collect an integration test that exercises the complete RAG pipeline.
+
+The related unit-test command collected 55 tests. Fifty-two tests passed and three existing tests failed. Those failures concern an empty keyword index, partial-overlap relevance scoring, and JSON-array parsing. They are separate existing problems and are outside the scope of issue #38.
+
+The reproduction confirms that individual RAG components have test coverage, but there is no integration test proving that retrieval, reranking, generation, and parsing work together.
+
+## Expected behavior
+
+PathReview should include a deterministic integration test at:
+
+```text
+tests/integration/test_rag_pipeline.py
+```
+
+The test should:
+
+1. Submit a representative query.
+2. Retrieve relevant document chunks.
+3. Order or rerank the retrieved results.
+4. Pass the selected context to a mocked LLM.
+5. Parse the mock LLM response.
+6. Assert that the final structured result is correct.
+
+The test must not make a real external LLM request or require a production API key.
+
+## Reproduction conclusion
+
+Issue #38 is reproducible. PathReview contains separate RAG components and unit tests, but the requested full-pipeline integration test is missing.

--- a/tests/integration/test_rag_pipeline.py
+++ b/tests/integration/test_rag_pipeline.py
@@ -1,0 +1,184 @@
+"""Integration tests for the complete RAG pipeline."""
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from rag.generator.review_generator import ReviewConfig, ReviewGenerator
+from rag.retriever.hybrid import HybridRetriever
+from rag.retriever.keyword_search import KeywordSearcher
+from rag.retriever.vector_store import VectorStore
+
+
+def test_full_rag_pipeline_with_mock_llm(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Run retrieval, reranking, generation, and parsing without a real LLM."""
+    profile_id = "issue38"
+    collection_name = f"profile_{profile_id}"
+
+    chunks = [
+        {
+            "id": "fastapi-project",
+            "text": (
+                "Built a Python FastAPI REST API with automated pytest "
+                "integration tests and PostgreSQL."
+            ),
+            "metadata": {
+                "source_id": "portfolio-api",
+                "chunk_index": 0,
+                "section": "projects",
+            },
+        },
+        {
+            "id": "painting-project",
+            "text": (
+                "Created watercolor landscape paintings and displayed them "
+                "in a community art exhibition."
+            ),
+            "metadata": {
+                "source_id": "portfolio-art",
+                "chunk_index": 0,
+                "section": "projects",
+            },
+        },
+        {
+            "id": "cooking-project",
+            "text": (
+                "Developed a collection of vegetarian recipes and documented "
+                "meal preparation techniques."
+            ),
+            "metadata": {
+                "source_id": "portfolio-food",
+                "chunk_index": 0,
+                "section": "projects",
+            },
+        },
+        {
+            "id": "music-project",
+            "text": (
+                "Recorded acoustic guitar performances and organized a local " "music showcase."
+            ),
+            "metadata": {
+                "source_id": "portfolio-music",
+                "chunk_index": 0,
+                "section": "projects",
+            },
+        },
+    ]
+
+    embeddings = [
+        [1.0, 0.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0, 0.0],
+        [0.0, 0.0, 1.0, 0.0],
+        [0.0, 0.0, 0.0, 1.0],
+    ]
+
+    vector_store = VectorStore(persist_dir=str(tmp_path / "chromadb"))
+    collection = vector_store.get_collection(collection_name)
+
+    collection.upsert(
+        ids=[chunk["id"] for chunk in chunks],
+        embeddings=embeddings,
+        documents=[chunk["text"] for chunk in chunks],
+        metadatas=[chunk["metadata"] for chunk in chunks],
+    )
+
+    keyword_searcher = KeywordSearcher()
+    keyword_searcher.index(chunks)
+
+    retriever = HybridRetriever(
+        vector_store=vector_store,
+        keyword_searcher=keyword_searcher,
+        vector_weight=0.7,
+        keyword_weight=0.3,
+    )
+
+    query = "Python FastAPI API integration testing"
+    query_embedding = [1.0, 0.0, 0.0, 0.0]
+
+    retrieved_chunks = retriever.retrieve(
+        query=query,
+        profile_id=profile_id,
+        query_embedding=query_embedding,
+        max_chunks=2,
+        min_score=0.0,
+    )
+
+    assert len(retrieved_chunks) == 2
+    assert retrieved_chunks[0]["id"] == "fastapi-project"
+    assert retrieved_chunks[0]["score"] >= retrieved_chunks[1]["score"]
+    assert retrieved_chunks[0]["vector_score"] > 0
+    assert retrieved_chunks[0]["keyword_score"] > 0
+
+    mock_llm_output = json.dumps(
+        {
+            "skills_feedback": {
+                "summary": (
+                    "The portfolio demonstrates Python, FastAPI, pytest, "
+                    "and PostgreSQL experience."
+                ),
+                "suggestions": [
+                    "Add deployment details.",
+                    "Document API performance results.",
+                ],
+            }
+        }
+    )
+
+    mock_create = Mock(
+        return_value=SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content=mock_llm_output))]
+        )
+    )
+
+    mock_llm_provider = SimpleNamespace(
+        chat=SimpleNamespace(completions=SimpleNamespace(create=mock_create))
+    )
+
+    generator = ReviewGenerator(
+        ReviewConfig(
+            api_key="test-key",
+            base_url="https://example.invalid/v1",
+            model="mock-model",
+            temperature=0.0,
+        )
+    )
+
+    monkeypatch.setattr(generator, "client", mock_llm_provider)
+
+    feedback = generator.generate_section(
+        section_name="skills_feedback",
+        context_chunks=retrieved_chunks,
+        profile_data={
+            "github_username": "integration-test-user",
+            "projects": [{"name": "FastAPI Portfolio API"}],
+        },
+    )
+
+    mock_create.assert_called_once()
+
+    request = mock_create.call_args.kwargs
+    user_prompt = request["messages"][1]["content"]
+
+    assert "Built a Python FastAPI REST API" in user_prompt
+    assert "portfolio-api" in user_prompt
+    assert request["model"] == "mock-model"
+    assert request["temperature"] == 0.0
+
+    assert feedback.section_name == "skills_feedback"
+    assert feedback.confidence == 0.9
+    assert feedback.suggestions == [
+        "Add deployment details.",
+        "Document API performance results.",
+    ]
+
+    parsed_content = json.loads(feedback.content)
+
+    assert parsed_content["summary"] == (
+        "The portfolio demonstrates Python, FastAPI, pytest, " "and PostgreSQL experience."
+    )


### PR DESCRIPTION
## Summary

Adds an integration test that runs the complete RAG workflow using deterministic test data and a mocked OpenAI-compatible LLM response.

The test verifies that vector retrieval, BM25 keyword retrieval, hybrid score blending, prompt generation, LLM invocation, and structured output parsing work together without making a real external API request.

## Issue

Closes #38

## Changes

* Added `tests/integration/test_rag_pipeline.py`.
* Created deterministic portfolio chunks for integration testing.
* Stored test chunks and embeddings in an isolated temporary ChromaDB collection.
* Indexed the same chunks with `KeywordSearcher` for BM25 retrieval.
* Ran a representative query through `HybridRetriever`.
* Verified that the most relevant FastAPI project ranks first.
* Mocked the OpenAI-compatible `chat.completions.create()` request.
* Verified that retrieved context and source metadata are included in the generated prompt.
* Verified that the mocked LLM response is parsed into a structured `FeedbackSection`.
* Confirmed that the test makes no real network or LLM request.

## Testing

Targeted integration test:

```bash
.venv/Scripts/python -m pytest tests/integration/test_rag_pipeline.py -v
```

Result:

```text
1 passed
```

The integration test passed repeatedly, including after Black formatting.

Targeted formatting and lint checks:

```bash
.venv/Scripts/python -m black --check tests/integration/test_rag_pipeline.py
.venv/Scripts/python -m ruff check tests/integration/test_rag_pipeline.py
```

Result:

```text
All checks passed
```

Full repository validation:

```bash
make check
make test-unit
```

`make check` currently reports 182 Ruff errors across pre-existing and unrelated repository files.

`make test-unit` reports:

```text
375 passed
53 failed
```

I ran the same commands directly on `upstream/main` and received the same lint-error count and the same unit-test pass/fail totals. Therefore, this contribution introduces no new lint or unit-test failures.

The commit-time mypy hook also identified three pre-existing type errors in:

* `rag/retriever/vector_store.py`
* `rag/retriever/keyword_search.py`
* `rag/generator/output_parser.py`

This contribution does not modify those files.

## Manual verification

1. Check out `test/38-rag-pipeline-integration-test`.
2. Install the project dependencies.
3. Run:

```bash
.venv/Scripts/python -m pytest tests/integration/test_rag_pipeline.py -v
```

4. Confirm that `test_full_rag_pipeline_with_mock_llm` passes.
5. No API key, network request, or running application service is required.

## Notes for reviewers

The test intentionally uses deterministic embeddings and a mocked OpenAI-compatible response so that it remains repeatable and does not depend on an external service.

The test focuses specifically on integration between the existing RAG components rather than retesting every behavior already covered by individual unit tests.
