### PR TITLE
fix(api): use redis_url instead of nonexistent redis_host/redis_port

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -20,3 +20,23 @@ file and required no changes to the `core/config.py` settings themselves.
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/unt-akanksha/pathreview/commit/82c2032
+
+**Reproduction summary:**
+I called `GET /health` locally and confirmed it returned a 503 with
+`"redis": "unhealthy"`, even though the Redis Docker container was running
+and healthy. Checking the code showed `settings.redis_host`/`settings.redis_port`
+don't exist on the `Settings` model, causing an `AttributeError` that was
+silently caught and reported as an unhealthy status.
+
+**PLAN.md link:** https://github.com/unt-akanksha/pathreview/blob/fix/155-health-check-redis-host/PLAN.md
+
+**Walkthrough video (recommended):** [not recorded — optional/ungraded]
+
+**Blockers or open questions:**
+None currently. One thing I noted in PLAN.md: fixing this surfaced an
+unrelated pre-existing bug (issue #154, raw SQL string not wrapped in
+`text()`), which I intentionally left out of scope for this fix.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -23,7 +23,7 @@ file and required no changes to the `core/config.py` settings themselves.
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** https://github.com/unt-akanksha/pathreview/commit/82c2032
+**Reproduction commit link:** https://github.com/unt-akanksha/pathreview/commit/adf2337
 
 **Reproduction summary:**
 I called `GET /health` locally and confirmed it returned a 503 with

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,22 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/155
+
+**Issue title:** Health check references `settings.redis_host`, which does not exist on Settings
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The `/health` endpoint's Redis check tries to connect using `settings.redis_host`
+and `settings.redis_port`, but the `Settings` model only defines a single combined
+`redis_url` field. This caused an `AttributeError` every time the Redis check ran,
+so the health endpoint always reported Redis as "unhealthy" even when Redis was
+working fine. I fixed it by using `redis.Redis.from_url(settings.redis_url)` instead,
+which correctly parses the existing connection string. This affects the `api/routes/health.py`
+file and required no changes to the `core/config.py` settings themselves.
+
+**Branch name:** fix/155-health-check-redis-host
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -40,3 +40,35 @@ silently caught and reported as an unhealthy status.
 None currently. One thing I noted in PLAN.md: fixing this surfaced an
 unrelated pre-existing bug (issue #154, raw SQL string not wrapped in
 `text()`), which I intentionally left out of scope for this fix.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Fix, tests, PLAN.md, and reproduction were already completed in Weeks 7-8. This week's focus was running the full make check/make test-unit suite to document pre-existing failures, then opening the PR.
+
+**Next steps:**
+Open the PR and fill in the full template, including documenting pre-existing failures unrelated to my change.
+
+**Blockers:**
+None.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/628
+
+**Branch:** fix/155-health-check-redis-host
+
+**What you built:**
+Fixed the `/health` endpoint's Redis check, which referenced nonexistent `settings.redis_host`/`settings.redis_port` fields, causing an `AttributeError` that made the health check always report Redis as unhealthy regardless of its real status. Replaced it with `redis.Redis.from_url(settings.redis_url)`, using the connection field that actually exists on the `Settings` model.
+
+**Tests added or updated:**
+Added `tests/unit/test_health.py` with two tests: one confirming Redis reports "healthy" on a successful mocked connection, one confirming a genuine connection failure is still correctly reported as "unhealthy."
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+(Both pass for my changed files specifically; the full suite has 178 pre-existing lint errors and 53 pre-existing test failures in unrelated modules, documented in the PR description — my changes introduce no new failures.)
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -75,14 +75,15 @@ Added `tests/unit/test_health.py` with two tests: one confirming Redis reports "
 
 ## Week 10 — Iteration & reflection
 
-**Reviewer feedback received?** [x] Yes  [ ] No
+### Reviewer feedback
 
-**Feedback summary and response:**
-Received an automated review from GitHub Copilot (no human maintainer review has arrived yet, which is normal for a course-timeline PR). Copilot flagged two issues in `tests/unit/test_health.py`:
-1. `cast("dict", ...)` passes a string literal instead of an actual type, which is invalid usage of `typing.cast`.
-2. The "uses redis_url" test only asserted `from_url()` was called once, without checking it was called with the correct arguments — meaning a regression that passed the wrong URL would still pass the test.
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
 
-I addressed both in commit `9e006d1`: replaced the `cast()` call with an `isinstance(detail, dict)` check to avoid the ambiguity entirely, and tightened the assertion to `mock_from_url.assert_called_once_with(settings.redis_url, decode_responses=True)` so the test actually verifies correct wiring, not just that a call happened. I replied on the PR summarizing both fixes and linking the commit. No human review has come in since; the PR remains open awaiting a maintainer with write access, which is outside my control.
+**Summary of feedback:**
+No human maintainer review has been received. Per this term's course note, reviewer feedback isn't a feature in Summer 2026, so no maintainer/reviewer comments were expected. For additional context: GitHub Copilot's automated review left two comments on `tests/unit/test_health.py` (an invalid `typing.cast` usage and a test assertion that didn't verify `from_url()`'s call arguments), which I addressed in commit `9e006d1` even though this doesn't count as reviewer feedback for this assignment.
+
+**How you responded:**
+N/A — no maintainer feedback arrived. (For the automated Copilot comments noted above, I replaced the `cast()` call with an `isinstance()` check and tightened the test assertion to check exact call arguments, then replied on the PR summarizing both fixes.)
 
 ### Reflection
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -72,3 +72,31 @@ Added `tests/unit/test_health.py` with two tests: one confirming Redis reports "
 (Both pass for my changed files specifically; the full suite has 178 pre-existing lint errors and 53 pre-existing test failures in unrelated modules, documented in the PR description — my changes introduce no new failures.)
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+**Reviewer feedback received?** [x] Yes  [ ] No
+
+**Feedback summary and response:**
+Received an automated review from GitHub Copilot (no human maintainer review has arrived yet, which is normal for a course-timeline PR). Copilot flagged two issues in `tests/unit/test_health.py`:
+1. `cast("dict", ...)` passes a string literal instead of an actual type, which is invalid usage of `typing.cast`.
+2. The "uses redis_url" test only asserted `from_url()` was called once, without checking it was called with the correct arguments — meaning a regression that passed the wrong URL would still pass the test.
+
+I addressed both in commit `9e006d1`: replaced the `cast()` call with an `isinstance(detail, dict)` check to avoid the ambiguity entirely, and tightened the assertion to `mock_from_url.assert_called_once_with(settings.redis_url, decode_responses=True)` so the test actually verifies correct wiring, not just that a call happened. I replied on the PR summarizing both fixes and linking the commit. No human review has come in since; the PR remains open awaiting a maintainer with write access, which is outside my control.
+
+### Reflection
+
+**What was harder than you expected?**
+The environment setup in Week 7 was far harder than the assignment implied. I hit a genuine architecture-compatibility bug — ChromaDB's Docker image auto-rebuilt its native library on Apple Silicon and pulled in an incompatible numpy 2.0, crashing with `AttributeError: np.float_ was removed`. On top of that, the container's health check called `curl`, which wasn't even installed in the image, so it could never report healthy regardless of whether the server worked. Neither problem was mentioned anywhere in the course materials — it took several rounds of reading logs, reverting changes, and testing hypotheses before I found a fix (overriding the entrypoint to pin compatible versions, then swapping the health check to a Python-based one).
+
+**What did you learn about working in a large codebase?**
+Working in pathreview taught me that consistency matters more than cleverness. Before writing my fix, I read the existing try/except/logging pattern already used for the Postgres and Vector DB checks in health.py, and matched it exactly rather than writing my own style. Same with tests — I read test_review_service.py first to copy its fixture and mocking conventions before writing test_health.py. I also learned that a large shared codebase always has pre-existing problems that aren't yours to fix: when I ran the full make check/make test-unit suite, I found 178 lint errors and 53 test failures completely unrelated to my change. Learning to document that clearly — "my change introduces zero new failures" — rather than either ignoring it or trying to fix everything, felt like a genuinely professional skill I hadn't practiced before.
+
+**How did AI tools help — and where did they fall short?**
+AI tools (Claude, used throughout this project) were most helpful for pattern-matching against the existing codebase — quickly locating the right files with grep, drafting test code that matched existing conventions, and helping me interpret dense error tracebacks (like the SQLAlchemy text() issue or the numpy/Docker crash) faster than I could have alone. It also helped me catch a real gap in my own work: my first REPRODUCTION.md was written from reading the code, not from actually watching the bug fail, and questioning that assumption led me to properly revert the fix and capture the real error log. Where it fell short: GitHub Copilot's automated PR review flagged a cast() issue as "invalid under mypy," but when I actually ran mypy locally, it reported zero errors — the AI's confidence didn't match the actual tool output. I fixed the underlying code anyway since the suggestion was reasonable, but it was a reminder that AI-generated feedback still needs to be checked against ground truth, not accepted at face value.
+
+**What would you do differently if you started over?**
+I'd translate documented risks into tests immediately, not just note them. My Week 9 instructor feedback pointed out that I'd identified a malformed/empty settings.redis_url as a risk in PLAN.md, but never wrote a test for it — the risk stayed on paper instead of becoming actual coverage. Going forward, I'd treat every "risk" or "edge case" I write down as an open test-writing task, not just a note. I'd also spend less time on trial-and-error with the ChromaDB Docker fix and instead search for the specific error message earlier — I eventually did this, but only after several manual attempts (platform overrides, entrypoint tweaks) that a targeted search would have shortcut. Lastly, I'd write my JOURNAL.md selection reasoning more explicitly in Week 7 — I'd actually worked through the "Is this right for me?" checklist, but didn't write that reasoning down, and lost points for it not being visible to the grader even though the thinking happened.
+
+**What are you most proud of from this module?**
+I'm most proud of catching my own mistake in Week 8 rather than letting it slide. My first reproduction was inferred from reading code, and when asked directly "when did we actually witness this bug fail," I didn't have a good answer — so I went back, reverted the fix, triggered the real AttributeError live, captured the actual server log, and rewrote REPRODUCTION.md with real evidence instead of an assumption. It would have been easy to leave the weaker version in place since it was already committed and technically met the requirement. I'm also proud of the discipline around issue #154 — noticing a second, unrelated bug in the same file and choosing to document it instead of fixing it, even though fixing it right there would have felt satisfying. Both of those decisions came from genuinely engaging with the work rather than just checking boxes, and that's the habit I most want to carry forward.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,66 @@
+## Solution plan
+
+**Issue:** Health check references `settings.redis_host`, which does not exist on Settings — [#155](https://github.com/ascherj/pathreview/issues/155)
+
+### Understand
+The `/health` endpoint's Redis probe constructs a `redis.Redis` client using
+`settings.redis_host` and `settings.redis_port`. Neither field exists on the
+`Settings` model — only a combined `redis_url` field does. This causes an
+`AttributeError` every time the Redis check runs, which the surrounding
+`except Exception` block silently catches and reports as `"unhealthy"`.
+Expected behavior: the health check should correctly report Redis's real
+status. Actual behavior: it always reports "unhealthy," regardless of whether
+Redis is actually reachable, because the code never even gets far enough to
+attempt a real connection.
+
+### Map
+- `api/routes/health.py` — contains the buggy Redis client construction; the
+  main file to fix
+- `core/config.py` — defines the `Settings` model and the existing
+  `redis_url` field; read-only reference, no changes needed here
+- `tests/unit/test_health.py` — new test file to add coverage (didn't exist
+  before this issue)
+
+### Plan
+1. Reproduce the bug locally by calling `GET /health` and confirming the
+   `AttributeError` / "unhealthy" Redis status.
+2. Replace the manual `host=`/`port=` client construction with
+   `redis.Redis.from_url(settings.redis_url, decode_responses=True)`.
+3. Add unit tests: one confirming Redis reports "healthy" via a mocked
+   successful connection, one confirming a genuine connection failure is
+   still correctly reported as "unhealthy" (so we don't just paper over
+   errors).
+4. Run `ruff`, `black`, and `mypy` locally to satisfy the project's
+   pre-commit hooks, fixing any type-annotation gaps introduced by touching
+   this file.
+5. Commit with a Conventional Commits message referencing the issue, and
+   push for review.
+
+### Inputs & outputs
+**Input:** the existing `settings.redis_url` connection string
+(`redis://localhost:6379/0` by default).
+**Output:** the `/health` endpoint correctly reports `"redis": "healthy"`
+when Redis is reachable, and `"redis": "unhealthy"` only on a genuine
+connection failure — not on every request due to a config bug.
+
+### Risks & unknowns
+- `redis.Redis.from_url()` needs to correctly parse the DB index (`/0`) at
+  the end of the URL — confirmed this works via manual testing against the
+  local Docker Redis container.
+- Touching `health.py` surfaced unrelated pre-existing type issues that
+  `mypy` flagged once `db` was properly typed (e.g. the raw `"SELECT 1"`
+  string not wrapped in `text()`, which is really issue #154). Risk of
+  scope creep — mitigated by using a scoped `# type: ignore` comment rather
+  than fixing that unrelated bug here.
+- Since #155 was a heavily-claimed "good first issue," there was a risk of
+  duplicate/conflicting PRs already open against the same lines — checked
+  the issue's linked PRs before starting to avoid wasted work.
+
+### Edge cases
+- Redis genuinely unreachable (e.g. container stopped) — should still
+  report `"unhealthy"` and return a 503, not silently succeed.
+- Malformed or missing `redis_url` in `.env` — `from_url()` will raise on
+  a clearly invalid string, which is caught by the existing `except
+  Exception` block and correctly reported as unhealthy.
+- Redis reachable but wrong DB index — out of scope for this fix, since
+  the URL's DB index is inherited as-is from settings.

--- a/REPRODUCTION.md
+++ b/REPRODUCTION.md
@@ -3,20 +3,33 @@
 ## Steps to reproduce
 
 1. Started the local dev environment via `docker compose up -d` and `make run`.
-2. Called the health endpoint directly:
+2. Temporarily reverted the Redis client construction in `api/routes/health.py`
+   back to the original buggy version:
+```python
+   r = redis.Redis(
+       host=settings.redis_host,
+       port=settings.redis_port,
+       db=0,
+       decode_responses=True,
+   )
+```
+3. Called the health endpoint:
 ```bash
    curl -s http://localhost:8000/health | python3 -m json.tool
 ```
-3. Observed a 503 response with `"redis": "unhealthy"`, even though the Redis
+4. Observed a 503 response with `"redis": "unhealthy"`, even though the Redis
    Docker container (`pathreview-redis-1`) was confirmed running and healthy
    via `docker compose ps`.
-4. Checked the server logs and found the root cause in `api/routes/health.py`:
-   the Redis client was being constructed with `settings.redis_host` and
-   `settings.redis_port`, neither of which exist on the `Settings` model
-   (`core/config.py` only defines `redis_url`). This raised an
-   `AttributeError` every time, which the broad `except Exception` block
-   caught and reported as `"unhealthy"` — masking the real problem and making
-   it look like a Redis outage instead of a config bug.
+5. Confirmed the exact root cause in the server logs:
+redis_health_check_failed error="'Settings' object has no attribute 'redis_host'"
+This is a genuine `AttributeError` — `settings.redis_host` does not exist
+   on the `Settings` model (`core/config.py` only defines `redis_url`). The
+   broad `except Exception` block in `health.py` silently caught this and
+   reported it as `"unhealthy"`, masking the real problem and making it look
+   like a Redis outage instead of a config bug.
+6. Reverted the file back to the working fix
+   (`redis.Redis.from_url(settings.redis_url, decode_responses=True)`) and
+   re-ran the same `curl` command, confirming `"redis": "healthy"` again.
 
 ## Confirmed root cause
 

--- a/REPRODUCTION.md
+++ b/REPRODUCTION.md
@@ -1,0 +1,25 @@
+# Reproducing Issue #155
+
+## Steps to reproduce
+
+1. Started the local dev environment via `docker compose up -d` and `make run`.
+2. Called the health endpoint directly:
+```bash
+   curl -s http://localhost:8000/health | python3 -m json.tool
+```
+3. Observed a 503 response with `"redis": "unhealthy"`, even though the Redis
+   Docker container (`pathreview-redis-1`) was confirmed running and healthy
+   via `docker compose ps`.
+4. Checked the server logs and found the root cause in `api/routes/health.py`:
+   the Redis client was being constructed with `settings.redis_host` and
+   `settings.redis_port`, neither of which exist on the `Settings` model
+   (`core/config.py` only defines `redis_url`). This raised an
+   `AttributeError` every time, which the broad `except Exception` block
+   caught and reported as `"unhealthy"` — masking the real problem and making
+   it look like a Redis outage instead of a config bug.
+
+## Confirmed root cause
+
+`grep -rn "redis_host" .` showed the field was only ever referenced in
+`api/routes/health.py`, never defined anywhere in `core/config.py`. The
+`Settings` class only has `redis_url: str = Field(default="redis://localhost:6379/0")`.

--- a/api/routes/health.py
+++ b/api/routes/health.py
@@ -1,6 +1,8 @@
-from fastapi import APIRouter, HTTPException, status, Depends
+from datetime import datetime
+
 import structlog
-from datetime import datetime, timedelta
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from core.database import get_db
 
@@ -10,12 +12,12 @@ router = APIRouter(prefix="/health", tags=["health"])
 
 
 @router.get("")
-async def health_check(db=Depends(get_db)):
+async def health_check(db: AsyncSession = Depends(get_db)) -> dict:  # noqa: B008
     """
     Check health of PostgreSQL, Redis, and Vector DB.
     Returns 200 if all healthy, 503 if any dependency is down.
     """
-    health_status = {
+    health_status: dict = {
         "status": "healthy",
         "dependencies": {
             "postgres": "unknown",
@@ -28,7 +30,7 @@ async def health_check(db=Depends(get_db)):
 
     try:
         # Check PostgreSQL
-        await db.execute("SELECT 1")
+        await db.execute("SELECT 1")  # type: ignore[call-overload]  # pre-existing bug, see #154
         health_status["dependencies"]["postgres"] = "healthy"
         log.debug("postgres_health_check_passed")
     except Exception as exc:
@@ -39,14 +41,10 @@ async def health_check(db=Depends(get_db)):
     try:
         # Check Redis (if available)
         import redis
+
         from core.config import settings
 
-        r = redis.Redis(
-            host=settings.redis_host,
-            port=settings.redis_port,
-            db=0,
-            decode_responses=True,
-        )
+        r = redis.Redis.from_url(settings.redis_url, decode_responses=True)
         r.ping()
         health_status["dependencies"]["redis"] = "healthy"
         log.debug("redis_health_check_passed")

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -1,0 +1,53 @@
+"""Tests for api/routes/health.py"""
+
+from typing import cast
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from api.routes.health import health_check
+
+
+@pytest.mark.unit
+class TestHealthCheck:
+    """Test suite for the /health endpoint."""
+
+    @pytest.fixture
+    def mock_db_session(self) -> AsyncMock:
+        """Create a mock async database session that succeeds."""
+        session = AsyncMock()
+        session.execute = AsyncMock()
+        return session
+
+    @pytest.mark.asyncio
+    async def test_redis_health_check_uses_redis_url(self, mock_db_session: AsyncMock) -> None:
+        """Test that Redis health check connects via settings.redis_url,
+        not the nonexistent settings.redis_host/redis_port fields."""
+        with patch("redis.Redis.from_url") as mock_from_url:
+            mock_redis_instance = Mock()
+            mock_redis_instance.ping.return_value = True
+            mock_from_url.return_value = mock_redis_instance
+
+            result = await health_check(db=mock_db_session)
+
+        assert result["dependencies"]["redis"] == "healthy"
+        mock_from_url.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_redis_health_check_reports_unhealthy_on_connection_failure(
+        self, mock_db_session: AsyncMock
+    ) -> None:
+        """Test that a genuine Redis connection failure is still reported correctly."""
+        from fastapi import HTTPException
+
+        with patch("redis.Redis.from_url") as mock_from_url:
+            mock_redis_instance = Mock()
+            mock_redis_instance.ping.side_effect = ConnectionError("connection refused")
+            mock_from_url.return_value = mock_redis_instance
+
+            with pytest.raises(HTTPException) as exc_info:
+                await health_check(db=mock_db_session)
+
+        assert exc_info.value.status_code == 503
+        detail = cast("dict", exc_info.value.detail)
+        assert detail["dependencies"]["redis"] == "unhealthy"

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -1,11 +1,11 @@
 """Tests for api/routes/health.py"""
 
-from typing import cast
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
 from api.routes.health import health_check
+from core.config import settings
 
 
 @pytest.mark.unit
@@ -31,7 +31,7 @@ class TestHealthCheck:
             result = await health_check(db=mock_db_session)
 
         assert result["dependencies"]["redis"] == "healthy"
-        mock_from_url.assert_called_once()
+        mock_from_url.assert_called_once_with(settings.redis_url, decode_responses=True)
 
     @pytest.mark.asyncio
     async def test_redis_health_check_reports_unhealthy_on_connection_failure(
@@ -49,5 +49,6 @@ class TestHealthCheck:
                 await health_check(db=mock_db_session)
 
         assert exc_info.value.status_code == 503
-        detail = cast("dict", exc_info.value.detail)
+        detail = exc_info.value.detail
+        assert isinstance(detail, dict)
         assert detail["dependencies"]["redis"] == "unhealthy"


### PR DESCRIPTION
## Summary
The `/health` endpoint's Redis probe constructed a `redis.Redis` client using `settings.redis_host` and `settings.redis_port`, neither of which exist on the `Settings` model — only a combined `redis_url` field does. This caused an `AttributeError` on every request, which the surrounding `except Exception` block silently caught and reported as `"unhealthy"`, making the health check always report Redis as down regardless of its actual status. This PR fixes the client construction to use the existing `settings.redis_url` field via `redis.Redis.from_url()`.

## Issue
Closes #155

## Changes
- Replaced manual `host=`/`port=` Redis client construction in `api/routes/health.py` with `redis.Redis.from_url(settings.redis_url, decode_responses=True)`
- Added type annotations to `health_check()` (`db: AsyncSession`, return type `dict`) to satisfy `mypy`
- Added `tests/unit/test_health.py` with two tests: one confirming Redis reports `"healthy"` on a successful mocked connection, one confirming a genuine connection failure is still correctly reported as `"unhealthy"`

## Testing
- [x] Unit tests pass (`make test-unit`) — verified `tests/unit/test_health.py` passes locally (2/2), and confirmed my changes introduce no new failures against the full suite
- [ ] Integration tests pass (`make test-integration`) — not applicable to this change
- [x] Linter passes (`make lint`) — `ruff check api/routes/health.py tests/unit/test_health.py` passes with no errors
- [x] Type checker passes (`make typecheck`) — `mypy api/routes/health.py tests/unit/test_health.py` passes with no errors
- [x] New/updated tests cover the changes — see `tests/unit/test_health.py`

**Note on pre-existing failures:** Running the full `make check`/`make test-unit` suite on `main` before my changes shows 178 pre-existing lint errors and 53 pre-existing test failures across unrelated modules (`safety/`, `rag/`, `ingestion/`, `test_review_service.py`, etc.) — none of these are introduced by this PR. My changes are scoped entirely to `api/routes/health.py` and `tests/unit/test_health.py`, both of which pass lint, type-checking, and tests cleanly in isolation.

## Screenshots / Demo
Manually verified by reverting the fix locally, calling `GET /health`, and observing the real error in server logs: `redis_health_check_failed error="'Settings' object has no attribute 'redis_host'"`. After applying the fix, the same request returns `"redis": "healthy"`. Full reproduction steps are documented in `REPRODUCTION.md` on this branch.

## Notes for Reviewers
This PR only touches the Redis portion of the health check. While investigating, I noticed the Postgres check in the same file (`await db.execute("SELECT 1")`) has an unrelated pre-existing bug — a raw SQL string not wrapped in `text()`, which fails under SQLAlchemy 2.x (tracked separately as #154). I intentionally left that untouched and out of scope for this PR, adding only a scoped `# type: ignore[call-overload]` comment so `mypy` doesn't block on it.

To manually verify: start the app locally (`make run`), then run `curl -s http://localhost:8000/health | python3 -m json.tool` — `dependencies.redis` should show `"healthy"` when the local Redis container is running.