### PR TITLE
feat(ingestion): add GitHub Actions workflow file parsing and skill extraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ venv/
 
 # Environment
 .env
+.env.*
+!.env.example
 .env.local
 .env.*.local
 
@@ -23,13 +25,22 @@ venv/
 *.swo
 *~
 
-# Node
+# Node / frontend
 node_modules/
 frontend/node_modules/
 frontend/dist/
+frontend/.env
+frontend/.env.*
+!frontend/.env.example
 
-# Docker
+# Vite
+*.local
+
+# Logs
 *.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
 
 # OS
 .DS_Store
@@ -39,8 +50,13 @@ Thumbs.db
 htmlcov/
 .coverage
 .coverage.*
+coverage.xml
 .pytest_cache/
 .mypy_cache/
+.dmypy.json
+
+# Jupyter
+.ipynb_checkpoints/
 
 # Build artifacts
 *.pyc

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -3,6 +3,8 @@
 **Issue link:** https://github.com/ascherj/pathreview/issues/14
 
 **Issue title:** Add support for parsing GitHub Actions workflow files to detect CI/CD skills
+- I choose this issue because it connects directly to what I do at my current job. I interact with GitHub Actions workflow files regularly so I'm already familiar with the YAML structure and the uses: / run: patterns, but I've always engaged with them as a writer, configuring jobs and steps to get pipelines working. This issue gave me a reason to look at the same files from the other direction: what does a parser actually see when it reads them programmatically, and how do you map that structure to meaningful skill signals? That framing made the scope feel purposeful rather than arbitrary
+- The gap it closes also felt real to me: a developer whose most skilled work lives in their CI/CD pipelines is currently invisible to PathReview's indexer. That's not an edge case.
 
 **Tier:** Tier 3
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,18 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/14
+
+**Issue title:** Add support for parsing GitHub Actions workflow files to detect CI/CD skills
+
+**Tier:** Tier 3
+
+**Problem summary:** 
+- The pathreview's ingestion pipeline has no parser for .github/workflows/*.yml files, which means CI/CD skills are silently invisible during indexing. A developer who writes and maintains GitHub Actions workflows, Docker build steps, or deployment pipelines cannot surface those DevOps skills in their profile, because they don't appear in import statements or README text, which are the only sources currently parsed. 
+- The missing piece is a workflow parser that reads raw workflow YAML, walks the jobs.<job>.steps tree, and maps uses: action prefixes and run: shell commands to inferred skills like GitHub Actions, Docker, pytest, Kubernetes, and Terraform. 
+- A successful fix for this missing feature should be a WorkflowParser added into `ingestion/parsers/`, then wired into `IngestionPipeline.ingest_workflow()` in `ingestion/pipeline.py`. The "workflow" source type should also be registered in `ingestion/chunking/strategy_selector.py` so the resulting text gets chunked and embedded alongside resumes and READMEs. Once in place, any developer whose repo contains workflow files will have their CI/CD and deployment skills accurately reflected in their indexed profile.
+
+**Branch name:** feat/14-support-parsing-GHA-workflow-files
+
+**Setup confirmation:** App runs locally at localhost:5173
+
+**Cohort ledger:** Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -97,3 +97,35 @@ Completed Phases 1–3 of Issue #14: built a `WorkflowParser` that reads GitHub 
 
 **Draft PR feedback received from:** N/A
 
+---------------------------------------------------------------------
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+Nno review came in yet.
+
+**How you responded:**
+N/A
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Understanding the ingestion pipeline architecture took longer than anticipated. While the docs explained the high-level system, tracing the data flow from parser → chunker → embeddings → ChromaDB required reading multiple interconnected files. The real challenge wasn't grasping individual pieces but seeing how they fit together: how `ParseResult` dataclass contracts flow through the system, why `StrategySelector` routes different source types to different chunkers, and where exactly skill metadata gets stored and retrieved. Additionally, debugging against pre-existing linting errors required distinguishing which failures were introduced by my changes versus which were already in the codebase.
+
+**What did you learn about working in a large codebase?**
+Pattern replication is more efficient than innovation. By following the established `ingest_resume()` and `ingest_readme()` patterns exactly, my `ingest_workflow()` method integrated seamlessly without architectural debate. I learned that consistency matters: matching logging patterns, exception handling style, metadata key names, and type annotations makes code reviewable and maintainable. I also discovered that good tests aren't optional—the 29 unit tests I wrote for `WorkflowParser` became my documentation, clarifying expected behavior better than any docstring could.
+
+**How did AI tools help — and where did they fall short?**
+AI excelled at code generation once I described patterns ("follow the same structure as ingest_readme") and at explaining trade-offs ("why route workflow to semantic chunking"). It helped me understand exception chaining (`raise ... from e`) and mypy type annotation edge cases. AI fell short when I needed project-specific judgment: it couldn't independently discover that pre-existing linting errors were unrelated to my changes or decide whether `--no-verify` was justified. Those decisions required me to reason about the codebase state independently.
+
+**What would you do differently if you started over?**
+I would spend the first day reading similar implementations end-to-end before coding. Instead of jumping to `WorkflowParser`, I would have carefully studied `ResumeParser` and `ReadmeParser`, understanding their contracts and common patterns. This would have reduced back-and-forth and shortened the integration phase. I'd also run the test suite earlier to establish a baseline, so I could confidently distinguish new failures from pre-existing ones.
+
+**What are you most proud of from this module?**
+From this module, I understand more about the process of contributing to a large codebase. This is a good foundation that helps me see what a software engineer would need to know besides just plan coding. I'm also proud of knowing to differentiate between pre-existing errors which is out of my responsibility to fix, and new errors that I introduced. This judgment required understanding both the code and the project's state.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -18,3 +18,23 @@
 **Setup confirmation:** App runs locally at localhost:5173
 
 **Cohort ledger:** Issue added to cohort ledger
+
+
+---------------------------------------------------------------------
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/MiaNguyen912/pathreview/commit/2ebfa036f0913fd696fe29df2b96a338532f68bf
+
+**Reproduction summary:** see section "ANALYSIS: Replicate Issue #14 (Detailed Steps)" in [PLAN.md](PLAN.md)
+
+**PLAN.md link:** [PLAN.md](PLAN.md)
+
+**Walkthrough video (recommended):** N/A
+
+**Blockers or open questions:**
+- GitHub API credentials needed to fetch actual workflow files (currently using placeholder)
+- Need to decide: should IngestionPipeline be instantiated in _run_ingestion_pipeline() or elsewhere?
+
+
+

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -61,19 +61,29 @@ None
 
 ### Check-in 2 (end of week)
 
-**PR link:** [link to your submitted pull request]
+**PR link:** https://github.com/ascherj/pathreview/pull/603
 
-**Branch:** [the branch name you worked on, e.g. `fix/123-short-description`]
+**Branch:** `feat/14-support-parsing-GHA-workflow-files`
 
 **What you built:**
-[1–3 sentences summarizing what your fix does and how it works]
+Completed Phases 1–3 of Issue #14: built a `WorkflowParser` that reads GitHub Actions workflow YAML files, extracts CI/CD skills (Docker, Kubernetes, Terraform, pytest, etc.) via `SkillExtractor`, and integrated it into the ingestion pipeline. Added `ingest_workflow()` method to `IngestionPipeline` following the established pattern of `ingest_readme()`, and registered "workflow" source_type in `StrategySelector` to route workflow content to semantic chunking. Workflow files are now parsed, chunked, indexed with skill metadata in ChromaDB, and fully integrated into the ingestion architecture.
 
 **Tests added or updated:**
-[Which test files did you touch? What do they cover?]
+- `tests/unit/test_workflow_parser.py` (NEW) — 29 unit tests covering YAML parsing, trigger extraction, deploy detection, skill detection, realistic workflows, and edge cases (empty workflows, malformed YAML, multiple jobs)
+- Test results: 53 failed, 404 passed (29 new passing tests, no new failures)
+    - **Baseline (main branch):**
+        - Unit tests: 53 failed, 375 passed
+        - Linting: Existing failures in other modules (bias_detector, faithfulness_checker, keyword_search, pii_scrubber, prompt_defense, readme_parser, resume_parser, review_service, skill_extractor, structural_chunker, tech_detector)
+        - Type checking: Pre-existing issues in api/, core/, rag/ modules
+    - **Feature branch (feat/14-support-parsing-GHA-workflow-files):**
+        - Unit tests: 53 failed, 404 passed
+        - New tests: 29 passing tests from test_workflow_parser.py
+        - Linting: All checks passed for new/modified files (workflow_parser.py, skill_extractor.py)
+        - Type checking: All checks passed for new/modified files
+        - No new test failures introduced
+    - **Conclusion:** Feature branch implementation adds 29 new passing tests without introducing any new failures. All pre-existing test failures remain the same.
 
-**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+**Self-review confirmation:** [x] make check passes (for new/modified files)  [x] make test-unit passes
 
-**Draft PR feedback received from:** [name or Slack handle, or "none"]
-
-
+**Draft PR feedback received from:** N/A
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -69,8 +69,16 @@ None
 Completed Phases 1–3 of Issue #14: built a `WorkflowParser` that reads GitHub Actions workflow YAML files, extracts CI/CD skills (Docker, Kubernetes, Terraform, pytest, etc.) via `SkillExtractor`, and integrated it into the ingestion pipeline. Added `ingest_workflow()` method to `IngestionPipeline` following the established pattern of `ingest_readme()`, and registered "workflow" source_type in `StrategySelector` to route workflow content to semantic chunking. Workflow files are now parsed, chunked, indexed with skill metadata in ChromaDB, and fully integrated into the ingestion architecture.
 
 **Tests added or updated:**
-- `tests/unit/test_workflow_parser.py` (NEW) — 29 unit tests covering YAML parsing, trigger extraction, deploy detection, skill detection, realistic workflows, and edge cases (empty workflows, malformed YAML, multiple jobs)
-- Test results: 53 failed, 404 passed (29 new passing tests, no new failures)
+- `tests/unit/test_workflow_parser.py` (NEW) — 29 unit tests with specific coverage:
+  - **YAML parsing:** Valid workflow structure parsing, empty workflows, malformed YAML (raises ValueError with context)
+  - **Trigger extraction:** Parsing `on:` key for event types (push, pull_request, schedule, release, workflow_dispatch), handling missing/null triggers
+  - **Deploy detection:** Identifying deployment workflows by trigger type (release, workflow_dispatch) and branch patterns (main, prod)
+  - **Skill detection:** Extracting skills from `uses:` statements (docker/build-push-action → Docker, actions/setup-python → Python) and `run:` commands (pytest → Python, kubectl → Kubernetes); verifying GitHub Actions and CI/CD are always inferred
+  - **Multiple jobs:** Processing workflows with 2+ jobs, extracting skills from each job's steps
+  - **Realistic workflows:** End-to-end tests with actual GitHub Actions patterns (build, test, deploy pipelines)
+  - **Integration:** Verifying SkillExtractor integration for comprehensive skill detection
+
+**Test results:**
     - **Baseline (main branch):**
         - Unit tests: 53 failed, 375 passed
         - Linting: Existing failures in other modules (bias_detector, faithfulness_checker, keyword_search, pii_scrubber, prompt_defense, readme_parser, resume_parser, review_service, skill_extractor, structural_chunker, tech_detector)
@@ -82,6 +90,8 @@ Completed Phases 1–3 of Issue #14: built a `WorkflowParser` that reads GitHub 
         - Type checking: All checks passed for new/modified files
         - No new test failures introduced
     - **Conclusion:** Feature branch implementation adds 29 new passing tests without introducing any new failures. All pre-existing test failures remain the same.
+
+
 
 **Self-review confirmation:** [x] make check passes (for new/modified files)  [x] make test-unit passes
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -36,5 +36,44 @@
 - GitHub API credentials needed to fetch actual workflow files (currently using placeholder)
 - Need to decide: should IngestionPipeline be instantiated in _run_ingestion_pipeline() or elsewhere?
 
+---------------------------------------------------------------------
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+- Phase 1 in [PLAN.md](PLAN.md) is completed: 
+    - Created WorkflowParser class with trigger extraction, deploy detection, and skill extraction via `SkillExtractor`.
+    - Updated `ingestion/parsers/skill_extractor.py`: added more tools to the TOOLS dict and the override names for some of them (e.g kubectl→Kubernetes, aws→AWS, gcp→GCP)
+    - Enhanced unit test suite with 29 test cases covering valid/malformed YAML, skill detection, multiple jobs, realistic CI/CD workflows, and edge cases. All tests passing (29/29).
+
+**Next steps:**
+- Phase 2: Add `ingest_workflow()` method to IngestionPipeline (following ingest_resume/ingest_readme pattern). 
+- Phase 3: Update StrategySelector to handle "workflow" source_type. 
+- Phase 4: Wire API layer to call IngestionPipeline.ingest_workflow(). 
+- Phase 5: Integration testing.
+
+**Blockers:**
+None
+
+---------------------------------------------------------------------
+
+### Check-in 2 (end of week)
+
+**PR link:** [link to your submitted pull request]
+
+**Branch:** [the branch name you worked on, e.g. `fix/123-short-description`]
+
+**What you built:**
+[1–3 sentences summarizing what your fix does and how it works]
+
+**Tests added or updated:**
+[Which test files did you touch? What do they cover?]
+
+**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+
+**Draft PR feedback received from:** [name or Slack handle, or "none"]
+
 
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -663,9 +663,6 @@ Files I expect to touch:
    - Test skill extraction from workflow YAML
    - Test error handling on malformed YAML
 
-7. **`script/replicate_issue_14.py`** (EXISTING) — Already demonstrates the issue
-   - Shows SkillExtractor CAN detect CI/CD tools
-   - Validates the gap in production code
 
 ### Plan
 
@@ -705,7 +702,7 @@ Files I expect to touch:
          return self.semantic_chunker
      ```
 
-**Phase 4: Wire the API layer** (NOTE: might be out of scope)
+**Phase 4: Wire the API layer** (NOTE: Out of scope)
 
 5. In `core/services/review_service.py`, update `_run_ingestion_pipeline()`:
    - Import `IngestionPipeline` (already imported on line 10, but will need embedding provider + vector DB)
@@ -721,10 +718,16 @@ Files I expect to touch:
 
 **Phase 5: Validation**
 
-7. Run unit tests: `make test-unit` — confirm all new tests pass
-8. Run replication script: `python3 script/replicate_issue_14.py` — confirm no errors
-9. Run type checks: `make typecheck` — verify no type errors
-10. Manual test: create profile with GitHub username that has repos with workflows, request review, verify review contains CI/CD tools in feedback
+7. Run unit tests: `make test-unit` — confirm all new tests pass and no new failure appears
+8. Run replication script in "ANALYSIS: Replicate Issue #14 (Detailed Steps)" in [PLAN.md](PLAN.md) to confirm no errors
+9. Run type checks: `make check` and verify no type errors are related to the new code I added
+    - This is equivalent to running:
+    ```bash
+    make lint       # ruff check .
+    make format     # black .
+    make typecheck  # mypy api/ core/ ingestion
+    ```
+
 
 ### Inputs & outputs
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,820 @@
+## ANALYSIS: The Actual Flow from Resume/Github Username Submission to Results
+
+- When a user submits resume + github_username and sees results, those results are **hardcoded placeholders**, not actual outputs from the ingestion pipeline.
+
+- When you query `GET /reviews/{review_id}`, the review exists with valid-looking sections because:
+    1. The hardcoded dicts are properly structured (match FeedbackSection schema)
+    2. Safety checks validate only structure, not content (see `_run_safety_checks()` line 357)
+    3. The DB stores whatever is in `review.sections`, real or hardcoded
+    4. The API returns it as-is
+
+- **Request Path:**
+    ```
+    POST /reviews (reviews.py:22)
+    ↓
+    FastAPI BackgroundTasks.add_task(process_review, db, review.id, profile_id)
+    ↓ (async, returns immediately to client with status="pending")
+    process_review() runs in background (review_service.py:82)
+    ```
+
+- **Background Processing (What Actually Executes)**:
+    - 1. Resume data is NOT parsed or ingested. Instead of calling `IngestionPipeline.ingest_resume()` or `IngestionPipeline.ingest_repo_metadata()`, the code just builds a raw dict (review_service.py:254-270):
+        ```python
+        if profile.resume_text: 
+            resume_data = {
+                "source_type": "resume",
+                "filename": profile.resume_filename,
+                "data": profile.resume_text,  # ← just raw text, never chunked/embedded
+            }
+            sources.append(resume_data)
+            
+            # Stores it in IngestedSource table but never calls the pipeline
+            ingested = IngestedSource(
+                profile_id=profile.id,
+                source_type="resume",
+                raw_data=json.dumps(resume_data),
+            )
+            db.add(ingested)
+        ```
+        - The entire ingestion pipeline infrastructure exists (chunking, embedding, vector storage in ChromaDB) but is **never instantiated or called from review_service.py**. The raw resume text is stored in the DB but never processed through `IngestionPipeline.ingest_resume()` or `IngestionPipeline.ingest_repo_metadata()`.
+
+    - 2. After collecting raw dicts, the code calls functions that return hardcoded placeholder output as results (review_service.py:282-354):
+        ```python
+        # _run_agent_orchestration() (line 282) returns:
+        return {
+            "sections": [
+                {
+                    "section_name": "Technical Skills",
+                    "content": "Analysis of technical skills from ingested sources",  # ← HARDCODED
+                    "confidence": 0.8,
+                    "suggestions": ["Add more detail on AI/ML experience"],
+                },
+                {
+                    "section_name": "Project Experience",
+                    "content": "Analysis of project experience",
+                    "confidence": 0.75,
+                    "suggestions": ["Include measurable impact metrics"],
+                },
+            ],
+            "overall_score": 0.75,
+        }
+
+        # _run_rag_retrieval_generation() (line 307) also returns hardcoded dict
+        # with enhanced but still placeholder feedback
+        ```
+
+        - Neither function actually:
+            - Queries the vector DB (ChromaDB)
+            - Retrieves context based on the resume
+            - Uses an LLM to generate personalized feedback
+            - Reads from the ingestion results at all
+
+    - 3. Results are stored (review_service.py:168-170):
+        ```python
+        review.status = "complete"
+        review.sections = [s.model_dump() for s in sections]  # ← the hardcoded feedback
+        review.overall_score = rag_output.get("overall_score", None)  # ← always 0.81
+        ```
+
+
+- **To fix this gap (required for Issue #14):**
+    1. Instantiate `IngestionPipeline` inside `_run_ingestion_pipeline()` with real embedding provider + vector DB
+    2. Call `pipeline.ingest_resume()`, `pipeline.ingest_readme()`, `pipeline.ingest_repo_metadata()` for each source
+    3. Update `_run_agent_orchestration()` and `_run_rag_retrieval_generation()` to query the vector DB instead of returning hardcoded dicts
+
+---
+
+## ANALYSIS: the ideal function flow when a GHA workflow file is encountered
+
+There is **no route** that accepts workflow files submissions. Instead, workflow files are touched indirectly during repo metadata ingestion. Here's the chain:
+
+- **1. Profile creation** (api/routes/profiles.py:23): User submits a GitHub username. The endpoint stores it in `profile.github_username`.
+- **2. Review requested** (api/routes/reviews.py:22): `create_review_endpoint()` registers `process_review` function as a `BackgroundTask`.
+- **3. Ingestion stub runs** (core/services/review_service.py:197): `process_review()` calls `_run_ingestion_pipeline(db, profile)` to run the ingestion pipeline, which checks `profile.github_username` and builds a raw dict:
+    ```python
+    # Placeholder: actual GitHub ingestion logic
+    github_data = {
+        "source_type": "github",
+        "username": profile.github_username,
+        "data": f"GitHub profile data for {profile.github_username}",
+    }
+    ```
+    - **Note:** Currently, no GitHub API call is made, no repo files are fetched, no workflow YAMLs are read. These data should be fetched and ingested into the `data` field in this dictionary.
+    - If `_run_ingestion_pipeline()` is properly wired, it would instead:
+        - Use a GitHub API client to fetch actual repo metadata for `profile.github_username`
+        - Instantiate IngestionPipeline with a vector DB, DB session, and embedding provider
+        - Call `IngestionPipeline.ingest_resume()` (currently it just builds a plain dict from profile.resume_text). Alternatively, you could make it call eagerly at profile creation in api/routes/profiles.py:84 right after the file is uploaded.
+        - Call `IngestionPipeline.ingest_repo_metadata(profile_id, repo_data)` for each repo
+- **4. Repo metadata path (if wired)** (ingestion/pipeline.py:201): `IngestionPipeline.ingest_repo_metadata()` calls 
+    - `RepoAnalyzer.parse(repo_data)`: Analyze repository
+    - `StrategySelector.chunk(text, metadata)`: Chunk the content
+        - this calls `select_chunker(source_type)` in ingestion/chunking/strategy_selector.py. 
+        - right now, select_chunker() only knows "resume", "readme", and "repo" source type
+            ```python
+            if source_type == "resume":
+                return self.semantic_chunker
+            elif source_type == "readme":
+                return self.structural_chunker
+            elif source_type == "repo":
+                return self.semantic_chunker
+            else:
+                # Default to semantic chunking
+                return self.semantic_chunker
+            ```
+        - We may add `"workflow"` as a new source type and select structural_chunker/semantic_chunker for it. Otherwise, it would fall through to the default semantic chunker
+    - `BatchEmbeddingProcessor.process(chunks)`: Generate embeddings and store
+- **5. Analyze GitHub repository, check if CI/CD workflow files exist**: `RepoAnalyzer.parse()` calls `_detect_ci()` (ingestion/parsers/repo_analyzer.py:111) to check if repository has CI/CD configured:
+    ```python
+    def _detect_ci(self, repo_data: dict) -> bool:
+        ci_indicators = [
+            ".github/workflows" in str(repo_data.get("file_structure", "")),
+            ...
+        ]
+        return any(ci_indicators)
+    ```
+    - **Note:** currently, _detect_ci() only sets `has_ci = True/False` in metadata in `RepoAnalyzer.parse()`. The workflow YAML content was never read — no skill was extracted.
+        ```python
+        summary_parts = [
+            f"Repository: {repo_data.get('name', 'Unknown')}",
+            f"Description: {repo_data.get('description', 'No description')}",
+            f"Language: {primary_language}",
+            f"Stars: {star_count}",
+            f"Forks: {fork_count}",
+            f"Open Issues: {open_issues_count}",
+            f"Has README: {has_readme}",
+            f"Has Tests: {has_tests}",
+            f"Has CI/CD: {has_ci}",
+            f"Tech Stack: {', '.join(tech_stack) if tech_stack else 'Not detected'}",
+            f"URL: {repo_data.get('html_url', 'Unknown')}",
+        ]
+        summary_text = "\n".join(summary_parts)
+        metadata = {
+            "source_type": "repo",
+            "primary_language": primary_language,
+            "has_tests": has_tests,
+            "has_readme": has_readme,
+            "has_ci": has_ci,
+            "last_commit_date": last_commit_date,
+            "star_count": star_count,
+            "fork_count": fork_count,
+            "open_issues_count": open_issues_count,
+            "tech_stack": tech_stack,
+            "repo_name": repo_data.get("name", "Unknown"),
+            "repo_url": repo_data.get("html_url", ""),
+        }
+        return ParseResult(
+            text=summary_text,
+            metadata=metadata,
+            source_type="repo",
+        )
+        ```
+    - We see that `RepoAnalyzer.parse()` also finds out if the repo has_readme, has_tests besides has_ci => we can add a new `IngestionPipeline.ingest_workflow()` function, and let `RepoAnalyzer.parse()` call  `IngestionPipeline.ingest_readme()` and `IngestionPipeline.ingest_workflow()` after RepoAnalyzer.parse() had checked for CI/CD and for readme file. For example:
+        ```python
+        if repo_result.metadata["has_readme"]:
+            readme_content = github_api.fetch_readme(username, repo_name)
+            pipeline.ingest_readme(profile_id, repo_name, readme_content)
+
+        if repo_result.metadata["has_ci"]:
+            for filename, content in github_api.fetch_workflows(username, repo_name):
+                pipeline.ingest_workflow(profile_id, repo_name, filename, content)
+        ```        
+    - Following the pattern of `IngestionPipeline.ingest_readme()` that makes a call to `readme_parser.parse()`, we should also have a `workflow_parser` class with a `parse()` function, and let `IngestionPipeline.ingest_workflow()` call `workflow_parser.parse()`
+        - `workflow_parser.parse()` is supposed to parse the workflow files and return a ParseResult object
+            ```python
+            class ParseResult:
+                """Result of parsing a source document."""
+                text: str
+                metadata: dict
+                source_type: str
+            ```
+            - `text`: the workflow file text (formatted). Something like:
+                ```python
+                text_parts = [f"Workflow: {workflow.get('name', 'unnamed')}"]
+                for job_name, job in workflow.get("jobs", {}).items():
+                    for step in job.get("steps", []):
+                        if step.get("uses"):
+                            text_parts.append(f"uses: {step['uses']}")
+                        if step.get("run"):
+                            text_parts.append(f"run: {step['run']}")
+                summary_text = "\n".join(text_parts)
+                ```
+            - `metadata`: something like: 
+                ```python
+                metadata = {
+                    "source_type": "repo_workflow",
+                    "workflow_name": workflow_name,
+                    "detected_skills": [s.name for s in detected_skills],
+                    "ci_tools": [s.name for s in detected if s.category == "Tool"]
+                }
+                ```
+                - notice that we have `SkillExtractor.extract_skills(self, text: str, filename: Optional[str] = None) -> list[SkillDetection]` that extract skills from source code or documentation text => we may use this function to generate `detected_skills` list (need to verify if this use case makes sense)
+                ```python
+                detected_skills = SkillExtractor.extract_skills(summary_text, filename="workflow.yml")
+                ```
+                - `extract_skills()` is currently only called in `/tests/unit/test_skill_extractor.py` -> read the test file to see how extract_skills() is used. For example: 
+                ```python
+                def test_devops_tool_detection(self, extractor):
+                    """Test DevOps tool detection."""
+                    text = """
+                    FROM python:3.9
+                    RUN pip install requirements.txt
+                    EXPOSE 8000
+                    """
+                    result = extractor.extract_skills(text)
+
+                    skill_names = [s.name for s in result]
+                    # Should detect Docker
+                    assert any("docker" in s.lower() for s in skill_names)
+                ```
+
+            - `source_type`: "repo_workflow"
+
+
+
+-------------------------------------------------------------------------
+
+
+## What's missing (the three gaps to close)
+
+| Gap | Location | What needs to be added |
+|---|---|---|
+| No workflow parser | `ingestion/parsers/` | `WorkflowParser` that reads YAML, walks `jobs.<job>.steps`, maps `uses:` and `run:` to skill signals |
+| No ingestion entry point | `ingestion/pipeline.py:201` | `ingest_workflow(profile_id, repo_name, content)` method alongside `ingest_readme` |
+| No chunking strategy | `ingestion/chunking/strategy_selector.py:14` | `elif source_type == "workflow": return self.semantic_chunker` |
+
+The `_detect_ci()` boolean flag in `RepoAnalyzer` tells you a workflow *exists* but throws away all the content. The fix routes actual YAML content through a new parser before that information is discarded.
+
+
+-------------------------------------------------------------------------
+
+
+## ANALYSIS: Replicate Issue #14 (Detailed Steps) 
+```
+(problem statement: Developers who maintain CI/CD workflows demonstrate DevOps skills that don't appear in import statements or README text. Add a parser that reads .github/workflows/*.yml files and extracts inferred skills (e.g., GitHub Actions, Docker, pytest, deployment).)
+```
+
+- **Step 1:** Start the PathReview App Locally, login and start a review request with a resume file + a GitHub username that has repos with CI/CD workflows (Example: Use `actions` (GitHub's own org has workflow files))
+- **Step 2:** submit that review request and check the server logs. I should see logs like "Repository metadata chunked successfully" and "Repository embeddings stored", but I do not. Besides I see the log: `[error    ] github_ingestion_failed        error="'raw_data' is an invalid keyword argument for IngestedSource" request_id=1dbbcc01-2fe4-4c29-967c-7770e7a36a22 username=abc` -> no github data or Workflow YAML were fetched
+- **Step 3**: read the review result and confirmed no CI/CD skills are extracted (No mention of: Docker, Kubernetes, Terraform, GitHub Actions, CI/CD tools)
+- **Step 6**: create a script to replicate issue 14. The script create an example workflow file and use the SkillExtractor.extract_skills(text, filename) to detect skills in that file, then validate the result to check if it correctly detect the skills 
+    <details>
+    <summary>Click here to expand the script</summary>
+
+    ```bash
+    #!/usr/bin/env python3
+    """
+    Replication script for Issue #14: Add support for parsing GitHub Actions workflow files to detect CI/CD skills
+
+    This script demonstrates that:
+    1. SkillExtractor CAN detect CI/CD tools from workflow YAML
+    2. But workflow files are never parsed in the production ingestion pipeline
+    3. Therefore, CI/CD skills are invisible to developers using GitHub Actions
+
+    Run this script to see what skills SkillExtractor detects from a sample workflow.
+    """
+
+    import sys
+    from pathlib import Path
+
+    # Add parent directory to path so we can import ingestion modules
+    sys.path.insert(0, str(Path(__file__).parent.parent))
+
+    from ingestion.parsers.skill_extractor import SkillExtractor
+
+    # Example GitHub Actions workflow file
+    EXAMPLE_WORKFLOW = """
+    name: CI/CD Pipeline with GitHub Actions
+
+    on:
+    push:
+        branches: [main, develop]
+    pull_request:
+        branches: [main]
+
+    env:
+    REGISTRY: ghcr.io
+    IMAGE_NAME: myapp
+    GITHUB_ACTIONS: true
+
+    jobs:
+    build:
+        runs-on: ubuntu-latest
+
+        steps:
+        - name: Checkout code using GitHub Actions
+            uses: actions/checkout@v3
+
+        - name: Set up Python with GitHub Actions
+            uses: actions/setup-python@v4
+            with:
+            python-version: '3.11'
+
+        - name: Install dependencies
+            run: |
+            python -m pip install --upgrade pip
+            pip install -r requirements.txt
+            pip install pytest pytest-cov pytest-xdist
+
+        - name: Lint with flake8
+            run: flake8 src/ --count --select=E9,F63,F7,F82 --show-source --statistics
+
+        - name: Run pytest unit tests with coverage
+            run: |
+            pytest tests/ --cov=src/ --cov-report=xml -v
+            pytest tests/integration/ --pytest-timeout=60
+            pytest tests/e2e/ -m "not slow"
+
+        - name: Upload coverage to Codecov via GitHub Actions
+            uses: codecov/codecov-action@v3
+            with:
+            files: ./coverage.xml
+
+    build-docker:
+        needs: build
+        runs-on: ubuntu-latest
+        permissions:
+        contents: read
+        packages: write
+
+        steps:
+        - name: Checkout code with GitHub Actions
+            uses: actions/checkout@v3
+
+        - name: Set up Docker Buildx for multi-platform builds
+            uses: docker/setup-buildx-action@v2
+
+        - name: Log in to Docker Container Registry
+            uses: docker/login-action@v2
+            with:
+            registry: ${{ env.REGISTRY }}
+            username: ${{ github.actor }}
+            password: ${{ secrets.GITHUB_TOKEN }}
+
+        - name: Extract Docker image metadata
+            id: meta
+            uses: docker/metadata-action@v4
+            with:
+            images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+            tags: |
+                type=ref,event=branch
+                type=semver,pattern={{version}}
+
+        - name: Build Docker image and push to registry
+            uses: docker/build-push-action@v4
+            with:
+            context: .
+            push: true
+            tags: ${{ steps.meta.outputs.tags }}
+            labels: ${{ steps.meta.outputs.labels }}
+            cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
+            cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache,mode=max
+
+        - name: Scan Docker image for vulnerabilities
+            run: |
+            docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \\
+                aquasec/trivy image ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+
+    deploy:
+        needs: build-docker
+        runs-on: ubuntu-latest
+        if: github.ref == 'refs/heads/main'
+
+        steps:
+        - name: Checkout code with GitHub Actions
+            uses: actions/checkout@v3
+
+        - name: Configure AWS credentials for deployment
+            uses: aws-actions/configure-aws-credentials@v2
+            with:
+            aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+            aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+            aws-region: us-east-1
+
+        - name: Deploy Docker image to AWS ECS
+            run: |
+            aws ecs update-service \\
+                --cluster production \\
+                --service myapp-service \\
+                --force-new-deployment
+
+        - name: Deploy infrastructure with Terraform
+            run: |
+            cd terraform/
+            terraform init
+            terraform plan -out=tfplan
+            terraform apply tfplan
+
+        - name: Configure kubectl for Kubernetes deployment
+            uses: azure/setup-kubectl@v3
+            with:
+            version: 'v1.27.0'
+
+        - name: Deploy Docker image to Kubernetes cluster
+            run: |
+            kubectl set image deployment/myapp \\
+                myapp=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest \\
+                -n production
+            kubectl rollout status deployment/myapp -n production
+            kubectl get deployment myapp -n production
+
+        - name: Run Ansible playbooks for deployment automation
+            run: |
+            ansible-playbook playbooks/configure-servers.yml
+            ansible-playbook playbooks/security-hardening.yml
+            ansible-playbook playbooks/post-deployment.yml
+
+        - name: Notify Slack of successful deployment
+            uses: slackapi/slack-github-action@v1
+            with:
+            webhook-url: ${{ secrets.SLACK_WEBHOOK }}
+            payload: |
+                {
+                "text": "Deployment to production completed successfully via GitHub Actions"
+                }
+
+        - name: Create GitHub release for deployment
+            uses: actions/create-release@v1
+            env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            with:
+            tag_name: deploy-${{ github.run_number }}
+            release_name: Deployment ${{ github.run_number }}
+            body: Automated deployment to production
+            draft: false
+            prerelease: false
+    """
+
+
+    def validate_skill_detection(skills, expected_tools):
+        """
+        Validate that detected skills include expected CI/CD tools.
+
+        Args:
+            skills: List of SkillDetection objects
+            expected_tools: Set of tool names that should be detected
+
+        Returns:
+            dict: Validation results
+        """
+        detected_names = {s.name.lower() for s in skills}
+        detected_tools = [s for s in skills if s.category == "Tool"]
+        detected_tool_names = {s.name.lower() for s in detected_tools}
+
+        results = {
+            "total_skills": len(skills),
+            "total_tools": len(detected_tools),
+            "detected_tool_names": sorted([t.name for t in detected_tools]),
+            "expected_tools": sorted(expected_tools),
+            "found_tools": sorted(expected_tools & detected_names),
+            "missing_tools": sorted(expected_tools - detected_names),
+            "validation_passed": expected_tools.issubset(detected_names),
+        }
+
+        return results
+
+
+    def main():
+        print("=" * 80)
+        print("ISSUE #14 REPLICATION: GitHub Actions Workflow Skill Extraction")
+        print("=" * 80)
+        print()
+        print("Sample workflow includes:")
+        print("  • GitHub Actions — checkout, setup-python, docker, kubectl, codecov")
+        print("  • Docker — Buildx, image builds, registry push, vulnerability scanning")
+        print("  • pytest — unit tests, integration tests, coverage reporting")
+        print("  • Deployment — ECS, Kubernetes, Terraform, Ansible, GitHub releases")
+        print()
+
+        # Initialize extractor
+        extractor = SkillExtractor()
+
+        # Extract skills from the workflow YAML
+        print("📝 Analyzing sample GitHub Actions workflow file...")
+        print()
+
+        skills = extractor.extract_skills(EXAMPLE_WORKFLOW, filename="ci-cd.yml")
+
+        # Display results
+        print(f"✓ Extracted {len(skills)} skills from workflow:\n")
+
+        # Group by category
+        by_category = {}
+        for skill in skills:
+            if skill.category not in by_category:
+                by_category[skill.category] = []
+            by_category[skill.category].append(skill)
+
+        for category in sorted(by_category.keys()):
+            print(f"  {category}:")
+            for skill in sorted(by_category[category], key=lambda s: s.confidence, reverse=True):
+                print(f"    - {skill.name:<25} (confidence: {skill.confidence:.2f})")
+                if skill.evidence:
+                    print(f"      Evidence: {', '.join(skill.evidence[:2])}")
+            print()
+
+        # Validate detection
+        print("-" * 80)
+        print("VALIDATION: Expected CI/CD Tools")
+        print("-" * 80)
+
+        # These tools are mentioned in the workflow YAML
+        expected_ci_cd_tools = {
+            "docker",
+            "kubernetes",
+            "terraform",
+            "aws",
+            "github",
+            "ci/cd",
+            "ansible",
+        }
+
+        validation = validate_skill_detection(skills, expected_ci_cd_tools)
+
+        print(f"\nTotal skills detected:     {validation['total_skills']}")
+        print(f"Total tools detected:      {validation['total_tools']}")
+        print()
+        print(f"Expected tools:            {', '.join(validation['expected_tools'])}")
+        print(f"✓ Found tools:             {', '.join(validation['found_tools'])}")
+        if validation["missing_tools"]:
+            print(f"✗ Missing tools:           {', '.join(validation['missing_tools'])}")
+        print()
+
+        if validation["validation_passed"]:
+            print("✓ VALIDATION PASSED: All expected CI/CD tools detected!")
+        else:
+            print(f"⚠ VALIDATION INCOMPLETE: {len(validation['missing_tools'])} tools not detected")
+            print("  This is expected — SkillExtractor uses substring matching")
+
+        # The key issue
+        print()
+        print("=" * 80)
+        print("ISSUE #14: THE GAP")
+        print("=" * 80)
+        print()
+        print("✓ PROVEN: SkillExtractor.extract_skills() CAN detect CI/CD tools")
+        print("          from GitHub Actions workflow YAML files.")
+        print()
+        print("✗ ISSUE:  But workflow files are NEVER passed to SkillExtractor")
+        print("          in the production ingestion pipeline.")
+        print()
+        print("📍 ROOT CAUSE:")
+        print("  1. _run_ingestion_pipeline() in review_service.py never calls")
+        print("     IngestionPipeline.ingest_resume() or ingest_repo_metadata()")
+        print()
+        print("  2. RepoAnalyzer._detect_ci() only returns a boolean (has_ci=True/False)")
+        print("     without reading the actual workflow YAML content")
+        print()
+        print("  3. No WorkflowParser exists to parse .github/workflows/*.yml files")
+        print()
+        print("  4. StrategySelector.select_chunker() has no 'workflow' source_type")
+        print()
+        print("🔧 SOLUTION: Issue #14 requires:")
+        print("  1. Create WorkflowParser class in ingestion/parsers/")
+        print("  2. Implement IngestionPipeline.ingest_workflow()")
+        print("  3. Add 'workflow' source type to StrategySelector")
+        print("  4. Wire _run_ingestion_pipeline() to call IngestionPipeline methods")
+        print()
+        print("=" * 80)
+
+
+    if __name__ == "__main__":
+        main()
+
+    ```
+    </details>
+
+    - **Result:**
+        - PROVEN: SkillExtractor.extract_skills() CAN detect CI/CD tools from GitHub Actions workflow YAML files.
+        - ISSUE: workflow files are NEVER passed to SkillExtractor in the production ingestion pipeline.
+
+    - **ROOT CAUSE:**
+        1. _run_ingestion_pipeline() in review_service.py never calls  IngestionPipeline.ingest_resume() or ingest_repo_metadata()
+        2. RepoAnalyzer._detect_ci() only returns a boolean (has_ci=True/False) without reading the actual workflow YAML content
+        3. No WorkflowParser exists to parse .github/workflows/*.yml files
+        4. StrategySelector.select_chunker() has no 'workflow' source_type
+
+    - **SOLUTION:**
+        1. Create WorkflowParser class in ingestion/parsers/
+        2. Implement IngestionPipeline.ingest_workflow()
+        3. Add 'workflow' source type to StrategySelector
+        4. Wire _run_ingestion_pipeline() to call IngestionPipeline methods
+
+-------------------------------------------------------------------------
+
+
+## Solution plan
+
+**Issue:** https://github.com/ascherj/pathreview/issues/14 — Add support for parsing GitHub Actions workflow files to detect CI/CD skills
+
+### Understand
+
+**Root cause:** The ingestion pipeline infrastructure exists (SkillExtractor, chunking, embeddings) but is architecturally disconnected from the API layer. When a developer submits a profile with a GitHub username, `_run_ingestion_pipeline()` builds raw dicts without calling `IngestionPipeline.ingest_resume()` or `ingest_repo_metadata()`. Workflow files are never fetched, parsed, or analyzed.
+
+Specifically:
+- `RepoAnalyzer._detect_ci()` only checks if `.github/workflows` exists in the file structure and returns a boolean — it never reads the YAML content
+- No `WorkflowParser` class exists to parse workflow YAML files
+- `IngestionPipeline` has no `ingest_workflow()` method
+- `StrategySelector.select_chunker()` has no "workflow" case
+- Review feedback is hardcoded; no vector DB queries happen
+
+**Expected behavior:** When a developer's repo contains `.github/workflows/*.yml` files, the system should:
+1. Fetch the workflow YAML from GitHub
+2. Parse it with `WorkflowParser`, extracting job names, step actions (uses:), and commands (run:)
+3. Call `SkillExtractor.extract_skills()` on the assembled text
+4. Store detected CI/CD tools (Docker, Kubernetes, Terraform, Ansible, AWS, etc.) in metadata
+5. Chunk the workflow content and embed it in ChromaDB
+6. Use those skills in review feedback generation
+
+**Current behavior:** Workflow files are never fetched or parsed. CI/CD skills remain invisible. Developers show zero DevOps expertise even if their most skilled work is in GitHub Actions.
+
+### Map
+
+Files I expect to touch:
+
+1. **`ingestion/parsers/skill_extractor.py`** (lines 93–106) — Extend CI/CD tool detection
+   - Currently has TOOLS dict with: Docker, Kubernetes, Git, GitHub, AWS, GCP, Azure, CI/CD, Jenkins, Terraform, Ansible
+   - Missing CI/CD tools that appear in workflows: Helm, GitLab CI, CircleCI, Codecov, Trivy, PyTest, flake8, pytest-cov
+   - Will add these tools to the TOOLS dict with appropriate confidence scores (0.85–0.95 range)
+   - May also add Docker Compose, Gradle, Maven, SonarQube if found in test workflows
+
+2. **`ingestion/parsers/workflow_parser.py`** (NEW FILE) — Create `WorkflowParser` class that reads YAML and extracts skills
+   - Will follow the pattern of `ResumeParser` and `ReadmeParser` (both inherit from `BaseParser`)
+   - Implements `parse(content: str | bytes) -> ParseResult`
+   
+3. **`ingestion/pipeline.py`** (lines 55–273) — Add `ingest_workflow()` method
+   - Will follow the same pattern as `ingest_resume()` (lines 55–125) and `ingest_readme()` (lines 126–200)
+   - Takes: `profile_id`, `repo_name`, `filename`, `content` (workflow YAML)
+   - Returns: embeddings stored in ChromaDB with `source_type="workflow"` metadata
+
+4. **`ingestion/chunking/strategy_selector.py`** (lines 14–32) — Add "workflow" case to `select_chunker()`
+   - Currently only recognizes: "resume", "readme", "repo"
+   - Will add: `elif source_type == "workflow": return self.semantic_chunker`
+
+5. **`core/services/review_service.py`** (lines 197–279) — Wire `IngestionPipeline` in `_run_ingestion_pipeline()` (NOTE: might be out of scope)
+   - Currently: builds raw dicts, never calls pipeline methods
+   - Will change to:
+     - Instantiate `IngestionPipeline` with embedding provider and vector DB
+     - Call `pipeline.ingest_resume()` if `profile.resume_text` exists
+     - Call `pipeline.ingest_repo_metadata()` for each GitHub repo
+     - Call `pipeline.ingest_workflow()` for each `.github/workflows/*.yml` file
+
+6. **`tests/unit/test_workflow_parser.py`** (NEW FILE) — Unit tests for `WorkflowParser`
+   - Test parsing a realistic GitHub Actions workflow
+   - Test skill extraction from workflow YAML
+   - Test error handling on malformed YAML
+
+7. **`script/replicate_issue_14.py`** (EXISTING) — Already demonstrates the issue
+   - Shows SkillExtractor CAN detect CI/CD tools
+   - Validates the gap in production code
+
+### Plan
+
+**Phase 1: Update skill_extractor.py and Create WorkflowParser**
+0. add more ci/cd skill to skill_extractor.py
+
+1. Create `ingestion/parsers/workflow_parser.py`:
+   - Import `yaml`, `BaseParser`, `ParseResult`, `SkillExtractor`
+   - Implement `WorkflowParser.parse(content: str | bytes) -> ParseResult`:
+     - Load YAML with `yaml.safe_load()`
+     - Walk `jobs.<job>.steps`, collect `uses:` action names and `run:` commands
+     - Assemble into text: `"Workflow: <name>\nuses: <action>\nrun: <command>"`
+     - Call `SkillExtractor().extract_skills(text, filename="workflow.yml")`
+     - Return `ParseResult(text=assembled_text, metadata={"source_type": "workflow", "detected_skills": [s.name for s in skills], "workflow_name": ...}, source_type="workflow")`
+
+2. Write unit tests in `tests/unit/test_workflow_parser.py`:
+   - Test parsing a valid workflow YAML (use the example from `script/replicate_issue_14.py`)
+   - Test that `SkillExtractor.extract_skills()` is called and skills are in metadata
+   - Test error handling: malformed YAML raises `ValueError`
+
+**Phase 2: Add ingest_workflow() to IngestionPipeline**
+
+3. In `ingestion/pipeline.py`, add `ingest_workflow()` method after `ingest_readme()`:
+   - Signature: `async def ingest_workflow(self, profile_id, repo_name, filename, content) -> None`
+   - Follow the exact pattern of `ingest_readme()`:
+     - Call `WorkflowParser().parse(content)`
+     - Pass result to `self.chunker.chunk(parse_result.text, parse_result.metadata)`
+     - For each chunk, call `self.embedding_processor.process(chunk, metadata)`
+     - Store in ChromaDB with metadata including `source_type="workflow"`
+
+**Phase 3: Update StrategySelector**
+
+4. In `ingestion/chunking/strategy_selector.py`, add workflow case:
+   - After line 32 (current repo case), add:
+     ```python
+     elif source_type == "workflow":
+         return self.semantic_chunker
+     ```
+
+**Phase 4: Wire the API layer** (NOTE: might be out of scope)
+
+5. In `core/services/review_service.py`, update `_run_ingestion_pipeline()`:
+   - Import `IngestionPipeline` (already imported on line 10, but will need embedding provider + vector DB)
+   - Initialize: `pipeline = IngestionPipeline(db=db, embedding_provider=OpenAIEmbedding(), vector_db=ChromaDB(".chromadb"))`
+   - Replace the hardcoded dicts with actual pipeline calls:
+     - For resume: `if profile.resume_text: pipeline.ingest_resume(profile.id, profile.resume_text)`
+     - For each GitHub repo: `pipeline.ingest_repo_metadata(profile.id, repo_data)`
+     - For each workflow in that repo: `pipeline.ingest_workflow(profile.id, repo_name, filename, content)`
+
+6. Update `_run_rag_retrieval_generation()` to actually query ChromaDB:
+   - Instead of returning hardcoded dict, use `HybridRetriever` to query for context matching user's skills
+   - Call LLM with retrieved context to generate personalized feedback
+
+**Phase 5: Validation**
+
+7. Run unit tests: `make test-unit` — confirm all new tests pass
+8. Run replication script: `python3 script/replicate_issue_14.py` — confirm no errors
+9. Run type checks: `make typecheck` — verify no type errors
+10. Manual test: create profile with GitHub username that has repos with workflows, request review, verify review contains CI/CD tools in feedback
+
+### Inputs & outputs
+
+**Functions I'm creating:**
+
+`WorkflowParser.parse(content: str | bytes) -> ParseResult`
+- Input: YAML workflow file content (string or bytes)
+- Output: `ParseResult` with:
+  - `text`: formatted workflow (job names, actions, commands)
+  - `metadata`: includes `source_type="workflow"`, `detected_skills: list[str]`, `ci_tools: list[str]`
+  - `source_type`: "workflow"
+
+`IngestionPipeline.ingest_workflow(profile_id, repo_name, filename, content) -> None`
+- Input: profile ID, repo name, workflow filename, YAML content
+- Output: embeddings stored in ChromaDB with workflow metadata
+
+**Test case:**
+
+```python
+def test_workflow_parser_extracts_ci_cd_skills():
+    """WorkflowParser detects CI/CD tools from GitHub Actions workflow."""
+    workflow_yaml = """
+    name: CI
+    jobs:
+      build:
+        steps:
+          - uses: docker/build-push-action@v2
+          - run: terraform apply
+    """
+    parser = WorkflowParser()
+    result = parser.parse(workflow_yaml)
+    
+    assert result.source_type == "workflow"
+    assert "Docker" in result.metadata["detected_skills"]
+    assert "Terraform" in result.metadata["detected_skills"]
+    assert "uses: docker/build-push-action" in result.text
+```
+
+### Risks & unknowns
+
+1. **GitHub API authentication:** Fetching workflow files requires GitHub API access. If no token is configured, this will fail silently (like current code does). I'll need to:
+   - Check if `GITHUB_TOKEN` env var exists before calling API
+   - Raise `IngestionError` if token is missing, not silently skip
+   - Update documentation on required environment variables
+
+2. **Workflow parsing robustness:** YAML can be malformed or non-standard. I need to:
+   - Catch `yaml.YAMLError` and raise `ParseError` with clear message
+   - Handle missing `jobs:` key gracefully (empty workflow is valid)
+   - Test with real-world workflows from major projects to confirm parsing works
+
+3. **Embedding provider initialization:** The current code doesn't show how `OpenAIEmbedding()` is initialized. I need to:
+   - Check `ingestion/embeddings/` for the actual class name and constructor
+   - Verify the API key is configured
+   - Handle rate limiting if processing many workflows
+
+4. **When are workflows fetched?** The current design has no GitHub API client integrated. I need to:
+   - Either add a GitHub API client in `core/services/review_service.py`
+   - Or have the caller (unknown) pass workflow content via the API
+   - The user's current implementation is a placeholder — I need to decide this design before coding
+
+5. **Source type naming:** I used `"workflow"`, but PLAN.md mentions `"repo_workflow"`. I need to:
+   - Decide on the canonical name (prefer `"workflow"` — shorter, clearer)
+   - Update StrategySelector to match
+   - Document in commit message why I chose this name
+
+### Edge cases
+
+1. **Repository with no workflows** — `.github/workflows/` directory exists but is empty
+   - Expected: skip gracefully, no error
+   - Implementation: `github_api.fetch_workflows(username, repo)` returns empty list; `ingest_workflow()` never called
+
+2. **Repository with workflows but no `jobs:` key** — YAML is present but malformed
+   - Expected: raise `ParseError` with message like "Invalid workflow format: no 'jobs' key found"
+   - Implementation: `WorkflowParser.parse()` catches `KeyError` and raises `ParseError`
+
+3. **Workflow with mixed action types** — Some steps use `uses:`, others use `run:` with inline scripts
+   - Expected: extract both; SkillExtractor detects tools from both action names and script content
+   - Implementation: walk all steps, collect both fields
+
+4. **Large workflow files (>100 KB of YAML)** — Some real workflows have thousands of lines
+   - Expected: chunk and embed normally; chunker handles large content
+   - Implementation: no special handling needed (chunker already handles this for README)
+
+5. **Workflow with secrets/sensitive data in comments** — E.g., `# aws-secret-key = xyz`
+   - Expected: no special filtering — we're only indexing tool names, not secrets
+   - But: good to document that users shouldn't put actual secrets in workflows (GitHub Actions best practice anyway)
+   - Implementation: no changes needed; SkillExtractor only looks for tool keywords
+
+6. **Developer with 50+ repos, some with workflows** — Processing takes a long time
+   - Expected: background task completes eventually; doesn't timeout
+   - Implementation: depends on how `_run_ingestion_pipeline()` is called (already async/background)
+   - May need to document expected runtime
+

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -99,7 +99,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -449,7 +448,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -473,7 +471,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1561,7 +1558,6 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1579,7 +1575,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1972,7 +1967,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3507,7 +3501,6 @@
       "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^2.0.1",
         "cssstyle": "^4.0.1",
@@ -4094,7 +4087,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4107,7 +4099,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4771,7 +4762,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/ingestion/chunking/strategy_selector.py
+++ b/ingestion/chunking/strategy_selector.py
@@ -16,7 +16,7 @@ class StrategySelector:
         Select appropriate chunker based on document type.
 
         Args:
-            source_type: One of "resume", "readme", "repo", or default
+            source_type: One of "resume", "readme", "repo", "workflow", or default
 
         Returns:
             Appropriate BaseChunker instance
@@ -26,6 +26,8 @@ class StrategySelector:
         elif source_type == "readme":
             return self.structural_chunker
         elif source_type == "repo":
+            return self.semantic_chunker
+        elif source_type == "workflow":
             return self.semantic_chunker
         else:
             # Default to semantic chunking

--- a/ingestion/parsers/skill_extractor.py
+++ b/ingestion/parsers/skill_extractor.py
@@ -1,11 +1,11 @@
 import re
 from dataclasses import dataclass
-from typing import Optional
 
 
 @dataclass
 class SkillDetection:
     """Result of detecting a skill."""
+
     name: str
     category: str
     confidence: float
@@ -93,8 +93,10 @@ class SkillExtractor:
     TOOLS = {
         "docker": 0.95,
         "kubernetes": 0.95,
+        "kubectl": 0.95,
         "git": 0.90,
         "github": 0.90,
+        "github actions": 0.95,
         "gitlab": 0.90,
         "aws": 0.90,
         "gcp": 0.90,
@@ -103,9 +105,20 @@ class SkillExtractor:
         "jenkins": 0.85,
         "terraform": 0.85,
         "ansible": 0.85,
+        "helm": 0.90,
+        "circleci": 0.85,
+        "codecov": 0.85,
+        "trivy": 0.85,
+        "pytest": 0.85,
+        "flake8": 0.85,
+        "docker compose": 0.90,
+        "gradle": 0.85,
+        "maven": 0.85,
+        "sonarqube": 0.85,
+        "deployment": 0.85,
     }
 
-    def extract_skills(self, text: str, filename: Optional[str] = None) -> list[SkillDetection]:
+    def extract_skills(self, text: str, filename: str | None = None) -> list[SkillDetection]:
         """
         Extract skills from source code or documentation text.
 
@@ -116,7 +129,7 @@ class SkillExtractor:
         Returns:
             List of detected skills with confidence scores
         """
-        detected_skills = {}
+        detected_skills: dict[str, SkillDetection] = {}
 
         # Detect languages first
         self._detect_languages(text, filename, detected_skills)
@@ -143,7 +156,7 @@ class SkillExtractor:
     def _detect_languages(
         self,
         text: str,
-        filename: Optional[str],
+        filename: str | None,
         skills_dict: dict,
     ) -> None:
         """Detect programming languages."""
@@ -266,7 +279,16 @@ class SkillExtractor:
 
         for tool, confidence in self.TOOLS.items():
             if tool in text_lower:
-                display_name = tool.upper() if tool in ["ci/cd"] else tool.title()
+                _display_overrides = {
+                    "ci/cd": "CI/CD",
+                    "github actions": "GitHub Actions",
+                    "gha": "GitHub Actions",
+                    "k8s": "Kubernetes",
+                    "kubectl": "Kubernetes",
+                    "aws": "AWS",
+                    "gcp": "GCP",
+                }
+                display_name = _display_overrides.get(tool, tool.title())
                 if display_name not in skills_dict:
                     skills_dict[display_name] = SkillDetection(
                         name=display_name,

--- a/ingestion/parsers/workflow_parser.py
+++ b/ingestion/parsers/workflow_parser.py
@@ -1,0 +1,171 @@
+import structlog
+import yaml  # type: ignore
+
+from .base import BaseParser, ParseResult
+from .skill_extractor import SkillExtractor
+
+logger = structlog.get_logger()
+
+_DEPLOY_TRIGGERS = {"release", "workflow_dispatch"}
+_DEPLOY_BRANCHES = {"main", "master", "production", "prod"}
+
+
+class WorkflowParser(BaseParser):
+    """Parser for GitHub Actions workflow files."""
+
+    def parse(self, content: str | bytes) -> ParseResult:
+        """
+        Parse GitHub Actions workflow YAML and extract skills.
+
+        Args:
+            content: Workflow YAML content (string or bytes)
+
+        Returns:
+            ParseResult with extracted text, metadata, and detected skills
+
+        Raises:
+            ValueError: If YAML is malformed or missing required structure
+        """
+        if isinstance(content, bytes):
+            content = content.decode("utf-8", errors="replace")
+
+        try:
+            workflow = yaml.safe_load(content) or {}
+        except yaml.YAMLError as e:
+            raise ValueError(f"Invalid workflow YAML: {str(e)}") from e
+
+        if not isinstance(workflow, dict):
+            workflow = {}
+
+        # Extract workflow metadata
+        workflow_name = workflow.get("name", "unnamed") or "unnamed"
+
+        # Extract trigger events
+        trigger_events = self._extract_triggers(workflow)
+
+        # Extract jobs and steps
+        jobs = workflow.get("jobs") or {}
+        if not isinstance(jobs, dict):
+            jobs = {}
+
+        job_count = len(jobs)
+        step_count = 0
+        step_names = []
+        text_parts = [f"Workflow: {workflow_name}"]
+
+        if trigger_events:
+            text_parts.append(f"Triggers: {', '.join(trigger_events)}")
+
+        for job_name, job in jobs.items():
+            if not isinstance(job, dict):
+                continue
+
+            text_parts.append(f"Job: {job_name}")
+
+            steps = job.get("steps") or []
+            if not isinstance(steps, list):
+                continue
+
+            for step in steps:
+                if not isinstance(step, dict):
+                    continue
+
+                step_count += 1
+
+                # Extract step name
+                step_name = step.get("name")
+                if step_name:
+                    step_names.append(str(step_name))
+
+                try:
+                    # Extract 'uses' actions
+                    if "uses" in step:
+                        uses_action = step["uses"]
+                        text_parts.append(f"uses: {uses_action}")
+
+                    # Extract 'run' commands
+                    if "run" in step:
+                        run_command = step["run"]
+                        text_parts.append(f"run: {run_command}")
+                except Exception:
+                    logger.warning("Failed to parse workflow step", job=job_name)
+
+        # Detect if this is a deployment workflow
+        has_deploy_step = self._is_deploy_workflow(trigger_events, workflow)
+
+        summary_text = "\n".join(text_parts)
+
+        # Extract skills from the assembled workflow text
+        skill_extractor = SkillExtractor()
+        detected_skills = skill_extractor.extract_skills(summary_text, filename="workflow.yml")
+
+        # Extract skill names and always infer GitHub Actions and CI/CD
+        # The existence of a workflow file proves the developer has these skills
+        all_skill_names = [s.name for s in detected_skills]
+
+        if "GitHub Actions" not in all_skill_names:
+            all_skill_names.append("GitHub Actions")
+
+        if "CI/CD" not in all_skill_names:
+            all_skill_names.append("CI/CD")
+
+        # Build metadata
+        ci_tools = [s.name for s in detected_skills if s.category == "Tool"]
+
+        metadata = {
+            "source_type": "workflow",
+            "workflow_name": workflow_name,
+            "trigger_events": trigger_events,
+            "job_count": job_count,
+            "step_count": step_count,
+            "step_names": step_names,
+            "detected_skills": all_skill_names,
+            "ci_tools": ci_tools,
+            "has_deploy_step": has_deploy_step,
+        }
+
+        logger.info(
+            "Workflow parsed successfully",
+            workflow_name=workflow_name,
+            job_count=job_count,
+            step_count=step_count,
+            trigger_events=trigger_events,
+            detected_skills=all_skill_names,
+        )
+
+        return ParseResult(
+            text=summary_text,
+            metadata=metadata,
+            source_type="workflow",
+        )
+
+    def _extract_triggers(self, workflow: dict) -> list[str]:
+        """Extract trigger events from workflow."""
+        on = workflow.get("on") or workflow.get(True)  # YAML parses `on:` as True
+        if not on:
+            return []
+        if isinstance(on, str):
+            return [on]
+        if isinstance(on, list):
+            return [str(t) for t in on]
+        if isinstance(on, dict):
+            return sorted(on.keys())
+        return []
+
+    def _is_deploy_workflow(self, trigger_events: list[str], workflow: dict) -> bool:
+        """Detect if workflow is a deployment workflow."""
+        # Check if triggered by deployment events
+        for event in trigger_events:
+            if event in _DEPLOY_TRIGGERS:
+                return True
+
+        # Check if it deploys to main/production branch
+        on = workflow.get("on") or workflow.get(True)
+        if isinstance(on, dict):
+            push = on.get("push") or {}
+            if isinstance(push, dict):
+                branches = push.get("branches") or []
+                for branch in branches:
+                    if str(branch).lower() in _DEPLOY_BRANCHES:
+                        return True
+        return False

--- a/ingestion/parsers/workflow_parser.py
+++ b/ingestion/parsers/workflow_parser.py
@@ -140,7 +140,14 @@ class WorkflowParser(BaseParser):
         )
 
     def _extract_triggers(self, workflow: dict) -> list[str]:
-        """Extract trigger events from workflow."""
+        """Extract trigger events from workflow.
+
+        Args:
+            workflow: Parsed workflow dictionary
+
+        Returns:
+            List of trigger event names (e.g., ['push', 'pull_request'])
+        """
         on = workflow.get("on") or workflow.get(True)  # YAML parses `on:` as True
         if not on:
             return []
@@ -153,7 +160,15 @@ class WorkflowParser(BaseParser):
         return []
 
     def _is_deploy_workflow(self, trigger_events: list[str], workflow: dict) -> bool:
-        """Detect if workflow is a deployment workflow."""
+        """Detect if workflow is a deployment workflow.
+
+        Args:
+            trigger_events: List of trigger event names from the workflow
+            workflow: Parsed workflow dictionary
+
+        Returns:
+            True if workflow is a deployment workflow, False otherwise
+        """
         # Check if triggered by deployment events
         for event in trigger_events:
             if event in _DEPLOY_TRIGGERS:

--- a/ingestion/pipeline.py
+++ b/ingestion/pipeline.py
@@ -10,6 +10,7 @@ from .embeddings.provider import EmbeddingProvider
 from .parsers.readme_parser import ReadmeParser
 from .parsers.repo_analyzer import RepoAnalyzer
 from .parsers.resume_parser import ResumeParser
+from .parsers.workflow_parser import WorkflowParser
 
 
 logger = structlog.get_logger()
@@ -51,6 +52,7 @@ class IngestionPipeline:
         self.resume_parser = ResumeParser()
         self.readme_parser = ReadmeParser()
         self.repo_analyzer = RepoAnalyzer()
+        self.workflow_parser = WorkflowParser()
 
     def ingest_resume(
         self,
@@ -194,6 +196,87 @@ class IngestionPipeline:
                 "README ingestion failed",
                 profile_id=profile_id,
                 repo_name=repo_name,
+                error=str(e),
+            )
+            raise
+
+    def ingest_workflow(
+        self,
+        profile_id: str,
+        repo_name: str,
+        filename: str,
+        content: str | bytes,
+    ) -> IngestResult:
+        """
+        Ingest a GitHub Actions workflow file.
+
+        Args:
+            profile_id: ID of the profile owner
+            repo_name: Name of the repository
+            filename: Workflow filename (e.g. ci.yml)
+            content: Workflow content (YAML string or bytes)
+
+        Returns:
+            IngestResult with ingestion status
+        """
+        source_id = f"workflow_{profile_id}_{repo_name}_{filename}_{self._hash_content(content)}"
+
+        logger.info(
+            "Starting workflow ingestion",
+            profile_id=profile_id,
+            repo_name=repo_name,
+            filename=filename,
+            source_id=source_id,
+        )
+
+        # Check if already ingested
+        skip_result = self._check_skip(source_id, "workflow")
+        if skip_result:
+            return skip_result
+
+        try:
+            # Parse workflow
+            parse_result = self.workflow_parser.parse(content)
+            logger.info(
+                "Workflow parsed successfully",
+                workflow_name=parse_result.metadata.get("workflow_name"),
+                detected_skills=parse_result.metadata.get("detected_skills"),
+                ci_tools=parse_result.metadata.get("ci_tools")
+            )
+
+            # Prepare metadata
+            metadata = parse_result.metadata.copy()
+            metadata.update({
+                "source_id": source_id,
+                "profile_id": profile_id,
+                "repo_name": repo_name,
+                "filename": filename,
+                "source_type": "workflow",
+            })
+
+            # Chunk the content
+            chunks = self.strategy_selector.chunk(parse_result.text, metadata)
+            logger.info("Workflow chunked successfully", chunk_count=len(chunks))
+
+            # Generate embeddings and store
+            self.batch_processor.process(chunks)
+            logger.info("Workflow embeddings stored", chunk_count=len(chunks))
+
+            # Record in database
+            self._record_ingested_source(source_id, "workflow", profile_id, len(chunks))
+
+            return IngestResult(
+                source_id=source_id,
+                chunk_count=len(chunks),
+                skipped=False,
+            )
+
+        except Exception as e:
+            logger.error(
+                "Workflow ingestion failed",
+                profile_id=profile_id,
+                repo_name=repo_name,
+                filename=filename,
                 error=str(e),
             )
             raise

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "structlog>=24.1.0",
     "rank-bm25>=0.2.2",
     "numpy>=1.26.0",
+    "PyYAML>=6.0",
 ]
 
 [project.optional-dependencies]
@@ -50,6 +51,7 @@ dev = [
     "pre-commit>=3.6.0",
     "mutmut>=2.4.4",
     "types-redis>=4.6.0",
+    "types-PyYAML>=6.0.12",
 ]
 
 [tool.setuptools.packages.find]

--- a/tests/unit/test_workflow_parser.py
+++ b/tests/unit/test_workflow_parser.py
@@ -1,0 +1,575 @@
+import pytest
+
+from ingestion.parsers.base import ParseResult
+from ingestion.parsers.workflow_parser import WorkflowParser
+
+
+@pytest.mark.unit
+class TestWorkflowParser:
+    """Unit tests for WorkflowParser."""
+
+    @pytest.fixture
+    def parser(self) -> WorkflowParser:
+        """Fixture to provide a WorkflowParser instance."""
+        return WorkflowParser()
+
+    def test_parse_returns_parse_result(self, parser: WorkflowParser) -> None:
+        """Test that parse returns a ParseResult instance."""
+        workflow_yaml = """
+name: Test
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo test
+"""
+        result = parser.parse(workflow_yaml)
+        assert isinstance(result, ParseResult)
+
+    def test_parse_valid_workflow_yaml(self, parser: WorkflowParser) -> None:
+        """Test parsing a valid GitHub Actions workflow."""
+        workflow_yaml = """
+name: CI Pipeline
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Run tests
+        run: pytest tests/
+"""
+        result = parser.parse(workflow_yaml)
+
+        assert result.source_type == "workflow"
+        assert result.metadata["workflow_name"] == "CI Pipeline"
+        assert result.metadata["job_count"] == 1
+        assert result.metadata["step_count"] == 4
+        assert "push" in result.metadata["trigger_events"]
+        assert "pull_request" in result.metadata["trigger_events"]
+        assert "Checkout" in result.metadata["step_names"]
+        assert "Workflow: CI Pipeline" in result.text
+        assert "uses: actions/checkout@v3" in result.text
+        assert "run: pip install" in result.text
+        assert "run: pytest" in result.text
+
+    def test_source_type_is_workflow(self, parser: WorkflowParser) -> None:
+        """Test that source_type is set to 'workflow'."""
+        workflow_yaml = """
+name: Test
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo test
+"""
+        result = parser.parse(workflow_yaml)
+        assert result.source_type == "workflow"
+        assert result.metadata["source_type"] == "workflow"
+
+    def test_workflow_name_extracted(self, parser: WorkflowParser) -> None:
+        """Test that workflow name is correctly extracted."""
+        workflow_yaml = """
+name: My Workflow
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo test
+"""
+        result = parser.parse(workflow_yaml)
+        assert result.metadata["workflow_name"] == "My Workflow"
+
+    def test_parse_extracts_skills(self, parser: WorkflowParser) -> None:
+        """Test that skills are extracted and stored in metadata."""
+        workflow_yaml = """
+name: Docker Build
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker/build-push-action@v4
+      - run: terraform plan
+"""
+        result = parser.parse(workflow_yaml)
+
+        assert "detected_skills" in result.metadata
+        assert "ci_tools" in result.metadata
+
+        # Check for expected tools
+        detected_skill_names = [s.lower() for s in result.metadata["detected_skills"]]
+        assert "docker" in detected_skill_names
+        assert "terraform" in detected_skill_names
+
+    def test_trigger_events_extracted(self, parser: WorkflowParser) -> None:
+        """Test that trigger events are correctly extracted."""
+        workflow_yaml = """
+name: Multi-Trigger
+on: [push, pull_request, schedule]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo test
+"""
+        result = parser.parse(workflow_yaml)
+        assert "push" in result.metadata["trigger_events"]
+        assert "pull_request" in result.metadata["trigger_events"]
+        assert "schedule" in result.metadata["trigger_events"]
+
+    def test_job_and_step_counts(self, parser: WorkflowParser) -> None:
+        """Test that job and step counts are accurate."""
+        workflow_yaml = """
+name: Multi-Job
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: pytest tests/
+      - run: coverage report
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: docker build .
+"""
+        result = parser.parse(workflow_yaml)
+        assert result.metadata["job_count"] == 2
+        assert result.metadata["step_count"] == 3
+
+    def test_parse_multiple_jobs(self, parser: WorkflowParser) -> None:
+        """Test parsing workflow with multiple jobs."""
+        workflow_yaml = """
+name: Multi-Job Workflow
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: pytest tests/
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - run: kubectl deploy
+      - run: ansible-playbook site.yml
+"""
+        result = parser.parse(workflow_yaml)
+
+        assert "Job: test" in result.text
+        assert "Job: deploy" in result.text
+        assert "run: pytest" in result.text
+        assert "run: kubectl" in result.text
+        assert "run: ansible-playbook" in result.text
+
+    def test_parse_workflow_with_both_uses_and_run(self, parser: WorkflowParser) -> None:
+        """Test workflow with both 'uses' and 'run' commands."""
+        workflow_yaml = """
+name: Mixed Steps
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker/login-action@v2
+      - run: docker build -t myapp:latest .
+      - uses: docker/build-push-action@v4
+      - run: docker push myapp:latest
+"""
+        result = parser.parse(workflow_yaml)
+
+        detected_skill_names = [s.lower() for s in result.metadata["detected_skills"]]
+        ci_tools_lower = [t.lower() for t in result.metadata["ci_tools"]]
+        assert "docker" in detected_skill_names
+        assert "docker" in ci_tools_lower
+
+    def test_github_actions_always_detected_when_uses_present(self, parser: WorkflowParser) -> None:
+        """Test that GitHub Actions is detected when uses: actions/* is present."""
+        workflow_yaml = """
+name: GA Test
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+"""
+        result = parser.parse(workflow_yaml)
+        assert "GitHub Actions" in result.metadata["detected_skills"]
+
+    def test_cicd_detected_when_triggers_present(self, parser: WorkflowParser) -> None:
+        """Test that CI/CD is detected when workflow has triggers."""
+        workflow_yaml = """
+name: CI Test
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo test
+"""
+        result = parser.parse(workflow_yaml)
+        assert "CI/CD" in result.metadata["detected_skills"]
+
+    def test_parse_malformed_yaml_raises_error(self, parser: WorkflowParser) -> None:
+        """Test that malformed YAML raises ValueError."""
+        malformed_yaml = """
+name: Bad YAML
+jobs: [unclosed bracket
+"""
+        with pytest.raises(ValueError, match="Invalid workflow YAML"):
+            parser.parse(malformed_yaml)
+
+    def test_parse_missing_jobs_key(self, parser: WorkflowParser) -> None:
+        """Test workflow without 'jobs' key (valid but empty)."""
+        workflow_yaml = """
+name: No Jobs
+on: push
+"""
+        result = parser.parse(workflow_yaml)
+
+        assert result.source_type == "workflow"
+        assert "Workflow: No Jobs" in result.text
+        assert result.metadata["workflow_name"] == "No Jobs"
+
+    def test_parse_empty_jobs(self, parser: WorkflowParser) -> None:
+        """Test workflow with empty jobs dict."""
+        workflow_yaml = """
+name: Empty Jobs
+on: push
+jobs: {}
+"""
+        result = parser.parse(workflow_yaml)
+
+        assert result.source_type == "workflow"
+        assert "Workflow: Empty Jobs" in result.text
+
+    def test_empty_workflow_no_crash(self, parser: WorkflowParser) -> None:
+        """Test that empty workflows don't crash and metadata is sensible."""
+        workflow_yaml = """
+on: push
+jobs: {}
+"""
+        result = parser.parse(workflow_yaml)
+        assert result.metadata["job_count"] == 0
+        assert result.metadata["step_count"] == 0
+        # No steps means no tool-specific skills
+        tools_to_check = ["docker", "pytest", "kubernetes"]
+        tool_skills = [
+            s.lower() for s in result.metadata["detected_skills"] if s.lower() in tools_to_check
+        ]
+        assert len(tool_skills) == 0
+
+    def test_empty_workflow_name_fallback(self, parser: WorkflowParser) -> None:
+        """Test that missing workflow name uses fallback."""
+        workflow_yaml = """
+on: push
+jobs: {}
+"""
+        result = parser.parse(workflow_yaml)
+        # Should have a fallback name, not None or empty string
+        assert result.metadata["workflow_name"] in ["unnamed", "unknown"]
+
+    def test_parse_workflow_bytes_input(self, parser: WorkflowParser) -> None:
+        """Test parsing workflow from bytes."""
+        workflow_yaml = b"""
+name: Byte Input
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: pytest
+"""
+        result = parser.parse(workflow_yaml)
+
+        assert result.source_type == "workflow"
+        assert "Workflow: Byte Input" in result.text
+
+    def test_text_contains_skills(self, parser: WorkflowParser) -> None:
+        """Test that detected skills appear in the result text."""
+        workflow_yaml = """
+name: Text Test
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker/build-push-action@v4
+      - run: pytest tests/
+"""
+        result = parser.parse(workflow_yaml)
+        # Skills should be mentioned in the assembled text
+        assert "docker" in result.text.lower() or "Docker" in result.text
+        assert "pytest" in result.text.lower() or "Pytest" in result.text
+
+    def test_text_contains_workflow_name(self, parser: WorkflowParser) -> None:
+        """Test that workflow name appears in the result text."""
+        workflow_yaml = """
+name: Named Workflow
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo test
+"""
+        result = parser.parse(workflow_yaml)
+        assert "Named Workflow" in result.text
+
+    def test_aws_action_infers_aws_and_github_actions(self, parser: WorkflowParser) -> None:
+        """Test that AWS actions infer both AWS and GitHub Actions skills."""
+        workflow_yaml = """
+name: Deploy AWS
+on: push
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: aws-actions/configure-aws-credentials@v2
+      - run: aws s3 sync . s3://bucket
+"""
+        result = parser.parse(workflow_yaml)
+        skills = result.metadata["detected_skills"]
+        assert "AWS" in skills
+        assert "GitHub Actions" in skills
+
+    def test_parse_realistic_ci_cd_workflow(self, parser: WorkflowParser) -> None:
+        """Test parsing a realistic CI/CD workflow with multiple tools."""
+        workflow_yaml = """
+name: Full CI/CD Pipeline
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - run: |
+          pip install -r requirements.txt
+          pytest tests/ --cov=src/
+      - uses: codecov/codecov-action@v3
+
+  build:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker/setup-buildx-action@v2
+      - uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: azure/setup-kubectl@v3
+      - run: |
+          kubectl set image deployment/app app=app:latest
+          kubectl rollout status deployment/app
+      - run: |
+          terraform init
+          terraform apply -auto-approve
+      - run: |
+          ansible-playbook site.yml
+"""
+        result = parser.parse(workflow_yaml)
+
+        # Verify structure
+        assert result.source_type == "workflow"
+        assert result.metadata["workflow_name"] == "Full CI/CD Pipeline"
+
+        # Verify jobs are extracted
+        assert "Job: test" in result.text
+        assert "Job: build" in result.text
+        assert "Job: deploy" in result.text
+
+        # Verify skills are detected
+        detected_skill_names = [s.lower() for s in result.metadata["detected_skills"]]
+        assert "python" in detected_skill_names
+        assert "docker" in detected_skill_names
+        assert "kubernetes" in detected_skill_names
+        assert "terraform" in detected_skill_names
+        assert "ansible" in detected_skill_names
+
+        # Verify CI tools are in metadata
+        ci_tools_lower = [t.lower() for t in result.metadata["ci_tools"]]
+        assert "docker" in ci_tools_lower
+        assert "kubernetes" in ci_tools_lower
+
+    def test_metadata_structure(self, parser: WorkflowParser) -> None:
+        """Test that metadata has the required structure."""
+        workflow_yaml = """
+name: Test Metadata
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Test step
+        run: echo test
+"""
+        result = parser.parse(workflow_yaml)
+
+        # Check metadata keys
+        assert "source_type" in result.metadata
+        assert "workflow_name" in result.metadata
+        assert "trigger_events" in result.metadata
+        assert "job_count" in result.metadata
+        assert "step_count" in result.metadata
+        assert "step_names" in result.metadata
+        assert "detected_skills" in result.metadata
+        assert "ci_tools" in result.metadata
+        assert "has_deploy_step" in result.metadata
+
+        # Check values
+        assert result.metadata["source_type"] == "workflow"
+        assert result.metadata["workflow_name"] == "Test Metadata"
+        assert isinstance(result.metadata["trigger_events"], list)
+        assert isinstance(result.metadata["job_count"], int)
+        assert isinstance(result.metadata["step_count"], int)
+        assert isinstance(result.metadata["step_names"], list)
+        assert isinstance(result.metadata["detected_skills"], list)
+        assert isinstance(result.metadata["ci_tools"], list)
+        assert isinstance(result.metadata["has_deploy_step"], bool)
+
+    def test_parse_workflow_with_special_characters_in_steps(self, parser: WorkflowParser) -> None:
+        """Test workflow with special characters in step commands."""
+        workflow_yaml = r"""
+name: Special Chars
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "Testing with quotes and $VARS"
+          grep -r "pattern" tests/ || true
+"""
+        result = parser.parse(workflow_yaml)
+
+        assert result.source_type == "workflow"
+        assert "run:" in result.text
+
+    def test_deploy_workflow_detection_by_event(self, parser: WorkflowParser) -> None:
+        """Test detection of deployment workflow by trigger event."""
+        workflow_yaml = """
+name: Deploy
+on: release
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - run: kubectl deploy
+"""
+        result = parser.parse(workflow_yaml)
+
+        assert result.metadata["has_deploy_step"] is True
+        assert "release" in result.metadata["trigger_events"]
+
+    def test_has_deploy_step_false_for_non_deploy(self, parser: WorkflowParser) -> None:
+        """Test that non-deploy workflows have has_deploy_step=False."""
+        workflow_yaml = """
+name: CI Pipeline
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: pytest
+"""
+        result = parser.parse(workflow_yaml)
+        assert result.metadata["has_deploy_step"] is False
+
+    def test_deploy_workflow_detection_by_branch(self, parser: WorkflowParser) -> None:
+        """Test detection of deployment workflow by target branch."""
+        workflow_yaml = """
+name: Deploy to Prod
+on:
+  push:
+    branches: [main, production]
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - run: terraform apply
+"""
+        result = parser.parse(workflow_yaml)
+
+        assert result.metadata["has_deploy_step"] is True
+        assert "push" in result.metadata["trigger_events"]
+
+    def test_kubernetes_detected_from_kubectl(self, parser: WorkflowParser) -> None:
+        """Test that Kubernetes is detected when kubectl is used."""
+        workflow_yaml = """
+name: K8s Deploy
+on: release
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: azure/setup-kubectl@v3
+      - run: kubectl apply -f k8s/
+"""
+        result = parser.parse(workflow_yaml)
+        assert "Kubernetes" in result.metadata["detected_skills"]
+
+    def test_step_names_extraction(self, parser: WorkflowParser) -> None:
+        """Test that step names are extracted."""
+        workflow_yaml = """
+name: Named Steps
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Run unit tests
+        run: pytest tests/
+      - name: Generate coverage report
+        run: coverage report
+"""
+        result = parser.parse(workflow_yaml)
+
+        assert "Checkout code" in result.metadata["step_names"]
+        assert "Run unit tests" in result.metadata["step_names"]
+        assert "Generate coverage report" in result.metadata["step_names"]
+        assert result.metadata["step_count"] == 3
+
+    def test_trigger_events_extraction(self, parser: WorkflowParser) -> None:
+        """Test extraction of trigger events."""
+        workflow_yaml = """
+name: Multi-Trigger
+on: [push, pull_request, schedule]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo test
+"""
+        result = parser.parse(workflow_yaml)
+
+        assert "push" in result.metadata["trigger_events"]
+        assert "pull_request" in result.metadata["trigger_events"]
+        assert "schedule" in result.metadata["trigger_events"]
+        assert "Triggers:" in result.text


### PR DESCRIPTION
## Summary

Added support for parsing GitHub Actions workflow files to detect CI/CD skills. The ingestion pipeline now extracts workflow YAML, detects CI/CD tools (Docker, Kubernetes, Terraform, etc.), and indexes them alongside resumes and READMEs. Developers whose primary DevOps work lives in `.github/workflows/*.yml` files now surface those CI/CD skills in PathReview.

## Issue

Closes #14

## Changes

**Root cause:** The ingestion pipeline infrastructure existed (SkillExtractor, chunking, embeddings, ChromaDB) but was architecturally disconnected from workflow files. `RepoAnalyzer._detect_ci()` only checked if `.github/workflows` existed (returning a boolean) without reading the actual YAML content. No `WorkflowParser` existed, no `IngestionPipeline.ingest_workflow()` method existed, and `StrategySelector` had no "workflow" case.

### Files changed:

- **`ingestion/parsers/skill_extractor.py`** — Extended CI/CD tool detection
  - Added tools: `kubectl`, `github actions`, `docker compose`, `helm`, `circleci`, `codecov`, `trivy`, `pytest`, `flake8`, `gradle`, `maven`, `sonarqube`, `deployment` to TOOLS dict
  - Added display name overrides for proper capitalization (e.g., `kubectl` → `Kubernetes`, `ci/cd` → `CI/CD`)

- **`ingestion/parsers/workflow_parser.py`** (NEW) — `WorkflowParser` class for GitHub Actions workflow YAML
  - `parse(content: str | bytes) -> ParseResult` — loads YAML, extracts job names, step actions (`uses:`), and commands (`run:`), calls `SkillExtractor.extract_skills()`, returns metadata with detected CI/CD skills
  - `_extract_triggers()` — parses workflow trigger events (`on:` key)
  - `_is_deploy_workflow()` — detects deployment workflows by release/workflow_dispatch triggers or main/prod branch pushes
  - Always infers `GitHub Actions` and `CI/CD` skills (presence of workflow file proves these skills)
  - Exception handling: wraps `yaml.YAMLError` as `ValueError` with context

- **`ingestion/pipeline.py`** — Added `ingest_workflow()` method
  - Signature: `def ingest_workflow(self, profile_id: str, repo_name: str, filename: str, content: str | bytes) -> IngestResult`
  - Follows exact pattern of `ingest_resume()` and `ingest_readme()`
  - Calls `WorkflowParser().parse()`, chunks content, generates embeddings, stores in ChromaDB with `source_type="workflow"` metadata
  - Includes skip detection (deduplication) and database recording
  - Initialize `self.workflow_parser = WorkflowParser()` in `__init__()`

- **`ingestion/chunking/strategy_selector.py`** — Registered workflow source type
  - Added `elif source_type == "workflow": return self.semantic_chunker` to route workflow content to semantic chunking
  - Updated docstring to document "workflow" as valid source_type

- **`tests/unit/test_workflow_parser.py`** (NEW) — Comprehensive test suite
  - 29 unit tests covering: YAML parsing, trigger extraction, deploy detection, skill detection, edge cases (empty workflows, malformed YAML), realistic workflows
  - All tests passing; no new test failures introduced

- **`pyproject.toml`** — Added PyYAML dependency
  - `PyYAML>=6.0` to main dependencies
  - `types-PyYAML>=6.0.12` to dev dependencies for mypy type stubs

## Testing

- [x] Unit tests pass (`make test-unit`)
  - **Before:** 53 failed, 375 passed
  - **After:** 53 failed, 404 passed (29 new passing tests from test_workflow_parser.py)
  - **Conclusion:** No new test failures introduced
- [x] Type checking passes for new/modified files (`make typecheck`)
- [x] Linting passes for new/modified files (`make lint`, `make format`)

**To verify the implementation:**

1. Checkout this branch:
   ```bash
   git checkout feat/14-support-parsing-GHA-workflow-files
   ```
2. Run unit tests: `make test-unit`
3. Test the WorkflowParser directly:
   ```bash
  .venv/bin/python -c "
  from ingestion.parsers.workflow_parser import WorkflowParser
  parser = WorkflowParser()
  workflow_yaml = '''
  name: CI
  on: push
  jobs:
    build:
      runs-on: ubuntu-latest
      steps:
        - uses: actions/checkout@v3
        - uses: docker/build-push-action@v4
        - run: pytest tests/
  '''
  result = parser.parse(workflow_yaml)
  print('Detected skills:', result.metadata['detected_skills'])
  # Expected: ['Docker', 'GitHub Actions', 'CI/CD', 'Python']
  "
  ```

## Screenshots / Demo
N/A — backend-only implementation. Observable behavior: workflow files are now indexed with extracted CI/CD skills stored in ChromaDB metadata. Next phases will wire API endpoints to call IngestionPipeline.ingest_workflow() and use the indexed skills in review feedback.

## Notes for Reviewers
Pre-existing mypy errors: make check reports ~12 pre-existing errors in other modules (bias_detector, batch_processor, semantic_chunker, structural_chunker, strategy_selector, provider, pipeline). None are introduced by this PR — all new code passes type checking.
Phase scope: This PR completes Phases 1–3 of Issue #14 (WorkflowParser, ingest_workflow, StrategySelector). Phases 4–5 (wiring API layer, integration testing) are out of scope for this PR.
Architecture: Follows established patterns from ResumeParser/ReadmeParser and ingest_resume()/ingest_readme() for consistency.