### PR TITLE
fix(agent): populate file_structure to enable has_tests detection (#50)

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,6 +1,9 @@
 ## Week 7 — Issue selection
 
 **Issue link:** https://github.com/ascherj/pathreview/issues/50
+
+
+
 **Issue title:** Add a `has_tests` boolean to the repo analysis output
 
 **Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
@@ -32,4 +35,6 @@ issue originally pointed.
 **Branch name:** feat/50-has-tests-detection
 
 **Setup confirmation:** [x] App runs locally at localhost:5173
+
+
 **Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -38,3 +38,20 @@ issue originally pointed.
 
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/Kshukla10/pathreview/commit/9fc5a9180a1d921bb5aef89e829ce6e832b2e8cd
+
+**Reproduction summary:**
+I fetched real GitHub repo data and ran it through the test-detection code.
+It never receives a file list in the first place, so it always says "no
+tests" even when tests exist — I wrote two committed pytest tests proving
+this in tests/unit/test_repo_analyzer.py.
+
+**PLAN.md link:** https://github.com/Kshukla10/pathreview/blob/feat/50-has-tests-detection/PLAN.md
+
+**Blockers or open questions:**
+Need to confirm whether we're using an authenticated GitHub connection to
+avoid rate limits, and whether file_structure should be a flat string or a
+list — leaning toward string based on how the existing detection code uses it.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,35 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/50
+**Issue title:** Add a `has_tests` boolean to the repo analysis output
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The repo analysis pipeline is supposed to report whether a scanned repository
+has tests, but the detection is currently broken. The logic for this already
+exists in `ingestion/parsers/repo_analyzer.py` (`_detect_tests`), and looks
+for common test indicators like a `tests/` directory or `pytest.ini`.
+However, this logic depends on a `file_structure` field in the repo data that
+is never actually populated anywhere in the codebase — `github_tool.py`,
+which fetches repo metadata from the GitHub API, never includes a file
+listing. As a result, `has_tests` always evaluates to `False` regardless of
+the real repository contents. A correct fix will likely involve fetching the
+repo's file tree in `github_tool.py` and
+passing it through as `file_structure` so the existing detection logic in
+`repo_analyzer.py` has real data to work with.
+
+**Selection notes:**
+I chose this issue as a Tier 1/good-first-issue because I'm working in this
+codebase for the first time and wanted something with a small, well-defined
+surface area. The issue names exactly two relevant files, which matched what
+I found once I explored the repo (one of the two had actually moved locations,
+which I confirmed before starting). The scope — adding/wiring up a single
+boolean field — felt appropriately sized for a first contribution, even though
+my investigation revealed the actual fix needs to happen upstream of where the
+issue originally pointed.
+
+**Branch name:** feat/50-has-tests-detection
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -55,3 +55,29 @@ this in tests/unit/test_repo_analyzer.py.
 Need to confirm whether we're using an authenticated GitHub connection to
 avoid rate limits, and whether file_structure should be a flat string or a
 list — leaning toward string based on how the existing detection code uses it.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the fix in agent/tools/github_tool.py — added a
+_fetch_file_structure method that calls GitHub's Git Trees API and wires
+it into the metadata dict returned by _fetch_repo_metadata. Verified
+locally that has_tests now correctly returns True for a real repo with
+tests (previously always False, since the file_structure field it depends
+on was never populated). Added 4 new unit tests in
+tests/unit/test_github_tool.py covering the success case, API failure
+handling, truncated tree handling, and metadata wiring. Fixed a
+pre-existing mypy no-any-return error in _has_readme while in the area.
+Confirmed via baseline comparison against main (57 failed/375 passed there
+vs. 53 failed/381 passed on this branch) that my changes introduce no new
+test failures — all pre-existing failures are in unrelated modules.
+
+**Next steps:**
+Opened a draft PR (#598) and shared it in Slack for feedback.
+Will incorporate any feedback received, then mark ready for review and
+finalize Check-in 2.
+
+**Blockers:**
+None currently.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -75,9 +75,8 @@ vs. 53 failed/381 passed on this branch) that my changes introduce no new
 test failures — all pre-existing failures are in unrelated modules.
 
 **Next steps:**
-Opened a draft PR (#598) and shared it in Slack for feedback.
-Will incorporate any feedback received, then mark ready for review and
-finalize Check-in 2.
+Opened a draft PR (#598), the fix is fully tested and self-reviewed
+against CONTRIBUTING.md standards.
 
 **Blockers:**
 None currently.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -80,3 +80,24 @@ against CONTRIBUTING.md standards.
 
 **Blockers:**
 None currently.
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/598
+
+**Branch:** feat/50-has-tests-detection
+
+**What you built:**
+Fixed has_tests detection by adding a _fetch_file_structure method to
+GitHubTool that calls GitHub's Git Trees API and populates the previously
+missing file_structure field, which the existing detection logic in
+repo_analyzer.py depends on. Also fixes has_ci and tech_stack, which
+depended on the same field.
+
+**Tests added or updated:**
+tests/unit/test_github_tool.py — 4 new tests covering the success case,
+API failure handling, truncated tree handling, and metadata wiring.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes (no new failures vs. baseline: 53 vs. 57 pre-existing)
+
+**Draft PR feedback received from:** None

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -101,3 +101,69 @@ API failure handling, truncated tree handling, and metadata wiring.
 **Self-review confirmation:** [x] make check passes  [x] make test-unit passes (no new failures vs. baseline: 53 vs. 57 pre-existing)
 
 **Draft PR feedback received from:** None
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No
+
+**Summary of feedback:**
+I worked through the issue selection, reproduction,
+and implementation close to the deadline, which didn't leave enough time to
+share my draft PR in Slack and get peer feedback before finalizing. That's
+a timing tradeoff I'd fix if I started over — noted in the reflection below.
+
+**How you responded:**
+N/A 
+
+### Reflection
+
+**What was harder than you expected?**
+The issue itself described a fix in the wrong file. `_detect_tests` in
+repo_analyzer.py was already implemented correctly — the issue's suggested
+location (agent/tools/repo_analyzer.py) didn't even exist anymore, and the
+real bug was one layer upstream, in github_tool.py never populating the
+file_structure field the detection logic depended on. I expected issue
+descriptions to be a reliable map of what to change; instead, verifying the
+premise of the issue against the actual code was itself most of the work.
+I also underestimated how much of my time would go to environment setup
+(Docker, WSL, Git Bash vs. PowerShell, make not being installed) before I
+wrote a single line of the actual fix.
+
+**What did you learn about working in a large codebase?**
+I learned to trace data through a pipeline rather than trust a single
+file in isolation — the bug only became visible once I followed
+repo_data from where GitHubTool builds it through to where
+RepoAnalyzer.parse() consumes it. I also learned that existing test files
+(like test_readme_parser.py) are a better guide to a codebase's conventions
+than any style guide, since they show real patterns for fixtures, mocking,
+and naming that I matched rather than guessed at.
+
+**How did AI tools help — and where did they fall short?**
+AI was most useful for quickly diagnosing tool errors (mypy/ruff/black
+failures, Docker/WSL setup issues) and for drafting boilerplate like test
+scaffolding once I'd already found the real bug. It fell short at the
+actual investigation — finding that file_structure was never populated
+required me to actually read both files side by side and reason about the
+data flow; that step needed my own attention on the specific codebase, not
+something I could shortcut.
+
+**What would you do differently if you started over?**
+I'd start earlier in the week rather than compressing issue selection,
+reproduction, and implementation close to the deadline — that timing
+crunch meant I didn't leave room to share my draft PR for peer feedback
+before finalizing, which the process explicitly recommends doing early.
+I'd also verify the issue's premise against the actual code before writing
+my Week 7 problem summary, rather than assuming the issue's suggested file
+paths were still accurate. And I'd set up my dev environment (Docker, make,
+correct shell) before selecting an issue, since that friction ate into time
+I could've spent on the actual investigation.
+
+**What are you most proud of from this module?**
+Finding that the bug wasn't where the issue said it was. The issue pointed
+at repo_analyzer.py, but the real problem was one layer upstream in
+github_tool.py, which never populated the file_structure field the
+detection logic depended on. Fixing that also silently fixed has_ci and
+tech_stack, which depended on the same missing data — that felt like real
+debugging, not just following instructions from the issue description.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,73 @@
+## Solution plan
+
+**Issue:** Add a `has_tests` boolean to the repo analysis output — https://github.com/ascherj/pathreview/issues/50
+
+### Understand
+The expected behavior is that `has_tests` reflects whether a scanned GitHub
+repository actually contains tests. The detection logic for this already
+exists in `ingestion/parsers/repo_analyzer.py` (`_detect_tests`), checking
+for indicators like a `tests/` directory, `pytest.ini`, or `test_*.py` files.
+The actual (broken) behavior is that `has_tests` is always `False`, because
+the `file_structure` field it depends on is never populated anywhere in the
+pipeline — `agent/tools/github_tool.py`, which builds the repo metadata dict,
+never fetches or includes a file listing. I confirmed this with a real
+reproduction against the pathreview repo itself, and with two committed
+pytest tests in `tests/unit/test_repo_analyzer.py`.
+
+### Map
+- `agent/tools/github_tool.py` — needs a new method to fetch the repo's file
+  tree from GitHub (likely via the Git Trees API:
+  `GET /repos/{owner}/{repo}/git/trees/{sha}?recursive=1`), and needs to add
+  a `file_structure` key to the metadata dict returned by `_fetch_repo_metadata`.
+- `ingestion/parsers/repo_analyzer.py` — no logic changes expected; `_detect_tests`,
+  `_detect_ci`, and `_detect_tech_stack` should all start working correctly
+  once real `file_structure` data flows in.
+- `tests/unit/test_repo_analyzer.py` — existing reproduction tests; will
+  extend or add integration-style tests once the fix is in place.
+
+### Plan
+1. Add a method to `GitHubTool` (e.g. `_fetch_file_structure`) that calls
+   GitHub's Git Trees API to get a recursive file listing for the repo.
+2. Flatten the tree response into a newline-joined string matching the
+   format `_detect_tests`/`_detect_ci` expect (they call `str(...).lower()`
+   on `file_structure`).
+3. Add `"file_structure": self._fetch_file_structure(username, repo_name)`
+   to the metadata dict in `_fetch_repo_metadata`.
+4. Update/extend tests to confirm `has_tests` now correctly returns `True`
+   for repos with tests and `False` for repos without, using real API calls
+   or mocked responses.
+5. Manually verify against a couple of real repos (one with tests, one
+   without) to confirm no false positives/negatives.
+
+### Inputs & outputs
+**Input:** a GitHub `username` and `repo_name`, as already accepted by
+`GitHubTool.execute()`.
+**Output:** the existing metadata dict, now including an accurate
+`file_structure` string, which flows into `RepoAnalyzer.parse()` and
+produces a correct `has_tests` boolean (also fixes `has_ci` and
+`tech_stack` as a side effect, since they depend on the same field).
+
+### Risks & unknowns
+- The Git Trees API can be paginated/truncated for very large repos
+  (GitHub returns `truncated: true`) — need to handle that gracefully
+  rather than silently missing files.
+- This adds an extra GitHub API call per repo analyzed, on top of existing
+  metadata and README calls — could hit rate limits faster, especially
+  unauthenticated. Need to confirm whether `GitHubTool` is used with an
+  authenticated token in practice.
+- `file_structure` format: current code assumes a flat string (via
+  `str(...).lower()`), so the new fetch method must produce a string,
+  not a list, to avoid changing `repo_analyzer.py`.
+- Fixing `file_structure` will also change `has_ci` and `tech_stack` output
+  for any already-analyzed repos — worth confirming this is in scope and
+  not an unintended expansion of the issue.
+
+### Edge cases
+- Empty repositories (no files at all) — should return `has_tests: False`
+  without erroring.
+- Repos where the file-tree API call fails (404, rate limit) — should
+  degrade gracefully (e.g. `file_structure` empty string, `has_tests: False`)
+  rather than crashing the whole analysis.
+- Very large repos where the tree response is `truncated: true`.
+- Repos using non-standard test directory names not covered by the
+  existing `_detect_tests` indicators (out of scope to fix, but worth noting).

--- a/agent/tools/github_tool.py
+++ b/agent/tools/github_tool.py
@@ -2,6 +2,7 @@
 
 import httpx
 import structlog
+
 from .base import BaseTool, ToolResult
 
 logger = structlog.get_logger()
@@ -35,44 +36,30 @@ class GitHubTool(BaseTool):
         repo_name = input_data.get("repo_name")
 
         if not username or not repo_name:
-            return ToolResult(
-                success=False,
-                data={},
-                error="Missing github_username or repo_name"
-            )
+            return ToolResult(success=False, data={}, error="Missing github_username or repo_name")
 
         try:
             repo_data = self._fetch_repo_metadata(username, repo_name)
             return ToolResult(success=True, data=repo_data)
 
         except httpx.HTTPStatusError as e:
-            logger.error("github_request_failed", status=e.response.status_code,
-                        username=username, repo=repo_name)
+            logger.error(
+                "github_request_failed",
+                status=e.response.status_code,
+                username=username,
+                repo=repo_name,
+            )
             if e.response.status_code == 404:
-                return ToolResult(
-                    success=False,
-                    data={},
-                    error="Repository not found"
-                )
+                return ToolResult(success=False, data={}, error="Repository not found")
             elif e.response.status_code == 403:
-                return ToolResult(
-                    success=False,
-                    data={},
-                    error="Rate limited or access denied"
-                )
+                return ToolResult(success=False, data={}, error="Rate limited or access denied")
             return ToolResult(
-                success=False,
-                data={},
-                error=f"GitHub API error: {e.response.status_code}"
+                success=False, data={}, error=f"GitHub API error: {e.response.status_code}"
             )
 
         except Exception as e:
             logger.error("github_tool_error", error=str(e))
-            return ToolResult(
-                success=False,
-                data={},
-                error=str(e)
-            )
+            return ToolResult(success=False, data={}, error=str(e))
 
     def _fetch_repo_metadata(self, username: str, repo_name: str) -> dict:
         """Fetch repository metadata from GitHub API.
@@ -105,12 +92,18 @@ class GitHubTool(BaseTool):
             "open_issues_count": repo_json.get("open_issues_count", 0),
             "last_commit_date": repo_json.get("pushed_at", ""),
             "has_readme": self._has_readme(username, repo_name),
+            "file_structure": self._fetch_file_structure(username, repo_name),
             "topics": repo_json.get("topics", []),
             "homepage": repo_json.get("homepage") or "",
         }
 
-        logger.info("github_repo_fetched", username=username, repo=repo_name,
-                   language=metadata["primary_language"], stars=metadata["star_count"])
+        logger.info(
+            "github_repo_fetched",
+            username=username,
+            repo=repo_name,
+            language=metadata["primary_language"],
+            stars=metadata["star_count"],
+        )
 
         return metadata
 
@@ -132,6 +125,47 @@ class GitHubTool(BaseTool):
 
         try:
             response = httpx.head(url, headers=headers, timeout=5.0)
-            return response.status_code == 200
+            return bool(response.status_code == 200)
         except Exception:
             return False
+
+    def _fetch_file_structure(self, username: str, repo_name: str) -> str:
+        """Fetch the file structure of the repository.
+
+        Args:
+            username: GitHub username
+            repo_name: Repository name
+
+        Returns:
+            String representation of the file structure
+        """
+        headers = {}
+        if self.api_token:
+            headers["Authorization"] = f"token {self.api_token}"
+
+        try:
+            repo_url = f"{self.base_url}/repos/{username}/{repo_name}"
+            repo_response = httpx.get(repo_url, headers=headers, timeout=10.0)
+            repo_response.raise_for_status()
+            default_branch = repo_response.json().get("default_branch", "main")
+
+            # Fetch the recursive tree for that branch
+            tree_url = (
+                f"{self.base_url}/repos/{username}/{repo_name}"
+                f"/git/trees/{default_branch}?recursive=1"
+            )
+            tree_response = httpx.get(tree_url, headers=headers, timeout=10.0)
+            tree_response.raise_for_status()
+            tree_data = tree_response.json()
+
+            if tree_data.get("truncated"):
+                logger.warning("file_tree_truncated", username=username, repo=repo_name)
+
+            paths = [item["path"] for item in tree_data.get("tree", [])]
+            return "\n".join(paths)
+
+        except Exception as e:
+            logger.error(
+                "file_structure_fetch_failed", username=username, repo=repo_name, error=str(e)
+            )
+        return ""

--- a/tests/unit/test_github_tool.py
+++ b/tests/unit/test_github_tool.py
@@ -1,0 +1,123 @@
+"""Tests for github_tool.py"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from agent.tools.github_tool import GitHubTool
+
+
+@pytest.mark.unit
+class TestGitHubTool:
+    """Test suite for GitHubTool."""
+
+    @pytest.fixture
+    def tool(self) -> GitHubTool:
+        """Create a GitHubTool instance."""
+        return GitHubTool()
+
+    def test_fetch_file_structure_returns_joined_paths(self, tool: GitHubTool) -> None:
+        """When the API returns a file tree, paths are flattened into a
+        newline-joined string, matching the format repo_analyzer.py expects."""
+        with patch("agent.tools.github_tool.httpx.get") as mock_get:
+            mock_repo_response = Mock()
+            mock_repo_response.json.return_value = {"default_branch": "main"}
+            mock_repo_response.raise_for_status.return_value = None
+
+            mock_tree_response = Mock()
+            mock_tree_response.json.return_value = {
+                "truncated": False,
+                "tree": [
+                    {"path": "README.md"},
+                    {"path": "tests/test_example.py"},
+                    {"path": "src/main.py"},
+                ],
+            }
+            mock_tree_response.raise_for_status.return_value = None
+
+            mock_get.side_effect = [mock_repo_response, mock_tree_response]
+
+            result = tool._fetch_file_structure("someuser", "somerepo")
+
+            assert result == "README.md\ntests/test_example.py\nsrc/main.py"
+
+    def test_fetch_file_structure_returns_empty_string_on_failure(self, tool: GitHubTool) -> None:
+        """When the API call fails, _fetch_file_structure degrades gracefully
+        and returns an empty string rather than raising."""
+        with patch("agent.tools.github_tool.httpx.get") as mock_get:
+            mock_get.side_effect = Exception("API error")
+
+            result = tool._fetch_file_structure("someuser", "somerepo")
+
+            assert result == ""
+
+    def test_fetch_file_structure_logs_warning_on_truncated_tree(self, tool: GitHubTool) -> None:
+        """When GitHub reports the tree as truncated, a warning is logged
+        but the method still returns whatever paths were included."""
+        with (
+            patch("agent.tools.github_tool.httpx.get") as mock_get,
+            patch("agent.tools.github_tool.logger") as mock_logger,
+        ):
+            mock_repo_response = Mock()
+            mock_repo_response.json.return_value = {"default_branch": "main"}
+            mock_repo_response.raise_for_status.return_value = None
+
+            mock_tree_response = Mock()
+            mock_tree_response.json.return_value = {
+                "truncated": True,
+                "tree": [{"path": "README.md"}],
+            }
+            mock_tree_response.raise_for_status.return_value = None
+
+            mock_get.side_effect = [mock_repo_response, mock_tree_response]
+
+            result = tool._fetch_file_structure("someuser", "somerepo")
+
+            assert result == "README.md"
+            mock_logger.warning.assert_called_once()
+
+    def test_fetch_repo_metadata_includes_file_structure_key(self, tool: GitHubTool) -> None:
+        """The metadata dict returned by _fetch_repo_metadata includes the
+        new file_structure field alongside existing fields."""
+        with (
+            patch("agent.tools.github_tool.httpx.get") as mock_get,
+            patch("agent.tools.github_tool.httpx.head") as mock_head,
+        ):
+            mock_repo_json_response = Mock()
+            mock_repo_json_response.json.return_value = {
+                "name": "somerepo",
+                "description": "A test repo",
+                "language": "Python",
+                "stargazers_count": 5,
+                "forks_count": 1,
+                "open_issues_count": 0,
+                "pushed_at": "2026-01-01T00:00:00Z",
+                "topics": [],
+                "homepage": "",
+                "default_branch": "main",
+            }
+            mock_repo_json_response.raise_for_status.return_value = None
+
+            mock_tree_response = Mock()
+            mock_tree_response.json.return_value = {
+                "truncated": False,
+                "tree": [{"path": "tests/test_example.py"}],
+            }
+            mock_tree_response.raise_for_status.return_value = None
+
+            # First call: main metadata fetch. Second/third: file structure fetch
+            # (repo lookup for default_branch, then tree lookup).
+            mock_get.side_effect = [
+                mock_repo_json_response,
+                mock_repo_json_response,
+                mock_tree_response,
+            ]
+
+            mock_head_response = Mock()
+            mock_head_response.status_code = 200
+            mock_head.return_value = mock_head_response
+
+            metadata = tool._fetch_repo_metadata("someuser", "somerepo")
+
+            assert "file_structure" in metadata
+            assert metadata["file_structure"] == "tests/test_example.py"

--- a/tests/unit/test_repo_analyzer.py
+++ b/tests/unit/test_repo_analyzer.py
@@ -1,0 +1,48 @@
+"""Tests for repo_analyzer.py"""
+
+import json
+
+import pytest
+
+from ingestion.parsers.base import ParseResult
+from ingestion.parsers.repo_analyzer import RepoAnalyzer
+
+
+@pytest.mark.unit
+class TestRepoAnalyzer:
+    """Test suite for RepoAnalyzer."""
+
+    @pytest.fixture
+    def analyzer(self) -> RepoAnalyzer:
+        """Create a RepoAnalyzer instance."""
+        return RepoAnalyzer()
+
+    def test_has_tests_true_when_file_structure_present(self, analyzer: RepoAnalyzer) -> None:
+        """When file_structure includes a tests/ path, has_tests should be True."""
+        repo_data = {
+            "name": "example-repo",
+            "file_structure": "README.md\ntests/test_example.py\nsrc/main.py",
+        }
+        result = analyzer.parse(json.dumps(repo_data))
+
+        assert isinstance(result, ParseResult)
+        assert result.metadata["has_tests"] is True
+
+    def test_has_tests_false_when_file_structure_missing(self, analyzer: RepoAnalyzer) -> None:
+        """
+        Reproduces issue #50: GitHubTool never populates 'file_structure' in
+        the metadata it returns, so has_tests always evaluates to False here,
+        even for repositories that genuinely contain tests. This test
+        documents the current (broken) behavior against real-world input
+        shape, i.e. a repo_data dict with no file_structure key at all,
+        matching what github_tool.py actually produces.
+        """
+        repo_data_missing_file_structure = {
+            "name": "example-repo",
+            "description": "A repo with real tests, but no file_structure key",
+            "language": "Python",
+        }
+        result = analyzer.parse(json.dumps(repo_data_missing_file_structure))
+
+        assert isinstance(result, ParseResult)
+        assert result.metadata["has_tests"] is False


### PR DESCRIPTION
## Summary
Fixes `has_tests` (and, incidentally, `has_ci` and `tech_stack`) always
evaluating to `False`/empty regardless of a repository's real contents.
The detection logic in `repo_analyzer.py` was already correct, but the
`file_structure` field it depends on was never populated by `GitHubTool` —
this PR fetches that data via GitHub's Git Trees API and wires it through.

## Issue
Closes #50

## Changes
- Added `_fetch_file_structure()` to `GitHubTool` in `agent/tools/github_tool.py`,
  which calls GitHub's Git Trees API to get a recursive file listing for the
  repo's default branch and flattens it into a newline-joined string.
- Wired `file_structure` into the metadata dict returned by
  `_fetch_repo_metadata()`.
- Fixed a pre-existing `mypy` `no-any-return` error in `_has_readme` while
  in the area (wrapped the boolean comparison explicitly with `bool(...)`).
- Added `tests/unit/test_github_tool.py` with 4 tests covering the fetch
  method's success case, failure handling, truncated-tree handling, and
  metadata wiring.

## Testing
- [x] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`) — no integration tests exist yet in this project (`tests/integration/` is currently empty)
- [x] Linter passes (`make lint`)
- [x] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes

**To verify manually:**
1. Check out this branch and ensure a `.env` file exists (copy from
   `.env.example` if needed). An `OPENROUTER_API_KEY` isn't required for
   this specific fix — GitHub API calls work unauthenticated, just with
   lower rate limits.
2. In a Python shell (with the venv activated), run:
```python
   from agent.tools.github_tool import GitHubTool
   from ingestion.parsers.repo_analyzer import RepoAnalyzer

   gh = GitHubTool()
   result = gh.execute({"github_username": "ascherj", "repo_name": "pathreview"})
   parsed = RepoAnalyzer().parse(result.data)
   print(parsed.metadata["has_tests"])  # should print True
```
3. Confirm it prints `True` — `pathreview` has a real `tests/` directory,
   so this proves the fix works end-to-end.
4. Run `python -m pytest tests/unit/test_github_tool.py -v` and confirm
   all 4 tests pass.


Verified locally against a real repo (`ascherj/pathreview`, which has a real
`tests/` directory): `has_tests` now correctly returns `True` (previously
always `False`). Baseline comparison against `main`: 57 failed/375 passed
there, vs. 53 failed/381 passed on this branch. All remaining failures are
in modules unrelated to this change (`test_bias_detector.py`,
`test_pii_scrubber.py`, `test_review_service.py`, `test_skill_extractor.py`,
etc.) — this PR introduces no new failures.

## Screenshots / Demo
N/A — backend-only change to metadata output, no UI change.

## Notes for Reviewers
The core insight here is that the original issue's suggested location for
this fix (`repo_analyzer.py`) was already implemented correctly — the real
bug was one layer upstream, in `github_tool.py` never fetching file data at
all. Worth double-checking my assumption that `file_structure` should be a
flat newline-joined string rather than a list, since `_detect_tests`/
`_detect_ci` call `str(...).lower()` on it — I matched that existing
expectation rather than changing `repo_analyzer.py`.