### PR TITLE
test(api): add integration tests for authentication middleware

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -84,7 +84,7 @@ disposing the pool on fixture entry resolved it.
 
 ### Check-in 2 (end of week)
 
-**PR link:** «FILL: paste the https://github.com/ascherj/pathreview/pull/NNN URL after opening»
+**PR link:** https://github.com/ascherj/pathreview/pull/601
 
 **Branch:** `test/90-auth-middleware-edge-cases`
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -38,3 +38,111 @@ None blocking. One boundary I am tracking: issue E-04 ("Authentication middlewar
 token expiry") may later change the expired-token message from the generic 401 to "Token has
 expired", which would require updating my expired-token assertion. I test the current behavior and
 note the dependency rather than coupling the two tickets.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implementation is complete. PLAN.md steps 1 through 9 are done and committed as `5998390`, and
+step 10 (verification) is finished apart from opening the pull request. I brought up Postgres
+(`docker compose up -d db`, `make migrate`), wrote three fixtures in a new
+`tests/integration/conftest.py` (`async_client`, `test_user`, `auth_token`), and replaced the four
+skipped stubs from Week 8 with seven tests covering thirteen parametrized cases:
+absent credential, undecodable token, expired token, bad signature or algorithm, a token with no
+`sub` claim, a valid token for a user that does not exist, and a valid token for a user that does.
+`make test-integration` reports 13 passed, 0 skipped. Both project baselines are unchanged from
+the readings I took before writing any code — `make check` still reports 182 pre-existing ruff
+errors and `make test-unit` still reports 53 failed / 375 passed — so this branch introduces no
+new failures.
+
+Mid-week I corrected the plan's scope, which is the most significant thing that happened. The
+original plan covered only the four rejection paths the issue names and deliberately excluded a
+valid-token test. That was wrong: a suite made entirely of rejection tests would pass against a
+middleware that rejected *every* request, valid credentials included, so it could not actually
+detect the failure it exists to catch. I re-derived coverage from the exits of `get_current_user`
+itself rather than from the issue's bullet list, which took the plan from four scenarios to eight
+and reached five of the function's eight exits. PLAN.md has been rewritten, with a revision
+history recording what changed and why.
+
+**Next steps:**
+Update my PR description for the final scope, open the pull request against `ascherj/pathreview`
+as a draft, and ask for peer review in Slack. Once feedback is addressed I will mark it ready for
+review, add Check-in 2 with the PR link and both self-review confirmations, and submit the branch
+URL through the course portal.
+
+**Blockers:**
+None. Two things I worked around rather than fixed, both documented for reviewers. First, the
+pre-commit mypy hook fails with 44 errors across seven files in `api/` and `core/`; all are
+pre-existing, none are in files I touched, and mypy only sees them because my tests import
+`api.main`. I committed with `SKIP=mypy` so that ruff and black still ran. Second, adding the
+database-backed tests produced a cross-event-loop `asyncpg` failure, because pytest-asyncio
+creates a fresh event loop per test while `core/database.py` holds a module-level connection pool;
+disposing the pool on fixture entry resolved it.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** «FILL: paste the https://github.com/ascherj/pathreview/pull/NNN URL after opening»
+
+**Branch:** `test/90-auth-middleware-edge-cases`
+
+**What you built:**
+This adds the repository's first integration tests for `get_current_user`
+(`api/middleware/auth.py`), the dependency guarding every protected route, which previously had no
+test coverage of any kind. Seven tests drive the real FastAPI app and a real Postgres database
+through `httpx.AsyncClient`, presenting each kind of credential — absent, undecodable, expired,
+wrongly signed, claimless, valid-but-unknown, and valid — to the protected `GET /reviews` route and
+asserting the exact status code and error message the middleware returns. No production code
+changed; this closes a test-coverage gap rather than fixing a bug.
+
+**Tests added or updated:**
+Two new files, both under `tests/integration/`.
+
+`tests/integration/test_auth_middleware.py` holds seven tests, thirteen cases once parametrized,
+covering five of the eight ways `get_current_user` can exit:
+
+- `test_absent_credential_returns_401` — no `Authorization` header at all, and a present-but-wrong
+  `Basic` scheme. Both assert `401` with the detail `"Not authenticated"`, which comes from
+  `OAuth2PasswordBearer` before the middleware runs at all.
+- `test_undecodable_token_returns_401` — four bearer tokens the JWT decoder cannot read: a non-JWT
+  string, a two-segment token, undecodable base64, and an empty token. All assert `401` with
+  `"Invalid authentication credentials"`.
+- `test_expired_token_returns_401` — a correctly signed token whose expiry is in the past. It
+  asserts the *generic* message rather than the `"Token has expired"` the middleware appears to
+  intend, because `decode_access_token` catches the expiry error and returns `None` before that
+  branch can run.
+- `test_bad_signature_or_algorithm_returns_401` — three forgeries that are structurally perfect and
+  unexpired, differing only in how they are signed: a token signed with a foreign secret, one
+  signed with the real secret but a non-whitelisted `HS512`, and a hand-assembled `alg=none` token
+  with an empty signature. Together these prove the `algorithms=["HS256"]` whitelist is what
+  protects the route.
+- `test_token_without_sub_claim_returns_401` — a valid, decodable token carrying no `sub` claim.
+  This is the only rejection that gets *past* the decoder, reaching the claim check.
+- `test_token_for_unknown_user_returns_401` — a valid token whose subject is a well-formed UUID
+  with no matching row, so the rejection happens after the database lookup returns nothing.
+- `test_valid_token_for_existing_user_returns_200` — a valid token for a user persisted by the
+  fixtures reaches the route and returns `200` with an empty result list. This case is what makes
+  the other six meaningful: without it, the suite would pass against a middleware that rejected
+  every request unconditionally.
+
+`tests/integration/conftest.py` is new and holds three shared fixtures: `async_client` (an
+`httpx.AsyncClient` wired to the app over `ASGITransport`), `test_user` (persists a real user row
+and deletes it afterwards), and `auth_token` (a valid JWT signed for that user by the app's own
+`create_access_token`). Both async fixtures dispose the SQLAlchemy connection pool on entry,
+because pytest-asyncio creates a fresh event loop per test while `core/database.py` holds a
+module-level pool, so a pooled connection can otherwise outlive the loop that opened it.
+
+**Self-review confirmation:** [x] make check passes [x] make test-unit passes
+
+Both are ticked in the sense the assignment defines for a codebase with documented pre-existing
+failures: my changes introduce no new ones. I recorded both gates before writing any code and
+again afterwards, and the numbers are identical — `make check` reports 182 pre-existing ruff errors
+and aborts at its lint stage both times, and `make test-unit` reports 53 failed / 375 passed both
+times. None of those failures is in a file this branch touches, and `make test-unit` runs
+`tests/unit` only, so it cannot be affected by tests added under `tests/integration/`. Scoped
+`ruff` and `black` pass cleanly on both new files, and `make test-integration` reports 13 passed,
+0 skipped.
+
+**Draft PR feedback received from:** Joseph Gutierrez 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -145,4 +145,81 @@ times. None of those failures is in a file this branch touches, and `make test-u
 `ruff` and `black` pass cleanly on both new files, and `make test-integration` reports 13 passed,
 0 skipped.
 
-**Draft PR feedback received from:** Joseph Gutierrez 
+**Draft PR feedback received from:** Joseph Gutierrez ---
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes [x] No — still awaiting review
+
+**Summary of feedback:**
+No review arrived. I opened PR #601 against `ascherj/pathreview` on August 2 and it has been open
+and marked ready for review ever since; as of August 6 it carries zero reviews and zero comments.
+Maintainer review is not part of this cohort, so this was the expected outcome rather than a sign
+the PR was overlooked.
+
+**How you responded:**
+There was nothing to respond to, so I left the PR open and ready for review rather than closing it,
+and I re-checked it immediately before submitting this entry to confirm no feedback had landed in
+the interim.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The scope. Issue #90 reads like four small tests, one per rejection path the issue names, and that
+is exactly how I planned it in Week 8, four skipped stubs and a deliberate decision not to touch
+the database. Once I started unpacking what those tests actually needed, that plan fell apart: a
+suite made only of rejection cases would pass against a middleware that rejected every request,
+valid credentials included, so it could not detect the failure it exists to catch. Fixing that
+meant standing up Postgres, persisting a real user, and signing a real token which was the exact work 
+I had scoped out. And it landed late in the week instead of at planning time. What surprised me is 
+that none of the difficulty lived in the code; after twenty years in the field, converting the fixtures
+to async and following that pattern through was routine. The hard part was that the true shape of
+the job only became visible after I had already committed to a smaller one.
+
+**What did you learn about working in a large codebase?**
+That it is sometimes correct to put blinders on. `make check` reports 182 pre-existing ruff errors
+on this repo and `make test-unit` reports 53 failures, and the pre-commit mypy hook fails with 44
+more across seven files in `api/` and `core/` that I never touched. It only sees them because my
+tests import `api.main`. I committed with `SKIP=mypy` so that ruff and black still ran, which is
+not something I would ever do in a project of my own. In a codebase this size the pre-existing
+problems will absorb exactly as much attention as you give them, and scoping tightly to the files
+you actually own is what keeps that from swallowing the week. I found that genuinely hard: errors
+feel wrong to me even when I know they are documented, expected, and not mine to fix.
+
+**How did AI tools help — and where did they fall short?**
+The most valuable thing AI did for me this module had almost nothing to do with writing code. I
+have executive functioning problems, so I built my own tooling, like a kickoff skill and a
+grader-simulation skill, that turns each week's rubric into a ledger of required exhibits and then
+audits the graded artifact against that ledger before I submit. That scaffolding is the bedrock of
+how I keep up. The engineering itself I can do on my own, but doing it on a deadline against a
+specific spec is where I have historically lost whole projects. Where it fell short was judgment
+about scope. The Week 8 plan to cover only the four rejection paths and skip the database was
+written with AI assistance, and it was confidently wrong. Nothing in that conversation
+flagged that a suite made entirely of rejection tests proves nothing about a middleware that
+rejects everything. It is the one point in the module where I got genuinely angry at the tool. What
+corrected it was reading the exits of `get_current_user` in `api/middleware/auth.py` myself. 
+
+**What would you do differently if you started over?**
+I would have pushed back immediately on the plan to avoid the database. I was optimizing for how
+long the work would take rather than how well it would work, and that is exactly why it ran long.
+The fixtures I skipped in Week 8 had to be written anyway in Week 9, under deadline, as
+`tests/integration/conftest.py`. Scoping to save time is what cost me the time. The second thing I
+would change came out of the feedback on my Week 9 submission, and I agree with it: my `test_user`
+fixture writes a row to a shared dev database and removes it in teardown, so a run that dies
+mid-test leaks a row that breaks the next run, where binding each test to a single connection and
+rolling back a transaction would make cleanup impossible to skip. The related point is one I would
+not have reached on my own. I treated the module-level connection pool in `core/database.py` as a
+constraint to work around, disposing the pool on fixture entry so it could survive pytest-asyncio's
+per-test event loop, when the fact that it made testing fragile was really signal about the
+production code's coupling. Next time I want to read that kind of friction as information rather
+than as an obstacle.
+
+**What are you most proud of from this module?**
+Completion. I have battled ADHD for half my life, and showing up ten weeks running through the lectures,
+issue selection, `PLAN.md`, PR #601, and now this reflection, and finishing each one before its deadline
+is not a small thing for me by any stretch of the word. The code was never the part in question, but 
+being there to write it is the fight. I fought it and won, and I want to do it again.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,19 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/90
+**Issue title:** Add integration tests for authentication edge cases
+**Tier:** [ ] Tier 1 [x] Tier 2 [ ] Tier 3
+
+**Problem summary:**
+There are currently no integration tests whatsoever for the authentication middleware. The issue identifies four specific gaps: expired tokens, malformed tokens, a missing Authorization header, and tokens signed with a different secret. This matters because right now we have no way to know whether an authentication bug is allowing unauthorized access to protected routes — the middleware is only exercised with a valid token, so any regression in the rejection paths would pass unnoticed. A successful fix means each of those four cases is covered by an automated test that fails if the middleware ever stops rejecting them. Because there are no integration tests in the repository yet, this also establishes the pattern that future integration tests will follow.
+
+**Selection notes:**
+I selected this issue because I want to focus on the contribution process as much as the implementation. I'm a professional developer and the code itself is familiar territory, but my commit and merge practices have always been low-key and built on worn-out habits, so getting the contribution side right matters more to me here than picking the hardest available problem. I could potentially contribute at a higher tier, but given time constraints I felt it prudent to prioritize the ability to finish within the timeframe above everything else.
+
+I ultimately decided on Tier 2 to balance the time commitment against doing meaningful work. I rejected #102, a Tier 3 frontend issue estimated at 7–10 hours, even though I would have found it more interesting, in favor of this one at 3–5 hours, both lower risk and smaller scope. Test work also degrades gracefully: if my available hours evaporate, four solid tests is still a complete, mergeable PR, whereas a half-finished feature would be nothing. If I get through this cleanly and come out knowing the codebase better, I can take on a higher tier for a second issue.
+
+I did notice that there are no integration tests whatsoever and conftest.py has no client fixture, so I'll be establishing a pattern rather than following one. That is a front-loaded risk I'm accepting knowingly rather than discovering later. I've worked through the "Is this issue right for me?" checklist and this fits.
+
+**Branch name:** test/90-auth-middleware-edge-cases
+**Setup confirmation:** [x] App runs locally at localhost:5173
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -17,3 +17,24 @@ I did notice that there are no integration tests whatsoever and conftest.py has 
 **Branch name:** test/90-auth-middleware-edge-cases
 **Setup confirmation:** [x] App runs locally at localhost:5173
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/houdinii/pathreview/commit/968fd45c59b5e328a861136cf41a95b1933410c4
+
+**Reproduction summary:**
+This is a test-coverage gap rather than a runtime bug, so I reproduced it by proving the rejection
+paths have no coverage today: a grep for `get_current_user` across `tests/` exits 1 (zero hits) and
+`tests/integration/` holds only `__init__.py`. I then confirmed the current behavior of each case by
+probing the protected `GET /reviews` route — a missing header returns 401 "Not authenticated", while
+malformed, expired, and wrong-secret tokens all return 401 "Invalid authentication credentials". The
+reproduction commit adds four skipped test stubs naming those cases and documents the confirmed
+behavior in its message.
+
+**PLAN.md link:** https://github.com/houdinii/pathreview/blob/test/90-auth-middleware-edge-cases/PLAN.md
+
+**Blockers or open questions:**
+None blocking. One boundary I am tracking: issue E-04 ("Authentication middleware doesn't validate
+token expiry") may later change the expired-token message from the generic 401 to "Token has
+expired", which would require updating my expired-token assertion. I test the current behavior and
+note the dependency rather than coupling the two tickets.

--- a/PLAN.md
+++ b/PLAN.md
@@ -2,132 +2,162 @@
 
 **Issue:** Add integration tests for authentication edge cases — https://github.com/ascherj/pathreview/issues/90
 
+> **Revised 2026-08-01.** The original plan (2026-07-26) scoped this to four rejection paths and
+> excluded happy-path coverage. That was wrong, and the revision history at the bottom of this
+> file records why. The plan below is the one being implemented.
+
 ### Understand
 
-The root cause is a **test-coverage gap, not a code bug**: no test in the repository exercises
-`get_current_user` (`api/middleware/auth.py`). A `grep` for the middleware across `tests/` exits
-`1` (zero hits) and `tests/integration/` contains only `__init__.py`, so the middleware is only
-ever exercised implicitly through the happy path.
+The issue states that "the auth middleware is tested with a valid token but there are no tests
+for" four rejection cases. The premise is false. No test in the repository references
+`get_current_user` at all — a `grep` across `tests/` returns zero hits, and `tests/integration/`
+contained only `__init__.py`. What exists is `tests/unit/test_security.py`, which tests the JWT
+helpers (`create_access_token`, `decode_access_token`) in isolation. Those prove the decoder
+returns `None` for bad input; nothing proves the middleware refuses entry to a protected route
+when it does.
 
-- **Expected:** each way of presenting a bad credential to a protected route returns `401`, and
-  that behavior is pinned by an automated test that fails if the middleware ever stops rejecting it.
-- **Actual:** the four rejection paths (missing header, malformed token, expired token, wrong-secret
-  token) have no coverage, so a regression that let unauthorized requests through would pass silently.
+So the real gap is wider than the issue describes: `get_current_user` has no coverage at all,
+neither its rejection paths nor its success path.
 
-I confirmed today's behavior by probing `GET /reviews` (a route guarded by `get_current_user`):
-a missing header returns `401 "Not authenticated"`; malformed, expired, and wrong-secret tokens all
-return `401 "Invalid authentication credentials"`. A successful fix is those behaviors captured as
-integration tests, plus the first integration-test pattern for this repo.
+- **Expected:** each way of presenting a credential to a protected route, good or bad, is pinned
+  by a test that fails if the middleware's behavior changes.
+- **Actual:** none of it is covered. A regression letting unauthorized requests through would pass
+  silently, and so would one rejecting every request.
 
-**Root cause:** No integration test imports or exercises `get_current_user`, so its four `401`
-rejection branches (`api/middleware/auth.py`) are untested — and `tests/integration/` has no fixture
-infrastructure to exercise them.
+That second failure mode is why rejection-only testing is insufficient: a middleware replaced with
+an unconditional `raise HTTPException(401)` would satisfy every rejection test. The success path is
+what gives the rejection tests meaning.
+
+**Root cause:** No test exercises `get_current_user` (`api/middleware/auth.py`), and
+`tests/integration/` has no fixture infrastructure with no app client, no persisted user, no token.
 
 ### Map
 
-This issue (manifest **E-15**) is scoped to a single new file. Files involved:
-
-- `tests/integration/test_auth_middleware.py` — **the only file changed.** Holds a module-level
-  `client` fixture (`TestClient(app)`) and the four rejection tests grouped in
-  `TestAuthMiddlewareRejections`. Kept self-contained (no `conftest.py` change) because the issue
-  scopes to one file and the rejection paths need no shared fixtures.
+- `tests/integration/conftest.py` *new* - Shared fixtures: an `async_client`
+  (`httpx.AsyncClient` over `ASGITransport`), a `test_user` that persists a real row and removes it
+  afterwards, and an `auth_token` signing a valid JWT for that user with the app's own helper.
+- `tests/integration/test_auth_middleware.py` — **the test module.** Seven tests, thirteen
+  parametrized cases.
 - Read-only references (not edited):
-  - `api/middleware/auth.py` — `get_current_user`; the four 401 branches under test.
-  - `core/security.py` — `create_access_token` / `decode_access_token`; used to forge the test JWTs.
-  - `api/routes/reviews.py` — `GET /reviews`, the protected route the tests hit.
-  - `api/main.py` — the `app` object the `TestClient` wraps.
+  - `api/middleware/auth.py` — `get_current_user`, the subject.
+  - `core/security.py` — `create_access_token` / `decode_access_token`; used to forge test JWTs.
+  - `core/database.py` — `get_db`, `AsyncSessionLocal`; the session the fixtures write through.
+  - `core/models/user.py` — the `User` row the happy path needs.
+  - `api/routes/reviews.py` — `GET /reviews`, the protected route under test.
+  - `api/main.py` — the `app` the clients wrap.
+  - `.venv/.../fastapi/security/oauth2.py` — `OAuth2PasswordBearer.__call__`, which owns the
+    `"Not authenticated"` response *before* `get_current_user` runs.
 
 ### Plan
 
-1. Add a module-level `client` fixture returning `TestClient(app)`. No `get_db` override is needed —
-   the four rejection paths raise before the DB lookup at `auth.py:58`.
-2. **Missing header** → request `GET /reviews` with no `Authorization` header; assert `401` and
-   `detail == "Not authenticated"`. Parametrize the "absent credential" variants: wrong scheme
-   (`Basic ...`) and an empty `Bearer` token.
-3. **Malformed token** → send junk bearer tokens (non-JWT string, wrong segment count, undecodable
-   base64) via `@pytest.mark.parametrize`; assert `401` and `detail == "Invalid authentication
-   credentials"`.
-4. **Expired token** → forge one with `create_access_token(..., expires_delta=timedelta(minutes=-5))`;
-   assert `401` and, specifically, `detail == "Invalid authentication credentials"` — pinning the
-   generic message, not `"Token has expired"`.
-5. **Wrong-secret token** → sign a structurally valid JWT with a different secret (and an
-   algorithm-confusion variant, e.g. `alg=none`/`HS512`); assert `401`.
-6. Run scoped checks green on the new file only: `ruff check`, `black`, `mypy`, and
-   `pytest tests/integration/test_auth_middleware.py`.
+Coverage is derived from the exits of `get_current_user`, not only from the issue's bullet list.
+Enumerating them (full trace in `personal/TRACE_AUTH_REQUEST.md`) gives eight; five are reachable
+without simulating infrastructure failure. The three uncovered are out of scope for this specific issue and will require additional issues to be resolved.
+
+1. **Bring up real infrastructure.** `docker compose up -d db`, `make migrate`. The
+   `integration` marker is defined in `pyproject.toml:87` as *"require Docker services"*, so these
+   tests use a real Postgres rather than a stubbed session.
+2. **Build the fixtures** in `tests/integration/conftest.py`: `async_client`, `test_user`,
+   `auth_token`.
+3. **Exit 1 — absent credential** → `401 "Not authenticated"`. Parametrized: no `Authorization`
+   header, and a non-`Bearer` scheme (`Basic ...`).
+4. **Exit 2 — undecodable token** → `401 "Invalid authentication credentials"`. Parametrized:
+   `not.a.jwt`, `a.b`, `aaa.bbb.ccc`, and the empty string (`Authorization: Bearer ` with no token).
+5. **Exit 2 — expired token** → same generic message. Forged with
+   `create_access_token(..., expires_delta=timedelta(minutes=-5))`.
+6. **Exit 2 — bad signature or algorithm** → same generic message. Parametrized: a JWT signed with
+   a foreign secret; one signed with the *correct* secret but `HS512`; and a hand-assembled
+   `alg=none` forgery, which `jose.encode` refuses to build and which must therefore be
+   constructed from base64 segments the way an attacker would.
+7. **Exit 3 — valid token, no `sub` claim** → same generic message. The only rejection that gets
+   *past* `decode_access_token`, raising at `auth.py:40-41`.
+8. **Exit 7 — valid token for a user that does not exist** → same generic message, raised at
+   `auth.py:68-69` after the database query returns nothing. Requires the database.
+9. **Exit 8 — happy path.** A valid token for a persisted user returns `200`. Requires the
+   database and the `test_user` fixture.
+10. **Verify and document.** Scoped `black` / `ruff` on the new files; `make test-integration`
+    green with zero skips; `make check` and `make test-unit` compared against the pre-change
+    baseline (182 lint errors; 53 failed / 375 passed) to confirm no new failures.
 
 ### Inputs & outputs
 
-- **Inputs:** crafted JWTs and raw header strings. Valid-but-bad tokens are built with
-  `core.security.create_access_token` (expired case) and `jose.jwt.encode` with a foreign secret
-  (wrong-secret case); malformed and missing-header cases are plain strings. All are delivered as the
-  `Authorization` header on `GET /reviews` through a `TestClient`.
-- **Outputs:** `httpx.Response` objects. Tests assert on `response.status_code` (always `401`) and
-  `response.json()["detail"]` (the exact message per case). **No production code changes** — this is
-  test-only; no function signature or runtime behavior is modified.
-
-**Test I'll write (drafted in advance, malformed case shown):**
-
-```python
-import pytest
-from fastapi.testclient import TestClient
-
-from api.main import app
-
-
-@pytest.fixture
-def client() -> TestClient:
-    return TestClient(app)
-
-
-@pytest.mark.integration
-class TestAuthMiddlewareRejections:
-    @pytest.mark.parametrize("bad_token", ["not.a.jwt", "a.b", "aaa.bbb.ccc"])
-    def test_malformed_token_returns_401(self, client: TestClient, bad_token: str) -> None:
-        """Test a malformed token returns 401 'Invalid authentication credentials'."""
-        response = client.get("/reviews", headers={"Authorization": f"Bearer {bad_token}"})
-        assert response.status_code == 401
-        assert response.json()["detail"] == "Invalid authentication credentials"
-```
-
-The other three cases follow the same shape: missing-header sends no `Authorization` header and
-asserts `"Not authenticated"`; expired uses `create_access_token(..., expires_delta=timedelta(
-minutes=-5))`; wrong-secret uses `jwt.encode(..., "wrong-secret", ...)`. Drafting this first defines
-"done" — the fixture wiring and the exact assertion — before implementation.
+- **Inputs:** HTTP requests to `GET /reviews` carrying an `Authorization` header. The header value
+  is either absent, a wrong scheme, or a `Bearer` token built one of four ways — by the app's own
+  `create_access_token` (valid, expired, or claimless), by `jose.jwt.encode` with a foreign secret
+  or non-whitelisted algorithm, by hand from base64 segments (`alg=none`), or by hand as a literal
+  junk string. The database-backed tests additionally insert a `User` row before the request.
+- **Outputs:** `httpx.Response` objects. Tests assert `response.status_code` (`401` for seven
+  cases, `200` for the happy path) and `response.json()["detail"]` — `"Not authenticated"` for
+  exit 1, `"Invalid authentication credentials"` for exits 2, 3 and 7.
+- **No production code changes.** No signature, no runtime behavior, no dependency is modified.
+  The diff is two test files.
 
 ### Risks & unknowns
 
-- **No `client`/app fixture exists yet** (`tests/conftest.py` has none). I'm establishing the
-  pattern; I keep it self-contained in the one test file so I don't touch shared infrastructure that
-  a reviewer might scope to another ticket.
-- **The `"Token has expired"` branch (`auth.py:44–49`) is unreachable dead code.** `decode_access_token`
-  (`core/security.py:78–86`) catches every `JWTError` — including `ExpiredSignatureError` — and returns
-  `None`, so `auth.py:35` fires first and expired tokens get the generic 401. My test must assert the
-  real behavior, not the intended-but-dead message.
-- **Interaction with issue E-04** ("Authentication middleware doesn't validate token expiry"). That
-  separate issue may make the expiry branch reachable and change the expired-token message to
-  `"Token has expired"`. If E-04 lands first, my expired-token assertion must be updated. I note this
-  explicitly rather than couple the two tickets.
-- **Fixture ownership (issue G-01).** A shared sample-user fixture is missing from `tests/fixtures/`
-  and is G-01's deliverable. Happy-path and user-not-found tests would depend on it, so I deliberately
-  keep those out of scope to avoid stepping on another ticket.
-- **Open question:** does `TestClient(app)` need `app.dependency_overrides[get_db]` for these four?
-  Reading `auth.py`, the 401s all raise before line 58, so no — but I will confirm during
-  implementation that no path reaches the DB session.
+- **Cross-event-loop `asyncpg` failures — the main technical risk, and it materialised.**
+  pytest-asyncio creates a fresh event loop per test, while `core/database.py:11` builds a
+  module-level pooled engine shared across all of them. A connection opened in one test's loop is
+  returned to the pool, outlives that loop, and then fails `pool_pre_ping` in the next test with
+  `got Future ... attached to a different loop`. Resolved by calling `await engine.dispose()` on
+  entry to both async fixtures, so every connection belongs to the current loop. Every test uses
+  `httpx.AsyncClient` over `ASGITransport` rather than a mix of sync and async clients, which keeps
+  one client and one pattern across the module.
+- **Test isolation against a real database.** `test_user` writes a row to a shared dev database and
+  must remove it on teardown, including when the test fails. A leaked row with a unique `email`
+  breaks the next run.
+- **The `"Token has expired"` branch (`auth.py:44-49`) is unreachable.** `decode_access_token`
+  (`core/security.py:78-86`) catches every `JWTError`, `ExpiredSignatureError` among them, and
+  returns `None` — so `auth.py:35` fires first and expired tokens get the generic message. The test
+  asserts observed behavior, not intended behavior.
+- **That assertion is coupled to a defect.** If the unreachable expiry branch is ever repaired so
+  that expired tokens return `"Token has expired"`, this one assertion will need updating. I am
+  pinning today's real behavior deliberately and flagging it in the PR rather than pre-empting a
+  fix that belongs in its own change.
 
 ### Edge cases
 
-At least two concrete input/state scenarios the tests must handle, all inside the four scenarios (no
-scope expansion):
+1. **Absent header vs. present-but-wrong scheme.** No `Authorization` at all and
+   `Authorization: Basic ...` both yield `401 "Not authenticated"` from `OAuth2PasswordBearer` —
+   a different code path and message from every token case.
+2. **`Bearer` with an empty token.** `Authorization: Bearer ` is **not** treated as a missing
+   credential. `get_authorization_scheme_param` splits on the space, the scheme is legitimately
+   `bearer`, and an empty string is passed on to be decoded — so it returns
+   `"Invalid authentication credentials"`, not `"Not authenticated"`.
+   *(The original plan predicted the opposite; probing the running app corrected it.)*
+3. **Structurally malformed vs. cryptographically invalid.** `not.a.jwt` and a well-formed token
+   signed with the wrong secret are different failure modes that must both be refused.
+4. **Algorithm confusion.** A token declaring `alg=none` with an empty signature — the classic JWT
+   forgery — must be rejected by the `algorithms=[HS256]` whitelist. So must a correct signature
+   made with `HS512`. `jose.encode` refuses to produce an `alg=none` token, so the test builds it
+   by hand; the library's refusal proves nothing about the application.
+5. **Expired token returns the generic message.** Asserting that exact string is what pins the
+   dead expiry branch, and what will fail loudly if that branch is ever repaired.
+6. **Valid, correctly signed token carrying no `sub` claim.** Decodes cleanly, then fails the
+   claim check — the only rejection reaching `auth.py:40-41`.
+7. **Valid token for a user absent from the database.** Signature and claims are fine; the lookup
+   returns nothing and the request is refused at `auth.py:68-69`.
+8. **Valid token for a user that exists** returns `200`. Without this case the suite cannot
+   distinguish correct rejection from blanket rejection.
 
-1. **Missing header vs. present-but-wrong scheme.** A truly absent `Authorization` header and an
-   `Authorization: Basic ...` header both yield `401 "Not authenticated"` from `OAuth2PasswordBearer`,
-   a *different* path and message than the token cases — the tests assert the correct message per path.
-2. **`Bearer` with an empty token.** `Authorization: Bearer ` (no token) must still be rejected, not
-   treated as anonymous-but-allowed.
-3. **Structurally malformed vs. cryptographically invalid.** `not.a.jwt` (bad structure) and a
-   correctly-structured token signed with the wrong secret are different failure modes that must both
-   return `401 "Invalid authentication credentials"`.
-4. **Algorithm confusion.** A token presented with `alg=none` (or a non-whitelisted algorithm) must be
-   rejected by the `algorithms=[HS256]` whitelist in `decode_access_token`, not silently accepted.
-5. **Expired token returns the generic message**, `"Invalid authentication credentials"` — asserting
-   this exact string is what proves the dead-code expiry branch and guards the E-04 boundary.
+---
+
+### Revision history
+
+**2026-08-01 — scope corrected.** The original plan covered only the four rejection paths named in
+the issue and kept happy-path and user-not-found tests out of scope on the grounds that they
+needed a shared user fixture this repo doesn't have. Two things were wrong with that:
+
+- **The suite it produced could not fail correctly.** Six passing rejection tests would all still
+  pass against a middleware that rejected every request unconditionally, valid credentials
+  included. The success path is what makes rejection tests meaningful. This is helpful as a unit test
+  but not a full integration test.
+- **The fixture was not actually blocked.** Nothing prevented a fixture local to
+  `tests/integration/` — it needed writing, not waiting on.
+
+The original plan also assumed these tests should avoid docker services, which contradicts
+`pyproject.toml:87` — the `integration` marker is defined as *"require Docker services."*
+
+Coverage was re-derived from the exits of `get_current_user` rather than from the issue's bullet
+list, taking the plan from 4 scenarios to 8 across 5 of the function's 8 exits. The three not
+covered are two unreachable branches and a database-failure path, all documented as findings in
+the PR rather than tested.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,100 @@
+## Solution plan
+
+**Issue:** Add integration tests for authentication edge cases — https://github.com/ascherj/pathreview/issues/90
+
+### Understand
+
+The root cause is a **test-coverage gap, not a code bug**: no test in the repository exercises
+`get_current_user` (`api/middleware/auth.py`). A `grep` for the middleware across `tests/` exits
+`1` (zero hits) and `tests/integration/` contains only `__init__.py`, so the middleware is only
+ever exercised implicitly through the happy path.
+
+- **Expected:** each way of presenting a bad credential to a protected route returns `401`, and
+  that behavior is pinned by an automated test that fails if the middleware ever stops rejecting it.
+- **Actual:** the four rejection paths (missing header, malformed token, expired token, wrong-secret
+  token) have no coverage, so a regression that let unauthorized requests through would pass silently.
+
+I confirmed today's behavior by probing `GET /reviews` (a route guarded by `get_current_user`):
+a missing header returns `401 "Not authenticated"`; malformed, expired, and wrong-secret tokens all
+return `401 "Invalid authentication credentials"`. A successful fix is those behaviors captured as
+integration tests, plus the first integration-test pattern for this repo.
+
+### Map
+
+This issue (manifest **E-15**) is scoped to a single new file. Files involved:
+
+- `tests/integration/test_auth_middleware.py` — **the only file changed.** Holds a module-level
+  `client` fixture (`TestClient(app)`) and the four rejection tests grouped in
+  `TestAuthMiddlewareRejections`. Kept self-contained (no `conftest.py` change) because the issue
+  scopes to one file and the rejection paths need no shared fixtures.
+- Read-only references (not edited):
+  - `api/middleware/auth.py` — `get_current_user`; the four 401 branches under test.
+  - `core/security.py` — `create_access_token` / `decode_access_token`; used to forge the test JWTs.
+  - `api/routes/reviews.py` — `GET /reviews`, the protected route the tests hit.
+  - `api/main.py` — the `app` object the `TestClient` wraps.
+
+### Plan
+
+1. Add a module-level `client` fixture returning `TestClient(app)`. No `get_db` override is needed —
+   the four rejection paths raise before the DB lookup at `auth.py:58`.
+2. **Missing header** → request `GET /reviews` with no `Authorization` header; assert `401` and
+   `detail == "Not authenticated"`. Parametrize the "absent credential" variants: wrong scheme
+   (`Basic ...`) and an empty `Bearer` token.
+3. **Malformed token** → send junk bearer tokens (non-JWT string, wrong segment count, undecodable
+   base64) via `@pytest.mark.parametrize`; assert `401` and `detail == "Invalid authentication
+   credentials"`.
+4. **Expired token** → forge one with `create_access_token(..., expires_delta=timedelta(minutes=-5))`;
+   assert `401` and, specifically, `detail == "Invalid authentication credentials"` — pinning the
+   generic message, not `"Token has expired"`.
+5. **Wrong-secret token** → sign a structurally valid JWT with a different secret (and an
+   algorithm-confusion variant, e.g. `alg=none`/`HS512`); assert `401`.
+6. Run scoped checks green on the new file only: `ruff check`, `black`, `mypy`, and
+   `pytest tests/integration/test_auth_middleware.py`.
+
+### Inputs & outputs
+
+- **Inputs:** crafted JWTs and raw header strings. Valid-but-bad tokens are built with
+  `core.security.create_access_token` (expired case) and `jose.jwt.encode` with a foreign secret
+  (wrong-secret case); malformed and missing-header cases are plain strings. All are delivered as the
+  `Authorization` header on `GET /reviews` through a `TestClient`.
+- **Outputs:** `httpx.Response` objects. Tests assert on `response.status_code` (always `401`) and
+  `response.json()["detail"]` (the exact message per case). **No production code changes** — this is
+  test-only; no function signature or runtime behavior is modified.
+
+### Risks & unknowns
+
+- **No `client`/app fixture exists yet** (`tests/conftest.py` has none). I'm establishing the
+  pattern; I keep it self-contained in the one test file so I don't touch shared infrastructure that
+  a reviewer might scope to another ticket.
+- **The `"Token has expired"` branch (`auth.py:44–49`) is unreachable dead code.** `decode_access_token`
+  (`core/security.py:78–86`) catches every `JWTError` — including `ExpiredSignatureError` — and returns
+  `None`, so `auth.py:35` fires first and expired tokens get the generic 401. My test must assert the
+  real behavior, not the intended-but-dead message.
+- **Interaction with issue E-04** ("Authentication middleware doesn't validate token expiry"). That
+  separate issue may make the expiry branch reachable and change the expired-token message to
+  `"Token has expired"`. If E-04 lands first, my expired-token assertion must be updated. I note this
+  explicitly rather than couple the two tickets.
+- **Fixture ownership (issue G-01).** A shared sample-user fixture is missing from `tests/fixtures/`
+  and is G-01's deliverable. Happy-path and user-not-found tests would depend on it, so I deliberately
+  keep those out of scope to avoid stepping on another ticket.
+- **Open question:** does `TestClient(app)` need `app.dependency_overrides[get_db]` for these four?
+  Reading `auth.py`, the 401s all raise before line 58, so no — but I will confirm during
+  implementation that no path reaches the DB session.
+
+### Edge cases
+
+At least two concrete input/state scenarios the tests must handle, all inside the four scenarios (no
+scope expansion):
+
+1. **Missing header vs. present-but-wrong scheme.** A truly absent `Authorization` header and an
+   `Authorization: Basic ...` header both yield `401 "Not authenticated"` from `OAuth2PasswordBearer`,
+   a *different* path and message than the token cases — the tests assert the correct message per path.
+2. **`Bearer` with an empty token.** `Authorization: Bearer ` (no token) must still be rejected, not
+   treated as anonymous-but-allowed.
+3. **Structurally malformed vs. cryptographically invalid.** `not.a.jwt` (bad structure) and a
+   correctly-structured token signed with the wrong secret are different failure modes that must both
+   return `401 "Invalid authentication credentials"`.
+4. **Algorithm confusion.** A token presented with `alg=none` (or a non-whitelisted algorithm) must be
+   rejected by the `algorithms=[HS256]` whitelist in `decode_access_token`, not silently accepted.
+5. **Expired token returns the generic message**, `"Invalid authentication credentials"` — asserting
+   this exact string is what proves the dead-code expiry branch and guards the E-04 boundary.

--- a/PLAN.md
+++ b/PLAN.md
@@ -19,6 +19,10 @@ a missing header returns `401 "Not authenticated"`; malformed, expired, and wron
 return `401 "Invalid authentication credentials"`. A successful fix is those behaviors captured as
 integration tests, plus the first integration-test pattern for this repo.
 
+**Root cause:** No integration test imports or exercises `get_current_user`, so its four `401`
+rejection branches (`api/middleware/auth.py`) are untested — and `tests/integration/` has no fixture
+infrastructure to exercise them.
+
 ### Map
 
 This issue (manifest **E-15**) is scoped to a single new file. Files involved:
@@ -60,6 +64,35 @@ This issue (manifest **E-15**) is scoped to a single new file. Files involved:
 - **Outputs:** `httpx.Response` objects. Tests assert on `response.status_code` (always `401`) and
   `response.json()["detail"]` (the exact message per case). **No production code changes** — this is
   test-only; no function signature or runtime behavior is modified.
+
+**Test I'll write (drafted in advance, malformed case shown):**
+
+```python
+import pytest
+from fastapi.testclient import TestClient
+
+from api.main import app
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+@pytest.mark.integration
+class TestAuthMiddlewareRejections:
+    @pytest.mark.parametrize("bad_token", ["not.a.jwt", "a.b", "aaa.bbb.ccc"])
+    def test_malformed_token_returns_401(self, client: TestClient, bad_token: str) -> None:
+        """Test a malformed token returns 401 'Invalid authentication credentials'."""
+        response = client.get("/reviews", headers={"Authorization": f"Bearer {bad_token}"})
+        assert response.status_code == 401
+        assert response.json()["detail"] == "Invalid authentication credentials"
+```
+
+The other three cases follow the same shape: missing-header sends no `Authorization` header and
+asserts `"Not authenticated"`; expired uses `create_access_token(..., expires_delta=timedelta(
+minutes=-5))`; wrong-secret uses `jwt.encode(..., "wrong-secret", ...)`. Drafting this first defines
+"done" — the fixture wiring and the exact assertion — before implementation.
 
 ### Risks & unknowns
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,47 @@
+from collections.abc import AsyncGenerator
+from uuid import uuid4
+
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import delete
+
+from api.main import app
+from core.database import AsyncSessionLocal, engine
+from core.models import User
+from core.security import create_access_token
+
+
+@pytest_asyncio.fixture
+async def async_client() -> AsyncGenerator[AsyncClient, None]:
+    """Return an httpx AsyncClient wired to the app for DB-backed tests."""
+    await engine.dispose()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+@pytest_asyncio.fixture
+async def test_user() -> AsyncGenerator[User, None]:
+    """Persist a real user for the duration of one test, then remove it."""
+    await engine.dispose()
+    user = User(
+        id=str(uuid4()),
+        email=f"auth-test-{uuid4()}@example.com",
+        hashed_password="not-a-real-hash",
+        is_active=True,
+    )
+    async with AsyncSessionLocal() as session:
+        session.add(user)
+        await session.commit()
+    try:
+        yield user
+    finally:
+        async with AsyncSessionLocal() as session:
+            await session.execute(delete(User).where(User.id == user.id))
+            await session.commit()
+
+
+@pytest_asyncio.fixture
+async def auth_token(test_user: User) -> str:
+    """Return a valid JWT for the persisted test user."""
+    return create_access_token({"sub": test_user.id})

--- a/tests/integration/test_auth_middleware.py
+++ b/tests/integration/test_auth_middleware.py
@@ -1,24 +1,144 @@
 """Integration tests for authentication middleware rejection paths."""
 
+import base64
+import json
+from collections.abc import Callable
+from datetime import UTC, datetime, timedelta
+from typing import cast
+from uuid import uuid4
+
 import pytest
+from httpx import AsyncClient
+from jose import jwt
+
+from core.config import settings
+from core.security import create_access_token
+
+
+def _future_exp() -> datetime:
+    """Return expiry five minutes from now."""
+    return datetime.now(UTC) + timedelta(minutes=5)
+
+
+def _b64(segment: dict[str, object]) -> str:
+    """Base64url-encode one JWT segment without padding."""
+    return base64.urlsafe_b64encode(json.dumps(segment).encode()).rstrip(b"=").decode()
+
+
+def _token_signed_with_foreign_secret() -> str:
+    """A structurally valid, unexpired JWT signed with a secret the app does not know."""
+    return cast(
+        "str",
+        jwt.encode({"sub": "someone", "exp": _future_exp()}, "wrong-secret", algorithm="HS256"),
+    )
+
+
+def _token_with_unwhitelisted_algorithm() -> str:
+    """A JWT signed with the app's REAL secret but an algorithm outside the whitelist."""
+    return cast(
+        "str",
+        jwt.encode(
+            {"sub": "someone", "exp": _future_exp()}, settings.secret_key, algorithm="HS512"
+        ),
+    )
+
+
+def _forged_alg_none_token() -> str:
+    """The classic alg=none forgery: real-looking claims, no signature."""
+    header = _b64({"alg": "none", "typ": "JWT"})
+    payload = _b64({"sub": "admin", "exp": int(_future_exp().timestamp())})
+    return f"{header}.{payload}."
 
 
 @pytest.mark.integration
-class TestAuthMiddlewareRejections:
+class TestAuthMiddleware:
     """Test suite for get_current_user rejection paths (issue #90)."""
 
-    @pytest.mark.skip(reason="stub — implemented in Week 9 (#90)")
-    def test_missing_authorization_header_returns_401(self) -> None:
-        """Test a missing Authorization header returns 401 'Not authenticated'."""
+    @pytest.mark.parametrize(
+        "headers",
+        [None, {"Authorization": "Basic YWJjOjEyMw=="}],
+        ids=["no-header", "wrong-scheme"],
+    )
+    @pytest.mark.asyncio
+    async def test_absent_credential_returns_401(
+        self, async_client: AsyncClient, headers: dict[str, str] | None
+    ) -> None:
+        """Test absent or non-Bearer credentials return 401 'Not authenticated'."""
+        response = await async_client.get("/reviews", headers=headers)
+        assert response.status_code == 401
+        assert response.json()["detail"] == "Not authenticated"
 
-    @pytest.mark.skip(reason="stub — implemented in Week 9 (#90)")
-    def test_malformed_token_returns_401(self) -> None:
-        """Test a malformed token returns 401 'Invalid authentication credentials'."""
+    @pytest.mark.parametrize(
+        "bad_token",
+        ["not.a.jwt", "a.b", "aaa.bbb.ccc", ""],
+        ids=["not-a-jwt", "two-segments", "undecodable-base64", "empty-token"],
+    )
+    @pytest.mark.asyncio
+    async def test_undecodable_token_returns_401(
+        self, async_client: AsyncClient, bad_token: str
+    ) -> None:
+        """Test tokens jose cannot decode return 401 'Invalid authentication credentials'."""
+        response = await async_client.get(
+            "/reviews", headers={"Authorization": f"Bearer {bad_token}"}
+        )
+        assert response.status_code == 401
+        assert response.json()["detail"] == "Invalid authentication credentials"
 
-    @pytest.mark.skip(reason="stub — implemented in Week 9 (#90)")
-    def test_expired_token_returns_401(self) -> None:
+    @pytest.mark.asyncio
+    async def test_expired_token_returns_401(self, async_client: AsyncClient) -> None:
         """Test an expired token returns the generic 401, not 'Token has expired'."""
+        expired_token = create_access_token(
+            {"sub": "someone"}, expires_delta=timedelta(minutes=-10)
+        )
+        response = await async_client.get(
+            "/reviews", headers={"Authorization": f"Bearer {expired_token}"}
+        )
+        assert response.status_code == 401
+        assert response.json()["detail"] == "Invalid authentication credentials"
 
-    @pytest.mark.skip(reason="stub — implemented in Week 9 (#90)")
-    def test_wrong_secret_token_returns_401(self) -> None:
-        """Test a token signed with a different secret returns 401."""
+    @pytest.mark.parametrize(
+        "make_token",
+        [
+            _token_signed_with_foreign_secret,
+            _token_with_unwhitelisted_algorithm,
+            _forged_alg_none_token,
+        ],
+        ids=["foreign-secret", "hs512-not-whitelisted", "alg-none-forgery"],
+    )
+    @pytest.mark.asyncio
+    async def test_bad_signature_or_algorithm_returns_401(
+        self, async_client: AsyncClient, make_token: Callable[[], str]
+    ) -> None:
+        """Test cryptographically invalid tokens return 401 regardless of how they are wrong."""
+        response = await async_client.get(
+            "/reviews", headers={"Authorization": f"Bearer {make_token()}"}
+        )
+        assert response.status_code == 401
+        assert response.json()["detail"] == "Invalid authentication credentials"
+
+    @pytest.mark.asyncio
+    async def test_token_without_sub_claim_returns_401(self, async_client: AsyncClient) -> None:
+        """Test a valid, decodable token carrying no 'sub' claim is rejected."""
+        token = create_access_token({"user_id": "123"})
+        response = await async_client.get("/reviews", headers={"Authorization": f"Bearer {token}"})
+        assert response.status_code == 401
+        assert response.json()["detail"] == "Invalid authentication credentials"
+
+    @pytest.mark.asyncio
+    async def test_token_for_unknown_user_returns_401(self, async_client: AsyncClient) -> None:
+        """Test a valid token whose subject has no row in the database is rejected."""
+        token = create_access_token({"sub": str(uuid4())})
+        response = await async_client.get("/reviews", headers={"Authorization": f"Bearer {token}"})
+        assert response.status_code == 401
+        assert response.json()["detail"] == "Invalid authentication credentials"
+
+    @pytest.mark.asyncio
+    async def test_valid_token_for_existing_user_returns_200(
+        self, async_client: AsyncClient, auth_token: str
+    ) -> None:
+        """Test a valid token for a persisted user reaches the protected route."""
+        response = await async_client.get(
+            "/reviews", headers={"Authorization": f"Bearer {auth_token}"}
+        )
+        assert response.status_code == 200
+        assert response.json()["items"] == []

--- a/tests/integration/test_auth_middleware.py
+++ b/tests/integration/test_auth_middleware.py
@@ -1,0 +1,24 @@
+"""Integration tests for authentication middleware rejection paths."""
+
+import pytest
+
+
+@pytest.mark.integration
+class TestAuthMiddlewareRejections:
+    """Test suite for get_current_user rejection paths (issue #90)."""
+
+    @pytest.mark.skip(reason="stub — implemented in Week 9 (#90)")
+    def test_missing_authorization_header_returns_401(self) -> None:
+        """Test a missing Authorization header returns 401 'Not authenticated'."""
+
+    @pytest.mark.skip(reason="stub — implemented in Week 9 (#90)")
+    def test_malformed_token_returns_401(self) -> None:
+        """Test a malformed token returns 401 'Invalid authentication credentials'."""
+
+    @pytest.mark.skip(reason="stub — implemented in Week 9 (#90)")
+    def test_expired_token_returns_401(self) -> None:
+        """Test an expired token returns the generic 401, not 'Token has expired'."""
+
+    @pytest.mark.skip(reason="stub — implemented in Week 9 (#90)")
+    def test_wrong_secret_token_returns_401(self) -> None:
+        """Test a token signed with a different secret returns 401."""


### PR DESCRIPTION
## Summary

The authentication middleware `get_current_user()` (`api/middleware/auth.py`) guards every
protected route in the API, but it had no test coverage of any kind. A grep for it across
`tests/` returned nothing, and `tests/integration/` contained only `__init__.py`. Nothing verified
that a bad credential is refused, and nothing verified that a good one is accepted, so a
regression in either direction would have shipped silently. This PR adds the repository's first
integration tests for it: seven tests, thirteen cases, driving the FastAPI app and a Postgres database 
to pin exactly what the middleware returns for each kind of credential.

## Issue

Closes #90

## Changes

**Root cause.** This is a test-coverage gap rather than a bug, and it is wider than the issue
describes. The issue states the middleware "is tested with a valid token" but it is not. No test in
the repository references `get_current_user` at all. What exists is `tests/unit/test_security.py`,
which tests the JWT helpers (`create_access_token`, `decode_access_token`) in isolation. Those
prove the decoder returns `None` for bad input. Nothing proves the middleware turns that `None`
into a refusal on a protected route. A refactor that made `get_current_user` ignore a `None`
payload would have left every existing test green. On top of that, `tests/integration/` had no
fixture infrastructure at all — no app client, no persisted user, no token — so there was nothing
to build on.

Coverage here is derived from the exits of `get_current_user` rather than from the issue's bullet
list. The function has eight ways out; five are reachable without simulating infrastructure
failure, and all five are now covered.

- **`tests/integration/test_auth_middleware.py`** (new) — seven tests, thirteen cases once
  parametrized, all against `GET /reviews`, a route guarded by `get_current_user` that needs no
  request body:
  - `test_absent_credential_returns_401` — no `Authorization` header, and a non-`Bearer` scheme.
    Both assert `401` / `"Not authenticated"`, which `OAuth2PasswordBearer` returns *before* the
    middleware runs.
  - `test_undecodable_token_returns_401` — a non-JWT string, a two-segment token, undecodable
    base64, and an empty token. All assert `401` / `"Invalid authentication credentials"`.
  - `test_expired_token_returns_401` — a correctly signed token with an expiry in the past.
  - `test_bad_signature_or_algorithm_returns_401` — three forgeries that are structurally perfect
    and unexpired, differing only in signing: a foreign secret, the real secret under a
    non-whitelisted `HS512`, and a hand-assembled `alg=none` token with an empty signature.
  - `test_token_without_sub_claim_returns_401` — a valid, decodable token with no `sub` claim.
    The only rejection that gets *past* the decoder, reaching the claim check at `auth.py:40-41`.
  - `test_token_for_unknown_user_returns_401` — a valid token whose subject is a well-formed UUID
    with no matching row; refused after the lookup at `auth.py:68-69`.
  - `test_valid_token_for_existing_user_returns_200` — a valid token for a persisted user reaches
    the route and returns `200`. Without this case the suite would pass against a middleware that
    rejected every request unconditionally.
- **`tests/integration/conftest.py`** (new) — three fixtures establishing the integration-test
  pattern this repo didn't have: `async_client` (`httpx.AsyncClient` over `ASGITransport`),
  `test_user` (persists a real `User` row with a randomised email, deletes it on teardown even if
  the test fails), and `auth_token` (a valid JWT for that user via the app's own
  `create_access_token`). Both async fixtures call `engine.dispose()` on entry — see Notes.
- **No production code changes.** No signature, no runtime behavior, no dependency is modified.

## Testing

- [x] Unit tests pass (`make test-unit`) — 53 failed / 375 passed, identical to the pre-change
  baseline; this PR introduces none of them and cannot affect that target (see Notes)
- [x] Integration tests pass (`make test-integration`) — 13 passed, 0 skipped
- [ ] Linter passes (`make lint`) — clean on both new files; repo-wide count unchanged but not passing, at 182
  pre-existing errors (see Notes)
- [ ] Type checker passes (`make typecheck`) — this target scopes `api/ core/ ingestion/ rag/
  agent/ safety/` and does not include `tests/`, so it is unaffected either way (see Notes), but type checker is not passing app-wide.
- [x] New/updated tests cover the changes

**Reproduce the gap (on `main`):**

1. `git checkout main`
2. `grep -rn "get_current_user" tests/` → no matches; nothing exercises the middleware
3. `ls tests/integration/` → only `__init__.py`; no integration test infrastructure exists
4. `make test-unit` → passes for `tests/unit/test_security.py`'s token tests, confirming the
   decoder is covered while the middleware that consumes it is not

**Verify the fix (on this branch):**

1. `git checkout test/90-auth-middleware-edge-cases`
2. `docker compose up -d db` — only the `db` service is needed; no Chroma, no frontend
3. `make migrate`
4. `make test-integration`
5. Expected: `13 passed, 0 skipped` in under a second

**Confirm the tests actually fail when the middleware breaks** — Both mutations below are temporary edits to
`api/middleware/auth.py`. Revert after each mutation.

*Mutation A — reject everything.* Add `raise credentials_exception` immediately after
`credentials_exception` is defined, before the `try` block:

```
make test-integration  ->  12 passed, 1 failed
```

Only `test_valid_token_for_existing_user_returns_200` fails. Every rejection test still passes,
because the middleware is still rejecting — it is just rejecting everything. That is precisely the
failure a rejection-only suite cannot detect, and the reason the valid-token case is included.

*Mutation B — accept everything.* Revert A, then make the first statement of the function body
`return User(id="00000000-0000-0000-0000-000000000000", email="mutation@example.com",
hashed_password="x")`:

```
make test-integration  ->  3 passed, 10 failed
```

Ten of the rejection cases fail. The two `test_absent_credential_returns_401` cases keep
passing, which is correct rather than a gap: `OAuth2PasswordBearer` rejects a missing or
non-`Bearer` header during dependency resolution, so `get_current_user` is never reached and the
mutation cannot affect them. The happy path also still passes, for a coincidental reason. The
fabricated user id owns no reviews, so the route returns `200` with an empty list either way.

**Verify the observed behavior by hand** (requires `make run`):

```bash
# Missing header -> "Not authenticated"
curl -s -w '\n%{http_code}\n' http://localhost:8000/reviews

# Malformed token -> "Invalid authentication credentials"
curl -s -w '\n%{http_code}\n' -H "Authorization: Bearer not.a.jwt" http://localhost:8000/reviews

# Expired token -> "Invalid authentication credentials" (NOT "Token has expired")
python -c "from datetime import timedelta; from core.security import create_access_token; \
print(create_access_token({'sub':'someone'}, expires_delta=timedelta(minutes=-5)))" \
  | { read TOK; curl -s -w '\n%{http_code}\n' -H "Authorization: Bearer $TOK" http://localhost:8000/reviews; }
```

The assertions in the test module match those responses exactly.

## Screenshots / Demo

N/A — test-only change with no user-facing behavior. The observable result is the
`make test-integration` output in the verification steps above.

## Notes for Reviewers

**Pre-existing failures, unchanged by this PR.** I recorded both gates before writing any code and
again afterwards:

| Gate | Before | After |
|---|---|---|
| `make check` | aborts at `lint` with **182** ruff errors | **182**, identical |
| `make test-unit` | **53 failed / 375 passed** | **53 failed / 375 passed**, identical |

None of those failures is in a file this PR touches. `make test-unit` runs `tests/unit -m unit`
(`Makefile:40`) while this PR adds files under `tests/integration/`, which run only under
`make test-integration` (`Makefile:43`) — so that target is structurally unable to be affected.
Worth flagging that `tests/unit/test_security.py` is among the pre-existing failures, but the
failing case is `test_verify_with_wrong_hash_format`, which exercises password hashing while this
PR touches only the JWT half of `core/security.py`.

**I committed with `SKIP=mypy`.** The pre-commit mypy hook fails with 44 errors across seven files
in `api/` and `core/` — all pre-existing annotation gaps. mypy only surfaces them here because the
new tests import `api.main`, which pulls in the routers and services; the hook then follows those
imports. `ruff` and `black` both ran and passed. Note this differs from `make typecheck`, which
never scopes `tests/` and so never sees them. Happy to fix them in a separate PR if wanted, but
they seemed out of scope for a test-only change.

**The expired-token assertion looks wrong and is deliberate.** `auth.py:44-49` intends to return
`"Token has expired"`, but that branch is unreachable: `decode_access_token`
(`core/security.py:78-86`) catches every `JWTError` — `ExpiredSignatureError` included — and
returns `None`, so `auth.py:35` fires first and the caller gets the generic message. I confirmed
this against a running instance. The test asserts real behavior, not intended behavior. If that
branch is ever repaired so expired tokens return `"Token has expired"`, this one assertion will
fail loudly — which seemed better than writing a test that passes either way. Fixing the branch
itself felt like a separate change. **A second branch, the generic `except Exception` at
`auth.py:53-55`, is also unreachable** for the same reason — `decode_access_token` swallows
everything it could raise.

**`engine.dispose()` in the fixtures is load-bearing.** pytest-asyncio creates a fresh event loop
per test while `core/database.py:11` builds a module-level pooled engine. A connection opened in
one test's loop is returned to the pool, outlives that loop, and then fails
`pool_pre_ping` in the next test with `got Future ... attached to a different loop`. Disposing on
fixture entry guarantees every connection belongs to the current loop. Flagging it because it
looks removable and isn't — and because it suggests the shared module-level engine is a general
hazard for testing this codebase, which may deserve its own issue.

**Scope I left alone.** Three of the eight exits are uncovered: the two unreachable branches above,
and the `500 "Database error"` path at `auth.py:61-66`, which would need a simulated database
failure. This PR covers the middleware's own behavior only — the reviews route's actual response
content is another module's concern.

**What I'd most like reviewed:** this is the first integration test module in the repo, so the
fixture shape is a precedent rather than a convention I followed. If `conftest.py` should live
elsewhere, or the client should be built differently, better to change it now than after other
modules copy it.
