### PR TITLE
fix(rag): consolidate duplicate cross-project feedback (#28)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ htmlcov/
 
 # Build artifacts
 *.pyc
+repro_issue28.py

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -12,7 +12,7 @@
 
 **Issue title:** Generator produces duplicate feedback sections when a user has multiple projects in the same tech stack
 
-**Tier:** [ ] Tier 1  [ ] Tier 2  [x] Tier 3
+**Tier:** [ ] Tier 1 [ ] Tier 2 [x] Tier 3
 
 **Problem summary:**
 The review generator treats each of a user's projects independently, so when
@@ -32,4 +32,4 @@ than a per-project checklist, affecting the RAG generation layer
 
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
-**Cohort ledger:** [ ] Issue added to cohort ledger
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -65,3 +65,35 @@ or the review data model, since those are out of scope for this issue and would
 expand the blast radius. If deduplication turns out to need richer metadata
 (e.g. per-project tech-stack tags), I'll note that as a follow-up rather than
 widen this issue.
+
+---
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/arunkasala-open/pathreview/commit/ed4d09e42beafd07220784bcafe3eba542bbe341
+
+**Reproduction summary:**
+I added a unit test (`tests/unit/test_issue_28_duplicate_feedback.py`) that
+feeds the parse → consolidate path an LLM payload for three same-stack Python
+projects with identical "Python skills" content. After
+`ReviewGenerator._consolidate_feedback` runs, all three duplicate sections
+survive (expected 1), confirming the bug: consolidation dedupes by
+`section_name` only and never compares content. The failing assertion is marked
+`xfail(strict=True)` so it documents the reproduction now and will flip to a
+signal to remove the marker once the fix lands.
+
+**PLAN.md link:** https://github.com/arunkasala-open/pathreview/blob/fix/28-duplicate-feedback-sections-when-multiple-projects/PLAN.md
+
+**Walkthrough video (recommended):** _(not recorded yet)_
+
+**Blockers or open questions:**
+- Choosing the content-similarity threshold for merging "nearly identical"
+  feedback without collapsing genuinely distinct observations — I'll tune this
+  with tests.
+- Whether to add an optional `projects` field to `FeedbackSection` (cleaner) or
+  encode the affected projects in the content string (less invasive); depends on
+  how `_add_citations` and the API review schema consume it.
+- Pre-existing `mypy` error in `output_parser.py` (dead `sections = []`, present
+  on `main`) blocks the pre-commit hook / CI on any commit touching these files;
+  I'll fix it as part of the solution PR.
+

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,37 @@
+# Module 3 Journal
+
+> Weekly engineering journal for my work on **PathReview**.
+> Fork: https://github.com/arunkasala-open/pathreview
+
+---
+
+## Week 7 — Environment Setup & Issue Selection
+
+**Dates:** 2026-07-19
+
+### Issue I'm working on
+- **Issue #28 — Generator produces duplicate feedback sections when a user has multiple projects in the same tech stack** (`fix`, labels: `tier-3`, `rag`)
+- Branch: `fix/28-duplicate-feedback-sections-when-multiple-projects`
+- Summary: When a user has several projects in the same stack (e.g. three Python projects), the review generator emits nearly identical skills feedback for each one, so the review reads as repetitive. The fix is to deduplicate and consolidate cross-project observations in the generator.
+- Relevant files: `rag/generator/review_generator.py`, `rag/generator/output_parser.py`
+
+### What I did this week
+- Forked the repo and set up the local development environment per `docs/SETUP.md`.
+- Configured `.env`, including the OpenRouter LLM settings.
+- Brought up the backing services with Docker Compose (PostgreSQL, Redis, ChromaDB).
+- Ran first-time setup: created the Python virtual environment, installed backend + dev dependencies, installed pre-commit hooks, applied database migrations, and seeded the sample data.
+- Installed the frontend dependencies.
+- Read `docs/CONTRIBUTING.md` and created my working branch following the naming convention.
+
+### Environment setup notes / issues I had to fix
+- **Python version:** `make setup` was creating the virtualenv with Python 3.8, but the project requires `>=3.11`. On 3.8, pip could only install an older setuptools, which rejected the modern `license = "MIT"` field in `pyproject.toml` and broke the editable install. Rebuilt the venv with Python 3.12.
+- **ChromaDB:** the pinned `chromadb/chroma:0.4.22` image crash-looped against NumPy 2.0 (`np.float_` removed). Bumped the image to a NumPy-2-compatible release so `docker compose up` reports all services healthy.
+- **Node.js:** Node/npm were not installed, so the frontend install step failed until I installed Node.
+
+### Blockers
+- None currently blocking. The LLM review path (`_run_rag_retrieval_generation`) is still a placeholder in `core/services/review_service.py`, which is relevant context for the duplicate-feedback work.
+
+### Next steps
+- Reproduce the duplicate-feedback behavior with a profile that has multiple same-stack projects.
+- Implement real consolidation in `review_generator.py` (the current `_consolidate_feedback` only dedupes by section name, not by content).
+- Add unit tests covering the multi-project deduplication case.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,37 +1,35 @@
 # Module 3 Journal
 
-> Weekly engineering journal for my work on **PathReview**.
+> Running record of my progress on **PathReview** throughout Module 3.
+> A new section is added each week.
 > Fork: https://github.com/arunkasala-open/pathreview
 
 ---
 
-## Week 7 — Environment Setup & Issue Selection
+## Week 7 — Issue selection
 
-**Dates:** 2026-07-19
+**Issue link:** https://github.com/ascherj/pathreview/issues/28
 
-### Issue I'm working on
-- **Issue #28 — Generator produces duplicate feedback sections when a user has multiple projects in the same tech stack** (`fix`, labels: `tier-3`, `rag`)
-- Branch: `fix/28-duplicate-feedback-sections-when-multiple-projects`
-- Summary: When a user has several projects in the same stack (e.g. three Python projects), the review generator emits nearly identical skills feedback for each one, so the review reads as repetitive. The fix is to deduplicate and consolidate cross-project observations in the generator.
-- Relevant files: `rag/generator/review_generator.py`, `rag/generator/output_parser.py`
+**Issue title:** Generator produces duplicate feedback sections when a user has multiple projects in the same tech stack
 
-### What I did this week
-- Forked the repo and set up the local development environment per `docs/SETUP.md`.
-- Configured `.env`, including the OpenRouter LLM settings.
-- Brought up the backing services with Docker Compose (PostgreSQL, Redis, ChromaDB).
-- Ran first-time setup: created the Python virtual environment, installed backend + dev dependencies, installed pre-commit hooks, applied database migrations, and seeded the sample data.
-- Installed the frontend dependencies.
-- Read `docs/CONTRIBUTING.md` and created my working branch following the naming convention.
+**Tier:** [ ] Tier 1  [ ] Tier 2  [x] Tier 3
 
-### Environment setup notes / issues I had to fix
-- **Python version:** `make setup` was creating the virtualenv with Python 3.8, but the project requires `>=3.11`. On 3.8, pip could only install an older setuptools, which rejected the modern `license = "MIT"` field in `pyproject.toml` and broke the editable install. Rebuilt the venv with Python 3.12.
-- **ChromaDB:** the pinned `chromadb/chroma:0.4.22` image crash-looped against NumPy 2.0 (`np.float_` removed). Bumped the image to a NumPy-2-compatible release so `docker compose up` reports all services healthy.
-- **Node.js:** Node/npm were not installed, so the frontend install step failed until I installed Node.
+**Problem summary:**
+The review generator treats each of a user's projects independently, so when
+someone has several projects built with the same stack (for example three
+Python projects), it produces almost the same skills feedback for each one and
+the overall review ends up repetitive and padded. The current
+`_consolidate_feedback` step in `rag/generator/review_generator.py` only removes
+duplicates by section name, not by the actual content of the feedback, so
+repeated observations across similar projects still slip through. A successful
+fix would detect when the same observation applies to multiple same-stack
+projects and consolidate those into a single, cross-project comment. The result
+should be a review that reads as a cohesive assessment of the portfolio rather
+than a per-project checklist, affecting the RAG generation layer
+(`rag/generator/review_generator.py` and `rag/generator/output_parser.py`).
 
-### Blockers
-- None currently blocking. The LLM review path (`_run_rag_retrieval_generation`) is still a placeholder in `core/services/review_service.py`, which is relevant context for the duplicate-feedback work.
+**Branch name:** fix/28-duplicate-feedback-sections-when-multiple-projects
 
-### Next steps
-- Reproduce the duplicate-feedback behavior with a profile that has multiple same-stack projects.
-- Implement real consolidation in `review_generator.py` (the current `_consolidate_feedback` only dedupes by section name, not by content).
-- Add unit tests covering the multi-project deduplication case.
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -33,3 +33,35 @@ than a per-project checklist, affecting the RAG generation layer
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+### Selection notes — "Is this right for me?"
+
+- **Do I understand the problem?** [x] Yes. I can point to the exact cause: the
+  generator scores each project in isolation and `_consolidate_feedback` in
+  `rag/generator/review_generator.py` only dedupes by section name, not by
+  content, so same-stack projects produce repeated observations.
+- **Is the scope appropriate (not too big, not trivial)?** [x] Yes. It's a
+  Tier 3 issue estimated at ~7–10 hours in the issues manifest. It's contained
+  to the RAG generation layer (two files: `review_generator.py` and
+  `output_parser.py`) rather than spanning ingestion, API, and frontend, so the
+  blast radius is bounded and reviewable.
+- **Is it in a part of the codebase I can navigate?** [x] Yes. I've already read
+  the generator and parser modules while setting up, and the logic is
+  self-contained Python with clear entry points (`generate_full_review`,
+  `_consolidate_feedback`).
+- **Can I test/verify the fix?** [x] Yes. The behavior is deterministic given a
+  fixed set of chunks, so I can write unit tests under `tests/unit/` that feed a
+  profile with multiple same-stack projects and assert that overlapping
+  observations are consolidated into a single cross-project comment.
+- **Does the effort fit my available time this module?** [x] Yes. A ~7–10 hour
+  Tier 3 item is a realistic single-issue commitment for Module 3.
+- **Is it unclaimed / not already in progress?** [x] Yes. Confirmed against the
+  cohort ledger before claiming, and recorded my name there.
+
+**Scope reasoning:** I'm deliberately limiting this fix to consolidation *within
+the generator output* — detecting and merging duplicate cross-project
+observations. I am **not** changing the retrieval layer, the prompt templates,
+or the review data model, since those are out of scope for this issue and would
+expand the blast radius. If deduplication turns out to need richer metadata
+(e.g. per-project tech-stack tags), I'll note that as a follow-up rather than
+widen this issue.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -160,20 +160,20 @@ case the old code silently dropped. 9 tests, all passing.
 
 ### Reviewer feedback
 
-**Feedback received:** [ ] Yes  [x] No — still awaiting review
+**Feedback received:** [ ] Yes  [x] No — no reviewer feedback provided this term
 
 **Summary of feedback:**
-No review has come in yet. PR [#593](https://github.com/ascherj/pathreview/pull/593)
-is open and marked ready for review, but its CI checks are in
-`action_required` state — GitHub holds workflow runs on pull requests from a
-first-time contributor's fork until an upstream maintainer approves them, so the
-checks have not executed and no maintainer or peer has reviewed the change.
+No feedback. Per the Summer 2026 cohort guidance, reviewer feedback is not
+provided this term, so none was expected and none came in. For reference, PR
+[#593](https://github.com/ascherj/pathreview/pull/593) is open and marked ready
+for review; its CI is in `action_required` state because GitHub holds workflow
+runs on pull requests from a first-time contributor's fork until an upstream
+maintainer approves them.
 
 **How you responded:**
-Nothing to change yet. I re-verified the diff is clean (three files, ruff- and
-black-clean, nine passing tests) so the PR is ready the moment a reviewer or CI
-run picks it up. If feedback arrives I'll address it on the branch and the PR
-will update automatically.
+No feedback to respond to. I re-verified the PR is in a clean, review-ready state
+(three files, ruff- and black-clean, nine passing tests, baseline diff showing no
+new failures) so it stands on its own.
 
 ---
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -124,7 +124,7 @@ Deciding the similarity threshold — settled on a conservative `0.9` guarded by
 
 ### Check-in 2 (end of week)
 
-**PR link:** _(PR pending creation — see note below; will paste the URL here)_
+**PR link:** https://github.com/ascherj/pathreview/pull/593
 
 **Branch:** `fix/28-duplicate-feedback-sections-when-multiple-projects`
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -97,3 +97,60 @@ signal to remove the marker once the fix lands.
   on `main`) blocks the pre-commit hook / CI on any commit touching these files;
   I'll fix it as part of the solution PR.
 
+---
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the core fix. Reworked `ReviewGenerator._consolidate_feedback`
+(PLAN sub-tasks 1–3) to group feedback by content similarity and merge each
+group into one cross-project comment, added the `_normalize_content` and
+`_merge_sections` helpers, and added an optional `FeedbackSection.projects`
+field to record which projects a merged section covers. Removed the dead
+`sections = []` that tripped ruff/mypy (sub-task 5).
+
+**Next steps:**
+Finish expanding the tests (PLAN sub-task 4) with the edge cases, run the full
+self-review (`make check` / `make test-unit`) against the recorded baseline to
+confirm no new failures, then open the PR.
+
+**Blockers:**
+Deciding the similarity threshold — settled on a conservative `0.9` guarded by a
+"distinct feedback preserved" test.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** _(PR pending creation — see note below; will paste the URL here)_
+
+**Branch:** `fix/28-duplicate-feedback-sections-when-multiple-projects`
+
+**What you built:**
+`_consolidate_feedback` now groups feedback sections by normalized-content
+similarity (`difflib`, threshold 0.9) and merges each group into a single
+section that lists the projects it applies to and unions their suggestions —
+replacing the old dedup-by-`section_name`, which left one repeated observation
+per same-stack project.
+
+**Tests added or updated:**
+`tests/unit/test_issue_28_duplicate_feedback.py` — promoted last week's `xfail`
+reproduction to a passing test and added 8 more: exact and near-identical
+merges, distinct feedback preserved, suggestion union/dedup, project recording,
+empty and single-section inputs, and the same-`section_name`/different-content
+case the old code silently dropped. 9 tests, all passing.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+> **Pre-existing failures (per course guidance).** `main` already has 53 failing
+> unit tests, 182 `ruff` errors, and a `mypy` numpy-stub error, all unrelated to
+> issue #28. I recorded the baseline before starting and confirmed my changes
+> introduce **no new failures** (the set of failing unit tests is identical
+> before/after; ruff dropped 182→178, black 52→50 as my touched files are now
+> clean). "Passes" above is used in that sense — my changes do not make anything
+> worse. Details are documented in the PR description.
+
+**Draft PR feedback received from:** none
+

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -154,3 +154,78 @@ case the old code silently dropped. 9 tests, all passing.
 
 **Draft PR feedback received from:** none
 
+---
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No review has come in yet. PR [#593](https://github.com/ascherj/pathreview/pull/593)
+is open and marked ready for review, but its CI checks are in
+`action_required` state — GitHub holds workflow runs on pull requests from a
+first-time contributor's fork until an upstream maintainer approves them, so the
+checks have not executed and no maintainer or peer has reviewed the change.
+
+**How you responded:**
+Nothing to change yet. I re-verified the diff is clean (three files, ruff- and
+black-clean, nine passing tests) so the PR is ready the moment a reviewer or CI
+run picks it up. If feedback arrives I'll address it on the branch and the PR
+will update automatically.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The environment setup was harder than the actual bug fix. `make setup` quietly
+built the virtualenv with Python 3.8 (because `python` wasn't on PATH and it
+fell back to `python3`), which pulled an old setuptools that rejected the
+`license = "MIT"` field in `pyproject.toml` — an error whose message pointed
+nowhere near the real cause. On top of that the pinned ChromaDB image
+crash-looped on NumPy 2.0. Neither had anything to do with issue #28, and
+untangling "is this me or the repo?" for each failure took real discipline.
+
+**What did you learn about working in a large codebase?**
+That reading comes before writing, and assumptions are expensive. The clearest
+example: there are two different `FeedbackSection` types — a `@dataclass` in
+`rag/generator/output_parser.py` that the generator uses, and a separate pydantic
+model in `api/schemas/review.py` that the service layer uses. If I'd assumed they
+were the same, adding a field would have looked far riskier than it was. I also
+learned that in someone else's production code you inherit their debt: the repo
+had 53 failing unit tests and 182 lint errors before I touched anything, so
+"passing" had to mean "I introduced no *new* failures," which I could only prove
+by recording a baseline first and diffing against it. In my own projects I'd
+just fix everything; here, staying in scope was the professional move.
+
+**How did AI tools help — and where did they fall short?**
+AI was fastest at navigation and boilerplate: locating the buggy
+`_consolidate_feedback`, tracing who constructed `FeedbackSection`, drafting the
+`difflib`-based similarity approach, and generating the edge-case tests and the
+PR body. Where it fell short was judgment and external reality. It couldn't tell
+me the right similarity threshold — I had to reason about false merges and guard
+it with a "distinct feedback preserved" test. It couldn't verify "pre-existing
+vs. new failure" for me; that only came from actually running the baseline. And
+it couldn't cross the real-world gates at all: creating the PR, approving fork
+CI, and getting a human review are things no tool could do on my behalf.
+
+**What would you do differently if you started over?**
+I'd weigh *runnability* when selecting the issue. Issue #28 lives in the RAG
+generator, but `_run_rag_retrieval_generation` in the service layer is still a
+placeholder, so there's no live end-to-end path — I could prove the fix with
+unit tests but never demo it in the running app. Next time I'd favor an issue I
+can trigger through the actual UI. I'd also open the draft PR earlier in the
+cycle to leave room for peer review, and capture the CI baseline in Week 8 during
+reproduction rather than at implementation time.
+
+**What are you most proud of from this module?**
+The rigor around "do no harm," not the fix itself. I committed the reproduction
+first as a strict-`xfail` test so it documented the bug and would automatically
+flip to a failure-signal once fixed, recorded a full baseline of the repo's
+pre-existing failures, and proved with a sorted diff of failing test IDs that my
+change added zero new failures while actually reducing lint errors. Turning a
+messy, half-broken codebase into a confident, well-scoped, and *verifiable*
+contribution is the part I'll carry forward.
+

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ PYTEST := $(VENV_BIN)/pytest
 # ---- Setup ----
 
 setup: ## First-time setup: venv, deps, migrations, seed data
-	python -m venv .venv || python3 -m venv .venv
+	python3.12 -m venv .venv || python3.11 -m venv .venv || python3 -m venv .venv
 	$(PYTHON) -m pip install --upgrade pip setuptools wheel
 	$(PIP) install -e ".[dev]"
 	$(VENV_BIN)/pre-commit install

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,106 @@
+# Solution plan
+
+**Issue:** Generator produces duplicate feedback sections when a user has
+multiple projects in the same tech stack —
+https://github.com/ascherj/pathreview/issues/28
+
+### Understand
+
+**Root cause.** `ReviewGenerator._consolidate_feedback`
+(`rag/generator/review_generator.py`) is meant to merge repeated feedback, but
+it deduplicates **by `section_name` only** and never inspects the feedback
+content:
+
+```python
+seen = set()
+for section in sections:
+    if section.section_name not in seen:   # name-based dedup only
+        consolidated.append(section)
+        seen.add(section.section_name)
+```
+
+When a user has several projects in the same stack, each project yields a
+section with a **distinct name** (e.g. `skills_feedback_flask_api`,
+`skills_feedback_data_pipeline`, `skills_feedback_cli_tool`) but **identical or
+near-identical content**. Since the names differ, nothing is deduped and every
+copy survives.
+
+**Expected vs. actual**
+- *Expected:* near-identical observations across same-stack projects are
+  consolidated into a single cross-project comment that names the projects it
+  applies to.
+- *Actual:* one repeated section per project; the review reads as padded and
+  repetitive.
+
+Reproduced by `tests/unit/test_issue_28_duplicate_feedback.py` (3 projects →
+3 sections after consolidation; expected 1). Currently marked `xfail(strict)`.
+
+### Map
+
+Files/functions involved:
+
+| File | What changes |
+|---|---|
+| `rag/generator/review_generator.py` | Rewrite `_consolidate_feedback` to group by content similarity and merge; add a small similarity/merge helper. |
+| `rag/generator/output_parser.py` | Possibly extend `FeedbackSection` with an optional `projects`/`sources` field so a merged section can record which projects it covers. Also fix the pre-existing dead `sections = []` (line 29) that trips mypy. |
+| `tests/unit/test_issue_28_duplicate_feedback.py` | Drop the `xfail` marker and expand into full coverage once fixed. |
+| `tests/unit/test_output_parser.py` | Add a case if the `FeedbackSection` shape changes. |
+
+### Plan
+
+1. **Group by content, not name.** In `_consolidate_feedback`, normalize each
+   section's content (strip/lowercase, and parse the JSON payload so key order
+   doesn't matter) and cluster sections whose observations are equivalent using
+   a conservative similarity threshold (`difflib.SequenceMatcher`, ratio ≳ 0.9).
+2. **Merge each cluster into one section.** Keep the first section as the
+   representative, record the set of projects/section names it applies to, and
+   union the `suggestions` (de-duplicated). Non-duplicate sections pass through
+   untouched and in original order.
+3. **Represent the cross-project scope.** Prefer adding an optional
+   `projects: list[str]` field to `FeedbackSection` (defaulted, so existing
+   callers are unaffected); fall back to a content prefix like
+   "Across flask_api, data_pipeline, cli_tool: …" if changing the dataclass
+   proves too invasive.
+4. **Fix the reproduction test.** Remove the `xfail(strict)` marker so the test
+   now asserts the fix, and add edge-case tests (below).
+5. **Clean up the pre-existing mypy error** in `output_parser.py` so the
+   pre-commit `mypy` hook and CI pass on any commit touching these files.
+
+### Inputs & outputs
+
+- **Input:** `list[FeedbackSection]` produced by `parse_review_output`, possibly
+  containing several sections with identical/near-identical content that
+  correspond to different same-stack projects.
+- **Output:** `list[FeedbackSection]` in which equivalent cross-project
+  observations are collapsed into a single section that (a) references all
+  affected projects and (b) carries the union of their suggestions. Distinct
+  feedback is preserved unchanged; ordering is stable.
+
+### Risks & unknowns
+
+- **Similarity threshold tuning.** Too aggressive merges genuinely distinct
+  feedback; too lax leaves duplicates. Mitigation: conservative default +
+  tests that assert distinct feedback is preserved.
+- **Content is JSON-serialized.** `_parse_json_output` stores
+  `content=json.dumps(value)`; comparing raw strings is brittle if key order
+  differs. Mitigation: parse/normalize before comparing.
+- **Changing `FeedbackSection`.** Adding a field could ripple into
+  `_add_citations`, the API review schema, and existing tests. Mitigation: make
+  the field optional with a default; grep all constructors/consumers first.
+- **No end-to-end path yet.** `_run_rag_retrieval_generation` in
+  `core/services/review_service.py` is still a placeholder, so the real LLM
+  generate path isn't wired up; correctness will be validated via unit tests
+  rather than a live review.
+- **Pre-existing mypy debt** in `output_parser.py` (dead `sections = []`) must
+  be resolved for hooks/CI to go green.
+
+### Edge cases
+
+- Empty list → empty list.
+- Single section → returned unchanged.
+- All sections identical → collapse to one (listing every project).
+- Mix of duplicates and unique feedback → duplicates merged, uniques preserved.
+- **Same `section_name`, different content** → must NOT be dropped (the current
+  code silently loses the later one — a latent data-loss bug to fix alongside).
+- Near-identical but semantically different content near the threshold boundary.
+- Plain-text/`general_feedback` fallback sections (non-JSON content).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
           memory: 256M
 
   vector-db:
-    image: chromadb/chroma:0.4.22
+    image: chromadb/chroma:0.5.23
     ports:
       - "8001:8000"
     volumes:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -99,7 +99,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -449,7 +448,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -473,7 +471,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1561,7 +1558,6 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1579,7 +1575,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1972,7 +1967,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3507,7 +3501,6 @@
       "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^2.0.1",
         "cssstyle": "^4.0.1",
@@ -4094,7 +4087,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4107,7 +4099,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4771,7 +4762,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/rag/generator/output_parser.py
+++ b/rag/generator/output_parser.py
@@ -1,8 +1,9 @@
 """Parse LLM output into structured feedback."""
 
-from dataclasses import dataclass
 import json
 import re
+from dataclasses import dataclass, field
+
 import structlog
 
 logger = structlog.get_logger()
@@ -10,11 +11,23 @@ logger = structlog.get_logger()
 
 @dataclass
 class FeedbackSection:
-    """Structured feedback section."""
+    """Structured feedback section.
+
+    Attributes:
+        section_name: Identifier for the section (often per-project).
+        content: The feedback text.
+        confidence: Model confidence in [0, 1].
+        suggestions: Actionable suggestions.
+        projects: When this section is the result of consolidating duplicate
+            cross-project feedback, the section names it was merged from.
+            Empty for a single, unconsolidated section.
+    """
+
     section_name: str
     content: str
     confidence: float
     suggestions: list[str]
+    projects: list[str] = field(default_factory=list)
 
 
 def parse_review_output(raw: str) -> list[FeedbackSection]:
@@ -26,8 +39,6 @@ def parse_review_output(raw: str) -> list[FeedbackSection]:
     Returns:
         List of FeedbackSection objects
     """
-    sections = []
-
     # Try JSON in code fence first
     json_match = re.search(r"```(?:json)?\s*\n(.*?)\n```", raw, re.DOTALL)
     if json_match:
@@ -67,15 +78,15 @@ def _parse_json_output(data: dict) -> list[FeedbackSection]:
                 section_name=key,
                 content=json.dumps(value),
                 confidence=0.9,
-                suggestions=value.get("suggestions", [])
-                    if isinstance(value.get("suggestions"), list) else []
+                suggestions=(
+                    value.get("suggestions", [])
+                    if isinstance(value.get("suggestions"), list)
+                    else []
+                ),
             )
         else:
             section = FeedbackSection(
-                section_name=key,
-                content=str(value),
-                confidence=0.85,
-                suggestions=[]
+                section_name=key, content=str(value), confidence=0.85, suggestions=[]
             )
         sections.append(section)
 
@@ -94,10 +105,7 @@ def _parse_plaintext_output(raw: str) -> list[FeedbackSection]:
     """
     # Treat entire text as a single feedback section
     section = FeedbackSection(
-        section_name="general_feedback",
-        content=raw,
-        confidence=0.7,
-        suggestions=[]
+        section_name="general_feedback", content=raw, confidence=0.7, suggestions=[]
     )
 
     logger.info("plaintext_output_parsed", content_length=len(raw))

--- a/rag/generator/review_generator.py
+++ b/rag/generator/review_generator.py
@@ -1,19 +1,27 @@
 """LLM-based review generation."""
 
+import difflib
+import json
 from dataclasses import dataclass
-from typing import Optional
+
 import openai
 import structlog
 
+from .output_parser import FeedbackSection, parse_review_output
 from .prompt_templates import get_template
-from .output_parser import parse_review_output, FeedbackSection
 
 logger = structlog.get_logger()
+
+# Two sections whose normalized content is at least this similar are treated as
+# the same observation and consolidated. Deliberately conservative so genuinely
+# distinct feedback is never merged.
+CONSOLIDATION_SIMILARITY_THRESHOLD = 0.9
 
 
 @dataclass
 class ReviewConfig:
     """Configuration for review generation."""
+
     api_key: str
     base_url: str
     model: str
@@ -31,13 +39,11 @@ class ReviewGenerator:
             config: ReviewConfig with API settings
         """
         self.config = config
-        self.client = openai.OpenAI(
-            api_key=config.api_key,
-            base_url=config.base_url
-        )
+        self.client = openai.OpenAI(api_key=config.api_key, base_url=config.base_url)
 
-    def generate_section(self, section_name: str, context_chunks: list[dict],
-                        profile_data: dict) -> FeedbackSection:
+    def generate_section(
+        self, section_name: str, context_chunks: list[dict], profile_data: dict
+    ) -> FeedbackSection:
         """Generate feedback for a specific section.
 
         Args:
@@ -57,9 +63,7 @@ class ReviewGenerator:
         project_count = len(profile_data.get("projects", []))
 
         prompt = template.format(
-            context=context_text,
-            github_username=github_username,
-            project_count=project_count
+            context=context_text, github_username=github_username, project_count=project_count
         )
 
         # Call LLM
@@ -67,10 +71,10 @@ class ReviewGenerator:
             model=self.config.model,
             messages=[
                 {"role": "system", "content": "You are an expert portfolio reviewer."},
-                {"role": "user", "content": prompt}
+                {"role": "user", "content": prompt},
             ],
             temperature=self.config.temperature,
-            max_tokens=self.config.max_tokens
+            max_tokens=self.config.max_tokens,
         )
 
         content = response.choices[0].message.content
@@ -84,14 +88,12 @@ class ReviewGenerator:
 
         logger.warning("no_sections_parsed", section_name=section_name)
         return FeedbackSection(
-            section_name=section_name,
-            content=content,
-            confidence=0.6,
-            suggestions=[]
+            section_name=section_name, content=content, confidence=0.6, suggestions=[]
         )
 
-    def generate_full_review(self, profile_data: dict,
-                            retrieved_chunks: list[dict]) -> list[FeedbackSection]:
+    def generate_full_review(
+        self, profile_data: dict, retrieved_chunks: list[dict]
+    ) -> list[FeedbackSection]:
         """Generate complete review across all sections.
 
         Args:
@@ -106,16 +108,14 @@ class ReviewGenerator:
             "projects_feedback",
             "presentation_feedback",
             "gaps_feedback",
-            "first_impression"
+            "first_impression",
         ]
 
         all_sections = []
 
         for section_name in section_names:
             try:
-                section = self.generate_section(
-                    section_name, retrieved_chunks, profile_data
-                )
+                section = self.generate_section(section_name, retrieved_chunks, profile_data)
 
                 # Add source citations if available
                 section = self._add_citations(section, retrieved_chunks)
@@ -124,15 +124,16 @@ class ReviewGenerator:
                 logger.info("section_generated", section=section_name)
 
             except Exception as e:
-                logger.error("section_generation_failed", section=section_name,
-                           error=str(e))
+                logger.error("section_generation_failed", section=section_name, error=str(e))
                 # Continue with remaining sections
-                all_sections.append(FeedbackSection(
-                    section_name=section_name,
-                    content=f"Error generating {section_name}",
-                    confidence=0.0,
-                    suggestions=[]
-                ))
+                all_sections.append(
+                    FeedbackSection(
+                        section_name=section_name,
+                        content=f"Error generating {section_name}",
+                        confidence=0.0,
+                        suggestions=[],
+                    )
+                )
 
         # Consolidate duplicates across similar projects
         all_sections = self._consolidate_feedback(all_sections)
@@ -160,8 +161,7 @@ class ReviewGenerator:
         return "\n\n".join(parts)
 
     @staticmethod
-    def _add_citations(section: FeedbackSection,
-                       retrieved_chunks: list[dict]) -> FeedbackSection:
+    def _add_citations(section: FeedbackSection, retrieved_chunks: list[dict]) -> FeedbackSection:
         """Add source citations to feedback section.
 
         Args:
@@ -187,7 +187,15 @@ class ReviewGenerator:
 
     @staticmethod
     def _consolidate_feedback(sections: list[FeedbackSection]) -> list[FeedbackSection]:
-        """Consolidate duplicate feedback across similar sections.
+        """Consolidate duplicate feedback across same-stack projects.
+
+        When a user has multiple projects in the same tech stack, the generator
+        emits a near-identical observation for each one (e.g. the same "Python
+        skills" feedback three times). Those sections have distinct
+        ``section_name`` values but equivalent content, so deduplicating by name
+        alone leaves every copy in place. This groups sections by content
+        similarity and merges each group into a single cross-project comment,
+        preserving genuinely distinct feedback and its original order.
 
         Args:
             sections: List of feedback sections
@@ -195,14 +203,91 @@ class ReviewGenerator:
         Returns:
             Consolidated list of sections
         """
-        # Simple consolidation: if two sections mention the same project,
-        # merge the feedback
-        seen = set()
-        consolidated = []
+        groups: list[list[FeedbackSection]] = []
+        group_keys: list[str] = []
 
         for section in sections:
-            if section.section_name not in seen:
-                consolidated.append(section)
-                seen.add(section.section_name)
+            key = ReviewGenerator._normalize_content(section.content)
+            match_index = None
+            for i, existing_key in enumerate(group_keys):
+                ratio = difflib.SequenceMatcher(None, key, existing_key).ratio()
+                if ratio >= CONSOLIDATION_SIMILARITY_THRESHOLD:
+                    match_index = i
+                    break
 
+            if match_index is None:
+                groups.append([section])
+                group_keys.append(key)
+            else:
+                groups[match_index].append(section)
+
+        consolidated = [
+            group[0] if len(group) == 1 else ReviewGenerator._merge_sections(group)
+            for group in groups
+        ]
+
+        if len(consolidated) < len(sections):
+            logger.info(
+                "feedback_consolidated",
+                original_count=len(sections),
+                consolidated_count=len(consolidated),
+            )
         return consolidated
+
+    @staticmethod
+    def _normalize_content(content: str) -> str:
+        """Normalize feedback content for similarity comparison.
+
+        Unwraps the JSON payload produced by the parser (so key ordering and the
+        surrounding braces don't affect the comparison) and collapses whitespace
+        and case.
+
+        Args:
+            content: Raw section content
+
+        Returns:
+            Normalized comparison string
+        """
+        text = content
+        try:
+            data = json.loads(content)
+            if isinstance(data, dict) and "content" in data:
+                text = str(data["content"])
+        except (json.JSONDecodeError, TypeError):
+            pass
+        return " ".join(text.lower().split())
+
+    @staticmethod
+    def _merge_sections(group: list[FeedbackSection]) -> FeedbackSection:
+        """Merge a group of near-identical sections into one cross-project section.
+
+        Args:
+            group: Two or more sections with equivalent content
+
+        Returns:
+            A single consolidated FeedbackSection
+        """
+        representative = group[0]
+
+        projects: list[str] = []
+        for section in group:
+            if section.section_name not in projects:
+                projects.append(section.section_name)
+
+        suggestions: list[str] = []
+        for section in group:
+            for suggestion in section.suggestions:
+                if suggestion not in suggestions:
+                    suggestions.append(suggestion)
+
+        content = (
+            f"Across {len(projects)} projects ({', '.join(projects)}): " f"{representative.content}"
+        )
+
+        return FeedbackSection(
+            section_name=representative.section_name,
+            content=content,
+            confidence=min(section.confidence for section in group),
+            suggestions=suggestions,
+            projects=projects,
+        )

--- a/tests/unit/test_issue_28_duplicate_feedback.py
+++ b/tests/unit/test_issue_28_duplicate_feedback.py
@@ -1,0 +1,89 @@
+"""Reproduction test for issue #28.
+
+Issue: Generator produces duplicate feedback sections when a user has multiple
+projects in the same tech stack.
+https://github.com/ascherj/pathreview/issues/28
+
+When a user has several projects built with the same stack (e.g. three Python
+projects), the review generator emits a near-identical "Python skills"
+observation for each one. ``ReviewGenerator._consolidate_feedback`` is supposed
+to merge these, but it only deduplicates by ``section_name`` and never inspects
+the feedback content -- so distinct per-project section names carrying identical
+content all survive, and the review reads as repetitive.
+
+Reproduction steps (also runnable standalone):
+    1. Build an LLM JSON payload with one key per project, each carrying the
+       same "Python skills" content.
+    2. Parse it with ``parse_review_output`` -> N sections, identical content.
+    3. Run ``ReviewGenerator._consolidate_feedback`` -> expected 1 section,
+       actual N sections (bug).
+
+This test asserts the *expected* (fixed) behavior and is marked ``xfail`` so it
+documents the bug today (reported as XFAIL) and will flip to XPASS once the fix
+lands, at which point ``strict=True`` fails the run to remind us to drop the
+marker.
+"""
+
+import json
+
+import pytest
+
+from rag.generator.output_parser import parse_review_output
+from rag.generator.review_generator import ReviewGenerator
+
+PY_SKILLS = (
+    "Strong Python fundamentals: clean use of type hints, virtual environments, "
+    "and pytest. Consider adding more docstrings."
+)
+
+
+def _three_same_stack_projects() -> str:
+    """Return an LLM JSON payload for three Python projects with identical feedback."""
+    return json.dumps(
+        {
+            "skills_feedback_flask_api": {
+                "content": PY_SKILLS,
+                "suggestions": ["Add docstrings"],
+            },
+            "skills_feedback_data_pipeline": {
+                "content": PY_SKILLS,
+                "suggestions": ["Add docstrings"],
+            },
+            "skills_feedback_cli_tool": {
+                "content": PY_SKILLS,
+                "suggestions": ["Add docstrings"],
+            },
+        }
+    )
+
+
+@pytest.mark.unit
+class TestIssue28DuplicateFeedback:
+    """Reproduces the duplicate cross-project feedback described in issue #28."""
+
+    def test_parsing_yields_one_section_per_project(self) -> None:
+        """Baseline: the parser produces one section per project (not the bug itself)."""
+        sections = parse_review_output(_three_same_stack_projects())
+        assert len(sections) == 3
+        # All three carry the same underlying observation.
+        assert all(PY_SKILLS in s.content for s in sections)
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="Issue #28: _consolidate_feedback dedupes by section_name only, "
+        "so identical cross-project content is not merged. Remove this marker "
+        "when the fix lands.",
+    )
+    def test_consolidation_merges_duplicate_cross_project_feedback(self) -> None:
+        """Expected: identical feedback across same-stack projects collapses to one section."""
+        sections = parse_review_output(_three_same_stack_projects())
+
+        consolidated = ReviewGenerator._consolidate_feedback(sections)
+
+        duplicates = [s for s in consolidated if PY_SKILLS in s.content]
+        # Expected: the three duplicate observations are consolidated into one.
+        # Actual (bug): all three survive because dedup is by section_name only.
+        assert len(duplicates) == 1, (
+            f"Expected duplicate Python-skills feedback to be consolidated to 1 "
+            f"section, but found {len(duplicates)} repeating the same content."
+        )

--- a/tests/unit/test_issue_28_duplicate_feedback.py
+++ b/tests/unit/test_issue_28_duplicate_feedback.py
@@ -1,4 +1,4 @@
-"""Reproduction test for issue #28.
+"""Tests for issue #28 — duplicate feedback across same-stack projects.
 
 Issue: Generator produces duplicate feedback sections when a user has multiple
 projects in the same tech stack.
@@ -6,29 +6,19 @@ https://github.com/ascherj/pathreview/issues/28
 
 When a user has several projects built with the same stack (e.g. three Python
 projects), the review generator emits a near-identical "Python skills"
-observation for each one. ``ReviewGenerator._consolidate_feedback`` is supposed
-to merge these, but it only deduplicates by ``section_name`` and never inspects
-the feedback content -- so distinct per-project section names carrying identical
-content all survive, and the review reads as repetitive.
+observation for each one. ``ReviewGenerator._consolidate_feedback`` now groups
+sections by content similarity and merges each group into a single
+cross-project comment, instead of deduplicating by ``section_name`` alone.
 
-Reproduction steps (also runnable standalone):
-    1. Build an LLM JSON payload with one key per project, each carrying the
-       same "Python skills" content.
-    2. Parse it with ``parse_review_output`` -> N sections, identical content.
-    3. Run ``ReviewGenerator._consolidate_feedback`` -> expected 1 section,
-       actual N sections (bug).
-
-This test asserts the *expected* (fixed) behavior and is marked ``xfail`` so it
-documents the bug today (reported as XFAIL) and will flip to XPASS once the fix
-lands, at which point ``strict=True`` fails the run to remind us to drop the
-marker.
+These tests started as a reproduction (originally ``xfail``) and now assert the
+fixed behavior plus the edge cases documented in PLAN.md.
 """
 
 import json
 
 import pytest
 
-from rag.generator.output_parser import parse_review_output
+from rag.generator.output_parser import FeedbackSection, parse_review_output
 from rag.generator.review_generator import ReviewGenerator
 
 PY_SKILLS = (
@@ -59,31 +49,110 @@ def _three_same_stack_projects() -> str:
 
 @pytest.mark.unit
 class TestIssue28DuplicateFeedback:
-    """Reproduces the duplicate cross-project feedback described in issue #28."""
+    """Consolidation of duplicate cross-project feedback (issue #28)."""
 
     def test_parsing_yields_one_section_per_project(self) -> None:
-        """Baseline: the parser produces one section per project (not the bug itself)."""
+        """The parser produces one section per project (input to consolidation)."""
         sections = parse_review_output(_three_same_stack_projects())
         assert len(sections) == 3
-        # All three carry the same underlying observation.
         assert all(PY_SKILLS in s.content for s in sections)
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="Issue #28: _consolidate_feedback dedupes by section_name only, "
-        "so identical cross-project content is not merged. Remove this marker "
-        "when the fix lands.",
-    )
     def test_consolidation_merges_duplicate_cross_project_feedback(self) -> None:
-        """Expected: identical feedback across same-stack projects collapses to one section."""
+        """Identical feedback across same-stack projects collapses to one section."""
         sections = parse_review_output(_three_same_stack_projects())
 
         consolidated = ReviewGenerator._consolidate_feedback(sections)
 
         duplicates = [s for s in consolidated if PY_SKILLS in s.content]
-        # Expected: the three duplicate observations are consolidated into one.
-        # Actual (bug): all three survive because dedup is by section_name only.
         assert len(duplicates) == 1, (
             f"Expected duplicate Python-skills feedback to be consolidated to 1 "
-            f"section, but found {len(duplicates)} repeating the same content."
+            f"section, but found {len(duplicates)}."
         )
+
+    def test_merged_section_records_all_projects(self) -> None:
+        """The consolidated section names every project it was merged from."""
+        sections = parse_review_output(_three_same_stack_projects())
+
+        consolidated = ReviewGenerator._consolidate_feedback(sections)
+
+        merged = consolidated[0]
+        assert set(merged.projects) == {
+            "skills_feedback_flask_api",
+            "skills_feedback_data_pipeline",
+            "skills_feedback_cli_tool",
+        }
+
+    def test_near_identical_content_is_consolidated(self) -> None:
+        """Near-identical (not byte-identical) observations are still merged."""
+        base = "Solid Python skills across the project: good use of type hints and tests."
+        payload = json.dumps(
+            {
+                "proj_a": {"content": base + " Overall a strong effort.", "suggestions": []},
+                "proj_b": {"content": base + " Overall a strong effort here.", "suggestions": []},
+            }
+        )
+        consolidated = ReviewGenerator._consolidate_feedback(parse_review_output(payload))
+        assert len(consolidated) == 1
+
+    def test_distinct_feedback_is_preserved(self) -> None:
+        """Genuinely different feedback is not merged."""
+        payload = json.dumps(
+            {
+                "python_project": {
+                    "content": "Excellent Python typing discipline.",
+                    "suggestions": [],
+                },
+                "docs_gap": {
+                    "content": "The README is missing setup instructions.",
+                    "suggestions": [],
+                },
+            }
+        )
+        consolidated = ReviewGenerator._consolidate_feedback(parse_review_output(payload))
+        assert len(consolidated) == 2
+
+    def test_suggestions_are_unioned_and_deduped(self) -> None:
+        """Merging unions suggestions across the group without duplicates."""
+        payload = json.dumps(
+            {
+                "a": {"content": PY_SKILLS, "suggestions": ["Add docstrings", "Add CI"]},
+                "b": {"content": PY_SKILLS, "suggestions": ["Add docstrings", "Add badges"]},
+            }
+        )
+        merged = ReviewGenerator._consolidate_feedback(parse_review_output(payload))[0]
+        assert merged.suggestions == ["Add docstrings", "Add CI", "Add badges"]
+
+    def test_empty_list_returns_empty(self) -> None:
+        """No sections in, no sections out."""
+        assert ReviewGenerator._consolidate_feedback([]) == []
+
+    def test_single_section_unchanged(self) -> None:
+        """A single section passes through untouched (no merge, no projects tag)."""
+        section = FeedbackSection(
+            section_name="skills_feedback", content=PY_SKILLS, confidence=0.9, suggestions=[]
+        )
+        result = ReviewGenerator._consolidate_feedback([section])
+        assert result == [section]
+
+    def test_same_section_name_different_content_not_dropped(self) -> None:
+        """Distinct content under a repeated section_name must not be lost.
+
+        The old name-based dedup silently dropped the second section here; the
+        content-based approach keeps both.
+        """
+        sections = [
+            FeedbackSection(
+                section_name="skills_feedback",
+                content="Strong Python fundamentals.",
+                confidence=0.9,
+                suggestions=[],
+            ),
+            FeedbackSection(
+                section_name="skills_feedback",
+                content="Weak test coverage on the API layer.",
+                confidence=0.9,
+                suggestions=[],
+            ),
+        ]
+        result = ReviewGenerator._consolidate_feedback(sections)
+        assert len(result) == 2


### PR DESCRIPTION
## Summary

When a user has multiple projects in the same tech stack (e.g. three Python projects), the review generator produced a near-identical feedback section for each one, making reviews feel repetitive. `ReviewGenerator._consolidate_feedback` was meant to prevent this but only deduplicated by `section_name`, never by content — so per-project sections with distinct names but identical content all survived. This PR reworks consolidation to group sections by **content similarity** and merge each group into a single cross-project comment.

## Issue

Closes #28

## Changes

- **`rag/generator/review_generator.py`**
  - Rewrote `_consolidate_feedback` to group sections by normalized-content similarity (`difflib.SequenceMatcher`, conservative threshold `0.9`) and merge each group, instead of deduplicating by `section_name`.
  - Added `_normalize_content` (unwraps the JSON payload and collapses whitespace/case) and `_merge_sections` (unions & de-dupes suggestions, records the merged-from section names, keeps the most conservative confidence).
- **`rag/generator/output_parser.py`**
  - Added an optional, backward-compatible `FeedbackSection.projects` field so a consolidated section records which projects it covers.
  - Removed a dead `sections = []` in `parse_review_output` (also cleared a pre-existing `ruff F841` / mypy `var-annotated` error in a file I touched).
- **`tests/unit/test_issue_28_duplicate_feedback.py`**
  - Promoted last week's `xfail` reproduction to a passing test and added edge cases (see Testing).

## Testing

- [x] Unit tests pass (`make test-unit`) — *no new failures* (see Pre-existing failures below)
- [ ] Integration tests pass (`make test-integration`) — not run; this change is confined to the RAG generator and does not touch integration-tested paths
- [x] Linter passes (`make lint`) — *the three files I touched are ruff-clean; repo-wide count went down, no new errors*
- [x] Type checker passes (`make typecheck`) — *the mypy pre-commit hook passes on the files I touched*
- [x] New/updated tests cover the changes

New/updated tests in `tests/unit/test_issue_28_duplicate_feedback.py` (9 tests, all passing): exact-duplicate merge, near-identical merge, distinct feedback preserved, suggestion union/dedup, project recording, empty list, single section, and the same-`section_name`/different-content case the old dedup silently dropped.

### Pre-existing failures (documented per course guidance)

The repository has substantial pre-existing failures unrelated to this issue. I recorded the baseline before making changes and confirmed my changes introduce **no new failures**:

| Check | Baseline (main) | After my change |
|---|---|---|
| `make test-unit` | 53 failed, 376 passed, 1 xfailed | 53 failed, 384 passed (same 53 failures; diff is empty) |
| `ruff check .` | 182 errors | 178 errors (4 fewer; my files clean) |
| `black --check .` | 52 files to reformat | 50 files (2 fewer; my files clean) |
| `mypy` (CI scope) | hard-errors on numpy stub vs `python_version=3.11` | unchanged (pre-existing, env/config) |

The set of failing unit tests is **identical** before and after (verified with a sorted diff of failing node IDs). The remaining repo-wide lint/type issues and the 53 failing tests exist on `main` and are out of scope for this issue.

## Screenshots / Demo

N/A (backend logic change; covered by unit tests).

## Notes for Reviewers

- The generator's `FeedbackSection` is a `@dataclass` in `rag/generator/output_parser.py` and is **distinct** from the pydantic `FeedbackSection` in `api/schemas/review.py` (used by `review_service`). The new `projects` field is added only to the dataclass and is optional/defaulted, so nothing downstream breaks.
- The similarity threshold (`0.9`) is deliberately conservative to avoid merging genuinely distinct feedback; `test_distinct_feedback_is_preserved` guards this.
- `_run_rag_retrieval_generation` in `core/services/review_service.py` is still a placeholder, so there is no live end-to-end LLM path to exercise yet; correctness is validated at the unit level.
