### PR TITLE
Feat/101 add copy link button

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -20,7 +20,7 @@ This is a Tier 2 issue and it's a good fit for me. I've worked as a dev on React
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** https://github.com/crbridges/pathreview/commit/43e1ce6a3b55b22bf467055d0f4384abd93dd609
+**Reproduction commit link:** https://github.com/crbridges/pathreview/commit/481fd960e86bc3b70f97677d814a4bf7a09b05a1
 
 **Reproduction summary:**
 This issue is a new feature (labeled `enhancement`), so there's no bug to reproduce. I confirmed the gap by tracing the code: every route in `api/routes/reviews.py` depends on `get_current_user`, `ReviewPage` is wrapped in `<ProtectedRoute>` in `App.tsx`, and the current Share button just copies `window.location.href` — so there is no way to view a review without logging in, and no public endpoint exists yet.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -17,3 +17,17 @@ A new feature request has been made that allows the user to click a copy link bu
 
 **Is this issue right for me?**
 This is a Tier 2 issue and it's a good fit for me. I've worked as a dev on React apps with backend APIs, so a feature that touches the frontend, a new service, and an API endpoint is in my wheelhouse. I've already located and read the code it affects-the Share button in ReviewPage.tsx and the get route in reviews.py, and reading the route is what told me I'll need a new unauthenticated endpoint instead of reusing the existing one. Right now the Share button copies an authenticated URL only the owner can open, and after the fix it copies a public link anyone can view for 30 days.
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/crbridges/pathreview/commit/43e1ce6a3b55b22bf467055d0f4384abd93dd609
+
+**Reproduction summary:**
+This issue is a new feature (labeled `enhancement`), so there's no bug to reproduce. I confirmed the gap by tracing the code: every route in `api/routes/reviews.py` depends on `get_current_user`, `ReviewPage` is wrapped in `<ProtectedRoute>` in `App.tsx`, and the current Share button just copies `window.location.href` — so there is no way to view a review without logging in, and no public endpoint exists yet.
+
+**PLAN.md link:** https://github.com/crbridges/pathreview/blob/feat/101-add-copy-link-button/PLAN.md
+
+**Walkthrough video (recommended):** not recorded
+
+**Blockers or open questions:**
+The new `/shared/:token` route has to be registered outside `<ProtectedRoute>` or logged-out visitors get bounced to `/login`, and `<NavBar />` renders on every route so it may need to be hidden on the public page. Still deciding whether the public view exposes the full review or a trimmed summary.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -14,3 +14,6 @@ A new feature request has been made that allows the user to click a copy link bu
 **Setup confirmation:** [ X ] App runs locally at localhost:5173
 
 **Cohort ledger:** [ X ] Issue added to cohort ledger
+
+**Is this issue right for me?**
+This is a Tier 2 issue and it's a good fit for me. I've worked as a dev on React apps with backend APIs, so a feature that touches the frontend, a new service, and an API endpoint is in my wheelhouse. I've already located and read the code it affects: the Share button in ReviewPage.tsx and the get route in reviews.py, and reading the route is what told me I'll need a new unauthenticated endpoint instead of reusing the existing one. The before-and-after is clear too: right now the Share button copies an authenticated URL only the owner can open, and after the fix it copies a public link anyone can view for 30 days. I'm confident I can finish it before the Week 9 deadline and there are no blockers.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -9,11 +9,11 @@
 **Problem summary:**
 A new feature request has been made that allows the user to click a copy link button that renders a page displaying a given review. The link should expire after 30 days, and it should not require any authentication to view. A button will be added to the ReviewPage.tsx that copies a link to clipboard, a new shareService.ts file will be generated to handle the logic for serving the links, and it will call a new unauthenticated public endpoint in reviews.py in order to pull the review text (the existing get route can't be used because it requires login and ownership). In addition, a new database table and schema will be created to hold the expiration date of the newly generated link.
 
-**Branch name:** enhancement/101-add-copy-link-button
+**Branch name:** feat/101-add-copy-link-button
 
 **Setup confirmation:** [ X ] App runs locally at localhost:5173
 
 **Cohort ledger:** [ X ] Issue added to cohort ledger
 
 **Is this issue right for me?**
-This is a Tier 2 issue and it's a good fit for me. I've worked as a dev on React apps with backend APIs, so a feature that touches the frontend, a new service, and an API endpoint is in my wheelhouse. I've already located and read the code it affects: the Share button in ReviewPage.tsx and the get route in reviews.py, and reading the route is what told me I'll need a new unauthenticated endpoint instead of reusing the existing one. The before-and-after is clear too: right now the Share button copies an authenticated URL only the owner can open, and after the fix it copies a public link anyone can view for 30 days. I'm confident I can finish it before the Week 9 deadline and there are no blockers.
+This is a Tier 2 issue and it's a good fit for me. I've worked as a dev on React apps with backend APIs, so a feature that touches the frontend, a new service, and an API endpoint is in my wheelhouse. I've already located and read the code it affects-the Share button in ReviewPage.tsx and the get route in reviews.py, and reading the route is what told me I'll need a new unauthenticated endpoint instead of reusing the existing one. Right now the Share button copies an authenticated URL only the owner can open, and after the fix it copies a public link anyone can view for 30 days.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,16 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/101
+
+**Issue title:** Add a "Copy link" button to share a public review summary
+
+**Tier:** Tier 2 
+
+**Problem summary:**
+A new feature request has been made that allows the user to click a copy link button that renders a page displaying a given review. The link should expire after 30 days, and it should not require any authentication to view. A button will be added to the ReviewPage.tsx that copies a link to clipboard, a new shareService.ts file will be generated to handle the logic for serving the links, and it will call a new unauthenticated public endpoint in reviews.py in order to pull the review text (the existing get route can't be used because it requires login and ownership). In addition, a new database table and schema will be created to hold the expiration date of the newly generated link.
+
+**Branch name:** enhancement/101-add-copy-link-button
+
+**Setup confirmation:** [ X ] App runs locally at localhost:5173
+
+**Cohort ledger:** [ X ] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -31,3 +31,34 @@ This issue is a new feature (labeled `enhancement`), so there's no bug to reprod
 
 **Blockers or open questions:**
 The new `/shared/:token` route has to be registered outside `<ProtectedRoute>` or logged-out visitors get bounced to `/login`, and `<NavBar />` renders on every route so it may need to be hidden on the public page. Still deciding whether the public view exposes the full review or a trimmed summary.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+The whole feature is implemented across the backend and frontend, one sub-task per commit. Backend: a `ShareLink` model (token as primary key) plus Alembic migration 003, `create_share_link`/`get_share_link` service functions, an authed owner-only mint endpoint `POST /reviews/{review_id}/share`, and a public `GET /reviews/shared/{token}` that returns 404 for an unknown or malformed token and 410 for an expired one. I went with a trimmed `PublicReviewResponse` (score, sections, created_at only) so an anonymous viewer never sees owner-linking or internal fields. Frontend: a new `shareService.ts`, a "Copy link" button next to the existing Share button on `ReviewPage`, and a `SharedReviewPage` wired to `/shared/:token` outside `<ProtectedRoute>`. The two open questions from Week 8 are resolved — the route sits outside the auth guard, `NavBar` already returns null without a user so nothing leaks, and the public view is the trimmed summary.
+
+**Next steps:**
+Write unit tests for the service functions and the route logic (the 404/410/success paths), run `make check` and `make test-unit` to confirm my changes add no new failures over the baseline, then open the PR and fill in the template.
+
+**Blockers:**
+The codebase has heavy pre-existing failures before I touched anything (53 failing unit tests, 182 ruff errors, 103 mypy errors). I recorded that as a baseline and I'm committing with `--no-verify` so the pre-commit hooks don't block my clean changes on that existing debt. I'll document the baseline in the PR and show my changes introduce no new failures.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [link to your submitted pull request]
+
+**Branch:** feat/101-add-copy-link-button
+
+**What you built:**
+[1–3 sentences summarizing what your fix does and how it works]
+
+**Tests added or updated:**
+[Which test files did you touch? What do they cover?]
+
+**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+
+**Draft PR feedback received from:** [name or Slack handle, or "none"]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -49,16 +49,17 @@ The codebase has heavy pre-existing failures before I touched anything (53 faili
 
 ### Check-in 2 (end of week)
 
-**PR link:** [link to your submitted pull request]
+**PR link:** https://github.com/ascherj/pathreview/pull/627
 
 **Branch:** feat/101-add-copy-link-button
 
 **What you built:**
-[1–3 sentences summarizing what your fix does and how it works]
+A new "Copy link" button on a completed review that gives the owner a public, no-login URL to a read-only view of the review, which expires 30 days after it's created. The button calls a new authed endpoint that mints a share token, the frontend builds the public URL from it, and a new public endpoint serves a trimmed read-only view (404 for an unknown or malformed token, 410 for an expired one) that leaves out any owner-linking or internal fields. The existing Share button is left untouched.
 
 **Tests added or updated:**
-[Which test files did you touch? What do they cover?]
+Added `tests/unit/test_share_link.py` (9 tests): the `create_share_link`/`get_share_link` service functions, the public view endpoint's 404/410/success paths, and the mint endpoint's ownership check. All pass.
 
-**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+(Both in the "no new failures vs. the pre-existing baseline" sense — the repo already had 53 failing unit tests, 182 ruff errors, and 103 mypy errors before my changes; after my changes those numbers are unchanged aside from my 9 new passing tests and 2 fewer ruff errors. Documented in the PR.)
 
-**Draft PR feedback received from:** [name or Slack handle, or "none"]
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -63,3 +63,34 @@ Added `tests/unit/test_share_link.py` (9 tests): the `create_share_link`/`get_sh
 (Both in the "no new failures vs. the pre-existing baseline" sense — the repo already had 53 failing unit tests, 182 ruff errors, and 103 mypy errors before my changes; after my changes those numbers are unchanged aside from my 9 new passing tests and 2 fewer ruff errors. Documented in the PR.)
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No reviewer feedback came in. PR review isn't an active part of the cohort this term, so no comments or change requests arrived on #627 before the module ended. The PR is open against `ascherj/pathreview` and closes #101.
+
+**How you responded:**
+N/A — there was nothing to respond to. If feedback had come in I'd have triaged it into quick fixes vs. things worth discussing, made the clear fixes, and replied on the ones I disagreed with instead of silently changing them.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The state of the codebase, not the feature. I assumed I'd write my change and `make check` / `make test-unit` would pass. Instead the repo already had 53 failing unit tests, 182 ruff errors, and 103 mypy errors before I touched anything, and the pre-commit hooks blocked my commits on that existing debt — even in files I only imported, because mypy follows imports. The real work became recording a baseline, proving my diff introduced zero new failures, and committing with `--no-verify` so the pre-existing debt didn't block clean changes. That bookkeeping took more effort than the actual feature did.
+
+**What did you learn about working in a large codebase?**
+Contributing is as much about not disturbing things as adding to them. I kept wanting to "fix" pre-existing lint and type errors in files I was already editing, and I had to stop myself — that's scope creep in someone else's project. I also learned to match what's already there: the auth turned out to be a per-route FastAPI dependency, not global middleware, so making an endpoint public just meant leaving the dependency off; and the public `/reviews/shared/{token}` route had to be declared before `/reviews/{review_id}` or the `{review_id}` route would swallow it. On my own project I'd never have hit either of those.
+
+**How did AI tools help — and where did they fall short?**
+AI was most useful for getting oriented fast in an unfamiliar codebase — tracing how auth worked, where routes registered, how the models/migrations/schemas fit together — and for catching this project's specific lint/type rules (B008, B904, UP017, a str-vs-UUID mismatch) before they turned into new failures. Where it fell short: it first assumed the fix was to repurpose the existing Share button, and I had to push back after actually reading the issue — it's labeled `enhancement` and says "add a button," so I kept the Share button and added a separate one. It also mangled my git history once while rewording commit messages — it dropped a whole commit, and I only caught it because I checked the log; we recovered from a backup branch. And it couldn't do the outward steps at all: opening the PR (no `gh` CLI on my machine) and the portal submission were on me. The judgment calls and the final verification stayed my job.
+
+**What would you do differently if you started over?**
+Run `make check` and `make test-unit` on day one, before writing a line, so I'd know the pre-existing baseline going in instead of discovering it mid-implementation. I'd also nail down the ambiguous product decisions earlier — new button vs. repurpose, and full vs. trimmed public response — ideally by asking on the issue up front rather than going back and forth about it. And I'd verify the git log after every history edit, not just at the end, after the dropped-commit scare.
+
+**What are you most proud of?**
+That my change came out clean and self-contained inside a messy repo. Every commit is one logical unit, my additions add zero new lint/type/test failures despite all the surrounding debt, and I can explain every decision — token as the primary key, 410 vs. 404 for an expired link, and the trimmed public response so an anonymous viewer never sees owner-linking or internal fields. It's not the biggest feature, but the discipline of it is the part I'd actually want to talk about in an interview.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,77 @@
+## Solution plan
+
+**Issue:** [Add a "Copy link" button to share a public review summary](https://github.com/ascherj/pathreview/issues/101)
+
+### Understand
+
+This is a new feature (labeled `enhancement`), not a bug — there is no broken
+behavior to reproduce. Today a review can only be viewed by its authenticated
+owner: `GET /reviews/{review_id}` in `api/routes/reviews.py` depends on
+`get_current_user` and filters by `user_id`, and the frontend `ReviewPage` is
+wrapped in `<ProtectedRoute>` (redirects to `/login` when there is no session).
+The existing "Share" button copies `window.location.href`, which points at that
+authenticated page, so a logged-out recipient cannot open it.
+
+**Expected after the fix:** the owner clicks a new "Copy link" button and gets a
+public URL to a read-only view of the review. Anyone can open it without logging
+in, and it stops working 30 days after it was created. The existing Share button
+is left unchanged (out of scope for this enhancement).
+
+### Map
+
+Files I expect to touch:
+
+**Backend**
+- `core/models/share_link.py` *(new)* — SQLAlchemy model: `token`, `review_id` (FK), `expires_at`, `created_at`.
+- `core/models/__init__.py` — import the new model so metadata/Alembic sees it.
+- `alembic/versions/003_add_share_links.py` *(new)* — migration creating the table (follows `001`/`002`).
+- `core/services/review_service.py` — add `create_share_link(review_id)` and `get_review_by_share_token(token)`.
+- `api/schemas/share.py` *(new)* — Pydantic response schemas (mint result + public read-only view).
+- `api/routes/reviews.py` — add `POST /reviews/{review_id}/share` (authed) and `GET /reviews/shared/{token}` (public).
+
+**Frontend**
+- `frontend/src/services/shareService.ts` *(new)* — `mintShareLink(reviewId)`, `getSharedReview(token)`.
+- `frontend/src/pages/ReviewPage.tsx` — new "Copy link" button next to Share.
+- `frontend/src/pages/SharedReviewPage.tsx` *(new)* — public read-only view.
+- `frontend/src/App.tsx` — register `/shared/:token` **outside** `<ProtectedRoute>`.
+- `frontend/src/types.ts` — types for the share responses.
+
+### Plan
+
+1. **Data layer** — add the `ShareLink` model + Alembic migration `003`, and the two
+   service functions (`create_share_link`, `get_review_by_share_token`).
+2. **Mint endpoint** — `POST /reviews/{review_id}/share` (keeps `get_current_user`,
+   owner-only): create a token with `expires_at = now + 30 days`, return token/URL.
+3. **Public endpoint** — `GET /reviews/shared/{token}` (no auth dependency): look up
+   the token, reject if missing/expired, return the read-only review schema.
+4. **Frontend service + button** — `shareService.ts` calling the mint endpoint;
+   wire a new "Copy link" button in `ReviewPage.tsx` that copies the returned URL.
+5. **Public view page + route** — `SharedReviewPage.tsx` that fetches by token and
+   renders read-only; register `/shared/:token` outside the auth guard.
+
+### Inputs & outputs
+
+- **Mint:** input = `review_id` (owner authenticated). Output = a new `share_links`
+  row and a public URL like `/shared/<token>`.
+- **Public view:** input = `token` from the URL (no auth). Output = the review's
+  read-only summary as JSON, or a 404/410 if the token is unknown or expired.
+- **UI:** input = a click on "Copy link". Output = the public URL on the clipboard.
+
+### Risks & unknowns
+
+- **Auth-guard escape (frontend):** `/shared/:token` must be registered outside
+  `<ProtectedRoute>` in `App.tsx`, or logged-out visitors get bounced to `/login`.
+- **NavBar leakage:** `<NavBar />` renders on every route in `App.tsx` and shows
+  logout/dashboard links a public visitor shouldn't see — may need to hide it on
+  the shared page.
+- **Auth-header assumption:** `apiClient.request()` always attaches the bearer
+  token; the public GET must not depend on a token being present, which is why
+  `shareService.ts` is separate.
+- **Field exposure:** the issue says "review *summary*"; unsure whether to expose
+  the full review shape or a trimmed subset — leaning trimmed to avoid leaking
+  more than intended.
+
+### Edge cases
+
+- Unknown or malformed/non-UUID token in the URL → 404, never a 500.
+- Token that exists but is past `expires_at` → 410 (or 404), not the review.

--- a/alembic/versions/003_add_share_links.py
+++ b/alembic/versions/003_add_share_links.py
@@ -1,0 +1,37 @@
+"""Add share_links table for public review sharing.
+
+Revision ID: 003
+Revises: 002
+Create Date: 2026-07-28 00:00:00.000000
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op  # type: ignore[attr-defined]
+
+revision = "003"
+down_revision = "002"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "share_links",
+        sa.Column("token", postgresql.UUID(as_uuid=False), primary_key=True),
+        sa.Column(
+            "review_id",
+            postgresql.UUID(as_uuid=False),
+            sa.ForeignKey("reviews.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+    )
+    op.create_index("ix_share_links_review_id", "share_links", ["review_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_share_links_review_id", table_name="share_links")
+    op.drop_table("share_links")

--- a/api/routes/reviews.py
+++ b/api/routes/reviews.py
@@ -1,11 +1,12 @@
 from fastapi import APIRouter, Depends, HTTPException, status, BackgroundTasks
+from datetime import UTC, datetime
 from typing import Annotated
 from uuid import UUID
 import structlog
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.schemas.review import ReviewCreate, ReviewResponse, ReviewListResponse
-from api.schemas.share import ShareLinkResponse
+from api.schemas.share import ShareLinkResponse, PublicReviewResponse
 from api.middleware.auth import get_current_user
 from core.models.user import User
 from core.models.review import Review
@@ -14,6 +15,7 @@ from core.services.review_service import (
     create_review,
     create_share_link,
     get_review,
+    get_share_link,
     list_reviews,
     process_review,
 )
@@ -64,6 +66,61 @@ async def create_review_endpoint(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to create review",
         )
+
+
+@router.get("/shared/{token}", response_model=PublicReviewResponse)
+async def get_shared_review_endpoint(
+    token: str,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> PublicReviewResponse:
+    """
+    Public, unauthenticated read-only view of a review via a share token.
+    Returns 404 if the token is unknown or malformed, 410 if it has expired.
+
+    Declared before GET /{review_id} so that /reviews/shared/... is not
+    captured by the {review_id} route.
+    """
+    # Reject malformed tokens up front so a non-UUID value returns 404 rather
+    # than triggering a database error on the UUID column.
+    try:
+        UUID(token)
+    except ValueError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Share link not found",
+        ) from None
+
+    try:
+        share_link = await get_share_link(db=db, token=token)
+
+        if share_link is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Share link not found",
+            )
+
+        # Normalize to an aware datetime so the comparison works whether the
+        # backing store returns naive (SQLite) or aware (Postgres) values.
+        expires_at = share_link.expires_at
+        if expires_at.tzinfo is None:
+            expires_at = expires_at.replace(tzinfo=UTC)
+
+        if expires_at < datetime.now(UTC):
+            raise HTTPException(
+                status_code=status.HTTP_410_GONE,
+                detail="Share link has expired",
+            )
+
+        return PublicReviewResponse.model_validate(share_link.review)
+
+    except HTTPException:
+        raise
+    except Exception as exc:
+        log.error("get_shared_review_error", error=str(exc))
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to retrieve shared review",
+        ) from exc
 
 
 @router.get("/{review_id}", response_model=ReviewResponse)

--- a/api/routes/reviews.py
+++ b/api/routes/reviews.py
@@ -1,14 +1,18 @@
 from fastapi import APIRouter, Depends, HTTPException, status, BackgroundTasks
+from typing import Annotated
 from uuid import UUID
 import structlog
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.schemas.review import ReviewCreate, ReviewResponse, ReviewListResponse
+from api.schemas.share import ShareLinkResponse
 from api.middleware.auth import get_current_user
 from core.models.user import User
 from core.models.review import Review
 from core.database import get_db
 from core.services.review_service import (
     create_review,
+    create_share_link,
     get_review,
     list_reviews,
     process_review,
@@ -96,6 +100,59 @@ async def get_review_endpoint(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to retrieve review",
         )
+
+
+@router.post("/{review_id}/share", response_model=ShareLinkResponse)
+async def create_share_link_endpoint(
+    review_id: UUID,
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> ShareLinkResponse:
+    """
+    Create a public, 30-day share link for a review the current user owns.
+    Returns 404 if the review does not exist or is not owned by the user.
+    """
+    try:
+        # Reuses the ownership check: a user cannot mint a link for a review
+        # that is not theirs. (user_id is stored as str; get_review annotates
+        # it as UUID, so the type: ignore matches the pre-existing endpoints.)
+        review = await get_review(
+            db=db,
+            review_id=review_id,
+            user_id=current_user.id,  # type: ignore[arg-type]
+        )
+
+        if not review:
+            log.warning(
+                "share_link_review_not_found",
+                review_id=str(review_id),
+                user_id=str(current_user.id),
+            )
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Review not found",
+            )
+
+        share_link = await create_share_link(db=db, review_id=review_id)
+
+        log.info(
+            "share_link_created",
+            review_id=str(review_id),
+            user_id=str(current_user.id),
+            token=str(share_link.token),
+        )
+
+        return ShareLinkResponse.model_validate(share_link)
+
+    except HTTPException:
+        raise
+    except Exception as exc:
+        log.error("share_link_creation_error", error=str(exc))
+        await db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to create share link",
+        ) from exc
 
 
 @router.get("", response_model=ReviewListResponse)

--- a/api/schemas/share.py
+++ b/api/schemas/share.py
@@ -1,0 +1,14 @@
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class ShareLinkResponse(BaseModel):
+    """Returned when a share link is minted. The frontend builds the public
+    URL as ``${origin}/shared/${token}``; ``expires_at`` lets the UI show when
+    the link stops working."""
+
+    token: str
+    expires_at: datetime
+
+    model_config = {"from_attributes": True}

--- a/api/schemas/share.py
+++ b/api/schemas/share.py
@@ -2,6 +2,8 @@ from datetime import datetime
 
 from pydantic import BaseModel
 
+from api.schemas.review import FeedbackSection
+
 
 class ShareLinkResponse(BaseModel):
     """Returned when a share link is minted. The frontend builds the public
@@ -10,5 +12,20 @@ class ShareLinkResponse(BaseModel):
 
     token: str
     expires_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class PublicReviewResponse(BaseModel):
+    """Read-only, public-safe view of a review served via a share token.
+
+    Deliberately omits owner-linking and internal fields (id, profile_id,
+    status, error_message) so an anonymous viewer only sees the review
+    summary itself.
+    """
+
+    overall_score: float | None
+    sections: list[FeedbackSection] | None
+    created_at: datetime
 
     model_config = {"from_attributes": True}

--- a/core/models/__init__.py
+++ b/core/models/__init__.py
@@ -1,9 +1,10 @@
 """Database models package."""
 
 from core.database import Base
-from core.models.user import User
-from core.models.profile import Profile
 from core.models.ingested_source import IngestedSource
+from core.models.profile import Profile
 from core.models.review import Review
+from core.models.share_link import ShareLink
+from core.models.user import User
 
-__all__ = ["Base", "User", "Profile", "IngestedSource", "Review"]
+__all__ = ["Base", "User", "Profile", "IngestedSource", "Review", "ShareLink"]

--- a/core/models/share_link.py
+++ b/core/models/share_link.py
@@ -1,0 +1,45 @@
+"""ShareLink model for public, time-limited review share links."""
+
+from datetime import datetime
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+from sqlalchemy import DateTime, ForeignKey
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from core.database import Base
+
+if TYPE_CHECKING:
+    from core.models.review import Review
+
+
+class ShareLink(Base):
+    """A public, expiring link to a read-only view of a review.
+
+    The ``token`` is the value embedded in the shareable URL and is the only
+    identifier needed, so it doubles as the primary key. A link stops working
+    once ``expires_at`` has passed (30 days after creation).
+    """
+
+    __tablename__ = "share_links"
+
+    token: Mapped[str] = mapped_column(
+        UUID(as_uuid=False), primary_key=True, default=lambda: str(uuid4())
+    )
+    review_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        ForeignKey("reviews.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=datetime.utcnow
+    )
+
+    # One-directional link to the review; no back_populates needed on Review.
+    review: Mapped["Review"] = relationship("Review")
+
+    def __repr__(self) -> str:
+        return f"<ShareLink(token={self.token}, review_id={self.review_id})>"

--- a/core/services/review_service.py
+++ b/core/services/review_service.py
@@ -1,15 +1,21 @@
-from uuid import UUID
-import structlog
 import json
-from datetime import datetime
-from sqlalchemy import select, and_
+from datetime import datetime, timedelta
+from uuid import UUID
 
-from core.models.review import Review
-from core.models.profile import Profile
-from core.models.ingested_source import IngestedSource
+import structlog
+from sqlalchemy import and_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
 from api.schemas.review import FeedbackSection
+from core.models.ingested_source import IngestedSource
+from core.models.profile import Profile
+from core.models.review import Review
+from core.models.share_link import ShareLink
 
 log = structlog.get_logger()
+
+SHARE_LINK_TTL_DAYS = 30
 
 
 async def create_review(
@@ -77,6 +83,39 @@ async def list_reviews(
     reviews = result.scalars().all()
 
     return reviews, total
+
+
+async def create_share_link(
+    db: AsyncSession,
+    review_id: UUID,
+) -> ShareLink:
+    """
+    Create a public share link for a review, expiring in SHARE_LINK_TTL_DAYS.
+    Returns the persisted ShareLink (its token is used in the public URL).
+    """
+    share_link = ShareLink(
+        review_id=review_id,
+        expires_at=datetime.utcnow() + timedelta(days=SHARE_LINK_TTL_DAYS),
+    )
+    db.add(share_link)
+    await db.commit()
+    await db.refresh(share_link)
+    return share_link
+
+
+async def get_share_link(
+    db: AsyncSession,
+    token: str,
+) -> ShareLink | None:
+    """
+    Fetch a share link by token with its review eager-loaded, regardless of
+    expiry. Returns None if no link exists for the token. The caller is
+    responsible for checking expires_at (so it can distinguish 404 from 410).
+    """
+    stmt = select(ShareLink).where(ShareLink.token == token).options(selectinload(ShareLink.review))
+    result = await db.execute(stmt)
+    share_link: ShareLink | None = result.scalars().first()
+    return share_link
 
 
 async def process_review(

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import { DashboardPage } from './pages/DashboardPage'
 import { NewProfilePage } from './pages/NewProfilePage'
 import { ReviewPage } from './pages/ReviewPage'
 import { ReviewHistoryPage } from './pages/ReviewHistoryPage'
+import { SharedReviewPage } from './pages/SharedReviewPage'
 
 const ProtectedRoute: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const { user, isLoading } = useAuth()
@@ -52,6 +53,9 @@ function App() {
         />
         <Route path="/login" element={<LoginPage />} />
         <Route path="/register" element={<RegisterPage />} />
+        {/* Public, unauthenticated read-only share view — must stay OUTSIDE
+            ProtectedRoute so logged-out visitors are not redirected to /login. */}
+        <Route path="/shared/:token" element={<SharedReviewPage />} />
         <Route
           path="/dashboard"
           element={

--- a/frontend/src/pages/ReviewPage.tsx
+++ b/frontend/src/pages/ReviewPage.tsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useState } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
-import { Share2, Download, ArrowLeft, Loader } from 'lucide-react'
+import { Share2, Download, ArrowLeft, Loader, Link as LinkIcon } from 'lucide-react'
 import { useReviewStatus } from '../hooks/useReviewStatus'
 import { ReviewSection } from '../components/ReviewSection'
 import { apiClient } from '../services/api'
+import { mintShareLink } from '../services/shareService'
 import { Review } from '../types'
 
 export const ReviewPage: React.FC = () => {
@@ -34,6 +35,16 @@ export const ReviewPage: React.FC = () => {
     navigator.clipboard.writeText(url).then(() => {
       alert('Review link copied to clipboard!')
     })
+  }
+
+  const handleCopyLink = async () => {
+    try {
+      const { url } = await mintShareLink(reviewId || '')
+      await navigator.clipboard.writeText(url)
+      alert('Public share link copied to clipboard! It expires in 30 days.')
+    } catch (err) {
+      alert(err instanceof Error ? err.message : 'Failed to create share link')
+    }
   }
 
   const handleExport = () => {
@@ -117,6 +128,13 @@ ${section.suggestions.map((s) => `- ${s}`).join('\n')}
                 >
                   <Share2 className="w-5 h-5" />
                   Share
+                </button>
+                <button
+                  onClick={handleCopyLink}
+                  className="inline-flex items-center gap-2 px-4 py-2 border border-gray-300 hover:bg-gray-50 text-gray-700 font-medium rounded-lg transition-colors"
+                >
+                  <LinkIcon className="w-5 h-5" />
+                  Copy link
                 </button>
                 <button
                   onClick={handleExport}

--- a/frontend/src/pages/SharedReviewPage.tsx
+++ b/frontend/src/pages/SharedReviewPage.tsx
@@ -1,0 +1,82 @@
+import React, { useEffect, useState } from 'react'
+import { useParams } from 'react-router-dom'
+import { Loader } from 'lucide-react'
+import { ReviewSection } from '../components/ReviewSection'
+import { getSharedReview } from '../services/shareService'
+import { PublicReview } from '../types'
+
+export const SharedReviewPage: React.FC = () => {
+  const { token } = useParams<{ token: string }>()
+  const [review, setReview] = useState<PublicReview | null>(null)
+  const [error, setError] = useState('')
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const data = await getSharedReview(token || '')
+        setReview(data)
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to load shared review')
+      } finally {
+        setLoading(false)
+      }
+    }
+    load()
+  }, [token])
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        {loading && (
+          <div className="p-8 bg-white rounded-lg shadow text-center">
+            <Loader className="w-8 h-8 animate-spin text-blue-600 mx-auto mb-4" />
+            <p className="text-gray-900 font-semibold">Loading shared review...</p>
+          </div>
+        )}
+
+        {error && !loading && (
+          <div className="p-8 bg-red-50 border border-red-200 rounded-lg text-center">
+            <p className="text-red-800 font-semibold">This link isn&apos;t available</p>
+            <p className="text-red-600 text-sm mt-2">{error}</p>
+          </div>
+        )}
+
+        {review && !loading && (
+          <>
+            <div className="mb-8">
+              <h1 className="text-3xl font-bold text-gray-900">Portfolio Review</h1>
+              <p className="text-gray-600 text-sm mt-1">Shared read-only view</p>
+            </div>
+
+            {typeof review.overall_score === 'number' && (
+              <div className="mb-8 bg-white rounded-lg shadow p-8">
+                <h2 className="text-lg font-semibold text-gray-900 mb-4">Overall Score</h2>
+                <div className="w-full bg-gray-200 rounded-full h-4 overflow-hidden">
+                  <div
+                    className="h-full bg-blue-600 transition-all"
+                    style={{ width: `${review.overall_score * 100}%` }}
+                  ></div>
+                </div>
+                <p className="mt-2 text-2xl font-bold text-blue-600">
+                  {Math.round(review.overall_score * 100)}/100
+                </p>
+              </div>
+            )}
+
+            <div className="space-y-6">
+              <h2 className="text-2xl font-bold text-gray-900">Feedback</h2>
+              {review.sections && review.sections.length > 0 ? (
+                review.sections.map((section, index) => (
+                  <ReviewSection key={index} section={section} />
+                ))
+              ) : (
+                <p className="text-gray-600">No feedback sections available</p>
+              )}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/services/shareService.ts
+++ b/frontend/src/services/shareService.ts
@@ -1,0 +1,50 @@
+import { PublicReview, ShareLinkResult } from '../types'
+
+const API_BASE = '/api'
+
+function authHeader(): Record<string, string> {
+  const token = localStorage.getItem('token')
+  return token ? { Authorization: `Bearer ${token}` } : {}
+}
+
+/**
+ * Mint a public, 30-day share link for a review the current user owns.
+ * Requires authentication. Returns the full public URL (built from the
+ * returned token) and the link's expiry.
+ */
+export async function mintShareLink(reviewId: string): Promise<ShareLinkResult> {
+  const response = await fetch(`${API_BASE}/reviews/${reviewId}/share`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...authHeader(),
+    },
+  })
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}))
+    throw new Error(error.detail || 'Failed to create share link')
+  }
+
+  const data = await response.json()
+  return {
+    url: `${window.location.origin}/shared/${data.token}`,
+    expiresAt: data.expires_at,
+  }
+}
+
+/**
+ * Fetch the read-only view of a shared review by token. This is the public
+ * endpoint, so it intentionally sends NO auth header — a logged-out visitor
+ * must be able to call it. Throws on 404 (unknown/expired) or 410 (expired).
+ */
+export async function getSharedReview(token: string): Promise<PublicReview> {
+  const response = await fetch(`${API_BASE}/reviews/shared/${token}`)
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}))
+    throw new Error(error.detail || 'Failed to load shared review')
+  }
+
+  return response.json()
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -37,6 +37,19 @@ export interface ReviewListResponse {
   page_size: number
 }
 
+// Public, read-only view of a review served via a share token. Mirrors the
+// backend PublicReviewResponse (no owner-linking/internal fields).
+export interface PublicReview {
+  overall_score?: number
+  sections?: FeedbackSection[]
+  created_at: string
+}
+
+export interface ShareLinkResult {
+  url: string
+  expiresAt: string
+}
+
 export interface AuthResponse {
   access_token: string
   token_type: string

--- a/tests/unit/test_share_link.py
+++ b/tests/unit/test_share_link.py
@@ -1,0 +1,168 @@
+"""Tests for the public share-link feature (issue #101).
+
+Covers the service functions (create_share_link, get_share_link) and the
+route logic for the public view endpoint (404 for unknown/malformed tokens,
+410 for expired links, success for valid links) and the authed mint endpoint
+(ownership check).
+"""
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, Mock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from api.routes.reviews import create_share_link_endpoint, get_shared_review_endpoint
+from core.services.review_service import create_share_link, get_share_link
+
+
+@pytest.mark.unit
+class TestShareLinkService:
+    """Unit tests for the share-link service functions."""
+
+    @pytest.mark.asyncio
+    async def test_create_share_link_persists_and_sets_30_day_expiry(self):
+        db = AsyncMock()
+        db.add = Mock()
+        db.commit = AsyncMock()
+        db.refresh = AsyncMock()
+        review_id = uuid4()
+
+        with patch("core.services.review_service.ShareLink") as mock_share_link_cls:
+            instance = mock_share_link_cls.return_value
+            result = await create_share_link(db, review_id)
+
+            kwargs = mock_share_link_cls.call_args[1]
+            assert kwargs["review_id"] == review_id
+            delta = kwargs["expires_at"] - datetime.utcnow()
+            # ~30 days out (allow a small window for execution time).
+            assert timedelta(days=29, hours=23) < delta <= timedelta(days=30)
+
+            db.add.assert_called_once_with(instance)
+            db.commit.assert_awaited_once()
+            db.refresh.assert_awaited_once_with(instance)
+            assert result is instance
+
+    @pytest.mark.asyncio
+    async def test_get_share_link_returns_row_when_found(self):
+        db = AsyncMock()
+        link = Mock()
+        result_mock = Mock()
+        result_mock.scalars.return_value.first.return_value = link
+        db.execute = AsyncMock(return_value=result_mock)
+
+        out = await get_share_link(db, str(uuid4()))
+
+        assert out is link
+        db.execute.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_get_share_link_returns_none_when_missing(self):
+        db = AsyncMock()
+        result_mock = Mock()
+        result_mock.scalars.return_value.first.return_value = None
+        db.execute = AsyncMock(return_value=result_mock)
+
+        out = await get_share_link(db, str(uuid4()))
+
+        assert out is None
+
+
+@pytest.mark.unit
+class TestPublicShareRoute:
+    """Unit tests for GET /reviews/shared/{token} logic (called directly)."""
+
+    @pytest.mark.asyncio
+    async def test_malformed_token_returns_404(self):
+        db = AsyncMock()
+        with pytest.raises(HTTPException) as exc_info:
+            await get_shared_review_endpoint(token="not-a-uuid", db=db)
+        assert exc_info.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_unknown_token_returns_404(self):
+        db = AsyncMock()
+        with (
+            patch("api.routes.reviews.get_share_link", new=AsyncMock(return_value=None)),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            await get_shared_review_endpoint(token=str(uuid4()), db=db)
+        assert exc_info.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_expired_token_returns_410(self):
+        db = AsyncMock()
+        expired_link = Mock()
+        expired_link.expires_at = datetime.now(UTC) - timedelta(days=1)
+        expired_link.review = Mock()
+
+        with (
+            patch(
+                "api.routes.reviews.get_share_link",
+                new=AsyncMock(return_value=expired_link),
+            ),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            await get_shared_review_endpoint(token=str(uuid4()), db=db)
+        assert exc_info.value.status_code == 410
+
+    @pytest.mark.asyncio
+    async def test_valid_token_returns_public_view(self):
+        db = AsyncMock()
+        link = Mock()
+        link.expires_at = datetime.now(UTC) + timedelta(days=10)
+        review = Mock()
+        review.overall_score = 0.8
+        review.sections = [
+            {
+                "section_name": "Technical Skills",
+                "content": "Solid",
+                "confidence": 0.9,
+                "suggestions": ["Add tests"],
+            }
+        ]
+        review.created_at = datetime.now(UTC)
+        link.review = review
+
+        with patch("api.routes.reviews.get_share_link", new=AsyncMock(return_value=link)):
+            result = await get_shared_review_endpoint(token=str(uuid4()), db=db)
+
+        assert result.overall_score == 0.8
+        assert result.sections is not None
+        assert result.sections[0].section_name == "Technical Skills"
+
+
+@pytest.mark.unit
+class TestMintShareRoute:
+    """Unit tests for POST /reviews/{review_id}/share ownership handling."""
+
+    @pytest.mark.asyncio
+    async def test_owner_gets_share_link(self):
+        db = AsyncMock()
+        user = Mock()
+        user.id = str(uuid4())
+        link = Mock()
+        link.token = str(uuid4())
+        link.expires_at = datetime.now(UTC) + timedelta(days=30)
+
+        with (
+            patch("api.routes.reviews.get_review", new=AsyncMock(return_value=Mock())),
+            patch("api.routes.reviews.create_share_link", new=AsyncMock(return_value=link)),
+        ):
+            result = await create_share_link_endpoint(review_id=uuid4(), current_user=user, db=db)
+
+        assert result.token == link.token
+
+    @pytest.mark.asyncio
+    async def test_non_owner_or_missing_review_returns_404(self):
+        db = AsyncMock()
+        user = Mock()
+        user.id = str(uuid4())
+
+        with (
+            patch("api.routes.reviews.get_review", new=AsyncMock(return_value=None)),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            await create_share_link_endpoint(review_id=uuid4(), current_user=user, db=db)
+        assert exc_info.value.status_code == 404


### PR DESCRIPTION
## Summary
Implements the "Copy link" feature (issue #101): the owner of a completed review can generate a public, read-only, no-login share link that expires 30 days after it's created.

## Issue
Closes #101

## Changes
- **Model + migration:** new `ShareLink` table (token PK, FK to reviews with cascade delete, `expires_at`) + Alembic migration 003.
- **Service:** `create_share_link` (30-day expiry) and `get_share_link` (token lookup, review eager-loaded).
- **Mint endpoint:** `POST /reviews/{review_id}/share` — authed, owner-only (reuses the `get_review` ownership check), returns `{token, expires_at}`.
- **Public endpoint:** `GET /reviews/shared/{token}` — no auth. 404 for unknown/malformed token, 410 for expired. Returns a trimmed `PublicReviewResponse` (overall_score, sections, created_at) that omits owner-linking/internal fields.
- **Frontend:** `shareService.ts` (mint builds the public URL from the token; the public fetch sends no auth header), a "Copy link" button beside the existing Share button on `ReviewPage`, and a `SharedReviewPage` at `/shared/:token` registered **outside** `<ProtectedRoute>`.
- **Tests:** `tests/unit/test_share_link.py` — 9 tests covering the service functions and route logic (404/410/success + ownership).

## Testing
- [x] Unit tests pass (`make test-unit`) — no new failures (see note)
- [ ] Integration tests pass (`make test-integration`) — not run (require Docker services)
- [x] Linter passes (`make lint`) — no new errors (see note)
- [x] Type checker passes (`make typecheck`) — no new errors (see note)
- [x] New/updated tests cover the changes

**Pre-existing failures (per the contribution guide):** before my changes the repo already had **53 failing unit tests, 182 ruff errors, 103 mypy errors**. After my changes: **53 failing tests (unchanged) + 9 new passing tests**, **180 ruff** (2 fewer — I sorted two import blocks in files I touched), **103 mypy (unchanged)**. My changes introduce **no new failures**. Backend Python commits use `--no-verify` because the pre-commit hooks fail on that pre-existing debt in files my changes touch/import; correctness is verified via `make check` / `make test-unit` diffs.

## Screenshots / Demo
_(optional — a shot of the Copy link button and the /shared page)_

## Notes for Reviewers
- `GET /reviews/shared/{token}` is declared **before** `GET /{review_id}` so the literal `/shared` path isn't captured by the `{review_id}` route.
- `token` is a `str` validated as a UUID in-handler, so a malformed token returns 404 rather than a DB error/500.
- The existing Share button is intentionally left unchanged — this adds a separate "Copy link" button (issue is labeled `enhancement`).
