### PR TITLE
Fix: 151 bias detector narrow patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ htmlcov/
 *.pyc
 docs/project.md
 docs/rubric_w8.md
+docs/rubric_w9.md

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,3 @@ htmlcov/
 
 # Build artifacts
 *.pyc
-docs/project.md
-docs/rubric_w8.md
-docs/rubric_w9.md

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ htmlcov/
 
 # Build artifacts
 *.pyc
+docs/project.md
+docs/rubric_w8.md

--- a/Journal.md
+++ b/Journal.md
@@ -1,0 +1,18 @@
+## Week 7 — Issue selection
+
+**Issue link:** [paste link here]
+
+**Issue title:** [paste issue title here]
+
+**Tier:** [ ] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+[In 3–5 sentences, in your own words: what the issue is (not a copy-paste of
+the title), what is currently broken or missing, and what a successful fix
+would accomplish. Naming the part of the codebase it affects is helpful context.]
+
+**Branch name:** [paste branch name here]
+
+**Setup confirmation:** [ ] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger

--- a/Journal.md
+++ b/Journal.md
@@ -48,9 +48,6 @@ FAILED tests/unit/test_bias_detector.py::TestBiasDetector::test_assumption_vs_ob
 ========================= 9 failed, 23 passed in 0.18s =========================
 ```
 
-**PLAN.md link:** [to fill in later this week]
-
-**Walkthrough video (recommended):** [optional — to fill in if recorded]
+**PLAN.md link:** https://github.com/brtran97/pathreview/commit/2b00be758a03d6e6a935ee9016aeaa33734eeb6f
 
 **Blockers or open questions:**
-[to fill in]

--- a/Journal.md
+++ b/Journal.md
@@ -1,18 +1,21 @@
 ## Week 7 — Issue selection
 
-**Issue link:** [paste link here]
+**Issue link:** https://github.com/ascherj/pathreview/issues/151
 
-**Issue title:** [paste issue title here]
+**Issue title:** Bias detector patterns are too narrow to match common phrasings
+ #151
 
-**Tier:** [ ] Tier 1  [ ] Tier 2  [ ] Tier 3
+ **Issue Selection:**
+ I am able to understand what the issue is from the comments in the github issue and can understand what the corrected version is supposed to do (pass the unit tests for bias detection). I was able to find where the issue exists from the tags that say it is in the safety folder and it is inside the bias detector.
+ This is my first open source contribution, so I am choosing a tier 1 issue in order to get more experience. I have read the actual code in the file where the issue exists. I have found the unit tests that call on the bias detector so I can understand the context behind how it works and how it is being tested. There are no other students in my session working on this problem but there are a good amount of students in other sections working on it going by the comments in the github issue. This issue should take me somewhere between 4-8 hours to implement by my estimate so I am confident I will be able to test and submit the PR by week 9. I have also verified that this issue has no open blockers or dependencies on other unresolved issues. These meet all the requirements for "Is This Issue Right for Me?"
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
 
 **Problem summary:**
-[In 3–5 sentences, in your own words: what the issue is (not a copy-paste of
-the title), what is currently broken or missing, and what a successful fix
-would accomplish. Naming the part of the codebase it affects is helpful context.]
+In the safety section folder of the project the file **bias_detector.py** uses regex patterns in order to detect phrasing that expresses a certain type of meaning however. The regex patterns are too strict and narrow so it fails to detect bias in 9 units tests. If the regex can be adjusted to pass all the unit tests then the bug will be successfully fixed.
 
-**Branch name:** [paste branch name here]
+**Branch name:** https://github.com/brtran97/pathreview/tree/fix/151-bias-detector-narrow-patterns
 
-**Setup confirmation:** [ ] App runs locally at localhost:5173
+**Setup confirmation:** [x] App runs locally at localhost:5173
 
-**Cohort ledger:** [ ] Issue added to cohort ledger
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/Journal.md
+++ b/Journal.md
@@ -19,3 +19,38 @@ In the safety section folder of the project the file **bias_detector.py** uses r
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [to fill in after committing this note]
+
+**Reproduction summary:**
+I reproduced the issue by running the bias detector unit tests in my local
+environment with `.venv/bin/python -m pytest tests/unit/test_bias_detector.py -v`
+(equivalent to `make test-unit` scoped to this file) or with vscodes pytest GUI. I observed **9 failed, 23
+passed**, exactly matching the counts described in issue #151. The failures confirm
+that `BiasDetector.detect_bias(...)` returns `(False, '')` for natural phrasings that
+should be flagged (e.g. dismissive bootcamp language and age-based assumptions),
+because the regex patterns in `safety/bias_detector.py` are too narrow.
+
+The 9 failing tests:
+
+```
+FAILED tests/unit/test_bias_detector.py::TestBiasDetector::test_dismissive_bootcamp_language_detected
+FAILED tests/unit/test_bias_detector.py::TestBiasDetector::test_bootcamp_lacks_rigor_detected
+FAILED tests/unit/test_bias_detector.py::TestBiasDetector::test_demographic_assumption_age_detected
+FAILED tests/unit/test_bias_detector.py::TestBiasDetector::test_coding_bootcamp_variant
+FAILED tests/unit/test_bias_detector.py::TestBiasDetector::test_developer_vs_programmer_distinction
+FAILED tests/unit/test_bias_detector.py::TestBiasDetector::test_multiple_bias_indicators
+FAILED tests/unit/test_bias_detector.py::TestBiasDetector::test_negative_educational_claim
+FAILED tests/unit/test_bias_detector.py::TestBiasDetector::test_rich_poor_assumption
+FAILED tests/unit/test_bias_detector.py::TestBiasDetector::test_assumption_vs_observation
+========================= 9 failed, 23 passed in 0.18s =========================
+```
+
+**PLAN.md link:** [to fill in later this week]
+
+**Walkthrough video (recommended):** [optional — to fill in if recorded]
+
+**Blockers or open questions:**
+[to fill in]

--- a/Journal.md
+++ b/Journal.md
@@ -164,3 +164,37 @@ change introduces none: full unit suite went from 53 failed → 44 failed (my 9 
 and `safety/bias_detector.py` passes ruff, black, and mypy cleanly.)
 
 **Draft PR feedback received from:** None
+
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [X] No code review will not be performed for this summer session
+
+**Summary of feedback:**
+No feedback was performed for this session as noted by the course information, but I am preparing myself for how I can respond or address any feed for my PR to make sure that it is accepted and merged into the main project.
+
+**How you responded:**
+N/A
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+I was suprised by seeing such a large codebase when I first looked at it. It was intimidating at first to see how many parts there was and all the different issues that where available to work on. This was my first time working on a github issue workflow so it also took me some time to get acquainted with the process and the onboarding to find and issue comment on it and perform the fix and make a PR it.
+
+**What did you learn about working in a large codebase?**
+[What's different about contributing to someone else's production code
+vs. building your own project?]
+I learned that it was less important to follow and understand the entire codebase and what every moving part does because it can get overwhelming very quickly. I had to identify where my issue lived and what can be defined as fixing the issue. It was also different to learn about how to follow their documentation like going through their architecture doc to understand the overview of the project and its modules. Then each open source repo should have a contributing.md that details how they want contributions to be done and to follow their format not just write my code freely as I would on my own personal projects.
+
+**How did AI tools help — and where did they fall short?**
+AI was most useful to me for exploring the codebase and getting myself orientated when I didn't know where to start. It was also very helpful and suggesting how to fix the issue and what can be done. Where it falls short is defining success and making my own decisions about how to approach the issue and defining the scope of my fix or feature.
+
+**What would you do differently if you started over?**
+If I was able to start over I think that I did a good job on this fix I might consider working on a 2nd issue to see what other type of issues exist. My issue was code related but I also saw documentation issues, testing issues, and the tier 2 & 3 problems which are larger and pertain more to the architecture of the codebase where the bug can flow from 1 module to another one.
+
+**What are you most proud of from this module?**
+I am proud to have done my first "open-source" contribution. It was my first time working with a large existing codebase like this and using github issues. I know there is still much to learn and my git skills are still a work in progress, but I enjoyed having my first experience working in this format.

--- a/Journal.md
+++ b/Journal.md
@@ -51,3 +51,57 @@ FAILED tests/unit/test_bias_detector.py::TestBiasDetector::test_assumption_vs_ob
 **PLAN.md link:** https://github.com/brtran97/pathreview/commit/2b00be758a03d6e6a935ee9016aeaa33734eeb6f
 
 **Blockers or open questions:**
+None — the failing tests clearly specify the intended behavior, so the path forward is well defined.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the fix from PLAN.md in two iterative commits on
+`safety/bias_detector.py`. (1) Broadened `DISMISSIVE_PATTERNS` into an
+education-keyword + nearby-negative-predicate structure so natural phrasings
+("bootcamp graduates can't write production code", "bootcamp education lacks
+fundamentals") match without requiring an exact word sequence — this fixed 7 of the
+9 failing tests. (2) Broadened `DEMOGRAPHIC_PATTERNS` to accept plural subjects and
+subject anchors beyond "person from" (e.g. "developers from poor backgrounds"),
+fixing the remaining 2. All 32 bias-detector tests now pass.
+
+**Next steps:**
+Run the full self-review (`make check` / `make test-unit`), open a draft PR into
+upstream `ascherj/pathreview`, request peer feedback in Slack, then mark ready for
+review and submit.
+
+**Blockers:**
+None.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/615
+
+**Branch:** `fix/151-bias-detector-narrow-patterns`
+
+**What you built:**
+Broadened the regex patterns in `safety/bias_detector.py` so `BiasDetector.detect_bias()`
+recognizes common natural phrasings of educational-background dismissiveness and
+demographic assumptions — not just near-exact phrase sequences. The `detect_bias()`
+signature and return shape (`tuple[bool, str]`) are unchanged; only detection coverage
+improved, and positive/neutral mentions of the same topics stay unflagged.
+
+**Tests added or updated:**
+No new tests written — the fix targets the 9 pre-existing failing tests in
+`tests/unit/test_bias_detector.py`, which now pass (suite is 32/32). Those tests cover:
+dismissive educational-background phrasings (bootcamp/self-taught/online-course +
+"can't"/"lacks"/"inadequate"/"not equal"), demographic assumptions (age, socioeconomic
+background, immigrant/international/foreign developers), and precision guardrails that
+positive/neutral mentions (e.g. "your bootcamp background shows strong fundamentals")
+remain unflagged.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+(Note: the repo has pre-existing, unrelated failures in other modules. Verified my
+change introduces none: full unit suite went from 53 failed → 44 failed (my 9 fixes),
+and `safety/bias_detector.py` passes ruff, black, and mypy cleanly.)
+
+**Draft PR feedback received from:** None

--- a/Journal.md
+++ b/Journal.md
@@ -22,7 +22,7 @@ In the safety section folder of the project the file **bias_detector.py** uses r
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [to fill in after committing this note]
+**Reproduction commit link:** https://github.com/brtran97/pathreview/commit/87268077bbfacb5fff7ff842d056fe1203c3c753
 
 **Reproduction summary:**
 I reproduced the issue by running the bias detector unit tests in my local

--- a/Journal.md
+++ b/Journal.md
@@ -81,6 +81,65 @@ None.
 
 **PR link:** https://github.com/ascherj/pathreview/pull/615
 
+**PR Body (if it cannot be pulled from link):**
+```
+## Summary
+The bias detector's regex patterns required near-exact phrase sequences, so natural
+rephrasings of the same bias slipped through. For example,
+`BiasDetector.detect_bias("The candidate only attended a bootcamp, so this project
+lacks the rigor of a formal CS education")` returned `(False, '')`. This PR broadens
+the patterns in `safety/bias_detector.py` so common phrasings of educational-background
+dismissiveness and demographic assumptions are correctly flagged, while positive and
+neutral mentions stay unflagged. The `detect_bias()` signature and return shape are
+unchanged — only detection coverage improves.
+
+## Issue
+Closes #151
+
+## Changes
+- Rewrote `DISMISSIVE_PATTERNS` as an education-keyword (`bootcamp` / `coding bootcamp`
+  / `self-taught` / `online course`) followed within a bounded window by a negative
+  predicate (`can't`, `cannot`, `lacks`, `insufficient`, `inadequate`,
+  `not/never equal|comparable`). This removes the previous hard dependency on the exact
+  word "is" and on singular-only subjects.
+- Broadened `DEMOGRAPHIC_PATTERNS`: age assumptions now accept plural subjects
+  ("young developers can't…"), and the socioeconomic-background pattern accepts subjects
+  beyond "person from" ("developers from poor backgrounds…").
+- Replaced an unbounded `.*` in the origin-based demographic pattern with a bounded
+  window to avoid catastrophic backtracking.
+
+## Testing
+- [x] Unit tests pass (`make test-unit`) — see note below
+- [ ] Integration tests pass (`make test-integration`)
+- [x] Linter passes (`make lint`) — on the changed file
+- [x] Type checker passes (`make typecheck`) — on the changed file
+- [ ] New/updated tests cover the changes (see Notes)
+
+**How to verify manually:**
+1. `python -m pytest tests/unit/test_bias_detector.py -v` — 32/32 pass (was 9 failed /
+   23 passed before this change; the 9 fixed tests include
+   `test_dismissive_bootcamp_language_detected`, `test_demographic_assumption_age_detected`,
+   `test_rich_poor_assumption`, `test_assumption_vs_observation`).
+2. Spot-check in a REPL:
+   - `BiasDetector.detect_bias("bootcamp graduates can't write production code")` → `(True, …)`
+   - `BiasDetector.detect_bias("young developers can't handle complex systems")` → `(True, "Demographic assumptions detected")`
+   - `BiasDetector.detect_bias("your bootcamp background shows strong fundamentals")` → `(False, "")` (positive mention, correctly not flagged)
+
+## Notes for Reviewers
+- **No new tests added** — this PR makes the 9 pre-existing failing tests in
+  `tests/unit/test_bias_detector.py` pass; that file already specifies the intended
+  coverage, including precision guardrails for positive/neutral phrasings.
+- **Pre-existing failures:** the repo has unrelated failing tests in other modules
+  (`test_review_service`, `test_skill_extractor`, etc.). This change introduces none —
+  the full unit suite went from 53 → 44 failures (my 9 fixes), and no failure is in
+  `test_bias_detector.py`.
+- **Approach:** kept the existing regex-based design to satisfy the specified tests. A
+  more semantic/NLP approach could generalize further but would be a larger change and
+  is out of scope here.
+```
+----------
+<br>
+
 **Branch:** `fix/151-bias-detector-narrow-patterns`
 
 **What you built:**

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,98 @@
+## Solution plan
+
+**Issue:** Bias detector patterns are too narrow to match common phrasings — #151
+(https://github.com/ascherj/pathreview/issues/151)
+
+### Understand
+**Root cause.** `BiasDetector.detect_bias()` in `safety/bias_detector.py` relies on two
+lists of regexes (`DISMISSIVE_PATTERNS`, `DEMOGRAPHIC_PATTERNS`) that require near-exact
+phrase sequences, so natural rephrasings of the same bias never match. Three specific
+narrowness bugs:
+
+- **Hardcoded connectors.** The dismissive education pattern is
+  `(?:education|training)\s+is\s+(?:insufficient|inadequate|lacks)` — it demands the word
+  "is", so "bootcamp education **lacks** fundamentals" (no "is") slips through.
+- **Singular-only subjects.** Patterns match `developer`/`graduate`/`programmer` but not
+  their plurals, so "young **developers** can't…" and "bootcamp **graduates** can't…"
+  don't match.
+- **Fixed subject anchors.** The demographic background pattern only anchors to
+  `person from` / `coming from`, so "**developers** from poor backgrounds can't…" is missed.
+
+**Expected vs. actual.** `detect_bias()` should return `(True, <reason>)` for dismissive
+educational-background language and demographic assumptions across common phrasings.
+Actual: it returns `(False, '')` for these phrasings. **9 of 32** unit tests fail.
+
+### Map
+Which files, functions, or modules are involved:
+
+- **`safety/bias_detector.py`** — the only file to edit. Specifically the
+  `DISMISSIVE_PATTERNS` list (lines 13–18), the `DEMOGRAPHIC_PATTERNS` list (lines 21–25),
+  and the `detect_bias()` static method (lines 27–51).
+- **`tests/unit/test_bias_detector.py`** — reference only, not edited. The 9 failing tests
+  define the target phrasings; the `*_not_flagged` tests (e.g.
+  `test_positive_bootcamp_mention_not_flagged`, `test_neutral_bootcamp_mention_not_flagged`,
+  `test_comparative_without_bias`) are precision guardrails that must stay green.
+
+The 9 failing tests to satisfy: `test_dismissive_bootcamp_language_detected`,
+`test_bootcamp_lacks_rigor_detected`, `test_demographic_assumption_age_detected`,
+`test_coding_bootcamp_variant`, `test_developer_vs_programmer_distinction`,
+`test_multiple_bias_indicators`, `test_negative_educational_claim`,
+`test_rich_poor_assumption`, `test_assumption_vs_observation`.
+
+### Plan
+Concrete sub-tasks:
+
+1. **Broaden the dismissive-subject patterns.** Allow plural subjects
+   (`graduates?`, `developers?`, `programmers?`) and negative predicates that don't require
+   "is" — e.g. `can'?t`/`cannot` + write/handle/afford, and `lacks?`. Covers
+   "bootcamp graduates can't write production code" and "bootcamp programmers lack proper
+   training".
+2. **Handle the `coding bootcamp` variant and the "…are not equal/comparable to…" phrasing.**
+   Covers "coding bootcamp graduates can't write enterprise code" and "self-taught
+   developers are not equal to university graduates".
+3. **Drop the hardcoded "is" in the education pattern** so "bootcamp education lacks
+   fundamentals" / "bootcamp attendance means inadequate training" match.
+4. **Broaden the demographic patterns.** Match plural demographic nouns and alternative
+   subject anchors ("developers from poor backgrounds", not just "person from"), and age
+   assumptions with plural subjects ("young developers can't…").
+5. **Add precision guards.** Require a negative predicate near the keyword so positive/
+   neutral mentions of "bootcamp" stay unflagged. Keep the demographic branch's `reason`
+   containing the word "demographic" (asserted by `test_demographic_assumption_age_detected`).
+6. **Verify.** Run `make test-unit` (or `.venv/bin/python -m pytest
+   tests/unit/test_bias_detector.py -v`) until 32/32 pass, then `make check`
+   (black + ruff + mypy).
+
+### Inputs & outputs
+- **Input:** `text: str` — the feedback string to scan (unchanged).
+- **Output:** unchanged signature `tuple[bool, str]` = `(is_biased, reason)`. On a match,
+  `reason` is one of the two existing category strings ("Dismissive language about
+  educational background" or "Demographic assumptions detected").
+- **What changes:** behavior only — more phrasings now map to `True` with a non-empty
+  reason. No signature, API, or return-shape change; callers of `detect_bias()` are
+  unaffected.
+
+### Risks & unknowns
+- **Precision regression (primary risk).** Broadening the regexes risks flagging the
+  positive/neutral cases in `tests/unit/test_bias_detector.py` (e.g.
+  `test_positive_bootcamp_mention_not_flagged`: "your bootcamp background shows strong
+  fundamentals"). Mitigation: re-run the whole test file, not just the 9, after each change.
+- **Catastrophic backtracking / readability.** The existing demographic pattern uses `.*`
+  (`safety/bias_detector.py:24`); adding more alternation could hurt readability or cause
+  slow matching. Mitigation: keep alternations bounded, avoid unbounded `.*` where possible.
+- **Unknown — approach preference.** Whether maintainers would prefer a more semantic
+  (non-regex) detector. Staying with regex to satisfy the specified unit tests; will note
+  this in the PR if relevant.
+
+### Edge cases
+The fix must handle these gracefully:
+
+1. **Positive/neutral bootcamp mentions stay unflagged** — "your bootcamp background shows
+   strong fundamentals"; "this bootcamp project demonstrates good coding practices".
+2. **Observation vs. assumption** — "your resume shows bootcamp attendance" (factual → not
+   flagged) vs. "bootcamp attendance means inadequate training" (biased → flagged).
+3. **Case-insensitivity** — "BOOTCAMP GRADUATES LACK FUNDAMENTALS" → flagged.
+4. **Empty / whitespace-only input** — `""` and `"   \n\t  "` → `(False, '')`.
+5. **Singular vs. plural subjects** — developer/developers, graduate/graduates,
+   programmer/programmers all detected.
+6. **Multiple bias indicators in one sentence** — "young bootcamp graduates can't write
+   code and immigrant developers lack fundamentals" → flagged.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -99,7 +99,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -449,7 +448,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -473,7 +471,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1561,7 +1558,6 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1579,7 +1575,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1972,7 +1967,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3507,7 +3501,6 @@
       "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^2.0.1",
         "cssstyle": "^4.0.1",
@@ -4094,7 +4087,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4107,7 +4099,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4771,7 +4762,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/safety/bias_detector.py
+++ b/safety/bias_detector.py
@@ -1,6 +1,7 @@
 """Bias detection in generated feedback."""
 
 import re
+
 import structlog
 
 logger = structlog.get_logger()
@@ -9,12 +10,18 @@ logger = structlog.get_logger()
 class BiasDetector:
     """Detect biased language in feedback."""
 
-    # Genuinely dismissive phrases about educational background
+    # Genuinely dismissive phrases about educational background.
+    # An education keyword (bootcamp / self-taught / online course) followed within a
+    # bounded window by a negative predicate. This matches natural phrasings ("bootcamp
+    # graduates can't write production code", "bootcamp education lacks fundamentals")
+    # without requiring an exact word sequence, while positive/neutral mentions ("your
+    # bootcamp background shows strong fundamentals") carry no negative predicate and so
+    # stay unflagged.
     DISMISSIVE_PATTERNS = [
-        r"(?:bootcamp|self-taught|online\s+course)\s+(?:education|training)\s+is\s+(?:insufficient|inadequate|lacks)",
-        r"(?:bootcamp|self-taught)\s+(?:graduates?|developers?)\s+(?:lack|missing)\s+(?:rigor|fundamentals|proper\s+training)",
-        r"(?:bootcamp|coding\s+bootcamp)\s+(?:doesn't|does\s+not)\s+prepare\s+(?:you|developers?)",
-        r"(?:self-taught|bootcamp)\s+is\s+(?:not|never)\s+(?:equal|comparable)\s+to\s+(?:university|traditional|formal)",
+        r"(?:(?:coding\s+)?bootcamp|self-?taught|online\s+course)\b.{0,40}?\b"
+        r"(?:can'?t|cannot|won'?t|will\s+not|lacks?|insufficient|inadequate"
+        r"|not\s+(?:equal|comparable)|never\s+(?:equal|comparable)"
+        r"|(?:isn'?t|aren'?t)\s+(?:equal|comparable))",
     ]
 
     # Demographic assumptions (about age, background, identity)

--- a/safety/bias_detector.py
+++ b/safety/bias_detector.py
@@ -24,11 +24,14 @@ class BiasDetector:
         r"|(?:isn'?t|aren'?t)\s+(?:equal|comparable))",
     ]
 
-    # Demographic assumptions (about age, background, identity)
+    # Demographic assumptions (about age, background, identity). Subjects allow both
+    # singular and plural forms, and the background pattern accepts subjects beyond
+    # "person from" (e.g. "developers from poor backgrounds"). The origin pattern uses a
+    # bounded window rather than an unbounded ".*" to avoid catastrophic backtracking.
     DEMOGRAPHIC_PATTERNS = [
-        r"(?:young|old|aged)\s+(?:person|developer|programmer)\s+(?:can't|cannot|won't|will\s+not)",
-        r"(?:person\s+from|coming\s+from)\s+(?:poor|rich|working[\s-]?class)",
-        r"(?:immigrant|international|foreign)\s+developers?.*(?:can't|cannot|won't|struggle)",
+        r"(?:young|old|aged)\s+(?:persons?|developers?|programmers?|engineers?)\s+(?:can'?t|cannot|won'?t|will\s+not)",
+        r"(?:persons?|people|developers?|programmers?|engineers?|candidates?|those)\s+(?:from|coming\s+from)\s+(?:poor|rich|working[\s-]?class)",
+        r"(?:immigrant|international|foreign)\s+developers?.{0,30}?(?:can'?t|cannot|won'?t|struggle)",
     ]
 
     @staticmethod


### PR DESCRIPTION
## Summary
The bias detector's regex patterns required near-exact phrase sequences, so natural
rephrasings of the same bias slipped through. For example,
`BiasDetector.detect_bias("The candidate only attended a bootcamp, so this project
lacks the rigor of a formal CS education")` returned `(False, '')`. This PR broadens
the patterns in `safety/bias_detector.py` so common phrasings of educational-background
dismissiveness and demographic assumptions are correctly flagged, while positive and
neutral mentions stay unflagged. The `detect_bias()` signature and return shape are
unchanged — only detection coverage improves.

## Issue
Closes #151

## Changes
- Rewrote `DISMISSIVE_PATTERNS` as an education-keyword (`bootcamp` / `coding bootcamp`
  / `self-taught` / `online course`) followed within a bounded window by a negative
  predicate (`can't`, `cannot`, `lacks`, `insufficient`, `inadequate`,
  `not/never equal|comparable`). This removes the previous hard dependency on the exact
  word "is" and on singular-only subjects.
- Broadened `DEMOGRAPHIC_PATTERNS`: age assumptions now accept plural subjects
  ("young developers can't…"), and the socioeconomic-background pattern accepts subjects
  beyond "person from" ("developers from poor backgrounds…").
- Replaced an unbounded `.*` in the origin-based demographic pattern with a bounded
  window to avoid catastrophic backtracking.

## Testing
- [x] Unit tests pass (`make test-unit`) — see note below
- [ ] Integration tests pass (`make test-integration`) — N/A, no integration tests in repo; change is an isolated pure function
- [x] Linter passes (`make lint`) — on the changed file
- [x] Type checker passes (`make typecheck`) — on the changed file
- [ ] New/updated tests cover the changes (see Notes)

**How to verify manually:**
1. `python -m pytest tests/unit/test_bias_detector.py -v` — 32/32 pass (was 9 failed /
   23 passed before this change; the 9 fixed tests include
   `test_dismissive_bootcamp_language_detected`, `test_demographic_assumption_age_detected`,
   `test_rich_poor_assumption`, `test_assumption_vs_observation`).
2. Spot-check in a REPL:
   - `BiasDetector.detect_bias("bootcamp graduates can't write production code")` → `(True, …)`
   - `BiasDetector.detect_bias("young developers can't handle complex systems")` → `(True, "Demographic assumptions detected")`
   - `BiasDetector.detect_bias("your bootcamp background shows strong fundamentals")` → `(False, "")` (positive mention, correctly not flagged)

## Notes for Reviewers
- **No new tests added** — this PR makes the 9 pre-existing failing tests in
  `tests/unit/test_bias_detector.py` pass; that file already specifies the intended
  coverage, including precision guardrails for positive/neutral phrasings.
- **Pre-existing failures:** the repo has unrelated failing tests in other modules
  (`test_review_service`, `test_skill_extractor`, etc.). This change introduces none —
  the full unit suite went from 53 → 44 failures (my 9 fixes), and no failure is in
  `test_bias_detector.py`.
- **Approach:** kept the existing regex-based design to satisfy the specified tests. A
  more semantic/NLP approach could generalize further but would be a larger change and
  is out of scope here.
