### PR TITLE
ci: add dependency vulnerability scan to CI pipeline

### DIFF
--- a/.github/audit-baseline.json
+++ b/.github/audit-baseline.json
@@ -1,0 +1,16 @@
+{
+  "_comment": "Advisories already present when the CI dependency scan was added. The scan fails only on advisory ids NOT listed here. Regenerate with `python scripts/dependency_audit.py --update-baseline` after intentionally changing dependencies. See docs/CONTRIBUTING.md.",
+  "python": [
+    "PYSEC-2026-1325",
+    "PYSEC-2026-311"
+  ],
+  "npm": [
+    "1115552",
+    "1120126",
+    "1120743",
+    "1123259",
+    "1123525",
+    "1124252",
+    "1124288"
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,3 +94,23 @@ jobs:
       - run: cd frontend && npm ci
       - name: Frontend lint and tests
         run: cd frontend && npm test -- --run
+
+  dependency-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - run: pip install -e ".[dev]"
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - run: cd frontend && npm ci
+      - name: Scan dependencies for known vulnerabilities
+        # Runs pip-audit + npm audit and fails on any advisory not recorded in
+        # .github/audit-baseline.json (see docs/CONTRIBUTING.md).
+        run: python scripts/dependency_audit.py

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -91,3 +91,65 @@ immediately. I need to confirm with the issue author whether to upgrade the
 fixable packages, use a documented allow-list of existing advisory IDs, or set a
 severity threshold. My default plan is an allow-list for existing advisories
 that still gates strictly on *newly introduced* high/critical ones.
+
+---
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the full fix. From PLAN.md: (1) added the npm scan and (2) the Python
+scan, both wired into a new `dependency-scan` CI job; (3) resolved the day-one
+baseline question by committing a generated baseline snapshot
+(`.github/audit-baseline.json`) so the gate blocks only *newly introduced*
+advisories rather than red-walling on pre-existing ones; (4) the job runs on the
+same `pull_request`/`push` triggers as the rest of the pipeline. The gating logic
+lives in a testable `scripts/dependency_audit.py` with 21 passing unit tests.
+
+**Next steps:**
+Finish the docs note (done, in `docs/CONTRIBUTING.md`), self-review against
+CONTRIBUTING, open a draft PR for peer feedback, then finalize.
+
+**Blockers:**
+None. Resolved the open baseline question with the baseline-snapshot approach
+(an auto-generated allow-list of pre-existing advisories) instead of hand-listing
+188 advisory IDs.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** _(to be added once the PR is opened)_
+
+**Branch:** `feat/128-dependency-vulnerability-scan`
+
+**What you built:**
+A CI `dependency-scan` job that runs `pip-audit` (Python) and `npm audit`
+(frontend) and fails the build when a vulnerability advisory appears that is not
+already recorded in a committed baseline (`.github/audit-baseline.json`). The
+gating logic lives in `scripts/dependency_audit.py`: it parses each scanner's
+JSON, gates npm findings at `high`/`critical` (Python advisories are gated
+regardless, since pip-audit reports no severity), and diffs against the baseline
+so only *newly introduced* advisories break the build.
+
+**Tests added or updated:**
+`tests/unit/test_dependency_audit.py` — 21 unit tests covering pip-audit and npm
+audit parsing, the severity threshold, baseline diffing, the end-to-end
+evaluation (pass when baseline covers everything; fail on a new Python or new
+high/critical npm advisory; ignore new moderate npm advisories), baseline
+load/build round-tripping, and the human-readable report.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+> Note on pre-existing failures: this checkout has failures unrelated to my
+> issue. Measured with my changes stashed vs. applied, the numbers are identical
+> except for my additions: `ruff` 161 errors → 161 (my files are clean),
+> `mypy` 5 errors → 5 (my files are outside the mypy scope), and `pytest
+> tests/unit` 375 passed / 53 failed → 396 passed / 53 failed (the 53 failures
+> are unchanged; the +21 are my new passing tests). My changes introduce **no
+> new failures** — "passes" here means "no new failures," per the Week 9
+> pre-existing-failure guidance. The new `dependency-scan` job itself is green
+> (`python scripts/dependency_audit.py` exits 0 against the committed baseline).
+
+**Draft PR feedback received from:** _(to be added — request in Slack peer-review channel)_

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -120,7 +120,7 @@ None. Resolved the open baseline question with the baseline-snapshot approach
 
 ### Check-in 2 (end of week)
 
-**PR link:** _(to be added once the PR is opened)_
+**PR link:** https://github.com/ascherj/pathreview/pull/637
 
 **Branch:** `feat/128-dependency-vulnerability-scan`
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,57 @@
+# PathReview — Module 3 Journal
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/128
+
+**Issue title:** Add a dependency vulnerability scan to the CI pipeline
+
+**Tier:** [ ] Tier 1  [ ] Tier 2  [x] Tier 3
+
+**Problem summary:**
+Right now the CI pipeline lints, type-checks, and runs tests, but nothing ever
+checks whether the project's third-party dependencies contain *known* security
+vulnerabilities. That means a Python package or npm module with a published CVE
+can be merged into `main` without anyone noticing. The fix is to add a new job
+to `.github/workflows/ci.yml` that runs `pip audit` against the Python
+dependencies and `npm audit` against the frontend's `package-lock.json`, and
+fails the build when a high-severity (or worse) advisory is found. A successful
+fix means every pull request is automatically gated on a clean dependency scan,
+so vulnerable packages are caught before merge instead of in production. This
+touches only the CI configuration and, optionally, an allow-list/threshold
+config — it does not change application code.
+
+**Branch name:** feat/128-dependency-vulnerability-scan
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger
+
+---
+
+### "Is this issue right for me?" — checklist reasoning
+
+- **Do I understand what's being asked?** Yes. The ask is concrete: add a CI
+  step that runs `pip audit` + `npm audit` and fails on high-severity findings.
+  There is no ambiguity about the desired end state.
+- **Is the scope bounded?** Yes. The issue names exactly one file to change
+  (`.github/workflows/ci.yml`). The change is additive — a new job — so it is
+  unlikely to break existing lint/typecheck/test jobs.
+- **Do I have (or can I get) the skills?** Yes. It requires reading a GitHub
+  Actions workflow and adding a job that invokes two well-documented CLI tools.
+  No changes to the Python/React application logic are required.
+- **Can I verify the fix?** Yes. Running `pip audit` and `npm audit` locally
+  reproduces what CI will do. In fact, `npm audit` on the freshly installed
+  frontend already reports 11 advisories (1 critical, 4 high), so I have a
+  real, observable signal to build the gating logic against.
+- **Scope risks I'm watching:** (1) `npm audit` finding pre-existing high-sev
+  issues means the new job would fail the build on day one — I'll need to
+  decide between fixing/upgrading those deps, adding a documented allow-list,
+  or scoping the failure threshold, and confirm the intended behavior with the
+  issue author. (2) `pip audit` needs the dependency set resolved in CI, so I'll
+  mirror how the existing jobs install deps (`pip install -e ".[dev]"`).
+  This is why the issue is rated Tier 3 / 3–5 hours rather than a trivial one.
+- **Note on tier:** This is a Tier 3 issue (higher difficulty than the Tier 1
+  recommended for a first contribution). I chose it deliberately because the
+  blast radius is small (CI-only, no app code) even though the devops surface
+  is more advanced.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -153,3 +153,94 @@ load/build round-tripping, and the human-readable report.
 > (`python scripts/dependency_audit.py` exits 0 against the committed baseline).
 
 **Draft PR feedback received from:** none (peer review waived by CodePath for this cohort)
+
+---
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No reviewer or maintainer feedback came in. CodePath confirmed that reviewer
+feedback is not a feature for the Summer 2026 cohort, and no comments or reviews
+were posted on PR #637 (https://github.com/ascherj/pathreview/pull/637) by the
+end of the week. The PR remains open and unreviewed.
+
+**How you responded:**
+No changes were warranted since no feedback arrived. Rather than let the branch
+go stale, I re-ran the full gate one more time to confirm the PR is still in a
+mergeable state: `python scripts/dependency_audit.py` exits 0 against the
+committed baseline, and my 21 unit tests still pass. If a maintainer does pick
+this up later, the two most likely review questions — "why a committed baseline
+instead of just failing on everything?" and "why are Python advisories gated
+regardless of severity?" — are already answered in the PR description and the
+Week 9 journal entry.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The hardest part wasn't the CI config — it was deciding what "correct" even
+meant given a repo that was already red. A naive `pip-audit` / `npm audit` gate
+fails on day one because the checkout ships with 188 Python advisories and 11
+npm advisories (1 critical, 4 high) that predate my change. So the real work was
+designing a gate that blocks *newly introduced* vulnerabilities without
+red-walling every unrelated PR. Landing on a committed baseline snapshot
+(`.github/audit-baseline.json`) and diffing against it took more design thought
+than the actual YAML. The second surprise was how much noise a large,
+partially-broken codebase throws at you: the checkout had 161 pre-existing
+`ruff` errors, 5 `mypy` errors, and 53 failing unit tests before I touched
+anything, so I had to carefully measure "with my changes stashed vs. applied"
+just to *prove* I introduced zero new failures. Separating my signal from the
+existing noise was harder and slower than writing the feature.
+
+**What did you learn about working in a large codebase?**
+Contributing to someone else's production code is mostly archaeology and
+restraint, not coding. On my own projects I'd have just upgraded the vulnerable
+packages — but here that would balloon the blast radius far past the issue's
+CI-only scope and risk breaking app code I don't understand. I learned to work
+*with* the existing state (baseline the known advisories) rather than try to fix
+the whole world in one PR. I also learned to mirror existing conventions instead
+of inventing my own: I wired the new `dependency-scan` job into the same
+`pull_request`/`push` triggers and dependency-install pattern (`pip install -e
+".[dev]"`) the other jobs already used, so a maintainer reads it as "one more of
+the same" rather than a foreign addition. And I learned that in a big repo,
+"passes" means "introduces no new failures," not "everything is green" — a
+distinction that doesn't exist when you own 100% of the code.
+
+**How did AI tools help — and where did they fall short?**
+AI was most useful as a fast reference for the mechanical, well-documented parts:
+the exact shape of `pip-audit` and `npm audit` JSON output, GitHub Actions job
+syntax, and scaffolding the unit tests for `scripts/dependency_audit.py`. It let
+me move quickly through the parts of the problem that were "known-answer."
+Where it fell short was the actual judgment calls — deciding that a committed
+baseline was the right pattern (vs. a hand-maintained allow-list of 188 advisory
+IDs, or a severity threshold), and figuring out that the pre-existing 53 test
+failures were unrelated to my change. Those required reading *this specific
+repo's* state and history and making a defensible engineering trade-off, which
+AI couldn't do for me because it didn't have the ground truth of what was
+already broken. AI accelerated the typing; the deciding was still mine.
+
+**What would you do differently if you started over?**
+I'd resolve the day-one baseline question earlier instead of carrying it as an
+open blocker into Week 9. I flagged it correctly in Week 8, but I spent time
+building against uncertainty before committing to the baseline-snapshot
+approach; deciding that up front would have made the implementation more direct.
+I'd also record the short Loom walkthrough I left as optional — for a CI change
+where the whole value is in the *reasoning* about scope and baselines, a
+two-minute narration would communicate the design intent far better than the
+diff alone. On issue selection, I'd make the same choice again: a Tier 3 issue
+with a small blast radius (CI-only, no app code) was a good bet.
+
+**What are you most proud of from this module?**
+That I turned a scope trap into a clean design decision. The easy version of this
+issue — "add `pip-audit` to CI" — would have produced a job that fails every PR
+on advisories nobody in this cohort introduced, and it would have been useless.
+Recognizing that the *interesting* problem was gating on the delta, and then
+building it as a testable, isolated `scripts/dependency_audit.py` with 21 unit
+tests rather than a pile of untestable shell in a YAML file, is the thing I'd
+point to. It's the difference between "made CI run a command" and "designed a
+gate the project can actually live with."

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -60,7 +60,7 @@ config — it does not change application code.
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** https://github.com/BengalPirate/pathreview/commit/ec61a72a516002736e921453a3950250d8cf101e
+**Reproduction commit link:** https://github.com/BengalPirate/pathreview/commit/74908f8
 
 **Reproduction summary:**
 I ran the exact scans the missing CI job would run, directly against the current

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -25,7 +25,7 @@ config — it does not change application code.
 
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
-**Cohort ledger:** [ ] Issue added to cohort ledger
+**Cohort ledger:** [x] Issue added to cohort ledger
 
 ---
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -55,3 +55,39 @@ config — it does not change application code.
   recommended for a first contribution). I chose it deliberately because the
   blast radius is small (CI-only, no app code) even though the devops surface
   is more advanced.
+
+---
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/BengalPirate/pathreview/commit/ec61a72a516002736e921453a3950250d8cf101e
+
+**Reproduction summary:**
+I ran the exact scans the missing CI job would run, directly against the current
+checkout. `pip-audit` on the installed Python environment exits non-zero with
+**39 vulnerable packages / 188 advisories** (e.g. `tornado`, `urllib3`,
+`transformers`, `pillow`, `cryptography`), and `npm audit --audit-level=high` in
+`frontend/` exits non-zero with **11 vulnerabilities (1 critical, 4 high)** —
+including `ws` and `react-router`. Meanwhile `.github/workflows/ci.yml` has only
+`lint`, `typecheck`, `test-unit`, `test-integration`, and `frontend` jobs, none
+of which inspect dependencies. This proves the gap: a package with a published
+CVE passes CI today.
+
+**Reproduction steps:**
+1. `cd frontend && npm audit --audit-level=high` → exit 1 (1 critical, 4 high).
+2. `pip install pip-audit && pip-audit` from the repo root → exit 1
+   (39 packages, 188 advisories).
+3. Inspect `.github/workflows/ci.yml` → confirm no `pip-audit` / `npm audit`
+   step exists in any job.
+
+**PLAN.md link:** https://github.com/BengalPirate/pathreview/blob/feat/128-dependency-vulnerability-scan/PLAN.md
+
+**Walkthrough video (recommended):** _(optional — to record via Loom)_
+
+**Blockers or open questions:**
+The main open question is the day-one baseline: the repo already carries
+pre-existing high/critical advisories, so a strict scan would fail the build
+immediately. I need to confirm with the issue author whether to upgrade the
+fixable packages, use a documented allow-list of existing advisory IDs, or set a
+severity threshold. My default plan is an allow-list for existing advisories
+that still gates strictly on *newly introduced* high/critical ones.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -152,4 +152,4 @@ load/build round-tripping, and the human-readable report.
 > pre-existing-failure guidance. The new `dependency-scan` job itself is green
 > (`python scripts/dependency_audit.py` exits 0 against the committed baseline).
 
-**Draft PR feedback received from:** _(to be added — request in Slack peer-review channel)_
+**Draft PR feedback received from:** none (peer review waived by CodePath for this cohort)

--- a/PLAN.md
+++ b/PLAN.md
@@ -76,6 +76,18 @@ No application code (Python or React) changes.
 - **Pre-existing advisories fail day one.** Reproduced: both ecosystems already
   have high/critical findings. Need author sign-off on allow-list vs. upgrade
   vs. threshold before this can merge green. *(Primary open question.)*
+- **The frontend fix is a breaking upgrade, not a patch.** The critical finding
+  is a CVSS 9.8 RCE in `vitest@1.6.1` (GHSA-5xrq-8626-4rwp — arbitrary file
+  read/execute while the Vitest UI server is listening). Remediating it (and the
+  related `vite`/`vite-node`/`esbuild` highs) is *not* a clean `npm audit fix`:
+  the dry run pulls in `vite@8`, a major version bump (46 packages added, 30
+  changed) that can break the frontend build and tests. So "just upgrade" is
+  itself a scoped task — the deps must be bumped deliberately and the frontend
+  test suite re-run, not force-fixed. This is a concrete reason the allow-list
+  path may be preferable for the initial gate, with the vite/vitest upgrade
+  tracked as follow-up work. *(Note: the RCE is dev/test-time only — it requires
+  the Vitest UI server to be running — so it is not exploitable in headless CI
+  runs or in shipped app code.)*
 - **Noise / flakiness.** Advisory databases update continuously, so a build that
   passed yesterday can fail today when a *new* CVE is published against an
   unchanged lockfile. Allow-list + clear failure messaging mitigates confusion.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,102 @@
+## Solution plan
+
+**Issue:** Add a dependency vulnerability scan to the CI pipeline —
+https://github.com/ascherj/pathreview/issues/128
+
+### Understand
+
+**Root cause.** The CI pipeline in `.github/workflows/ci.yml` runs `lint`,
+`typecheck`, `test-unit`, `test-integration`, and `frontend` jobs. None of these
+inspect third-party dependencies for *known* published vulnerabilities. There is
+no `pip-audit` step for the Python dependency set and no `npm audit` step for the
+frontend's `package-lock.json`. As a result, a Python package or npm module with
+a published CVE can be merged into `main` with a fully green build.
+
+**Expected vs. actual.**
+- *Expected:* every pull request is automatically gated on a clean dependency
+  scan. A newly introduced high-severity (or worse) advisory fails the build
+  before merge.
+- *Actual:* dependency advisories are never checked in CI. Reproduced locally:
+  `pip-audit` reports **39 vulnerable packages / 188 advisories**, and
+  `npm audit --audit-level=high` exits non-zero with **11 vulnerabilities
+  (1 critical, 4 high)** — yet CI stays green.
+
+### Map
+
+Files I expect to touch:
+
+- **`.github/workflows/ci.yml`** *(primary)* — add a new `dependency-scan` job
+  (or two jobs / a matrix) that installs the project, runs `pip-audit` against
+  the Python dependencies and `npm audit` against `frontend/package-lock.json`,
+  and fails on a high-or-worse advisory.
+- **`.github/audit-config/`** *(optional, new)* — a documented allow-list /
+  ignore file (e.g. `pip-audit` `--ignore-vuln` IDs and an npm allow-list) so
+  that pre-existing, unfixable-today advisories don't red-wall the pipeline on
+  day one while still gating *newly introduced* ones.
+- **`pyproject.toml`** *(maybe)* — add `pip-audit` to the `[dev]` optional
+  dependencies so the tool version is pinned/reproducible rather than floating.
+- **`README.md` / `docs/`** *(maybe)* — a short note documenting the scan, the
+  chosen severity threshold, and how to update the allow-list.
+
+No application code (Python or React) changes.
+
+### Plan
+
+1. **Add the npm scan.** New job `dependency-scan-frontend` (or a step in a
+   combined job): `actions/setup-node@v4`, `cd frontend && npm ci`, then
+   `npm audit --audit-level=high`. Confirm it fails the build against the
+   current lockfile (already reproduced: 1 critical / 4 high).
+2. **Add the Python scan.** New job `dependency-scan-python`: `setup-python@v5`,
+   `pip install -e ".[dev]"` (mirroring existing jobs) plus `pip-audit`, then
+   run `pip-audit` on the resolved environment, failing on the chosen threshold.
+3. **Decide the day-one baseline.** The repo already has pre-existing high-sev
+   advisories, so a naive scan reds the pipeline immediately. Choose and
+   document one of: (a) upgrade the fixable packages, (b) an explicit,
+   commented allow-list of advisory IDs to ignore, or (c) a severity threshold —
+   and confirm the intended behavior against the issue. Default proposal:
+   allow-list existing advisories + gate strictly on *new* high/critical ones.
+4. **Wire it into the pipeline gate.** Ensure the new job(s) are required for the
+   PR to pass (they run on the same `pull_request`/`push` triggers as the rest).
+5. **Verify & document.** Re-run locally, push, confirm the job appears and
+   behaves as intended on a PR, and add a short README/docs note on the
+   threshold + how to update the allow-list.
+
+### Inputs & outputs
+
+- **Input:** the project's resolved dependency sets — the installed Python
+  environment (from `pyproject.toml` / `pip install -e ".[dev]"`) and
+  `frontend/package-lock.json` — plus the optional allow-list config.
+- **Output:** a CI job that exits non-zero (fails the build) when a
+  high-severity-or-worse advisory is present outside the allow-list, and exits
+  zero on a clean scan. No changes to runtime/app behavior. Human-readable audit
+  output in the CI logs for triage.
+
+### Risks & unknowns
+
+- **Pre-existing advisories fail day one.** Reproduced: both ecosystems already
+  have high/critical findings. Need author sign-off on allow-list vs. upgrade
+  vs. threshold before this can merge green. *(Primary open question.)*
+- **Noise / flakiness.** Advisory databases update continuously, so a build that
+  passed yesterday can fail today when a *new* CVE is published against an
+  unchanged lockfile. Allow-list + clear failure messaging mitigates confusion.
+- **`npm audit` scope.** By default it flags transitive/dev-only deps that may
+  not be exploitable at runtime; `--omit=dev` or `--production` may be more
+  appropriate — need to decide.
+- **Tool availability/pinning.** `pip-audit` must be installed in CI; pin a
+  version so results are reproducible.
+- **Network dependency.** Both tools query remote advisory DBs; a registry
+  outage could fail the job for reasons unrelated to the code.
+
+### Edge cases
+
+- **Clean scan** → job passes (exit 0), no false failure.
+- **Only low/moderate advisories** below the threshold → job passes but surfaces
+  them in logs.
+- **A high/critical advisory that is on the allow-list** → job passes; allow-list
+  entry documented with a reason/expiry.
+- **A newly introduced high/critical advisory not on the allow-list** → job
+  fails — the core behavior being added.
+- **`npm ci` / `pip install` failure** (unrelated to advisories) → job fails
+  loudly and distinguishably, not silently skipped.
+- **Empty/absent lockfile or dependency set** → job errors clearly rather than
+  falsely reporting "clean."

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -82,6 +82,36 @@ make check      # All three
 make test-unit  # Unit tests
 ```
 
+## Dependency Vulnerability Scan
+
+CI runs a `dependency-scan` job that scans third-party dependencies for known
+published advisories using [`pip-audit`](https://pypi.org/project/pip-audit/)
+(Python) and `npm audit` (frontend). The gate lives in
+`scripts/dependency_audit.py`.
+
+To keep the pipeline from red-walling on pre-existing, not-yet-fixable
+advisories, the scan compares against a committed baseline at
+`.github/audit-baseline.json`. The build fails only when a vulnerability appears
+whose advisory id is **not** already in the baseline — i.e. a *newly introduced*
+one. Python advisories are gated regardless of severity (pip-audit reports no
+severity); npm advisories are gated at `high` or `critical`.
+
+When you intentionally change dependencies and a scan flags a new advisory:
+
+1. **Preferred:** upgrade or replace the affected package so the advisory clears.
+2. **If it cannot be fixed today:** accept it by regenerating the baseline and
+   noting why in your PR description:
+
+   ```bash
+   python scripts/dependency_audit.py --update-baseline
+   ```
+
+Run the scan locally the same way CI does:
+
+```bash
+python scripts/dependency_audit.py
+```
+
 ## Adding a New Parser
 
 If your issue involves adding a new document parser to the ingestion pipeline:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dev = [
     "ruff>=0.2.0",
     "black>=24.1.0",
     "mypy>=1.8.0",
+    "pip-audit>=2.7.0",
     "pre-commit>=3.6.0",
     "mutmut>=2.4.4",
     "types-redis>=4.6.0",

--- a/scripts/dependency_audit.py
+++ b/scripts/dependency_audit.py
@@ -1,0 +1,263 @@
+"""Dependency vulnerability scan gate for CI.
+
+Runs ``pip-audit`` (Python) and ``npm audit`` (frontend) and fails the build when
+a vulnerability advisory appears that is not already recorded in the committed
+baseline at ``.github/audit-baseline.json``.
+
+The baseline captures the advisories that were already present when this gate was
+introduced, so the pipeline does not red-wall on day one over pre-existing,
+not-yet-fixable findings while still blocking *newly introduced* vulnerabilities.
+Regenerate it deliberately after intentionally changing dependencies::
+
+    python scripts/dependency_audit.py --update-baseline
+
+Severity handling differs by ecosystem: ``pip-audit`` does not emit a normalized
+severity, so every new Python advisory is gated; ``npm audit`` reports a severity
+per advisory, so only ``high`` and ``critical`` npm advisories are gated.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+BASELINE_PATH = REPO_ROOT / ".github" / "audit-baseline.json"
+FRONTEND_DIR = REPO_ROOT / "frontend"
+
+# npm severities that fail the build. Python advisories carry no severity from
+# pip-audit, so they are all gated regardless of this set.
+GATED_NPM_SEVERITIES = frozenset({"high", "critical"})
+
+
+@dataclass(frozen=True)
+class Advisory:
+    """A single vulnerability advisory reported by one of the scanners.
+
+    Attributes:
+        ecosystem: Either ``"python"`` or ``"npm"``.
+        advisory_id: The scanner's stable identifier for the advisory.
+        package: The name of the affected package.
+        severity: Lower-cased severity string, or ``""`` when unknown.
+        title: A short human-readable summary for triage output.
+    """
+
+    ecosystem: str
+    advisory_id: str
+    package: str
+    severity: str
+    title: str
+
+
+@dataclass(frozen=True)
+class Baseline:
+    """Sets of already-known advisory ids, keyed by ecosystem."""
+
+    python: frozenset[str]
+    npm: frozenset[str]
+
+
+@dataclass(frozen=True)
+class ScanResult:
+    """The advisories that are new relative to the baseline."""
+
+    new_python: list[Advisory]
+    new_npm: list[Advisory]
+
+    @property
+    def passed(self) -> bool:
+        """Return ``True`` when no new advisories were found."""
+        return not self.new_python and not self.new_npm
+
+
+def _pip_audit_dependencies(report: dict | list) -> list[dict]:
+    """Return the dependency list from a pip-audit report, tolerating formats.
+
+    Different ``pip-audit`` versions emit either a top-level ``{"dependencies":
+    [...]}`` object or a bare list of dependency records.
+    """
+    if isinstance(report, list):
+        return report
+    return report.get("dependencies", [])
+
+
+def parse_pip_audit(report: dict | list) -> list[Advisory]:
+    """Extract advisories from ``pip-audit --format=json`` output.
+
+    Args:
+        report: The parsed JSON produced by ``pip-audit``.
+
+    Returns:
+        One :class:`Advisory` per (package, vulnerability id) pair. pip-audit does
+        not provide a severity, so :attr:`Advisory.severity` is left empty.
+    """
+    advisories: list[Advisory] = []
+    for dep in _pip_audit_dependencies(report):
+        name = dep.get("name", "")
+        for vuln in dep.get("vulns", []):
+            advisory_id = vuln.get("id", "")
+            if not advisory_id:
+                continue
+            description = vuln.get("description") or ""
+            advisories.append(Advisory("python", advisory_id, name, "", description[:80]))
+    return advisories
+
+
+def parse_npm_audit(report: dict) -> list[Advisory]:
+    """Extract advisories from ``npm audit --json`` output.
+
+    Args:
+        report: The parsed JSON produced by ``npm audit`` (npm v7+ schema).
+
+    Returns:
+        One :class:`Advisory` per concrete advisory. String ``via`` entries are
+        transitive references to other advisories and are skipped so each
+        advisory is counted once at its source.
+    """
+    advisories: list[Advisory] = []
+    for package, info in report.get("vulnerabilities", {}).items():
+        for via in info.get("via", []):
+            if not isinstance(via, dict):
+                continue
+            source = via.get("source")
+            if source is None:
+                continue
+            severity = (via.get("severity") or "").lower()
+            title = via.get("title") or ""
+            advisories.append(Advisory("npm", str(source), package, severity, title[:80]))
+    return advisories
+
+
+def gated_npm(advisories: list[Advisory]) -> list[Advisory]:
+    """Return only the npm advisories at or above the gated severity."""
+    return [a for a in advisories if a.severity in GATED_NPM_SEVERITIES]
+
+
+def new_advisories(current: list[Advisory], known_ids: frozenset[str]) -> list[Advisory]:
+    """Return the advisories whose ids are not already in ``known_ids``."""
+    return [a for a in current if a.advisory_id not in known_ids]
+
+
+def evaluate(pip_report: dict | list, npm_report: dict, baseline: Baseline) -> ScanResult:
+    """Compare current scans against the baseline and report what is new.
+
+    Args:
+        pip_report: Parsed ``pip-audit`` JSON.
+        npm_report: Parsed ``npm audit`` JSON.
+        baseline: The known-advisory baseline to diff against.
+
+    Returns:
+        A :class:`ScanResult` listing the new Python and npm advisories.
+    """
+    python = parse_pip_audit(pip_report)
+    npm = gated_npm(parse_npm_audit(npm_report))
+    return ScanResult(
+        new_advisories(python, baseline.python),
+        new_advisories(npm, baseline.npm),
+    )
+
+
+def load_baseline(path: Path) -> Baseline:
+    """Load the advisory baseline, treating a missing file as empty."""
+    if not path.exists():
+        return Baseline(frozenset(), frozenset())
+    data = json.loads(path.read_text())
+    return Baseline(frozenset(data.get("python", [])), frozenset(data.get("npm", [])))
+
+
+def build_baseline(pip_report: dict | list, npm_report: dict) -> dict:
+    """Build a baseline document snapshotting all currently-present advisories."""
+    python = sorted({a.advisory_id for a in parse_pip_audit(pip_report)})
+    npm = sorted({a.advisory_id for a in gated_npm(parse_npm_audit(npm_report))})
+    return {
+        "_comment": (
+            "Advisories already present when the CI dependency scan was added. The "
+            "scan fails only on advisory ids NOT listed here. Regenerate with "
+            "`python scripts/dependency_audit.py --update-baseline` after "
+            "intentionally changing dependencies. See docs/CONTRIBUTING.md."
+        ),
+        "python": python,
+        "npm": npm,
+    }
+
+
+def format_report(result: ScanResult) -> str:
+    """Render a human-readable summary of the scan result for CI logs."""
+    if result.passed:
+        return "Dependency scan passed: no new advisories outside the baseline."
+
+    lines = ["Dependency scan FAILED: new advisories found outside the baseline.", ""]
+    for advisory in result.new_python:
+        lines.append(f"  [python] {advisory.advisory_id} {advisory.package}: {advisory.title}")
+    for advisory in result.new_npm:
+        lines.append(
+            f"  [npm/{advisory.severity}] {advisory.advisory_id} "
+            f"{advisory.package}: {advisory.title}"
+        )
+    lines += [
+        "",
+        "Fix the dependency, or, if the advisory is accepted, add its id to",
+        "`.github/audit-baseline.json` (or run with --update-baseline) with a note.",
+    ]
+    return "\n".join(lines)
+
+
+def _run_json(command: list[str], cwd: Path) -> dict:
+    """Run a scanner and parse its JSON stdout.
+
+    The scanners exit non-zero when advisories are found, so the exit code is
+    ignored; only empty output is treated as a hard failure.
+    """
+    proc = subprocess.run(command, capture_output=True, text=True, cwd=cwd)  # noqa: S603
+    if not proc.stdout.strip():
+        raise RuntimeError(
+            f"`{' '.join(command)}` produced no JSON (exit {proc.returncode}).\n"
+            f"stderr:\n{proc.stderr}"
+        )
+    return json.loads(proc.stdout)
+
+
+def run_pip_audit() -> dict:
+    """Run ``pip-audit`` against the installed environment and return its JSON."""
+    return _run_json(["pip-audit", "--format=json"], cwd=REPO_ROOT)
+
+
+def run_npm_audit() -> dict:
+    """Run ``npm audit`` in the frontend directory and return its JSON."""
+    return _run_json(["npm", "audit", "--json"], cwd=FRONTEND_DIR)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run both scanners and gate the build on new advisories.
+
+    Returns:
+        ``0`` when the scan passes (or the baseline is updated), ``1`` otherwise.
+    """
+    parser = argparse.ArgumentParser(description="CI dependency vulnerability scan gate.")
+    parser.add_argument(
+        "--update-baseline",
+        action="store_true",
+        help="Snapshot current advisories to the baseline file instead of gating.",
+    )
+    args = parser.parse_args(argv)
+
+    pip_report = run_pip_audit()
+    npm_report = run_npm_audit()
+
+    if args.update_baseline:
+        document = build_baseline(pip_report, npm_report)
+        BASELINE_PATH.write_text(json.dumps(document, indent=2) + "\n")
+        print(f"Baseline written to {BASELINE_PATH}")
+        return 0
+
+    result = evaluate(pip_report, npm_report, load_baseline(BASELINE_PATH))
+    print(format_report(result))
+    return 0 if result.passed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_dependency_audit.py
+++ b/tests/unit/test_dependency_audit.py
@@ -1,0 +1,283 @@
+"""Tests for scripts/dependency_audit.py"""
+
+import json
+
+import pytest
+
+from scripts.dependency_audit import (
+    Advisory,
+    Baseline,
+    build_baseline,
+    evaluate,
+    format_report,
+    gated_npm,
+    load_baseline,
+    new_advisories,
+    parse_npm_audit,
+    parse_pip_audit,
+)
+
+# A pip-audit --format=json report with one advisory (no severity field, as
+# pip-audit does not emit one).
+PIP_AUDIT_REPORT = {
+    "dependencies": [
+        {
+            "name": "chromadb",
+            "version": "1.5.9",
+            "vulns": [
+                {
+                    "id": "PYSEC-2026-311",
+                    "fix_versions": [],
+                    "description": "A pre-authentication code injection vulnerability.",
+                }
+            ],
+        },
+        {"name": "fastapi", "version": "0.115.0", "vulns": []},
+    ]
+}
+
+# An npm audit --json report mixing severities. String `via` entries are
+# transitive references and must not be double-counted.
+NPM_AUDIT_REPORT = {
+    "vulnerabilities": {
+        "vitest": {
+            "severity": "critical",
+            "via": [{"source": 1120126, "severity": "critical", "title": "Vitest UI RCE"}],
+        },
+        "ws": {
+            "severity": "high",
+            "via": [
+                {"source": 1123259, "severity": "high", "title": "ws DoS"},
+                {"source": 1119108, "severity": "moderate", "title": "ws memory disclosure"},
+            ],
+        },
+        "esbuild": {
+            "severity": "moderate",
+            "via": [{"source": 1102341, "severity": "moderate", "title": "esbuild dev server"}],
+        },
+        "vite": {
+            "severity": "high",
+            # Transitive reference to esbuild's advisory, plus a real one.
+            "via": ["esbuild", {"source": 1123525, "severity": "high", "title": "vite fs.deny"}],
+        },
+    }
+}
+
+
+@pytest.mark.unit
+class TestParsePipAudit:
+    """Test suite for pip-audit report parsing."""
+
+    def test_extracts_advisory_ids(self):
+        """Advisory ids are extracted for packages that have vulns."""
+        advisories = parse_pip_audit(PIP_AUDIT_REPORT)
+
+        assert [a.advisory_id for a in advisories] == ["PYSEC-2026-311"]
+        assert advisories[0].ecosystem == "python"
+        assert advisories[0].package == "chromadb"
+        assert advisories[0].severity == ""  # pip-audit provides no severity
+
+    def test_ignores_clean_packages(self):
+        """Packages with an empty vulns list contribute no advisories."""
+        advisories = parse_pip_audit(PIP_AUDIT_REPORT)
+
+        assert all(a.package != "fastapi" for a in advisories)
+
+    def test_accepts_bare_list_format(self):
+        """A top-level list of dependency records is tolerated."""
+        report = PIP_AUDIT_REPORT["dependencies"]
+
+        advisories = parse_pip_audit(report)
+
+        assert [a.advisory_id for a in advisories] == ["PYSEC-2026-311"]
+
+    def test_empty_report_yields_no_advisories(self):
+        """An empty report produces an empty list rather than crashing."""
+        assert parse_pip_audit({}) == []
+        assert parse_pip_audit({"dependencies": []}) == []
+
+
+@pytest.mark.unit
+class TestParseNpmAudit:
+    """Test suite for npm audit report parsing."""
+
+    def test_extracts_each_source_advisory(self):
+        """One advisory is produced per dict `via` entry."""
+        advisories = parse_npm_audit(NPM_AUDIT_REPORT)
+        ids = {a.advisory_id for a in advisories}
+
+        assert ids == {"1120126", "1123259", "1119108", "1102341", "1123525"}
+
+    def test_skips_string_via_references(self):
+        """String `via` entries (transitive refs) are not counted."""
+        advisories = parse_npm_audit(NPM_AUDIT_REPORT)
+
+        # "esbuild" appears as a string via under vite but must not add an entry.
+        vite_entries = [a for a in advisories if a.package == "vite"]
+        assert [a.advisory_id for a in vite_entries] == ["1123525"]
+
+    def test_severity_is_lowercased(self):
+        """Severities are normalised to lower case for comparison."""
+        advisories = parse_npm_audit(NPM_AUDIT_REPORT)
+        crit = next(a for a in advisories if a.advisory_id == "1120126")
+
+        assert crit.severity == "critical"
+
+    def test_empty_report_yields_no_advisories(self):
+        """A report with no vulnerabilities returns an empty list."""
+        assert parse_npm_audit({}) == []
+        assert parse_npm_audit({"vulnerabilities": {}}) == []
+
+
+@pytest.mark.unit
+class TestGatedNpm:
+    """Test suite for the npm severity threshold."""
+
+    def test_keeps_only_high_and_critical(self):
+        """Moderate and low advisories are dropped; high/critical are kept."""
+        gated = gated_npm(parse_npm_audit(NPM_AUDIT_REPORT))
+        ids = {a.advisory_id for a in gated}
+
+        assert ids == {"1120126", "1123259", "1123525"}  # critical + two high
+
+    def test_drops_everything_below_threshold(self):
+        """A report of only moderate advisories gates to nothing."""
+        report = {
+            "vulnerabilities": {
+                "esbuild": {"severity": "moderate", "via": [{"source": 1, "severity": "moderate"}]}
+            }
+        }
+
+        assert gated_npm(parse_npm_audit(report)) == []
+
+
+@pytest.mark.unit
+class TestNewAdvisories:
+    """Test suite for baseline diffing."""
+
+    def test_returns_only_ids_absent_from_baseline(self):
+        """Advisories already in the baseline are filtered out."""
+        current = [
+            Advisory("npm", "1123259", "ws", "high", ""),
+            Advisory("npm", "9999999", "left-pad", "high", ""),
+        ]
+
+        result = new_advisories(current, frozenset({"1123259"}))
+
+        assert [a.advisory_id for a in result] == ["9999999"]
+
+    def test_empty_baseline_returns_all(self):
+        """With no baseline, every advisory is considered new."""
+        current = [Advisory("python", "PYSEC-1", "pkg", "", "")]
+
+        assert new_advisories(current, frozenset()) == current
+
+
+@pytest.mark.unit
+class TestEvaluate:
+    """Test suite for the end-to-end evaluation against a baseline."""
+
+    def test_passes_when_baseline_covers_everything(self):
+        """A baseline covering all current advisories yields a passing result."""
+        baseline = Baseline(
+            python=frozenset({"PYSEC-2026-311"}),
+            npm=frozenset({"1120126", "1123259", "1123525"}),
+        )
+
+        result = evaluate(PIP_AUDIT_REPORT, NPM_AUDIT_REPORT, baseline)
+
+        assert result.passed
+        assert result.new_python == []
+        assert result.new_npm == []
+
+    def test_fails_on_new_python_advisory(self):
+        """A Python advisory not in the baseline fails the scan."""
+        baseline = Baseline(
+            python=frozenset(),
+            npm=frozenset({"1120126", "1123259", "1123525"}),
+        )
+
+        result = evaluate(PIP_AUDIT_REPORT, NPM_AUDIT_REPORT, baseline)
+
+        assert not result.passed
+        assert [a.advisory_id for a in result.new_python] == ["PYSEC-2026-311"]
+
+    def test_fails_on_new_high_npm_advisory(self):
+        """A new high/critical npm advisory fails the scan."""
+        baseline = Baseline(
+            python=frozenset({"PYSEC-2026-311"}),
+            npm=frozenset({"1120126", "1123259"}),  # missing the vite 'high'
+        )
+
+        result = evaluate(PIP_AUDIT_REPORT, NPM_AUDIT_REPORT, baseline)
+
+        assert not result.passed
+        assert [a.advisory_id for a in result.new_npm] == ["1123525"]
+
+    def test_ignores_new_moderate_npm_advisory(self):
+        """A brand-new moderate npm advisory does not fail the scan."""
+        report = {
+            "vulnerabilities": {
+                "left-pad": {
+                    "severity": "moderate",
+                    "via": [{"source": 8888888, "severity": "moderate", "title": "x"}],
+                }
+            }
+        }
+        baseline = Baseline(python=frozenset(), npm=frozenset())
+
+        result = evaluate({"dependencies": []}, report, baseline)
+
+        assert result.passed
+
+
+@pytest.mark.unit
+class TestBaselineIO:
+    """Test suite for loading and building the baseline document."""
+
+    def test_missing_file_loads_empty_baseline(self, tmp_path):
+        """A non-existent baseline path yields empty sets, not an error."""
+        baseline = load_baseline(tmp_path / "does-not-exist.json")
+
+        assert baseline.python == frozenset()
+        assert baseline.npm == frozenset()
+
+    def test_round_trips_through_disk(self, tmp_path):
+        """A built baseline can be written and reloaded to the same ids."""
+        document = build_baseline(PIP_AUDIT_REPORT, NPM_AUDIT_REPORT)
+        path = tmp_path / "audit-baseline.json"
+        path.write_text(json.dumps(document))
+
+        baseline = load_baseline(path)
+
+        assert baseline.python == frozenset({"PYSEC-2026-311"})
+        # Only high/critical npm ids are baselined.
+        assert baseline.npm == frozenset({"1120126", "1123259", "1123525"})
+
+    def test_build_baseline_is_documented(self):
+        """The generated baseline carries an explanatory comment."""
+        document = build_baseline(PIP_AUDIT_REPORT, NPM_AUDIT_REPORT)
+
+        assert "_comment" in document
+        assert "--update-baseline" in document["_comment"]
+
+
+@pytest.mark.unit
+class TestFormatReport:
+    """Test suite for the human-readable report."""
+
+    def test_passing_report_is_concise(self):
+        """A passing result reports success on a single line."""
+        result = evaluate({"dependencies": []}, {}, Baseline(frozenset(), frozenset()))
+
+        assert "passed" in format_report(result).lower()
+
+    def test_failing_report_lists_advisories(self):
+        """A failing result names each new advisory and how to resolve it."""
+        result = evaluate(PIP_AUDIT_REPORT, NPM_AUDIT_REPORT, Baseline(frozenset(), frozenset()))
+
+        message = format_report(result)
+
+        assert "FAILED" in message
+        assert "PYSEC-2026-311" in message
+        assert "audit-baseline.json" in message


### PR DESCRIPTION
## Summary

Adds a dependency vulnerability scan to CI. A new `dependency-scan` job runs
`pip-audit` (Python) and `npm audit` (frontend) on every pull request and push to
`main`, and fails the build when a third-party advisory appears that is not
already recorded in a committed baseline. This closes the gap where a package
with a published CVE could be merged into `main` with a fully green build.

To avoid red-walling the pipeline on day one over pre-existing, not-yet-fixable
advisories, the gate diffs current findings against a baseline snapshot
(`.github/audit-baseline.json`) and fails only on **newly introduced**
advisories. Python advisories are gated regardless of severity (pip-audit reports
none); npm advisories are gated at `high`/`critical`.

## Issue
Closes #128

## Changes
- **`scripts/dependency_audit.py`** — new, testable gate. Parses each scanner's
  JSON, applies the npm severity threshold, diffs against the baseline, prints a
  triage-friendly report, and exits non-zero on new advisories. Supports
  `--update-baseline` to re-snapshot after intentional dependency changes.
- **`.github/workflows/ci.yml`** — new `dependency-scan` job (installs the
  project + frontend, then runs the gate) on the same `pull_request`/`push`
  triggers as the other jobs.
- **`.github/audit-baseline.json`** — generated snapshot of the advisories
  present today (2 Python, 7 high/critical npm) so the gate starts green.
- **`pyproject.toml`** — pin `pip-audit>=2.7.0` in the `dev` extras.
- **`docs/CONTRIBUTING.md`** — document the scan, the severity policy, and the
  baseline-update workflow.

## Testing
- [x] Unit tests pass (`make test-unit`) — see note on pre-existing failures below
- [ ] Integration tests pass (`make test-integration`) — not run; unaffected (no app code changed, requires Docker services)
- [x] Linter passes (`make lint`) — see note below
- [x] Type checker passes (`make typecheck`) — see note below
- [x] New/updated tests cover the changes

`tests/unit/test_dependency_audit.py` adds 21 unit tests covering pip-audit / npm
audit parsing, the high/critical npm threshold, baseline diffing, the end-to-end
evaluation (pass when the baseline covers everything; fail on a new Python or new
high/critical npm advisory; ignore new moderate npm advisories), baseline
load/build round-tripping, and the report output.

I also confirmed the gate behaves end-to-end: `python scripts/dependency_audit.py`
exits `0` against the committed baseline, and removing an id from the baseline
makes it exit `1` and name the offending advisory.

### Pre-existing failures (documented)

This checkout has lint/type/test failures **unrelated to this issue**. I measured
the repo with my changes stashed vs. applied; the numbers are identical apart
from my additions, so this PR introduces **no new failures**:

| Check | Baseline (without this PR) | With this PR |
| --- | --- | --- |
| `ruff check .` | 161 errors | 161 errors (my files are clean) |
| `mypy` (app packages) | 5 errors in 4 files | 5 errors in 4 files (my files are outside the mypy scope) |
| `pytest tests/unit` | 375 passed / 53 failed | 396 passed / 53 failed (same 53; +21 new passing) |

## Notes for Reviewers
- **Baseline vs. allow-list.** I used a generated baseline snapshot rather than a
  hand-written allow-list because the pre-existing set is large and pip-audit
  doesn't emit severity. The baseline is the set of "already-known" advisory ids;
  the gate fails only on ids outside it. Regenerate with
  `python scripts/dependency_audit.py --update-baseline`.
- **The one critical npm finding** (vitest UI RCE, GHSA-5xrq-8626-4rwp) is
  dev/test-time only — it requires the Vitest UI server to be listening, so it is
  not exploitable in headless CI or shipped app code. It's baselined here and the
  `vite`/`vitest` major-version upgrade that clears it is worth tracking as
  follow-up (it pulls in `vite@8`, a breaking change).
- No application code (Python or React) changed.
