### PR TITLE
fix: route structlog output through stdlib logging for caplog capture (#159)

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,16 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/159
+
+**Issue title:** structlog output is not captured by pytest caplog — log assertions fail suite-wide
+
+**Tier:** [x] Tier 1
+
+**Problem summary:**
+[we'll draft this together — let me know when you're ready]
+
+**Branch name:** fix/159-structlog-caplog-capture
+
+**Setup confirmation:** [ ] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -33,3 +33,17 @@ aren't wired into stdlib logging during tests, so pytest's `caplog` fixture (whi
   fewer claims than issues like #154/#155, and no PR was linked yet, so I expect smoother
   coaching/review. I estimate this is a 3–6 hour Tier 1 fix, achievable well within the
   Week 8–9 window, with no blockers noted on the issue.
+
+  ## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [will fill in after this commit]
+
+**Reproduction summary:**
+Ran `pytest tests/unit/test_batch_processor.py::TestBatchEmbeddingProcessor::test_empty_chunks_list_returns_empty -v` and confirmed the failure: `caplog.text` was empty even though the captured stdout showed the log line `[warning] Empty chunks list provided to BatchEmbeddingProcessor` was actually emitted. This confirms structlog output isn't propagating into stdlib logging, so caplog can't see it.
+
+**PLAN.md link:** [will fill in next]
+
+**Walkthrough video (recommended):** [optional, skipping for now]
+
+**Blockers or open questions:**
+[to fill in]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -34,16 +34,16 @@ aren't wired into stdlib logging during tests, so pytest's `caplog` fixture (whi
   coaching/review. I estimate this is a 3–6 hour Tier 1 fix, achievable well within the
   Week 8–9 window, with no blockers noted on the issue.
 
-  ## Week 8 — Reproduction & solution planning
+## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [will fill in after this commit]
+**Reproduction commit link:** https://github.com/turanyavarri/pathreview/commit/fedded9
 
 **Reproduction summary:**
 Ran `pytest tests/unit/test_batch_processor.py::TestBatchEmbeddingProcessor::test_empty_chunks_list_returns_empty -v` and confirmed the failure: `caplog.text` was empty even though the captured stdout showed the log line `[warning] Empty chunks list provided to BatchEmbeddingProcessor` was actually emitted. This confirms structlog output isn't propagating into stdlib logging, so caplog can't see it.
 
-**PLAN.md link:** [will fill in next]
+**PLAN.md link:** https://github.com/turanyavarri/pathreview/blob/fix/159-structlog-caplog-capture/PLAN.md
 
-**Walkthrough video (recommended):** [optional, skipping for now]
+**Walkthrough video (recommended):** Not recorded
 
 **Blockers or open questions:**
-[to fill in]
+Still need to check how structlog is configured in the app's production code (likely somewhere in `core/`) to make sure the test fixture mirrors the real processor chain rather than reinventing it.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -14,3 +14,22 @@ The app logs using structlog, but structlog isn't configured to route its output
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+**Checklist reasoning:**
+
+- **Understanding the issue:** I can explain this without re-reading it,structlog logs
+aren't wired into stdlib logging during tests, so pytest's `caplog` fixture (which only
+  hooks into stdlib logging) can't see log events that structlog actually emits. I confirmed
+  this by reading `tests/conftest.py`, which has no logging/structlog setup at all, and by
+  reading the failing test (`test_empty_chunks_list_returns_empty` in
+  `tests/unit/test_batch_processor.py`), which asserts on `caplog.text`/`caplog.records`.
+- **Tier fit:** This is my first open source contribution, so Tier 1 is the right level.
+  The fix is scoped to one file (`conftest.py`) and doesn't require understanding the
+  broader system.
+- **Codebase readiness:** I located and read both `conftest.py` and the test file end-to-end
+  before claiming the issue, and I have a rough plan (configure structlog via
+  `structlog.stdlib` processors or `capture_logs` so logs propagate to stdlib logging).
+- **Scope and crowding:** I checked the issue comments. At the time I claimed it, #159 had
+  fewer claims than issues like #154/#155, and no PR was linked yet, so I expect smoother
+  coaching/review. I estimate this is a 3–6 hour Tier 1 fix, achievable well within the
+  Week 8–9 window, with no blockers noted on the issue.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -7,10 +7,10 @@
 **Tier:** [x] Tier 1
 
 **Problem summary:**
-[we'll draft this together — let me know when you're ready]
+The app logs using structlog, but structlog isn't configured to route its output into Python's standard logging module during tests. Since pytest's caplog fixture only captures logs going through stdlib logging, any test asserting on caplog fails even when the expected log event genuinely fires. For example, test_empty_chunks_list_returns_empty in tests/unit/test_batch_processor.py fails on its caplog assertion even though the warning is visibly printed to stderr. I confirmed this by reading tests/conftest.py, which currently has no logging or structlog setup at all, just two unrelated fixtures. The fix is to configure structlog in conftest.py (likely via structlog.stdlib processors or structlog.testing.capture_logs) so its output propagates into stdlib logging and becomes visible to caplog. This affects the test suite broadly, since any test relying on caplog to check log output is currently unreliable, not just the one in test_batch_processor.py.
 
 **Branch name:** fix/159-structlog-caplog-capture
 
-**Setup confirmation:** [ ] App runs locally at localhost:5173
+**Setup confirmation:** [x] App runs locally at localhost:5173
 
-**Cohort ledger:** [ ] Issue added to cohort ledger
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -78,3 +78,35 @@ No new test files — updated `tests/conftest.py`. Verified `tests/unit/test_bat
 **Self-review confirmation:** [x] make check passes  [x] make test-unit passes
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No review came in. Reviewer feedback isn't a feature this term (Su26), so this is expected rather than a gap in my process.
+
+**How you responded:**
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The environment setup ate far more time than the actual fix. I hit a stale virtual environment from a completely different project silently shadowing the correct one in my shell — `alembic` was resolving to the wrong `.venv` even though my prompt showed `(.venv)` as active. On top of that, `make` isn't available by default in Git Bash on Windows, so I had to manually run each command from the Makefile instead of relying on `make setup`/`make run`. The actual code fix — adding a fixture to `tests/conftest.py` — took maybe an hour once I understood the root cause. The tooling around it took most of a session.
+
+**What did you learn about working in a large codebase?**
+The biggest shift was realizing I couldn't just fix the symptom — I had to trace the fix back to how the system was *supposed* to work in production. The failing test pointed at `caplog`, but the actual root cause was in `core/logging.py`: `configure_logging()` existed and was correctly written, but nothing ever called it during test setup. In my own projects, I'd probably have just patched around the symptom. Here, I had to search the codebase (`grep -rn "structlog.configure"`) to find the real configuration, understand its processor chain, and make sure my test fixture mirrored it rather than inventing a parallel, possibly inconsistent setup. I also learned to separate "my change's failures" from "pre-existing failures" — running the full suite before and after my fix (53 failures → 52) was the only way to prove I hadn't broken anything else in a codebase with dozens of unrelated pre-existing issues.
+
+**How did AI tools help — and where did they fall short?**
+AI was most useful for diagnosis — once I pasted the actual error tracebacks and file contents, it could quickly point to the specific line (`logger_factory=structlog.stdlib.LoggerFactory()`) that explained the disconnect between structlog and caplog, and it explained *why* the fix needed `ProcessorFormatter.wrap_for_formatter` specifically, not just that it was needed. It also caught things I'd have missed on my own, like the pre-commit hook checking `tests/` more strictly than `make check` does, which is why my fixture needed a return type annotation.
+
+Where it fell short: it couldn't run commands on my actual machine, so every environment issue (stale venv, missing `.venv` folder, no `make`, no Postgres running) still required me to run things, paste the real output, and iterate — AI could interpret errors, but I was the one debugging my specific Windows/Git Bash setup in real time. There was also a moment where a copy-paste from an AI-suggested edit merged a docstring onto the same line as a function signature, breaking indentation — a reminder that I still need to actually read and verify code before assuming it's correct just because it came from a suggestion.
+
+**What would you do differently if you started over?**
+I'd fully verify my local environment in Week 7 — confirm `.venv` exists, `make` works or I have manual fallback commands ready, and the app actually starts — before claiming an issue, instead of rediscovering venv/PATH problems again in Week 9 under time pressure. I'd also open a draft PR earlier in Week 9 rather than finalizing everything right before the deadline; I never got real feedback partly because I didn't leave time for it, even though the option existed.
+
+**What are you most proud of from this module?**
+Running the full test suite before and after my change and actually diffing the failure lists to prove I introduced zero regressions — not just checking that my one target test passed. That felt like the difference between "it works on my machine" and actually verifying a change is safe in a codebase I don't fully own.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -47,3 +47,34 @@ Ran `pytest tests/unit/test_batch_processor.py::TestBatchEmbeddingProcessor::tes
 
 **Blockers or open questions:**
 Still need to check how structlog is configured in the app's production code (likely somewhere in `core/`) to make sure the test fixture mirrors the real processor chain rather than reinventing it.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Investigated the root cause: structlog was never configured to route through stdlib logging in tests, so it fell back to its own PrintLogger, meaning caplog never saw any log output even though logs genuinely fired. Traced this to `core/logging.py`'s `configure_logging()` never being called during test setup.
+
+**Next steps:**
+Add a fixture in `tests/conftest.py` that wires structlog into stdlib logging for the test session, verify the target test passes, and run the full suite to check for regressions.
+
+**Blockers:**
+None.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/648
+
+**Branch:** `fix/159-structlog-caplog-capture`
+
+**What you built:**
+Added an `autouse` fixture in `tests/conftest.py` that configures structlog with `logger_factory=structlog.stdlib.LoggerFactory()` and `ProcessorFormatter.wrap_for_formatter`, routing structlog output through stdlib logging so pytest's `caplog` fixture can capture it.
+
+**Tests added or updated:**
+No new test files — updated `tests/conftest.py`. Verified `tests/unit/test_batch_processor.py::TestBatchEmbeddingProcessor::test_empty_chunks_list_returns_empty` now passes. Ran full suite before/after: 53 failures → 52, with the only difference being the target test now passing (no new failures introduced).
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+**Draft PR feedback received from:** none

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,50 @@
+## Solution plan
+
+**Issue:** structlog output is not captured by pytest caplog — log assertions fail suite-wide
+https://github.com/ascherj/pathreview/issues/159
+
+### Understand
+structlog is configured to emit logs (confirmed via stdout: "[warning] Empty chunks list
+provided to BatchEmbeddingProcessor"), but it never propagates into Python's stdlib `logging`
+module. pytest's `caplog` fixture only captures records that pass through stdlib `logging`,
+so `caplog.text` stays empty even though the log genuinely fired. Expected behavior: caplog
+should capture structlog-emitted log events. Actual behavior: caplog sees nothing.
+
+### Map
+- `tests/conftest.py` — currently has no logging/structlog configuration; this is where the
+  fix needs to live (likely a fixture or `pytest_configure` hook)
+- `tests/unit/test_batch_processor.py` — contains the failing test
+  (`test_empty_chunks_list_returns_empty`) used to verify the fix
+- Possibly a `core/` logging setup file, to check how structlog is configured in production
+  so the test config mirrors it
+
+### Plan
+1. Locate how structlog is configured in the app itself (check `core/` for a logging config
+   module) to understand the existing processor chain
+2. Add a fixture or global config in `tests/conftest.py` that wires structlog's output into
+   stdlib `logging`, using `structlog.stdlib.ProcessorFormatter` (or
+   `structlog.testing.capture_logs`)
+3. Run the failing test to confirm `caplog.text` now captures the log line
+4. Run the full test suite (`pytest`) to check for any other tests relying on `caplog` that
+   are affected by this change (positively or negatively)
+5. Clean up / add a comment explaining the fixture's purpose for future contributors
+
+### Inputs & outputs
+Input: structlog log calls made anywhere in the app during test execution.
+Output: those log records become visible via pytest's `caplog.text` and `caplog.records`,
+so any test asserting on them passes when the expected log event fires.
+
+### Risks & unknowns
+- Not yet confirmed how structlog is configured in production code — if the processor chain
+  is complex, mirroring it in tests could require more than a simple fixture
+- Risk of breaking other tests if the fixture changes log level or formatting in a way other
+  tests unintentionally depend on
+- Unsure yet whether the fix should be a global `autouse` fixture in `conftest.py` or applied
+  per-test — need to check if any tests intentionally rely on the current (broken) behavior
+
+### Edge cases
+- Tests that don't use `caplog` at all shouldn't be affected by the fix
+- Log calls made at different levels (debug, info, warning, error) should all propagate
+  correctly, not just warning-level ones
+- Structured log fields (e.g. key-value pairs structlog attaches) shouldn't break stdlib
+  logging's plain-text formatting

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,33 @@
 """Shared test fixtures for PathReview."""
 
+from collections.abc import Iterator
+
 import pytest
+import structlog
+
+
+@pytest.fixture(autouse=True)
+def configure_structlog_for_caplog() -> Iterator[None]:
+    """Route structlog output through stdlib logging so pytest's caplog
+    fixture can capture it. Without this, structlog uses its own
+    PrintLogger and caplog.text/caplog.records stay empty even though
+    log calls genuinely fire."""
+    structlog.configure(
+        processors=[
+            structlog.stdlib.filter_by_level,
+            structlog.stdlib.add_logger_name,
+            structlog.stdlib.add_log_level,
+            structlog.stdlib.PositionalArgumentsFormatter(),
+            structlog.processors.TimeStamper(fmt="iso"),
+            structlog.processors.StackInfoRenderer(),
+            structlog.processors.format_exc_info,
+            structlog.processors.UnicodeDecoder(),
+            structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
+        ],
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        cache_logger_on_first_use=False,
+    )
+    yield
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
structlog output was never captured by pytest's `caplog` fixture, causing log assertions to fail suite-wide even when the expected log calls genuinely fired. This was because `tests/conftest.py` had no structlog configuration, so structlog fell back to its own default `PrintLogger`, which writes straight to stdout and bypasses Python's stdlib `logging` module entirely — the exact mechanism `caplog` relies on. This PR adds an `autouse` fixture that configures structlog to route through stdlib logging during test runs, so `caplog.text` and `caplog.records` correctly capture structlog-emitted log events.

## Issue
Closes #159

## Changes
- Added `configure_structlog_for_caplog()`, an `autouse=True` fixture in `tests/conftest.py`
- Configures `structlog.configure(...)` with `logger_factory=structlog.stdlib.LoggerFactory()` and `structlog.stdlib.ProcessorFormatter.wrap_for_formatter` as the final processor, wiring structlog's output into stdlib `logging`
- Uses `cache_logger_on_first_use=False` to prevent the first test that grabs a logger from locking in config for the entire session, avoiding cross-test interference
- Fixture is scoped `autouse=True` so it applies session-wide without requiring every test file to opt in, while tests that don't use `caplog` are unaffected

## Testing
- [x] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`) — not applicable to this change
- [x] Linter passes (`make lint`)
- [x] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes

Verified the previously-failing `tests/unit/test_batch_processor.py::TestBatchEmbeddingProcessor::test_empty_chunks_list_returns_empty` now passes.

Ran the full suite before and after this change to confirm no regressions: 53 pre-existing failures → 52, with the only difference being the target test now passing. All other failures are identical before and after (pre-existing issues in `test_review_service.py`, `test_tech_detector.py`, `test_bias_detector.py`, `test_pii_scrubber.py`, `test_skill_extractor.py`, and others — unrelated to structlog/caplog and unaffected by this change).

## Screenshots / Demo
N/A — this is a test infrastructure fix with no user-facing behavior change.

## Notes for Reviewers
- The codebase's `core/logging.py` defines `configure_logging()` for production use, but it's never actually called anywhere in the app (including at startup) — this is a separate, pre-existing gap outside the scope of this issue, but may be worth a follow-up issue.
- `mypy` doesn't check `tests/` under the `make check` target's scope, but the pre-commit hook does check `tests/conftest.py` directly, so I added a return type annotation (`Iterator[None]`) to satisfy that.
- Repo-wide, there are ~53 files with pre-existing lint/format debt and a handful of pre-existing mypy stub gaps — none of these are touched by this PR.