### PR TITLE
fix: handle None context chunk text in FaithfulnessChecker

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -41,7 +41,7 @@ None.
 
 ### Check-in 2 (end of week)
 
-**PR link:** [to be added once submitted to ascherj/pathreview]
+**PR link:** https://github.com/ascherj/pathreview/pull/600
 
 **Branch:** `fix/153-rag-chunk-error`
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -16,10 +16,10 @@
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [link to commit documenting the reproduced issue]
+**Reproduction commit link:** https://github.com/DineshM4/pathreview/commit/f83a2cf75f614a926b17ca2399c9106f1fc47056
 
 **Reproduction summary:** Ran the minimal repro (FaithfulnessChecker().check('Knows Python.', [{'text': None}])) and the failing test test_none_context_chunk_text against the project venv, both of which raised TypeError: sequence item 0: expected str instance, NoneType found at faithfulness_checker.py:34. This confirmed that chunk.get("text", "") returns None (not the "" default) when the text key is present but null, and " ".join(...) then crashes on the non-string item.
 
-**PLAN.md link:** [link to PLAN.md in your fork]
+**PLAN.md link:** https://github.com/DineshM4/pathreview/blob/fix/153-rag-chunk-error/PLAN.md
 
 **Blockers or open questions:** None

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -23,3 +23,34 @@
 **PLAN.md link:** https://github.com/DineshM4/pathreview/blob/fix/153-rag-chunk-error/PLAN.md
 
 **Blockers or open questions:** None
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the core fix from PLAN.md. Changed the context concatenation in `rag/evaluator/faithfulness_checker.py` from `chunk.get("text", "")` to `chunk.get("text") or ""`. The `or ""` guardrail coerces an explicitly-null `text` value (`{"text": None}`) to an empty string before `" ".join(...)`, which is the exact case the missing-key default never handled. The previously-failing `test_none_context_chunk_text` now passes.
+
+**Next steps:**
+Add one more regression test covering a `None` chunk mixed with valid chunks (to confirm valid text is still used and not just that it avoids crashing), run the full self-review, and open the PR.
+
+**Blockers:**
+None.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [to be added once submitted to ascherj/pathreview]
+
+**Branch:** `fix/153-rag-chunk-error`
+
+**What you built:**
+A one-line guardrail fix in `FaithfulnessChecker.check()` that stops the faithfulness checker from crashing when a retrieved context chunk has `text: None`. Replacing `chunk.get("text", "")` with `chunk.get("text") or ""` coerces a null text value to an empty string so `" ".join(...)` no longer raises `TypeError: sequence item 0: expected str instance, NoneType found`.
+
+**Tests added or updated:**
+`tests/unit/test_faithfulness_checker.py` — the existing `test_none_context_chunk_text` (which reproduced the bug) now passes. `test_none_chunk_mixed_with_valid_chunks` now covers a `None` chunk mixed with valid chunks to pass.
+
+**Self-review confirmation:** [x] make check passes (ruff + black clean on the changed file)  [x] make test-unit passes for the target test — note: the repo has ~52 pre-existing unit-test failures in unrelated modules (skill_extractor, tech_detector, structural_chunker) plus 3 pre-existing failures in the scoring-math tests of this file; all were verified to fail on the original code before my change and are outside the scope of issue #153.
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -13,3 +13,13 @@
 **Setup confirmation:** Yes, App runs locally at localhost:5173
 
 **Cohort ledger:** Yes, Issue added to cohort ledger in row 108
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [link to commit documenting the reproduced issue]
+
+**Reproduction summary:** Ran the minimal repro (FaithfulnessChecker().check('Knows Python.', [{'text': None}])) and the failing test test_none_context_chunk_text against the project venv, both of which raised TypeError: sequence item 0: expected str instance, NoneType found at faithfulness_checker.py:34. This confirmed that chunk.get("text", "") returns None (not the "" default) when the text key is present but null, and " ".join(...) then crashes on the non-string item.
+
+**PLAN.md link:** [link to PLAN.md in your fork]
+
+**Blockers or open questions:** None

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -54,3 +54,37 @@ A one-line guardrail fix in `FaithfulnessChecker.check()` that stops the faithfu
 **Self-review confirmation:** [x] make check passes (ruff + black clean on the changed file)  [x] make test-unit passes for the target test — note: the repo has ~52 pre-existing unit-test failures in unrelated modules (skill_extractor, tech_detector, structural_chunker) plus 3 pre-existing failures in the scoring-math tests of this file; all were verified to fail on the original code before my change and are outside the scope of issue #153.
 
 **Draft PR feedback received from:** none
+
+---
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+[What did reviewers comment on? Or note that no review came in.]
+
+**How you responded:**
+[What changes did you make, or what did you reply? If no feedback,
+leave blank.]
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The one-line fix in `rag/evaluator/faithfulness_checker.py:34` was trivial; establishing that it was correct was not. I had to internalize that `dict.get("text", "")` only falls back to `""` on a *missing key*, never on a present-but-null value, so the crash was `" ".join()` receiving `None` rather than anything wrong with the default. Then `make test-unit` surfaced ~52 unrelated failures (skill_extractor, tech_detector, structural_chunker) plus 3 scoring-math failures in my own test file, and I had to re-run them on unmodified `main` to prove they were pre-existing and not mine.
+
+**What did you learn about working in a large codebase?**
+In my own projects I'd have normalized every chunk at the boundary or added a schema validator; here the correct move was the smallest diff that closes the issue without changing behavior any other caller depends on. `chunk.get("text") or ""` also silently absorbs `0` and `[]`, which I accepted only because the field is a text string by contract. That kind of "is this coercion safe for this specific field" reasoning only comes from reading the surrounding code, not from the issue text.
+
+**How did AI tools help — and where did they fall short?**
+AI was most useful for orientation — locating the `join()` call site, drafting the minimal repro `FaithfulnessChecker().check("Knows Python.", [{"text": None}])`, and scaffolding `test_none_chunk_mixed_with_valid_chunks`. Where it fell short was scope judgment: it would happily have "fixed" the unrelated failing modules or widened the change into input validation across the evaluator. Deciding that issue #153 ends at the `None`-to-`""` coercion, and that the other 55 failures were explicitly out of scope, was a call I had to make and defend in the PR.
+
+**What would you do differently if you started over?**
+I'd capture a baseline `make test-unit` run on untouched `main` before writing a single line, so pre-existing failures were recorded up front instead of reconstructed afterward. I'd also write the mixed-chunk regression test in the same commit as the repro test, since "doesn't crash" and "still concatenates the valid text" are two different guarantees and I initially only proved the first. Finally I'd open the draft PR earlier to get review in flight rather than finishing everything before asking.
+
+**What are you most proud of from this module?**
+The reproduction, not the patch. I pinned the exact failure mechanism — `TypeError: sequence item 0: expected str instance, NoneType found` traced to a null `text` slipping past the `get()` default into `" ".join(...)` — and committed that as a failing test before changing any production code. Because of that, the fix was a one-line consequence of a diagnosis rather than a guess that happened to make a test go green.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -70,8 +70,6 @@ A one-line guardrail fix in `FaithfulnessChecker.check()` that stops the faithfu
 [What changes did you make, or what did you reply? If no feedback,
 leave blank.]
 
----
-
 ### Reflection
 
 **What was harder than you expected?**

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,15 @@
+## Week 7 — Issue selection
+
+**Issue link:** (https://github.com/ascherj/pathreview/issues/153)
+
+**Issue title:** Faithfulness checker crashes when a context chunk has text: None #153
+
+**Tier:** Tier 1. Since it is my first time contributing I wanted to do an issue that would be easier for me to fix. Additionally I am more experienced in RAG and ingestion compared to some of the other topics on this issue lists(API, Database, etc.), and decided it would be better to work on a issue that I have more experience in. As such I chose this tier 1 issue which focuses on RAG as it covers both my criterias.
+
+**Problem summary:** The issue revolves around the get() function when chunking. get() works but getting the required value, in this case the text or if it does not exists it doesn't crash the program by letting us send a "default" value to insert. However, what if the orignal retrieved value is NONE? In this case, the get() function will recieve the NONE and send that into a join() method which ends up giving an error as it requires the same type(Strings). A succesful fix would be adding a guardrail for this specific case with if statements or the "or" keyword to prevent this issue from occuring, letting the chunker work as it should.
+
+**Branch name:** fix/153-rag-chunk-error
+
+**Setup confirmation:** Yes, App runs locally at localhost:5173
+
+**Cohort ledger:** Yes, Issue added to cohort ledger in row 108

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,40 @@
+## Solution plan
+
+**Issue:** Faithfulness checker crashes when a context chunk has text: None #153
+**Link:** https://github.com/ascherj/pathreview/issues/153
+
+### Understand
+What is the root cause of this issue? What behavior is expected vs. actual?
+
+The root cause is `chunk.get("text", "")` in `FaithfulnessChecker.check()`: the `""` default only applies when the `text` key is missing, so a present-but-null value (`{"text": None}`) returns `None`. That `None` reaches `" ".join(...)`, which requires all items to be strings. Expected: the checker coerces null text and returns a valid float score; actual: it raises `TypeError: sequence item 0: expected str instance, NoneType found`.
+
+### Map
+Which files, functions, or modules are involved?
+List the specific files you expect to touch.
+
+- `rag/evaluator/faithfulness_checker.py` — the `check()` method, specifically the context-concatenation list comprehension at lines 34–36.
+- `tests/unit/test_faithfulness_checker.py` — already contains the failing `test_none_context_chunk_text` that reproduces the bug and will verify the fix.
+
+### Plan
+What are the steps to fix this issue?
+Break it into 3–5 concrete sub-tasks.
+
+1. Replace `chunk.get("text", "")` with `chunk.get("text") or ""` so both missing and null values coerce to an empty string.
+2. Run `test_none_context_chunk_text` to confirm it now passes.
+3. Run the full `test_faithfulness_checker.py` suite to ensure no regressions.
+4. Commit the fix on branch `fix/153-rag-chunk-error` and open a PR referencing issue #153.
+
+### Inputs & outputs
+What does your fix take as input? What should it produce or change?
+
+Input: `feedback` (str) and `context_chunks` (list of dicts) where a chunk's `text` may be missing, `None`, or a string. Output: a faithfulness score as a float in `[0.0, 1.0]`, with null/missing chunk text treated as empty and never crashing.
+
+### Risks & unknowns
+What could go wrong? What are you still unsure about?
+
+Using `or ""` also converts other falsy values (e.g. `0` or `False`) to empty strings, which is fine here since `text` is expected to be a string. Overall risk is low since the change is one line covered by existing tests; the main unknown is whether any caller relies on the current crashing behavior, which is unlikely.
+
+### Edge cases
+What inputs or states should your fix handle gracefully?
+
+`{"text": None}` (present but null), `{"content": "..."}` (missing `text` key), and multiple chunks mixing valid text with null/missing values. All should produce a valid float score without raising.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -449,7 +449,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -473,7 +472,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1561,7 +1559,6 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1579,7 +1576,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1972,7 +1968,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3507,7 +3502,6 @@
       "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^2.0.1",
         "cssstyle": "^4.0.1",
@@ -4094,7 +4088,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4107,7 +4100,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4771,7 +4763,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/rag/evaluator/faithfulness_checker.py
+++ b/rag/evaluator/faithfulness_checker.py
@@ -1,6 +1,7 @@
 """Check if generated feedback is supported by retrieved context."""
 
 import re
+
 import structlog
 
 logger = structlog.get_logger()
@@ -20,8 +21,11 @@ class FaithfulnessChecker:
             Faithfulness score 0.0-1.0 (ratio of supported claims)
         """
         if not feedback or not context_chunks:
-            logger.info("faithfulness_empty_input", has_feedback=bool(feedback),
-                       has_chunks=bool(context_chunks))
+            logger.info(
+                "faithfulness_empty_input",
+                has_feedback=bool(feedback),
+                has_chunks=bool(context_chunks),
+            )
             return 0.0
 
         # Extract key claims from feedback (sentences)
@@ -31,9 +35,7 @@ class FaithfulnessChecker:
             return 0.5  # Default to neutral if no extractable claims
 
         # Concatenate context text
-        context_text = " ".join([
-            chunk.get("text", "") for chunk in context_chunks
-        ])
+        context_text = " ".join([chunk.get("text") or "" for chunk in context_chunks])
 
         # Check each claim for support
         supported = 0
@@ -43,8 +45,9 @@ class FaithfulnessChecker:
 
         score = supported / len(claims) if claims else 0.0
 
-        logger.info("faithfulness_checked", claims_count=len(claims),
-                   supported_count=supported, score=score)
+        logger.info(
+            "faithfulness_checked", claims_count=len(claims), supported_count=supported, score=score
+        )
 
         return score
 
@@ -59,7 +62,7 @@ class FaithfulnessChecker:
             List of claims (sentences)
         """
         # Split by sentence (simple regex)
-        sentences = re.split(r'[.!?]+', text)
+        sentences = re.split(r"[.!?]+", text)
         claims = [s.strip() for s in sentences if s.strip() and len(s.strip()) > 10]
         return claims[:10]  # Limit to 10 claims for scoring
 
@@ -81,8 +84,25 @@ class FaithfulnessChecker:
         # Require at least some meaningful overlap
         overlap = claim_tokens & context_tokens
         # Filter out common stop words
-        stop_words = {'a', 'an', 'the', 'is', 'are', 'was', 'were', 'be', 'been',
-                     'and', 'or', 'but', 'in', 'of', 'to', 'for', 'that'}
+        stop_words = {
+            "a",
+            "an",
+            "the",
+            "is",
+            "are",
+            "was",
+            "were",
+            "be",
+            "been",
+            "and",
+            "or",
+            "but",
+            "in",
+            "of",
+            "to",
+            "for",
+            "that",
+        }
         meaningful_overlap = overlap - stop_words
 
         return len(meaningful_overlap) >= 2

--- a/tests/unit/test_faithfulness_checker.py
+++ b/tests/unit/test_faithfulness_checker.py
@@ -18,9 +18,7 @@ class TestFaithfulnessChecker:
         """Test feedback fully supported by context returns score close to 1.0."""
         feedback = "The developer has strong Python skills and experience with Django."
         context_chunks = [
-            {
-                "text": "The portfolio shows Python expertise and Django framework experience."
-            },
+            {"text": "The portfolio shows Python expertise and Django framework experience."},
         ]
 
         score = checker.check(feedback, context_chunks)
@@ -34,9 +32,7 @@ class TestFaithfulnessChecker:
         """Test feedback with no support in context returns score close to 0.0."""
         feedback = "This developer is an expert in Rust systems programming."
         context_chunks = [
-            {
-                "text": "The developer has Python and JavaScript experience."
-            },
+            {"text": "The developer has Python and JavaScript experience."},
         ]
 
         score = checker.check(feedback, context_chunks)
@@ -48,9 +44,7 @@ class TestFaithfulnessChecker:
         """Test partial support returns score between 0 and 1."""
         feedback = "The developer shows Python expertise and Kubernetes knowledge."
         context_chunks = [
-            {
-                "text": "Strong Python programming skills demonstrated in projects."
-            },
+            {"text": "Strong Python programming skills demonstrated in projects."},
         ]
 
         score = checker.check(feedback, context_chunks)
@@ -63,9 +57,7 @@ class TestFaithfulnessChecker:
     def test_empty_feedback_returns_zero(self, checker):
         """Test empty feedback returns 0.0."""
         feedback = ""
-        context_chunks = [
-            {"text": "Some context"}
-        ]
+        context_chunks = [{"text": "Some context"}]
 
         score = checker.check(feedback, context_chunks)
 
@@ -155,15 +147,11 @@ class TestFaithfulnessChecker:
         """Test that score varies with input, never hardcoded 1.0 or 0.0."""
         # First test: fully supported
         score1 = checker.check(
-            "Python and JavaScript skills",
-            [{"text": "Expert in Python and JavaScript"}]
+            "Python and JavaScript skills", [{"text": "Expert in Python and JavaScript"}]
         )
 
         # Second test: no support
-        score2 = checker.check(
-            "Rust expertise",
-            [{"text": "Java programming background"}]
-        )
+        score2 = checker.check("Rust expertise", [{"text": "Java programming background"}])
 
         # Scores should be different
         assert score1 != score2
@@ -173,9 +161,7 @@ class TestFaithfulnessChecker:
     def test_multiple_claims_varying_support(self, checker):
         """Test scoring with multiple claims of varying support."""
         feedback = "Python expert. Knows Rust. Skilled with Docker."
-        context_chunks = [
-            {"text": "Python and Docker expertise shown in projects."}
-        ]
+        context_chunks = [{"text": "Python and Docker expertise shown in projects."}]
 
         score = checker.check(feedback, context_chunks)
 
@@ -186,9 +172,7 @@ class TestFaithfulnessChecker:
     def test_very_long_feedback(self, checker):
         """Test handling of very long feedback text."""
         feedback = "The developer. " * 100
-        context_chunks = [
-            {"text": "Developer portfolio content"}
-        ]
+        context_chunks = [{"text": "Developer portfolio content"}]
 
         score = checker.check(feedback, context_chunks)
 
@@ -198,9 +182,7 @@ class TestFaithfulnessChecker:
     def test_very_long_context(self, checker):
         """Test handling of very long context."""
         feedback = "The developer has Python skills."
-        context_chunks = [
-            {"text": "Python " * 1000}
-        ]
+        context_chunks = [{"text": "Python " * 1000}]
 
         score = checker.check(feedback, context_chunks)
 
@@ -211,7 +193,8 @@ class TestFaithfulnessChecker:
         """Test that common stop words are filtered in overlap calculation."""
         # This test verifies that "the", "is", "and" etc. don't count as meaningful overlap
         claim = "The project is well documented"
-        context = "The project is poorly documented"  # Opposite meaning but same stop words
+        # Opposite meaning but same stop words
+        context = "The project is poorly documented"
 
         supported = checker._is_supported(claim, context)
 
@@ -231,9 +214,7 @@ class TestFaithfulnessChecker:
     def test_none_context_chunk_text(self, checker):
         """Test handling of None in context chunk text."""
         feedback = "Has Python skills"
-        context_chunks = [
-            {"text": None}
-        ]
+        context_chunks = [{"text": None}]
 
         score = checker.check(feedback, context_chunks)
 
@@ -241,12 +222,23 @@ class TestFaithfulnessChecker:
         assert isinstance(score, float)
         assert 0.0 <= score <= 1.0
 
+    def test_none_chunk_mixed_with_valid_chunks(self, checker):
+        """None text among valid chunks is skipped, not crashing; valid text still counts."""
+        feedback = "Has Python skills."
+        context_chunks = [
+            {"text": None},
+            {"text": "Strong Python skills demonstrated"},
+        ]
+
+        score = checker.check(feedback, context_chunks)
+
+        assert isinstance(score, float)
+        assert score > 0.0  # valid chunk's text is still used for support
+
     def test_missing_text_key_in_chunk(self, checker):
         """Test handling of missing 'text' key in context chunk."""
         feedback = "Has Python skills"
-        context_chunks = [
-            {"content": "Python skills"}  # Wrong key
-        ]
+        context_chunks = [{"content": "Python skills"}]  # Wrong key
 
         score = checker.check(feedback, context_chunks)
 


### PR DESCRIPTION
## Summary

`FaithfulnessChecker.check()` in `rag/evaluator/faithfulness_checker.py` crashed
with a `TypeError` when a retrieved context chunk had an explicitly-null `text`
value (`{"text": None}`). The context-concatenation step now coerces a null
`text` to an empty string before `" ".join(...)`, so a `None` chunk is skipped
harmlessly and the checker continues scoring against the remaining valid chunks.

## Issue

Closes #153

## Changes

Root cause: the concatenation used `chunk.get("text", "")`, whose `""` default
only applies when the `text` key is **missing**. When the key is present but
`None` (a real shape produced upstream in the RAG pipeline), `get()` returns
`None`, and `" ".join([...None...])` raises
`TypeError: sequence item 0: expected str instance, NoneType found`. There was no
guard for the present-but-null case.

- `rag/evaluator/faithfulness_checker.py` — changed the context concatenation
  from `chunk.get("text", "")` to `chunk.get("text") or ""`. The `or ""`
  guardrail coerces a null `text` value to an empty string so the join operates
  only on strings; valid chunks in the same list are still concatenated and used
  for support scoring
- `tests/unit/test_faithfulness_checker.py` — the existing
  `test_none_context_chunk_text` (which reproduced the crash) now passes; added
  `test_none_chunk_mixed_with_valid_chunks` to confirm a `None` chunk mixed with
  valid chunks is skipped without crashing **and** that the valid chunk's text
  still contributes to the score
- No changes to callers were needed — the fix is contained to the concatenation
  step and preserves the existing `0.0–1.0` return contract

## Testing

- [x] Unit tests pass (`make test-unit`) — the target file's `None`-handling
      tests (`test_none_context_chunk_text`, `test_none_chunk_mixed_with_valid_chunks`)
      pass; see Notes for pre-existing unrelated failures
- [ ] Integration tests pass (`make test-integration`) — not run; change is a
      contained unit-level fix in the RAG evaluator
- [x] Linter passes (`make lint`) — ruff + black clean on the changed source file
- [x] Type checker passes (`make typecheck`) — mypy clean on the changed source file
- [x] New/updated tests cover the changes

**Reproduce the original bug (before the fix, on `main`):**
1. Check out `main`
2. In the project venv, run:
   ```python
   from rag.evaluator.faithfulness_checker import FaithfulnessChecker
   FaithfulnessChecker().check("Knows Python.", [{"text": None}])
   ```
3. Observe: `TypeError: sequence item 0: expected str instance, NoneType found`
   raised at `faithfulness_checker.py` in the `" ".join(...)` step

**Verify the fix (on this branch):**
1. Check out `fix/153-rag-chunk-error`
2. Run the same snippet
3. Expected: returns a `float` in `0.0–1.0` (no exception); a mixed list such as
   `[{"text": None}, {"text": "Strong Python skills demonstrated"}]` returns a
   score `> 0.0`, confirming the valid chunk is still used

## Screenshots / Demo

N/A — internal RAG-evaluator change with no UI surface; the observable behavior
is the absence of the `TypeError` and a valid float score in the steps above.

## Notes for Reviewers

- The changed source file (`rag/evaluator/faithfulness_checker.py`) is clean on
  ruff, black, and mypy.
- `make test-unit` still reports pre-existing failures unrelated to this change:
  ~52 failures in other modules (`skill_extractor`, `tech_detector`,
  `structural_chunker`) and 3 scoring-math tests in
  `test_faithfulness_checker.py` (`test_partial_support_returns_middle_score`,
  `test_multiple_context_chunks`, `test_multiple_claims_varying_support`). All
  were verified to fail on the original code before this change and are outside
  the scope of #153.