### PR TITLE
fix: resolve /health AttributeError on settings.redis_host (#155)

### DIFF
--- a/=0.29.0
+++ b/=0.29.0
@@ -1,6 +1,0 @@
-Collecting asyncpg
-  Downloading asyncpg-0.31.0-cp314-cp314-win_amd64.whl.metadata (4.5 kB)
-Downloading asyncpg-0.31.0-cp314-cp314-win_amd64.whl (604 kB)
-   ---------------------------------------- 604.9/604.9 kB 3.0 MB/s  0:00:00
-Installing collected packages: asyncpg
-Successfully installed asyncpg-0.31.0

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -35,3 +35,26 @@
 
 **Blockers or open questions:**
 [Anything you're still uncertain about going into Week 9, or leave blank]
+
+
+
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:** Implemented the fix (redis.Redis.from_url() replacing the broken host/port kwargs), added the first test coverage for /health (2 passing tests), and established a documented baseline of pre-existing lint/type/test failures unrelated to this issue.
+
+**Next steps:** Open the PR, write the full PR description, and complete Check-in 2.
+
+**Blockers:** None — ready to open the PR.
+---
+
+#### Check-in 2 (end of week)
+
+**PR link:** [https://github.com/ascherj/pathreview/pull/590]
+**Branch:** fix/155-redis-host-attributeerror
+**What you built:** Fixed the /health Redis check by using redis.Redis.from_url(settings.redis_url) instead of nonexistent redis_host/redis_port fields; added first-ever test coverage for the endpoint (2 passing tests covering healthy and unhealthy Redis states).
+**Tests added or updated:** tests/unit/test_health.py — new file, 2 tests.
+**Self-review confirmation:** [x] make check passes (no new failures introduced) [x] make test-unit passes (no new failures introduced)
+**Draft PR feedback received from:** none (submitted directly due to time constraints)

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -24,7 +24,7 @@
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [link to commit documenting the reproduced issue]
+**Reproduction commit link:** [https://github.com/Jwalcott02/pathreview/commit/ba91c39]
 
 **Reproduction summary:**
 [Reproduced by temporarily reverting to the pre-fix code and calling curl http://localhost:8000/health, which triggered redis_health_check_failed error=\"'Settings' object has no attribute 'redis_host'\" in the server logs confirming the AttributeError occurs exactly as described in the issue.]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -7,7 +7,7 @@
 **Tier:** [X] Tier 1  [ ] Tier 2  [ ] Tier 3
 
 **Problem summary:**
-[The core issue for this bug is that the `redis_host` field is missing from `Settings` in config.py, which raises an AttributeError when it's referenced within api/routes/health.py. While investigating, I also found that `settings.redis_port` is referenced in the same block and is also missing from `Settings` — meaning fixing only `redis_host` wouldn't fully resolve the crash. Additionally, the broad `except Exception` in the health check silently catches this error, so instead of visibly failing, the endpoint just reports `redis: unhealthy` — a false negative regardless of Redis's actual status. A good fix could look like using `redis.Redis.from_url(settings.redis_url)` instead of relying on separate host/port fields.]
+[The core issue for this bug is that the `redis_host` field is missing from `Settings` in config.py, which raises an AttributeError when it's referenced within api/routes/health.py. While investigating, I also found that `settings.redis_port` is referenced in the same block and is also missing from `Settings`  meaning fixing only `redis_host` wouldn't fully resolve the crash. Additionally, the broad `except Exception` in the health check silently catches this error, so instead of visibly failing, the endpoint just reports `redis: unhealthy`  a false negative regardless of Redis's actual status. A good fix could look like using `redis.Redis.from_url(settings.redis_url)` instead of relying on separate host/port fields.]
 
 
 
@@ -17,3 +17,21 @@
 **Setup confirmation:** [X] App runs locally at localhost:5173
 
 **Cohort ledger:** [X] Issue added to cohort ledger
+
+
+
+
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [link to commit documenting the reproduced issue]
+
+**Reproduction summary:**
+[Reproduced by temporarily reverting to the pre-fix code and calling curl http://localhost:8000/health, which triggered redis_health_check_failed error=\"'Settings' object has no attribute 'redis_host'\" in the server logs confirming the AttributeError occurs exactly as described in the issue.]
+
+**PLAN.md link:** [link to PLAN.md in your fork]
+
+**Walkthrough video (recommended):** [link to your Loom video, ≤2 min — recommended, not graded]
+
+**Blockers or open questions:**
+[Anything you're still uncertain about going into Week 9, or leave blank]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,19 @@
+## Week 7 — Issue selection
+
+**Issue link:** [https://github.com/ascherj/pathreview/issues/155]
+
+**Issue title:** [Health check references settings.redis_host, which does not exist on Settings]
+
+**Tier:** [X] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+[The core issue for this bug is that the `redis_host` field is missing from `Settings` in config.py, which raises an AttributeError when it's referenced within api/routes/health.py. While investigating, I also found that `settings.redis_port` is referenced in the same block and is also missing from `Settings` — meaning fixing only `redis_host` wouldn't fully resolve the crash. Additionally, the broad `except Exception` in the health check silently catches this error, so instead of visibly failing, the endpoint just reports `redis: unhealthy` — a false negative regardless of Redis's actual status. A good fix could look like using `redis.Redis.from_url(settings.redis_url)` instead of relying on separate host/port fields.]
+
+
+
+
+**Branch name:** [fix/155-redis-host-attributeerror]
+
+**Setup confirmation:** [X] App runs locally at localhost:5173
+
+**Cohort ledger:** [X] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -58,3 +58,37 @@
 **Tests added or updated:** tests/unit/test_health.py — new file, 2 tests.
 **Self-review confirmation:** [x] make check passes (no new failures introduced) [x] make test-unit passes (no new failures introduced)
 **Draft PR feedback received from:** none (submitted directly due to time constraints)
+
+
+
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [X] No — still awaiting review
+
+**Summary of feedback:**
+No review feedback received (not a feature in Summer 2026 per course note).
+
+**How you responded:**
+N/A
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Environment setup took far longer than anticipated. PowerShell doesn't support the Makefile's Unix syntax (wait, trap, &), so I had to switch to Git Bash mid-week, and Docker Desktop needing to be manually started each session caused repeated, confusing connection errors that looked like code bugs but were actually just infrastructure not running.
+
+**What did you learn about working in a large codebase?**
+Fixing the actual bug was small, but understanding it safely required reading multiple files (health.py, config.py) and running mypy and tests before and after to prove I hadn't broken anything else. In a codebase with 179 pre-existing lint errors and 53 pre-existing test failures, "my change is correct" isn't enough; you have to prove "my change didn't make things worse."
+
+**How did AI tools help — and where did they fall short?**
+AI was most useful for explaining unfamiliar tooling (git rebase, PowerShell vs Bash differences, mypy error messages) and for structuring tests I hadn't written before. It fell short on the actual judgment calls, like choosing redis.Redis.from_url() over adding new Settings fields, which required understanding this specific codebase's conventions, not something AI could decide for me.
+
+**What would you do differently if you started over?**
+I'd check docs/SETUP.md before troubleshooting environment issues by hand. I spent significant time fighting PowerShell and Makefile incompatibilities that the setup guide explicitly warned about upfront.
+
+**What are you most proud of from this module?**
+Finding that redis_port was also missing from Settings, beyond what the original issue text mentioned, and that the health check's broad exception handling was silently reporting false "unhealthy" statuses even when Redis was actually fine.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,58 @@
+## Solution plan
+
+**Issue:** [Health check references settings.redis_host, which does not exist on Settings. https://github.com/ascherj/pathreview/issues/155]
+
+### Understand
+What is the root cause of this issue? What behavior is expected vs. actual?
+
+The core issue for this bug is that the `redis_host` field is missing from `Settings` in config.py, which raises an AttributeError when it's referenced within api/routes/health.py. When Redis is reachable, GET /health should report "redis": "healthy" in the response, with an overall 200 OK status. Right now, even when Redis is actually reachable, the health check crashes with an AttributeError ('Settings' object has no attribute 'redis_host'), which gets silently caught by the broad except Exception block causing the endpoint to falsely report "redis": "unhealthy" and return an overall 503 Service Unavailable, regardless of Redis's real status.
+
+### Map
+Which files, functions, or modules are involved?
+List the specific files you expect to touch.
+
+### Map
+
+- `api/routes/health.py` — contains the actual bug (the Redis probe) and is where my fix lives (replacing the broken `host=`/`port=` call with `redis.Redis.from_url()`).
+- `core/config.py` — read closely to understand the `Settings` class and `redis_url` field; not modified in the final fix, but important context since it's the single source of truth for Redis connection info.
+- `tests/unit/test_health.py` (new file) — doesn't exist yet; I'll create it to add the first test coverage for the `/health` endpoint, following the naming pattern used by other files in `tests/unit/`.
+
+### Plan
+What are the steps to fix this issue?
+Break it into 3–5 concrete sub-tasks.
+
+Step 1: Replace the broken redis.Redis(host=settings.redis_host, port=settings.redis_port, ...) call in health.py with redis.Redis.from_url(settings.redis_url, decode_responses=True), avoiding the need for separate host/port fields on Settings
+
+Step 2: Create tests/unit/test_health.py (doesn't exist yet) with at least two test cases: one confirming /health reports "redis": "healthy" when Redis is reachable, and one confirming it reports "redis": "unhealthy" (not a raised exception) when Redis is unreachable since the endpoint should degrade gracefully, not crash.
+
+Step 3: Run mypy on health.py and config.py before and after the fix to confirm the fix resolves the redis_host/redis_port attribute errors without introducing new ones (confirmed: errors dropped from 11 to 8, with the remaining 8 being pre-existing and unrelated to this issue).
+
+Step 4: Write up the PR description documenting the fix, including the additional redis_port bug discovered beyond the original issue text, and the reasoning for choosing from_url() over adding new Settings fields.
+
+### Inputs & outputs
+What does your fix take as input? What should it produce or change?
+
+"The input is settings.redis_url, which comes from the .env file (or environment variables, with a hardcoded default as fallback), and represents a full Redis connection string containing the host, port, and database number.
+
+The fix produces an accurate reflection of Redis's real status: \"redis\": \"healthy\" with an overall 200 OK when Redis is reachable, and \"redis\": \"unhealthy\" with a 503 Service Unavailable when it's genuinely down  rather than always reporting unhealthy regardless of Redis's actual state.
+
+### Risks & unknowns
+What could go wrong? What are you still unsure about?
+
+There are pre-existing issues in health.py outside this fix's scope — the 8 remaining mypy errors (missing type annotations, indexed-assignment issues) and the separate Postgres health check bug ('SELECT 1' should be explicitly declared as text('SELECT 1'))that could make the health endpoint's overall reliability look worse than it is, even though they're unrelated to the Redis fix.
+
+
+I'm not fully certain how redis.Redis.from_url() behaves if settings.redis_url is malformed or empty (e.g., missing the redis:// scheme) whether it fails immediately with a clear error, or fails in some way that doesn't get caught cleanly by the existing except Exception block.
+
+
+
+
+
+### Edge cases
+What inputs or states should your fix handle gracefully?
+
+
+When Redis is down but redis_url is valid, the fix should gracefully report \"redis\": \"unhealthy\" rather than crashing the whole app I confirmed this behavior when Docker wasn't running and /health returned \"redis\": \"unhealthy\" with an overall 503, without any unhandled exception.
+
+
+"If redis_url is empty or malformed, the fix should still gracefully report \"redis\": \"unhealthy\" (caught by the existing except Exception block and logged via log.error(...)) rather than causing an unhandled crash that takes down the entire /health endpoint.

--- a/api/routes/health.py
+++ b/api/routes/health.py
@@ -1,6 +1,7 @@
-from fastapi import APIRouter, HTTPException, status, Depends
+from datetime import datetime
+
 import structlog
-from datetime import datetime, timedelta
+from fastapi import APIRouter, Depends, HTTPException, status
 
 from core.database import get_db
 
@@ -39,14 +40,10 @@ async def health_check(db=Depends(get_db)):
     try:
         # Check Redis (if available)
         import redis
+
         from core.config import settings
 
-        r = redis.Redis(
-            host=settings.redis_host,
-            port=settings.redis_port,
-            db=0,
-            decode_responses=True,
-        )
+        r = redis.Redis.from_url(settings.redis_url, decode_responses=True)
         r.ping()
         health_status["dependencies"]["redis"] = "healthy"
         log.debug("redis_health_check_passed")

--- a/core/config.py
+++ b/core/config.py
@@ -8,7 +8,9 @@ class Settings(BaseSettings):
     """Application settings with support for .env file and environment variables."""
 
     # Database
-    database_url: str = Field(default="postgresql+asyncpg://pathreview:pathreview@localhost:5432/pathreview_dev")
+    database_url: str = Field(
+        default="postgresql+asyncpg://pathreview:pathreview@localhost:5432/pathreview_dev"
+    )
     redis_url: str = Field(default="redis://localhost:6379/0")
     vector_db_url: str = Field(default="http://localhost:8001")
 

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -1,0 +1,37 @@
+"""Tests for api/routes/health.py"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from api.routes.health import health_check
+
+
+@pytest.mark.asyncio
+async def test_health_check_reports_redis_healthy_when_reachable() -> None:
+    """Test that health_check reports redis as healthy when Redis responds to ping."""
+    mock_db = AsyncMock()
+    mock_db.execute = AsyncMock()
+
+    with patch("redis.Redis.from_url") as mock_from_url:
+        mock_from_url.return_value.ping.return_value = True
+
+        result = await health_check(db=mock_db)
+
+        assert result["dependencies"]["redis"] == "healthy"
+
+
+@pytest.mark.asyncio
+async def test_health_check_reports_redis_unhealthy_when_unreachable() -> None:
+    """Test that health_check reports redis as unhealthy when Redis does not respond to ping."""
+    mock_db = AsyncMock()
+    mock_db.execute = AsyncMock()
+
+    with patch("redis.Redis.from_url") as mock_from_url:
+        mock_from_url.return_value.ping.side_effect = ConnectionError("Connection refused")
+
+        with pytest.raises(HTTPException) as exc_info:
+            await health_check(db=mock_db)
+
+        assert exc_info.value.detail["dependencies"]["redis"] == "unhealthy"


### PR DESCRIPTION
## What this PR does
Fixes issue #155: the /health endpoint crashed with `AttributeError: 'Settings' object has no attribute 'redis_host'` because `Settings` never defined that field. Also discovered `redis_port` was equally missing. Fixed by replacing the broken `redis.Redis(host=settings.redis_host, port=settings.redis_port, ...)` call with `redis.Redis.from_url(settings.redis_url, decode_responses=True)`, using the existing `redis_url` field as the single source of truth rather than adding redundant fields to Settings.

## Tests
Added `tests/unit/test_health.py` (first test coverage for /health): verifies "redis": "healthy" when reachable, and "redis": "unhealthy" (503) when unreachable.

## Pre-existing failures (documented, not caused by this change)
- `make check`: 179 pre-existing ruff errors, 8 pre-existing mypy errors in health.py (missing type annotations, dict-indexing issues) — confirmed present before this fix via `git show HEAD~4`.
- `make test-unit`: 53 pre-existing failures across unrelated modules (bias_detector, resume_parser, tech_detector, review_service, etc.) — none touch health.py, config.py, or Redis logic.
- My changes introduce zero new lint, type, or test failures (confirmed via before/after comparison).

## Manual testing
1. `docker compose up -d`
2. `make run`
3. `curl http://localhost:8000/health` → confirms `"redis": "healthy"` when Redis container is up.