### PR TITLE
Fix #156: extend README scorer test fixture to genuinely reach comprehensive tier

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,4 +1,5 @@
-﻿## Week 7 — Issue selection
+﻿@"
+## Week 7 — Issue selection
 
 **Issue link:** https://github.com/ascherj/pathreview/issues/156
 
@@ -14,3 +15,15 @@ The test_readme_with_all_quality_signals test in tests/unit/test_readme_scorer.p
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+**Issue selection checklist reasoning:**
+
+- **Understanding:** The test test_readme_with_all_quality_signals in tests/unit/test_readme_scorer.py asserts a fixture README scores word_count_category == "comprehensive," but the scorer (agent/tools/readme_scorer.py) defines "comprehensive" as 500+ words. The fixture only has ~51 words, so it fails well before even reaching the "adequate" threshold (100-499 words), let alone "comprehensive." This is a mismatch between the fixture and the category thresholds it's meant to validate, not a bug in the scorer logic itself.
+- **Affected area:** tests/unit/test_readme_scorer.py (test) and agent/tools/readme_scorer.py (scorer being tested). Confirmed both files exist and read the full test function plus the _score_readme method's category logic.
+- **Definition of done:** Before the fix, the test fails on assert 51 > 100. A correct fix has two possible paths: (1) extend the fixture README to genuinely exceed 500 words so it legitimately earns "comprehensive," matching the test's original intent to validate a top-tier README, or (2) keep the fixture short and change the expected category to "adequate" to match realistic ~100-150 word content. I'll pick whichever better matches what the test is actually trying to demonstrate.
+- **Tier fit:** First open-source contribution, so choosing Tier 1 intentionally. The fix is localized to one test file (and possibly a fixture string), matching Tier 1's "broken test" description.
+- **Codebase readiness:** Read the full test class and the _score_readme method, including the word-count categorization logic and all quality-signal checks (installation, usage, badges, demo link, tech stack). Can sketch the fix without further research.
+- **Claims/competition:** I found an open PR (#164) from an external contributor claiming to fix this issue by extending the fixture to >100 words. However, on inspection, this doesn't fully align with the scorer's actual logic, which requires 500+ words for the "comprehensive" category, so their fix may only get the fixture to "adequate," not resolve the original assertion. Per the checklist, claims are non-exclusive and grading is based on my own artifacts, so I'm proceeding with my own solution.
+- **Time estimate:** Small, focused fix, either extending fixture text or adjusting one assertion, plus confirming other quality-signal assertions still pass. Estimate 1-2 hours, comfortably within Tier 1's 3-6 hour range.
+- **Blockers:** No open blockers referenced on the issue.
+"@ | Out-File -FilePath JOURNAL.md -Encoding utf8

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,16 @@
+﻿## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/156
+
+**Issue title:** README scorer test fixture is too short for its own word-count assertion
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The test_readme_with_all_quality_signals test in tests/unit/test_readme_scorer.py checks that a README with strong quality signals scores as "comprehensive," which requires a word count over 100. However, the fixture README used in the test only contains about 51 words, so the assertion word_count > 100 fails even though the scorer itself is working correctly. This is a test data bug, not a bug in the scorer logic. A successful fix will either extend the fixture README's content so it genuinely exceeds 100 words and qualifies as "comprehensive," or adjust the assertion to match realistic fixture length.
+
+**Branch name:** fix/156-readme-scorer-test-fixture-word-count
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -27,3 +27,20 @@ The test_readme_with_all_quality_signals test in tests/unit/test_readme_scorer.p
 - **Time estimate:** Small, focused fix, either extending fixture text or adjusting one assertion, plus confirming other quality-signal assertions still pass. Estimate 1-2 hours, comfortably within Tier 1's 3-6 hour range.
 - **Blockers:** No open blockers referenced on the issue.
 "@ | Out-File -FilePath JOURNAL.md -Encoding utf8
+
+Add-Content -Path JOURNAL.md -Value @"
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/AbuIdrak/pathreview/commit/4fb1e431e07feca9584fd289ed8af66c7763dc1
+
+**Reproduction summary:**
+Ran the failing test locally with pytest, confirming the fixture README produces word_count=51 and word_count_category="minimal" (not "comprehensive" as the test expects, since the scorer requires 500+ words for that category). Documented the reproduction with an inline comment in the test file explaining the root cause.
+
+**PLAN.md link:** https://github.com/AbuIdrak/pathreview/blob/fix/156-readme-scorer-test-fixture-word-count/PLAN.md
+
+**Walkthrough video (recommended):** [not recorded]
+
+**Blockers or open questions:**
+An open, unmerged PR (#164) from an external contributor attempts to fix this issue by extending the fixture to just over 100 words, which would not satisfy the "comprehensive" category (500+ words) per the scorer's actual logic. Planning to proceed with my own fix regardless, per the course's non-exclusive claims policy, but noting this in case it becomes relevant during review.
+"@

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -60,3 +60,24 @@ Run make check to confirm no new lint/type errors were introduced (ruff and blac
 **Blockers:**
 None currently.
 "@
+
+Add-Content -Path JOURNAL.md -Value @"
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/622
+
+**Branch:** fix/156-readme-scorer-test-fixture-word-count
+
+**What you built:**
+Extended the fixture README in test_readme_with_all_quality_signals to genuinely exceed 500 words with meaningful content (Table of Contents, expanded Installation/Usage, API Reference, Configuration, Contributing, Testing sections), and corrected the assertion from word_count > 100 to word_count > 500 to match the scorer's actual "comprehensive" threshold defined in agent/tools/readme_scorer.py.
+
+**Tests added or updated:**
+Updated tests/unit/test_readme_scorer.py - specifically the fixture and assertion in test_readme_with_all_quality_signals. All 23 tests in the file pass. Confirmed via full suite run that the fix resolves the target failure with no new regressions (52 failed/376 passed, down from a baseline of 53 failed/375 passed).
+
+**Self-review confirmation:** [x] make check passes (for my file - ruff clean, black clean, mypy shows only a pre-existing, unrelated numpy stub error)  [x] make test-unit passes (for my target test - full suite has 52 pre-existing unrelated failures, documented in PR description)
+
+**Draft PR feedback received from:** none yet
+"@

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -44,3 +44,19 @@ Ran the failing test locally with pytest, confirming the fixture README produces
 **Blockers or open questions:**
 An open, unmerged PR (#164) from an external contributor attempts to fix this issue by extending the fixture to just over 100 words, which would not satisfy the "comprehensive" category (500+ words) per the scorer's actual logic. Planning to proceed with my own fix regardless, per the course's non-exclusive claims policy, but noting this in case it becomes relevant during review.
 "@
+
+Add-Content -Path JOURNAL.md -Value @"
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the fix from PLAN.md: extended the fixture README in test_readme_with_all_quality_signals to genuinely exceed 500 words (added Table of Contents, expanded Installation/Usage prose, API Reference, Configuration, Contributing, and Testing sections), and corrected the assertion from word_count > 100 to word_count > 500 to match the scorer's actual "comprehensive" threshold. All 23 tests in test_readme_scorer.py pass, including the previously failing one. Ran the full suite before and after: baseline was 53 failed/375 passed, now 52 failed/376 passed - confirming the fix resolves the target issue with no new regressions elsewhere.
+
+**Next steps:**
+Run make check to confirm no new lint/type errors were introduced (ruff and black already confirmed clean on my file). Open a draft PR for early feedback, then finalize the PR description documenting the pre-existing baseline failures and my verification steps.
+
+**Blockers:**
+None currently.
+"@

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,35 @@
+@"
+## Solution plan
+
+**Issue:** README scorer test fixture is too short for its own word-count assertion - https://github.com/ascherj/pathreview/issues/156
+
+### Understand
+The test test_readme_with_all_quality_signals in tests/unit/test_readme_scorer.py asserts that a "high quality" fixture README scores word_count > 100 and word_count_category == "comprehensive". In agent/tools/readme_scorer.py, _score_readme categorizes word count as: <100 = "minimal", 100-499 = "adequate", 500+ = "comprehensive". The fixture README used in the test contains only ~51 words. Locally reproducing the test confirms word_count=51, category="minimal" - well short of even "adequate," let alone "comprehensive." Expected behavior: the fixture should represent a genuinely comprehensive README and the test should validate that the scorer correctly identifies it as such. Actual behavior: the fixture is too short to satisfy its own assertions, so the test fails independent of whether the scorer logic is correct (it is - this is a test data bug, not a scorer bug).
+
+### Map
+- tests/unit/test_readme_scorer.py - contains the failing test and its fixture (primary file to edit)
+- agent/tools/readme_scorer.py - the scorer being tested; read to confirm category thresholds, not expected to change
+- No other files reference this specific fixture or test, based on a repo-wide search for test_readme_with_all_quality_signals
+
+### Plan
+1. Decide the fix approach: extend the fixture to genuinely exceed 500 words (true "comprehensive"), since that best matches the test's intent to validate a top-tier README with every quality signal present.
+2. Extend the existing fixture's content (e.g. add realistic Configuration, Contributing, and expanded Features/Tech Stack sections) rather than padding with filler text, so the fixture stays meaningful and continues exercising all the quality-signal checks (installation, usage, badges, demo link, tech stack).
+3. Re-run the target test locally to confirm word_count > 500 and word_count_category == "comprehensive" both pass.
+4. Run the full test file (pytest tests/unit/test_readme_scorer.py -v) to confirm no other test in the suite was relying on the old fixture's exact word count or content.
+5. Add a short comment near the fixture noting the word-count threshold it's designed to satisfy, so a future contributor doesn't accidentally shrink it below 500 words again.
+
+### Inputs & outputs
+Input: The fixture README string inside test_readme_with_all_quality_signals.
+Output: An extended fixture string with >500 words, all existing structural elements preserved (installation, usage, badges, demo link, tech stack sections), so all nine assertions in the test pass together.
+
+### Risks & unknowns
+- Risk: Padding the fixture carelessly (e.g. repeating text) could make it look artificial and reduce the test's value as a realistic example; will write genuine, varied prose instead.
+- Risk: Extending the fixture could push overall_score above 1.0 or otherwise change other passing assertions in the same test (e.g. the overall_score > 0.7 check) - need to re-verify all assertions still hold after editing.
+- Unknown: PR #164 (open, unmerged, from an external contributor) claims to fix this by extending the fixture to only slightly over 100 words, which would not resolve word_count_category == "comprehensive" per the 500-word threshold - need to confirm this during implementation and note the discrepancy if relevant.
+- Unknown: whether the maintainer intended "comprehensive" or would consider changing the assertion to "adequate" instead - will default to matching the fixture to the test's stated intent (a README with "all quality signals") unless feedback suggests otherwise.
+
+### Edge cases
+- Fixture must remain valid Markdown that the scorer's regex-based section detectors (installation, usage, badges, demo, tech stack) still correctly recognize after edits.
+- Word count must clear 500 by a comfortable margin, not just barely (e.g. 501), to avoid flakiness if minor future edits are made.
+- Must confirm the fixture doesn't accidentally trip has_readme or word_count_category into an unexpected category due to leading/trailing whitespace handling in _score_readme.
+"@ | Out-File -FilePath PLAN.md -Encoding utf8

--- a/tests/unit/test_readme_scorer.py
+++ b/tests/unit/test_readme_scorer.py
@@ -53,6 +53,10 @@ class TestReadmeScorer:
         assert result.success is True
         data = result.data
         assert data["has_readme"] is True
+        # REPRODUCED (#156): fixture is only ~51 words, category resolves to
+        # "minimal" (see readme_scorer.py word_count thresholds: <100=minimal,
+        # 100-499=adequate, 500+=comprehensive). Confirmed via local pytest run:
+        # `assert 51 > 100` fails; overall_score (0.87) already passes independently.
         assert data["word_count"] > 100
         assert data["word_count_category"] == "comprehensive"
         assert data["has_installation_section"] is True
@@ -157,9 +161,10 @@ class TestReadmeScorer:
 
         result = scorer.execute({"readme_content": readme})
         # "Getting Started" matches the pattern
-        assert result.data["has_installation_section"] is True or result.data[
-            "has_usage_section"
-        ] is True
+        assert (
+            result.data["has_installation_section"] is True
+            or result.data["has_usage_section"] is True
+        )
 
     def test_quickstart_counts_as_usage(self, scorer):
         """Test that 'quickstart' counts as usage."""
@@ -218,7 +223,8 @@ class TestReadmeScorer:
 
     def test_overall_score_calculation(self, scorer):
         """Test that overall score aggregates components."""
-        readme = """
+        readme = (
+            """
         # Good README
 
         ## Installation
@@ -233,7 +239,9 @@ class TestReadmeScorer:
         ![Build](https://example.com/build.svg)
 
         This readme has lots of content here.
-        """ * 3  # Make it comprehensive
+        """
+            * 3
+        )  # Make it comprehensive
 
         result = scorer.execute({"readme_content": readme})
 

--- a/tests/unit/test_readme_scorer.py
+++ b/tests/unit/test_readme_scorer.py
@@ -18,34 +18,118 @@ class TestReadmeScorer:
         """Test README with all quality signals returns high score."""
         readme = """
         # Project Name
-        A comprehensive project description.
+
+        A comprehensive project description that explains what this application
+        does, who it's for, and why it exists. This tool was built to help
+        developers streamline their workflow by automating repetitive tasks
+        and providing clear, actionable insights into their codebase health.
+
+        ## Table of Contents
+        - Installation
+        - Usage
+        - Features
+        - Tech Stack
+        - Configuration
+        - Contributing
+        - License
 
         ## Installation
-        ```bash
+
+        To get started, clone the repository and install the dependencies:
+
+```bash
+        git clone https://github.com/example/project.git
+        cd project
         pip install package
-        ```
+```
+
+        Make sure you have Python 3.9 or higher installed before proceeding.
+        You will also need to set up a virtual environment to avoid conflicts
+        with other Python packages on your system.
 
         ## Usage
-        ```python
+
+        Once installed, you can start using the package right away:
+
+```python
         import package
         package.run()
-        ```
+```
+
+        The `run()` method accepts several optional parameters that let you
+        customize its behavior, including verbosity level, output format, and
+        target directory. See the API reference below for full details on
+        each available option and how it affects the resulting output.
+
+        ## API Reference
+
+        The core API surface consists of a small number of well-documented
+        functions and classes. The main entry point accepts a configuration
+        dictionary and returns a result object containing status information,
+        any output data produced, and error details if something went wrong.
+        Advanced users can also import individual submodules directly for
+        finer-grained control over specific parts of the pipeline, such as
+        parsing, validation, or output formatting. Each submodule includes
+        its own docstrings and type hints to make integration straightforward
+        even without consulting external documentation.
 
         ## Features
-        - Feature 1
-        - Feature 2
-        - Feature 3
+
+        - Feature 1: Automatic detection of common code quality issues
+        - Feature 2: Configurable rules engine for custom validation logic
+        - Feature 3: Detailed reporting with actionable recommendations
+        - Feature 4: Integration with popular CI/CD pipelines
+        - Feature 5: Support for multiple output formats including JSON and HTML
+
+        ## Testing
+
+        This project maintains a comprehensive test suite covering unit tests,
+        integration tests, and end-to-end scenarios. Run the full suite with a
+        single command before submitting any changes, and check the generated
+        coverage report to identify any untested code paths. Continuous
+        integration automatically runs the test suite on every pull request,
+        so contributors get fast feedback on whether their changes introduce
+        regressions. We aim to keep test coverage above ninety percent across
+        the core modules, and new features should include corresponding tests
+        as part of the same change. If you find a bug, adding a failing test
+        that reproduces it before fixing the underlying issue is the preferred
+        workflow, since it documents the problem and prevents regressions.
 
         ## Tech Stack
+
         - Python 3.9
         - FastAPI
         - PostgreSQL
+        - Redis for caching
+        - Docker for containerization
+
+        ## Configuration
+
+        The application can be configured through environment variables or a
+        configuration file. Available options include database connection
+        strings, logging verbosity, and feature flags for experimental
+        functionality. Refer to the `.env.example` file for a complete list
+        of supported configuration values and their default settings.
+
+        ## Contributing
+
+        Contributions are welcome! Please read our contributing guidelines
+        before submitting a pull request. All contributions should include
+        appropriate tests and follow the existing code style. Run the full
+        test suite locally before opening your PR to catch any regressions
+        early in the review process.
 
         ![Build Status](https://example.com/badge.svg)
         ![Coverage](https://example.com/coverage.svg)
 
         ## Live Demo
+
         [Try it here](https://demo.example.com)
+
+        ## License
+
+        This project is licensed under the MIT License. See the LICENSE file
+        for more details.
         """
 
         result = scorer.execute({"readme_content": readme})
@@ -53,11 +137,7 @@ class TestReadmeScorer:
         assert result.success is True
         data = result.data
         assert data["has_readme"] is True
-        # REPRODUCED (#156): fixture is only ~51 words, category resolves to
-        # "minimal" (see readme_scorer.py word_count thresholds: <100=minimal,
-        # 100-499=adequate, 500+=comprehensive). Confirmed via local pytest run:
-        # `assert 51 > 100` fails; overall_score (0.87) already passes independently.
-        assert data["word_count"] > 100
+        assert data["word_count"] > 500
         assert data["word_count_category"] == "comprehensive"
         assert data["has_installation_section"] is True
         assert data["has_usage_section"] is True

--- a/tests/unit/test_readme_scorer.py
+++ b/tests/unit/test_readme_scorer.py
@@ -303,8 +303,7 @@ class TestReadmeScorer:
 
     def test_overall_score_calculation(self, scorer):
         """Test that overall score aggregates components."""
-        readme = (
-            """
+        readme = """
         # Good README
 
         ## Installation
@@ -319,9 +318,7 @@ class TestReadmeScorer:
         ![Build](https://example.com/build.svg)
 
         This readme has lots of content here.
-        """
-            * 3
-        )  # Make it comprehensive
+        """ * 3  # Make it comprehensive
 
         result = scorer.execute({"readme_content": readme})
 


### PR DESCRIPTION
## Summary

Fixes #156.

The `test_readme_with_all_quality_signals` test in `tests/unit/test_readme_scorer.py` asserted that a fixture README would score `word_count > 100` and `word_count_category == "comprehensive"`. However, the scorer (`agent/tools/readme_scorer.py`) defines "comprehensive" as requiring 500+ words, and the fixture only contained ~51 words — so the test failed regardless of whether the scorer logic was correct (it was).

## Changes

- Extended the fixture README in `test_readme_with_all_quality_signals` with genuine, meaningful content (Table of Contents, expanded Installation/Usage sections, API Reference, Configuration, Contributing, and Testing sections) so it authentically exceeds 500 words and legitimately earns the "comprehensive" category, rather than padding with filler text.
- Corrected the assertion from `word_count > 100` to `word_count > 500` to match the scorer's actual category threshold.
- Verified all other assertions in the test (installation/usage/badges/demo link/tech stack detection, `overall_score > 0.7`) still pass with the extended fixture.

## Testing

- `pytest tests/unit/test_readme_scorer.py -v` — all 23 tests pass (previously 1 failing).
- Full suite (`make test-unit`) before my change: **53 failed, 375 passed**. After my change: **52 failed, 376 passed** — confirms the fix resolves the target issue with no new regressions.
- `ruff check tests/unit/test_readme_scorer.py` — passes, no lint issues.
- `black --check tests/unit/test_readme_scorer.py` — passes, no formatting issues.
- `mypy tests/unit/test_readme_scorer.py` — only reports a pre-existing, unrelated error inside numpy's own type stubs (`numpy/__init__.pyi:737`), not in this file.

## Pre-existing issues (not introduced by this PR)

The codebase has 182 pre-existing `ruff` lint errors and 52 pre-existing failing unit tests across unrelated modules (bias detector, PII scrubber, resume parser, review service async mocking, skill extractor, tech detector, etc.), confirmed via baseline runs before I made any changes. This PR does not touch or affect any of those files or tests.

## Related

An earlier open PR (#164) attempts to fix this issue by extending the fixture to just over 100 words, which would not satisfy the "comprehensive" category per the scorer's actual 500-word threshold. This PR resolves the issue by matching the fixture to the scorer's real logic instead.