### PR TITLE
Fix health check SQLAlchemy text query

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,4 +1,4 @@
-# PathReview Contribution Journal
+# JOURNAL.md
 
 ## Week 7 — Issue selection
 
@@ -9,13 +9,33 @@
 **Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
 
 **Problem summary:**
-The database portion of the application’s health check runs a simple `SELECT 1` query to confirm that PostgreSQL is reachable. However, the query is currently passed to SQLAlchemy as a plain string, which is not accepted by SQLAlchemy 2.x for textual SQL statements. This causes the health check to report that the database is unavailable even when the database itself is running normally. A successful fix will execute the probe using SQLAlchemy’s supported textual SQL format so that the health endpoint accurately reports database availability.
 
-**Selection notes and scope reasoning:**
-I selected this issue because it is labeled Tier 1 and provides a manageable first contribution to a large multi-service codebase while still involving real backend application logic. The issue has a clear failure condition, a specific affected route, and an expected outcome that can be reproduced and tested. The likely scope is limited to the health-check implementation and its related tests, so I can investigate it without needing to redesign unrelated modules. This makes the issue challenging enough to strengthen my understanding of FastAPI and SQLAlchemy while remaining realistic to complete within the module timeline.
+The database portion of the application's health check runs a simple `SELECT 1` query to verify that PostgreSQL is reachable. However, the query is currently passed to SQLAlchemy as a plain string, which is not supported in SQLAlchemy 2.x for textual SQL statements. As a result, the health check can incorrectly report that the database is unavailable even when it is running normally. A successful fix will update the query to use SQLAlchemy's supported syntax so the health endpoint accurately reports the database status.
+
+**Why I selected this issue:**
+
+I chose this issue because it seemed like a good balance between being challenging and manageable. It focuses on a real backend bug instead of a simple documentation change, so I can learn more about SQLAlchemy and how the application's health check works. Since it is a Tier 1 issue with a clear scope, I felt it was a good first contribution to a larger open-source codebase.
 
 **Branch name:** `fix/154-health-check-sqlalchemy-text`
 
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+---
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** *(Will be added after creating the reproduction commit.)*
+
+**Reproduction summary:**
+
+I reproduced the issue by starting the PathReview application and confirming that the PostgreSQL Docker container was healthy. I then requested the `GET /health` endpoint using `curl`, and the endpoint returned HTTP 503 while reporting PostgreSQL as unhealthy even though the database container itself was running normally. I traced the behavior to `api/routes/health.py`, where the health check executes `SELECT 1` as a plain SQL string.
+
+**PLAN.md link:** *(Will be added after creating PLAN.md.)*
+
+**Walkthrough video (recommended):** Not recorded.
+
+**Blockers or open questions:**
+
+I still need to confirm the exact SQLAlchemy 2.x syntax required for executing textual SQL and determine whether any existing tests need to be updated or if a new test should be added.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,21 @@
+# PathReview Contribution Journal
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/154
+
+**Issue title:** Health check DB probe passes a raw SQL string, which fails under SQLAlchemy 2.x
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The database portion of the application’s health check runs a simple `SELECT 1` query to confirm that PostgreSQL is reachable. However, the query is currently passed to SQLAlchemy as a plain string, which is not accepted by SQLAlchemy 2.x for textual SQL statements. This causes the health check to report that the database is unavailable even when the database itself is running normally. A successful fix will execute the probe using SQLAlchemy’s supported textual SQL format so that the health endpoint accurately reports database availability.
+
+**Selection notes and scope reasoning:**
+I selected this issue because it is labeled Tier 1 and provides a manageable first contribution to a large multi-service codebase while still involving real backend application logic. The issue has a clear failure condition, a specific affected route, and an expected outcome that can be reproduced and tested. The likely scope is limited to the health-check implementation and its related tests, so I can investigate it without needing to redesign unrelated modules. This makes the issue challenging enough to strengthen my understanding of FastAPI and SQLAlchemy while remaining realistic to complete within the module timeline.
+
+**Branch name:** `fix/154-health-check-sqlalchemy-text`
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -4,38 +4,50 @@
 
 **Issue link:** https://github.com/ascherj/pathreview/issues/154
 
-**Issue title:** Health check DB probe passes a raw SQL string, which fails under SQLAlchemy 2.x
+**Issue title:** Health check DB probe should use SQLAlchemy text()
 
 **Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
 
 **Problem summary:**
 
-The database portion of the application's health check runs a simple `SELECT 1` query to verify that PostgreSQL is reachable. However, the query is currently passed to SQLAlchemy as a plain string, which is not supported in SQLAlchemy 2.x for textual SQL statements. As a result, the health check can incorrectly report that the database is unavailable even when it is running normally. A successful fix will update the query to use SQLAlchemy's supported syntax so the health endpoint accurately reports the database status.
+The database portion of the application's health check runs a simple `SELECT 1` query to verify that PostgreSQL is available. Currently, the query is passed to SQLAlchemy as a plain string, which is not compatible with SQLAlchemy 2.x. This can cause the health endpoint to incorrectly report that the database is unhealthy even when it is running normally. A successful fix will execute the query using SQLAlchemy's supported `text()` function so the health check reports the database status correctly.
 
 **Why I selected this issue:**
 
-I chose this issue because it seemed like a good balance between being challenging and manageable. It focuses on a real backend bug instead of a simple documentation change, so I can learn more about SQLAlchemy and how the application's health check works. Since it is a Tier 1 issue with a clear scope, I felt it was a good first contribution to a larger open-source codebase.
+I chose this issue because it is a good introduction to working in a larger codebase while still requiring me to understand how SQLAlchemy works. It is more meaningful than a documentation-only task and will help me learn how backend health checks interact with the database. The scope is manageable for my current experience while still challenging enough to build new skills.
 
-**Branch name:** `fix/154-health-check-sqlalchemy-text`
+**Branch name:**
 
-**Setup confirmation:** [x] App runs locally at localhost:5173
+`fix/154-health-check-sqlalchemy-text`
 
-**Cohort ledger:** [x] Issue added to cohort ledger
+**Setup confirmation:**
+
+- [x] App runs locally at `http://localhost:5173`
+
+**Cohort ledger:**
+
+- [x] Issue added to cohort ledger
 
 ---
 
-## Week 8 — Reproduction & solution planning
+# Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** *(Will be added after creating the reproduction commit.)*
+**Reproduction commit link:**
+
+https://github.com/akodali65/pathreview/commit/1cc1317
 
 **Reproduction summary:**
 
-I reproduced the issue by starting the PathReview application and confirming that the PostgreSQL Docker container was healthy. I then requested the `GET /health` endpoint using `curl`, and the endpoint returned HTTP 503 while reporting PostgreSQL as unhealthy even though the database container itself was running normally. I traced the behavior to `api/routes/health.py`, where the health check executes `SELECT 1` as a plain SQL string.
+I reproduced the issue by running the PathReview application locally and checking the `/health` endpoint using `curl`. The endpoint returned PostgreSQL as unhealthy even though the PostgreSQL Docker container was running correctly. After tracing the code, I found that `api/routes/health.py` executes `SELECT 1` as a plain SQL string, which matches the issue description.
 
-**PLAN.md link:** *(Will be added after creating PLAN.md.)*
+**PLAN.md link:**
 
-**Walkthrough video (recommended):** Not recorded.
+https://github.com/akodali65/pathreview/blob/fix/154-health-check-sqlalchemy-text/PLAN.md
+
+**Walkthrough video (recommended):**
+
+Not recorded.
 
 **Blockers or open questions:**
 
-I still need to confirm the exact SQLAlchemy 2.x syntax required for executing textual SQL and determine whether any existing tests need to be updated or if a new test should be added.
+I want to verify whether changing the query to SQLAlchemy's `text()` function is the only modification required or whether any existing tests should also be updated to reflect the new behavior.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -18,4 +18,4 @@ I selected this issue because it is labeled Tier 1 and provides a manageable fir
 
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
-**Cohort ledger:** [ ] Issue added to cohort ledger
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -51,3 +51,34 @@ Not recorded.
 **Blockers or open questions:**
 
 I want to verify whether changing the query to SQLAlchemy's `text()` function is the only modification required or whether any existing tests should also be updated to reflect the new behavior.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the fix for issue #154 by updating the PostgreSQL health check to execute `text("SELECT 1")` instead of a raw SQL string. I also created `tests/unit/test_health.py` to verify that the health check passes a SQLAlchemy `TextClause` to the database session.
+
+**Next steps:**
+Finalize the pull request description, run the focused test and code-quality checks, document the repository’s pre-existing failures, and submit the PR for review.
+
+**Blockers:**
+The repository has pre-existing unit-test and lint failures unrelated to issue #154. These failures were documented, and the focused test for this change passes.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/643
+
+**Branch:** `fix/154-health-check-sqlalchemy-text`
+
+**What you built:**
+Updated the PostgreSQL health check to wrap the `SELECT 1` query with SQLAlchemy’s `text()` function for SQLAlchemy 2.x compatibility. This prevents the health endpoint from incorrectly reporting PostgreSQL as unhealthy because of a raw SQL execution error.
+
+**Tests added or updated:**
+Created `tests/unit/test_health.py`. The test verifies that the PostgreSQL probe executes a SQLAlchemy `TextClause`, confirms that the statement is `SELECT 1`, and checks that PostgreSQL is reported as healthy when the dependency checks succeed.
+
+**Self-review confirmation:** [x] make check passes with no new failures  [x] make test-unit passes with no new failures
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -82,3 +82,41 @@ Created `tests/unit/test_health.py`. The test verifies that the PostgreSQL probe
 **Self-review confirmation:** [x] make check passes with no new failures  [x] make test-unit passes with no new failures
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & Reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+
+I did not receive any reviewer or maintainer feedback on my pull request before completing this reflection. Since no review was available, there were no comments for me to address.
+
+**How you responded:**
+
+No response or code changes were necessary because I did not receive any reviewer feedback.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+
+The hardest part was navigating a large codebase and identifying exactly where the issue originated. Although the fix itself was small, I needed to trace the health check logic in `api/routes/health.py` to understand why the PostgreSQL check was failing and how SQLAlchemy 2.x handles raw SQL execution differently.
+
+**What did you learn about working in a large codebase?**
+
+I learned that even a small contribution requires understanding the existing project structure and following its coding conventions. Instead of writing everything from scratch, I had to read existing code, understand how different components worked together, and make a focused change without affecting other parts of the application.
+
+**How did AI tools help — and where did they fall short?**
+
+AI was helpful for explaining unfamiliar code, helping me understand why SQLAlchemy requires `text("SELECT 1")`, and guiding me through the Git workflow. However, I still needed to verify the solution myself, understand the repository's structure, and make sure my implementation matched the issue requirements rather than relying entirely on AI suggestions.
+
+**What would you do differently if you started over?**
+
+If I started over, I would spend more time exploring the repository before implementing my fix. I would also read more of the project's documentation and related files first so I could better understand how the health check and database components fit together before making changes.
+
+**What are you most proud of from this module?**
+
+I am most proud of successfully contributing to a real open-source project. Completing the full workflow—from selecting an issue and creating a branch to implementing the fix, testing it, documenting my work, and submitting a pull request—gave me valuable experience with a professional software development process and increased my confidence working with an existing codebase.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,64 @@
+# Solution Plan
+
+**Issue:** Health check DB probe should use SQLAlchemy text()
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/154
+
+---
+
+## Understand
+
+The application's health check verifies that PostgreSQL is available by executing a simple `SELECT 1` query. The current implementation passes this query directly to SQLAlchemy as a plain Python string. SQLAlchemy 2.x requires textual SQL statements to be wrapped using `text()`. Because of this, the health check may incorrectly report PostgreSQL as unavailable even when the database is running normally.
+
+---
+
+## Map
+
+### Files involved
+
+- `api/routes/health.py`
+- Health check tests (if available)
+- `JOURNAL.md`
+
+---
+
+## Plan
+
+1. Reproduce the issue using the `/health` endpoint and verify that PostgreSQL is reported as unhealthy even when the Docker container is healthy.
+2. Locate the PostgreSQL health check implementation in `api/routes/health.py`.
+3. Replace the raw SQL string with SQLAlchemy's `text()` function.
+4. Verify that the health endpoint correctly reports PostgreSQL as healthy after the change.
+5. Run existing tests (or update/add a health check test if necessary) to ensure the fix works correctly.
+
+---
+
+## Inputs & Outputs
+
+### Input
+
+- GET `/health`
+- PostgreSQL database connection
+- SQLAlchemy session
+
+### Output
+
+- PostgreSQL health status is reported correctly.
+- SQLAlchemy 2.x compatibility is restored.
+- The health endpoint accurately reflects database availability.
+
+---
+
+## Risks & Unknowns
+
+- Confirm that `text()` is the only required SQLAlchemy change.
+- Determine whether automated tests already cover the health endpoint.
+- Ensure the change does not affect Redis or Vector DB health checks.
+
+---
+
+## Edge Cases
+
+- PostgreSQL is unavailable.
+- SQL execution fails.
+- PostgreSQL is healthy while another dependency is unhealthy.
+- Multiple services fail simultaneously.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,6 +1,6 @@
 # Solution Plan
 
-**Issue:** Health check DB probe should use SQLAlchemy text()
+**Issue:** Health check DB probe passes a raw SQL string, which fails under SQLAlchemy 2.x
 
 **Issue link:** https://github.com/ascherj/pathreview/issues/154
 
@@ -8,7 +8,7 @@
 
 ## Understand
 
-The application's health check verifies that PostgreSQL is available by executing a simple `SELECT 1` query. The current implementation passes this query directly to SQLAlchemy as a plain Python string. SQLAlchemy 2.x requires textual SQL statements to be wrapped using `text()`. Because of this, the health check may incorrectly report PostgreSQL as unavailable even when the database is running normally.
+The application's health check verifies that PostgreSQL is available by executing a simple `SELECT 1` query. The current implementation passes this query directly to SQLAlchemy as a plain Python string. SQLAlchemy 2.x requires textual SQL statements to be wrapped using the `text()` function. Because of this, the health check incorrectly reports PostgreSQL as unavailable even when the database is running normally. The expected behavior is for the health endpoint to accurately report the database status when PostgreSQL is healthy.
 
 ---
 
@@ -16,19 +16,19 @@ The application's health check verifies that PostgreSQL is available by executin
 
 ### Files involved
 
-- `api/routes/health.py`
-- Health check tests (if available)
-- `JOURNAL.md`
+- `api/routes/health.py` — contains the PostgreSQL health check logic that executes the database query.
+- Health check test files (if available) — verify that the health endpoint behaves correctly after the fix.
+- `PLAN.md` and `JOURNAL.md` — document the investigation, reproduction, and implementation plan.
 
 ---
 
 ## Plan
 
-1. Reproduce the issue using the `/health` endpoint and verify that PostgreSQL is reported as unhealthy even when the Docker container is healthy.
+1. Reproduce the issue by starting the application and calling the `/health` endpoint.
 2. Locate the PostgreSQL health check implementation in `api/routes/health.py`.
-3. Replace the raw SQL string with SQLAlchemy's `text()` function.
-4. Verify that the health endpoint correctly reports PostgreSQL as healthy after the change.
-5. Run existing tests (or update/add a health check test if necessary) to ensure the fix works correctly.
+3. Replace the raw SQL string with SQLAlchemy's `text()` function so the query is compatible with SQLAlchemy 2.x.
+4. Verify that the health endpoint correctly reports PostgreSQL as healthy when the database is running.
+5. Run existing tests (or add/update a health check test if necessary) to confirm the fix works correctly and prevent regressions.
 
 ---
 
@@ -36,29 +36,29 @@ The application's health check verifies that PostgreSQL is available by executin
 
 ### Input
 
-- GET `/health`
+- GET `/health` request
 - PostgreSQL database connection
-- SQLAlchemy session
+- SQLAlchemy database session
 
 ### Output
 
 - PostgreSQL health status is reported correctly.
-- SQLAlchemy 2.x compatibility is restored.
-- The health endpoint accurately reflects database availability.
+- The health endpoint accurately reflects the database availability.
+- Compatibility with SQLAlchemy 2.x is restored.
 
 ---
 
 ## Risks & Unknowns
 
-- Confirm that `text()` is the only required SQLAlchemy change.
-- Determine whether automated tests already cover the health endpoint.
-- Ensure the change does not affect Redis or Vector DB health checks.
+- Confirm that replacing the raw SQL string with `text()` fully resolves the issue.
+- Determine whether the project already includes tests for the health endpoint or whether a new test should be added.
+- Verify that the change does not affect the Redis or Vector DB health checks.
 
 ---
 
 ## Edge Cases
 
-- PostgreSQL is unavailable.
-- SQL execution fails.
-- PostgreSQL is healthy while another dependency is unhealthy.
-- Multiple services fail simultaneously.
+- PostgreSQL is unavailable or cannot be reached.
+- Executing the health check query fails even though the database connection exists.
+- PostgreSQL is healthy while another dependency (Redis or Vector DB) is unavailable.
+- Multiple services become unavailable at the same time, and the health endpoint should still report each dependency accurately.

--- a/api/routes/health.py
+++ b/api/routes/health.py
@@ -1,6 +1,10 @@
-from fastapi import APIRouter, HTTPException, status, Depends
+from datetime import datetime
+from typing import Any
+
 import structlog
-from datetime import datetime, timedelta
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from core.database import get_db
 
@@ -10,12 +14,14 @@ router = APIRouter(prefix="/health", tags=["health"])
 
 
 @router.get("")
-async def health_check(db=Depends(get_db)):
+async def health_check(
+    db: AsyncSession = Depends(get_db),  # noqa: B008
+) -> dict[str, Any]:
     """
     Check health of PostgreSQL, Redis, and Vector DB.
     Returns 200 if all healthy, 503 if any dependency is down.
     """
-    health_status = {
+    health_status: dict[str, Any] = {
         "status": "healthy",
         "dependencies": {
             "postgres": "unknown",
@@ -28,7 +34,7 @@ async def health_check(db=Depends(get_db)):
 
     try:
         # Check PostgreSQL
-        await db.execute("SELECT 1")
+        await db.execute(text("SELECT 1"))
         health_status["dependencies"]["postgres"] = "healthy"
         log.debug("postgres_health_check_passed")
     except Exception as exc:
@@ -39,6 +45,7 @@ async def health_check(db=Depends(get_db)):
     try:
         # Check Redis (if available)
         import redis
+
         from core.config import settings
 
         r = redis.Redis(

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -1,0 +1,41 @@
+"""Tests for the health-check route."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from sqlalchemy.sql.elements import TextClause
+
+from api.routes.health import health_check
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_health_check_executes_postgres_probe_as_sqlalchemy_text() -> None:
+    """Verify the PostgreSQL probe uses a SQLAlchemy TextClause."""
+    mock_db = AsyncMock()
+    mock_db.execute = AsyncMock()
+
+    mock_redis_client = Mock()
+    mock_redis_client.ping.return_value = True
+
+    mock_settings = SimpleNamespace(
+        redis_host="localhost",
+        redis_port=6379,
+        vector_db_url="http://vector-db",
+    )
+
+    with (
+        patch("redis.Redis", return_value=mock_redis_client),
+        patch("core.config.settings", mock_settings),
+    ):
+        result = await health_check(db=mock_db)
+
+    mock_db.execute.assert_awaited_once()
+
+    executed_statement = mock_db.execute.call_args.args[0]
+
+    assert isinstance(executed_statement, TextClause)
+    assert str(executed_statement) == "SELECT 1"
+    assert result["status"] == "healthy"
+    assert result["dependencies"]["postgres"] == "healthy"


### PR DESCRIPTION
## Summary

This PR updates the PostgreSQL health check to wrap the `SELECT 1` query with SQLAlchemy’s `text()` function. SQLAlchemy 2.x does not support passing a raw SQL string directly to `execute()`, which could cause the health endpoint to incorrectly report PostgreSQL as unhealthy even when the database is available.

## Issue

Closes #154

## Changes

- Imported SQLAlchemy’s `text` function in `api/routes/health.py`.
- Changed the PostgreSQL database probe from `db.execute("SELECT 1")` to `db.execute(text("SELECT 1"))`.
- Added type annotations to the health-check function and health-status dictionary.
- Added `tests/unit/test_health.py`.
- Added a focused unit test confirming that the PostgreSQL probe is executed with a SQLAlchemy `TextClause`.
- Updated `PLAN.md` to describe the SQLAlchemy 2.x compatibility problem and planned solution.

## Testing

- [ ] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`)
- [ ] Linter passes (`make lint`)
- [ ] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes

### Focused automated testing

Ran:

```bash
pytest tests/unit/test_health.py -v
```

Result:

```text
1 passed
```

Ran:

```bash
ruff check api/routes/health.py tests/unit/test_health.py
```

Result:

```text
All checks passed!
```

The pre-commit hooks also passed successfully:

- Ruff passed
- Black passed
- Mypy passed

The full `make test-unit` command currently reports 53 pre-existing failures in unrelated modules. The new health-check test passes, and this change did not introduce any new failures.

The repository-wide `make check` command also reports pre-existing lint errors in unrelated files. The files changed in this PR pass the focused Ruff check, and the commit passed the configured Ruff, Black, and mypy hooks.

### Manual verification

1. Start the PathReview application with PostgreSQL running.
2. Request the health endpoint:

```bash
curl http://localhost:8000/health
```

3. Confirm that the response reports PostgreSQL as healthy:

```json
{
  "dependencies": {
    "postgres": "healthy"
  }
}
```

4. Confirm that the health check does not fail with an SQLAlchemy error about executing a raw SQL string.

## Screenshots / Demo

Not applicable. This is a backend compatibility fix covered by a focused unit test and manual health-endpoint verification steps.

## Notes for Reviewers

Please verify that the PostgreSQL health probe is executed using a SQLAlchemy `TextClause` and that the new unit test correctly covers this behavior.

The repository currently contains unrelated pre-existing unit-test and lint failures. The focused health-check test passes, the changed files pass Ruff, and all pre-commit hooks passed.