### PR TITLE
Test/105 review page accessibility tests

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -17,6 +17,6 @@ core screens.
 
 **Branch name:** test/105-review-page-accessibility-tests
 
-**Setup confirmation:** [ ] App runs locally at localhost:5173
+**Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -9,11 +9,13 @@
 **Problem summary:**
 The review page (`frontend/src/pages/ReviewPage.tsx`) has no automated
 accessibility checks, so regressions like poor color contrast, missing form
-labels, or broken heading hierarchy can slip in unnoticed. The fix adds
+labels, or broken heading hierarchy can slip in unnoticed. The page renders
+different DOM depending on state — polling/loading, failed, and complete —
+so an a11y violation could exist in one state and not another. The fix adds
 `jest-axe`-based tests in `frontend/src/pages/__tests__/ReviewPage.test.tsx`
-that render the page and assert it has no detectable a11y violations. This
-gives the frontend a regression net for accessibility on one of the app's
-core screens.
+that render each of these states and assert none has detectable a11y
+violations. This gives the frontend a regression net for accessibility
+across the full lifecycle of one of the app's core screens.
 
 **Branch name:** test/105-review-page-accessibility-tests
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -76,3 +76,69 @@ need their own axe check, per the plan's Understand section.
 - jsdom (used by vitest) doesn't do real layout/paint, so `jest-axe` may not
   catch color-contrast violations in this environment — scoping expectations
   to what's actually testable
+
+  ## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+All 5 sub-tasks from PLAN.md's Plan section are implemented and committed
+individually in `frontend/src/pages/__tests__/ReviewPage.test.tsx`: (1)
+`jest-axe`'s `toHaveNoViolations` matcher wired into global test setup
+(`src/test/setup.ts`), (2) test file scaffolded with `react-router-dom` and
+`useReviewStatus`/`apiClient` mocks, (3) `jest-axe` checks for the polling,
+failed, and complete states, (4) a check for stacked error banners (`error`
++ `fetchError` rendered together), and (5) full suite run — 5/5 tests pass.
+Also ran `make check`/`make test-unit` to baseline pre-existing failures
+(53 pytest failures, 182 ruff errors, 5 mypy errors, all in Python files
+this change never touches) and confirmed no new failures introduced.
+
+**Next steps:**
+Open the PR with the pre-existing-failures note in the description, and
+resolve the two open questions from Week 8: router mocking approach
+(went with mocking `react-router-dom`'s `useParams`/`useNavigate` directly,
+no `MemoryRouter`) and matcher registration (went with global, in
+`setup.ts`, rather than per-file) — both now resolved by the implementation,
+just need to reflect that back into Week 8 if graded together.
+
+**Blockers:**
+None currently. One thing to watch: `make format` (black) mutates files in
+place rather than just checking — accidentally reformatted 52 unrelated
+Python files when I ran `make check` for baselining; reverted with
+`git checkout --` before it touched staging. Using `black --check .`
+instead going forward to avoid repeating that.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/thisiswhale/pathreview/pull/1
+
+**Branch:** test/105-review-page-accessibility-tests
+
+**What you built:**
+Automated accessibility coverage for `ReviewPage` using `jest-axe`, with a
+separate check per conditionally-rendered state (polling, failed, complete)
+plus one for the stacked polling-error/fetch-error banners, since a
+violation could exist in one state and not another.
+
+**Tests added or updated:**
+- `frontend/src/pages/__tests__/ReviewPage.test.tsx` (new) — 5 tests: a
+  smoke render of the polling state, and `jest-axe` zero-violations checks
+  for polling, failed, complete, and stacked-error-banner states
+- `frontend/src/test/setup.ts` — registers `jest-axe`'s `toHaveNoViolations`
+  matcher globally so any test file can use it
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+Both are Python-only and don't cover this frontend-only change; checked
+under this codebase's documented-baseline definition — no new failures
+introduced. Baselined pre-existing failures before starting (53/428 pytest
+failures, 182 ruff errors, 5 mypy errors, 52 unformatted files, all in
+Python files this PR never touches — confirmed disjoint from this diff).
+Frontend: `npx vitest run` on the new file is 5/5 passing; one pre-existing
+frontend failure (`ReviewSection.test.tsx`) and one pre-existing broken
+file (`ProfileForm.test.tsx`, missing dep) predate this change too. Full
+detail in the PR description.
+
+**Draft PR feedback received from:** none 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,5 +1,14 @@
 ## Week 7 — Issue selection
 
+<!--   Email: user1@example.com
+  Password: password1
+
+  Email: user2@example.com
+  Password: password2
+
+  Email: user3@example.com
+  Password: password3 -->
+
 **Issue link:** https://github.com/ascherj/pathreview/issues/105
 
 **Issue title:** Add accessibility tests for the review page using `jest-axe`
@@ -41,3 +50,29 @@ across the full lifecycle of one of the app's core screens.
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/thisiswhale/pathreview/commit/7cc60f1eb7d3a1147f97794d75a5551ab537ec4e
+
+**Reproduction summary:**
+This is a missing-coverage issue, not a bug, so "reproducing" it meant
+confirming the gap: `ls frontend/src/pages/__tests__/` fails (directory
+doesn't exist), and `jest-axe` is present only as a devDependency with no
+usage anywhere in `frontend/src`. Also confirmed `ReviewPage.tsx` has three
+conditionally-rendered states (polling, failed, complete) that would each
+need their own axe check, per the plan's Understand section.
+
+**PLAN.md link:** https://github.com/thisiswhale/pathreview/blob/test/105-review-page-accessibility-tests/PLAN.md
+
+**Walkthrough video (recommended):** [link to your Loom video, ≤2 min — recommended, not graded]
+
+**Blockers or open questions:**
+- Whether `jest-axe`'s `toHaveNoViolations` matcher is already registered
+  globally in a `setupTests`/`vitest.config.ts` file, or needs adding per-file
+- Whether to wrap `ReviewPage` in `MemoryRouter` or mock `react-router-dom`
+  directly for `useParams`/`useNavigate` — following whichever existing
+  tests already lean toward
+- jsdom (used by vitest) doesn't do real layout/paint, so `jest-axe` may not
+  catch color-contrast violations in this environment — scoping expectations
+  to what's actually testable

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -17,6 +17,25 @@ that render each of these states and assert none has detectable a11y
 violations. This gives the frontend a regression net for accessibility
 across the full lifecycle of one of the app's core screens.
 
+**Acceptance checklist:**
+- [ ] `jest-axe`'s `toHaveNoViolations` matcher wired into the test setup
+- [ ] Test renders the polling/loading state and asserts zero axe violations
+- [ ] Test renders the failed state and asserts zero axe violations
+- [ ] Test renders the complete state (with review sections) and asserts zero axe violations
+- [ ] All new tests pass via `make test-unit`
+
+**Why this issue fits (scope-fit reasoning):**
+- Tier 2, 4–6h estimated effort — matches what I can commit this week
+- `jest-axe` is already a devDependency in `frontend/package.json`, so no new
+  tooling setup is required, just test code
+- The repo already has React Testing Library test patterns to follow
+  (`ProfileForm.test.tsx`, `ReviewSection.test.tsx`), so I'm extending an
+  established pattern rather than inventing one
+- Scope is one new file (`ReviewPage.test.tsx`); no backend, API, or
+  component changes needed, keeping blast radius small
+- `useReviewStatus` is a mockable hook, so all three render states can be
+  driven in tests without a live backend
+
 **Branch name:** test/105-review-page-accessibility-tests
 
 **Setup confirmation:** [x] App runs locally at localhost:5173

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,22 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/105
+
+**Issue title:** Add accessibility tests for the review page using `jest-axe`
+
+**Tier:** [ ] Tier 1  [x] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The review page (`frontend/src/pages/ReviewPage.tsx`) has no automated
+accessibility checks, so regressions like poor color contrast, missing form
+labels, or broken heading hierarchy can slip in unnoticed. The fix adds
+`jest-axe`-based tests in `frontend/src/pages/__tests__/ReviewPage.test.tsx`
+that render the page and assert it has no detectable a11y violations. This
+gives the frontend a regression net for accessibility on one of the app's
+core screens.
+
+**Branch name:** test/105-review-page-accessibility-tests
+
+**Setup confirmation:** [ ] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -112,7 +112,7 @@ instead going forward to avoid repeating that.
 
 ### Check-in 2 (end of week)
 
-**PR link:** https://github.com/thisiswhale/pathreview/pull/1
+**PR link:** https://github.com/ascherj/pathreview/pull/625
 
 **Branch:** test/105-review-page-accessibility-tests
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -142,3 +142,75 @@ file (`ProfileForm.test.tsx`, missing dep) predate this change too. Full
 detail in the PR description.
 
 **Draft PR feedback received from:** none 
+
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [x] Yes  [ ] No — still awaiting review
+
+**Summary of feedback:**
+`rafayet-git` approved PR #625 with one inline suggestion on
+`frontend/src/pages/__tests__/ReviewPage.test.tsx:91` — the complete-state
+test waits on `screen.findByText('Portfolio Review')` before running the
+axe check, but that heading is a static page title, not evidence the score
+data actually arrived. They recommended waiting on something more obviously
+tied to the data landing, e.g. `"Overall Score"`.
+
+**How you responded:**
+Agreed — `findByText('Portfolio Review')` happens to work because that
+heading is gated behind `fullReview.status === 'complete'` in the component,
+but it doesn't read as an intentional "wait for the score" condition.
+Swapped the wait to `screen.findByText('Overall Score')` so the test's
+intent matches what it's actually confirming.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Scoping "add accessibility tests" turned out to be less about `jest-axe`
+mechanics and more about mapping every state a component can actually be
+in. My first pass at the journal problem summary described the fix as one
+render + one axe check; it took explicit feedback to notice `ReviewPage`
+has three distinct render branches (polling, failed, complete) plus
+stacked error banners, and a violation in one state says nothing about
+the others. The actual test-writing was mechanical once that mapping was
+right — most of the effort was in the "what does 'done' mean here" step.
+
+**What did you learn about working in a large codebase?**
+Consistency mattered more than cleverness. Instead of designing my own
+mocking approach, I went looking for how `ProfileForm.test.tsx` already
+mocked a hook with `vi.mock` and copied that shape for `useReviewStatus`
+and `apiClient`. That made the new test file read like it belonged next
+to the existing ones, and it surfaced a real constraint I wouldn't have
+guessed upfront — `apiClient` is a class singleton, not a plain module of
+functions, so the mock factory has to shape it accordingly.
+
+**How did AI tools help — and where did they fall short?**
+AI assistance (Claude Code, this session) was most useful for the
+grunt work that's easy to get subtly wrong under time pressure: reading
+the actual component/hook/types before writing fixtures instead of
+guessing their shape, running the real test suite after every change
+instead of assuming green, and catching two mistakes before they became
+problems — `make format` silently reformatting 52 unrelated files (caught
+and reverted before it touched any commit), and a first-draft PR opened
+against my own fork instead of upstream (`ascherj/pathreview`), which
+would have been invisible to a grader. It fell short at judgment calls
+that needed my input directly — deciding whether a change like the
+router-mocking approach was "right" for this codebase, and, in this
+check-in, judging whether the reviewer's feedback was worth acting on
+rather than just applying it mechanically.
+
+**What would you do differently if you started over?**
+I'd map the component's render states as part of Week 7's problem summary,
+not after feedback flagged the gap in Week 8. That mapping was the
+single most useful artifact in the whole plan — it should have come first.
+
+**What are you most proud of from this module?**
+Catching the wrong-repo PR before it went to grading. It was easy to miss
+— the PR I opened worked, had a clean description, and looked done — but
+it was invisible to anyone without access to my personal fork. Verifying
+the actual PR target instead of assuming the first "it worked" result was
+correct is the habit I want to keep from this module.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,76 @@
+## Solution plan
+
+**Issue:** Add accessibility tests for the review page using `jest-axe` ([#105](https://github.com/ascherj/pathreview/issues/105))
+
+### Understand
+Not a bug — a test gap. `ReviewPage` (`frontend/src/pages/ReviewPage.tsx`)
+has no automated accessibility coverage, so violations (missing labels,
+bad heading order, insufficient contrast) could ship unnoticed. Expected:
+`jest-axe` tests exist and run in CI, asserting zero violations. Actual:
+zero a11y tests for this page today. Root complication is that the page
+isn't one static tree — it conditionally renders one of three states
+(polling, failed, complete) plus optional error banners, so "the page has
+no violations" has to be checked per state, not once.
+
+### Map
+- `frontend/src/pages/ReviewPage.tsx` — component under test, 3 render
+  branches driven by `isPolling`, `currentReview?.status === 'failed'`,
+  `fullReview?.status === 'complete'`
+- `frontend/src/hooks/useReviewStatus.ts` — polling hook; needs mocking to
+  force each state deterministically
+- `frontend/src/services/api.ts` (`apiClient.getReview`) — fetched once
+  status is `complete`; needs mocking
+- `frontend/src/types.ts` — `Review` / `FeedbackSection` shapes for fixtures
+- New file: `frontend/src/pages/__tests__/ReviewPage.test.tsx` (dir doesn't
+  exist yet, confirmed via `ls`)
+- Reference patterns: `frontend/src/components/__tests__/ProfileForm.test.tsx`
+  (`vi.mock` on a hook) and `ReviewSection.test.tsx` (RTL + vitest style)
+
+### Plan
+1. Create `frontend/src/pages/__tests__/ReviewPage.test.tsx`, wrap render in
+   a router context (`MemoryRouter` with a `:reviewId` route, or mock
+   `useParams`/`useNavigate` from `react-router-dom`) since `ReviewPage`
+   calls both directly.
+2. `vi.mock('../../hooks/useReviewStatus')` and `vi.mock('../../services/api')`,
+   following the `ProfileForm.test.tsx` pattern, so each test can force a
+   specific `{ review, isPolling, error }` shape without a real backend.
+3. Write one `jest-axe` case per state: polling (`isPolling: true`), failed
+   (`status: 'failed'`, with `error_message`), complete (`status: 'complete'`
+   with `overall_score` and populated `sections` so `ReviewSection` also
+   renders) — each asserts `expect(await axe(container)).toHaveNoViolations()`.
+4. Add a case for the error-banner paths (`error` from the hook, and
+   `fetchError` from a failed `getReview` call) since those inject extra DOM
+   (`role`/live-region considerations) on top of whichever base state is active.
+5. Wire `jest-axe`'s matcher (`toHaveNoViolations`) into test setup if not
+   already global, run `make test-unit` / `npm test`, confirm all pass.
+
+### Inputs & outputs
+Input: mocked `useReviewStatus` return values and mocked `apiClient.getReview`
+resolved/rejected values, one fixture per state. Output: new test file with
+no production code changes; CI gains a permanent regression check that fails
+loudly if a future edit introduces an a11y violation in any of the three states.
+
+### Risks & unknowns
+- `useEffect` in `ReviewPage` fires `getReview` async — tests need
+  `await`/`findBy*` or `waitFor` around the axe check for the complete state,
+  or the DOM snapshot could be checked mid-fetch.
+- Unsure whether `jest-axe`'s matcher is already registered globally
+  (e.g. in a `setupTests` file) or needs adding per-file — check
+  `vite.config.ts`/`vitest.config.ts` `setupFiles` before assuming.
+- Router mocking approach (`MemoryRouter` vs. mocking `react-router-dom`)
+  affects how much boilerplate each test needs — pick whichever the existing
+  tests already lean toward, for consistency.
+- Tailwind color-contrast violations are common false-negatives/positives
+  with jsdom (no real rendering) — `jest-axe` may not catch contrast issues
+  at all in this environment; scope expectations accordingly.
+
+### Edge cases
+- Both `error` (from polling) and `fetchError` (from `getReview`) present at
+  once — two error banners stacked.
+- `complete` status but `fullReview.sections` empty/undefined — renders the
+  "No feedback sections available" fallback text instead of `ReviewSection`s.
+- `complete` status but `overall_score` undefined — score block should not
+  render at all (conditional at line 131).
+- Transition moment where `statusReview` is `complete` but `fullReview` is
+  still `null` (fetch in flight) — falls through all three branches, renders
+  just the back button; still must have zero violations.

--- a/frontend/src/pages/__tests__/ReviewPage.test.tsx
+++ b/frontend/src/pages/__tests__/ReviewPage.test.tsx
@@ -3,6 +3,16 @@ import { render, screen } from '@testing-library/react'
 import { axe } from 'jest-axe'
 import { ReviewPage } from '../ReviewPage'
 import { useReviewStatus } from '../../hooks/useReviewStatus'
+import { Review } from '../../types'
+
+const failedReview: Review = {
+  id: 'review-123',
+  profile_id: 'profile-123',
+  status: 'failed',
+  error_message: 'The analysis service timed out.',
+  created_at: '2026-07-01T00:00:00Z',
+  updated_at: '2026-07-01T00:05:00Z'
+}
 
 vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
@@ -41,6 +51,15 @@ describe('ReviewPage', () => {
 
     const { container } = render(<ReviewPage />)
 
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('has no accessibility violations in the failed state', async () => {
+    mockUseReviewStatus.mockReturnValue({ review: failedReview, isPolling: false, error: null })
+
+    const { container } = render(<ReviewPage />)
+
+    expect(screen.getByText('Review Failed')).toBeInTheDocument()
     expect(await axe(container)).toHaveNoViolations()
   })
 })

--- a/frontend/src/pages/__tests__/ReviewPage.test.tsx
+++ b/frontend/src/pages/__tests__/ReviewPage.test.tsx
@@ -92,4 +92,20 @@ describe('ReviewPage', () => {
 
     expect(await axe(container)).toHaveNoViolations()
   })
+
+  it('has no accessibility violations with stacked error banners', async () => {
+    mockUseReviewStatus.mockReturnValue({
+      review: completeReview,
+      isPolling: false,
+      error: 'Lost connection while polling'
+    })
+    mockGetReview.mockRejectedValue(new Error('Failed to load review'))
+
+    const { container } = render(<ReviewPage />)
+
+    await screen.findByText('Failed to load review')
+    expect(screen.getByText('Lost connection while polling')).toBeInTheDocument()
+
+    expect(await axe(container)).toHaveNoViolations()
+  })
 })

--- a/frontend/src/pages/__tests__/ReviewPage.test.tsx
+++ b/frontend/src/pages/__tests__/ReviewPage.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from '@testing-library/react'
 import { axe } from 'jest-axe'
 import { ReviewPage } from '../ReviewPage'
 import { useReviewStatus } from '../../hooks/useReviewStatus'
+import { apiClient } from '../../services/api'
 import { Review } from '../../types'
 
 const failedReview: Review = {
@@ -10,6 +11,23 @@ const failedReview: Review = {
   profile_id: 'profile-123',
   status: 'failed',
   error_message: 'The analysis service timed out.',
+  created_at: '2026-07-01T00:00:00Z',
+  updated_at: '2026-07-01T00:05:00Z'
+}
+
+const completeReview: Review = {
+  id: 'review-123',
+  profile_id: 'profile-123',
+  status: 'complete',
+  overall_score: 0.82,
+  sections: [
+    {
+      section_name: 'Code Quality',
+      content: 'Solid structure overall.',
+      suggestions: ['Add more inline comments for complex logic'],
+      confidence: 0.9
+    }
+  ],
   created_at: '2026-07-01T00:00:00Z',
   updated_at: '2026-07-01T00:05:00Z'
 }
@@ -32,6 +50,7 @@ vi.mock('../../services/api', () => ({
 }))
 
 const mockUseReviewStatus = vi.mocked(useReviewStatus)
+const mockGetReview = vi.mocked(apiClient.getReview)
 
 describe('ReviewPage', () => {
   beforeEach(() => {
@@ -60,6 +79,17 @@ describe('ReviewPage', () => {
     const { container } = render(<ReviewPage />)
 
     expect(screen.getByText('Review Failed')).toBeInTheDocument()
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('has no accessibility violations in the complete state', async () => {
+    mockUseReviewStatus.mockReturnValue({ review: completeReview, isPolling: false, error: null })
+    mockGetReview.mockResolvedValue(completeReview)
+
+    const { container } = render(<ReviewPage />)
+
+    await screen.findByText('Portfolio Review')
+
     expect(await axe(container)).toHaveNoViolations()
   })
 })

--- a/frontend/src/pages/__tests__/ReviewPage.test.tsx
+++ b/frontend/src/pages/__tests__/ReviewPage.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
+import { axe } from 'jest-axe'
 import { ReviewPage } from '../ReviewPage'
 import { useReviewStatus } from '../../hooks/useReviewStatus'
 
@@ -33,5 +34,13 @@ describe('ReviewPage', () => {
     render(<ReviewPage />)
 
     expect(screen.getByText('Analyzing your portfolio...')).toBeInTheDocument()
+  })
+
+  it('has no accessibility violations in the polling state', async () => {
+    mockUseReviewStatus.mockReturnValue({ review: null, isPolling: true, error: null })
+
+    const { container } = render(<ReviewPage />)
+
+    expect(await axe(container)).toHaveNoViolations()
   })
 })

--- a/frontend/src/pages/__tests__/ReviewPage.test.tsx
+++ b/frontend/src/pages/__tests__/ReviewPage.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ReviewPage } from '../ReviewPage'
+import { useReviewStatus } from '../../hooks/useReviewStatus'
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return {
+    ...actual,
+    useParams: () => ({ reviewId: 'review-123' }),
+    useNavigate: () => vi.fn()
+  }
+})
+
+vi.mock('../../hooks/useReviewStatus')
+
+vi.mock('../../services/api', () => ({
+  apiClient: {
+    getReview: vi.fn()
+  }
+}))
+
+const mockUseReviewStatus = vi.mocked(useReviewStatus)
+
+describe('ReviewPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the polling state', () => {
+    mockUseReviewStatus.mockReturnValue({ review: null, isPolling: true, error: null })
+
+    render(<ReviewPage />)
+
+    expect(screen.getByText('Analyzing your portfolio...')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/__tests__/ReviewPage.test.tsx
+++ b/frontend/src/pages/__tests__/ReviewPage.test.tsx
@@ -88,7 +88,7 @@ describe('ReviewPage', () => {
 
     const { container } = render(<ReviewPage />)
 
-    await screen.findByText('Portfolio Review')
+    await screen.findByText('Overall Score')
 
     expect(await axe(container)).toHaveNoViolations()
   })

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,6 +1,9 @@
 import '@testing-library/jest-dom'
 import { expect, afterEach, vi } from 'vitest'
 import { cleanup } from '@testing-library/react'
+import { toHaveNoViolations } from 'jest-axe'
+
+expect.extend(toHaveNoViolations)
 
 afterEach(() => {
   cleanup()


### PR DESCRIPTION
## Summary
Adds automated accessibility coverage for the review page using `jest-axe`, checking each of its three conditionally-rendered states (polling, failed, complete) plus the stacked-error-banner case, since a violation could exist in one state and not another.

## Issue
Closes #105

## Changes
- Register `jest-axe`'s `toHaveNoViolations` matcher globally in `frontend/src/test/setup.ts`
- Add `frontend/src/pages/__tests__/ReviewPage.test.tsx`:
  - mocks `react-router-dom` (`useParams`/`useNavigate`) and `useReviewStatus`/`apiClient`, following the existing `vi.mock` pattern from `ProfileForm.test.tsx`
  - `jest-axe` checks for the polling, failed, and complete states
  - `jest-axe` check for the polling-error + fetch-error banners rendered together

## Testing
- [x] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`)
- [ ] Linter passes (`make lint`)
- [ ] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes

`make test-unit` and `make lint`/`make typecheck` are Python-only and don't cover this frontend-only change. Baselined pre-existing failures on `main` before starting (all in files this PR never touches, confirmed disjoint):
- `make lint`: 182 ruff errors (`agent/`, `ingestion/`, `rag/`, `tests/unit/`)
- `make format` (check mode): 52 files not black-formatted
- `make typecheck`: 5 mypy errors (missing stubs for `PyPDF2`, `jose`, `passlib`, `rank_bm25`, plus a numpy stub issue)
- `make test-unit`: 53 of 428 pytest tests failing
- Frontend (`npx vitest run`, not covered by `make`): `ReviewSection.test.tsx` has 1 pre-existing failure; `ProfileForm.test.tsx` can't run (missing `@testing-library/user-event` dep)

New `ReviewPage.test.tsx`: 5/5 passing.

**To manually verify:**
1. `cd frontend && npm test -- ReviewPage` — should report 5 passing tests, 0 failures.
2. To see the states directly: `make run` (or `cd frontend && npm run dev`), log into the app with one of the seed accounts in `docs/SETUP.md` (e.g. `user1@example.com` / `password1`), start a review from the dashboard, and open `/reviews/<reviewId>`. You'll see the polling state immediately, then either the failed or complete state once processing finishes.
3. Optional: with a browser a11y extension (e.g. axe DevTools) open on that page, re-check each state — this is the same check the new tests automate, so it should also report zero violations.

## Screenshots / Demo
N/A — test-only change, no UI changes.

## Notes for Reviewers
PLAN.md (in this branch) documents the state-by-state approach and the risks/edge cases considered before writing the tests.
