### PR TITLE
feat: add public review sharing via share token (#101)

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -116,3 +116,106 @@ Currently, portfolio review results are only accessible to authenticated users w
 ## Verdict
 
 ✅ **Ready to claim.** All checklist items verified. Tier 2 scope is appropriate, codebase is well-understood, and timeline is realistic.
+
+---
+
+## Week 8
+
+### Issue Worked On
+
+- Issue link: https://github.com/ascherj/pathreview/issues/101
+- Issue title: Add a Copy link button to share a public review summary
+- Scope: Reproduce current behavior, trace root cause, and prepare implementation plan
+
+### What I Learned
+
+- The current Share button copies the current protected review URL, not a public URL.
+- Review endpoints are ownership-protected through auth dependencies.
+- There is no share token in the Review model, so there is no durable public identifier.
+- A complete solution requires coordinated changes across model, service, API, frontend route, and tests.
+
+### Reproduction Steps
+
+Static/code-level reproduction (confirmed):
+
+1. Open frontend/src/pages/ReviewPage.tsx and inspect handleShare.
+2. Confirm it copies window.location.href directly.
+3. Open frontend/src/App.tsx and confirm /reviews/:reviewId is wrapped by ProtectedRoute.
+4. Open api/routes/reviews.py and confirm all review endpoints require get_current_user.
+5. Search for share_token and /reviews/share references across backend/frontend files.
+6. Observe there are no model/service/route/client implementations for public review sharing.
+
+Command evidence used:
+
+```bash
+rg -n "share_token|/reviews/share|handleShare|path=\"/reviews/:reviewId\"|get_current_user" \
+  core/models/review.py api/routes/reviews.py frontend/src/pages/ReviewPage.tsx frontend/src/App.tsx
+
+rg -n "share_token|/reviews/share" \
+  core/models/review.py api/routes/reviews.py core/services/review_service.py frontend/src/services/api.ts
+```
+
+Expected result:
+- A Share/Copy link action should produce a public URL that works without authentication.
+
+Actual result:
+- Share currently copies only the authenticated page URL.
+- No public token or public endpoint exists.
+
+Additional local test baseline:
+
+```bash
+.venv/bin/pytest tests/unit/test_review_service.py -q
+```
+
+Observed output summary:
+- Multiple existing failures unrelated to issue #101 (AsyncMock coroutine chaining in test setup).
+
+### Challenges
+
+- The issue requires cross-layer planning rather than a single-file fix.
+- Existing test failures in test_review_service.py can mask confidence if not isolated.
+- Public sharing design requires careful decisions on sanitization and token lifecycle.
+
+### Research Performed
+
+- Reviewed:
+  - core/models/review.py
+  - core/services/review_service.py
+  - api/routes/reviews.py
+  - api/schemas/review.py
+  - frontend/src/pages/ReviewPage.tsx
+  - frontend/src/services/api.ts
+  - frontend/src/App.tsx
+  - docs/SETUP.md and Makefile for local run/test workflows
+
+- Traced call path:
+  - ReviewPage Share click -> handleShare -> clipboard current URL
+  - Route /reviews/:reviewId requires auth
+  - Backend /reviews endpoints require get_current_user
+  - No token-backed public retrieval path exists
+
+### Solution Plan
+
+- Added detailed plan in PLAN.md covering:
+  - Problem summary
+  - Root cause
+  - Proposed solution
+  - Implementation steps
+  - Risks, unknowns, and testing plan
+
+### Remaining Questions
+
+- Should share tokens be revocable?
+- Should tokens expire?
+- Which fields are allowed in public response payloads?
+- Should share creation be idempotent or rotate token each time?
+
+### Next Steps
+
+1. Implement model + migration for share_token.
+2. Add service methods for token creation and public token lookup.
+3. Add auth-protected share generation route and public share read route.
+4. Update frontend API client and Review page Copy link behavior.
+5. Add a public shared review page route/component.
+6. Add tests for token flow and endpoint auth boundaries.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -127,6 +127,13 @@ Currently, portfolio review results are only accessible to authenticated users w
 - Issue title: Add a Copy link button to share a public review summary
 - Scope: Reproduce current behavior, trace root cause, and prepare implementation plan
 
+### Week 8 Deliverable Links
+
+- Reproduction commit: https://github.com/wiinc355/pathreview/commit/9f57a18
+- PLAN.md: https://github.com/wiinc355/pathreview/blob/feat/101-public-review-sharing/PLAN.md
+- Working branch URL: https://github.com/wiinc355/pathreview/tree/feat/101-public-review-sharing
+- Walkthrough video (optional): Not recorded yet
+
 ### What I Learned
 
 - The current Share button copies the current protected review URL, not a public URL.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,118 @@
+# Week 7 — Issue Journal
+
+## Issue Selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/101
+
+**Issue title:** Add a "Copy link" button to share a public review summary
+
+**Tier:** Tier 2
+
+---
+
+## Problem Summary
+
+Currently, portfolio review results are only accessible to authenticated users who own them through the private `/reviews/{review_id}` API endpoint. Users cannot share their portfolio reviews with others (mentors, employers, colleagues) without granting full account access. This feature requires implementing a public review sharing mechanism by: (1) adding a unique public share token to the Review database model, (2) creating a new public API endpoint that fetches review summaries by share token (without authentication), and (3) adding a "Copy link" button in the ReviewPage frontend component that generates and copies a shareable URL. The implementation spans the Review model (`core/models/review.py`), review service (`core/services/review_service.py`), API routes (`api/routes/reviews.py`), and the ReviewPage component (`frontend/src/pages/ReviewPage.tsx`).
+
+---
+
+## "Is This Right for Me?" Checklist
+
+### Part 1 — Understanding the Issue
+
+- [x] **Can I explain what this issue is asking for in my own words?**
+  - Yes. Users need to share portfolio reviews publicly without granting account access. Solution requires: a share token mechanism, public API endpoint, and UI "Copy link" button.
+  
+- [x] **Do I understand which part of the app is affected?**
+  - Yes. Located files:
+    - `core/models/review.py` — Add public share token field
+    - `core/services/review_service.py` — Service methods for token generation and retrieval
+    - `api/routes/reviews.py` — New public endpoint for fetching by share token
+    - `frontend/src/pages/ReviewPage.tsx` — UI button to generate and copy link
+  
+- [x] **Do I understand what "done" looks like?**
+  - Before: Users see current Share button that only copies internal authenticated URL; reviews require login to access
+  - After: Users see "Copy link" button that generates a public share URL with unique token; unauthenticated users can view shared review via public endpoint
+
+### Part 2 — Tier Fit
+
+- [x] **Is the tier a realistic match for where I am right now?**
+  - Yes. This is Tier 2 (requires understanding module interactions). I have prior open-source contribution experience and this involves:
+    - Database model modification (1 new field)
+    - Service layer update (token generation/retrieval)
+    - API endpoint addition (1 new public route)
+    - Frontend button implementation (existing component update)
+  - Scope is well-contained within review subsystem, not cross-cutting
+
+### Part 3 — Codebase Readiness
+
+- [x] **Can I find the relevant code?**
+  - Yes. Reviewed:
+    - Review model: Fields, relationships, migrations
+    - Review service: CRUD operations, query patterns
+    - Reviews API routes: Endpoint structure, auth patterns, response schemas
+    - ReviewPage component: Current Share button implementation
+  
+- [x] **Do I understand the surrounding code well enough to change it safely?**
+  - Yes. I understand:
+    - Database models use SQLAlchemy with UUID primary keys
+    - Services follow async pattern with dependency injection
+    - API routes use FastAPI with auth middleware
+    - Frontend uses React hooks and TypeScript
+  - Can predict changes: adding String field to model, adding service methods, adding new route, updating button handler
+  
+- [x] **Have I read the relevant test file?**
+  - Need to verify test file structure (will check in `tests/unit/`)
+
+### Part 4 — Scope and Time
+
+- [x] **How many others are already working on this issue?**
+  - Checked cohort ledger: Issue #101 has minimal claims, reasonable crowd level
+  
+- [x] **Is the scope realistic for Weeks 8–9?**
+  - Yes. Tier 2 scope (8-12 hours estimated):
+    - Model/migration: 1-2 hours
+    - Service/API: 2-3 hours
+    - Frontend: 1-2 hours
+    - Tests: 2-3 hours
+    - Testing/debugging: 1-2 hours
+  - Total: ~9-12 hours over 2 weeks is achievable with focused work
+  
+- [x] **Are there any blockers or dependencies?**
+  - No blockers. Issue is self-contained within review subsystem. No dependencies on other issues.
+
+---
+
+## Implementation Plan
+
+### Phase 1: Backend Foundation (Model & Migration)
+1. Add `share_token` field to Review model (nullable, unique, indexed)
+2. Create database migration
+3. Add token generation utility function
+
+### Phase 2: Service & API Layer
+1. Add service methods for:
+   - `generate_share_token()` — create new token when sharing
+   - `get_review_by_share_token()` — retrieve review without auth
+2. Add new public API route: `GET /reviews/share/{share_token}`
+   - No auth required
+   - Returns sanitized review data (no sensitive fields)
+
+### Phase 3: Frontend
+1. Update ReviewPage component:
+   - Add "Copy link" button (or enhance existing Share button)
+   - Generate share token via API if not already set
+   - Copy public URL to clipboard
+   - Show success confirmation
+
+### Phase 4: Testing & Polish
+1. Unit tests for service methods
+2. API endpoint tests (public access, error cases)
+3. Frontend component tests
+4. Manual testing of full flow
+
+---
+
+## Verdict
+
+✅ **Ready to claim.** All checklist items verified. Tier 2 scope is appropriate, codebase is well-understood, and timeline is realistic.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -292,3 +292,101 @@ charset, and share-token lookup success / unknown-token / empty-token cases.
 > the Week 9 guidance, "passes" here means my changes introduce no new failures.
 
 **Draft PR feedback received from:** none (draft PR opened for peer review in Slack)
+
+---
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No reviewer or maintainer feedback came in on PR #634 by the end of the week.
+Per the Summer 2026 course note, reviewer feedback on the upstream repo
+(`ascherj/pathreview`) is not an active feature this term, so none was expected.
+The PR remains open against upstream `main` with the full public-review-sharing
+implementation and my 7 new unit tests.
+
+**How you responded:**
+No changes were required, since no feedback arrived. I did a final self-review
+pass on the branch to confirm the PR is still in a mergeable, reviewable state:
+the diff stays scoped to the review-sharing subsystem (model + migration,
+service functions, two routes, schemas, frontend client/route/page), my new
+Python files remain black-clean, and my 7 tests still pass on top of the same
+53 documented pre-existing failures — no new failures introduced.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The hardest part wasn't the feature logic — it was working *around* the state of
+the codebase and local environment rather than *in* it. Two things surprised me.
+First, the local environment was subtly broken in ways that had nothing to do
+with my issue: the project virtualenv (and copies of `docs/` and `.github/`) had
+been nested under `core/`, the Makefile expected a root `.venv` that didn't
+exist, and the console-script shebangs pointed at a stale path — so I had to run
+every tool in module form (`core/.venv/bin/python -m pytest|ruff|black`) instead
+of the normal `make` targets. Second, `make check` and `make test-unit` had
+heavy *pre-existing* failures (53 failing tests, 182 ruff errors, 52 unformatted
+files, missing mypy stubs) before I touched anything. Separating "failures I
+caused" from "failures that were already there" took real discipline and became
+the whole basis of how I had to phrase my self-review. The actual token +
+endpoint + button work was the *smaller* half of the effort.
+
+**What did you learn about working in a large codebase?**
+That "matching the house style" often matters more than writing what you'd
+consider the cleanest code. In `api/routes/reviews.py`, the existing endpoints
+uniformly use `Depends()` in default arguments (which ruff flags as B008), raise
+bare `HTTPException` in except blocks (B904), and pass `current_user.id` as a
+string where services annotate `UUID`. My instinct was to "fix" those in my new
+handlers — but doing so would have made my code inconsistent with every other
+endpoint and would have signaled to a reviewer that I didn't understand the
+conventions. So I deliberately matched the existing patterns and documented that
+choice. Contributing to someone else's production code is much more about
+*fitting in* — respecting existing decisions, keeping the diff small and
+scoped, and not surprising the maintainer — than about building my own project,
+where I own every convention and can refactor freely. I also learned to design
+for boundaries I couldn't see initially: sanitizing the public response so it
+omits owner fields, keeping every existing private endpoint auth-protected, and
+making token creation idempotent so re-clicking "Copy link" doesn't rotate a
+link someone already shared.
+
+**How did AI tools help — and where did they fall short?**
+AI was most useful for *orientation and boilerplate*: quickly tracing the call
+path (ReviewPage → handleShare → clipboard; the `/reviews/:reviewId` protected
+route; the auth-gated backend endpoints), scaffolding the Alembic migration and
+the new Pydantic schemas, and drafting test cases for the token flow. That
+compressed hours of reading into minutes. Where it fell short was anything that
+depended on the *specific broken state* of this repo — AI happily suggested
+`make check` and `make test-unit` as if they'd pass cleanly, and couldn't have
+known that the venv was misplaced or that 53 tests were already red for reasons
+unrelated to my work. It also couldn't make the judgment call about whether to
+match the existing B008/B904 "code smells" or fix them; that required
+understanding the social context of a PR (don't surprise the maintainer), not
+just the code. The security-sensitive decisions — using `secrets.token_urlsafe`
+for the token, deciding which fields are safe to expose publicly — were things I
+had to reason through and verify myself, not take on faith.
+
+**What would you do differently if you started over?**
+I'd validate the local environment *before* writing any code — run the test
+suite on a clean checkout first to capture the true baseline, so I'd know from
+day one exactly which failures were pre-existing instead of discovering it
+mid-implementation. That baseline turned out to be the single most important
+fact for my whole self-review, and I established it later than I should have.
+I'd also open the draft PR earlier in the week to leave a real window for peer
+feedback in Slack, rather than finishing most of the implementation first. On
+planning, PLAN.md held up well, but I'd add an explicit "environment / tooling"
+section to it next time, since that's where the actual friction lived.
+
+**What are you most proud of from this module?**
+The clarity and honesty of the self-review. It would have been easy to write
+"make check passes" and move on, or to panic at 53 failing tests. Instead I
+took the time to establish a real before/after baseline (53 failed / 375 passed
+→ 53 failed / **382 passed**), prove my 7 new tests all pass, and document
+precisely why the pre-existing failures aren't mine — including keeping my new
+files black-clean and matching the existing lint patterns deliberately rather
+than accidentally. Being able to defend exactly what my change does and doesn't
+affect, in a messy real-world repo, is the skill I most wanted to build this
+module.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -226,3 +226,69 @@ Observed output summary:
 4. Update frontend API client and Review page Copy link behavior.
 5. Add a public shared review page route/component.
 6. Add tests for token flow and endpoint auth boundaries.
+
+---
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+All backend sub-tasks from PLAN.md are done. Implemented `share_token` on the
+Review model (`core/models/review.py`) with a matching Alembic migration
+(`003_add_share_token_to_reviews.py`), added two service functions in
+`core/services/review_service.py` — `create_or_get_share_token` (idempotent,
+cryptographically secure `secrets.token_urlsafe`) and
+`get_review_by_share_token` — plus the API layer: `POST /reviews/{review_id}/share`
+(auth + ownership) and public `GET /reviews/share/{share_token}`, backed by new
+`ShareTokenResponse` / `PublicReviewResponse` schemas that omit owner fields.
+Frontend sub-tasks are also done: `api.ts` client methods, a public
+`/shared/:shareToken` route, a new read-only `SharedReviewPage`, and the
+ReviewPage "Copy link" flow with copied/error states.
+
+**Next steps:**
+Finalize unit tests, run the full self-review (`make check` / `make test-unit`),
+get draft-PR feedback in Slack, and open the PR for review.
+
+**Blockers:**
+None. Noted a pre-existing environment quirk (the project virtualenv and
+`docs/`/`.github/` had been copied into `core/`; restored the layout locally so
+it does not pollute the PR) and heavy pre-existing failures in `make check` and
+`make test-unit` unrelated to this issue (documented below).
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** _(opened from branch `feat/101-public-review-sharing` — see PR URL added on submission)_
+
+**Branch:** `feat/101-public-review-sharing`
+
+**What you built:**
+A token-based public review sharing flow. An owner clicks "Copy link" on their
+completed review, which calls an authenticated endpoint that generates (or
+reuses) a unique `share_token` and returns a `/shared/{token}` URL. Anyone with
+that URL can view a sanitized, read-only summary via a public, unauthenticated
+endpoint, while all existing private review endpoints stay auth-protected.
+
+**Tests added or updated:**
+`tests/unit/test_review_service.py` — added a `TestReviewSharing` suite (7 tests)
+covering token idempotency (reuse of an existing token), fresh-token generation
+and persistence, `None` when the review is not owned/found, URL-safe token
+charset, and share-token lookup success / unknown-token / empty-token cases.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+> In this codebase both commands have **documented pre-existing failures**
+> unrelated to issue #101. Baseline before my changes: `make test-unit` = 53
+> failed / 375 passed; `make check` fails at `ruff` (182 errors), `black` (52
+> files), and `mypy` (missing third-party stubs). After my changes:
+> `make test-unit` = 53 failed / **382 passed** (my 7 new tests pass; the same
+> 53 pre-existing failures remain — **no new failures**). My new Python files are
+> black-clean and my two service functions are ruff/mypy-clean; the new route
+> handlers intentionally follow the existing file's FastAPI patterns
+> (`Depends()` defaults, `current_user.id`), so any lint/type notes they produce
+> are the same categories already present on every pre-existing endpoint. Per
+> the Week 9 guidance, "passes" here means my changes introduce no new failures.
+
+**Draft PR feedback received from:** none (draft PR opened for peer review in Slack)

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -260,7 +260,7 @@ it does not pollute the PR) and heavy pre-existing failures in `make check` and
 
 ### Check-in 2 (end of week)
 
-**PR link:** _(opened from branch `feat/101-public-review-sharing` — see PR URL added on submission)_
+**PR link:** https://github.com/ascherj/pathreview/pull/634
 
 **Branch:** `feat/101-public-review-sharing`
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,177 @@
+# Problem Summary
+
+Issue: Add a Copy link workflow to share a public review summary (Issue #101).
+
+Current behavior:
+- The Review page Share button copies the current browser URL, which points to a protected route.
+- Backend review endpoints require authentication and ownership checks.
+- No public review token or unauthenticated share endpoint exists.
+
+Expected behavior:
+- Users can generate a shareable public URL for a review.
+- Anyone with that URL can view a sanitized review summary without logging in.
+- Private review endpoints remain protected.
+
+---
+
+# Root Cause
+
+The sharing flow is incomplete across database, service, API, and frontend layers:
+
+1. Data model gap
+- Review model has no share token field to represent a public share identifier.
+
+2. Service layer gap
+- Review service has ownership-scoped retrieval only.
+- No method exists to generate, persist, rotate, or query by share token.
+
+3. API gap
+- All current /reviews routes depend on auth middleware.
+- No public endpoint exists for share-token lookup.
+
+4. Frontend routing/UI gap
+- Review page is behind protected routing.
+- Share button only copies a private route URL and does not create a public URL.
+
+---
+
+# Proposed Solution
+
+Implement a token-based public sharing flow:
+
+1. Add share_token to Review model
+- Nullable, unique, indexed string token.
+- Generated only when user requests sharing.
+
+2. Add backend share methods
+- Generate token endpoint for owners of the review.
+- Public read endpoint that fetches a review by token and returns sanitized fields.
+
+3. Update frontend sharing behavior
+- Replace current Share handler with flow that requests (or reuses) token.
+- Copy public URL (for example: /shared/{token}) to clipboard.
+
+4. Add a public frontend page
+- New route/page for public read-only summary.
+- No auth required.
+
+---
+
+# Implementation Steps
+
+1. Locate affected files and confirm existing patterns for auth-protected and public routes.
+2. Add share_token field and migration.
+3. Add service methods:
+   - create_or_get_share_token(review_id, user_id)
+   - get_review_by_share_token(share_token)
+4. Add API routes:
+   - POST /reviews/{review_id}/share (auth required)
+   - GET /reviews/share/{share_token} (public)
+5. Add schema updates for share response and public review response.
+6. Update frontend API client to call share endpoints.
+7. Update Review page button label and behavior to Copy link.
+8. Add public route and public review page component.
+9. Add unit/integration tests for service and API behavior.
+10. Run tests and manual regression checks.
+
+---
+
+# Files to Modify
+
+- core/models/review.py
+  - Add share_token column and index.
+
+- alembic/versions/<new_migration>.py
+  - Add migration for share_token schema change.
+
+- core/services/review_service.py
+  - Add token generation/query functions.
+
+- api/schemas/review.py
+  - Add share/public response models.
+
+- api/routes/reviews.py
+  - Add share token creation route and public token lookup route.
+
+- frontend/src/services/api.ts
+  - Add methods for generate share link and get public review.
+
+- frontend/src/App.tsx
+  - Add public route for shared review page.
+
+- frontend/src/pages/ReviewPage.tsx
+  - Replace Share behavior to copy public share URL.
+
+- frontend/src/pages/<new_shared_review_page>.tsx
+  - Render public read-only review summary.
+
+- tests/unit/test_review_service.py
+  - Add tests for token generation and token lookup.
+
+- tests/integration/<new_reviews_share_test>.py
+  - Add API tests for auth/public route behavior.
+
+---
+
+# Risks
+
+- Breaking changes
+  - Migration errors or uniqueness constraints could break review writes if misconfigured.
+
+- Security concerns
+  - Public endpoint could expose too much data if response is not sanitized.
+  - Token entropy must be high enough to prevent guessing.
+
+- Backward compatibility
+  - Existing reviews will have null share_token until generated.
+
+- Edge cases
+  - Deleted review with stale token.
+  - Token regeneration invalidating previously shared links.
+  - Clipboard API denial in some browsers.
+
+---
+
+# Unknowns
+
+- Should share links be revocable?
+- Should tokens expire?
+- Which review fields are approved for public display?
+- Should token creation be idempotent or always rotate?
+- Should access be logged/rate-limited for public share endpoint?
+
+---
+
+# Testing Plan
+
+Existing tests to run:
+- tests/unit/test_review_service.py
+- tests/integration review-route tests (existing and new)
+
+New tests to add:
+- Unit: token creation, uniqueness handling, token lookup success/failure.
+- API integration:
+  - POST share route requires auth and ownership.
+  - GET public share route works without auth.
+  - Invalid/unknown token returns 404.
+
+Manual testing:
+1. Log in, open completed review, click Copy link.
+2. Open copied link in private/incognito window.
+3. Verify review summary loads without login.
+4. Verify protected /reviews/{review_id} still redirects/rejects unauthenticated users.
+
+Regression testing:
+- Re-run unit and integration suites.
+- Validate no regressions in review creation/status polling/export.
+
+---
+
+# Estimated Difficulty
+
+Medium.
+
+Reason:
+- Cross-layer change (DB + backend + frontend + tests) but scoped to one feature.
+- Requires careful auth/public boundary design and token security.
+- Existing architecture already provides clear service and routing patterns to extend.

--- a/PLAN.md
+++ b/PLAN.md
@@ -55,6 +55,22 @@ Implement a token-based public sharing flow:
 - New route/page for public read-only summary.
 - No auth required.
 
+5. Define explicit inputs and outputs for the new flow
+- Service input/output contracts in core/services/review_service.py:
+  - create_or_get_share_token(review_id: UUID, user_id: UUID) -> str
+  - get_review_by_share_token(share_token: str) -> Review | None
+- API contract in api/routes/reviews.py and api/schemas/review.py:
+  - POST /reviews/{review_id}/share (auth)
+    - Input: path review_id, bearer token user context
+    - Output: {"share_token": string, "share_url": string}
+  - GET /reviews/share/{share_token} (public)
+    - Input: path share_token
+    - Output: sanitized review payload only
+      {"id", "status", "sections", "overall_score", "created_at"}
+- Frontend contract in frontend/src/services/api.ts and frontend/src/pages/ReviewPage.tsx:
+  - Input: reviewId from route params on review page
+  - Output: copied public URL and success/failure UI state
+
 ---
 
 # Implementation Steps
@@ -116,29 +132,37 @@ Implement a token-based public sharing flow:
 # Risks
 
 - Breaking changes
-  - Migration errors or uniqueness constraints could break review writes if misconfigured.
+  - Migration errors or uniqueness constraints in core/models/review.py and alembic/versions/<new_migration>.py could break review writes if misconfigured.
+  - Investigation path: run alembic upgrade on a seeded DB, then create/list reviews via existing /reviews endpoints.
 
 - Security concerns
-  - Public endpoint could expose too much data if response is not sanitized.
-  - Token entropy must be high enough to prevent guessing.
+  - Public endpoint in api/routes/reviews.py could expose too much data if ReviewResponse is reused instead of a constrained public schema in api/schemas/review.py.
+  - Token entropy in core/services/review_service.py may be insufficient if token generation uses predictable/randomly weak values.
+  - Investigation path: verify schema excludes profile_id and user identifiers; verify token generator uses a cryptographically secure source.
 
 - Backward compatibility
-  - Existing reviews will have null share_token until generated.
+  - Existing reviews will have null share_token until generated, which can break frontend assumptions if ReviewPage.tsx expects a token to always exist.
+  - Investigation path: test old reviews with no token and ensure POST /reviews/{review_id}/share creates one on demand.
 
 - Edge cases
-  - Deleted review with stale token.
-  - Token regeneration invalidating previously shared links.
-  - Clipboard API denial in some browsers.
+  - Deleted review with stale token should return 404 from GET /reviews/share/{share_token}.
+  - Token regeneration policy (reuse vs rotate) affects old link validity in core/services/review_service.py.
+  - Clipboard API denial in frontend/src/pages/ReviewPage.tsx must show fallback/error state instead of silent failure.
 
 ---
 
 # Unknowns
 
-- Should share links be revocable?
-- Should tokens expire?
-- Which review fields are approved for public display?
-- Should token creation be idempotent or always rotate?
-- Should access be logged/rate-limited for public share endpoint?
+- Revocation behavior in core/services/review_service.py:
+  - Should we support explicit revoke endpoint now, or defer to token rotation?
+- Expiration policy in core/models/review.py:
+  - Do we need expires_at for share tokens, or non-expiring links for MVP?
+- Public payload scope in api/schemas/review.py:
+  - Are confidence and suggestions safe for public exposure, or should we hide confidence?
+- Token lifecycle in core/services/review_service.py:
+  - Should POST /reviews/{review_id}/share be idempotent (return existing token) or rotate each request?
+- Abuse protections in api/routes/reviews.py and safety/rate_limiter.py:
+  - Should GET /reviews/share/{share_token} be integrated with current rate limiting before release?
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -69,3 +69,20 @@ make run           # Start the dev servers
 ## License
 
 MIT
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/101
+
+**Issue title:** Add a "Copy link" button to share a public review summary
+
+**Tier:** [ ] Tier 1  [X] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+Currently, portfolio review results are only accessible to authenticated users who own the review through the private `/reviews/{review_id}` API endpoint. There is no way for users to share their review summaries with others (colleagues, mentors, potential employers) without granting full account access. The issue requires implementing a public review sharing feature by: (1) adding a unique public share token to the Review model, (2) creating a new public API endpoint to fetch review summaries by share token, and (3) adding a "Copy link" button in the ReviewPage component (frontend) that generates and copies a shareable public URL. This affects the Review model in `core/models/review.py`, review service in `core/services/review_service.py`, API routes in `api/routes/reviews.py`, and the ReviewPage component in `frontend/src/pages/ReviewPage.tsx`.
+
+**Branch name:** feat/101-public-review-sharing
+
+**Setup confirmation:** [X] App runs locally at localhost:5173
+
+**Cohort ledger:** [X] Issue added to cohort ledger

--- a/alembic/versions/003_add_share_token_to_reviews.py
+++ b/alembic/versions/003_add_share_token_to_reviews.py
@@ -1,0 +1,33 @@
+"""Add share_token column to reviews table.
+
+Revision ID: 003
+Revises: 002
+Create Date: 2026-08-02 00:00:00.000000
+"""
+
+import sqlalchemy as sa
+
+from alembic import op  # type: ignore[attr-defined]
+
+revision = "003"
+down_revision = "002"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "reviews",
+        sa.Column("share_token", sa.String(length=64), nullable=True),
+    )
+    op.create_index(
+        "ix_reviews_share_token",
+        "reviews",
+        ["share_token"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_reviews_share_token", table_name="reviews")
+    op.drop_column("reviews", "share_token")

--- a/api/routes/reviews.py
+++ b/api/routes/reviews.py
@@ -1,15 +1,23 @@
-from fastapi import APIRouter, Depends, HTTPException, status, BackgroundTasks
 from uuid import UUID
-import structlog
 
-from api.schemas.review import ReviewCreate, ReviewResponse, ReviewListResponse
+import structlog
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
+
 from api.middleware.auth import get_current_user
-from core.models.user import User
-from core.models.review import Review
+from api.schemas.review import (
+    PublicReviewResponse,
+    ReviewCreate,
+    ReviewListResponse,
+    ReviewResponse,
+    ShareTokenResponse,
+)
 from core.database import get_db
+from core.models.user import User
 from core.services.review_service import (
+    create_or_get_share_token,
     create_review,
     get_review,
+    get_review_by_share_token,
     list_reviews,
     process_review,
 )
@@ -59,6 +67,89 @@ async def create_review_endpoint(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to create review",
+        )
+
+
+@router.get("/share/{share_token}", response_model=PublicReviewResponse)
+async def get_shared_review_endpoint(
+    share_token: str,
+    db=Depends(get_db),
+):
+    """
+    Public endpoint: fetch a sanitized review summary by its share token.
+
+    No authentication required. Returns 404 if the token is unknown so that
+    revoked or mistyped tokens are indistinguishable from never-shared reviews.
+    """
+    try:
+        review = await get_review_by_share_token(db=db, share_token=share_token)
+
+        if not review:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Shared review not found",
+            )
+
+        return PublicReviewResponse.model_validate(review)
+
+    except HTTPException:
+        raise
+    except Exception as exc:
+        log.error("get_shared_review_error", error=str(exc))
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to retrieve shared review",
+        )
+
+
+@router.post("/{review_id}/share", response_model=ShareTokenResponse)
+async def create_share_link_endpoint(
+    review_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db=Depends(get_db),
+):
+    """
+    Generate (or return the existing) public share link for a review.
+
+    Requires authentication and ownership of the review. Idempotent: repeated
+    calls return the same token so previously shared links keep working.
+    Returns 404 if the review does not exist or is not owned by the caller.
+    """
+    try:
+        share_token = await create_or_get_share_token(
+            db=db, review_id=review_id, user_id=current_user.id
+        )
+
+        if share_token is None:
+            log.warning(
+                "share_review_not_found",
+                review_id=str(review_id),
+                user_id=str(current_user.id),
+            )
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Review not found",
+            )
+
+        log.info(
+            "share_link_created",
+            review_id=str(review_id),
+            user_id=str(current_user.id),
+        )
+
+        return ShareTokenResponse(
+            share_token=share_token,
+            share_url=f"/shared/{share_token}",
+        )
+
+    except HTTPException:
+        raise
+    except Exception as exc:
+        log.error("create_share_link_error", error=str(exc))
+        await db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to create share link",
         )
 
 

--- a/api/schemas/review.py
+++ b/api/schemas/review.py
@@ -33,3 +33,26 @@ class ReviewListResponse(BaseModel):
     total: int
     page: int
     page_size: int
+
+
+class ShareTokenResponse(BaseModel):
+    """Response returned when an owner generates a public share link."""
+
+    share_token: str
+    share_url: str
+
+
+class PublicReviewResponse(BaseModel):
+    """Sanitized review payload exposed through the public share endpoint.
+
+    Deliberately omits owner-identifying fields (``profile_id``,
+    ``error_message``) so a shared link never leaks who created the review.
+    """
+
+    id: UUID
+    status: str
+    sections: list[FeedbackSection] | None
+    overall_score: float | None
+    created_at: datetime
+
+    model_config = {"from_attributes": True}

--- a/core/models/review.py
+++ b/core/models/review.py
@@ -31,6 +31,9 @@ class Review(Base):
     status: Mapped[str] = mapped_column(
         String(50), nullable=False, default="pending"
     )  # "pending", "processing", "complete", "failed"
+    share_token: Mapped[str | None] = mapped_column(
+        String(64), nullable=True, unique=True, index=True
+    )  # Public share token; null until the owner generates a share link
     sections: Mapped[dict | None] = mapped_column(JSON, nullable=True)  # Structured review output
     overall_score: Mapped[float | None] = mapped_column(Float, nullable=True)
     error_message: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/core/services/review_service.py
+++ b/core/services/review_service.py
@@ -1,15 +1,22 @@
-from uuid import UUID
-import structlog
 import json
+import secrets
 from datetime import datetime
-from sqlalchemy import select, and_
+from uuid import UUID
 
-from core.models.review import Review
-from core.models.profile import Profile
-from core.models.ingested_source import IngestedSource
+import structlog
+from sqlalchemy import and_, select
+
 from api.schemas.review import FeedbackSection
+from core.models.ingested_source import IngestedSource
+from core.models.profile import Profile
+from core.models.review import Review
 
 log = structlog.get_logger()
+
+# Number of random bytes used to generate a public share token. 32 bytes of
+# entropy from `secrets` yields a ~43 character URL-safe string, well within
+# the 64 character column limit.
+SHARE_TOKEN_BYTES = 32
 
 
 async def create_review(
@@ -43,6 +50,75 @@ async def get_review(
     stmt = select(Review).join(Profile).where(
         and_(Review.id == review_id, Profile.user_id == user_id)
     )
+    result = await db.execute(stmt)
+    return result.scalars().first()
+
+
+async def create_or_get_share_token(
+    db,
+    review_id: UUID,
+    user_id: UUID,
+) -> str | None:
+    """Return a public share token for an owned review, creating one if needed.
+
+    The operation is idempotent: if the review already has a share token it is
+    returned unchanged so existing shared links keep working. A fresh,
+    cryptographically secure token is generated only the first time a review is
+    shared.
+
+    Args:
+        db: Async database session.
+        review_id: ID of the review to share.
+        user_id: ID of the user requesting the share link (ownership is
+            enforced via the review's profile).
+
+    Returns:
+        The share token string, or ``None`` if no review with ``review_id`` is
+        owned by ``user_id``.
+    """
+    review = await get_review(db, review_id, user_id)
+    if review is None:
+        return None
+
+    if review.share_token:
+        return review.share_token
+
+    # Retry on the astronomically unlikely event of a token collision.
+    for _ in range(5):
+        token = secrets.token_urlsafe(SHARE_TOKEN_BYTES)
+        existing = await get_review_by_share_token(db, token)
+        if existing is None:
+            review.share_token = token
+            db.add(review)
+            await db.commit()
+            await db.refresh(review)
+            log.info(
+                "share_token_created",
+                review_id=str(review_id),
+                user_id=str(user_id),
+            )
+            return token
+
+    log.error("share_token_generation_failed", review_id=str(review_id))
+    raise RuntimeError("Could not generate a unique share token")
+
+
+async def get_review_by_share_token(
+    db,
+    share_token: str,
+) -> Review | None:
+    """Fetch a review by its public share token without any ownership check.
+
+    Args:
+        db: Async database session.
+        share_token: The public share token from a shared link.
+
+    Returns:
+        The matching :class:`Review`, or ``None`` if the token is unknown.
+    """
+    if not share_token:
+        return None
+    stmt = select(Review).where(Review.share_token == share_token)
     result = await db.execute(stmt)
     return result.scalars().first()
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import { RegisterPage } from './pages/RegisterPage'
 import { DashboardPage } from './pages/DashboardPage'
 import { NewProfilePage } from './pages/NewProfilePage'
 import { ReviewPage } from './pages/ReviewPage'
+import { SharedReviewPage } from './pages/SharedReviewPage'
 import { ReviewHistoryPage } from './pages/ReviewHistoryPage'
 
 const ProtectedRoute: React.FC<{ children: React.ReactNode }> = ({ children }) => {
@@ -52,6 +53,7 @@ function App() {
         />
         <Route path="/login" element={<LoginPage />} />
         <Route path="/register" element={<RegisterPage />} />
+        <Route path="/shared/:shareToken" element={<SharedReviewPage />} />
         <Route
           path="/dashboard"
           element={

--- a/frontend/src/pages/ReviewPage.tsx
+++ b/frontend/src/pages/ReviewPage.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
-import { Share2, Download, ArrowLeft, Loader } from 'lucide-react'
+import { Share2, Download, ArrowLeft, Loader, Check } from 'lucide-react'
 import { useReviewStatus } from '../hooks/useReviewStatus'
 import { ReviewSection } from '../components/ReviewSection'
 import { apiClient } from '../services/api'
@@ -12,6 +12,8 @@ export const ReviewPage: React.FC = () => {
   const [fullReview, setFullReview] = useState<Review | null>(null)
   const { review: statusReview, isPolling, error } = useReviewStatus(reviewId || '')
   const [fetchError, setFetchError] = useState('')
+  const [shareStatus, setShareStatus] = useState<'idle' | 'copied' | 'error'>('idle')
+  const [isSharing, setIsSharing] = useState(false)
 
   useEffect(() => {
     if (!isPolling && statusReview?.status === 'complete') {
@@ -29,11 +31,26 @@ export const ReviewPage: React.FC = () => {
 
   const currentReview = fullReview || statusReview
 
-  const handleShare = () => {
-    const url = window.location.href
-    navigator.clipboard.writeText(url).then(() => {
-      alert('Review link copied to clipboard!')
-    })
+  const handleCopyLink = async () => {
+    if (!reviewId || isSharing) return
+    setIsSharing(true)
+    setShareStatus('idle')
+    try {
+      // Generate (or reuse) a public share token, then copy the public URL.
+      const { share_url } = await apiClient.createShareLink(reviewId)
+      const publicUrl = `${window.location.origin}${share_url}`
+      await navigator.clipboard.writeText(publicUrl)
+      setShareStatus('copied')
+      setTimeout(() => setShareStatus('idle'), 3000)
+    } catch (err) {
+      // Covers both share-link creation failures and clipboard denial.
+      setShareStatus('error')
+      setFetchError(
+        err instanceof Error ? err.message : 'Could not create a shareable link'
+      )
+    } finally {
+      setIsSharing(false)
+    }
   }
 
   const handleExport = () => {
@@ -112,11 +129,16 @@ ${section.suggestions.map((s) => `- ${s}`).join('\n')}
               <h1 className="text-3xl font-bold text-gray-900">Portfolio Review</h1>
               <div className="flex items-center gap-3">
                 <button
-                  onClick={handleShare}
-                  className="inline-flex items-center gap-2 px-4 py-2 border border-gray-300 hover:bg-gray-50 text-gray-700 font-medium rounded-lg transition-colors"
+                  onClick={handleCopyLink}
+                  disabled={isSharing}
+                  className="inline-flex items-center gap-2 px-4 py-2 border border-gray-300 hover:bg-gray-50 text-gray-700 font-medium rounded-lg transition-colors disabled:opacity-60"
                 >
-                  <Share2 className="w-5 h-5" />
-                  Share
+                  {shareStatus === 'copied' ? (
+                    <Check className="w-5 h-5 text-green-600" />
+                  ) : (
+                    <Share2 className="w-5 h-5" />
+                  )}
+                  {isSharing ? 'Copying...' : shareStatus === 'copied' ? 'Link copied!' : 'Copy link'}
                 </button>
                 <button
                   onClick={handleExport}

--- a/frontend/src/pages/SharedReviewPage.tsx
+++ b/frontend/src/pages/SharedReviewPage.tsx
@@ -1,0 +1,94 @@
+import React, { useEffect, useState } from 'react'
+import { useParams } from 'react-router-dom'
+import { Loader } from 'lucide-react'
+import { ReviewSection } from '../components/ReviewSection'
+import { apiClient } from '../services/api'
+import { PublicReview } from '../types'
+
+/**
+ * Public, read-only view of a shared review summary.
+ *
+ * Rendered at `/shared/:shareToken` outside the authenticated area so anyone
+ * with the link can view a sanitized review without logging in.
+ */
+export const SharedReviewPage: React.FC = () => {
+  const { shareToken } = useParams<{ shareToken: string }>()
+  const [review, setReview] = useState<PublicReview | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    const fetchSharedReview = async () => {
+      if (!shareToken) return
+      try {
+        const data = await apiClient.getSharedReview(shareToken)
+        setReview(data)
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'This shared review is not available')
+      } finally {
+        setIsLoading(false)
+      }
+    }
+    fetchSharedReview()
+  }, [shareToken])
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        {isLoading && (
+          <div className="mb-12 p-8 bg-white rounded-lg shadow text-center">
+            <Loader className="w-8 h-8 animate-spin text-blue-600 mx-auto mb-4" />
+            <p className="text-gray-900 font-semibold">Loading shared review...</p>
+          </div>
+        )}
+
+        {error && (
+          <div className="mb-6 p-4 bg-red-50 border border-red-200 rounded-lg">
+            <p className="text-sm text-red-800">{error}</p>
+          </div>
+        )}
+
+        {review && review.status === 'complete' && (
+          <>
+            <div className="mb-8">
+              <h1 className="text-3xl font-bold text-gray-900">Portfolio Review</h1>
+              <p className="text-gray-600 text-sm mt-1">Shared read-only summary</p>
+            </div>
+
+            {review.overall_score !== undefined && (
+              <div className="mb-8 bg-white rounded-lg shadow p-8">
+                <h2 className="text-lg font-semibold text-gray-900 mb-4">Overall Score</h2>
+                <div className="w-full bg-gray-200 rounded-full h-4 overflow-hidden">
+                  <div
+                    className="h-full bg-blue-600 transition-all"
+                    style={{ width: `${review.overall_score * 100}%` }}
+                  ></div>
+                </div>
+                <p className="mt-2 text-2xl font-bold text-blue-600">
+                  {Math.round(review.overall_score * 100)}/100
+                </p>
+              </div>
+            )}
+
+            <div className="space-y-6">
+              <h2 className="text-2xl font-bold text-gray-900">Feedback</h2>
+              {review.sections && review.sections.length > 0 ? (
+                review.sections.map((section, index) => (
+                  <ReviewSection key={index} section={section} />
+                ))
+              ) : (
+                <p className="text-gray-600">No feedback sections available</p>
+              )}
+            </div>
+          </>
+        )}
+
+        {review && review.status !== 'complete' && !error && (
+          <div className="mb-12 p-8 bg-white rounded-lg shadow text-center">
+            <p className="text-gray-900 font-semibold">This review is not ready to view yet.</p>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,4 +1,11 @@
-import { AuthResponse, Profile, Review, ReviewListResponse } from '../types'
+import {
+  AuthResponse,
+  Profile,
+  Review,
+  ReviewListResponse,
+  ShareTokenResponse,
+  PublicReview,
+} from '../types'
 
 const API_BASE = '/api'
 
@@ -109,6 +116,16 @@ class ApiClient {
 
   async listReviews(page: number = 1, pageSize: number = 10): Promise<ReviewListResponse> {
     return this.request(`/reviews?page=${page}&page_size=${pageSize}`)
+  }
+
+  // Generate (or reuse) a public share link for an owned review.
+  async createShareLink(reviewId: string): Promise<ShareTokenResponse> {
+    return this.request(`/reviews/${reviewId}/share`, { method: 'POST' })
+  }
+
+  // Fetch a sanitized shared review by its public token (no auth required).
+  async getSharedReview(shareToken: string): Promise<PublicReview> {
+    return this.request(`/reviews/share/${shareToken}`)
   }
 
   async deleteProfile(id: string): Promise<void> {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -41,3 +41,17 @@ export interface AuthResponse {
   access_token: string
   token_type: string
 }
+
+export interface ShareTokenResponse {
+  share_token: string
+  share_url: string
+}
+
+// Sanitized review returned by the public share endpoint (no owner fields).
+export interface PublicReview {
+  id: string
+  status: 'pending' | 'processing' | 'complete' | 'failed'
+  overall_score?: number
+  sections?: FeedbackSection[]
+  created_at: string
+}

--- a/tests/unit/test_review_service.py
+++ b/tests/unit/test_review_service.py
@@ -2,13 +2,15 @@
 
 import pytest
 from uuid import uuid4
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 import asyncio
 
 from core.services.review_service import (
     create_review,
     get_review,
     list_reviews,
+    create_or_get_share_token,
+    get_review_by_share_token,
 )
 
 
@@ -338,3 +340,139 @@ class TestReviewService:
 
         # Should order by created_at descending
         mock_db_session.execute.assert_called_once()
+
+
+@pytest.mark.unit
+class TestReviewSharing:
+    """Test suite for public share-token generation and lookup (issue #101)."""
+
+    @pytest.fixture
+    def mock_db_session(self):
+        """Create a mock async database session."""
+        session = AsyncMock()
+        session.add = Mock()
+        session.commit = AsyncMock()
+        session.refresh = AsyncMock()
+        session.execute = AsyncMock()
+        return session
+
+    def _result_with_first(self, value):
+        """Build a synchronous execute() result whose scalars().first() == value.
+
+        The service calls ``result.scalars().first()`` synchronously, so the
+        result object must be a MagicMock (not AsyncMock) to avoid returning a
+        coroutine from ``scalars()``.
+        """
+        result = MagicMock()
+        result.scalars.return_value.first.return_value = value
+        return result
+
+    @pytest.mark.asyncio
+    async def test_create_share_token_returns_existing_token(self, mock_db_session):
+        """An already-shared review returns its existing token (idempotent)."""
+        review = Mock()
+        review.share_token = "existing-token"
+
+        with patch(
+            "core.services.review_service.get_review",
+            new=AsyncMock(return_value=review),
+        ):
+            token = await create_or_get_share_token(
+                mock_db_session, uuid4(), uuid4()
+            )
+
+        assert token == "existing-token"
+        # No new token should be persisted when one already exists.
+        mock_db_session.commit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_create_share_token_generates_new_token(self, mock_db_session):
+        """A never-shared review gets a fresh token persisted to the DB."""
+        review = Mock()
+        review.share_token = None
+
+        with patch(
+            "core.services.review_service.get_review",
+            new=AsyncMock(return_value=review),
+        ), patch(
+            "core.services.review_service.get_review_by_share_token",
+            new=AsyncMock(return_value=None),
+        ):
+            token = await create_or_get_share_token(
+                mock_db_session, uuid4(), uuid4()
+            )
+
+        assert isinstance(token, str)
+        assert len(token) >= 20  # secrets.token_urlsafe(32) is ~43 chars
+        assert review.share_token == token
+        mock_db_session.add.assert_called_once_with(review)
+        mock_db_session.commit.assert_awaited_once()
+        mock_db_session.refresh.assert_awaited_once_with(review)
+
+    @pytest.mark.asyncio
+    async def test_create_share_token_returns_none_when_not_owned(self, mock_db_session):
+        """No token is created when the review is missing or not owned."""
+        with patch(
+            "core.services.review_service.get_review",
+            new=AsyncMock(return_value=None),
+        ):
+            token = await create_or_get_share_token(
+                mock_db_session, uuid4(), uuid4()
+            )
+
+        assert token is None
+        mock_db_session.commit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_create_share_token_is_url_safe(self, mock_db_session):
+        """Generated tokens use only URL-safe characters."""
+        review = Mock()
+        review.share_token = None
+
+        with patch(
+            "core.services.review_service.get_review",
+            new=AsyncMock(return_value=review),
+        ), patch(
+            "core.services.review_service.get_review_by_share_token",
+            new=AsyncMock(return_value=None),
+        ):
+            token = await create_or_get_share_token(
+                mock_db_session, uuid4(), uuid4()
+            )
+
+        allowed = set(
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+        )
+        assert set(token) <= allowed
+
+    @pytest.mark.asyncio
+    async def test_get_review_by_share_token_returns_review(self, mock_db_session):
+        """A known token resolves to its review without any auth check."""
+        review = Mock()
+        mock_db_session.execute = AsyncMock(
+            return_value=self._result_with_first(review)
+        )
+
+        result = await get_review_by_share_token(mock_db_session, "some-token")
+
+        assert result is review
+        mock_db_session.execute.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_get_review_by_share_token_returns_none_for_unknown(self, mock_db_session):
+        """An unknown token resolves to None."""
+        mock_db_session.execute = AsyncMock(
+            return_value=self._result_with_first(None)
+        )
+
+        result = await get_review_by_share_token(mock_db_session, "nope")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_get_review_by_share_token_empty_token_short_circuits(self, mock_db_session):
+        """An empty token returns None without querying the database."""
+        result = await get_review_by_share_token(mock_db_session, "")
+
+        assert result is None
+        mock_db_session.execute.assert_not_called()


### PR DESCRIPTION
## Summary
Adds a token-based public sharing flow for portfolio reviews. An owner can click **Copy link** on a completed review to generate (or reuse) a unique share token and copy a public `/shared/{token}` URL. Anyone with that link can view a sanitized, read-only review summary without logging in, while all existing private review endpoints remain authentication-protected.

## Issue
Closes #101

## Changes
**Backend**
- Add nullable, unique, indexed `share_token` column to the `Review` model (`core/models/review.py`) + Alembic migration `003_add_share_token_to_reviews.py`.
- Add `create_or_get_share_token` (idempotent; cryptographically secure token via `secrets.token_urlsafe`, with collision retry) and `get_review_by_share_token` to `core/services/review_service.py`.
- Add `POST /reviews/{review_id}/share` (auth + ownership) returning `{share_token, share_url}`, and public `GET /reviews/share/{share_token}` returning a sanitized summary.
- Add `ShareTokenResponse` and `PublicReviewResponse` schemas (`api/schemas/review.py`); the public schema deliberately omits owner-identifying fields (`profile_id`, `error_message`).

**Frontend**
- Add `createShareLink` / `getSharedReview` client methods + `ShareTokenResponse` / `PublicReview` types.
- Add public `/shared/:shareToken` route and a read-only `SharedReviewPage`.
- Replace the ReviewPage `Share` handler with a `Copy link` flow (generates token, copies absolute URL, shows copied/error state).

**Tests**
- Add `TestReviewSharing` suite (7 unit tests) in `tests/unit/test_review_service.py`.

## Testing
- [x] Unit tests pass (`make test-unit`) — see pre-existing-failures note below
- [ ] Integration tests pass (`make test-integration`) — not run (require Docker services)
- [x] Linter passes (`make lint`) — see note below
- [x] Type checker passes (`make typecheck`) — see note below
- [x] New/updated tests cover the changes

**Pre-existing failures (unrelated to this issue).** This codebase has documented pre-existing failures in both commands. Baseline **before** my changes: `make test-unit` = 53 failed / 375 passed; `make check` fails at `ruff` (182 errors), `black` (52 files), and `mypy` (missing third-party stubs). **After** my changes: `make test-unit` = 53 failed / **382 passed** — my 7 new tests pass and the same 53 pre-existing failures remain, so **no new failures are introduced**. My new Python files are `black`-clean and the two new service functions are `ruff`/`mypy`-clean; the two new route handlers intentionally follow this file's existing FastAPI conventions (`Depends()` in defaults, `current_user.id`), so any lint/type notes they produce are the same categories already present on every pre-existing endpoint in `api/routes/reviews.py`.

## Screenshots / Demo
_N/A — backend + wiring change; manual flow: log in → open a completed review → **Copy link** → open the copied `/shared/{token}` URL in an incognito window and confirm the summary loads without auth, while `/reviews/{id}` still requires login._

## Notes for Reviewers
- Token generation uses `secrets.token_urlsafe(32)` and is idempotent — re-sharing returns the same token so existing links keep working.
- The public route is declared before `/{review_id}` and, being a distinct path shape, does not collide with existing review routes.
- Existing reviews have `share_token = NULL` until first shared (backward compatible).
