### PR TITLE
fix(api): serialize concurrent POST /reviews per profile (#82)

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,29 @@
+# JOURNAL
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/82
+
+**Issue title:** Concurrent review requests for the same profile can produce inconsistent results
+
+**Tier:** [ ] Tier 1  [ ] Tier 2  [x] Tier 3
+
+**Selection Reasoning:**
+
+1. **I understand the problem.** Concurrent `POST /reviews` for the same profile race in `api/routes/reviews.py` and `core/services/review_service.py` — no per-profile lock, no idempotency, stale in-memory state across long awaits, no `IngestedSource` dedup. Before the fix: two overlapping runs overwrite each other's `sections` and double-insert evidence rows. After: duplicates are rejected up front, or serialized safely with consistent output. See problem summary below.
+
+2. **Tier 3 is a scope match.** I've contributed to large codebases before, so navigating multi-file changes across `api/`, `core/services/`, and the DB layer isn't new territory. The problem sits squarely in mutex + caching territory, which I'm actively studying — so the difficulty is a stretch, not a leap.
+
+3. **I've read the actual code, not just the issue.** I traced the request path through the two files, identified where the session leaks into the background task and where the state transition needs a lock + version guard, and posted a rough fix plan in [issue #82 comment](https://github.com/ascherj/pathreview/issues/82#issuecomment-5014425733).
+
+4. **The claim count is fine (4–5), no blockers, and I've scoped it to fit before the Week 9 deadline.**
+
+**Problem summary:**
+
+Concurrent review requests for the same profile can produce inconsistent results because the pipeline in `api/routes/reviews.py` and `core/services/review_service.py` has no protection against overlapping runs. The request-scoped DB session leaks into the background task, `POST /reviews` has no idempotency check, the `Review` row has no lock or version guard, the in-memory review is held stale across long ingestion/agent/RAG awaits, and `IngestedSource` inserts have no dedup — so two loops can overwrite each other's `sections` and pile up duplicate ingestion rows. A successful fix gives the background task its own session, rejects duplicate in-flight creates for the same profile, gates the state transition on a per-profile lock and optimistic version, and enforces ingestion dedup so overlapping runs cannot double-insert. After the fix, two concurrent reviews should either converge on one consistent result or be safely serialized without lost writes or duplicated evidence.
+
+**Out of scope**: LLM sampling non-determinism, external source drift, and orphaned `"processing"` rows from crashed tasks — separate issues.
+
+**Branch name:** `fix/82-concurrent-reviews-races`
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -27,3 +27,163 @@ Concurrent review requests for the same profile can produce inconsistent results
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [6daedb7 — `test(api): add regression test for concurrent review race (#82)`](https://github.com/ascherj/pathreview/commit/6daedb7)
+
+**Reproduction summary:**
+Wrote a throwaway `scripts/repro_82.py` (inlined below) that opens two `AsyncSessionLocal` sessions against the local dev Postgres, seeds one User + one Profile, then fires `create_review` + `process_review` concurrently against the same `profile_id` via `asyncio.gather`. Both calls are accepted as `pending` with distinct review IDs and both pipelines run to completion — the profile ends up with **two `complete` reviews** produced from overlapping reads/writes, confirming there is no per-profile serialization today.
+
+**PLAN.md link:** [PLAN.md on `fix/82-concurrent-reviews-races`](https://github.com/zuccamia/pathreview/blob/fix/82-concurrent-reviews-races/PLAN.md)
+
+**Walkthrough video (recommended):** _TBD — Loom, ≤2 min_
+
+**Blockers or open questions:**
+- The original problem summary called out "double-insert `IngestedSource` rows" as a second observable symptom, but that evidence path can't be reproduced on `main`: `_run_ingestion_pipeline` constructs `IngestedSource(raw_data=...)` against a model that has no `raw_data` column, so the constructor raises `TypeError`, the surrounding `except Exception` swallows it as `*_ingestion_failed`, and no rows are ever persisted. Flagged as an adjacent finding on the issue thread and kept out of scope for this PR. The concurrency race itself still reproduces cleanly via the two overlapping `complete` reviews above.
+
+<details>
+<summary>Reproduction script (inlined; not committed to the repo)</summary>
+
+```python
+"""Reproduce issue #82: concurrent reviews for the same profile race.
+
+Runs against the local dev stack (Docker Postgres). Demonstrates the core
+symptom called out in the issue: `POST /reviews` has no per-profile
+serialization, so two overlapping requests both create pending reviews and
+both drive `process_review` to completion against the same profile state.
+
+Run:
+
+    python -m scripts.repro_82
+
+Prereqs: postgres up (docker compose up -d db), migrations applied
+(alembic upgrade head).
+"""
+
+import asyncio
+import sys
+from uuid import uuid4
+
+from sqlalchemy import delete, select
+
+from core.database import AsyncSessionLocal
+from core.models.ingested_source import IngestedSource
+from core.models.profile import Profile
+from core.models.review import Review
+from core.models.user import User
+from core.services.review_service import create_review, process_review
+
+
+async def _make_fixture(db) -> Profile:
+    user = User(
+        id=str(uuid4()),
+        email=f"repro-{uuid4().hex[:8]}@example.com",
+        hashed_password="not-a-real-hash",
+    )
+    db.add(user)
+    await db.flush()
+
+    profile = Profile(
+        id=str(uuid4()),
+        user_id=user.id,
+        github_username="octocat",
+        portfolio_url="https://example.com",
+        resume_filename="resume.pdf",
+        resume_text="resume body",
+    )
+    db.add(profile)
+    await db.commit()
+    await db.refresh(profile)
+    return profile
+
+
+async def _cleanup(db, profile_id: str, user_id: str) -> None:
+    await db.execute(delete(IngestedSource).where(IngestedSource.profile_id == profile_id))
+    await db.execute(delete(Review).where(Review.profile_id == profile_id))
+    await db.execute(delete(Profile).where(Profile.id == profile_id))
+    await db.execute(delete(User).where(User.id == user_id))
+    await db.commit()
+
+
+async def demonstrate_race() -> bool:
+    print("Fixture: one User + one Profile.")
+    async with AsyncSessionLocal() as db_a, AsyncSessionLocal() as db_b:
+        profile = await _make_fixture(db_a)
+
+        print("\nFiring two concurrent create_review calls for the same profile…")
+        review_1, review_2 = await asyncio.gather(
+            create_review(db_a, profile.id, profile.user_id),
+            create_review(db_b, profile.id, profile.user_id),
+        )
+        print(f"  request A → review {review_1.id}  status={review_1.status}")
+        print(f"  request B → review {review_2.id}  status={review_2.status}")
+
+        both_pending = review_1.status == "pending" and review_2.status == "pending"
+        distinct = review_1.id != review_2.id
+        print(
+            f"\n  both accepted as pending?   {both_pending}"
+            f"\n  distinct review ids?        {distinct}"
+        )
+
+        print("\nRunning both process_review pipelines concurrently…")
+        await asyncio.gather(
+            process_review(db_a, review_1.id, profile.id),
+            process_review(db_b, review_2.id, profile.id),
+        )
+
+        async with AsyncSessionLocal() as reader:
+            all_for_profile = (
+                await reader.execute(
+                    select(Review).where(Review.profile_id == profile.id)
+                )
+            ).scalars().all()
+
+        completes = [r for r in all_for_profile if r.status == "complete"]
+        print(f"  reviews on this profile: {len(all_for_profile)}")
+        print(f"  reviews in 'complete' status: {len(completes)}")
+
+        bug_reproduced = both_pending and distinct and len(completes) == 2
+        await _cleanup(db_a, profile.id, profile.user_id)
+
+    print(f"\n→ Race reproduced: {bug_reproduced}")
+    print(
+        "  Expectation once the per-profile lock lands:"
+        "\n    - request A gets 201/200 with a pending review;"
+        "\n    - request B is rejected with 400 while A is in flight;"
+        "\n    - exactly one 'complete' review exists for the profile."
+    )
+    return bug_reproduced
+
+
+async def main() -> int:
+    print("Reproducing issue #82: concurrent reviews for the same profile\n")
+    ok = await demonstrate_race()
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))
+```
+
+Observed run against local dev Postgres:
+
+```
+Fixture: one User + one Profile.
+
+Firing two concurrent create_review calls for the same profile…
+  request A → review 1dfde8f9-…  status=pending
+  request B → review c164862e-…  status=pending
+
+  both accepted as pending?   True
+  distinct review ids?        True
+
+Running both process_review pipelines concurrently…
+  reviews on this profile: 2
+  reviews in 'complete' status: 2
+
+→ Race reproduced: True
+```
+
+</details>
+

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -187,3 +187,36 @@ Running both process_review pipelines concurrently…
 
 </details>
 
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+PLAN.md sub-tasks 1–4 are done. `core/services/review_lock.py` implements a Redis SET NX EX primitive with a per-instance token and a compare-and-delete Lua release; `POST /reviews` in `api/routes/reviews.py` now acquires the lock before creating the row and releases it in the background task's `finally`. Concurrent callers get a 409 with the in-progress review's id. Unit tests cover the lock (acquire/release/foreign-owner/error swallow) and the route-level race regression using a fake Redis.
+
+**Next steps:**
+Run through the self-review checklist against `docs/CONTRIBUTING.md`, open the PR against `main`, and share the draft link for peer feedback before Sunday.
+
+**Blockers:**
+None.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/591
+
+**Branch:** `fix/82-concurrent-reviews-races`
+
+**What you built:**
+A per-profile Redis lock that serializes `POST /reviews`: the first request acquires `review_lock:{profile_id}` via SET NX EX (5-minute TTL), creates the review, and releases the lock in the background task's `finally` using a compare-and-delete Lua script so a stale TTL can't drop someone else's lock. Concurrent callers on the same profile get 409 with the in-progress review id instead of racing to insert duplicate rows.
+
+**Tests added or updated:**
+- `tests/unit/test_review_lock.py` — 6 unit tests covering SET NX EX arguments, TTL default, contention (only one acquirer wins), release Lua semantics, error swallowing during teardown, and the foreign-owner safety guarantee.
+- `tests/unit/test_reviews_race.py` — regression test that exercises two concurrent `POST /reviews` calls against a fake Redis and asserts exactly one 201 and one 409.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+(Pre-existing ruff/mypy failures unrelated to issue #82 documented in the PR description; my changes introduce no new failures.)
+
+**Draft PR feedback received from:** _pending_
+

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -220,3 +220,35 @@ A per-profile Redis lock that serializes `POST /reviews`: the first request acqu
 
 **Draft PR feedback received from:** _pending_
 
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [x] Yes  [ ] No — still awaiting review
+
+**Summary of feedback:**
+- Peer reviewer: PR description promised `409` with an in-progress review id, but the code returned `400` with a static message; `lock.acquire()` sat above the endpoint's `try:` block, so a Redis outage there bypassed the endpoint's logged error path.
+- Architectural reviewer: lock design is sound, but the background task still uses the request-scoped `AsyncSession`, so the lock only prevents duplicate rows, not corrupted state within a single review run. Asked me to be explicit in the PR description about what the fix does and doesn't guarantee.
+
+**How you responded:**
+Two commits: (1) 400 → 409 with `profile_id` in the detail; (2) wrapped `acquire()` in its own try/except that emits a dedicated `review_lock_acquire_error` log and returns 500 with a specific message, plus a unit test simulating a Redis outage. Updated the PR body so the "409" wording matches what shipped and added a **Scope** section naming what's in scope (row-level duplication) and what's deferred (session lifecycle in `process_review`), linking my earlier out-of-scope comment on the issue.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Writing the PR description honestly. I paraphrased from PLAN.md instead of re-reading the code, and shipped "409 with the review id" in the description while the code returned 400 with no id. Intent documents drift the moment you start implementing — the PR body has to be written against the diff, not the plan.
+
+**What did you learn about working in a large codebase?**
+The bar is "don't break things," not "make everything green" — `main` had 53 failing tests and 186 ruff errors, and the honest move was to note the baseline and confirm my diff added zero new failures rather than treat pre-existing debt as my scope. And a surprising amount of review is about the PR description itself: in a shared codebase it's the primary interface for everyone who comes after you.
+
+**How did AI tools help — and where did they fall short?**
+Helped most with navigation, running the test/lint/typecheck matrix, drafting commits and messages, and reasoning through the compare-and-delete release. Fell short on judgment calls that needed codebase or stakeholder context — it drafted a verbose PR body I hadn't approved, defaulted to 503 for the Redis-outage case when the existing pattern was 500, and ran `gh pr create` against my fork instead of upstream without checking `git remote -v` first (I would have caught that if I'd been driving the terminal myself). Excellent at *doing* a specific thing well; needs a human on the "which thing" and "how much" calls, and on the sanity checks that live in muscle memory rather than in the current context.
+
+**What would you do differently if you started over?**
+Write the PR description last, from the diff, not from the plan — that's where the 409/400 mismatch came from. Decide up front whether the concurrency guard and the session-lifecycle fix ship together, and put that decision in the PR body from the first draft rather than letting a reviewer draw the scope line for me. And when delegating routine git/gh operations to AI, name the pre-flight checks explicitly (remote, branch target, staged files) instead of assuming they'll happen — the assistant is confident enough to skip them if I don't ask.
+
+**What are you most proud of from this module?**
+The compare-and-delete Lua release. My first draft had a bare `DEL`, which would silently delete a foreign owner's key if my TTL expired mid-pipeline and a fresh request took the same lock. Adding a per-instance token and gating the delete on `GET == token` is the one change that made the lock actually safe rather than probably-safe-most-of-the-time — and it's the specific piece both reviewers called out.
+

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -218,7 +218,7 @@ A per-profile Redis lock that serializes `POST /reviews`: the first request acqu
 **Self-review confirmation:** [x] make check passes  [x] make test-unit passes
 (Pre-existing ruff/mypy failures unrelated to issue #82 documented in the PR description; my changes introduce no new failures.)
 
-**Draft PR feedback received from:** _pending_
+**Draft PR feedback received from:** @hkumar30 (peer review exchange)
 
 ## Week 10 — Iteration & reflection
 
@@ -242,6 +242,8 @@ Writing the PR description honestly. I paraphrased from PLAN.md instead of re-re
 
 **What did you learn about working in a large codebase?**
 The bar is "don't break things," not "make everything green" — `main` had 53 failing tests and 186 ruff errors, and the honest move was to note the baseline and confirm my diff added zero new failures rather than treat pre-existing debt as my scope. And a surprising amount of review is about the PR description itself: in a shared codebase it's the primary interface for everyone who comes after you.
+
+Reviewing a peer's health-check PR also pushed me to articulate the codebase's dependency-injection pattern out loud — something I'd applied correctly in my own PR without having to defend it. The pattern has two halves that give different perks: services take their Redis/DB client as a plain constructor argument (no `Depends`), which is what keeps them framework-independent — the same code runs from a worker or a script, not just a FastAPI request. The route, on the other side, wires those clients via `Depends(get_redis_client)`, which is what enables clean test overrides (`app.dependency_overrides[...]`) and self-documenting endpoint signatures. Applying a convention correctly and being able to explain *why* each half is shaped that way are two different skills, and code review is where the second one gets built.
 
 **How did AI tools help — and where did they fall short?**
 Helped most with navigation, running the test/lint/typecheck matrix, drafting commits and messages, and reasoning through the compare-and-delete release. Fell short on judgment calls that needed codebase or stakeholder context — it drafted a verbose PR body I hadn't approved, defaulted to 503 for the Redis-outage case when the existing pattern was 500, and ran `gh pr create` against my fork instead of upstream without checking `git remote -v` first (I would have caught that if I'd been driving the terminal myself). Excellent at *doing* a specific thing well; needs a human on the "which thing" and "how much" calls, and on the sanity checks that live in muscle memory rather than in the current context.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,65 @@
+# Solution plan
+
+**Issue:** [#82 — Concurrent review requests for the same profile can produce inconsistent results](https://github.com/ascherj/pathreview/issues/82)
+
+### Understand
+
+**Root cause:** `POST /reviews` has no per-profile serialization. Two overlapping requests both create a `Review` and both drive `process_review` through ingestion / agent / RAG / safety against the same profile state, interleaving reads and writes.
+
+**Expected:** concurrent reviews for the same profile produce consistent, non-conflicting results — the final `Review` state reflects one coherent run, not two overlapping ones. The issue doesn't prescribe *how* (reject vs queue vs merge); that's a design decision — see below.
+
+**Actual (reproduced in [`6daedb7`](https://github.com/ascherj/pathreview/commit/6daedb7)):** two concurrent creates both succeed, both complete, profile ends up with two `complete` reviews from overlapping runs with last-writer-wins commits.
+
+### Serialization: where and how
+
+**Design decision — reject, don't queue.** Two ways to prevent overlap: (A) reject the second request with 400, or (B) queue it server-side until the first finishes. Chose **A** — matches the existing `POST /auth/register`-returns-400 convention, and a full review is too long to reasonably hold an HTTP connection open waiting. Queue-and-wait would need `202 Accepted` + polling / SSE machinery for the same correctness guarantee.
+
+**Where:** in `create_review_endpoint`, before any `Review` row is written — otherwise the race window just moves.
+
+**How:** Redis `SET review_lock:{profile_id} <token> NX EX 300` for atomic acquire; Lua compare-and-delete against the per-request token for safe release (so a stale owner whose TTL fired can't delete a fresh holder's key). Release runs in the background task's `finally`. Redis over an in-process `asyncio.Lock` because a per-process lock silently breaks across workers/replicas.
+
+### Map
+
+Files touched:
+- `api/routes/reviews.py` — acquire at the top of `create_review_endpoint`; release wrapped around the background task.
+- `core/redis_client.py` *(new)* — cached `redis.asyncio` client provider.
+- `core/services/review_lock.py` *(new)* — `ReviewLock` primitive.
+- `tests/unit/test_review_lock.py` *(new)* — primitive tests.
+- `tests/unit/test_reviews_race.py` *(already committed in `6daedb7`)* — endpoint-level regression, flips green when the lock lands.
+
+**Not touched** (out of scope per the reviewer): `core/services/review_service.py` (session-leak + stale-`review`-across-awaits bugs).
+
+### Plan
+
+1. Add `core/redis_client.py` — `get_redis_client()` returning an `lru_cache`d `redis.asyncio` client.
+2. Add `core/services/review_lock.py` — `ReviewLock(redis, profile_id, ttl_seconds=300)` with `acquire()` (SET NX EX) and `release()` (Lua compare-and-delete, swallows Redis errors).
+3. Wire into `create_review_endpoint`: acquire → on failure raise `HTTPException(400, "A review for this profile is already in progress")`; on success create the review and hand the background task a `_process_and_release()` wrapper that releases in `finally`. Release on the create-time error path too.
+4. Add primitive tests for `ReviewLock` (acquire, contention, release token match, error tolerance).
+5. Confirm `test_reviews_race.py` flips green.
+
+### Inputs & outputs
+
+**Input:** existing `POST /reviews` payload (`profile_id`) — no schema change.
+
+**Outputs:**
+- First request → unchanged (200, pending review, background task).
+- Second concurrent request for the same profile → `HTTPException(400, "A review for this profile is already in progress")`.
+- After the first completes / crashes and TTL expires → next request behaves like the first again.
+
+**New side effect:** one Redis key per active review (`review_lock:{profile_id}`, 300s TTL), deleted at background-task teardown.
+
+### Risks & unknowns
+
+- **TTL vs review duration.** 300s is comfortably longer than the current mock pipeline; if the real pipeline exceeds it, a second create could slip through. TTL is a knob, not a hard fix. No refresh/renewal in this PR.
+- **Redis outage.** `acquire()` propagates → 500 via the existing catch-all. Stricter than `RateLimiter`'s fail-open, but fail-open here would silently reintroduce the bug. Worth flagging to the reviewer.
+- **Not load-tested against real Redis.** Primitive tests use an in-process fake honoring `SET NX EX` + `EVAL`. Spot-check against `pathreview-redis-1` before opening the PR.
+- **Adjacent bug flagged on the thread** (`_run_ingestion_pipeline` never persists `IngestedSource` rows) is unrelated to the lock and stays out of scope.
+
+### Edge cases
+
+- **Same profile, different users** → still serialized (key is `profile_id`; profile state is shared).
+- **Different profiles, same user** → no contention (independent keys).
+- **`create_review` raises after acquire** → released in the error path (no 300s hang).
+- **`process_review` raises** → `try/finally` still releases.
+- **Redis dies mid-review** → `release()` swallows the error; key auto-expires; the review still completes.
+- **Rapid retries after 400** → each is one cheap `SET NX`. Rate limiting is the right layer for pushback, not the lock.

--- a/api/routes/reviews.py
+++ b/api/routes/reviews.py
@@ -1,12 +1,13 @@
-from fastapi import APIRouter, Depends, HTTPException, status, BackgroundTasks
 from uuid import UUID
-import structlog
 
-from api.schemas.review import ReviewCreate, ReviewResponse, ReviewListResponse
+import structlog
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from api.middleware.auth import get_current_user
-from core.models.user import User
-from core.models.review import Review
+from api.schemas.review import ReviewCreate, ReviewListResponse, ReviewResponse
 from core.database import get_db
+from core.models.user import User
 from core.services.review_service import (
     create_review,
     get_review,
@@ -24,8 +25,8 @@ async def create_review_endpoint(
     data: ReviewCreate,
     background_tasks: BackgroundTasks,
     current_user: User = Depends(get_current_user),
-    db=Depends(get_db),
-):
+    db: AsyncSession = Depends(get_db),
+) -> ReviewResponse:
     """
     Create a new review for a profile.
     Triggers ingestion pipeline and agent orchestration asynchronously.
@@ -49,7 +50,8 @@ async def create_review_endpoint(
             user_id=str(current_user.id),
         )
 
-        return ReviewResponse.model_validate(review)
+        response: ReviewResponse = ReviewResponse.model_validate(review)
+        return response
 
     except HTTPException:
         raise
@@ -59,15 +61,15 @@ async def create_review_endpoint(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to create review",
-        )
+        ) from exc
 
 
 @router.get("/{review_id}", response_model=ReviewResponse)
 async def get_review_endpoint(
     review_id: UUID,
     current_user: User = Depends(get_current_user),
-    db=Depends(get_db),
-):
+    db: AsyncSession = Depends(get_db),
+) -> ReviewResponse:
     """
     Get a review by ID.
     Returns 404 if not found or not owned by current user.
@@ -86,7 +88,8 @@ async def get_review_endpoint(
                 detail="Review not found",
             )
 
-        return ReviewResponse.model_validate(review)
+        response: ReviewResponse = ReviewResponse.model_validate(review)
+        return response
 
     except HTTPException:
         raise
@@ -95,7 +98,7 @@ async def get_review_endpoint(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to retrieve review",
-        )
+        ) from exc
 
 
 @router.get("", response_model=ReviewListResponse)
@@ -103,8 +106,8 @@ async def list_reviews_endpoint(
     page: int = 1,
     page_size: int = 20,
     current_user: User = Depends(get_current_user),
-    db=Depends(get_db),
-):
+    db: AsyncSession = Depends(get_db),
+) -> ReviewListResponse:
     """
     List reviews for current user with pagination.
     """
@@ -133,15 +136,15 @@ async def list_reviews_endpoint(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to list reviews",
-        )
+        ) from exc
 
 
 @router.get("/{review_id}/status")
 async def get_review_status(
     review_id: UUID,
     current_user: User = Depends(get_current_user),
-    db=Depends(get_db),
-):
+    db: AsyncSession = Depends(get_db),
+) -> dict:
     """
     Get review status and progress.
     Returns {review_id, status, progress_pct}
@@ -173,4 +176,4 @@ async def get_review_status(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to retrieve review status",
-        )
+        ) from exc

--- a/api/routes/reviews.py
+++ b/api/routes/reviews.py
@@ -2,12 +2,15 @@ from uuid import UUID
 
 import structlog
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
+from redis.asyncio import Redis
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.middleware.auth import get_current_user
 from api.schemas.review import ReviewCreate, ReviewListResponse, ReviewResponse
 from core.database import get_db
 from core.models.user import User
+from core.redis_client import get_redis_client
+from core.services.review_lock import ReviewLock
 from core.services.review_service import (
     create_review,
     get_review,
@@ -26,42 +29,64 @@ async def create_review_endpoint(
     background_tasks: BackgroundTasks,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
+    redis: Redis = Depends(get_redis_client),
 ) -> ReviewResponse:
     """
     Create a new review for a profile.
     Triggers ingestion pipeline and agent orchestration asynchronously.
     Returns review with status="pending" immediately.
+
+    Rejects with 400 if another review for the same profile is already in
+    flight (issue #82). Serializes overlapping requests via a Redis lock
+    keyed by profile_id, released when the background task finishes.
     """
+    lock = ReviewLock(redis, data.profile_id)
+    if not await lock.acquire():
+        log.info(
+            "review_in_flight_rejected",
+            profile_id=str(data.profile_id),
+            user_id=str(current_user.id),
+        )
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="A review for this profile is already in progress",
+        )
+
     try:
-        # Create review with status="pending"
         review = await create_review(
             db=db,
             profile_id=data.profile_id,
             user_id=current_user.id,
         )
-
-        # Add background task for processing
-        background_tasks.add_task(process_review, db, review.id, data.profile_id)
-
-        log.info(
-            "review_created",
-            review_id=str(review.id),
-            profile_id=str(data.profile_id),
-            user_id=str(current_user.id),
-        )
-
-        response: ReviewResponse = ReviewResponse.model_validate(review)
-        return response
-
     except HTTPException:
+        await lock.release()
         raise
     except Exception as exc:
+        await lock.release()
         log.error("review_creation_error", error=str(exc))
         await db.rollback()
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to create review",
         ) from exc
+
+    async def _process_and_release() -> None:
+        try:
+            await process_review(db, review.id, data.profile_id)
+        finally:
+            await lock.release()
+
+    background_tasks.add_task(_process_and_release)
+
+    log.info(
+        "review_created",
+        review_id=str(review.id),
+        profile_id=str(data.profile_id),
+        user_id=str(current_user.id),
+    )
+
+    response: ReviewResponse = ReviewResponse.model_validate(review)
+    return response
 
 
 @router.get("/{review_id}", response_model=ReviewResponse)

--- a/api/routes/reviews.py
+++ b/api/routes/reviews.py
@@ -41,7 +41,20 @@ async def create_review_endpoint(
     keyed by profile_id, released when the background task finishes.
     """
     lock = ReviewLock(redis, data.profile_id)
-    if not await lock.acquire():
+    try:
+        acquired = await lock.acquire()
+    except Exception as exc:
+        log.error(
+            "review_lock_acquire_error",
+            profile_id=str(data.profile_id),
+            error=str(exc),
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to acquire review lock",
+        ) from exc
+
+    if not acquired:
         log.info(
             "review_in_flight_rejected",
             profile_id=str(data.profile_id),

--- a/api/routes/reviews.py
+++ b/api/routes/reviews.py
@@ -36,7 +36,7 @@ async def create_review_endpoint(
     Triggers ingestion pipeline and agent orchestration asynchronously.
     Returns review with status="pending" immediately.
 
-    Rejects with 400 if another review for the same profile is already in
+    Rejects with 409 if another review for the same profile is already in
     flight (issue #82). Serializes overlapping requests via a Redis lock
     keyed by profile_id, released when the background task finishes.
     """
@@ -48,8 +48,8 @@ async def create_review_endpoint(
             user_id=str(current_user.id),
         )
         raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="A review for this profile is already in progress",
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"A review for profile {data.profile_id} is already in progress",
         )
 
     try:

--- a/core/redis_client.py
+++ b/core/redis_client.py
@@ -1,0 +1,16 @@
+"""Async Redis client provider."""
+
+from functools import lru_cache
+
+from redis.asyncio import Redis
+
+from core.config import settings
+
+
+@lru_cache(maxsize=1)
+def get_redis_client() -> Redis:
+    """Return a process-wide async Redis client.
+
+    Cached so route dependencies reuse a single connection pool.
+    """
+    return Redis.from_url(settings.redis_url, decode_responses=True)

--- a/core/services/review_lock.py
+++ b/core/services/review_lock.py
@@ -1,0 +1,59 @@
+"""Per-profile review lock backed by Redis.
+
+Serializes concurrent review requests for the same profile so overlapping
+agent loops cannot read/write the same rows and produce inconsistent output.
+See issue #82.
+"""
+
+import secrets
+from uuid import UUID
+
+import structlog
+from redis.asyncio import Redis
+
+log = structlog.get_logger()
+
+# Compare-and-delete: only release the lock if we still own the token.
+# Prevents a stale owner (whose TTL fired) from deleting a fresh holder's lock.
+_RELEASE_LUA = """
+if redis.call("get", KEYS[1]) == ARGV[1] then
+    return redis.call("del", KEYS[1])
+else
+    return 0
+end
+"""
+
+
+class ReviewLock:
+    """Redis-backed per-profile mutex.
+
+    Uses SET NX EX for atomic acquire and a token + Lua compare-and-delete
+    on release. TTL bounds the blast radius of a crashed holder.
+    """
+
+    def __init__(
+        self,
+        redis_client: Redis,
+        profile_id: UUID,
+        ttl_seconds: int = 300,
+    ) -> None:
+        self._redis = redis_client
+        self._key = f"review_lock:{profile_id}"
+        self._ttl_seconds = ttl_seconds
+        self._token = secrets.token_hex(16)
+
+    @property
+    def key(self) -> str:
+        return self._key
+
+    async def acquire(self) -> bool:
+        """Attempt to acquire the lock. Returns True on success."""
+        acquired = await self._redis.set(self._key, self._token, nx=True, ex=self._ttl_seconds)
+        return bool(acquired)
+
+    async def release(self) -> None:
+        """Release the lock if we still own it. Silent on foreign locks."""
+        try:
+            await self._redis.eval(_RELEASE_LUA, 1, self._key, self._token)
+        except Exception as exc:
+            log.error("review_lock_release_failed", key=self._key, error=str(exc))

--- a/core/services/review_service.py
+++ b/core/services/review_service.py
@@ -1,19 +1,21 @@
-from uuid import UUID
-import structlog
 import json
 from datetime import datetime
-from sqlalchemy import select, and_
+from uuid import UUID
 
-from core.models.review import Review
-from core.models.profile import Profile
-from core.models.ingested_source import IngestedSource
+import structlog
+from sqlalchemy import and_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from api.schemas.review import FeedbackSection
+from core.models.ingested_source import IngestedSource
+from core.models.profile import Profile
+from core.models.review import Review
 
 log = structlog.get_logger()
 
 
 async def create_review(
-    db,
+    db: AsyncSession,
     profile_id: UUID,
     user_id: UUID,
 ) -> Review:
@@ -33,22 +35,23 @@ async def create_review(
 
 
 async def get_review(
-    db,
+    db: AsyncSession,
     review_id: UUID,
     user_id: UUID,
 ) -> Review | None:
     """
     Get a review by ID, checking that it belongs to the user's profile.
     """
-    stmt = select(Review).join(Profile).where(
-        and_(Review.id == review_id, Profile.user_id == user_id)
+    stmt = (
+        select(Review).join(Profile).where(and_(Review.id == review_id, Profile.user_id == user_id))
     )
     result = await db.execute(stmt)
-    return result.scalars().first()
+    review: Review | None = result.scalars().first()
+    return review
 
 
 async def list_reviews(
-    db,
+    db: AsyncSession,
     user_id: UUID,
     page: int = 1,
     page_size: int = 20,
@@ -80,7 +83,7 @@ async def list_reviews(
 
 
 async def process_review(
-    db,
+    db: AsyncSession,
     review_id: UUID,
     profile_id: UUID,
 ) -> None:
@@ -194,7 +197,7 @@ async def process_review(
             log.error("review_status_update_failed", review_id=str(review_id), error=str(e))
 
 
-async def _run_ingestion_pipeline(db, profile: Profile) -> list[dict]:
+async def _run_ingestion_pipeline(db: AsyncSession, profile: Profile) -> list[dict]:
     """
     Run ingestion pipeline to extract data from profile sources.
     Returns list of ingested source data.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ select = ["E", "F", "I", "N", "W", "UP", "B", "SIM", "TCH"]
 "core/models/*.py" = ["E501"]
 "scripts/*.py" = ["E501"]
 "alembic/versions/*.py" = ["E501"]
+"api/routes/*.py" = ["B008"]  # FastAPI uses Depends(...) in argument defaults by design
 
 [tool.black]
 target-version = ["py311"]

--- a/tests/unit/test_review_lock.py
+++ b/tests/unit/test_review_lock.py
@@ -1,13 +1,15 @@
 """Tests for the per-profile review lock (issue #82)."""
 
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import AsyncMock
 from uuid import uuid4
 
 import pytest
-from redis.asyncio import Redis
 
 from core.services.review_lock import ReviewLock
+
+if TYPE_CHECKING:
+    from redis.asyncio import Redis
 
 
 @pytest.mark.unit
@@ -76,15 +78,15 @@ class TestReviewLock:
                 return 0
 
         redis: Any = FakeRedis()
-        first = ReviewLock(cast(Redis, redis), profile_id)
-        second = ReviewLock(cast(Redis, redis), profile_id)
+        first = ReviewLock(cast("Redis", redis), profile_id)
+        second = ReviewLock(cast("Redis", redis), profile_id)
 
         assert await first.acquire() is True
         assert await second.acquire() is False
 
         # After the winner releases, another acquirer can take the lock.
         await first.release()
-        third = ReviewLock(cast(Redis, redis), profile_id)
+        third = ReviewLock(cast("Redis", redis), profile_id)
         assert await third.acquire() is True
 
     @pytest.mark.asyncio
@@ -147,7 +149,7 @@ class TestReviewLock:
                 return 0
 
         redis: Any = FakeRedis()
-        lock = ReviewLock(cast(Redis, redis), uuid4())
+        lock = ReviewLock(cast("Redis", redis), uuid4())
         # Foreign owner takes the key with a different token.
         redis._store[lock.key] = "someone-elses-token"
 

--- a/tests/unit/test_review_lock.py
+++ b/tests/unit/test_review_lock.py
@@ -1,0 +1,157 @@
+"""Tests for the per-profile review lock (issue #82)."""
+
+from typing import Any, cast
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+from redis.asyncio import Redis
+
+from core.services.review_lock import ReviewLock
+
+
+@pytest.mark.unit
+class TestReviewLock:
+    """Tests for ReviewLock's acquire/release semantics against a fake Redis."""
+
+    @pytest.mark.asyncio
+    async def test_acquire_uses_set_nx_ex_on_profile_key(self) -> None:
+        profile_id = uuid4()
+        redis = AsyncMock()
+        redis.set = AsyncMock(return_value=True)
+
+        lock = ReviewLock(redis, profile_id, ttl_seconds=300)
+        acquired = await lock.acquire()
+
+        assert acquired is True
+        redis.set.assert_awaited_once()
+        args, kwargs = redis.set.call_args
+        assert args[0] == f"review_lock:{profile_id}"
+        assert kwargs["nx"] is True
+        assert kwargs["ex"] == 300
+
+    @pytest.mark.asyncio
+    async def test_acquire_returns_false_when_key_exists(self) -> None:
+        """redis-py returns None when SET NX loses the race."""
+        redis = AsyncMock()
+        redis.set = AsyncMock(return_value=None)
+
+        lock = ReviewLock(redis, uuid4())
+        assert await lock.acquire() is False
+
+    @pytest.mark.asyncio
+    async def test_ttl_defaults_to_five_minutes(self) -> None:
+        redis = AsyncMock()
+        redis.set = AsyncMock(return_value=True)
+
+        lock = ReviewLock(redis, uuid4())
+        await lock.acquire()
+
+        _, kwargs = redis.set.call_args
+        assert kwargs["ex"] == 300
+
+    @pytest.mark.asyncio
+    async def test_concurrent_acquire_only_one_wins(self) -> None:
+        """Two ReviewLocks contending on one profile: exactly one gets True."""
+        profile_id = uuid4()
+
+        class FakeRedis:
+            def __init__(self) -> None:
+                self._store: dict[str, str] = {}
+                self.set = AsyncMock(side_effect=self._set)
+                self.eval = AsyncMock(side_effect=self._eval)
+
+            async def _set(
+                self, key: str, value: str, nx: bool = False, ex: int | None = None
+            ) -> bool | None:
+                if nx and key in self._store:
+                    return None
+                self._store[key] = value
+                return True
+
+            async def _eval(self, _script: str, _numkeys: int, key: str, token: str) -> int:
+                if self._store.get(key) == token:
+                    del self._store[key]
+                    return 1
+                return 0
+
+        redis: Any = FakeRedis()
+        first = ReviewLock(cast(Redis, redis), profile_id)
+        second = ReviewLock(cast(Redis, redis), profile_id)
+
+        assert await first.acquire() is True
+        assert await second.acquire() is False
+
+        # After the winner releases, another acquirer can take the lock.
+        await first.release()
+        third = ReviewLock(cast(Redis, redis), profile_id)
+        assert await third.acquire() is True
+
+    @pytest.mark.asyncio
+    async def test_release_uses_compare_and_delete_lua(self) -> None:
+        redis = AsyncMock()
+        redis.set = AsyncMock(return_value=True)
+        redis.eval = AsyncMock(return_value=1)
+
+        lock = ReviewLock(redis, uuid4())
+        await lock.acquire()
+        await lock.release()
+
+        redis.eval.assert_awaited_once()
+        args, _ = redis.eval.call_args
+        script, numkeys, key, token = args
+        assert "redis.call" in script
+        assert numkeys == 1
+        assert key == lock.key
+        # Token is generated in __init__ and passed as ARGV[1].
+        assert isinstance(token, str) and len(token) > 0
+
+    @pytest.mark.asyncio
+    async def test_release_swallows_redis_errors(self) -> None:
+        """Background-task teardown must not crash if Redis is unavailable."""
+        redis = AsyncMock()
+        redis.eval = AsyncMock(side_effect=RuntimeError("redis down"))
+        lock = ReviewLock(redis, uuid4())
+        # Should not propagate.
+        await lock.release()
+
+    @pytest.mark.asyncio
+    async def test_release_does_not_delete_foreign_lock(self) -> None:
+        """
+        If our TTL fires and someone else acquires the same key, our release
+        must not delete their key. The Lua script does GET==token ? DEL : 0
+        on the server side; here we assert the eval returns 0 (no delete)
+        when the token doesn't match.
+        """
+
+        class FakeRedis:
+            def __init__(self) -> None:
+                # Simulate a foreign owner already holding the key with a
+                # different token.
+                self._store: dict[str, str] = {}
+                self.set = AsyncMock(side_effect=self._set)
+                self.eval = AsyncMock(side_effect=self._eval)
+
+            async def _set(
+                self, key: str, value: str, nx: bool = False, ex: int | None = None
+            ) -> bool | None:
+                if nx and key in self._store:
+                    return None
+                self._store[key] = value
+                return True
+
+            async def _eval(self, _script: str, _numkeys: int, key: str, token: str) -> int:
+                if self._store.get(key) == token:
+                    del self._store[key]
+                    return 1
+                return 0
+
+        redis: Any = FakeRedis()
+        lock = ReviewLock(cast(Redis, redis), uuid4())
+        # Foreign owner takes the key with a different token.
+        redis._store[lock.key] = "someone-elses-token"
+
+        await lock.release()
+
+        # Foreign owner's key still there — we did not delete it.
+        assert redis._store.get(lock.key) == "someone-elses-token"

--- a/tests/unit/test_reviews_race.py
+++ b/tests/unit/test_reviews_race.py
@@ -1,0 +1,121 @@
+"""Regression test for issue #82: concurrent reviews for the same profile.
+
+Two concurrent `POST /reviews` for the same profile must not both succeed.
+The second overlapping request must be rejected with HTTPException(400)
+while the first is still in flight.
+
+This test FAILS against `main` today (both concurrent calls succeed) and
+turns green once the per-profile Redis lock is wired into the endpoint.
+"""
+
+import asyncio
+import inspect
+from typing import Any
+from unittest.mock import AsyncMock, Mock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import BackgroundTasks, HTTPException
+
+from api.routes.reviews import create_review_endpoint
+from api.schemas.review import ReviewCreate
+
+
+class _InProcessRedis:
+    """Minimal async fake honoring SET NX EX + EVAL compare-and-delete.
+
+    Shared across the two concurrent endpoint invocations so they contend
+    for the same profile lock key the way real Redis would.
+    """
+
+    def __init__(self) -> None:
+        self._store: dict[str, str] = {}
+
+    async def set(
+        self, key: str, value: str, nx: bool = False, ex: int | None = None
+    ) -> bool | None:
+        if nx and key in self._store:
+            return None
+        self._store[key] = value
+        return True
+
+    async def eval(self, _script: str, _numkeys: int, key: str, token: str) -> int:
+        if self._store.get(key) == token:
+            del self._store[key]
+            return 1
+        return 0
+
+
+def _endpoint_accepts_redis() -> bool:
+    """True once the fix wires a `redis` dependency into the endpoint."""
+    return "redis" in inspect.signature(create_review_endpoint).parameters
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_concurrent_creates_for_same_profile_reject_second() -> None:
+    """
+    Fires two concurrent create_review_endpoint calls for the same profile
+    and asserts exactly one succeeds while the other raises
+    HTTPException(status_code=400).
+    """
+    profile_id = uuid4()
+    user = Mock()
+    user.id = uuid4()
+    redis = _InProcessRedis()
+
+    async def one_call() -> tuple[str, Any]:
+        db = AsyncMock()
+        db.add = Mock()
+        db.commit = AsyncMock()
+        db.refresh = AsyncMock()
+        db.rollback = AsyncMock()
+        bg = BackgroundTasks()
+
+        fake_review = Mock()
+        fake_review.id = uuid4()
+        fake_review.profile_id = profile_id
+        fake_review.status = "pending"
+        fake_review.sections = None
+        fake_review.overall_score = None
+        fake_review.created_at = None
+        fake_review.updated_at = None
+
+        kwargs: dict[str, Any] = dict(
+            data=ReviewCreate(profile_id=profile_id),
+            background_tasks=bg,
+            current_user=user,
+            db=db,
+        )
+        if _endpoint_accepts_redis():
+            kwargs["redis"] = redis
+
+        with (
+            patch(
+                "api.routes.reviews.create_review",
+                AsyncMock(return_value=fake_review),
+            ),
+            patch(
+                "api.routes.reviews.ReviewResponse.model_validate",
+                return_value=fake_review,
+            ),
+        ):
+            try:
+                await create_review_endpoint(**kwargs)
+            except HTTPException as exc:
+                return ("err", exc.status_code)
+            return ("ok", None)
+
+    outcomes = await asyncio.gather(one_call(), one_call())
+
+    ok_count = sum(1 for tag, _ in outcomes if tag == "ok")
+    rejects = [code for tag, code in outcomes if tag == "err"]
+
+    assert ok_count == 1, (
+        f"Regression #82: expected exactly one success across two concurrent "
+        f"POST /reviews for the same profile, got outcomes={outcomes}"
+    )
+    assert rejects == [400], (
+        f"Regression #82: expected the second concurrent request to be "
+        f"rejected with HTTP 400, got rejects={rejects}"
+    )

--- a/tests/unit/test_reviews_race.py
+++ b/tests/unit/test_reviews_race.py
@@ -1,7 +1,7 @@
 """Regression test for issue #82: concurrent reviews for the same profile.
 
 Two concurrent `POST /reviews` for the same profile must not both succeed.
-The second overlapping request must be rejected with HTTPException(400)
+The second overlapping request must be rejected with HTTPException(409)
 while the first is still in flight.
 
 This test FAILS against `main` today (both concurrent calls succeed) and
@@ -115,7 +115,7 @@ async def test_concurrent_creates_for_same_profile_reject_second() -> None:
         f"Regression #82: expected exactly one success across two concurrent "
         f"POST /reviews for the same profile, got outcomes={outcomes}"
     )
-    assert rejects == [400], (
+    assert rejects == [409], (
         f"Regression #82: expected the second concurrent request to be "
-        f"rejected with HTTP 400, got rejects={rejects}"
+        f"rejected with HTTP 409, got rejects={rejects}"
     )

--- a/tests/unit/test_reviews_race.py
+++ b/tests/unit/test_reviews_race.py
@@ -119,3 +119,42 @@ async def test_concurrent_creates_for_same_profile_reject_second() -> None:
         f"Regression #82: expected the second concurrent request to be "
         f"rejected with HTTP 409, got rejects={rejects}"
     )
+
+
+class _BrokenRedis:
+    """Async fake whose SET raises, simulating a Redis outage."""
+
+    async def set(self, *_args: Any, **_kwargs: Any) -> bool | None:
+        raise ConnectionError("redis is down")
+
+    async def eval(self, *_args: Any, **_kwargs: Any) -> int:
+        raise ConnectionError("redis is down")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_redis_outage_during_acquire_returns_500() -> None:
+    """
+    If Redis raises during lock.acquire(), the endpoint must return a
+    structured 500 through its own handler (not an unhandled exception).
+    """
+    profile_id = uuid4()
+    user = Mock()
+    user.id = uuid4()
+
+    db = AsyncMock()
+    bg = BackgroundTasks()
+
+    kwargs: dict[str, Any] = dict(
+        data=ReviewCreate(profile_id=profile_id),
+        background_tasks=bg,
+        current_user=user,
+        db=db,
+        redis=_BrokenRedis(),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await create_review_endpoint(**kwargs)
+
+    assert exc_info.value.status_code == 500
+    assert "review lock" in exc_info.value.detail.lower()


### PR DESCRIPTION
## Summary
Concurrent `POST /reviews` on the same profile created duplicate rows and ran the pipeline twice. Adds a per-profile Redis lock; the second caller gets `409 Conflict` naming the profile that's already in progress.

## Issue
Closes #82

## Changes
- `core/services/review_lock.py` — `SET NX EX` acquire (5-min TTL) + compare-and-delete Lua release so a stale TTL can't drop someone else's lock.
- `api/routes/reviews.py` — acquire before insert, release in the background task's `finally`, return 409 with the contended `profile_id` on contention. Redis-outage during acquire is routed through the endpoint's error path as a structured `review_lock_acquire_error` log + HTTP 500 with a specific detail message.
- `core/redis_client.py` — expose async Redis as a FastAPI dependency.
- `tests/unit/test_review_lock.py`, `tests/unit/test_reviews_race.py` — 9 new unit tests (lock semantics + end-to-end race regression + Redis-outage during acquire).

## Scope

**In scope:** serialize concurrent `POST /reviews` for the same profile so only one review row is created per contended request wave, per issue #82.

**Out of scope (deferred):** the background task still uses the request-scoped DB session injected by FastAPI. Once the HTTP response is sent, that session's lifecycle is ambiguous — `process_review` could observe a closed or inconsistent session on its later awaits, which can still produce corrupted state *within* a single review run. The lock in this PR prevents duplicate rows; it does not fix the session lifecycle. I raised this on the issue in [this comment](https://github.com/ascherj/pathreview/issues/82#issuecomment-5014425733) and did not receive direction to expand scope, so I'm keeping this PR to the serialization fix and leaving the session lifecycle for a follow-up.

## Testing
- [x] Unit tests pass (`make test-unit`) — 9 new pass; 53 pre-existing failures identical to `main`, zero introduced.
- [ ] Integration tests pass (`make test-integration`) — not run, out of scope.
- [x] Linter passes (`make lint`) — clean on touched files; repo-wide errors are pre-existing.
- [x] Type checker passes (`make typecheck`) — no new mypy errors on touched files.
- [x] New/updated tests cover the changes

## Notes for Reviewers
- Redis lock, not DB row lock — the pipeline runs in a background task past the request scope.
- Compare-and-delete release keeps a stale TTL from dropping someone else's lock.