### PR TITLE
feat(api): reject POST /reviews when profile has no content

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,18 @@
+## Week 7 — Issue selection
+
+**Issue link:** [paste link here]
+
+**Issue title:** [paste issue title here]
+
+**Tier:** [ ] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+[In 3–5 sentences, in your own words: what the issue is (not a copy-paste of
+the title), what is currently broken or missing, and what a successful fix
+would accomplish. Naming the part of the codebase it affects is helpful context.]
+
+**Branch name:** [paste branch name here]
+
+**Setup confirmation:** [ ] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,18 +1,29 @@
 ## Week 7 — Issue selection
 
-**Issue link:** [paste link here]
+**Issue link:** [[paste link here](https://github.com/ascherj/pathreview/issues/88)]
 
-**Issue title:** [paste issue title here]
+**Issue title:** [POST /reviews endpoint has no test for when the profile has no ingested documents
+]
 
-**Tier:** [ ] Tier 1  [ ] Tier 2  [ ] Tier 3
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
 
 **Problem summary:**
-[In 3–5 sentences, in your own words: what the issue is (not a copy-paste of
-the title), what is currently broken or missing, and what a successful fix
-would accomplish. Naming the part of the codebase it affects is helpful context.]
+The `POST /reviews` endpoint lets a user request an AI review of a profile, but
+there is no test covering the case where the profile exists yet has no ingested
+content (i.e. the profile has no content to review). What's missing is
+purely test coverage for this edge case in `tests/unit/test_review_routes.py` —
+a file that doesn't exist yet. This matters because the endpoint currently
+doesn't validate that a profile has any content before starting a review:
+instead of returning a clear client error, it silently accepts the request and
+the background pipeline goes on to produce a review anyway. A successful fix adds
+a test that drives the endpoint with a content-less profile and asserts it
+responds with an appropriate error (a 4xx) rather than crashing or silently
+"succeeding," which pins down the intended behavior for this edge case. This
+affects the review API route (`api/routes/reviews.py`) and its processing logic
+in `core/services/review_service.py`.
 
-**Branch name:** [paste branch name here]
+**Branch name:** [test/88-verify-review-endpoint-tests]
 
-**Setup confirmation:** [ ] App runs locally at localhost:5173
+**Setup confirmation:** [X] App runs locally at localhost:5173
 
-**Cohort ledger:** [ ] Issue added to cohort ledger
+**Cohort ledger:** [X] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -8,19 +8,23 @@
 **Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
 
 **Problem summary:**
-The `POST /reviews` endpoint lets a user request an AI review of a profile, but
-there is no test covering the case where the profile exists yet has no ingested
-content (i.e. the profile has no content to review). What's missing is
-purely test coverage for this edge case in `tests/unit/test_review_routes.py` —
-a file that doesn't exist yet. This matters because the endpoint currently
-doesn't validate that a profile has any content before starting a review:
-instead of returning a clear client error, it silently accepts the request and
-the background pipeline goes on to produce a review anyway. A successful fix adds
-a test that drives the endpoint with a content-less profile and asserts it
-responds with an appropriate error (a 4xx) rather than crashing or silently
-"succeeding," which pins down the intended behavior for this edge case. This
-affects the review API route (`api/routes/reviews.py`) and its processing logic
-in `core/services/review_service.py`.
+The `POST /reviews` endpoint (in `api/routes/reviews.py`, with logic in
+`core/services/review_service.py`) lets a user request an AI review of a profile,
+but there is no test for the case where the profile exists yet has no content to
+review. Currently the endpoint doesn't validate this — instead of returning a
+clear client error, it silently accepts the request and the background pipeline
+produces a review anyway, so a successful fix adds a test in the not-yet-created
+`tests/unit/test_review_routes.py` that drives the endpoint with a content-less
+profile and asserts it responds with an appropriate 4xx error rather than
+crashing or silently succeeding. This is a good Tier 1 fit for me: the change is
+localized to a single test file and doesn't require understanding the whole
+system, and I've confirmed the referenced files exist. I've read the specific
+code (`create_review_endpoint` → `process_review` → `_run_ingestion_pipeline`)
+and the existing `tests/unit/test_review_service.py` end-to-end for its
+fixture/mock/assertion patterns, so I can plan the fix (FastAPI TestClient +
+`dependency_overrides` to fake auth and the DB). The manifest estimates 2–3
+hours with no blockers, and although the ledger shows 3 others have claimed it,
+claims are non-exclusive so I'm comfortable proceeding.
 
 **Branch name:** [test/88-verify-review-endpoint-tests]
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -83,16 +83,23 @@ documented as out of scope.
 
 ### Check-in 2 (end of week)
 
-**PR link:** [link to your submitted pull request]
+**PR link:** [[link to my submitted pull request](https://github.com/ascherj/pathreview/pull/587)]
 
-**Branch:** [the branch name you worked on, e.g. `fix/123-short-description`]
+**Branch:** [test/88-verify-review-endpoint-tests]
 
 **What you built:**
-[1–3 sentences summarizing what your fix does and how it works]
+`POST /reviews` now rejects a profile that has nothing to review. Before
+scheduling the background task, `create_review_endpoint` loads the profile (via
+`get_profile`) and returns 422 if it has no GitHub/résumé/portfolio content, or
+404 if it is missing or not owned by the caller.
 
 **Tests added or updated:**
-[Which test files did you touch? What do they cover?]
+Added `tests/unit/test_review_routes.py` — the repo's first TestClient-based route
+test. It covers content-less profile → 422, missing/unowned profile → 404, and a
+profile with content → 200 "pending".
 
-**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+**Self-review confirmation:** [X] make check passes  [X] make test-unit passes
+("passes" = my changes introduce no new failures; the repo's pre-existing
+ruff/mypy/test failures are documented in the PR's Notes for Reviewers.)
 
-**Draft PR feedback received from:** [name or Slack handle, or "none"]
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -31,3 +31,25 @@ claims are non-exclusive so I'm comfortable proceeding.
 **Setup confirmation:** [X] App runs locally at localhost:5173
 
 **Cohort ledger:** [X] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [fill after pushing — the commit that adds this section]
+
+**Reproduction summary:**
+Running the API locally, I logged in through Swagger, created a profile with all
+fields (GitHub, portfolio, résumé) left empty, and called `POST /reviews` for it.
+The endpoint returned HTTP 200 with `status: "pending"` (and the review later
+completed with generic placeholder feedback) instead of a 4xx error — the missing
+check lives in `create_review_endpoint` in `api/routes/reviews.py`, which accepts
+the request without verifying the profile has any content.
+
+**PLAN.md link:** [fill after PLAN.md is written and pushed]
+
+**Blockers or open questions:**
+No blockers. One design decision (raised in feedback) is resolved: the validation
+belongs in the route layer — inside `create_review_endpoint`, before the
+background task is scheduled — returning 422, mirroring how `POST /profiles`
+returns 422 for an invalid résumé file. Aside: `_run_ingestion_pipeline` builds
+`IngestedSource(raw_data=...)` but the model has no `raw_data` column — a separate
+latent bug, out of scope here.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -44,7 +44,7 @@ completed with generic placeholder feedback) instead of a 4xx error — the miss
 check lives in `create_review_endpoint` in `api/routes/reviews.py`, which accepts
 the request without verifying the profile has any content.
 
-**PLAN.md link:** [fill after PLAN.md is written and pushed]
+**PLAN.md link:** [[commit link](https://github.com/priscillayouziqian/ai201-pathreview/commit/190fa9a4cebb93264d648cc426750e8260626d2b)]
 
 **Blockers or open questions:**
 No blockers. One design decision (raised in feedback) is resolved: the validation

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -34,7 +34,7 @@ claims are non-exclusive so I'm comfortable proceeding.
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [fill after pushing — the commit that adds this section]
+**Reproduction commit link:** [[commit link](https://github.com/priscillayouziqian/ai201-pathreview/commit/f1687f7b8a9274b1fa7c7cf46383b4b69650c2b9)]
 
 **Reproduction summary:**
 Running the API locally, I logged in through Swagger, created a profile with all

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -53,3 +53,46 @@ background task is scheduled — returning 422, mirroring how `POST /profiles`
 returns 422 for an invalid résumé file. Aside: `_run_ingestion_pipeline` builds
 `IngestedSource(raw_data=...)` but the model has no `raw_data` column — a separate
 latent bug, out of scope here.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the fix in two commits. In `api/routes/reviews.py`,
+`create_review_endpoint` now loads the target profile before scheduling the
+background task and returns 404 if it is missing/not owned, or 422 ("Profile has
+no content to review") if it has no GitHub, resume, or portfolio content. Added
+`tests/unit/test_review_routes.py` — the repo's first TestClient-based route
+test — covering three cases: content-less profile → 422, missing profile → 404,
+and a profile with content → 200 "pending". PLAN.md sub-tasks 1–4 are done;
+sub-task 5 (self-review) is also done — `ruff`, `black --check`, `mypy`, and
+`make test-unit` confirm my changes introduce no new failures versus baseline
+(53 pre-existing test failures unchanged; +3 new passing tests).
+
+**Next steps:**
+Open a draft PR, request peer/mentor review in Slack, and address any feedback I
+agree with before marking it ready for review.
+
+**Blockers:**
+None blocking. The repo has pre-existing, unrelated failures — ~180 ruff errors,
+52 files needing black, and mypy halting on a third-party numpy stub — which I've
+documented as out of scope.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [link to your submitted pull request]
+
+**Branch:** [the branch name you worked on, e.g. `fix/123-short-description`]
+
+**What you built:**
+[1–3 sentences summarizing what your fix does and how it works]
+
+**Tests added or updated:**
+[Which test files did you touch? What do they cover?]
+
+**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+
+**Draft PR feedback received from:** [name or Slack handle, or "none"]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -103,3 +103,51 @@ profile with content → 200 "pending".
 ruff/mypy/test failures are documented in the PR's Notes for Reviewers.)
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [X] No — still awaiting review
+
+**Summary of feedback:**
+No reviewer comments arrived on PR #587 by end of week.
+
+**How you responded:**
+N/A — will keep monitoring and respond if feedback comes in later.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The issue read like "just add a test," but reproducing it showed the endpoint
+returned no error at all — so making the test meaningful meant first adding
+validation to the route. Deciding *where* that check belonged took real thought:
+I learned the background task runs *after* the response is sent, so it can't
+change the status code — the check had to be synchronous in the route.
+
+**What did you learn about working in a large codebase?**
+Contributing to someone else's code is mostly about matching existing patterns,
+not inventing your own. I mirrored the 422 pattern from `create_profile_endpoint`
+and the mock/assertion style from `test_review_service.py`. I also learned to
+scope tightly: the repo had ~180 pre-existing lint errors, and the job was to not
+make things worse — not to fix all of it.
+
+**How did AI tools help — and where did they fall short?**
+AI was most useful for exploring an unfamiliar codebase fast (tracing endpoint →
+service → background task) and drafting the plan, tests, and PR text. It fell
+short on the judgment calls I had to own: which status code to use, how to scope
+the fix vs. the repo's pre-existing debt, and whether to bypass the failing
+pre-commit hooks — I had to decide those and verify the baseline myself.
+
+**What would you do differently if you started over?**
+Follow the commit-message convention (`type(scope): …`, `Fixes #88`) from the
+very first commit instead of catching it at self-review. I'd also confirm the
+correct base repo earlier, since the issue lived in a different repo than my git
+upstream.
+
+**What are you most proud of from this module?**
+I wrote the repo's first TestClient route test, so the next person has a working
+example to copy. And instead of just saying my change broke nothing, I proved it:
+I ran the tests and lint before and after to show I added no new failures.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,86 @@
+# Solution plan
+
+**Issue:** POST /reviews endpoint has no test for when the profile has no
+ingested documents — https://github.com/ascherj/pathreview/issues/88
+
+## Understand
+
+**Root cause:** `create_review_endpoint` accepts a review request without ever
+checking that the profile has anything to review. When a profile has no GitHub
+username, résumé, or portfolio URL, `_run_ingestion_pipeline` skips all three
+branches and returns an empty source list — but the downstream `_run_agent_
+orchestration` and `_run_rag_retrieval_generation` steps ignore the ingestion
+result and return hardcoded placeholder feedback, so `_run_safety_checks` passes
+and the review is marked "complete". No test covers this case today.
+
+**Expected vs. actual:**
+- *Expected:* requesting a review for a content-less profile returns a clear 4xx
+  error (422) explaining there is nothing to review.
+- *Actual:* the endpoint returns HTTP 200 with `status: "pending"`, and the
+  review later completes with generic feedback unrelated to the (absent) content.
+
+## Map
+
+**Involved (read to understand):**
+- `api/routes/reviews.py` — `create_review_endpoint` (the endpoint under test)
+- `core/services/review_service.py` — `create_review`, `process_review`,
+  `_run_ingestion_pipeline` (where "content" is / isn't produced)
+- `core/models/profile.py`, `core/models/ingested_source.py` — what "content" means
+- `api/routes/profiles.py` — existing 404/422 pattern to mirror (`:50`, `:130`)
+- `tests/unit/test_review_service.py` — reference for fixture/mock/assert style
+
+**Files I expect to touch:**
+1. `tests/unit/test_review_routes.py` — NEW; the test (primary deliverable)
+2. `api/routes/reviews.py` — add the no-content validation
+3. `tests/conftest.py` — possibly add a shared TestClient / fake-auth fixture
+
+## Plan
+
+1. **Define "no content".** Treat a profile as having no content when
+   `github_username`, `resume_text`, and `portfolio_url` are all empty. (Ingested
+   rows are created only during processing, so they're always 0 before the first
+   review — the profile's own source fields are the right synchronous signal.)
+2. **Add validation in `create_review_endpoint`,** before
+   `background_tasks.add_task(...)`: load the profile and, if it has no content,
+   `raise HTTPException(422, "Profile has no content to review")` — mirroring the
+   422 pattern already used in `create_profile_endpoint`.
+3. **Write `tests/unit/test_review_routes.py`** using FastAPI's `TestClient` with
+   `app.dependency_overrides` to fake `get_current_user` and `get_db`; assert that
+   `POST /reviews` for a content-less profile returns 422.
+4. **Add a contrast test:** a profile *with* content still returns 200 / "pending",
+   proving the check doesn't over-reject.
+5. **Verify:** run `make test-unit` (green), then `make lint` / `make typecheck`.
+
+## Inputs & outputs
+
+- **Input:** an authenticated `POST /reviews` whose `profile_id` points at a
+  profile with no source content.
+- **Output / change:** the endpoint returns **422** with a clear message instead
+  of 200 "pending"; no `Review` row is created for such a request. Profiles that
+  *do* have content are unaffected (still 200 "pending"). A new unit test locks in
+  both behaviors.
+
+## Risks & unknowns
+
+- **Status code:** choosing 422 to match the résumé-validation precedent; a
+  reviewer might prefer 400. Low risk, easy to change.
+- **"No content" definition:** using the profile's source fields rather than
+  `IngestedSource` rows; need to confirm this matches the issue's intent.
+- **Profile existence/ownership:** `create_review` currently never checks the
+  profile exists or belongs to the user. Loading it for the content check invites
+  a 404 too — I'll scope this to the 422 case and note 404 as a follow-up to avoid
+  scope creep.
+- **First endpoint test in the repo:** no existing `TestClient` example, so I'm
+  establishing the pattern (sync client, dependency overrides) — small learning risk.
+- **Pre-existing bugs nearby** (`IngestedSource(raw_data=...)` invalid kwarg;
+  passing a request-scoped DB session into a background task) are out of scope but
+  may surface while testing.
+
+## Edge cases the fix should handle
+
+- Profile with all source fields empty → **422** (target case).
+- Profile with just one source (e.g. only `github_username`) → **allowed**, 200.
+- Valid profile with content → **200 "pending"** (unchanged).
+- Missing/invalid auth → **401** (already handled by `get_current_user`).
+- Nonexistent or not-owned `profile_id` → ideally **404** (currently unhandled;
+  flagged as out-of-scope follow-up).

--- a/api/routes/reviews.py
+++ b/api/routes/reviews.py
@@ -1,12 +1,16 @@
-from fastapi import APIRouter, Depends, HTTPException, status, BackgroundTasks
 from uuid import UUID
-import structlog
 
-from api.schemas.review import ReviewCreate, ReviewResponse, ReviewListResponse
+import structlog
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
+
 from api.middleware.auth import get_current_user
-from core.models.user import User
-from core.models.review import Review
+from api.schemas.review import ReviewCreate, ReviewListResponse, ReviewResponse
 from core.database import get_db
+from core.models.user import User
+
+# get_profile already checks that the profile exists AND is owned by the user,
+# so I reuse it here instead of re-implementing that lookup.
+from core.services.profile_service import get_profile
 from core.services.review_service import (
     create_review,
     get_review,
@@ -32,6 +36,30 @@ async def create_review_endpoint(
     Returns review with status="pending" immediately.
     """
     try:
+        # Validate BEFORE scheduling the background task. Processing runs after
+        # the HTTP response is sent, so it can no longer change the status code
+        # the caller sees — any rejection must happen here, synchronously.
+        profile = await get_profile(db=db, profile_id=data.profile_id, user_id=current_user.id)
+
+        # profile is None when it doesn't exist OR isn't owned by this user.
+        # We must handle it: reading .github_username off None would raise and
+        # surface as a 500. 404 matches how the profile routes report this.
+        if not profile:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Profile not found",
+            )
+
+        # A profile with no GitHub username, resume, or portfolio URL has nothing
+        # to ingest or review. Reject it with 422 (well-formed request, but the
+        # resource isn't in a reviewable state) rather than silently creating a
+        # review that would only produce generic, content-less feedback.
+        if not (profile.github_username or profile.resume_text or profile.portfolio_url):
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="Profile has no content to review",
+            )
+
         # Create review with status="pending"
         review = await create_review(
             db=db,

--- a/tests/unit/test_review_routes.py
+++ b/tests/unit/test_review_routes.py
@@ -1,0 +1,114 @@
+"""Tests for the review routes in api/routes/reviews.py.
+
+Focus (issue 88): POST /reviews when the target profile has no content to
+review. This is the repo's first HTTP-endpoint test, so it establishes the
+pattern of using FastAPI's TestClient with `app.dependency_overrides` to fake
+authentication and the database, plus patching the service-layer functions the
+route calls (get_profile / create_review / process_review) so the test exercises
+only the endpoint's own logic.
+"""
+
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.main import app
+from api.middleware.auth import get_current_user
+from core.database import get_db
+
+
+@pytest.mark.unit
+class TestCreateReviewRoute:
+    """POST /reviews — validation of the target profile before processing."""
+
+    @pytest.fixture(autouse=True)
+    def override_auth_and_db(self):
+        # Replace the real auth + DB dependencies so the endpoint runs entirely
+        # in memory: no JWT to decode, no database connection to open. Every test
+        # in this class gets these overrides automatically (autouse).
+        fake_user = SimpleNamespace(id=uuid4())
+        app.dependency_overrides[get_current_user] = lambda: fake_user
+        app.dependency_overrides[get_db] = lambda: AsyncMock()
+        self.fake_user = fake_user
+        yield
+        # Clear overrides so state never leaks into other tests.
+        app.dependency_overrides.clear()
+
+    @staticmethod
+    def _profile(*, github=None, resume=None, portfolio=None):
+        # Stand-in for a Profile row. Attributes are set explicitly (not left as
+        # auto-created Mock attributes) so the route's "has no content" check
+        # sees real None values instead of truthy mocks.
+        return SimpleNamespace(
+            id=uuid4(),
+            github_username=github,
+            resume_text=resume,
+            portfolio_url=portfolio,
+        )
+
+    def test_profile_with_no_content_returns_422(self):
+        """A profile with no github/resume/portfolio is rejected with 422.
+
+        This is the case the issue describes: the endpoint must return an
+        appropriate client error, not crash and not silently succeed.
+        """
+        empty_profile = self._profile()  # all three source fields are None
+        with patch(
+            "api.routes.reviews.get_profile",
+            AsyncMock(return_value=empty_profile),
+        ):
+            client = TestClient(app)
+            response = client.post("/reviews", json={"profile_id": str(uuid4())})
+
+        assert response.status_code == 422
+        assert response.json()["detail"] == "Profile has no content to review"
+
+    def test_missing_or_unowned_profile_returns_404(self):
+        """When get_profile returns None (missing or not owned), respond 404.
+
+        Loading the profile forces us to handle the None case; without it, the
+        content check would dereference None and surface as a 500.
+        """
+        with patch(
+            "api.routes.reviews.get_profile",
+            AsyncMock(return_value=None),
+        ):
+            client = TestClient(app)
+            response = client.post("/reviews", json={"profile_id": str(uuid4())})
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Profile not found"
+
+    def test_profile_with_content_is_accepted(self):
+        """A profile with at least one source still returns 200 + "pending".
+
+        Guards against the new validation over-rejecting valid profiles.
+        """
+        profile = self._profile(github="octocat")
+        fake_review = SimpleNamespace(
+            id=uuid4(),
+            profile_id=profile.id,
+            status="pending",
+            sections=None,
+            overall_score=None,
+            error_message=None,
+            created_at=datetime(2024, 1, 1),
+            updated_at=datetime(2024, 1, 1),
+        )
+        # Patch the two service calls the happy path makes so no real DB work or
+        # background processing happens; we only care that the endpoint accepts
+        # the request and echoes back the pending review.
+        with (
+            patch("api.routes.reviews.get_profile", AsyncMock(return_value=profile)),
+            patch("api.routes.reviews.create_review", AsyncMock(return_value=fake_review)),
+            patch("api.routes.reviews.process_review", AsyncMock()),
+        ):
+            client = TestClient(app)
+            response = client.post("/reviews", json={"profile_id": str(profile.id)})
+
+        assert response.status_code == 200
+        assert response.json()["status"] == "pending"


### PR DESCRIPTION
## Summary
`POST /reviews` accepted profiles with no content (no GitHub, résumé, or portfolio)
and returned `200 pending` instead of an error. This adds a check so those requests
get a 4xx, plus tests.

## Issue
Closes #88
Ref: https://github.com/ascherj/pathreview/issues/88

## Changes
The endpoint never checked the profile had any content before scheduling review
processing, so empty profiles slipped through and produced placeholder feedback.

- `api/routes/reviews.py`: `create_review_endpoint` now loads the profile (via
  `get_profile`) before scheduling the task — 404 if missing/not owned, 422 if it
  has no GitHub/résumé/portfolio content.
- `tests/unit/test_review_routes.py` (new): TestClient tests for the 422, 404, and
  200 cases.

## Testing
- [x] Unit tests pass (`make test-unit`) — 3 new tests pass; 53 pre-existing failures unrelated
- [ ] Integration tests pass (`make test-integration`) — N/A
- [ ] Linter passes (`make lint`) — pre-existing failures; my files clean
- [ ] Type checker passes (`make typecheck`) — pre-existing (mypy halts on a numpy stub)
- [x] New/updated tests cover the changes

To verify: log in via Swagger, create a profile with all fields empty, `POST /reviews`
→ now returns 422 `{"detail": "Profile has no content to review"}` (was 200 pending).

## Screenshots / Demo
N/A — backend only; the change is the 422 response above.

## Notes for Reviewers
Pre-existing failures unrelated to this PR — my changes add none:

| Check | Before | After |
|---|---|---|
| `ruff check .` | 182 | 180 |
| `make test-unit` | 53 failed / 375 passed | 53 failed / 378 passed |

Validation is in the route layer, matching how `POST /profiles` returns 422 for a bad résumé.
