### PR TITLE
Fix: Skill Extractor's failure to detect JavaScript, TypeScript, Docker, Docker Compose

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -51,7 +51,7 @@ Therefore, with the above-mentioned reasoning, I decided to choose `issue #148` 
 **Reproduction commit link:** https://github.com/dineshigdd/pathreview/commit/d1bb46fb9fa2dfe219dda68c08766a321520b802
 
 **Reproduction summary:**
-Before reprodicing bugs, I analyzed the code in `skill_extractor.py` that detects JavaScript/TypeScript.
+Before reprodicing bugs, I analyzed the `extract_skills()` in `skill_extractor.py` that detects JavaScript/TypeScript.
 
 ```python
  if ".js" in str(filename or "").lower():
@@ -132,6 +132,75 @@ for index, test in enumerate(test_cases, start=1):
     print("-" * 50)
 
 ```
+
+The `issue #148` also states that the `extract_skills()` function fails the test_devops_tool_detection() test case, which includes keywords for setting up `Docker` and `Docker Compose`.
+I have reproduced this bug as follows:
+ 
+```python
+from ingestion.parsers.skill_extractor import SkillExtractor
+
+docker_false_negative_cases = [
+    {
+        "name": "Dockerfile",
+        "snippet": """
+FROM python:3.9
+RUN pip install requirements.txt
+EXPOSE 8000
+""",
+        "expected_bug": (
+            "Should detect Docker from Dockerfile directives "
+            "(FROM, RUN, EXPOSE) but does not because "
+            "the word 'docker' never appears."
+        ),
+    },
+    {
+        "name": "Docker Compose",
+        "snippet": """
+version: '3.8'
+services:
+  web:
+    build: .
+    ports:
+      - "8000:8000"
+""",
+        "expected_bug": (
+            "Should detect Docker from docker-compose syntax "
+            "(services, build, ports) but does not because "
+            "the word 'docker' never appears."
+        ),
+    },
+]
+
+e = SkillExtractor()
+
+print("=== Running Docker False Negative Reproduction Suite ===\n")
+
+for index, test in enumerate(docker_false_negative_cases, start=1):
+    skills_dict = {}
+    e._detect_tools(test["snippet"], skills_dict)
+
+    print(f"Test Case {index}: {test['name']}")
+    print(f"Detected Skills: {list(skills_dict.keys())}")
+    print(f"Expected Bug: {test['expected_bug']}")
+    print("-" * 60)
+
+```
+
+*Output*
+
+```bash
+=== Running Docker False Negative Reproduction Suite ===
+
+Test Case 1: Dockerfile
+Detected Skills: []
+Expected Bug: Should detect Docker from Dockerfile directives (FROM, RUN, EXPOSE) but does not because the word 'docker' never appears.
+------------------------------------------------------------
+Test Case 2: Docker Compose
+Detected Skills: []
+Expected Bug: Should detect Docker from docker-compose syntax (services, build, ports) but does not because the word 'docker' never appears.
+
+```
+
 The following section shows the plan to fix the issue by detecting JavaScript/TypeScript for the optimal possible solution.
 
 **PLAN.md link:** [link to PLAN.md in your fork]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -322,6 +322,6 @@ The tests added for Docker and Docker compose detection:
     | `test_docker_keywords_in_shell_script_not_detected` | Ignores lowercase `from/copy/run` keywords inside a shell script |
        
 
-**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
 
-**Draft PR feedback received from:** [name or Slack handle, or "none"]
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -68,7 +68,9 @@ In the above code, is `if re.search(r"\b(import|require)\s+", text):` the only c
 
 
 **Bug Reproduction Script:**
-```python
+```bash
+python3 <<'PY'
+
 from ingestion.parsers.skill_extractor import SkillExtractor
 
 # Comprehensive Bug Reproduction Suite for JavaScript/TypeScript Detection
@@ -132,12 +134,15 @@ for index, test in enumerate(test_cases, start=1):
     print(f"Detected Skills: {skill_names}")
     print("-" * 50)
 
+PY
 ```
 
 The `issue #148` also states that the `extract_skills()` function fails the test_devops_tool_detection() test case, which includes keywords for setting up `Docker` and `Docker Compose`.
 I have reproduced this bug as follows:
  
-```python
+```bash
+python3 <<'PY'
+
 from ingestion.parsers.skill_extractor import SkillExtractor
 
 docker_false_negative_cases = [
@@ -185,6 +190,8 @@ for index, test in enumerate(docker_false_negative_cases, start=1):
     print(f"Expected Bug: {test['expected_bug']}")
     print("-" * 60)
 
+PY
+
 ```
 
 *Output*
@@ -204,9 +211,8 @@ Expected Bug: Should detect Docker from docker-compose syntax (services, build, 
 
 The following section shows the plan to fix the issue by detecting JavaScript/TypeScript for the optimal possible solution.
 
-**PLAN.md link:** [link to PLAN.md in your fork]
+**PLAN.md link:** [My plan to fix issue #148](./PLAN.md)
 
-**Walkthrough video (recommended):** [link to your Loom video, ≤2 min — recommended, not graded]
+**Walkthrough video (recommended):** (Issue #148 : bug reproduction and planning)[https://www.loom.com/share/7b5502a57ead43c2b4d9db79e6441d73]
 
-**Blockers or open questions:**
-[Anything you're still uncertain about going into Week 9, or leave blank]
+**Blockers or open questions:** --

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -325,3 +325,65 @@ The tests added for Docker and Docker compose detection:
 **Self-review confirmation:** [x] make check passes  [x] make test-unit passes
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**  No review came in
+
+**How you responded:**
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The most difficult part of the process was setting up the local development environment. The reason for this was partly because I did not read the correct documentation related to setup and pre-existing conditions on my local machine.
+
+The biggest mistake I made in setting up the local development environment was not reading the correct documents. I initially started setting up by following the "What to Do This Week" section in the Week 7 `Show (Project) section` and using AI tools such as `Gemini`, and completely missed the `SETUP.md`. Consequently, it took me a long time to set up the local environment, and I had a lot of compatibility issues because I did not install Docker. Eventually, I found out my mistake and followed the `SETUP.md`. From that point onward, setting up became a smooth process.
+
+I was doing all the project work in Windows and used Git Bash as the terminal. This works well for a small codebase. However, this project had a large and complex codebase. With some support from AI, I decided to install the project in Linux (WSL) as it is a useful experience for future projects as well. As a result, I had to install some of the prerequisites needed for this project, such as Docker and Docker Compose, and update other requirements such as Node and Python.
+
+Other than setting up the local environment, I also found it somewhat challenging initially to understand the architecture (project structure) of the codebase. But with the resources available in the Student Hub, I overcame this challenge by first trying to gain a high-level understanding of the project structure and then navigating from the front end to the back end in detail for the specific part of the project related to the `issue #148` I tried to address.
+
+**What did you learn about working in a large codebase?**
+I think building your own project is surprisingly easier than understanding someone else's codebase. When building your own project, you know the ins and outs of the project from the beginning and you are gradually aware of how a simple project grows into a large, complex project layer by layer.
+
+On the other hand, contributing to someone else's codebase is synonymous with dropping a traveler into a thick jungle with a compass and a map. A traveler has to use their knowledge of reading maps and compasses to navigate the thick jungle. So as a developer, with knowledge in software engineering and with the assistance of documents such as `README.md`, `CONTRIBUTING.md`, and `SETUP.md`, a developer has to find their way to the section of the codebase to address the issue they are concerned with, rather than getting lost in the details and depth of the codebase and researching unnecessary sections that are not related to the issue.
+
+**How did AI tools help — and where did they fall short?**
+*How I use AI tools*  
+- Implementation phase  
+    AI tools were most useful in the implementation stage when I expanded the functionality of `_detect_languages()` for JavaScript and TypeScript detection and when I added the new function `_detect_docker` for Docker and Docker Compose detection in `skill_extractor.py`. The code generated based on the `PLAN.md` was initially not as I expected and did not detect JavaScript or TypeScript. Therefore, I revised my prompt and instructed the AI to use all the keywords in `JS_TS_KEYWORDS` and regular expressions to cover the test cases that I had planned.
+
+- Planning phase  
+    While I primarily came up with the steps myself in the planning phase, I had some assistance from AI in planning and developing test cases in `test_skill_extractor.py` . In bug reproduction, I used AI mainly to come up with the Python code after analyzing the `issue #148` thoroughly and informing the AI of the type of bug reproduction I expected.
+
+*Beyond AI*  
+- Understanding the codebase and issue  
+    While AI is immensely helpful, in understanding the codebase, issue, and planning, I used AI minimally. I found through my experience in this course that AI produces useful solutions when the prompt is more specific. Vague prompts produce broad solutions that are not very useful. Therefore, I tried to have a good understanding of the codebase and especially about the issue I tried to address without using AI, and then used AI only for validating my understanding.
+
+- Creativity in the planning phase  
+    When developing `Map` and `Plan` to create a solution for this issue, I came up with the high-level idea. As I had an in-depth understanding of the issue, I was able to come up with a fairly reasonable solution. 
+
+    When identifying limitations, unknowns, and edge cases, I came up with the high-level idea. However, I did use AI partially in refining my ideas.
+
+- Reviewing the AI code  
+    I manually reviewed and tested all the code generated by AI. This helped me instruct the AI to refine some of the code it generated, as I mentioned before with the JavaScript/TypeScript logic implementation.
+
+**What would you do differently if you started over?**
+- Issue selection  
+    I chose a beginner-friendly issue(`issue #148`). While I am satisfied with my issue selection, I would probably choose an issue related to AI if I started over. The reason for this is that I could have applied the concepts I learned in previous modules to the open-source contribution.
+
+- Refining test cases  
+    I would use AI to refine my test cases more. I used AI to come up with test cases, but if I were to start this issue or any other issue over again, I would carefully review the test cases to refine them. I had overlapping test cases in this project; I would combine those and minimize redundant test cases, with or without using AI tools.
+
+- Planning and scope  
+    When planning the solution for the issue, I focused more on improving the regular expressions and did not put much effort into identifying other JavaScript- and TypeScript-related file extensions, such as `JSX` or `TSX`. Therefore, I would address these extensions if I started over.
+
+
+**What are you most proud of from this module?**
+I am proud that I used AI as a tool without blindly accepting its outcomes for the most part. I tried to understand the codebase and the issue with minimal use of AI. I think this part is critical as it provides an opportunity for real learning about the codebase and the issue to address. This understanding helped me to address the issue effectively, and I am proud of that achievement. I am confident that I can address more challenging issues later in open-source contributions.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -283,7 +283,7 @@ When committing changes to the test files, `mypy` flagged missing type annotatio
 
 ### Check-in 2 (end of week)
 
-**PR link:** [link to your submitted pull request]
+**PR link:** https://github.com/ascherj/pathreview/pull/647
 
 **Branch:** `fix/148-skill-extractor-fails`
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -48,10 +48,9 @@ Therefore, with the above-mentioned reasoning, I decided to choose `issue #148` 
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [link to commit documenting the reproduced issue]
+**Reproduction commit link:** https://github.com/dineshigdd/pathreview/commit/d1bb46fb9fa2dfe219dda68c08766a321520b802
 
 **Reproduction summary:**
-[1–2 sentences: How did you reproduce the issue? What did you observe?]
 Before reprodicing bugs, I analyzed the code in `skill_extractor.py` that detects JavaScript/TypeScript.
 
 ```python
@@ -64,7 +63,7 @@ Before reprodicing bugs, I analyzed the code in `skill_extractor.py` that detect
         if "package.json" in text_lower:
             js_evidence.append("package.json found")
 ```
-In the above code that `if re.search(r"\b(import|require)\s+", text):` the only code-level check that can trigger JavaScript detection. Therefore, any pattern that is not deteceted by the regex `"\b(import|require)\s+` will not be counted as JavaScript. The following section shows 4 cases with some edge cases in which JavaScript is not detected.
+In the above code, is if `re.search(r"\b(import|require)\s+", text):` the only code-level check that can trigger JavaScript detection? Therefore, any pattern that is not detected by the regex `\b(import|require)\s+` will not be counted as JavaScript. The following section shows four cases --with some edge cases-- in which JavaScript is not detected
 
 
 **Bug Reproduction Script:**
@@ -133,6 +132,7 @@ for index, test in enumerate(test_cases, start=1):
     print("-" * 50)
 
 ```
+The following section shows the plan to fix the issue by detecting JavaScript/TypeScript for the optimal possible solution.
 
 **PLAN.md link:** [link to PLAN.md in your fork]
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -63,7 +63,7 @@ Before reprodicing bugs, I analyzed the code in `skill_extractor.py` that detect
         if "package.json" in text_lower:
             js_evidence.append("package.json found")
 ```
-In the above code, is if `re.search(r"\b(import|require)\s+", text):` the only code-level check that can trigger JavaScript detection? Therefore, any pattern that is not detected by the regex `\b(import|require)\s+` will not be counted as JavaScript. The following section shows four cases --with some edge cases-- in which JavaScript is not detected
+In the above code, is `if re.search(r"\b(import|require)\s+", text):` the only code-level check that can trigger JavaScript detection? Therefore, any pattern that is not detected by the regex `\b(import|require)\s+` will not be counted as JavaScript. The following section shows four cases --with some edge cases-- in which JavaScript is not detected.
 
 
 **Bug Reproduction Script:**

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -8,13 +8,37 @@
 
 **Problem summary:**
 The issue is located in the `extract_skills()` function within `ingestion/parsers/skill_extractor.py`. The function takes a text string as input for analysis. Currently, it fails to identify JavaScript-related work, and it fails to properly recognize TypeScript keywords or associated file extensions (.tsx/.ts). In the case of TypeScript, it incorrectly attributes the skills only to `React` rather than identifying the language itself. Essentially, the language detection for the JavaScript/TypeScript family is broken. 
+I exectuted the tests and found that five tests are failing 
+```bash
+FAILED tests/unit/test_skill_extractor.py::TestSkillExtractor::test_text_with_typescript_files - assert False
+FAILED tests/unit/test_skill_extractor.py::TestSkillExtractor::test_database_technology_detection - UnboundLocalError: cannot access local variable 'skill_names' where it is not associated with a value
+FAILED tests/unit/test_skill_extractor.py::TestSkillExtractor::test_devops_tool_detection - assert False
+FAILED tests/unit/test_skill_extractor.py::TestSkillExtractor::test_javascript_detection - assert False
+```
 
 A successful fix would restore the ability of the SkillExtractor to accurately parse and categorize JS/TS-related content. Specifically, it would accomplish the following:
 
 - **Comprehensive Detection:** Enable the function to recognize and return "JavaScript" as a detected skill when the input text mentions JS-related terminology or file extensions (e.g., index.js).
 
--  **Correct TypeScript Attribution:** Ensure that TypeScript keywords and files (e.g., .tsx, .ts) are correctly identified as "TypeScript" rather than defaulting only to "React."
+-  **Correct TypeScript Attribution:** Ensure that TypeScript keywords and files (e.g., .tsx, .ts) are correctly identified as "TypeScript" rather than defaulting only to "React.
 
+- **Unit Tests:** The fix must successfully pass the specified unit test cases: `test_javascript_detection`, `test_text_with_typescript_files`, `test_devops_tool_detection`, and `test_docker_compose_detection`.
+
+**Is this issue right for me:**  
+
+- **Part 1 — Understanding the Issue**  
+    As described in the problem summary section, I can explain the issue in my own words, locate the relevant files and functions affected, and clearly explain the expected outcome once the issue is fixed.
+
+- **Part 2 — Tier Fit**  
+    This is a localized issue that primarily affects the `skill_extractor.py` file. I chose a `Tier 1` issue because I have limited exposure to contributing to open-source projects, and this is the first AI-related codebase I have contributed to. The scope of the issue is a bug fix, and I am confident that my skill level and understanding of the subject are sufficient to resolve this issue.
+
+- **Part 3 — Codebase Readiness**  
+    I have found the specific parts of the codebase that cause the mentioned test cases to fail. I also looked into the test cases that pass. By comparing these tests, I have found the missing pieces of code that cause the test cases to fail. I believe at this point, I have sufficient contextual codebase knowledge to write a rough plan for fixing the issue.
+
+-   **Part 4 — Scope and Time**  
+    I checked the issue description and other related comments of this issue on the issue tracker. At the time of writing, several students are working on this issue. With my schedule, it might take me one to two weeks to complete, depending on the limited time available to me; however, I am confident I can make a PR before the deadline with relevant documentation. This issue has no open blockers or dependencies on other unresolved issues. It references only a PR that has failed to merge.
+
+Therefore, with the above-mentioned reasoning, I decided to choose `issue #148` to be fixed.  
 
 **Branch name:** fix/148-skill-extractor-fails
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -268,13 +268,16 @@ The following section shows the plan to fix the issue by detecting JavaScript/Ty
 ### Check-in 1 (mid-week)
 
 **Current progress:**
-[What have you implemented so far? Which sub-tasks from PLAN.md are done?]
+I have successfully implemented both JavaScript/TypeScript and Docker/Docker Compose detection for this issue.
+    - **JavaScript/TypeScript:** Improved the regular expression within `_detect_languages()` in `skill_extractor.py` and added corresponding unit tests in `test_skill_extractor.py`.  
+    - **Docker/Docker Compose:** Refactored the detection logic by introducing a new helper function, `_detect_docker()`, and integrating it into `_detect_tools()`. Verified these changes using comprehensive test cases in `test_skill_extractor.py`
 
 **Next steps:**
-[What are you working on for the rest of the week?]
+I will review the new code and run all added tests to ensure my modifications haven't introduced any errors. Finally, I will finalize the documentation and prepare the pull request (PR).
 
 **Blockers:**
-[Anything slowing you down? Or leave blank.]
+When committing changes to the test files, `mypy` flagged missing type annotations in both existing and newly added test functions. While these new test cases strictly follow the project guideline of **The Core Rule: Match the Existing Pattern**, `mypy` enforced stricter type-checking. Following guidance from class, this was resolved by using the `--no-verify` flag during the commit.
+
 
 ---
 
@@ -282,13 +285,42 @@ The following section shows the plan to fix the issue by detecting JavaScript/Ty
 
 **PR link:** [link to your submitted pull request]
 
-**Branch:** [the branch name you worked on, e.g. `fix/123-short-description`]
+**Branch:** `fix/148-skill-extractor-fails`
 
 **What you built:**
-[1–3 sentences summarizing what your fix does and how it works]
+I updated `_detect_languages()` in `skill_extractor.py` by expanding its regular expressions — introducing JavaScript/TypeScript keyword patterns (JS_TS_KEYWORD_PATTERNS), TypeScript syntax patterns (TS_SYNTAX_PATTERNS), and a JavaScript arrow-function pattern (JS_ARROW_PATTERN). This improves the JavaScript/TypeScript detection in `extract_skills()`, which invokes `_detect_languages()`.
+
+I also added a new function, `_detect_docker()`, in `skill_extractor.py`. It detects Dockerfile instructions and docker-compose syntax, and is invoked inside `_detect_tools()`. Because of it, `extract_skills()` — which calls `_detect_tools()` — can now recognise Docker and Docker Compose even when the literal word "docker" is absent.
 
 **Tests added or updated:**
-[Which test files did you touch? What do they cover?]
+The tests added for JavaScript/TypeScript detection:  
+    | Test case | Description |
+    | :--- | :--- |
+    | `test_javascript_es6_import_detection` | Detects ES6 `import ... from` syntax as JavaScript |
+    | `test_javascript_arrow_function_detection` | Detects arrow functions and variable declarations |
+    | `test_javascript_function_class_export_detection` | Detects `function/class/export` syntax as JavaScript |
+    | `test_plain_text_not_detected_as_javascript` | Ignores prose containing JS-like words to prevent false positives |
+    | `test_unsupported_language_not_detected_as_javascript` | Ignores Go source code to prevent misdetection as JavaScript/TypeScript |
+    | `test_missing_filename_returns_list` | Handles missing filenames with non-code text by returning a list without error |
+    | `test_empty_filename_does_not_crash` | Handles empty filename strings gracefully |
+    | `test_python_shared_keywords_not_detected_as_javascript` | Avoids collisions by keeping Python code using import/class/async/await strictly as Python |
+    | `test_malformed_snippet_does_not_crash` | Handles truncated or incomplete code by returning a list without raising an error |
+    | `test_minimal_valid_snippet_still_detected` | Guards against false negatives by successfully detecting tiny valid JS declarations |
+   
+The tests added for Docker and Docker compose detection:  
+    | Test case | Description |
+    | :--- | :--- |
+    | `test_dockerfile_copy_cmd_detection` | Detects a Dockerfile using COPY and CMD as Docker |
+    | `test_multistage_dockerfile_detection` | Detects a multi-stage Dockerfile as Docker |
+    | `test_compose_services_image_detection` | Detects a compose file using services + image |
+    | `test_compose_volumes_detection` | Detects a compose file declaring volumes |
+    | `test_non_docker_yaml_not_detected` | Ignores generic YAML with no services or Dockerfile |
+    | `test_pip_install_alone_not_detected_as_docker` | Ignores a bare pip install line to prevent misdetection |
+    | `test_partial_docker_config_does_not_crash` | Handles incomplete configs by returning a list without crashing |
+    | `test_docker_detected_in_large_multiblock_text` | Detects a Dockerfile embedded within large text blocks |
+    | `test_docker_detected_regardless_of_filename` | Identifies Docker based on its body regardless of the filename |
+    | `test_docker_keywords_in_shell_script_not_detected` | Ignores lowercase `from/copy/run` keywords inside a shell script |
+       
 
 **Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -50,7 +50,8 @@ Therefore, with the above-mentioned reasoning, I decided to choose `issue #148` 
 
 **Reproduction commit links:** 
 - https://github.com/dineshigdd/pathreview/commit/d1bb46fb9fa2dfe219dda68c08766a321520b802
-- https://github.com/dineshigdd/pathreview/commit/0518faa6cb423a0b71275b076e679baa46c1a8f8
+- https://github.com/dineshigdd/pathreview/commit/0518faa6cb423a0b71275b076e679baa46c1a8f8  
+
 **Reproduction summary:**
 Before reprodicing bugs, I analyzed the `extract_skills()` in `skill_extractor.py` that detects JavaScript/TypeScript.
 
@@ -135,7 +136,52 @@ for index, test in enumerate(test_cases, start=1):
     print("-" * 50)
 
 PY
-```
+```  
+
+*Output*  
+
+```bash
+=== Running Skill Extractor Bug Reproduction Suite ===
+
+Test Case 1: Standard ES6 Modern Syntax (No extension, no import/require)
+Code Snippet:
+const calculateTotal = (items) => {
+            let subtotal = 0;
+            var taxRate = 0.05;
+            return subtotal * taxRate;
+        };
+Detected Skills: []
+--------------------------------------------------
+Test Case 2: Traditional Function Declaration with Console Logging
+Code Snippet:
+function displayWelcomeMessage(username) {
+            console.log("Welcome back, " + username);
+        }
+Detected Skills: []
+--------------------------------------------------
+Test Case 3: ES6 Class Definition without Module Imports
+Code Snippet:
+class ShoppingCart {
+            constructor() {
+                this.items = [];
+            }
+            addItem(item) {
+                this.items.push(item);
+            }
+        }
+Detected Skills: []
+--------------------------------------------------
+Test Case 4: Asynchronous Function Using Promise/Fetch Patterns
+Code Snippet:
+async function fetchData(url) {
+            let response = await fetch(url);
+            let data = await response.json();
+            return data;
+        }
+Detected Skills: []
+--------------------------------------------------
+
+```   
 
 The `issue #148` also states that the `extract_skills()` function fails the test_devops_tool_detection() test case, which includes keywords for setting up `Docker` and `Docker Compose`.
 I have reproduced this bug as follows:
@@ -213,6 +259,6 @@ The following section shows the plan to fix the issue by detecting JavaScript/Ty
 
 **PLAN.md link:** [My plan to fix issue #148](./PLAN.md)
 
-**Walkthrough video (recommended):** (Issue #148 : bug reproduction and planning)[https://www.loom.com/share/7b5502a57ead43c2b4d9db79e6441d73]
+**Walkthrough video (recommended):** [Issue #148 : bug reproduction and planning](https://www.loom.com/share/7b5502a57ead43c2b4d9db79e6441d73)
 
 **Blockers or open questions:** --

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -48,8 +48,9 @@ Therefore, with the above-mentioned reasoning, I decided to choose `issue #148` 
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** https://github.com/dineshigdd/pathreview/commit/d1bb46fb9fa2dfe219dda68c08766a321520b802
-
+**Reproduction commit links:** 
+- https://github.com/dineshigdd/pathreview/commit/d1bb46fb9fa2dfe219dda68c08766a321520b802
+- https://github.com/dineshigdd/pathreview/commit/0518faa6cb423a0b71275b076e679baa46c1a8f8
 **Reproduction summary:**
 Before reprodicing bugs, I analyzed the `extract_skills()` in `skill_extractor.py` that detects JavaScript/TypeScript.
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -45,3 +45,98 @@ Therefore, with the above-mentioned reasoning, I decided to choose `issue #148` 
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [link to commit documenting the reproduced issue]
+
+**Reproduction summary:**
+[1–2 sentences: How did you reproduce the issue? What did you observe?]
+Before reprodicing bugs, I analyzed the code in `skill_extractor.py` that detects JavaScript/TypeScript.
+
+```python
+ if ".js" in str(filename or "").lower():
+            js_evidence.append("JavaScript file extension (.js)")
+        if ".ts" in str(filename or "").lower():
+            js_evidence.append("TypeScript file extension (.ts)")
+        if re.search(r"\b(import|require)\s+", text):
+            js_evidence.append("CommonJS or ES6 imports")
+        if "package.json" in text_lower:
+            js_evidence.append("package.json found")
+```
+In the above code that `if re.search(r"\b(import|require)\s+", text):` the only code-level check that can trigger JavaScript detection. Therefore, any pattern that is not deteceted by the regex `"\b(import|require)\s+` will not be counted as JavaScript. The following section shows 4 cases with some edge cases in which JavaScript is not detected.
+
+
+**Bug Reproduction Script:**
+```python
+from ingestion.parsers.skill_extractor import SkillExtractor
+
+# Comprehensive Bug Reproduction Suite for JavaScript/TypeScript Detection
+# This suite covers both standard JavaScript patterns and edge cases where 
+# the current heuristics (file extensions, package.json, import/require regex) fail.
+
+test_cases = [
+    {
+        "name": "Standard ES6 Modern Syntax (No extension, no import/require)",
+        "code": """
+        const calculateTotal = (items) => {
+            let subtotal = 0;
+            var taxRate = 0.05;
+            return subtotal * taxRate;
+        };
+        """
+    },
+    {
+        "name": "Traditional Function Declaration with Console Logging",
+        "code": """
+        function displayWelcomeMessage(username) {
+            console.log("Welcome back, " + username);
+        }
+        """
+    },
+    {
+        "name": "ES6 Class Definition without Module Imports",
+        "code": """
+        class ShoppingCart {
+            constructor() {
+                this.items = [];
+            }
+            addItem(item) {
+                this.items.push(item);
+            }
+        }
+        """
+    },
+    {
+        "name": "Asynchronous Function Using Promise/Fetch Patterns",
+        "code": """
+        async function fetchData(url) {
+            let response = await fetch(url);
+            let data = await response.json();
+            return data;
+        }
+        """
+    }
+]
+
+e = SkillExtractor()
+
+print("=== Running Skill Extractor Bug Reproduction Suite ===\n")
+for index, test in enumerate(test_cases, start=1):
+    detected_skills = e.extract_skills(test["code"])
+    skill_names = [d.name for d in detected_skills]
+    
+    print(f"Test Case {index}: {test['name']}")
+    print("Code Snippet:")
+    print(test["code"].strip())
+    print(f"Detected Skills: {skill_names}")
+    print("-" * 50)
+
+```
+
+**PLAN.md link:** [link to PLAN.md in your fork]
+
+**Walkthrough video (recommended):** [link to your Loom video, ≤2 min — recommended, not graded]
+
+**Blockers or open questions:**
+[Anything you're still uncertain about going into Week 9, or leave blank]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,23 @@
+## Week 7 — Issue selection
+
+**Issue link:** (https://github.com/ascherj/pathreview/issues/148)
+
+**Issue title:** Skill extractor fails to detect JavaScript and TypeScript
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The issue is located in the `extract_skills()` function within `ingestion/parsers/skill_extractor.py`. The function takes a text string as input for analysis. Currently, it fails to identify JavaScript-related work, and it fails to properly recognize TypeScript keywords or associated file extensions (.tsx/.ts). In the case of TypeScript, it incorrectly attributes the skills only to `React` rather than identifying the language itself. Essentially, the language detection for the JavaScript/TypeScript family is broken. 
+
+A successful fix would restore the ability of the SkillExtractor to accurately parse and categorize JS/TS-related content. Specifically, it would accomplish the following:
+
+- **Comprehensive Detection:** Enable the function to recognize and return "JavaScript" as a detected skill when the input text mentions JS-related terminology or file extensions (e.g., index.js).
+
+-  **Correct TypeScript Attribution:** Ensure that TypeScript keywords and files (e.g., .tsx, .ts) are correctly identified as "TypeScript" rather than defaulting only to "React."
+
+
+**Branch name:** fix/148-skill-extractor-fails
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -262,3 +262,34 @@ The following section shows the plan to fix the issue by detecting JavaScript/Ty
 **Walkthrough video (recommended):** [Issue #148 : bug reproduction and planning](https://www.loom.com/share/7b5502a57ead43c2b4d9db79e6441d73)
 
 **Blockers or open questions:** --
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+[What have you implemented so far? Which sub-tasks from PLAN.md are done?]
+
+**Next steps:**
+[What are you working on for the rest of the week?]
+
+**Blockers:**
+[Anything slowing you down? Or leave blank.]
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [link to your submitted pull request]
+
+**Branch:** [the branch name you worked on, e.g. `fix/123-short-description`]
+
+**What you built:**
+[1–3 sentences summarizing what your fix does and how it works]
+
+**Tests added or updated:**
+[Which test files did you touch? What do they cover?]
+
+**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+
+**Draft PR feedback received from:** [name or Slack handle, or "none"]

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,128 @@
+## Solution plan
+
+**Issue:** [#148 - Skill extractor fails to detect JavaScript and TypeScript](https://github.com/ascherj/pathreview/issues/148)
+
+
+### Understand
+This issue can be divided into two parts,but the root cause is similar
+
+1. Not detecting JavaScript/TypeScript
+*root cause:*  
+The following code in `_detect_languages()` function in `SkillExtractor` class detects `JavaScript/TypeScript`
+```python
+if ".js" in str(filename or "").lower():
+            js_evidence.append("JavaScript file extension (.js)")
+        if ".ts" in str(filename or "").lower():
+            js_evidence.append("TypeScript file extension (.ts)")
+        if re.search(r"\b(import|require)\s+", text):
+            js_evidence.append("CommonJS or ES6 imports")
+        if "package.json" in text_lower:
+            js_evidence.append("package.json found")
+```
+The root cause of this bug is that the regular expression `r"\b(import|require)\s"` only detects `JavaScript/TypeScript` code containing the `import` or `require` keyword followed by one or more whitespace characters. Therefore, it will detect, for example, `import React from 'react';` or `import { useState } from 'react';`, but not `const fs = require('fs');`. Additionally, it can produce false positives because `import` matches Python statements such as `import os` or `import sys`. This regular expression does not detect other keywords in `JS_TS_KEYWORDS`: `export`, `const`, `let`, `var`, `function`, `async`, `await`, and `class`. Another concern that could complicate detecting JavaScript/TypeScript is that the `JS_TS_KEYWORDS` set includes overlapping keywords (`import`, `class`, `async`, `await`) that are also present in the `PYTHON_KEYWORDS` set.
+
+
+2. Not detecting devops tools such as docker and docker compose
+*root cause:*  
+The root cause for not detecting `docker` or `docker compose` is that the `_detect_tools()` function detects DevOps tools by matching keywords in the `TOOLS` set. As issue [#148](https://github.com/ascherj/pathreview/issues/148) states, `test_devops_tool_detection` and `test_docker_compose_detection` fail. The reason for this is because these test cases do not contain the keyword `docker` (which is used in the `TOOLS` set) in the `text` variable. The following code, `detect_tools()`, is responsible for this keyword matching.
+
+```python
+for tool, confidence in self.TOOLS.items():
+            if tool in text_lower:
+                display_name = tool.upper() if tool in ["ci/cd"] else tool.title()
+```
+
+### Map
+Files I expect to touch:
+- `ingestion/parsers/skill_extractor.py` - conditional statement `if re.search(r"\b(import|require)\s+", text)` , which attempt to detecgt JavaScript/TypeScript text using keywords, of `_detect_languages()` function. I will modify this regular expression to match more complex `JavaScript/TypeScript` code.
+
+- I will add more keywords to `JS_TS_KEYWORDS` set so that logic for detecting `python` scripts will not connfuse `JavaScript/TypeScript` code
+
+- `tests/unit/test_skill_extractor.py` - I will add test cases that covers Positive cases, Negative cases,false positives,false negatives,and TypeScript-specific syntax.
+
+- In this issue resolution , I will focus on improving the logic to detect `docker` and `docker compose`. I will add special Docker detection logic using regex patterns in `_detect_tools` function. If it is neccessary I will implemnt this as separate function.
+
+- I will also add more test cases in `test_skill_extractor.py` that covers Dockerfile,Multi-stage Dockerfile,Compose, Non-Docker YAML,and pip install requirements.txt.
+
+### Plan
+**For detecting JavaScript/TypeScript**
+1. In `ingestion/parsers/skill_extractor.py`, identify the function and code within the `SkillExtractor` class that detects JavaScript/TypeScript.
+2. Improve the regular expression that detects JavaScript/TypeScript in the code identified in Step 1.
+3. Add test cases in `tests/unit/test_skill_extractor.py` to cover:
+    - Positive cases (should detect JavaScript/TypeScript)
+    - Negative cases (plain text, unsupported languages, empty/missing filenames)
+    - False positives & cross-language collisions (Python code with shared keywords)
+    - False negatives & malformed/incomplete code snippets
+    - TypeScript-specific syntax (interfaces, type annotations)
+    - Conflicting signals (mismatched filename extensions vs. code body)
+    - Size extremes (very small snippets vs. large multi-block text)
+4. Run each test case that I added in Step 3, as well as `test_mixed_language_text` in `tests/unit/test_skill_extractor.py`.
+
+
+**For detecting Docker and Docker Compose**
+1. In `ingestion/parsers/skill_extractor.py`, identify the function and the part of the code within the `SkillExtractor` class that detects Docker and Docker Compose.
+2. Improve the regular expression that detects Docker and Docker Compose tools in the code identified in Step 1.
+3. Add test cases in `tests/unit/test_skill_extractor.py` to cover:
+    - Dockerfile (`FROM`, `RUN`, `EXPOSE`)
+    - Dockerfile (`COPY`, `CMD`)
+    - Multi-stage Dockerfile
+    - Compose (`services`, `build`)
+    - Compose (`services`, `image`)
+    - Compose (`volumes`)
+    - Non-Docker YAML (negative)
+    - `pip install requirements.txt` alone (negative)
+    - Partial or malformed configurations & size extremes (small snippets vs. large multi-block files)
+    - Missing, empty, or neutral filenames providing no technology hints
+    - Contextual keyword collisions (Docker-related keywords used in non-Docker contexts like shell scripts)
+
+### Inputs & outputs
+**Functions that I'm changing:**
+- `_detect_languages(text: str, filename: Optional[str]) skills_dict: dict ) -> None:`
+- `_detect_tools(text, detected_skills)`
+
+**Existing happy path:**
+*Inputs*
+- `text`: String variable that holds JavaScript, TypeScript, Docker, and Docker Compose texts.
+- `filename`: String variable  An optional variable that contains the filenames of JavaScript or TypeScript files with the extension `.js` or `.ts`.
+- `skills_dict`: A dictionary that stores detected skills.
+
+*Output*
+- Return Value: `None`  
+Although this function returns `None`, it modifies the `skills_dict` dictionary passed to it. Specifically, it adds detected programming languages as `SkillDetection` objects, using the language name as the key and the corresponding `SkillDetection` instance as the value.
+
+For example, if JavaScript code is detected, the function may add an entry such as:
+
+```python
+skills_dict["JavaScript"] = SkillDetection(...)
+```
+
+### Risks & unknowns
+- **Cross-language keyword collision:** Broad regex patterns or shared syntax keywords (such as import, export, or class structures) risk misclassifying JavaScript or TypeScript code as Python skills. We need to ensure language parsers are scoped strictly by file extensions (e.g., .js, .ts, .py) or explicit context rather than generic keyword matching alone.
+- ***Regex limitations for full language coverage:***
+     JavaScript contains 38+ reserved keywords, and TypeScript adds numerous type-system-specific keywords. Attempting to catch every edge case or combination via regular expressions is impractical and risks high false-positive rates (particularly due to keyword overlap with Python, such as `import`, `class`, `async`, and `await`). We will focus on capturing the most common and critical patterns.
+- ***Regex limitations for Docker and Docker Compose structures:*** Dockerfiles support complex multi-line syntax, flags, and build arguments, while Docker Compose files rely on nested YAML structures that can vary significantly. Using basic regular expressions to capture every valid configuration risks missing edge cases or misclassifying generic YAML files (false positives). Therefore , we will focus on detecting high-confidence indicators like common Dockerfile instructions (`FROM`, `RUN`, `CMD`) and Compose service keys.
+
+### Edge cases
+**For langauge detection** 
+- No language indicators are present in the input text.
+- The filename is missing, empty, or uses an unsupported extension.
+- The input contains code from multiple programming languages.
+- The input contains ambiguous syntax or keywords shared across languages.
+- The filename and source code indicate different languages.
+- The input contains malformed, incomplete, or non-executable code.
+- The input contains only documentation, comments, or plain text.
+- The input contains unsupported programming languages.
+- The input is very small and contains limited evidence for language detection.
+- The input is very large and contains multiple code blocks or language indicators.
+
+**For Docker and Docker Compose detection**
+- No Docker or Docker Compose indicators are present in the input text.
+- The input contains only a partial Dockerfile or Docker Compose configuration.
+- The input contains configuration syntax that resembles Docker Compose but belongs to another YAML-based tool.
+- The input contains keywords commonly used in Docker configurations but in a non-Docker context.
+- The input contains multiple technologies or configuration formats in the same text.
+- The input contains malformed or incomplete Dockerfile or Docker Compose content.
+- The input is very small and contains limited evidence for reliable detection.
+- The input is very large and contains multiple configuration blocks.
+- The filename is unavailable, empty, or provides no indication of the underlying technology.
+- Docker-related evidence appears in the content without the literal word "Docker".

--- a/PLAN.md
+++ b/PLAN.md
@@ -33,7 +33,7 @@ This issue can be divided into two parts,but the root cause is similar
     ```
 
 ### Map
-Files I expect to touch:
+**Files I expect to touch:**
 - `ingestion/parsers/skill_extractor.py` - conditional statement `if re.search(r"\b(import|require)\s+", text)` , which attempt to detecgt JavaScript/TypeScript text using keywords, of `_detect_languages()` function. I will modify this regular expression to match more complex `JavaScript/TypeScript` code.
 
 - I will add more keywords to `JS_TS_KEYWORDS` set so that logic for detecting `python` scripts will not connfuse `JavaScript/TypeScript` code
@@ -80,7 +80,7 @@ Files I expect to touch:
 - `_detect_languages(text: str, filename: Optional[str]) skills_dict: dict ) -> None:`
 - `_detect_tools(text, detected_skills)`
 
-**Existing happy path:**
+**Existing happy path:**  
 *Inputs*
 - `text`: String variable that holds JavaScript, TypeScript, Docker, and Docker Compose texts.
 - `filename`: String variable  An optional variable that contains the filenames of JavaScript or TypeScript files with the extension `.js` or `.ts`.

--- a/PLAN.md
+++ b/PLAN.md
@@ -6,31 +6,31 @@
 ### Understand
 This issue can be divided into two parts,but the root cause is similar
 
-1. Not detecting JavaScript/TypeScript
-*root cause:*  
-The following code in `_detect_languages()` function in `SkillExtractor` class detects `JavaScript/TypeScript`
-```python
-if ".js" in str(filename or "").lower():
-            js_evidence.append("JavaScript file extension (.js)")
-        if ".ts" in str(filename or "").lower():
-            js_evidence.append("TypeScript file extension (.ts)")
-        if re.search(r"\b(import|require)\s+", text):
-            js_evidence.append("CommonJS or ES6 imports")
-        if "package.json" in text_lower:
-            js_evidence.append("package.json found")
-```
-The root cause of this bug is that the regular expression `r"\b(import|require)\s"` only detects `JavaScript/TypeScript` code containing the `import` or `require` keyword followed by one or more whitespace characters. Therefore, it will detect, for example, `import React from 'react';` or `import { useState } from 'react';`, but not `const fs = require('fs');`. Additionally, it can produce false positives because `import` matches Python statements such as `import os` or `import sys`. This regular expression does not detect other keywords in `JS_TS_KEYWORDS`: `export`, `const`, `let`, `var`, `function`, `async`, `await`, and `class`. Another concern that could complicate detecting JavaScript/TypeScript is that the `JS_TS_KEYWORDS` set includes overlapping keywords (`import`, `class`, `async`, `await`) that are also present in the `PYTHON_KEYWORDS` set.
+**1. Not detecting JavaScript/TypeScript**  
+    **Root cause:**  
+    The following code in `_detect_languages()` function in `SkillExtractor` class detects `JavaScript/TypeScript`
+    ```python
+    if ".js" in str(filename or "").lower():
+                js_evidence.append("JavaScript file extension (.js)")
+            if ".ts" in str(filename or "").lower():
+                js_evidence.append("TypeScript file extension (.ts)")
+            if re.search(r"\b(import|require)\s+", text):
+                js_evidence.append("CommonJS or ES6 imports")
+            if "package.json" in text_lower:
+                js_evidence.append("package.json found")
+    ```
+    The root cause of this bug is that the regular expression `r"\b(import|require)\s"` only detects `JavaScript/TypeScript` code containing the `import` or `require` keyword followed by one or more whitespace characters. Therefore, it will detect, for example, `import React from 'react';` or `import { useState } from 'react';`, but not `const fs = require('fs');`. Additionally, it can produce false positives because `import` matches Python statements such as `import os` or `import sys`. This regular expression does not detect other keywords in `JS_TS_KEYWORDS`: `export`, `const`, `let`, `var`, `function`, `async`, `await`, and `class`. Another concern that could complicate detecting JavaScript/TypeScript is that the `JS_TS_KEYWORDS` set includes overlapping keywords (`import`, `class`, `async`, `await`) that are also present in the `PYTHON_KEYWORDS` set.
 
 
-2. Not detecting devops tools such as docker and docker compose
-*root cause:*  
-The root cause for not detecting `docker` or `docker compose` is that the `_detect_tools()` function detects DevOps tools by matching keywords in the `TOOLS` set. As issue [#148](https://github.com/ascherj/pathreview/issues/148) states, `test_devops_tool_detection` and `test_docker_compose_detection` fail. The reason for this is because these test cases do not contain the keyword `docker` (which is used in the `TOOLS` set) in the `text` variable. The following code, `detect_tools()`, is responsible for this keyword matching.
+**2. Not detecting devops tools such as docker and docker compose**   
+    **Root cause:**     
+    The root cause for not detecting `docker` or `docker compose` is that the `_detect_tools()` function detects DevOps tools by matching keywords in the `TOOLS` set. As issue [#148](https://github.com/ascherj/pathreview/issues/148) states, `test_devops_tool_detection` and `test_docker_compose_detection` fail. The reason for this is because these test cases do not contain the keyword `docker` (which is used in the `TOOLS` set) in the `text` variable. The following code, `detect_tools()`, is responsible for this keyword matching.
 
-```python
-for tool, confidence in self.TOOLS.items():
-            if tool in text_lower:
-                display_name = tool.upper() if tool in ["ci/cd"] else tool.title()
-```
+    ```python
+    for tool, confidence in self.TOOLS.items():
+                if tool in text_lower:
+                    display_name = tool.upper() if tool in ["ci/cd"] else tool.title()
+    ```
 
 ### Map
 Files I expect to touch:

--- a/ingestion/parsers/skill_extractor.py
+++ b/ingestion/parsers/skill_extractor.py
@@ -1,11 +1,11 @@
 import re
 from dataclasses import dataclass
-from typing import Optional
 
 
 @dataclass
 class SkillDetection:
     """Result of detecting a skill."""
+
     name: str
     category: str
     confidence: float
@@ -39,6 +39,50 @@ class SkillExtractor:
         "await",
         "class",
     }
+
+    # Each JS/TS keyword paired with the syntactic context that makes it a
+    # reliable signal. Keywords shared with Python (import/class/async/await)
+    # use JS-only framing, and words that also occur in plain English
+    # ("let"/"function"/"require") only match inside real code, so neither
+    # Python nor prose false-positives. Keys mirror JS_TS_KEYWORDS.
+    JS_TS_KEYWORD_PATTERNS = {
+        # ES6 `import X from '...'` (Python is `from x import y`, never
+        # `import ... from`) or side-effect `import './x'` / `import '@scope/x'`.
+        # The side-effect form is restricted to relative/scoped specifiers so
+        # Go's `import "fmt"` / `import "net/http"` does not collide.
+        "import": r"\bimport\b[^\n;]*\bfrom\s+['\"]|\bimport\s+['\"](?:\.{1,2}/|@[\w.-]+/)",
+        "export": (
+            r"\bexport\s+(?:default|const|let|var|function|class"
+            r"|async|type|interface|enum|\{|\*)"
+        ),
+        "require": r"\brequire\s*\(\s*['\"]",
+        "const": r"\bconst\s+[\w$]+\s*[:=]",
+        "let": r"\blet\s+[\w$]+\s*[:=]",
+        "var": r"\bvar\s+[\w$]+\s*[:=]",
+        # function definition, incl. anonymous / generator, requires a body brace
+        "function": r"\bfunction\b\s*\*?\s*[\w$]*\s*\([^)]*\)\s*\{",
+        # `async function` / `async () =>` / `async x =>` (Python is `async def`).
+        "async": r"\basync\s+function\b|\basync\s*\([^)]*\)\s*=>|\basync\s+[\w$]+\s*=>",
+        # `const/let/var x = await ...` — JS-only because of the declaration.
+        "await": r"\b(?:const|let|var)\s+[\w$]+\s*=\s*await\b",
+        # JS class: `class X extends` or `class X {` (Python uses `class X:`).
+        "class": r"\bclass\s+[\w$]+\s+extends\b|\bclass\s+[\w$]+\s*\{",
+    }
+
+    # TypeScript-only syntax. Primitive type names are the TS spellings
+    # (string/number/boolean), distinct from Python's (str/int/bool), so
+    # typed Python code does not match here.
+    TS_SYNTAX_PATTERNS = (
+        r"\binterface\s+[\w$]+\s*\{",  # interface declarations
+        r"\btype\s+[\w$]+\s*=",  # type aliases
+        r"\benum\s+[\w$]+\s*\{",  # enums
+        # type annotation, anchored so prose like "status: number of items"
+        # is not treated as a `: number` annotation.
+        r":\s*(?:string|number|boolean|any|void|unknown|never)\s*(?:[;,)\]|&=>]|$)",
+    )
+
+    # Arrow functions are a strong standalone JS/TS signal.
+    JS_ARROW_PATTERN = r"(?:\([^)]*\)|[\w$]+)\s*=>"
 
     REACT_INDICATORS = {
         "import React",
@@ -105,7 +149,7 @@ class SkillExtractor:
         "ansible": 0.85,
     }
 
-    def extract_skills(self, text: str, filename: Optional[str] = None) -> list[SkillDetection]:
+    def extract_skills(self, text: str, filename: str | None = None) -> list[SkillDetection]:
         """
         Extract skills from source code or documentation text.
 
@@ -116,7 +160,7 @@ class SkillExtractor:
         Returns:
             List of detected skills with confidence scores
         """
-        detected_skills = {}
+        detected_skills: dict[str, SkillDetection] = {}
 
         # Detect languages first
         self._detect_languages(text, filename, detected_skills)
@@ -143,7 +187,7 @@ class SkillExtractor:
     def _detect_languages(
         self,
         text: str,
-        filename: Optional[str],
+        filename: str | None,
         skills_dict: dict,
     ) -> None:
         """Detect programming languages."""
@@ -176,14 +220,27 @@ class SkillExtractor:
             js_evidence.append("JavaScript file extension (.js)")
         if ".ts" in str(filename or "").lower():
             js_evidence.append("TypeScript file extension (.ts)")
-        if re.search(r"\b(import|require)\s+", text):
-            js_evidence.append("CommonJS or ES6 imports")
+        matched_keywords = [
+            keyword
+            for keyword, pattern in self.JS_TS_KEYWORD_PATTERNS.items()
+            if re.search(pattern, text)
+        ]
+        if matched_keywords:
+            js_evidence.append("JS/TS keywords (" + ", ".join(sorted(matched_keywords)) + ")")
+        if re.search(self.JS_ARROW_PATTERN, text):
+            js_evidence.append("Arrow function syntax")
+
+        ts_syntax = any(re.search(pattern, text) for pattern in self.TS_SYNTAX_PATTERNS)
+        if ts_syntax:
+            js_evidence.append("TypeScript-specific syntax")
+
         if "package.json" in text_lower:
             js_evidence.append("package.json found")
 
         if js_evidence:
             confidence = min(0.95, 0.6 + len(js_evidence) * 0.1)
-            lang = "TypeScript" if ".ts" in str(filename or "").lower() else "JavaScript"
+            is_typescript = ".ts" in str(filename or "").lower() or ts_syntax
+            lang = "TypeScript" if is_typescript else "JavaScript"
             skills_dict[lang] = SkillDetection(
                 name=lang,
                 category="Language",

--- a/ingestion/parsers/skill_extractor.py
+++ b/ingestion/parsers/skill_extractor.py
@@ -149,6 +149,24 @@ class SkillExtractor:
         "ansible": 0.85,
     }
 
+    # Dockerfile instructions, matched uppercase at the start of a line so
+    # Python's lowercase `from ... import` and prose do not collide.
+    DOCKERFILE_INSTRUCTION_RE = re.compile(
+        r"^\s*(FROM|RUN|CMD|COPY|ADD|EXPOSE|ENV|ENTRYPOINT|WORKDIR|VOLUME"
+        r"|LABEL|ARG|USER|HEALTHCHECK|ONBUILD|STOPSIGNAL|SHELL|MAINTAINER)\b",
+        re.MULTILINE,
+    )
+    # Every Dockerfile begins with a `FROM <image>` instruction.
+    DOCKERFILE_FROM_RE = re.compile(r"^\s*FROM\s+\S+", re.MULTILINE)
+    # docker-compose: a top-level `services:` mapping...
+    COMPOSE_SERVICES_RE = re.compile(r"^\s*services:\s*(?:#.*)?$", re.MULTILINE)
+    # ...plus at least one service-level key beneath it.
+    COMPOSE_SERVICE_KEY_RE = re.compile(
+        r"^\s*(build|image|ports|volumes|container_name|depends_on|networks"
+        r"|environment|command|expose|restart):",
+        re.MULTILINE,
+    )
+
     def extract_skills(self, text: str, filename: str | None = None) -> list[SkillDetection]:
         """
         Extract skills from source code or documentation text.
@@ -321,6 +339,10 @@ class SkillExtractor:
         """Detect tools and DevOps technologies."""
         text_lower = text.lower()
 
+        # Structural Docker detection (Dockerfile / compose) runs first so its
+        # richer evidence is not overwritten by the plain keyword scan below.
+        self._detect_docker(text, skills_dict)
+
         for tool, confidence in self.TOOLS.items():
             if tool in text_lower:
                 display_name = tool.upper() if tool in ["ci/cd"] else tool.title()
@@ -331,3 +353,47 @@ class SkillExtractor:
                         confidence=confidence,
                         evidence=[f"Found '{tool}' reference in content"],
                     )
+
+    def _detect_docker(self, text: str, skills_dict: dict) -> None:
+        """Detect Docker and Docker Compose from Dockerfile / compose syntax.
+
+        Recognises Dockerfiles even when the literal word "docker" is absent
+        (a `FROM` instruction plus at least one other instruction), and
+        docker-compose files (a top-level ``services:`` mapping plus a
+        service-level key such as ``build:`` or ``image:``).
+        """
+        # Dockerfile: a real FROM plus at least two distinct instruction types.
+        instructions = self.DOCKERFILE_INSTRUCTION_RE.findall(text)
+        if self.DOCKERFILE_FROM_RE.search(text) and len(set(instructions)) >= 2:
+            found = ", ".join(sorted(set(instructions)))
+            skills_dict.setdefault(
+                "Docker",
+                SkillDetection(
+                    name="Docker",
+                    category="Tool",
+                    confidence=0.95,
+                    evidence=[f"Dockerfile instructions ({found})"],
+                ),
+            )
+
+        # Docker Compose: top-level services mapping plus a service-level key.
+        if self.COMPOSE_SERVICES_RE.search(text) and self.COMPOSE_SERVICE_KEY_RE.search(text):
+            skills_dict.setdefault(
+                "Docker Compose",
+                SkillDetection(
+                    name="Docker Compose",
+                    category="Tool",
+                    confidence=0.95,
+                    evidence=["docker-compose services definition"],
+                ),
+            )
+            # A compose file implies Docker itself.
+            skills_dict.setdefault(
+                "Docker",
+                SkillDetection(
+                    name="Docker",
+                    category="Tool",
+                    confidence=0.90,
+                    evidence=["docker-compose configuration"],
+                ),
+            )

--- a/tests/unit/test_skill_extractor.py
+++ b/tests/unit/test_skill_extractor.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from ingestion.parsers.skill_extractor import SkillExtractor, SkillDetection
+from ingestion.parsers.skill_extractor import SkillDetection, SkillExtractor
 
 
 @pytest.mark.unit
@@ -135,7 +135,7 @@ class TestSkillExtractor:
         """
         result = extractor.extract_skills(text)
 
-        skill_names = [s.name for s in skill_names]
+        skill_names = [s.name for s in result]
         # Should detect PostgreSQL
         assert any("postgres" in s.lower() or "sql" in s.lower() for s in skill_names)
 
@@ -229,13 +229,121 @@ class TestSkillExtractor:
             assert isinstance(skill.confidence, float)
             assert 0.0 <= skill.confidence <= 1.0
 
+    # --- PLAN.md line 52: Positive cases (should detect JavaScript/TypeScript) ---
+
+    def test_javascript_es6_import_detection(self, extractor):
+        """Positive: ES6 `import ... from` is detected as JavaScript."""
+        text = """
+        import { readFile } from 'fs/promises';
+        import path from 'path';
+        """
+        result = extractor.extract_skills(text)
+
+        skill_names = [s.name for s in result]
+        assert any("javascript" in s.lower() for s in skill_names)
+
+    def test_javascript_arrow_function_detection(self, extractor):
+        """Positive: arrow functions and variable declarations are detected."""
+        text = """
+        const add = (a, b) => a + b;
+        let double = x => x * 2;
+        """
+        result = extractor.extract_skills(text)
+
+        skill_names = [s.name for s in result]
+        assert any("javascript" in s.lower() for s in skill_names)
+
+    def test_javascript_function_class_export_detection(self, extractor):
+        """Positive: function/class/export syntax is detected as JavaScript."""
+        text = """
+        export function greet(name) {
+            return "Hi " + name;
+        }
+
+        class Animal extends Base {}
+        """
+        result = extractor.extract_skills(text)
+
+        skill_names = [s.name for s in result]
+        assert any("javascript" in s.lower() for s in skill_names)
+
+    # --- PLAN.md line 53: Negative cases (plain text, unsupported langs, no filename) ---
+
+    def test_plain_text_not_detected_as_javascript(self, extractor):
+        """Negative: prose containing JS-like words is not detected as JS/TS."""
+        text = (
+            "This function lets you import ideas from a class of problems "
+            "and does not require any special export."
+        )
+        result = extractor.extract_skills(text)
+
+        skill_names = [s.name for s in result]
+        assert not any("javascript" in s.lower() or "typescript" in s.lower() for s in skill_names)
+
+    def test_unsupported_language_not_detected_as_javascript(self, extractor):
+        """Negative: Go source is not misdetected as JavaScript/TypeScript."""
+        text = """
+        package main
+
+        import "fmt"
+
+        func main() {
+            fmt.Println("hello")
+        }
+        """
+        result = extractor.extract_skills(text)
+
+        skill_names = [s.name for s in result]
+        assert not any("javascript" in s.lower() or "typescript" in s.lower() for s in skill_names)
+
+    def test_missing_filename_returns_list(self, extractor):
+        """Negative: missing filename with non-code text returns a list, no error."""
+        result = extractor.extract_skills("just some notes", filename=None)
+        assert isinstance(result, list)
+
+    def test_empty_filename_does_not_crash(self, extractor):
+        """Negative: an empty filename string is handled gracefully."""
+        result = extractor.extract_skills("const x = 1;", filename="")
+        assert isinstance(result, list)
+
+    # --- PLAN.md line 54: False positives & cross-language collisions ---
+
+    def test_python_shared_keywords_not_detected_as_javascript(self, extractor):
+        """Collision: Python using import/class/async/await stays Python only."""
+        text = """
+        import asyncio
+
+        class DataProcessor:
+            async def process(self):
+                result = await self.fetch()
+                return result
+        """
+        result = extractor.extract_skills(text)
+
+        skill_names = [s.name for s in result]
+        assert any("python" in s.lower() for s in skill_names)
+        assert not any("javascript" in s.lower() or "typescript" in s.lower() for s in skill_names)
+
+    # --- PLAN.md line 55: False negatives & malformed/incomplete snippets ---
+
+    def test_malformed_snippet_does_not_crash(self, extractor):
+        """Malformed: truncated/incomplete code returns a list without raising."""
+        text = "function brokenFn( const x ="
+        result = extractor.extract_skills(text)
+        assert isinstance(result, list)
+
+    def test_minimal_valid_snippet_still_detected(self, extractor):
+        """False-negative guard: a tiny valid JS declaration is still detected."""
+        text = "const total = 42;"
+        result = extractor.extract_skills(text)
+
+        skill_names = [s.name for s in result]
+        assert any("javascript" in s.lower() for s in skill_names)
+
     def test_skill_detection_dataclass(self):
         """Test SkillDetection dataclass structure."""
         skill = SkillDetection(
-            name="Python",
-            category="Language",
-            confidence=0.95,
-            evidence=["import statement"]
+            name="Python", category="Language", confidence=0.95, evidence=["import statement"]
         )
 
         assert skill.name == "Python"

--- a/tests/unit/test_skill_extractor.py
+++ b/tests/unit/test_skill_extractor.py
@@ -197,6 +197,153 @@ class TestSkillExtractor:
         skill_names = [s.name for s in result]
         assert any("docker" in s.lower() for s in skill_names)
 
+    # --- PLAN.md lines 66-71: Dockerfile & Compose positive variants ---
+
+    def test_dockerfile_copy_cmd_detection(self, extractor):
+        """Positive: a Dockerfile using COPY and CMD is detected as Docker."""
+        text = """
+        FROM node:18-alpine
+        COPY . /app
+        CMD ["node", "server.js"]
+        """
+        result = extractor.extract_skills(text)
+
+        skill_names = [s.name for s in result]
+        assert any("docker" in s.lower() for s in skill_names)
+
+    def test_multistage_dockerfile_detection(self, extractor):
+        """Positive: a multi-stage Dockerfile is detected as Docker."""
+        text = """
+        FROM golang:1.21 AS builder
+        WORKDIR /src
+        COPY . .
+        RUN go build -o app
+
+        FROM alpine:latest
+        COPY --from=builder /src/app /usr/local/bin/app
+        CMD ["app"]
+        """
+        result = extractor.extract_skills(text)
+
+        skill_names = [s.name for s in result]
+        assert any("docker" in s.lower() for s in skill_names)
+
+    def test_compose_services_image_detection(self, extractor):
+        """Positive: a compose file using services + image is detected."""
+        text = """
+        version: "3.9"
+        services:
+          db:
+            image: postgres:15
+            environment:
+              POSTGRES_PASSWORD: secret
+        """
+        result = extractor.extract_skills(text)
+
+        skill_names = [s.name for s in result]
+        assert any("docker" in s.lower() for s in skill_names)
+
+    def test_compose_volumes_detection(self, extractor):
+        """Positive: a compose file declaring volumes is detected."""
+        text = """
+        services:
+          cache:
+            image: redis:7
+            volumes:
+              - cache-data:/data
+
+        volumes:
+          cache-data:
+        """
+        result = extractor.extract_skills(text)
+
+        skill_names = [s.name for s in result]
+        assert any("docker" in s.lower() for s in skill_names)
+
+    # --- PLAN.md lines 72-73: Negative cases ---
+
+    def test_non_docker_yaml_not_detected(self, extractor):
+        """Negative: generic YAML with no services/Dockerfile is not Docker."""
+        text = """
+        name: my-app
+        version: 1.0.0
+        settings:
+          debug: true
+          timeout: 30
+        database:
+          host: localhost
+          port: 5432
+        """
+        result = extractor.extract_skills(text)
+
+        skill_names = [s.name for s in result]
+        assert not any("docker" in s.lower() for s in skill_names)
+
+    def test_pip_install_alone_not_detected_as_docker(self, extractor):
+        """Negative: a bare pip install line is not misdetected as Docker."""
+        text = "pip install -r requirements.txt"
+        result = extractor.extract_skills(text)
+
+        skill_names = [s.name for s in result]
+        assert not any("docker" in s.lower() for s in skill_names)
+
+    # --- PLAN.md line 74: Malformed configs & size extremes ---
+
+    def test_partial_docker_config_does_not_crash(self, extractor):
+        """Malformed/small: incomplete configs return a list without raising."""
+        for snippet in ("FROM", "services:", "version: '3'\nservices:", "RUN echo hi"):
+            result = extractor.extract_skills(snippet)
+            assert isinstance(result, list)
+
+    def test_docker_detected_in_large_multiblock_text(self, extractor):
+        """Size extreme: a Dockerfile embedded in large text is still detected."""
+        filler = "lorem ipsum dolor sit amet\n" * 500
+        dockerfile = """
+        FROM python:3.11-slim
+        WORKDIR /app
+        COPY requirements.txt .
+        RUN pip install -r requirements.txt
+        EXPOSE 8080
+        CMD ["python", "app.py"]
+        """
+        text = filler + dockerfile + filler
+        result = extractor.extract_skills(text)
+
+        skill_names = [s.name for s in result]
+        assert any("docker" in s.lower() for s in skill_names)
+
+    # --- PLAN.md line 75: Missing, empty, or neutral filenames ---
+
+    def test_docker_detected_regardless_of_filename(self, extractor):
+        """Filename-agnostic: Dockerfile body detects Docker for any filename."""
+        text = """
+        FROM ubuntu:22.04
+        RUN apt-get update
+        CMD ["bash"]
+        """
+        for filename in (None, "", "notes.txt"):
+            result = extractor.extract_skills(text, filename=filename)
+            skill_names = [s.name for s in result]
+            assert any(
+                "docker" in s.lower() for s in skill_names
+            ), f"filename={filename!r} gave {skill_names}"
+
+    # --- PLAN.md line 76: Contextual keyword collisions ---
+
+    def test_docker_keywords_in_shell_script_not_detected(self, extractor):
+        """Collision: lowercase from/copy/run in a shell script is not Docker."""
+        text = """
+        #!/bin/sh
+        # Deployment script: copy build artifacts from the dist folder
+        build() {
+            echo "running build and copying files from dist"
+        }
+        """
+        result = extractor.extract_skills(text)
+
+        skill_names = [s.name for s in result]
+        assert not any("docker" in s.lower() for s in skill_names)
+
     def test_aws_gcp_azure_detection(self, extractor):
         """Test cloud platform detection."""
         text = """


### PR DESCRIPTION
## Summary
<!-- One paragraph describing what this PR does and why -->
_detect_languages()` in `ingestion/parsers/skill_extractor.py` detects JavaScript and TypeScript using newly added keyword patterns, TypeScript syntax patterns, and JavaScript arrow-function patterns in the regular expression used in this function. 

Newly added `_detect_docker()`, invoked inside the `_detect_tools()` function in `ingestion/parsers/skill_extractor.py`, detects Dockerfile instructions and docker-compose syntax.

20 new tests are added in `tests/unit/test_skill_extractor.py` to test the functionality of both of the above functions.

## Issue
Closes #148 

## Changes
<!-- Bullet list of the specific changes made -->
Root cause:  
1. The reason for not detecting JavaScript/TypeScript: The regular expression used in the `_detect_languages()` function in the `SkillExtractor` class only detects `JavaScript/TypeScript`  code containing the `import` or `require` keyword followed by one or more whitespace characters.  
2. The reason for not detecting `docker` or `docker compose` is that the `_detect_tools()` function detects DevOps tools by matching keywords in the `TOOLS` set. 

 `ingestion/parsers/skill_extractor.py`  - _detect_languages()**, invoked inside the `extract_skills()` function in `ingestion/parsers/skill_extractor.py`, now detects JavaScript and TypeScript code using keyword patterns (`JS_TS_KEYWORD_PATTERNS`), TypeScript syntax patterns (`TS_SYNTAX_PATTERNS`), and JavaScript arrow-function patterns (`JS_ARROW_PATTERN`).

`ingestion/parsers/skill_extractor.py` - _detect_docker()**, invoked inside `_detect_tools()` (which is called by `extract_skills()`), now recognizes Docker and Docker Compose even when the literal word "docker" is absent. It leverages Dockerfile instruction regular expressions (`DOCKERFILE_INSTRUCTION_RE` and `DOCKERFILE_FROM_RE`) and Docker Compose regular expressions (`COMPOSE_SERVICES_RE` and `COMPOSE_SERVICE_KEY_RE`).

`tests/unit/test_skill_extractor.py`- 20 new tests are added to test the implementation of JavaScript.TypeScript, Docker, and Docker Compose detection logic.  

10 new tests are added to test the functionality of _detect_languages(). 
      * `test_javascript_es6_import_detection`
      * `test_javascript_arrow_function_detection`
      * `test_javascript_function_class_export_detection`
      * `test_plain_text_not_detected_as_javascript`
      * `test_unsupported_language_not_detected_as_javascript`
      * `test_missing_filename_returns_list`
      * `test_empty_filename_does_not_crash`
      * `test_python_shared_keywords_not_detected_as_javascript`
      * `test_malformed_snippet_does_not_crash`
      *  `test_minimal_valid_snippet_still_detected` 
  
10 new tests are added to test the functionality of the newly added `_detect_docker()` function.
      * `test_dockerfile_copy_cmd_detection`
      * `test_multistage_dockerfile_detection`
      * `test_compose_services_image_detection`
      * `test_compose_volumes_detection`
      * `test_non_docker_yaml_not_detected`
      * `test_pip_install_alone_not_detected_as_docker`
      * `test_partial_docker_config_does_not_crash`
      * `test_docker_detected_in_large_multiblock_text`
      * `test_docker_detected_regardless_of_filename`
      * `test_docker_keywords_in_shell_script_not_detected`

## Testing
<!-- How did you verify your changes? -->
- [x] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`)
- [x] Linter passes (`make lint`)
- [x] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes

To run the tests in the terminal to test JavaScript/TypeScript Detection
```bash
python3 <<'PY'

from ingestion.parsers.skill_extractor import SkillExtractor

test_cases = [
    {
        "name": "Standard ES6 Modern Syntax (No extension, no import/require)",
        "code": """
        const calculateTotal = (items) => {
            let subtotal = 0;
            var taxRate = 0.05;
            return subtotal * taxRate;
        };
        """
    },
    {
        "name": "Traditional Function Declaration with Console Logging",
        "code": """
        function displayWelcomeMessage(username) {
            console.log("Welcome back, " + username);
        }
        """
    },
    {
        "name": "ES6 Class Definition without Module Imports",
        "code": """
        class ShoppingCart {
            constructor() {
                this.items = [];
            }
            addItem(item) {
                this.items.push(item);
            }
        }
        """
    },
    {
        "name": "Asynchronous Function Using Promise/Fetch Patterns",
        "code": """
        async function fetchData(url) {
            let response = await fetch(url);
            let data = await response.json();
            return data;
        }
        """
    }
]

e = SkillExtractor()

print("=== Running Skill Extractor Bug Reproduction Suite ===\n")
for index, test in enumerate(test_cases, start=1):
    detected_skills = e.extract_skills(test["code"])
    skill_names = [d.name for d in detected_skills]
    
    print(f"Test Case {index}: {test['name']}")
    print("Code Snippet:")
    print(test["code"].strip())
    print(f"Detected Skills: {skill_names}")
    print("-" * 50)

PY
```  

To run the tests in the terminal to test Docker/Docker Compose  Detection 
```bash
python3 <<'PY'

from ingestion.parsers.skill_extractor import SkillExtractor

docker_false_negative_cases = [
    {
        "name": "Dockerfile",
        "snippet": """
FROM python:3.9
RUN pip install requirements.txt
EXPOSE 8000
""",
        "expected_bug": (
            "Should detect Docker from Dockerfile directives "
            "(FROM, RUN, EXPOSE) but does not because "
            "the word 'docker' never appears."
        ),
    },
    {
        "name": "Docker Compose",
        "snippet": """
version: '3.8'
services:
  web:
    build: .
    ports:
      - "8000:8000"
""",
        "expected_bug": (
            "Should detect Docker from docker-compose syntax "
            "(services, build, ports) but does not because "
            "the word 'docker' never appears."
        ),
    },
]

e = SkillExtractor()

print("=== Running Docker False Negative Reproduction Suite ===\n")

for index, test in enumerate(docker_false_negative_cases, start=1):
    skills_dict = {}
    e._detect_tools(test["snippet"], skills_dict)

    print(f"Test Case {index}: {test['name']}")
    print(f"Detected Skills: {list(skills_dict.keys())}")
    print(f"Expected Bug: {test['expected_bug']}")
    print("-" * 60)

PY

```

You can also run all the test cases in `tests/unit/test_skill_extractor.py` with
```
.venv/bin/pytest tests/unit/test_skill_extractor.py -v
```
## Screenshots / Demo
<!-- If applicable, add screenshots or a link to a demo video -->
The total number of tests before fixing the issue
<img width="1402" height="430" alt="total-tests-before-fix" src="https://github.com/user-attachments/assets/7975fd32-27c4-4d56-934e-2152c278ae60" />

The total number of tests after fixing the issue  
<img width="1386" height="296" alt="total-tests-after-fix" src="https://github.com/user-attachments/assets/8bfb00e5-7c7c-41bc-9aab-821dcd72b9b0" />

Number of tests passed in `tests/unit/test_skill_extractor.py before fixing the issue.
<img width="1402" height="430" alt="skill_extractor-tests-before-fix" src="https://github.com/user-attachments/assets/e571db30-8a2f-4831-a1ba-29afdcec75e4" />

Number of tests passed in `tests/unit/test_skill_extractor.py` after fixing the issue.
<img width="1371" height="900" alt="skill_extractor-tests-after-fix" src="https://github.com/user-attachments/assets/94560e29-a908-4cc3-8a19-515e32005808" />

## Notes for Reviewers
<!-- Anything the reviewer should pay particular attention to -->
I added 20 new tests in `tests/unit/test_skill_extractor.py`. Note that one existing test (`test_database_technology_detection`) failed both before and after my changes, but it is unrelated to the issue addressed.
