### PR TITLE
Fix README scorer comprehensive test fixture

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -27,3 +27,15 @@ contribution to a larger codebase.
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** 
+
+**Reproduction summary:**  
+I activated the project’s virtual environment and ran `python -m pytest tests/unit/test_readme_scorer.py -q`. The test suite produced 1 failed test and 22 passing tests. The failing test expected the README fixture to contain more than 100 words, but the scorer counted only 51 words and categorized it as `minimal`.
+
+**PLAN.md link:** (https://github.com/DelightOti/pathreview/blob/test/156-readme-scorer-fixture/PLAN.md)
+
+**Blockers or open questions:**  
+I still need to confirm whether the maintainers prefer expanding the README fixture to more than 500 words or changing the expected category. Based on the test name and existing category tests, expanding the fixture appears to match the intended behavior.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -30,7 +30,7 @@ contribution to a larger codebase.
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** 
+**Reproduction commit link:** [https://github.com/DelightOti/pathreview/commit/b995ff04b624d17a9d116697a75e0bf796597894]
 
 **Reproduction summary:**  
 I activated the project’s virtual environment and ran `python -m pytest tests/unit/test_readme_scorer.py -q`. The test suite produced 1 failed test and 22 passing tests. The failing test expected the README fixture to contain more than 100 words, but the scorer counted only 51 words and categorized it as `minimal`.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -39,3 +39,6 @@ I activated the project’s virtual environment and ran `python -m pytest tests/
 
 **Blockers or open questions:**  
 I still need to confirm whether the maintainers prefer expanding the README fixture to more than 500 words or changing the expected category. Based on the test name and existing category tests, expanding the fixture appears to match the intended behavior.
+
+**Blockers:**
+Before making my changes, I ran `make check`. It failed with 182 pre-existing lint errors across unrelated files. I will rerun it after my changes to confirm that I did not introduce any new failures.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -84,3 +84,44 @@ and the complete README scorer test file passes with 23 tests.
 **Self-review confirmation:** [x] make check introduces no new failures  [x] make test-unit introduces no new failures
 
 **Draft PR feedback received from:** none yet
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+I did not receive any reviewer feedback. My PR is still open, but there have not been any reviews or comments from maintainers yet.
+
+**How you responded:**
+Since I did not receive any feedback, I did not have any changes or responses to make.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+One thing that was harder than I expected was figuring out what was actually causing the test to fail. At first, I thought there might be something wrong with the README scorer itself, but after looking through the test and the scoring requirements more closely, I realized the problem was actually the test fixture. The README in the test only had 51 words, even though the test expected it to be scored as comprehensive.
+
+Another difficult part was running tests and seeing a lot of errors that had nothing to do with my changes. The repo already had 182 lint errors and 53 failing unit tests before I made my fix, so I had to make sure I was not accidentally blaming my work for problems that were already there.
+
+**What did you learn about working in a large codebase?**
+I learned that working in someone else's codebase is very different from working on my own projects. I could not just jump in and change whatever looked wrong. I had to understand how the scorer worked, how the test was supposed to work, and what the original developer was trying to test.
+
+I also learned that sometimes the best fix is actually a small one. For this issue, I did not need to change the README scorer logic at all. I just needed to update the test fixture so it actually matched what the test expected. After I made the change, the focused test passed and all 23 tests in the README scorer test file passed.
+
+**How did AI tools help — and where did they fall short?**
+AI helped me a lot with understanding the repo, figuring out what different parts of the code were doing, and helping me troubleshoot errors. It was also useful for Git commands and for helping me understand some of the testing output when I was unsure what it meant.
+
+At the same time, I learned that I could not just trust everything AI suggested. Sometimes I still had to go back into the code myself and check whether the explanation actually made sense. AI also could not automatically tell me which errors were already in the repo and which ones came from my own changes. I still had to test things myself and compare the results.
+
+**What would you do differently if you started over?**
+If I started over, I would probably spend more time testing the repo before changing anything. I would run the exact failing test first, then the related test file, and write down what was already failing before I touched the code. That would have made it easier later when I was trying to figure out if I caused any new problems.
+
+I also would have looked at the test fixture and the word-count requirement side by side earlier. Once I realized the fixture only had 51 words, the issue became a lot more obvious.
+
+**What are you most proud of from this module?**
+I am most proud that I was able to work through an actual issue in a codebase that I was not familiar with. I was able to reproduce the problem, figure out what was causing it, make a fix, and test it to make sure it worked.
+
+I also feel more comfortable now with using Git, working on a branch, making commits, opening a pull request, and reading through code that I did not write myself. Even though my change was not huge, I feel like I understand the open-source contribution process a lot better now.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -42,3 +42,45 @@ I still need to confirm whether the maintainers prefer expanding the README fixt
 
 **Blockers:**
 Before making my changes, I ran `make check`. It failed with 182 pre-existing lint errors across unrelated files. I will rerun it after my changes to confirm that I did not introduce any new failures.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+I reproduced issue #156 and updated the README scorer test fixture so that it
+contains enough realistic content to satisfy the intended word-count threshold.
+I also updated the related unit test annotations and confirmed that the focused
+README scorer tests pass.
+
+**Next steps:**
+Request peer or mentor feedback on the pull request, address any relevant
+feedback, confirm that my changes introduce no new failures, and finalize the
+submission.
+
+**Blockers:**
+The repository already had pre-existing lint errors and failing unit tests
+unrelated to my issue. I documented the existing failures and compared the
+results before and after my changes.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/610
+
+**Branch:** `test/156-readme-scorer-fixture`
+
+**What you built:**
+I expanded the README fixture used by the comprehensive README scorer test so
+that it contains enough meaningful content to meet the scorer’s word-count
+expectation. This fixes the test data without changing the production README
+scorer logic.
+
+**Tests added or updated:**
+Updated `tests/unit/test_readme_scorer.py`. The focused failing test now passes,
+and the complete README scorer test file passes with 23 tests.
+
+**Self-review confirmation:** [x] make check introduces no new failures  [x] make test-unit introduces no new failures
+
+**Draft PR feedback received from:** none yet

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,29 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/156
+
+**Issue title:** README scorer test fixture is too short for its own word-count assertion
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The README scorer test uses a sample README that is shorter than the minimum
+word count required by the test's own assertion. This causes the test to fail
+because of the test data rather than because the scorer is behaving incorrectly.
+The issue affects the README scorer unit tests. A successful fix will update the
+fixture so it contains enough words while continuing to test the intended scorer
+behavior.
+
+**Selection notes — “Is this right for me?” checklist:**
+I selected this issue because it is labeled Tier 1 and has a small, clearly
+defined scope. The issue appears to involve updating an existing test fixture
+rather than changing core application or database logic. I can identify the
+relevant unit test, reproduce the failure, make a focused change, and run the
+affected tests to confirm the fix. This makes the issue appropriate for my first
+contribution to a larger codebase.
+
+**Branch name:** test/156-readme-scorer-fixture
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,50 @@
+# Solution plan
+
+**Issue:** README scorer test fixture is too short for its expected word-count category — Issue #156
+
+### Understand
+
+The issue is caused by a mismatch between the README content used in `test_readme_with_all_quality_signals` and the assertions in that test.
+
+The README fixture contains only 51 words. However, the test expects the word count to be greater than 100 and expects the word-count category to be `comprehensive`.
+
+The scorer currently categorizes the README as `minimal`, which matches its actual length. Based on the existing word-count tests, a README must contain more than 500 words to be categorized as `comprehensive`.
+
+The expected behavior is for the test fixture to contain enough meaningful content to satisfy the comprehensive category. The actual behavior is that the fixture is too short, causing the test to fail.
+
+### Map
+
+The main files involved are:
+
+- `tests/unit/test_readme_scorer.py`
+  - Contains `test_readme_with_all_quality_signals`
+  - Contains the short README fixture
+  - Contains the failing assertions
+  - Contains tests for the word-count categories
+
+- `agent/tools/readme_scorer.py`
+  - Contains the `ReadmeScorer` implementation
+  - Calculates the README word count
+  - Assigns the `minimal`, `adequate`, or `comprehensive` category
+  - Calculates the overall README score
+
+I expect the final change to mainly affect `tests/unit/test_readme_scorer.py`.
+
+### Plan
+
+1. Review `agent/tools/readme_scorer.py` to confirm the exact word-count thresholds used by the scorer.
+
+2. Review the category tests in `tests/unit/test_readme_scorer.py` to confirm that more than 500 words is required for the `comprehensive` category.
+
+3. Expand the README fixture in `test_readme_with_all_quality_signals` so that it contains more than 500 meaningful words.
+
+4. Preserve the existing README quality signals, including installation instructions, usage instructions, features, technologies, badges, and a live demo link.
+
+5. Run the focused test and the full README scorer test file to verify that the issue is fixed without breaking the other tests.
+
+### Inputs & outputs
+
+The input is a Markdown README string passed into:
+
+```python
+scorer.execute({"readme_content": readme})

--- a/tests/unit/test_readme_scorer.py
+++ b/tests/unit/test_readme_scorer.py
@@ -18,33 +18,181 @@ class TestReadmeScorer:
         """Test README with all quality signals returns high score."""
         readme = """
         # Project Name
-        A comprehensive project description.
+
+        Project Name is a production-ready portfolio review platform that helps
+        developers analyze project documentation, identify missing information,
+        and present their work more clearly to technical reviewers. The project
+        focuses on dependable scoring, transparent feedback, and maintainable
+        architecture so that contributors can understand how each result is
+        produced and how each part of the system can be improved over time.
+
+        The application accepts project content, evaluates documentation quality,
+        and returns structured signals that describe whether a README contains the
+        information expected from a complete software project. These signals help
+        users improve installation instructions, usage examples, feature summaries,
+        technology descriptions, deployment references, and supporting links.
 
         ## Installation
+
+        Create and activate a virtual environment before installing dependencies.
+        This keeps project packages separate from other Python applications on the
+        same machine and makes local development easier to reproduce.
+
         ```bash
+        python -m venv .venv
+        source .venv/bin/activate
         pip install package
         ```
 
+        On Windows PowerShell, activate the environment with the appropriate script
+        from the `.venv` directory. After installation, copy the example environment
+        file, provide the required configuration values, and confirm that the local
+        database or other dependent services are available before starting the app.
+
         ## Usage
+
+        Import the package and run the main application entry point. The package can
+        be used from Python code, automated scripts, or an API service depending on
+        the integration needs of the project.
+
         ```python
         import package
-        package.run()
+
+        result = package.run()
+        print(result)
         ```
 
+        Users can provide README content and inspect the returned quality signals.
+        Each response includes the detected word count, word-count category, section
+        indicators, badge detection, demo-link detection, technology-section
+        detection, and an overall score. These values can be displayed in a user
+        interface or used by another service to generate improvement suggestions.
+
         ## Features
-        - Feature 1
-        - Feature 2
-        - Feature 3
+
+        - Detects whether README content exists and contains meaningful text.
+        - Calculates the total number of whitespace-separated words.
+        - Categorizes documentation as minimal, adequate, or comprehensive.
+        - Detects installation, setup, and getting-started instructions.
+        - Detects usage, quickstart, and example sections.
+        - Recognizes build, coverage, license, and status badges.
+        - Identifies live demos, hosted examples, and try-it links.
+        - Detects technology, tech-stack, and built-with sections.
+        - Produces a normalized overall quality score.
+        - Returns structured data that is easy to test and integrate.
 
         ## Tech Stack
-        - Python 3.9
-        - FastAPI
-        - PostgreSQL
+
+        - Python 3.9 or newer for the core application and tests.
+        - FastAPI for typed request handling and service endpoints.
+        - PostgreSQL for persistent application and review data.
+        - Pytest for focused unit tests and regression coverage.
+        - Ruff for linting, import organization, and formatting checks.
+        - Structured logging for readable development and production diagnostics.
+
+        ## Architecture
+
+        The application uses a modular architecture that separates API handling,
+        business logic, persistence, scoring tools, and tests. Request validation is
+        handled near the system boundary, while reusable scoring behavior lives in
+        focused modules. This separation reduces coupling and makes it easier to add
+        new quality signals without rewriting unrelated features.
+
+        Service modules coordinate application behavior and return consistent data
+        structures. Database access is isolated so that tests can replace external
+        dependencies with mocks or fixtures. Logging captures useful operational
+        context without changing the result returned to callers. The design favors
+        small functions, explicit inputs, predictable outputs, and targeted tests.
+
+        ## Development
+
+        Contributors should review the contribution guide before changing code.
+        Work should be completed on a clearly named branch, divided into small
+        sub-tasks, and committed frequently so progress is visible. Each code change
+        should include relevant tests that follow the patterns already established
+        in the surrounding unit-test files.
+
+        Before opening a pull request, contributors should run focused tests for the
+        modified module, then run the complete unit-test command and the full project
+        checks. Any failures that existed before the change should be documented so
+        reviewers can distinguish pre-existing issues from newly introduced ones.
+
+        ## Testing
+
+        The test suite covers successful inputs, empty content, boundary conditions,
+        section detection, score calculations, and expected result fields. Focused
+        tests make it easier to diagnose failures because each test describes one
+        behavior. Regression tests protect previously reported issues from returning.
+
+        Contributors should run the smallest relevant test first while developing.
+        After the focused test passes, they should run the complete test file and
+        then the full unit-test suite. Test data should be realistic enough to match
+        the expectations being asserted. In particular, a fixture described as
+        comprehensive should actually contain enough content to reach that category.
+
+        ## Configuration
+
+        Environment-specific values should be stored outside source control. The
+        example environment file documents supported settings without exposing real
+        credentials. Developers should verify database URLs, API keys, service hosts,
+        and feature flags before starting the application. Production deployments
+        should use secure secret management and least-privilege access.
+
+        ## Deployment
+
+        The project can be deployed with containers or a standard Python runtime.
+        A reliable deployment should install locked dependencies, apply migrations,
+        validate required environment variables, start the API service, and expose a
+        health endpoint for monitoring. Teams should test changes in a staging
+        environment before releasing them to users.
+
+        ## Troubleshooting
+
+        Common development problems include missing packages, inactive virtual
+        environments, unavailable databases, incorrect environment variables, and
+        unsupported Python versions. Developers should inspect the full error output,
+        reproduce the issue with the smallest command possible, and compare results
+        before and after their changes. Focused tests and structured logs usually make
+        the source of a failure easier to identify.
+
+        ## Security
+
+        Input should be validated before processing, and sensitive values should not
+        be written to logs or committed to the repository. Dependencies should be
+        reviewed regularly, credentials should be rotated when necessary, and access
+        should follow the principle of least privilege. Security-related behavior
+        should be covered by tests just like other application requirements.
+
+        ## Contributing
+
+        Pull requests should explain the problem, summarize the implementation, list
+        the tests performed, and mention any known limitations or pre-existing
+        failures. Reviewers should be able to understand why the change is needed,
+        how it works, and whether it preserves existing behavior. Feedback should be
+        addressed before a draft pull request is marked ready for review.
+
+        ## Maintenance
+
+        Maintainers should keep dependencies current, review open issues, improve
+        documentation, and remove obsolete code when it is safe to do so. Regular
+        cleanup keeps the project understandable as new features are added. Clear
+        ownership, small pull requests, and reliable automated checks help prevent
+        technical debt from growing unnoticed.
+
+        ## Project Goals
+
+        The project is designed to provide a dependable, understandable, and
+        extensible foundation for documentation analysis. Its structure emphasizes
+        maintainability, clear feedback, predictable scoring, realistic test data,
+        and strong automated verification across the development lifecycle. The
+        system should help users improve their project presentation while giving
+        contributors a codebase that is straightforward to review and extend.
 
         ![Build Status](https://example.com/badge.svg)
         ![Coverage](https://example.com/coverage.svg)
 
         ## Live Demo
+
         [Try it here](https://demo.example.com)
         """
 
@@ -53,7 +201,7 @@ class TestReadmeScorer:
         assert result.success is True
         data = result.data
         assert data["has_readme"] is True
-        assert data["word_count"] > 100
+        assert data["word_count"] > 500
         assert data["word_count_category"] == "comprehensive"
         assert data["has_installation_section"] is True
         assert data["has_usage_section"] is True
@@ -157,9 +305,10 @@ class TestReadmeScorer:
 
         result = scorer.execute({"readme_content": readme})
         # "Getting Started" matches the pattern
-        assert result.data["has_installation_section"] is True or result.data[
-            "has_usage_section"
-        ] is True
+        assert (
+            result.data["has_installation_section"] is True
+            or result.data["has_usage_section"] is True
+        )
 
     def test_quickstart_counts_as_usage(self, scorer):
         """Test that 'quickstart' counts as usage."""
@@ -218,7 +367,8 @@ class TestReadmeScorer:
 
     def test_overall_score_calculation(self, scorer):
         """Test that overall score aggregates components."""
-        readme = """
+        readme = (
+            """
         # Good README
 
         ## Installation
@@ -233,7 +383,9 @@ class TestReadmeScorer:
         ![Build](https://example.com/build.svg)
 
         This readme has lots of content here.
-        """ * 3  # Make it comprehensive
+        """
+            * 3
+        )  # Make it comprehensive
 
         result = scorer.execute({"readme_content": readme})
 


### PR DESCRIPTION
## Summary

This PR fixes Issue #156 by making the README used in `test_readme_with_all_quality_signals` longer and more detailed. The test expected the README to be categorized as `comprehensive`, but the original fixture only had 51 words. I updated the fixture so it now has more than 500 words and matches the scorer’s existing requirements.

## Issue

Closes #156

## Changes

- Expanded the README fixture in `tests/unit/test_readme_scorer.py`
- Kept the installation, usage, features, tech stack, badges, and live demo sections
- Updated the word-count assertion to match the comprehensive category
- Did not change the actual README scorer logic

## Testing

- [ ] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`)
- [ ] Linter passes (`make lint`)
- [ ] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes

I ran the focused test:

`python -m pytest tests/unit/test_readme_scorer.py::TestReadmeScorer::test_readme_with_all_quality_signals -v`

Result: `1 passed`

I also ran the full README scorer test file:

`python -m pytest tests/unit/test_readme_scorer.py -v`

Result: `23 passed`

Before I made my changes, the repository already had 182 lint errors and 53 failing unit tests. My changes did not add any new failures.

## Screenshots / Demo

Not applicable because this change only updates a test fixture.

## Notes for Reviewers

The main thing to review is whether the updated README fixture has enough meaningful content while still keeping all of the quality signals expected by the scorer.