### PR TITLE
fix: broaden bias detector regex patterns to catch natural phrasing variations

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,26 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/151
+
+**Issue title:** Bias detector patterns are too narrow to match common phrasings
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Selection notes (checklist reasoning):**
+I used the "Is this right for me?" checklist before committing to this issue.
+- Is it actually open? Yes. I checked the Development section on the issue page and confirmed there are no linked branches or pull requests yet, so nobody has already solved it.
+- Is the scope clear? Yes. The issue names the exact file (`safety/bias_detector.py`) and lists 9 specific failing unit tests in `tests/unit/test_bias_detector.py`, so I know exactly what "done" looks like.
+- Is it the right size? Yes. This is a regex and pattern matching fix inside one file, which matches a Tier 1 scope.
+- Is the maintainer active? Yes. The maintainer (ascherj) opened this issue only 3 days ago and tagged it live.
+- Does it match where I am? Yes. I'm comfortable with Python string and pattern logic from past projects, and this issue doesn't require touching the RAG pipeline or agent system, so I'm not stacking an unfamiliar codebase on top of an unfamiliar concept.
+
+This is my first time contributing to a codebase this large, so I picked Tier 1 to keep the learning curve limited to just the codebase, not the codebase plus a hard problem.
+
+**Problem summary:**
+The bias detector in `safety/bias_detector.py` is supposed to flag biased language in generated reviews, like dismissing a candidate's education or making assumptions based on age. Right now the regex patterns only catch near word-for-word phrasings of that bias, so more natural, real world ways of saying the same thing slip through undetected. Nine unit tests in `tests/unit/test_bias_detector.py` already define what the detector should catch, and all nine currently fail. A successful fix means broadening the patterns so the detector correctly flags these natural phrasings, without breaking any tests that currently pass.
+
+**Branch name:** fix/151-bias-detector-patterns
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -38,3 +38,34 @@ I reproduced the issue by running `BiasDetector.detect_bias()` directly on the e
 
 **Blockers or open questions:**
 Not yet sure how loose I can make the regex before it starts flagging clean/positive feedback as biased — I'll need to test carefully against the 23 currently-passing tests while I fix the 9 failing ones.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+I implemented the fix in `safety/bias_detector.py`, broadening the regex patterns per my PLAN.md: added support for plural nouns (developers/programmers, not just singular), can't/won't phrasing, removed the unnecessary "is" requirement before "lacks," and added a new pattern for "attendance means inadequate training" phrasing. All 9 previously-failing tests in `tests/unit/test_bias_detector.py` now pass, with no regressions to the 23 that were already passing.
+
+**Next steps:**
+Open a draft PR, run it through `make check` and the full test suite one more time, get a classmate or mentor to review it in Slack, then finalize and submit.
+
+**Blockers:**
+None currently.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [will add once opened]
+
+**Branch:** fix/151-bias-detector-patterns
+
+**What you built:**
+[fill in after PR opened]
+
+**Tests added or updated:**
+[fill in after PR opened]
+
+**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+
+**Draft PR feedback received from:** [fill in after review]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -27,5 +27,14 @@ The bias detector in `safety/bias_detector.py` is supposed to flag biased langua
 
 ## Week 8 — Reproduction & solution planning
 
+**Reproduction commit link:** https://github.com/Fidan222/pathreview/commit/c81dd43
+
 **Reproduction summary:**
 I reproduced the issue by running `BiasDetector.detect_bias()` directly on the exact phrase from the issue ("The candidate only attended a bootcamp, so this project lacks the rigor of a formal CS education") and confirmed it returned `(False, '')` instead of flagging it as biased. I also ran `pytest tests/unit/test_bias_detector.py -v` and confirmed 9 tests fail while 23 pass, matching the count described in the issue exactly. The failures show a consistent pattern: the detector catches some phrasings of bootcamp/age/demographic bias but misses natural variations like "can't write production code," "can't handle complex systems," and "aren't equal to."
+
+**PLAN.md link:** https://github.com/Fidan222/pathreview/blob/fix/151-bias-detector-patterns/PLAN.md
+
+**Walkthrough video (recommended):** (not recorded — optional, not graded)
+
+**Blockers or open questions:**
+Not yet sure how loose I can make the regex before it starts flagging clean/positive feedback as biased — I'll need to test carefully against the 23 currently-passing tests while I fix the 9 failing ones.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -24,3 +24,8 @@ The bias detector in `safety/bias_detector.py` is supposed to flag biased langua
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [ ] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction summary:**
+I reproduced the issue by running `BiasDetector.detect_bias()` directly on the exact phrase from the issue ("The candidate only attended a bootcamp, so this project lacks the rigor of a formal CS education") and confirmed it returned `(False, '')` instead of flagging it as biased. I also ran `pytest tests/unit/test_bias_detector.py -v` and confirmed 9 tests fail while 23 pass, matching the count described in the issue exactly. The failures show a consistent pattern: the detector catches some phrasings of bootcamp/age/demographic bias but misses natural variations like "can't write production code," "can't handle complex systems," and "aren't equal to."

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -69,3 +69,34 @@ No new test files — the issue included 9 pre-written failing tests in `tests/u
 **Self-review confirmation:** [x] make check passes  [x] make test-unit passes
 
 **Draft PR feedback received from:** None — per the Week 9 lecture, no code review feedback is provided this term; completed self-review against the seven conditions checklist instead.
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+no feedback came in, which makes sense since code review isnt a thing this term. instead i just self reviewed against the seven conditions checklist (fix works, tests pass, code follows conventions, linter passes, docs updated, pr description written).
+
+**How you responded:**
+n/a, nothing to respond to since there was no feedback
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+honestly just getting my environment running took way longer than actually fixing the bug did. my computer had python 3.9.6 by default but the project needed 3.11+, so make setup kept failing until i found a newer python already on my machine and rebuilt my venv pointed at that. then i didnt even have docker installed, and once i got it, the rosetta installer inside docker kept failing with some virtualization error that had literally nothing to do with my actual code. none of that was even real coding, it was just setup stuff, but it ate almost my whole first session.
+
+**What did you learn about working in a large codebase?**
+the actual fix was small, like a few regex patterns in one file, but the codebase around it is massive. theres dozens of other files with their own tests, and a bunch of those were already broken before i even touched anything. i learned that "does the whole test suite pass" isnt really the right thing to check in a big codebase like this, the real question is "did MY change break something that wasnt already broken." i actually had to go through like 44 unrelated failing tests just to make sure none of them were caused by me instead of just assuming i broke everything.
+
+**How did AI tools help — and where did they fall short?**
+ai was super helpful for reading through the failing tests and figuring out exactly why each one failed compared to the regex patterns, that would've taken me forever to do line by line on my own. it also helped a lot with drafting PLAN.md and the pr description so i wasnt just staring at a blank template. where it couldnt help was actually fixing my computer, like the python version thing or getting docker working, i had to just run commands myself and read the actual errors to figure that stuff out step by step.
+
+**What would you do differently if you started over?**
+i'd check my python version and get docker installed before even picking an issue, instead of finding out both were broken in the middle of setup. i'd also actually read the "development" section on an issue (to check for existing branches/prs) before committing to it, i almost picked one that already had a pr from someone else that was only 7 hours old, which could've just closed on me randomly mid week.
+
+**What are you most proud of from this module?**
+getting all 9 of the failing tests to pass on my first real attempt at the fix, without breaking any of the 23 that were already passing. felt like proof that the plan i actually wrote out in week 8 held up once i started writing real code instead of falling apart the second i opened the file.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -56,16 +56,16 @@ None currently.
 
 ### Check-in 2 (end of week)
 
-**PR link:** [will add once opened]
+**PR link:** https://github.com/ascherj/pathreview/pull/609
 
 **Branch:** fix/151-bias-detector-patterns
 
 **What you built:**
-[fill in after PR opened]
+Broadened the regex patterns in `safety/bias_detector.py` to catch natural phrasings of biased language that the original patterns missed — plural nouns, "can't/won't" phrasing, and a new pattern for "attendance means inadequate training."
 
 **Tests added or updated:**
-[fill in after PR opened]
+No new test files — the issue included 9 pre-written failing tests in `tests/unit/test_bias_detector.py` that define the expected behavior. All 9 now pass, with no regressions to the 23 that were already passing.
 
-**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
 
-**Draft PR feedback received from:** [fill in after review]
+**Draft PR feedback received from:** None — per the Week 9 lecture, no code review feedback is provided this term; completed self-review against the seven conditions checklist instead.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,32 @@
+## Solution plan
+
+**Issue:** Bias detector patterns are too narrow to match common phrasings
+https://github.com/ascherj/pathreview/issues/151
+
+### Understand
+so basically the bias detector uses regex to catch biased language, but the patterns are written super specific, like they only match if someone uses the exact same words the dev originally typed. like it needs the word "is" in a sentence or it needs "developer" singular instead of "developers" plural, stuff like that. so the actual problem isnt that the regex is broken, its that its way too picky about exact wording. it should be catching the same biased idea even if someone phrases it a little different, but right now it just doesnt.
+
+### Map
+- `safety/bias_detector.py` this is the only file i actually need to touch, it has the two pattern lists (DISMISSIVE_PATTERNS and DEMOGRAPHIC_PATTERNS)
+- `tests/unit/test_bias_detector.py` not touching this file but im using the 9 failing tests as my checklist for what needs to pass once im done
+
+### Plan
+1. fix DISMISSIVE_PATTERNS so it accepts more verb variations (cant/cannot/wont/lack/missing) not just "lack|missing", so stuff like "cant write production code" gets caught
+2. get rid of the required "is" in the first pattern so "education lacks fundamentals" matches without needing "is" stuck in there
+3. fix DEMOGRAPHIC_PATTERNS to accept plural words too (developers, programmers, people) since right now its only singular (developer, programmer, person)
+4. widen the poor/rich background pattern so "developers from poor backgrounds" matches, not just "person from poor"
+5. add something to catch phrases like "attendance/background means inadequate training" since nothing catches that right now at all
+6. after every change run pytest tests/unit/test_bias_detector.py -v again to make sure i didnt break any of the 23 tests that already pass while im fixing the 9 that fail
+
+### Inputs & outputs
+input is just a string of feedback text. output doesnt change, still returns (bool, string) like before, is it biased and why. im only changing what makes it return True, not changing the shape of what it gives back
+
+### Risks & unknowns
+- if i make the regex too loose i could start flagging stuff that isnt actually biased, like the positive bootcamp mention test or the clean feedback test that currently pass fine. need to double check those still work after i change stuff
+- not sure if using .* like the existing immigrant/international pattern is totally safe to copy everywhere else, since it could accidentally match across a whole sentence and catch weird word combos i didnt mean to catch
+- some tests check the actual reason string too (like it checks "demographic" is somewhere in the reason), so i gotta make sure i dont accidentally mix up which pattern list gives which reason message
+
+### Edge cases
+- empty string and just whitespace should still return False, already works, just dont wanna break it
+- has to stay case insensitive, already works via re.IGNORECASE
+- if someone mentions bootcamp/age/whatever in a positive or neutral way it needs to stay False, gotta be careful i dont make my patterns so broad they start flagging good feedback too

--- a/safety/bias_detector.py
+++ b/safety/bias_detector.py
@@ -1,6 +1,7 @@
 """Bias detection in generated feedback."""
 
 import re
+
 import structlog
 
 logger = structlog.get_logger()
@@ -11,16 +12,26 @@ class BiasDetector:
 
     # Genuinely dismissive phrases about educational background
     DISMISSIVE_PATTERNS = [
-        r"(?:bootcamp|self-taught|online\s+course)\s+(?:education|training)\s+is\s+(?:insufficient|inadequate|lacks)",
-        r"(?:bootcamp|self-taught)\s+(?:graduates?|developers?)\s+(?:lack|missing)\s+(?:rigor|fundamentals|proper\s+training)",
+        # "bootcamp/self-taught/online course education is insufficient/inadequate"
+        r"(?:bootcamp|self-taught|online\s+course)\s+(?:education|training)\s+is\s+(?:insufficient|inadequate)",
+        # "bootcamp education lacks fundamentals" (no "is" required)
+        r"(?:bootcamp|self-taught|online\s+course)\s+(?:education|training)\s+lacks\s+(?:rigor|fundamentals)",
+        # bootcamp/self-taught grads/devs/programmers lack rigor/fundamentals/training
+        r"(?:bootcamp|self-taught)\s+(?:graduates?|developers?|programmers?)\s+(?:lack|missing)\s+(?:rigor|fundamentals|proper\s+training)",
+        # bootcamp grads/devs/programmers can't write/handle/build/create X
+        r"(?:bootcamp|self-taught)\s+(?:graduates?|developers?|programmers?)\s+(?:can't|cannot|won't|will\s+not)\s+(?:write|handle|build|create)\s+\S+(?:\s+\S+)?",
+        # "bootcamp doesn't prepare you"
         r"(?:bootcamp|coding\s+bootcamp)\s+(?:doesn't|does\s+not)\s+prepare\s+(?:you|developers?)",
-        r"(?:self-taught|bootcamp)\s+is\s+(?:not|never)\s+(?:equal|comparable)\s+to\s+(?:university|traditional|formal)",
+        # self-taught/bootcamp (devs) is/are not/never equal/comparable to formal ed
+        r"(?:self-taught|bootcamp)(?:\s+(?:developers?|graduates?|programmers?))?\s+(?:is|are)\s+(?:not|never)\s+(?:equal|comparable)\s+to\s+(?:university|traditional|formal)",
+        # "bootcamp attendance means inadequate training"
+        r"(?:bootcamp|self-taught|online\s+course)\s+attendance\s+means\s+(?:inadequate|insufficient|lesser)\s+(?:training|education)",
     ]
 
     # Demographic assumptions (about age, background, identity)
     DEMOGRAPHIC_PATTERNS = [
-        r"(?:young|old|aged)\s+(?:person|developer|programmer)\s+(?:can't|cannot|won't|will\s+not)",
-        r"(?:person\s+from|coming\s+from)\s+(?:poor|rich|working[\s-]?class)",
+        r"(?:young|old|aged)\s+(?:person|people|developer|developers|programmer|programmers)\s+(?:can't|cannot|won't|will\s+not)",
+        r"(?:(?:person|people|developers?|programmers?)\s+from|coming\s+from)\s+(?:poor|rich|working[\s-]?class)",
         r"(?:immigrant|international|foreign)\s+developers?.*(?:can't|cannot|won't|struggle)",
     ]
 
@@ -34,14 +45,12 @@ class BiasDetector:
         Returns:
             Tuple of (is_biased, reason)
         """
-        # Check for dismissive language about education
         for pattern in BiasDetector.DISMISSIVE_PATTERNS:
             if re.search(pattern, text, re.IGNORECASE):
                 reason = "Dismissive language about educational background"
                 logger.warning("bias_detected", reason=reason)
                 return True, reason
 
-        # Check for demographic assumptions
         for pattern in BiasDetector.DEMOGRAPHIC_PATTERNS:
             if re.search(pattern, text, re.IGNORECASE):
                 reason = "Demographic assumptions detected"


### PR DESCRIPTION
## Summary
The bias detector in `safety/bias_detector.py` used regex patterns that required near-exact wording to catch biased language, such as requiring the literal word "is" or only matching singular nouns like "developer" instead of "developers." This meant many natural phrasings of the same biased ideas (dismissing bootcamp/self-taught backgrounds, age-based assumptions, etc.) went undetected. This PR broadens the patterns so the detector catches these phrasings correctly, without breaking any of the cases it already handled.

## Issue
Closes #151

## Changes
- Broadened `DISMISSIVE_PATTERNS` to accept plural nouns (developers/programmers, not just singular)
- Added support for "can't/cannot/won't" phrasing (e.g. "can't write production code")
- Removed an unnecessary requirement for the literal word "is" before "lacks"
- Added a new pattern to catch "attendance means inadequate training" phrasing
- Broadened `DEMOGRAPHIC_PATTERNS` to accept plural nouns (people/developers/programmers, not just singular person/developer/programmer)

## Testing
- [x] Unit tests pass (`make test-unit`)
- [x] Linter passes (`make lint`)
- [x] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes

All 9 previously-failing tests in `tests/unit/test_bias_detector.py` now pass, with no regressions to the 23 tests that were already passing (32/32 total). I did not add new tests since the issue already included 9 specific failing tests that fully define the expected behavior — my fix targets exactly those cases.

I also ran the full test suite (`tests/`) and confirmed 44 pre-existing failures in unrelated files (`test_resume_parser.py`, `test_review_service.py`, `test_skill_extractor.py`, `test_pii_scrubber.py`, `test_tech_detector.py`, and others). These failures existed before my change and are unrelated to issue #151. My change introduces zero new failures.

## Screenshots / Demo
N/A — this is a backend logic change with no UI component.

## Notes for Reviewers
The riskiest part of this change is making the regex too broad and causing false positives on legitimate feedback. I verified this doesn't happen by confirming the tests that check clean/positive feedback (`test_clean_feedback_not_flagged`, `test_positive_bootcamp_mention_not_flagged`, `test_comparative_without_bias`, etc.) all still pass.