### PR TITLE
Feat/50 test detection

### DIFF
--- a/=0.29.0
+++ b/=0.29.0
@@ -1,6 +1,0 @@
-Collecting asyncpg
-  Downloading asyncpg-0.31.0-cp314-cp314-win_amd64.whl.metadata (4.5 kB)
-Downloading asyncpg-0.31.0-cp314-cp314-win_amd64.whl (604 kB)
-   ---------------------------------------- 604.9/604.9 kB 3.0 MB/s  0:00:00
-Installing collected packages: asyncpg
-Successfully installed asyncpg-0.31.0

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -14,3 +14,15 @@ The PathReview analyzer currently does not detect whether a repository contains 
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/Alessandra005/pathreview/commit/3cfb305
+
+**Reproduction summary:**
+Created a mocked unit test (`tests/unit/test_github_tool.py`) that runs `GitHubTool.execute()` and checks that `"has_tests"` appears in the returned metadata. The test fails, showing that the field is completely missing even though the sample repo includes a `tests/` directory. The test uses mocked `httpx.get` and `httpx.head` calls so it stays offline and avoids GitHub rate limits, following the same mocking style already used in other tests under `tests/unit/`.
+
+**PLAN.md link:** https://github.com/Alessandra005/pathreview/blob/feat/50-test-detection/PLAN.md
+
+**Blockers or open questions:**
+The original issue pointed to `agent/tools/repo_analyzer.py`, but that file doesn’t exist in this project. The correct place for the fix is `GitHubTool._fetch_repo_metadata`, next to where `has_readme` is already computed. While writing the test, a separate mypy error surfaced in the `_has_readme` helper. This issue isn’t related to #50, so I’m not fixing it here, but I’m noting it in the plan for future cleanup.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -26,3 +26,36 @@ Created a mocked unit test (`tests/unit/test_github_tool.py`) that runs `GitHubT
 
 **Blockers or open questions:**
 The original issue pointed to `agent/tools/repo_analyzer.py`, but that file doesn’t exist in this project. The correct place for the fix is `GitHubTool._fetch_repo_metadata`, next to where `has_readme` is already computed. While writing the test, a separate mypy error surfaced in the `_has_readme` helper. This issue isn’t related to #50, so I’m not fixing it here, but I’m noting it in the plan for future cleanup.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1
+
+**Current progress:**
+Implemented the fix in `GitHubTool`. Added a `_has_tests(username, repo_name)` helper (modeled on `_has_readme`) that lists the repo root via the GitHub contents API and detects a `tests/` or `test/` directory, a `pytest.ini` file, or a root-level `test_*.py` file, then wired its result into `_fetch_repo_metadata` as a new `has_tests` boolean. The Week 8 reproduction test now passes. Sub-tasks 1–3 from PLAN.md are done.
+
+**Next steps:**
+Expand `tests/unit/test_github_tool.py` from the single reproduction test into a full suite covering every detection branch and the graceful-failure paths (non-200, non-list payload, network error). Run `make check` and `make test-unit`, confirm my changes add no new failures on top of the codebase's documented pre-existing ones, then open a draft PR for peer feedback.
+
+**Blockers:**
+The codebase has a large number of pre-existing `make check`/`make test-unit` failures unrelated to #50. I recorded a baseline (54 failing unit tests, 182 ruff errors, 5 mypy errors) before starting so I can prove my change doesn't make things worse.
+
+---
+
+### Check-in 2 
+
+**PR link:** https://github.com/ascherj/pathreview/pull/644
+
+**Branch:** `feat/50-test-detection`
+
+**What you built:**
+A `has_tests` boolean was added to the GitHub repo analysis output. `GitHubTool._has_tests` queries the GitHub contents API for the repository root and returns `True` when it finds a `tests/`/`test/` directory, a `pytest.ini`, or a root-level `test_*.py` file, mirroring the existing `has_readme` signal. It returns explicit booleans and swallows non-200/malformed/network errors as `False`, so it adds no new failure mode to metadata fetching.
+
+**Tests added or updated:**
+`tests/unit/test_github_tool.py` — replaced the single reproduction test with 10 unit tests: each detection branch (`tests/`, `test/`, `pytest.ini`, `test_*.py`), the no-indicator case, a negative case for non-test files that merely contain "test", the non-200 / non-list / exception fallbacks, and an end-to-end check that `execute()` surfaces `has_tests` as a boolean. All 10 pass.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+_Interpreted per the course guidance on pre-existing failures — "passes" means my changes introduce no new failures. Baseline before my change: 54 failing unit tests, 182 ruff errors, 5 mypy errors. After: 53 failing unit tests (my reproduction test now passes; +10 new tests all pass), 181 ruff errors (I fixed the one import-sort error in the file I edited), 5 mypy errors (unchanged). The two files I touched (`agent/tools/github_tool.py`, `tests/unit/test_github_tool.py`) pass `ruff`, `black`, and `mypy` cleanly. To let the touched file pass the mypy pre-commit hook I also wrapped the pre-existing `_has_readme` return in `bool()` (the `no-any-return` error noted in Week 8) — a one-line, behavior-preserving change._
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -56,6 +56,6 @@ A `has_tests` boolean was added to the GitHub repo analysis output. `GitHubTool.
 
 **Self-review confirmation:** [x] make check passes  [x] make test-unit passes
 
-_Interpreted per the course guidance on pre-existing failures — "passes" means my changes introduce no new failures. Baseline before my change: 54 failing unit tests, 182 ruff errors, 5 mypy errors. After: 53 failing unit tests (my reproduction test now passes; +10 new tests all pass), 181 ruff errors (I fixed the one import-sort error in the file I edited), 5 mypy errors (unchanged). The two files I touched (`agent/tools/github_tool.py`, `tests/unit/test_github_tool.py`) pass `ruff`, `black`, and `mypy` cleanly. To let the touched file pass the mypy pre-commit hook I also wrapped the pre-existing `_has_readme` return in `bool()` (the `no-any-return` error noted in Week 8) — a one-line, behavior-preserving change._
+_"Passes" = no new failures vs. the documented pre-existing ones. Baseline → after: unit tests 54 → 53 failing, ruff 182 → 181, mypy 5 → 5. My two files pass ruff, black, and mypy clean._
 
 **Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,16 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/50
+
+**Issue title:** Test coverage detection logic
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The PathReview analyzer currently does not detect whether a repository contains tests. This issue requires adding logic to identify test directories (tests/ or test/), pytest.ini, or files matching test_*.py. The goal is to surface a boolean field `has_tests` in the analysis output. This affects the repo analyzer and GitHub tool modules.
+
+**Branch name:** feat/50-test-detection
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -59,3 +59,34 @@ A `has_tests` boolean was added to the GitHub repo analysis output. `GitHubTool.
 _"Passes" = no new failures vs. the documented pre-existing ones. Baseline → after: unit tests 54 → 53 failing, ruff 182 → 181, mypy 5 → 5. My two files pass ruff, black, and mypy clean._
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] N/A
+
+**Summary of feedback:**
+Reviewer feedback isn't part of the Summer 2026 offering per the course note.
+
+**How you responded:**
+N/A.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The setup took more time than the fix. PowerShell broke the `pip install httpx>=0.29.0` command and made a random `=0.29.0` file. `pytest` kept running from a global Python instead of my venv. Then `pip install -e .` didn’t install `pytest` because it’s under the `[dev]` extras, so I had to use `pip install -e ".[dev]"`. I also spent part of Week 8 on the wrong branch and had to check both logs before deleting the stale one.
+
+**What did you learn about working in a large codebase?**
+The issue's own file list was wrong. It named `agent/tools/repo_analyzer.py` as one of two relevant files, and that file simply doesn't exist in this codebase. I had to trace `agent/orchestrator.py` to understand that there's no separate "analysis" layer at all; each tool just returns its own dict, and `GitHubTool`'s metadata dict is the real "repo analysis output" the issue meant. I only found the right place to add `has_tests` by grepping for how the existing `has_readme` field was implemented and matching that pattern exactly. 
+
+**How did AI tools help — and where did they fall short?**
+AI was most useful for the archaeology, pointing me at `orchestrator.py` when the issue's file reference turned out to be stale, catching that `_has_readme` used `httpx.head` while the main metadata fetch used `httpx.get`, and matching this codebase's existing test conventions instead of me guessing at a style from scratch. It also caught concrete mistakes fast such as an unclosed code fence in my PLAN.md that would've broken rendering. It fell short sometimes because it can help explain an error, but it can’t prevent the real-world setup problems. All the messy parts like PowerShell breaking the command, missing dev deps, being on the wrong branch, and mypy only failing once a test touched the module, I still had to catch by actually running things myself. It really couldn’t see any of this without me testing it on my own machine first.
+
+**What would you do differently if you started over?**
+I’d check the `[dev]` optional deps on day one and install everything with `pip install -e ".[dev]"` instead of wasting time wondering why `pytest` wasn’t there. I’d also double‑check my active branch before doing any work so I don’t repeat the Week 8 mistake of landing commits on `issue-50` instead of `feat/50-test-detection`. And I’d plan time upfront to verify the issue against the actual codebase, since the stale `repo_analyzer.py` reference cost more time than it should have.
+
+**What are you most proud of from this module?**
+Catching that the issue's stated file (`repo_analyzer.py`) didn't actually exist, instead of assuming the issue description was accurate and trying to force my fix into a file I'd have had to invent from scratch. Going and verifying the real structure of the codebase before writing PLAN.md, and documenting that discovery instead of quietly working around it. It felt like the most honest.

--- a/PLAN.md
+++ b/PLAN.md
@@ -3,7 +3,12 @@
 **Issue:** Add a `has_tests` boolean to the repo analysis output — [#50](https://github.com/Alessandra005/pathreview/issues/50)
 
 ### Understand
+The current repo metadata doesn’t indicate whether a project contains tests. This is an important quality signal we want to surface, similar to how we already report `has_readme`. Right now, the GitHubTool returns a metadata dictionary with fields like stars, forks, languages, and `has_readme`, but it never checks for test directories or test files. The fix is to extend the GitHubTool’s metadata generation so it detects common test patterns (e.g., `tests/`, `test/`, `test_*.py`) and adds a new boolean field `has_tests` to the output. Once implemented, any repo analyzed by the tool will clearly indicate whether it includes tests, improving the usefulness of the overall analysis.
 
+### Expected Behavior
+The metadata dict should include a new boolean field:
+```python
+has_tests: bool
 
 ### Map
 - `agent/tools/github_tool.py` — `_fetch_repo_metadata` builds the `metadata` dict (name, description, star_count, has_readme, etc.); this is where a `has_tests` key needs to be added, and where a new `_has_tests` helper method (mirroring the existing `_has_readme`) should live.

--- a/PLAN.md
+++ b/PLAN.md
@@ -9,6 +9,7 @@ The current repo metadata doesn’t indicate whether a project contains tests. T
 The metadata dict should include a new boolean field:
 ```python
 has_tests: bool
+```
 
 ### Map
 - `agent/tools/github_tool.py` — `_fetch_repo_metadata` builds the `metadata` dict (name, description, star_count, has_readme, etc.); this is where a `has_tests` key needs to be added, and where a new `_has_tests` helper method (mirroring the existing `_has_readme`) should live.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,34 @@
+## Solution plan
+
+**Issue:** Add a `has_tests` boolean to the repo analysis output — [#50](https://github.com/Alessandra005/pathreview/issues/50)
+
+### Understand
+
+
+### Map
+- `agent/tools/github_tool.py` — `_fetch_repo_metadata` builds the `metadata` dict (name, description, star_count, has_readme, etc.); this is where a `has_tests` key needs to be added, and where a new `_has_tests` helper method (mirroring the existing `_has_readme`) should live.
+- `tests/test_github_tool.py` (new file) — unit tests for the new `_has_tests` logic.
+
+### Plan
+1. Add a `_has_tests(self, username, repo_name)` method to `GitHubTool`, modeled on `_has_readme`: hit the GitHub contents API (`/repos/{owner}/{repo}/contents`) to list root-level files/folders, since there's no dedicated "has tests" endpoint like there is for READMEs.
+2. In that method, check the returned names for: a `tests` or `test` directory, a `pytest.ini` file, or any file matching `test_*.py`.
+3. Call `self._has_tests(username, repo_name)` inside `_fetch_repo_metadata` and add the result to the `metadata` dict as `"has_tests"`.
+4. Write unit tests in `tests/test_github_tool.py` covering: repo with a `tests/` dir, repo with `pytest.ini`, repo with root-level `test_*.py` files, and a repo with none of the above (mock the `httpx` GET call rather than hitting the real API).
+5. Manually re-run the reproduction script against a real repo and confirm `has_tests` now appears correctly.
+
+### Inputs & outputs
+**Input:** a repo path or repo file listing (already available).
+**Output:** the existing analysis output dict/object, now including one additional field: `has_tests: bool`.
+
+### Risks & unknowns
+- The GitHub contents API only lists root-level entries by default — a `test_*.py` file nested in a subfolder (not inside a `tests/` dir) would be missed unless I add a recursive call, which costs extra API requests and could hit rate limits (the tool already handles 403/rate-limit errors, so this needs to stay within that budget).
+- Case sensitivity / naming variants (e.g. `Tests/`, `spec/`, `__tests__/` for JS-style repos) aren't covered by the issue's stated detection rules — need to decide whether to go strictly by what's specified (tests/test dir, pytest.ini, test_*.py) or generalize later.
+- `_fetch_repo_metadata` already makes one extra HTTP call for `_has_readme`; adding `_has_tests` means a second extra call per analysis, which adds latency and another failure point to handle gracefully (e.g. contents endpoint 404 on an empty repo).
+- Confirmed the output is a plain dict, not a dataclass/pydantic model, so adding a new key is low-risk for existing consumers — but should still check if `market_analyzer.py` or `skill_extractor.py` assume a fixed set of keys anywhere.
+- Discovered a pre-existing mypy error in `_has_readme` (`github_tool.py:135`, "Returning Any from function declared to return bool") that surfaced only once a test started importing this module through the strict `mypy` pre-commit hook. Not caused by this change, and out of scope to fix this week, but `_has_tests` should be written carefully (likely with an explicit `bool(...)` cast) to avoid introducing the same issue.
+
+### Edge cases
+- Repo with an empty `tests/` directory (no actual test files inside) — still counts as `has_tests: true`, or should it require files inside?
+- Repo with a `test_*.py` file at the root but no `tests/` folder.
+- Repo with a `pytest.ini` but no test files at all (misconfigured repo).
+- Very large repos — performance of listing/searching for test indicators shouldn't blow up runtime.

--- a/agent/tools/github_tool.py
+++ b/agent/tools/github_tool.py
@@ -2,6 +2,7 @@
 
 import httpx
 import structlog
+
 from .base import BaseTool, ToolResult
 
 logger = structlog.get_logger()
@@ -35,44 +36,30 @@ class GitHubTool(BaseTool):
         repo_name = input_data.get("repo_name")
 
         if not username or not repo_name:
-            return ToolResult(
-                success=False,
-                data={},
-                error="Missing github_username or repo_name"
-            )
+            return ToolResult(success=False, data={}, error="Missing github_username or repo_name")
 
         try:
             repo_data = self._fetch_repo_metadata(username, repo_name)
             return ToolResult(success=True, data=repo_data)
 
         except httpx.HTTPStatusError as e:
-            logger.error("github_request_failed", status=e.response.status_code,
-                        username=username, repo=repo_name)
+            logger.error(
+                "github_request_failed",
+                status=e.response.status_code,
+                username=username,
+                repo=repo_name,
+            )
             if e.response.status_code == 404:
-                return ToolResult(
-                    success=False,
-                    data={},
-                    error="Repository not found"
-                )
+                return ToolResult(success=False, data={}, error="Repository not found")
             elif e.response.status_code == 403:
-                return ToolResult(
-                    success=False,
-                    data={},
-                    error="Rate limited or access denied"
-                )
+                return ToolResult(success=False, data={}, error="Rate limited or access denied")
             return ToolResult(
-                success=False,
-                data={},
-                error=f"GitHub API error: {e.response.status_code}"
+                success=False, data={}, error=f"GitHub API error: {e.response.status_code}"
             )
 
         except Exception as e:
             logger.error("github_tool_error", error=str(e))
-            return ToolResult(
-                success=False,
-                data={},
-                error=str(e)
-            )
+            return ToolResult(success=False, data={}, error=str(e))
 
     def _fetch_repo_metadata(self, username: str, repo_name: str) -> dict:
         """Fetch repository metadata from GitHub API.
@@ -105,12 +92,18 @@ class GitHubTool(BaseTool):
             "open_issues_count": repo_json.get("open_issues_count", 0),
             "last_commit_date": repo_json.get("pushed_at", ""),
             "has_readme": self._has_readme(username, repo_name),
+            "has_tests": self._has_tests(username, repo_name),
             "topics": repo_json.get("topics", []),
             "homepage": repo_json.get("homepage") or "",
         }
 
-        logger.info("github_repo_fetched", username=username, repo=repo_name,
-                   language=metadata["primary_language"], stars=metadata["star_count"])
+        logger.info(
+            "github_repo_fetched",
+            username=username,
+            repo=repo_name,
+            language=metadata["primary_language"],
+            stars=metadata["star_count"],
+        )
 
         return metadata
 
@@ -132,6 +125,51 @@ class GitHubTool(BaseTool):
 
         try:
             response = httpx.head(url, headers=headers, timeout=5.0)
-            return response.status_code == 200
+            return bool(response.status_code == 200)
         except Exception:
             return False
+
+    def _has_tests(self, username: str, repo_name: str) -> bool:
+        """Check if repository contains tests.
+
+        Lists the repository's root contents via the GitHub contents API
+        and looks for common Python test indicators: a ``tests`` or
+        ``test`` directory, a ``pytest.ini`` file, or a root-level file
+        matching ``test_*.py``.
+
+        Args:
+            username: GitHub username
+            repo_name: Repository name
+
+        Returns:
+            True if a test indicator is found, False otherwise
+        """
+        url = f"{self.base_url}/repos/{username}/{repo_name}/contents"
+
+        headers = {}
+        if self.api_token:
+            headers["Authorization"] = f"token {self.api_token}"
+
+        try:
+            response = httpx.get(url, headers=headers, timeout=5.0)
+            if response.status_code != 200:
+                return False
+            entries = response.json()
+        except Exception:
+            return False
+
+        if not isinstance(entries, list):
+            return False
+
+        for entry in entries:
+            name = entry.get("name", "")
+            entry_type = entry.get("type", "")
+            if entry_type == "dir" and name in ("tests", "test"):
+                return True
+            if entry_type == "file":
+                if name == "pytest.ini":
+                    return True
+                if name.startswith("test_") and name.endswith(".py"):
+                    return True
+
+        return False

--- a/tests/unit/test_github_tool.py
+++ b/tests/unit/test_github_tool.py
@@ -1,0 +1,68 @@
+"""Unit tests for GitHubTool, focused on reproducing issue #50.
+
+Reproduction for #50: GitHubTool's metadata dict has a `has_readme`
+boolean field but no `has_tests` field, even for repos that clearly
+have tests. This is documented here as a failing test rather than a
+live API call, so it runs offline and isn't subject to GitHub's rate
+limits.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.tools.github_tool import GitHubTool
+
+
+@pytest.mark.unit
+class TestGitHubToolHasTests:
+    """Reproduction tests for missing has_tests field (#50)."""
+
+    @pytest.fixture
+    def tool(self) -> GitHubTool:
+        """Create a GitHubTool instance."""
+        return GitHubTool()
+
+    @pytest.fixture
+    def mock_repo_response(self) -> dict:
+        """A minimal fake GitHub API repo response."""
+        return {
+            "name": "pathreview",
+            "description": "AI-powered portfolio review assistant",
+            "language": "Python",
+            "stargazers_count": 0,
+            "forks_count": 0,
+            "open_issues_count": 0,
+            "pushed_at": "2026-07-20T17:40:56Z",
+            "topics": [],
+            "homepage": "",
+        }
+
+    def test_metadata_has_no_has_tests_field(
+        self, tool: GitHubTool, mock_repo_response: dict
+    ) -> None:
+        """Reproduction: has_tests is entirely absent from the metadata dict.
+
+        Even though this repo has a tests/ directory at its root
+        (confirmed manually), GitHubTool never checks for or reports
+        this, unlike has_readme which is already implemented.
+        """
+        mock_repo_resp = MagicMock(status_code=200)
+        mock_repo_resp.json.return_value = mock_repo_response
+        mock_repo_resp.raise_for_status = MagicMock()
+
+        mock_readme_resp = MagicMock(status_code=200)
+
+        with patch("httpx.get", return_value=mock_repo_resp), \
+             patch("httpx.head", return_value=mock_readme_resp):
+            result = tool.execute({
+                "github_username": "Alessandra005",
+                "repo_name": "pathreview",
+            })
+
+        assert result.success is True
+        assert "has_readme" in result.data  # sanity check: sibling field exists
+        assert "has_tests" in result.data, (
+            "Reproduction of #50: 'has_tests' key is missing from the "
+            "metadata dict, even for a repo with a tests/ directory."
+        )

--- a/tests/unit/test_github_tool.py
+++ b/tests/unit/test_github_tool.py
@@ -1,10 +1,7 @@
-"""Unit tests for GitHubTool, focused on reproducing issue #50.
+"""Unit tests for GitHubTool, covering has_tests detection (issue #50).
 
-Reproduction for #50: GitHubTool's metadata dict has a `has_readme`
-boolean field but no `has_tests` field, even for repos that clearly
-have tests. This is documented here as a failing test rather than a
-live API call, so it runs offline and isn't subject to GitHub's rate
-limits.
+These tests mock the ``httpx`` calls so they run offline and are not
+subject to GitHub's rate limits.
 """
 
 from unittest.mock import MagicMock, patch
@@ -14,19 +11,91 @@ import pytest
 from agent.tools.github_tool import GitHubTool
 
 
+def _contents_response(entries: object, status_code: int = 200) -> MagicMock:
+    """Build a fake GitHub contents API response.
+
+    Args:
+        entries: Value returned by ``response.json()`` (normally a list
+            of ``{"name": ..., "type": ...}`` entries).
+        status_code: HTTP status code for the mocked response.
+
+    Returns:
+        A MagicMock standing in for an ``httpx.Response``.
+    """
+    resp = MagicMock(status_code=status_code)
+    resp.json.return_value = entries
+    return resp
+
+
 @pytest.mark.unit
 class TestGitHubToolHasTests:
-    """Reproduction tests for missing has_tests field (#50)."""
+    """Tests for GitHubTool._has_tests and the has_tests metadata field (#50)."""
 
     @pytest.fixture
     def tool(self) -> GitHubTool:
         """Create a GitHubTool instance."""
         return GitHubTool()
 
-    @pytest.fixture
-    def mock_repo_response(self) -> dict:
-        """A minimal fake GitHub API repo response."""
-        return {
+    def test_detects_tests_directory(self, tool: GitHubTool) -> None:
+        """A root-level tests/ directory counts as having tests."""
+        entries = [{"name": "tests", "type": "dir"}, {"name": "README.md", "type": "file"}]
+        with patch("httpx.get", return_value=_contents_response(entries)):
+            assert tool._has_tests("octocat", "hello-world") is True
+
+    def test_detects_test_directory_singular(self, tool: GitHubTool) -> None:
+        """A root-level test/ directory (singular) also counts."""
+        entries = [{"name": "test", "type": "dir"}]
+        with patch("httpx.get", return_value=_contents_response(entries)):
+            assert tool._has_tests("octocat", "hello-world") is True
+
+    def test_detects_pytest_ini(self, tool: GitHubTool) -> None:
+        """A pytest.ini file counts as having tests."""
+        entries = [{"name": "pytest.ini", "type": "file"}, {"name": "src", "type": "dir"}]
+        with patch("httpx.get", return_value=_contents_response(entries)):
+            assert tool._has_tests("octocat", "hello-world") is True
+
+    def test_detects_root_test_file(self, tool: GitHubTool) -> None:
+        """A root-level test_*.py file counts as having tests."""
+        entries = [{"name": "test_main.py", "type": "file"}]
+        with patch("httpx.get", return_value=_contents_response(entries)):
+            assert tool._has_tests("octocat", "hello-world") is True
+
+    def test_returns_false_when_no_test_indicators(self, tool: GitHubTool) -> None:
+        """A repo with no test dir/file/config returns False."""
+        entries = [
+            {"name": "README.md", "type": "file"},
+            {"name": "src", "type": "dir"},
+            {"name": "main.py", "type": "file"},
+        ]
+        with patch("httpx.get", return_value=_contents_response(entries)):
+            assert tool._has_tests("octocat", "hello-world") is False
+
+    def test_does_not_match_non_test_python_file(self, tool: GitHubTool) -> None:
+        """A file that merely contains 'test' in its name is not matched."""
+        entries = [{"name": "latest.py", "type": "file"}, {"name": "contest.py", "type": "file"}]
+        with patch("httpx.get", return_value=_contents_response(entries)):
+            assert tool._has_tests("octocat", "hello-world") is False
+
+    def test_returns_false_on_non_200_status(self, tool: GitHubTool) -> None:
+        """A non-200 response (e.g. empty repo 404) returns False."""
+        resp = _contents_response([], status_code=404)
+        with patch("httpx.get", return_value=resp):
+            assert tool._has_tests("octocat", "hello-world") is False
+
+    def test_returns_false_when_contents_not_a_list(self, tool: GitHubTool) -> None:
+        """The contents API returns a dict (not a list) on error payloads."""
+        resp = _contents_response({"message": "Not Found"})
+        with patch("httpx.get", return_value=resp):
+            assert tool._has_tests("octocat", "hello-world") is False
+
+    def test_returns_false_on_request_exception(self, tool: GitHubTool) -> None:
+        """Network errors are handled gracefully and return False."""
+        with patch("httpx.get", side_effect=Exception("boom")):
+            assert tool._has_tests("octocat", "hello-world") is False
+
+    def test_metadata_includes_has_tests_field(self, tool: GitHubTool) -> None:
+        """execute() surfaces has_tests as a boolean in the metadata dict (#50)."""
+        repo_json = {
             "name": "pathreview",
             "description": "AI-powered portfolio review assistant",
             "language": "Python",
@@ -37,36 +106,25 @@ class TestGitHubToolHasTests:
             "topics": [],
             "homepage": "",
         }
+        repo_resp = MagicMock(status_code=200)
+        repo_resp.json.return_value = repo_json
+        repo_resp.raise_for_status = MagicMock()
 
-    def test_metadata_has_no_has_tests_field(
-        self, tool: GitHubTool, mock_repo_response: dict
-    ) -> None:
-        """Reproduction: has_tests is entirely absent from the metadata dict.
+        contents_resp = _contents_response([{"name": "tests", "type": "dir"}])
 
-        Even though this repo has a tests/ directory at its root
-        (confirmed manually), GitHubTool never checks for or reports
-        this, unlike has_readme which is already implemented.
-        """
-        mock_repo_resp = MagicMock(status_code=200)
-        mock_repo_resp.json.return_value = mock_repo_response
-        mock_repo_resp.raise_for_status = MagicMock()
-
-        mock_readme_resp = MagicMock(status_code=200)
+        def get_dispatch(url: str, **kwargs: object) -> MagicMock:
+            """Return the contents response for the contents URL, repo JSON otherwise."""
+            if url.endswith("/contents"):
+                return contents_resp
+            return repo_resp
 
         with (
-            patch("httpx.get", return_value=mock_repo_resp),
-            patch("httpx.head", return_value=mock_readme_resp),
+            patch("httpx.get", side_effect=get_dispatch),
+            patch("httpx.head", return_value=MagicMock(status_code=200)),
         ):
-            result = tool.execute(
-                {
-                    "github_username": "Alessandra005",
-                    "repo_name": "pathreview",
-                }
-            )
+            result = tool.execute({"github_username": "Alessandra005", "repo_name": "pathreview"})
 
         assert result.success is True
-        assert "has_readme" in result.data  # sanity check: sibling field exists
-        assert "has_tests" in result.data, (
-            "Reproduction of #50: 'has_tests' key is missing from the "
-            "metadata dict, even for a repo with a tests/ directory."
-        )
+        assert "has_tests" in result.data
+        assert result.data["has_tests"] is True
+        assert isinstance(result.data["has_tests"], bool)

--- a/tests/unit/test_github_tool.py
+++ b/tests/unit/test_github_tool.py
@@ -53,12 +53,16 @@ class TestGitHubToolHasTests:
 
         mock_readme_resp = MagicMock(status_code=200)
 
-        with patch("httpx.get", return_value=mock_repo_resp), \
-             patch("httpx.head", return_value=mock_readme_resp):
-            result = tool.execute({
-                "github_username": "Alessandra005",
-                "repo_name": "pathreview",
-            })
+        with (
+            patch("httpx.get", return_value=mock_repo_resp),
+            patch("httpx.head", return_value=mock_readme_resp),
+        ):
+            result = tool.execute(
+                {
+                    "github_username": "Alessandra005",
+                    "repo_name": "pathreview",
+                }
+            )
 
         assert result.success is True
         assert "has_readme" in result.data  # sanity check: sibling field exists


### PR DESCRIPTION
## Summary
This PR adds a `has_tests` boolean to the GitHub repo analysis output. Right now the analyzer reports whether a repo has a README (`has_readme`) but says nothing about tests, even though test coverage is a strong portfolio signal. This change checks the repository for common test indicators and reports the result as a new field, so the analysis is more useful.

## Issue
Closes #50

## Changes
- Added a `_has_tests(username, repo_name)` helper to `GitHubTool`, built the same way as the existing `_has_readme` helper.
- The helper lists the repo's root files through the GitHub contents API and returns `True` if it finds a `tests/` or `test/` directory, a `pytest.ini` file, or a root-level `test_*.py` file.
- Added the result to the metadata dict as a new `has_tests` field, right next to `has_readme`.
- Made the helper safe: if the API returns an error, an unexpected shape, or the network fails, it just returns `False` instead of crashing.

## Testing
- [x] Unit tests pass (`make test-unit`) — see note below
- [x] Linter passes (`make lint`) — see note below
- [x] Type checker passes (`make typecheck`) — see note below
- [x] New/updated tests cover the changes

## Screenshots / Demo
Not applicable.

## Notes for Reviewers
I added 10 unit tests in `tests/unit/test_github_tool.py` covering each detection case (`tests/`, `test/`, `pytest.ini`, `test_*.py`), the "no tests" case, a file that only looks like a test (e.g. `latest.py`), the error/fallback paths, and an end-to-end check that `execute()` returns `has_tests` as a boolean. All 10 pass.

**About pre-existing failures:** this codebase already has failures in `make check` and `make test-unit` that are unrelated to this issue.