### PR TITLE
Docs(api/117): add curl examples for API endpoints

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -73,3 +73,25 @@ on similar tasks, but claims are non-exclusive.
 This issue is a good fit because it is a focused Tier 1 documentation 
 improvement with clear acceptance criteria.
 
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:**
+(To be added after committing)
+
+**Reproduction summary:**
+
+I opened docs/API.md and confirmed that each API endpoint is described 
+only with text. There are no example curl commands demonstrating how to 
+call the endpoints, making it difficult for new developers to verify the 
+API is working locally.
+
+**PLAN.md link:**
+(To be added after PLAN.md is committed)
+
+**Walkthrough video (recommended):**
+Not recorded for now but will do a final video after all.
+
+**Blockers or open questions:**
+Need to verify request bodies for authentication and profile creation 
+before writing examples.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -183,3 +183,67 @@ situation, so I did not receive peer review feedback before submitting
 the PR. The PR was still completed, validated, and submitted with 
 documented test and lint results.
 
+
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+
+No reviewer or maintainer feedback was received before the course 
+deadline. The pull request remains open and is awaiting review.
+
+**How you responded:**
+
+No response was required because no review comments were received.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+
+The most challenging part was understanding a large existing codebase 
+before making even a small documentation change. Although my task only 
+involved adding curl examples to the API documentation, I still needed 
+to inspect the authentication routes, profile endpoints, request 
+formats, and existing documentation structure to make sure every example 
+matched the actual implementation. Learning how an unfamiliar project is 
+organized took much more time than writing the documentation itself.
+
+**What did you learn about working in a large codebase?**
+
+I learned that contributing to an existing project is very different 
+from building my own projects. Instead of deciding everything myself, I 
+had to follow the repository's structure, coding standards, branch 
+naming conventions, commit message style, and contribution process. I 
+also learned the importance of reading documentation first and verifying 
+how features actually work before making changes.
+
+**How did AI tools help — and where did they fall short?**
+
+AI was very helpful for understanding unfamiliar files, explaining how 
+different API endpoints worked, and helping me prepare documentation and 
+my pull request. However, AI could not replace manually verifying the 
+repository or checking whether examples matched the implementation. I 
+still needed to review the code, confirm request formats, run project 
+commands, and ensure the documentation was accurate.
+
+**What would you do differently if you started over?**
+
+If I started over, I would claim an issue and open a draft pull request 
+earlier. I would also spend more time exploring the repository before 
+beginning implementation so I could understand how different parts of 
+the project fit together. This would make the implementation process 
+smoother and leave more time for review and feedback.
+
+**What are you most proud of from this module?**
+
+I am most proud that I completed my first open-source contribution from 
+start to finish. I successfully selected an issue, investigated the 
+project, planned the solution, updated the documentation, submitted a 
+pull request, and documented the entire development process using 
+professional Git and GitHub workflows.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -78,6 +78,7 @@ improvement with clear acceptance criteria.
 
 **Reproduction commit link:**
 (To be added after committing)
+https://github.com/Williyam30/pathreview/commit/a83fd91
 
 **Reproduction summary:**
 
@@ -133,3 +134,16 @@ final JOURNAL.md submission update with the PR link.
 **Blockers:**
 
 None.
+
+### Pull Request
+
+**PR link:**
+https://github.com/ascherj/pathreview/pull/595
+
+**PR status:**
+Open
+
+**Validation notes:**
+- `make test-unit` fails due to existing unrelated failures.
+- `make check` fails due to existing lint issues unrelated to 
+documentation changes.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -86,6 +86,15 @@ only with text. There are no example curl commands demonstrating how to
 call the endpoints, making it difficult for new developers to verify the 
 API is working locally.
 
+I compared the documentation in docs/API.md with the implementation in 
+the API route files. I found that while the endpoints are listed, the 
+documentation does not explain the correct request formats. For example, 
+/auth/login uses OAuth2PasswordRequestForm, which requires 
+application/x-www-form-urlencoded data instead of JSON, and profile 
+creation accepts form data rather than a simple JSON body. Without 
+runnable curl examples, developers are likely to send incorrect requests 
+when testing the API.
+
 **PLAN.md link:**
 (To be added after PLAN.md is committed)
 https://github.com/Williyam30/pathreview/blob/docs/117-api-curl-examples/PLAN.md

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,35 @@
+# JOURNAL
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/117
+
+**Issue title:** API docs don't include example curl commands
+
+**Tier:** ☑ Tier 1 ☐ Tier 2 ☐ Tier 3
+
+**Problem summary:**
+
+The current API documentation lists the available endpoints, but it does 
+not include example `curl` commands that developers can copy and run to 
+test the API. This makes it harder for new contributors to verify that 
+their local server is working correctly during setup. The issue affects 
+the `docs/API.md` documentation. A successful fix will add clear, 
+copy-pasteable `curl` examples for each documented endpoint while 
+keeping the documentation consistent and easy to follow.
+
+**"Is this right for me?" checklist reasoning:**
+
+I selected this issue because it is a Tier 1 documentation task with a 
+clearly defined scope. It only requires updating the API documentation 
+without changing application logic, making it a good first contribution 
+to the project. I reviewed the existing documentation and confirmed the 
+missing examples before choosing this issue.
+
+**Branch name:** `docs/117-api-curl-examples`
+
+**Setup confirmation:** ☑ App runs locally at `http://localhost:5173`
+
+**Cohort ledger:** ☐ Issue added to cohort ledger (will update after 
+adding my information)
+

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -147,3 +147,39 @@ Open
 - `make test-unit` fails due to existing unrelated failures.
 - `make check` fails due to existing lint issues unrelated to 
 documentation changes.
+
+
+### Check-in 2 (end of week)
+
+**PR link:**
+https://github.com/ascherj/pathreview/pull/595
+
+**Branch:**
+`docs/117-api-curl-examples`
+
+**What you built:**
+I updated the API documentation by adding copy-paste curl examples for 
+the documented endpoints, including health checks, authentication, 
+profile, and review endpoints. The goal was to make it easier for 
+developers to test the API locally and understand the required request 
+formats.
+
+**Tests added or updated:**
+No tests were added or updated because this was a documentation-only 
+contribution. No application code was modified.
+
+**Self-review confirmation:**
+[ ] make check passes (fails due to documented pre-existing lint issues 
+unrelated to this documentation change)
+[ ] make test-unit passes (fails due to documented pre-existing failures 
+in security, RAG, parsing, and detection modules)
+
+**Draft PR feedback received from:**
+none
+
+**Additional notes:**
+I was unable to attend the final review calls due to an emergency 
+situation, so I did not receive peer review feedback before submitting 
+the PR. The PR was still completed, validated, and submitted with 
+documented test and lint results.
+

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -88,6 +88,7 @@ API is working locally.
 
 **PLAN.md link:**
 (To be added after PLAN.md is committed)
+https://github.com/Williyam30/pathreview/blob/docs/117-api-curl-examples/PLAN.md
 
 **Walkthrough video (recommended):**
 Not recorded for now but will do a final video after all.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -10,13 +10,14 @@
 
 **Problem summary:**
 
-The current API documentation lists the available endpoints, but it does 
-not include example `curl` commands that developers can copy and run to 
-test the API. This makes it harder for new contributors to verify that 
-their local server is working correctly during setup. The issue affects 
-the `docs/API.md` documentation. A successful fix will add clear, 
-copy-pasteable `curl` examples for each documented endpoint while 
-keeping the documentation consistent and easy to follow.
+The API documentation currently explains the available endpoints but 
+doesn't provide example `curl` commands that developers can copy and 
+run. This makes it harder for new contributors to quickly verify that 
+the API is working after setting up the project locally. The missing 
+examples are located in `docs/API.md` and affect developer onboarding 
+rather than application functionality. A successful fix will add clear 
+curl examples for the documented endpoints so users can test the API 
+more easily.
 
 **"Is this right for me?" checklist reasoning:**
 
@@ -32,4 +33,43 @@ missing examples before choosing this issue.
 
 **Cohort ledger:** ☐ Issue added to cohort ledger (will update after 
 adding my information)
+
+## Selection reasoning
+
+### Part 1 — Understanding the Issue
+
+- I can explain the issue: The API documentation lists endpoints but 
+does not show example curl commands. The goal is to improve docs/API.md 
+by adding runnable examples.
+- Affected area: This issue affects the documentation layer. The 
+referenced file is docs/API.md.
+- Definition of done: Developers should be able to copy the curl 
+commands from the documentation and use them to test API endpoints.
+
+### Part 2 — Tier Fit
+
+- Tier: Tier 1
+- Reason: This is a small documentation change limited to one file and 
+does not require changes to application logic.
+- This scope is appropriate for my first open-source contribution.
+
+### Part 3 — Codebase Readiness
+
+- I located the affected file: docs/API.md.
+- I reviewed the existing API documentation structure and understand 
+where examples should be added.
+- I will verify examples against the available endpoints and local API 
+setup.
+
+### Part 4 — Scope and Time
+
+- I reviewed issue comments and confirmed other contributors are working 
+on similar tasks, but claims are non-exclusive.
+- Estimated effort: 2–3 hours, which fits within Weeks 8–9.
+- No blockers or dependencies were listed on the issue.
+
+### Verdict
+
+This issue is a good fit because it is a focused Tier 1 documentation 
+improvement with clear acceptance criteria.
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -105,3 +105,31 @@ Not recorded for now but will do a final video after all.
 **Blockers or open questions:**
 Need to verify request bodies for authentication and profile creation 
 before writing examples.
+
+
+---
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+
+I implemented the main documentation update from my PLAN.md by adding 
+runnable curl examples to `docs/API.md`. I added examples for all API 
+endpoints including health checks, authentication, profiles, and 
+reviews. During implementation, I verified request formats from the 
+FastAPI route files, including JSON payloads for registration and 
+reviews, form-encoded login requests using OAuth2PasswordRequestForm, 
+and multipart form data for profile creation with resume uploads.
+
+**Next steps:**
+
+I will review the updated documentation for accuracy, run the required 
+project checks, and prepare a pull request. I will also verify that the 
+curl examples work correctly with the local API server and complete the 
+final JOURNAL.md submission update with the PR link.
+
+**Blockers:**
+
+None.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,61 @@
+# Solution Plan
+
+**Issue**
+
+API docs don't include example curl commands
+
+https://github.com/ascherj/pathreview/issues/117
+
+## Understand
+
+The API documentation lists all available endpoints but does not provide 
+example curl commands. Developers must manually determine request 
+methods, headers, and JSON payloads before testing the API. Adding copy 
+and paste examples will make onboarding much easier.
+
+
+## Map
+
+Files involved:
+
+- docs/API.md
+
+Reference files:
+
+- api/routes/
+- README.md
+- OpenAPI documentation at localhost:8000/docs
+
+## Plan
+
+1. Review every endpoint documented in API.md.
+2. Verify request methods and required JSON bodies.
+3. Write example curl commands for each endpoint.
+4. Keep formatting consistent with the existing documentation.
+5. Verify examples against the local development server if possible.
+
+
+## Inputs & Outputs
+
+Input:
+
+Current API documentation.
+
+Output:
+
+Updated documentation with complete curl examples for every endpoint.
+
+
+## Risks & Unknowns
+
+- Some endpoints require authentication tokens.
+- Need to verify exact JSON payloads.
+- Endpoint paths may differ from assumptions.
+
+## Edge Cases
+
+- Authenticated endpoints should clearly indicate Authorization headers.
+- Examples should use localhost.
+- JSON formatting should be copy-paste ready.
+
+

--- a/PLAN.md
+++ b/PLAN.md
@@ -28,11 +28,16 @@ Reference files:
 
 ## Plan
 
-1. Review every endpoint documented in API.md.
-2. Verify request methods and required JSON bodies.
-3. Write example curl commands for each endpoint.
-4. Keep formatting consistent with the existing documentation.
-5. Verify examples against the local development server if possible.
+1. Review api/routes/auth.py to determine the exact request format for 
+/auth/register and /auth/login.
+2. Inspect the authentication implementation to confirm how Bearer 
+tokens should be included in authenticated curl examples.
+3. Review the profile routes and schemas to determine whether requests 
+require JSON, form data, or file uploads.
+4. Write tested curl examples for every documented endpoint in 
+docs/API.md.
+5. Verify each example against the local server and ensure the 
+documentation formatting remains consistent.
 
 
 ## Inputs & Outputs
@@ -48,14 +53,23 @@ Updated documentation with complete curl examples for every endpoint.
 
 ## Risks & Unknowns
 
-- Some endpoints require authentication tokens.
-- Need to verify exact JSON payloads.
-- Endpoint paths may differ from assumptions.
+- Some endpoints require authentication tokens: api/routes/auth.py may 
+require different request formats for registration and login, so I need 
+to verify the expected content type before writing examples.
+- Need to verify exact JSON payloads: api/routes/auth.py may require 
+different request formats for registration and login, so I need to 
+verify the expected content type before writing examples.
+- Endpoint paths may differ from assumptions: Authenticated endpoints 
+require a Bearer token, so I need to determine the correct way to 
+demonstrate token usage consistently across the documentation.
 
 ## Edge Cases
 
-- Authenticated endpoints should clearly indicate Authorization headers.
-- Examples should use localhost.
-- JSON formatting should be copy-paste ready.
-
-
+- Login endpoint requires form-encoded data rather than JSON.
+- Profile creation may include uploaded files as multipart form data.
+- Authenticated requests must demonstrate a valid Authorization: Bearer 
+<token> header.
+- Example requests should work against a fresh local installation using 
+http://localhost:8000.
+- Placeholder IDs and tokens should be clearly marked so users know what 
+to replace.

--- a/docs/API.md
+++ b/docs/API.md
@@ -8,25 +8,104 @@ Base URL: `http://localhost:8000`
 
 `GET /health` — Returns service status and dependency health.
 
+Example:
+
+```sh
+curl http://localhost:8000/health
+```
+
 ### Authentication
 
 `POST /auth/register` — Create a new account.
+
+Example:
+
+```sh
+curl -X POST http://localhost:8000/auth/register \
+  -H "Content-Type: application/json" \
+  -d '{
+    "email": "user@example.com",
+    "password": "password123"
+  }'
+```
+
 `POST /auth/login` — Obtain a JWT access token.
+
+Example:
+
+```sh
+curl -X POST http://localhost:8000/auth/login \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "username=user@example.com&password=password123"
+```
 
 ### Profiles
 
 `POST /profiles` — Create a profile with resume and GitHub username.
+
+Example:
+
+```sh
+curl -X POST http://localhost:8000/profiles \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
+  -F "github_username=example-user" \
+  -F "portfolio_url=https://example.com" \
+  -F "resume_file=@resume.pdf"
+```
+
 `GET /profiles/{profile_id}` — Retrieve a profile.
+
+Example:
+
+```sh
+curl http://localhost:8000/profiles/PROFILE_ID \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
+```
+
 `DELETE /profiles/{profile_id}` — Delete a profile and associated data.
+
+Example:
+
+```sh
+curl -X DELETE http://localhost:8000/profiles/PROFILE_ID \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
+```
 
 ### Reviews
 
 `POST /reviews` — Request a new portfolio review for a profile.
+
+Example:
+
+```sh
+curl -X POST http://localhost:8000/reviews \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "profile_id": "PROFILE_ID"
+  }'
+```
+
 `GET /reviews/{review_id}` — Retrieve a completed review.
+
+Example:
+
+```sh
+curl http://localhost:8000/reviews/REVIEW_ID \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
+```
+
 `GET /reviews` — List reviews for the authenticated user (paginated).
+
+Example:
+
+```sh
+curl "http://localhost:8000/reviews?page=1&page_size=20" \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
+```
 
 ## Interactive Docs
 
 When the API is running, visit:
 - **Swagger UI:** http://localhost:8000/docs
-- **ReDoc:** http://localhost:8000/redoc
+- **ReDoc:** http://localhost:8000/redoc -->


### PR DESCRIPTION
## Summary

Added curl examples to the API documentation to make API endpoints easier to test and understand.

This addresses issue #117 by adding copy-paste examples for developers to verify the API locally.

## Changes Made

Updated `docs/API.md` with curl examples for:

- Health endpoint
- Authentication endpoints
- Profile endpoints
- Review endpoints

Also updated:
- `PLAN.md`
- `JOURNAL.md`

with contribution planning and progress notes.

## Validation

Testing performed:

- `make test-unit`
  - Fails due to existing unrelated failures in security, RAG, parsing, and detection modules.

- `make check`
  - Fails due to existing lint issues across repository files unrelated to this documentation change.

No application code was modified. Changes are limited to documentation and contribution tracking files.