### PR TITLE
fix: redact US phone numbers with mixed separators (parens/space)

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,26 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/146
+
+**Issue title:** PII scrubber fails to redact parenthesized US phone numbers
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The PII scrubber's phone number regex in `safety/pii_scrubber.py` handled
+separators inconsistently across the pattern — the gap after the optional
+parenthesis allowed a space, dash, or dot, but the gap before the final four
+digits only allowed a dash or dot, not a space. This meant formats like
+`(555) 123-4567` and `+1 555 123 4567` passed through both `scrub()` and
+`detect()` completely unredacted, since the regex simply didn't match them.
+The fix updates all three separator groups in the `phone_us` pattern to
+consistently allow space, dash, dot, or no separator at all, so every common
+US phone format is caught. All four tests named in the issue now pass:
+test_us_phone_number_redaction, test_us_phone_formats, test_detect_phone_pii,
+and test_phone_at_start_of_text.
+
+**Branch name:** fix/146-parenthesized-phone-redaction
+
+**Setup confirmation:** [ ] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -44,3 +44,47 @@ separator handling in the `phone_us` regex.
 Still need to confirm the app runs locally at localhost:5173 — Docker
 Desktop install has been delayed by a slow internet connection. No other
 open questions on the fix itself; all four named tests pass.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the core fix to the `phone_us` regex in `safety/pii_scrubber.py`,
+correcting the inconsistent separator groups so parenthesized and
+space-separated phone formats are properly redacted. All four tests named
+in issue #146 pass.
+
+**Next steps:**
+Run `make check` and `make test-unit` to compare against the pre-existing
+baseline on `main`, clean up any lint issues introduced by my own change,
+and open the PR for review.
+
+**Blockers:**
+Local environment setup took longer than expected (Python version mismatch,
+missing Rust toolchain for compiling `cryptography`), but resolved by
+installing Python 3.11 and Rust via rustup.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/623
+
+**Branch:** fix/146-parenthesized-phone-redaction
+
+**What you built:**
+Fixed the `phone_us` regex in the PII scrubber so it consistently redacts
+US phone numbers across all common separator formats (dashes, dots, spaces,
+and parentheses), resolving issue #146.
+
+**Tests added or updated:**
+No new tests were added — the existing tests in
+`tests/unit/test_pii_scrubber.py` already covered the required scenarios.
+All four tests named in the issue now pass.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+(No new lint errors or test failures introduced compared to `main`; see
+PR description for the full before/after comparison.)
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -88,3 +88,77 @@ All four tests named in the issue now pass.
 PR description for the full before/after comparison.)
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No reviewer feedback came in. Per the Su26 course note, reviewer feedback
+is not a feature this term, so no review was expected.
+
+**How you responded:**
+N/A — no feedback to respond to. I did post my PR link in the class
+Slack channel requesting peer feedback as recommended in Week 9.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Getting the local environment running was by far the hardest part of the
+whole module — harder than the actual bug fix. My Mac had an outdated
+Python (3.9) when the project required 3.11+, my pip version was too old
+to do editable installs from a pyproject.toml-only project, and once I
+got past that, `cryptography` and `libcst` failed to build because they
+needed a Rust compiler I didn't have installed. Each fix uncovered the
+next missing piece. The actual code change — fixing an inconsistent
+separator pattern in a regex — took a few minutes once I could run the
+tests. I underestimated how much of "real" contribution work is just
+getting your machine into a state where you can even start.
+
+**What did you learn about working in a large codebase?**
+I learned to scope my changes carefully and verify what I actually
+touched versus what was already broken. Running `make check` and
+`make test-unit` on this project surfaced 182 lint errors and dozens of
+failing tests that had nothing to do with my issue. Instead of panicking
+or trying to fix everything, I learned to isolate my diff (`git diff
+--name-only`), run tools scoped to just my file, and directly compare
+`main` against my branch to prove my change introduced zero new
+failures. That before/after comparison table ended up being the most
+convincing part of my PR description — it's a much stronger argument
+than just saying "my tests pass."
+
+**How did AI tools help — and where did they fall short?**
+AI assistance was most useful for debugging the regex itself — walking
+through exactly why `(?<!\d)` and inconsistent `[-.\s]?` groups caused
+certain formats to fail, and for troubleshooting the environment issues
+step by step (recognizing that `maturin`/Rust build failures meant a
+missing compiler, or that pip's dependency resolution needed a specific
+flag). Where it fell short was anything requiring my actual GitHub
+account, terminal, or physical machine — no AI tool can install Python
+or Rust for you, run `git push`, or click "Create pull request." I also
+had to catch and correct an AI-suggested command myself once (creating a
+branch inside my home directory instead of inside the actual cloned
+repo), which was a good reminder to actually read command output rather
+than just copy-pasting blindly.
+
+**What would you do differently if you started over?**
+I'd set up my full local dev environment (correct Python version, Rust,
+Docker) in Week 7 before even picking an issue, rather than discovering
+the gaps midway through Week 9 under deadline pressure. I'd also
+double-check early which repository a PR is actually targeting — I
+initially opened a PR against my own fork's `main` instead of the
+upstream `ascherj/pathreview`, which I only caught because I stopped to
+verify the URL instead of assuming it was correct.
+
+**What are you most proud of from this module?**
+Diagnosing the actual root cause of the regex bug rather than just
+patching the one example format mentioned in the issue title. The issue
+was titled around parenthesized numbers, but tracing through the pattern
+showed the real problem was inconsistent separator handling across all
+three digit groups — which also silently broke `+1 555 123 4567` in a
+way the issue never mentioned. Catching that made the fix genuinely
+correct instead of narrowly correct.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -24,3 +24,23 @@ and test_phone_at_start_of_text.
 **Setup confirmation:** [ ] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/Akhrorxuja/pathreview/commit/7922612
+
+**Reproduction summary:**
+Ran the existing unit test suite before fixing the code and confirmed
+`test_us_phone_formats` failed on parenthesized and space-separated phone
+numbers (e.g. `(555) 123-4567`, `+1 555 123 4567`), which passed through
+`scrub()` and `detect()` completely unredacted due to inconsistent
+separator handling in the `phone_us` regex.
+
+**PLAN.md link:** https://github.com/Akhrorxuja/pathreview/blob/fix/146-parenthesized-phone-redaction/PLAN.md
+
+**Walkthrough video (recommended):**
+
+**Blockers or open questions:**
+Still need to confirm the app runs locally at localhost:5173 — Docker
+Desktop install has been delayed by a slow internet connection. No other
+open questions on the fix itself; all four named tests pass.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,78 @@
+## Solution plan
+
+**Issue:** PII scrubber fails to redact parenthesized US phone numbers — https://github.com/ascherj/pathreview/issues/146
+
+### Understand
+The `phone_us` regex in `safety/pii_scrubber.py` used inconsistent separator
+groups between the three digit groups of a phone number. The gap after the
+optional area-code parenthesis allowed a space, dash, or dot (`[-.\s]?`), but
+the gap before the final four digits only allowed a dash or dot (`[-.]?`),
+with no space option. As a result, formats like `(555) 123-4567` and
+`+1 555 123 4567` — both of which rely on a space separator somewhere in
+the number — were never matched. Expected behavior: any common US phone
+format (dashed, dotted, parenthesized, spaced, or a mix) should be detected
+and redacted. Actual behavior (before fix): only fully dash/dot-separated
+numbers like `555-123-4567` were caught; anything with a space passed
+through `scrub()` unredacted and was invisible to `detect()`.
+
+### Map
+- `safety/pii_scrubber.py` — contains the `PII_PATTERNS` dict and the
+  `phone_us` regex that needed correction. This is the only file changed
+  for the core fix.
+- `tests/unit/test_pii_scrubber.py` — existing test file with the four
+  tests named in the issue (`test_us_phone_number_redaction`,
+  `test_us_phone_formats`, `test_detect_phone_pii`,
+  `test_phone_at_start_of_text`) that define what "fixed" means. No test
+  changes were needed since the existing tests already covered the bug.
+
+### Plan
+1. Reproduce the bug locally by running the existing test suite and
+   confirming which tests failed and why (`test_us_phone_formats`,
+   later also `test_mixed_pii_and_text`, though the latter is unrelated).
+2. Isolate the root cause by manually tracing the regex against each
+   failing input format to find exactly which separator group was
+   too strict.
+3. Update the `phone_us` pattern so all three separator positions
+   (after country code, after area code, before final four digits)
+   consistently allow space, dash, dot, or nothing.
+4. Re-run the full unit test suite to confirm the four named tests pass
+   without breaking any previously-passing tests.
+5. Document the reproduction and root cause directly in the code (comment
+   above the regex) and in JOURNAL.md, then commit and push.
+
+### Inputs & outputs
+**Input:** raw text strings potentially containing US phone numbers in
+various formats (dashed, dotted, parenthesized, spaced, or combinations),
+passed to `PIIScrubber.scrub()` or `PIIScrubber.detect()`.
+**Output:** `scrub()` returns the text with all matched phone numbers
+replaced by `[REDACTED]`; `detect()` returns a list of dicts identifying
+each phone number's type, value, and position in the text. After the fix,
+both methods correctly catch all four format variants named in the issue.
+
+### Risks & unknowns
+- Loosening the separator groups too much could cause false positives —
+  e.g., accidentally matching a run of digits that isn't actually a phone
+  number (like a long ID or timestamp embedded in text). This needs to be
+  watched for in `test_detect_no_false_positives`.
+- The `phone_intl` pattern is separate and wasn't touched, but there could
+  be overlap between `phone_us` and `phone_intl` matching the same
+  substring differently — worth double-checking if new international test
+  cases are added later.
+- A separate, pre-existing bug in the `street_address` pattern (unrelated
+  to this issue) causes `test_mixed_pii_and_text` to fail because "Pl" in
+  "applications" gets matched as an address suffix. This is out of scope
+  for issue #146 and should not be fixed as part of this PR, but is noted
+  here in case it causes confusion during review.
+
+### Edge cases
+- Phone number at the very start or end of a string (already covered by
+  `test_phone_at_start_of_text` / `test_phone_at_end_of_text`).
+- Phone number immediately adjacent to other digits (e.g. part of a longer
+  numeric ID) should NOT be falsely matched — handled by the `(?<!\d)` /
+  `(?!\d)` lookaround boundaries.
+- Numbers with a leading `+1` country code combined with spaces, e.g.
+  `+1 555 123 4567`, must be matched as a single phone number, not broken
+  into fragments.
+- Multiple different phone formats appearing in the same text block
+  should all be redacted independently (covered by
+  `test_multiple_emails_redacted`-style multi-match tests).

--- a/safety/pii_scrubber.py
+++ b/safety/pii_scrubber.py
@@ -12,6 +12,12 @@ class PIIScrubber:
     # Regex patterns for common PII
     PII_PATTERNS = {
         "email": r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b",
+        # Reproduction (Issue #146): original pattern used inconsistent
+        # separators across the three groups, so parenthesized and
+        # space-separated formats like "(555) 123-4567" and
+        # "+1 555 123 4567" were not matched by scrub()/detect().
+        # Repro: PIIScrubber().scrub("Call me at (555) 123-4567")
+        #   -> returned the text unredacted before this fix.
         "phone_us": r"(?<!\d)(?:\+?1[-.\s]?)?\(?([0-9]{3})\)?[-.\s]?([0-9]{3})[-.\s]?([0-9]{4})(?!\d)",
         "phone_intl": r"\+[0-9]{1,3}[-.]?[0-9]{1,14}",
         "ssn": r"\b(?!000|666)[0-9]{3}-(?!00)[0-9]{2}-(?!0000)[0-9]{4}\b",

--- a/safety/pii_scrubber.py
+++ b/safety/pii_scrubber.py
@@ -18,7 +18,10 @@ class PIIScrubber:
         # "+1 555 123 4567" were not matched by scrub()/detect().
         # Repro: PIIScrubber().scrub("Call me at (555) 123-4567")
         #   -> returned the text unredacted before this fix.
-        "phone_us": r"(?<!\d)(?:\+?1[-.\s]?)?\(?([0-9]{3})\)?[-.\s]?([0-9]{3})[-.\s]?([0-9]{4})(?!\d)",
+        "phone_us": (
+            r"(?<!\d)(?:\+?1[-.\s]?)?\(?([0-9]{3})\)?[-.\s]?"
+            r"([0-9]{3})[-.\s]?([0-9]{4})(?!\d)"
+        ),
         "phone_intl": r"\+[0-9]{1,3}[-.]?[0-9]{1,14}",
         "ssn": r"\b(?!000|666)[0-9]{3}-(?!00)[0-9]{2}-(?!0000)[0-9]{4}\b",
         "street_address": r"\b\d+\s+[A-Za-z\s]+(?:Street|St|Avenue|Ave|Road|Rd|Boulevard|Blvd|Drive|Dr|Lane|Ln|Court|Ct|Circle|Cir|Park|Pl|Plaza|Place|Drive|Dr|Way|Parkway|Pkwy|Point|Pt|Pike|Run|Summit|Summit|Terrace|Ter|Trail|Trl|Tunnel|Turnpike|View|Vista|Vlg|Village|Vly|Valley)",

--- a/safety/pii_scrubber.py
+++ b/safety/pii_scrubber.py
@@ -12,7 +12,7 @@ class PIIScrubber:
     # Regex patterns for common PII
     PII_PATTERNS = {
         "email": r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b",
-        "phone_us": r"\b(?:\+?1[-.]?)?\(?([0-9]{3})\)?[-.]?([0-9]{3})[-.]?([0-9]{4})\b",
+        "phone_us": r"(?<!\d)(?:\+?1[-.\s]?)?\(?([0-9]{3})\)?[-.\s]?([0-9]{3})[-.\s]?([0-9]{4})(?!\d)",
         "phone_intl": r"\+[0-9]{1,3}[-.]?[0-9]{1,14}",
         "ssn": r"\b(?!000|666)[0-9]{3}-(?!00)[0-9]{2}-(?!0000)[0-9]{4}\b",
         "street_address": r"\b\d+\s+[A-Za-z\s]+(?:Street|St|Avenue|Ave|Road|Rd|Boulevard|Blvd|Drive|Dr|Lane|Ln|Court|Ct|Circle|Cir|Park|Pl|Plaza|Place|Drive|Dr|Way|Parkway|Pkwy|Point|Pt|Pike|Run|Summit|Summit|Terrace|Ter|Trail|Trl|Tunnel|Turnpike|View|Vista|Vlg|Village|Vly|Valley)",


### PR DESCRIPTION
## Summary
Fixes #146. The `phone_us` regex in `safety/pii_scrubber.py` used inconsistent
separator groups between the three digit groups of a US phone number — some
gaps allowed a space, dash, or dot, while others only allowed a dash or dot.
This meant common formats like `(555) 123-4567` and `+1 555 123 4567` were
never matched by `scrub()` or `detect()` and passed through completely
unredacted.

## What changed
- Updated the `phone_us` pattern in `PII_PATTERNS` so all three separator
  positions consistently accept space, dash, dot, or nothing.
- Wrapped the regex across multiple lines to satisfy the project's line
  length lint rule.
- Added a code comment documenting the original bug and how to reproduce it.

## Tests
No new test file changes were needed — the existing tests in
`tests/unit/test_pii_scrubber.py` already covered the four scenarios named
in the issue (`test_us_phone_number_redaction`, `test_us_phone_formats`,
`test_detect_phone_pii`, `test_phone_at_start_of_text`). All four now pass.

## Pre-existing failures (documented per Week 9 guidance)
This codebase has pre-existing lint and test failures unrelated to this
issue. I compared `main` against this branch directly:

| | `main` | this branch |
|---|---|---|
| `make check` (lint) | 182 errors | 182 errors |
| `make test-unit` | 53 failed, 375 passed | 49 failed, 379 passed |

- **Lint:** identical error count on both branches — this PR introduces
  no new lint errors. Verified with `ruff check safety/pii_scrubber.py`,
  which shows only 4 pre-existing issues (import order, an overly long
  `street_address` pattern, an unused loop variable, and a long
  `logger.info` line), none in the lines this PR touches.
- **Tests:** 4 fewer failures on this branch, matching the phone-format
  tests this fix resolves. No new failures were introduced; the remaining
  49 failures (e.g. in `test_tech_detector.py`, `test_structural_chunker.py`)
  are unrelated to PII scrubbing and pre-date this change.

## Self-review
- [x] `make check` — no new errors introduced (182 on both `main` and this branch)
- [x] `make test-unit` — no new failures introduced (4 fewer failures than `main`)