### PR TITLE
test(rag): add real snapshot assertions for prompt templates

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -26,3 +26,15 @@ The RAG prompt generator (`rag/generator/prompt_templates.py`) stores five versi
 - Scope/time: checked the ledger claims count and issue comments — comfortable with how many others are on this issue. 3–5 hr estimate fits within Weeks 8–9. No blockers or dependencies listed on the issue.
 
 All boxes checked — proceeding with this issue.
+
+
+## Reproduction notes (issue #37)
+
+**Steps to reproduce:**
+1. Ran `python -m pytest tests/unit/test_prompt_templates.py -v` on a clean checkout — all 37 tests pass, including `test_template_snapshot_content_hash`.
+2. Edited the wording of the `skills_feedback` template in `rag/generator/prompt_templates.py` (changed template text under the `v1` key, no version bump).
+3. Re-ran `python -m pytest tests/unit/test_prompt_templates.py::TestPromptTemplates::test_template_snapshot_content_hash -v` — test still **PASSED**.
+
+**Observation:** `test_template_snapshot_content_hash` computes an MD5 hash of template content but only asserts `isinstance(content_hash, str)` and `len(content_hash) == 32` — it never compares against a fixed expected hash. This confirms the bug: template wording can change silently with zero test failures, and no version bump is enforced.
+
+Reverted the temporary edit afterward — no production code changes made on this branch yet.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -38,3 +38,16 @@ All boxes checked — proceeding with this issue.
 **Observation:** `test_template_snapshot_content_hash` computes an MD5 hash of template content but only asserts `isinstance(content_hash, str)` and `len(content_hash) == 32` — it never compares against a fixed expected hash. This confirms the bug: template wording can change silently with zero test failures, and no version bump is enforced.
 
 Reverted the temporary edit afterward — no production code changes made on this branch yet.
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/ronak-adhikari/pathreview/commit/a778bce
+
+**Reproduction summary:**
+Ran the existing `test_template_snapshot_content_hash` test, then edited the wording of the `skills_feedback` template with no version bump. The test still passed — confirming it never actually validates content, only that the hash is a 32-character string.
+
+**PLAN.md link:** https://github.com/ronak-adhikari/pathreview/blob/test/37-prompt-template-snapshot-tests/PLAN.md
+
+
+**Blockers or open questions:**
+Deciding between one combined snapshot hash vs. per-template hashes — leaning per-template for better diagnostics, will finalize in Week 9.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -16,3 +16,13 @@ The RAG prompt generator (`rag/generator/prompt_templates.py`) stores five versi
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+
+**"Is this right for me?" checklist reasoning:**
+- Understanding: I can explain the issue without re-reading it — `test_template_snapshot_content_hash` computes a hash but never asserts it against a fixed expected value, so it can't catch template edits. Relevant files confirmed: `rag/generator/prompt_templates.py`, `tests/unit/test_prompt_templates.py`.
+- Done looks like: editing any template's text without bumping its version key causes a test to fail.
+- Tier fit: Tier 1, appropriate as my first contribution to this codebase.
+- Codebase readiness: read `get_template()` and the existing ~30 tests end-to-end; the module is self-contained (a dict + one accessor), so I can predict the blast radius of my change.
+- Scope/time: checked the ledger claims count and issue comments — comfortable with how many others are on this issue. 3–5 hr estimate fits within Weeks 8–9. No blockers or dependencies listed on the issue.
+
+All boxes checked — proceeding with this issue.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,18 @@
+# Module 3 Journal
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/37
+
+**Issue title:** Add snapshot tests for prompt templates to catch accidental changes
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The RAG prompt generator (`rag/generator/prompt_templates.py`) stores five versioned templates used to generate portfolio feedback. `tests/unit/test_prompt_templates.py` already has a test named `test_template_snapshot_content_hash` that looks like a snapshot test, but it only checks that the computed MD5 hash is a 32-character string — it never compares it to a stored expected value, so it passes regardless of what the templates say. This means a developer can silently edit prompt wording (which directly changes review quality) with no automated signal, and no test enforces the intended practice of bumping the version key when content changes. A successful fix adds real per-template snapshot tests with fixed expected hashes (or literal expected strings) that fail loudly when template text changes, forcing a conscious version bump.
+
+**Branch name:** test/37-prompt-template-snapshot-tests
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -51,3 +51,18 @@ Ran the existing `test_template_snapshot_content_hash` test, then edited the wor
 
 **Blockers or open questions:**
 Deciding between one combined snapshot hash vs. per-template hashes — leaning per-template for better diagnostics, will finalize in Week 9.
+
+
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the fix for issue #37. Replaced the broken `test_template_snapshot_content_hash` test (which only checked hash type/length) with a parametrized `test_template_snapshot_matches_expected_hash` test that asserts each of the 5 templates' v1 content against a hardcoded expected MD5 hash. Verified the fix works by re-running the Week 8 reproduction: editing `skills_feedback` wording now fails the test with a clear message, while reverting brings it back to green. All 41 tests in the file pass (up from 37 — net +4 from swapping 1 broken test for 5 real ones). Confirmed `make test-unit` shows no new failures (53 pre-existing failures, same as Week 8 baseline; 379 passed, up from 375).
+
+**Next steps:**
+Write the PR description using the strong-PR-description examples as reference, run through the full pre-submission self-review checklist, and open a draft PR for peer/mentor feedback before marking it ready for review.
+
+**Blockers:**
+`make check`'s mypy hook flags `disallow_untyped_defs` on every pre-existing test method in this file (none had `-> None` before my change either) — documented this as pre-existing in my commit message and will note it in the PR's "Notes for Reviewers" section rather than fixing all 37 unrelated methods.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -85,3 +85,21 @@ Replaced the broken prompt template snapshot test (which only checked hash type/
 *(both pass with only pre-existing, unrelated failures — documented in commit message and PR "Notes for Reviewers"; no new failures introduced)*
 
 **Draft PR feedback received from:** none — skipped peer review due to time constraints on submission day
+
+
+### Reflection
+
+**What was harder than you expected?**
+Understanding the actual bug took more care than I expected. The existing "snapshot test" looked legitimate at first glance — it computed a real MD5 hash — so it took reading the assertions carefully to realize it only checked `isinstance()` and `len() == 32`, meaning it could never fail no matter what changed. It wasn't a broken feature so much as a test that gave false confidence, which is a different kind of bug to spot than something that visibly crashes.
+
+**What did you learn about working in a large codebase?**
+I learned that "done" isn't just "the code works" — it has to work inside someone else's conventions. Things like `disallow_untyped_defs = true` in mypy, or CONTRIBUTING.md's exact commit format, aren't optional style preferences; they're gates that block your commit or PR if you don't match them. I also learned to separate pre-existing issues (the 53 failing tests, the 182 lint errors) from problems my own change introduced — reproducing the baseline first made it much easier to prove my change didn't make things worse.
+
+**How did AI tools help — and where did they fall short?**
+AI assistance was most useful for reading and reasoning through the codebase quickly — finding the exact broken test, confirming the real vs. reported behavior, and drafting things like the PLAN.md and PR description in the project's expected format. Where it fell short was anything requiring me to actually be at my terminal: environment setup (Docker, Rosetta, venv activation), watching real test output, and catching my own mistakes (forgetting to save JOURNAL.md twice, an incomplete revert leaving a third hash value). Those needed me to actually run things and read the real output, not just trust a plan.
+
+**What would you do differently if you started over?**
+I'd save files before running git commands more consistently — I lost time twice from committing an unsaved/empty file. I'd also run `make check` on my target files earlier, before writing the fix, so I knew about the pre-existing mypy issue ahead of time instead of hitting it right as I tried to commit.
+
+**What are you most proud of from this module?**
+Actually proving the bug and the fix with real before/after test output — editing a template, watching the old test wrongly pass, then watching the new test correctly fail with a clear message, then reverting and confirming green again. That felt like real engineering rigor rather than just writing code that looked plausible.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -66,3 +66,22 @@ Write the PR description using the strong-PR-description examples as reference, 
 
 **Blockers:**
 `make check`'s mypy hook flags `disallow_untyped_defs` on every pre-existing test method in this file (none had `-> None` before my change either) — documented this as pre-existing in my commit message and will note it in the PR's "Notes for Reviewers" section rather than fixing all 37 unrelated methods.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/594
+
+**Branch:** test/37-prompt-template-snapshot-tests
+
+**What you built:**
+Replaced the broken prompt template snapshot test (which only checked hash type/length and could never fail) with a parametrized test that asserts each of the 5 templates' v1 content hash against a hardcoded expected value. Editing a template's wording without bumping its version now fails with a clear, actionable error message.
+
+**Tests added or updated:**
+`tests/unit/test_prompt_templates.py` — replaced `test_template_snapshot_content_hash` with `EXPECTED_TEMPLATE_HASHES` and a parametrized `test_template_snapshot_matches_expected_hash`, covering all 5 templates individually. All 41 tests in the file pass.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+*(both pass with only pre-existing, unrelated failures — documented in commit message and PR "Notes for Reviewers"; no new failures introduced)*
+
+**Draft PR feedback received from:** none — skipped peer review due to time constraints on submission day

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,29 @@
+## Solution plan
+
+**Issue:** Add snapshot tests for prompt templates to catch accidental changes — https://github.com/ascherj/pathreview/issues/37
+
+### Understand
+`tests/unit/test_prompt_templates.py::test_template_snapshot_content_hash` computes an MD5 hash of all concatenated template content but only asserts it's a 32-character string — it never compares against a fixed expected value. Expected behavior: editing any template's text under `PROMPT_TEMPLATES` without adding a new version key should cause a test failure. Actual behavior: the test passes regardless of content changes, confirmed via reproduction in Week 8.
+
+### Map
+- `rag/generator/prompt_templates.py` — source of truth, `PROMPT_TEMPLATES` dict (5 templates, each currently only `v1`) and `get_template()`.
+- `tests/unit/test_prompt_templates.py` — will add/replace the snapshot test here (existing broken test at lines 175–188).
+
+### Plan
+1. Compute and hardcode the real expected MD5 hash for each of the 5 templates individually (per-template snapshot instead of one combined hash, so a failure points to exactly which template changed).
+2. Replace `test_template_snapshot_content_hash` with a parametrized test (or 5 explicit tests) asserting each template's current hash equals its stored expected hash.
+3. Add a clear failure message pointing to updating the hash *and* bumping the version key when a change is intentional.
+4. Add a short comment/docstring in the test explaining the intended developer workflow (edit template → bump version → update snapshot).
+5. Run `make check` (lint/format/type-check) and `make test-unit` to confirm nothing else breaks.
+
+### Inputs & outputs
+Input: the `PROMPT_TEMPLATES` dict content at test time. Output: pass/fail signal — test fails if any template's current hash doesn't match its recorded expected hash.
+
+### Risks & unknowns
+- Whole-file combined hash (current design) vs. per-template hashes — per-template is more diagnostic but is a bigger delta from the existing test; noting this as a design decision to explain in the PR description.
+- Need to confirm hardcoded hashes are computed from the *current* template text, not accidentally computed after an unintended edit.
+- Full `make test-unit` run has ~53 pre-existing unrelated failures in the sandbox (bias_detector, review_service, etc.) — need to scope verification to `test_prompt_templates.py` specifically so those don't create false signal.
+
+### Edge cases
+- A template gaining a new version (e.g. `v2` added) shouldn't break the `v1` snapshot.
+- Empty or missing template version should still raise `ValueError` via `get_template()` — not something this test should affect, but worth confirming test additions don't accidentally change that behavior.

--- a/tests/unit/test_prompt_templates.py
+++ b/tests/unit/test_prompt_templates.py
@@ -1,7 +1,8 @@
 """Tests for prompt_templates.py - Snapshot tests"""
 
-import pytest
 import hashlib
+
+import pytest
 
 from rag.generator.prompt_templates import PROMPT_TEMPLATES, get_template
 
@@ -52,7 +53,9 @@ class TestPromptTemplates:
         """Test each template contains {context} placeholder."""
         for template_name, versions in PROMPT_TEMPLATES.items():
             for version, template_text in versions.items():
-                assert "{context}" in template_text, f"{template_name} v{version} missing {{context}}"
+                assert (
+                    "{context}" in template_text
+                ), f"{template_name} v{version} missing {{context}}"
 
     def test_each_template_contains_github_username_placeholder(self):
         """Test each template contains {github_username} placeholder."""
@@ -151,19 +154,32 @@ class TestPromptTemplates:
         """Test gaps_feedback template mentions missing/gap concepts."""
         template = PROMPT_TEMPLATES["gaps_feedback"]["v1"]
 
-        assert "gap" in template.lower() or "missing" in template.lower() or "demand" in template.lower()
+        assert (
+            "gap" in template.lower()
+            or "missing" in template.lower()
+            or "demand" in template.lower()
+        )
 
     def test_presentation_feedback_mentions_readme(self):
         """Test presentation_feedback template mentions README or presentation."""
         template = PROMPT_TEMPLATES["presentation_feedback"]["v1"]
 
-        assert "readme" in template.lower() or "presentation" in template.lower() or "organization" in template.lower()
+        assert (
+            "readme" in template.lower()
+            or "presentation" in template.lower()
+            or "organization" in template.lower()
+        )
 
     def test_first_impression_is_concise(self):
         """Test first_impression template instructs concise output."""
         template = PROMPT_TEMPLATES["first_impression"]["v1"]
 
-        assert "2" in template or "3" in template or "sentence" in template.lower() or "summary" in template.lower()
+        assert (
+            "2" in template
+            or "3" in template
+            or "sentence" in template.lower()
+            or "summary" in template.lower()
+        )
 
     def test_get_template_default_version(self):
         """Test get_template() defaults to v1 when version not specified."""
@@ -172,20 +188,38 @@ class TestPromptTemplates:
 
         assert template_default == template_v1
 
-    def test_template_snapshot_content_hash(self):
-        """Snapshot test: verify template content hash."""
-        # Create hash of all template content
-        template_content = ""
-        for name in sorted(PROMPT_TEMPLATES.keys()):
-            for version in sorted(PROMPT_TEMPLATES[name].keys()):
-                template_content += PROMPT_TEMPLATES[name][version]
+    # Expected content hashes — computed from the current v1 template text.
+    # If you intentionally change a template's wording, add a new version key
+    # (e.g. "v2") rather than editing this file's v1 value in place, then
+    # update the expected hash below to match the new v1 content.
+    EXPECTED_TEMPLATE_HASHES = {
+        "first_impression": "ef6429d3a6d426b3c9913381020dd7e4",
+        "gaps_feedback": "e5bfd6644fd62a0fe01f60c9aa456762",
+        "presentation_feedback": "43549ee59818dfc8eb3627554a563b2e",
+        "projects_feedback": "d346d01b24ee7aad92594014a46557af",
+        "skills_feedback": "f93103d823482a2e65decc6653e4ee5c",
+    }
 
-        content_hash = hashlib.md5(template_content.encode()).hexdigest()
+    @pytest.mark.parametrize("template_name", sorted(EXPECTED_TEMPLATE_HASHES.keys()))
+    def test_template_snapshot_matches_expected_hash(self, template_name):
+        """Snapshot test: each template's v1 content hash must match its
+        recorded expected hash.
 
-        # Expected hash - update if templates intentionally change
-        # This helps detect unintended changes to templates
-        assert isinstance(content_hash, str)
-        assert len(content_hash) == 32  # MD5 hash length
+        If this test fails, you've changed a template's wording. That's
+        fine — but it means you should add a new version (e.g. "v2")
+        instead of silently editing "v1", then update
+        EXPECTED_TEMPLATE_HASHES to match the new content.
+        """
+        content = PROMPT_TEMPLATES[template_name]["v1"]
+        actual_hash = hashlib.md5(content.encode()).hexdigest()
+        expected_hash = self.EXPECTED_TEMPLATE_HASHES[template_name]
+
+        assert actual_hash == expected_hash, (
+            f"Template '{template_name}' v1 content has changed "
+            f"(expected hash {expected_hash}, got {actual_hash}). "
+            "If this change is intentional, add a new version key "
+            "instead of editing v1 in place."
+        )
 
     def test_skills_feedback_requests_json_format(self):
         """Test skills_feedback requests JSON output."""
@@ -216,7 +250,11 @@ class TestPromptTemplates:
         template = PROMPT_TEMPLATES["first_impression"]["v1"]
 
         # Should specify format (JSON or plain text)
-        assert "json" in template.lower() or "text" in template.lower() or "summary" in template.lower()
+        assert (
+            "json" in template.lower()
+            or "text" in template.lower()
+            or "summary" in template.lower()
+        )
 
     def test_templates_have_portfolio_context(self):
         """Test templates mention portfolio or context."""
@@ -230,7 +268,8 @@ class TestPromptTemplates:
         # Import logger to verify it's used
         with pytest.MonkeyPatch.context() as mp:
             from unittest.mock import patch
-            with patch('rag.generator.prompt_templates.logger') as mock_logger:
+
+            with patch("rag.generator.prompt_templates.logger") as mock_logger:
                 get_template("skills_feedback")
                 # Should log template retrieval
 
@@ -267,7 +306,8 @@ class TestPromptTemplates:
             for version, template_text in versions.items():
                 # All placeholders should use {name} syntax
                 import re
-                placeholders = re.findall(r'\{(\w+)\}', template_text)
+
+                placeholders = re.findall(r"\{(\w+)\}", template_text)
                 assert "context" in placeholders
                 assert "github_username" in placeholders
                 assert "project_count" in placeholders


### PR DESCRIPTION
## Title
test(rag): add real snapshot assertions for prompt templates

## Summary
The prompt template snapshot test only checked that a hash was a 32-character string, never comparing it against a fixed expected value. This meant template wording could change silently with no test failure. This PR replaces it with per-template assertions against hardcoded expected hashes, so an unversioned content change now fails loudly.

## Issue
Closes #37

## Changes
Root cause: `test_template_snapshot_content_hash` computed an MD5 hash of all template content but only asserted `isinstance(content_hash, str)` and `len(content_hash) == 32` — both trivially true regardless of what the templates said.

- Added `EXPECTED_TEMPLATE_HASHES`, hardcoded MD5 hashes computed from the current `v1` content of all 5 templates
- Replaced the old test with a parametrized `test_template_snapshot_matches_expected_hash`, run once per template, asserting its current hash matches its recorded expected hash
- Failure message explains the intended workflow: add a new version key instead of silently editing `v1`
- Removed the old dead assertions that could never fail

## Testing
- [x] Ran `make test-unit` before changes — 53 pre-existing failures unrelated to this file, 375 passed
- [x] Ran `make test-unit` after changes — same 53 pre-existing failures, 379 passed (net +4 from replacing 1 test with 5 parametrized tests)
- [x] Ran `tests/unit/test_prompt_templates.py` in isolation — 41/41 pass

Manual reproduction steps:
1. Edit any wording inside `PROMPT_TEMPLATES["skills_feedback"]["v1"]` in `rag/generator/prompt_templates.py`
2. Run `pytest tests/unit/test_prompt_templates.py::TestPromptTemplates::test_template_snapshot_matches_expected_hash -v`
3. Before this fix: passes regardless of the edit. After this fix: fails with a message naming the changed template and explaining the fix (add a version key)
4. Revert the edit — test passes again

## Screenshots / Demo
N/A — this is a test-only change with no UI or observable output; the change is visible in the test run output pasted above.

## Notes for Reviewers
- `make check`'s mypy hook (`disallow_untyped_defs = true`) flags missing `-> None` return type annotations on every test method in `test_prompt_templates.py` — this is pre-existing across the entire file (none of the original ~30 tests had them either) and unrelated to this change. Didn't add annotations to unrelated methods to keep this diff scoped to the issue.
- `make check`'s ruff/black hooks also reformatted minor pre-existing style issues (import order, line wrapping) in this file as a side effect of running pre-commit — no logic changes.
- `make test-unit` has 53 pre-existing failures across the codebase (bias_detector, review_service, resume_parser, etc.) unrelated to this issue; verified they exist identically before and after this change.