### PR TITLE
Fix JavaScript and TypeScript skill detection in SkillExtractor

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -26,3 +26,40 @@ and several keywords aside from "import" and "require" should be detected.
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [link to commit documenting the reproduced issue]
+
+**Reproduction summary:**
+I followed the step-by-step production code provided in the issues in my local python interpreter.
+The issues are as described with the SkillExtractor only extracting JavaScript and TypeScript
+if provided in a certain way (filename, and import statements). But the extractor fails to detect
+mentions of filenames or other JS/TS keywords inside the text itself.
+
+**Reproduction note:**
+First I went over to issue [#148](https://github.com/ascherj/pathreview/issues/148) to read through the issue again.
+I then took the `steps to reproduce` section and went over to my terminal and started with `py`.
+After the Python intepreter is up, I pasted the reproduction steps line-by-line:
+```
+from ingestion.parsers.skill_extractor import SkillExtractor
+e = SkillExtractor()
+print(e.extract_skills('Wrote index.js using const arrow functions and async/await callbacks'))
+print([d.name for d in e.extract_skills('Built app.tsx and types.ts with strict TypeScript interfaces')])
+print([d.name for d in e.extract_skills('Built app.tsx and types.ts with strict TypeScript interfaces', 'test.ts')])
+print([d.name for d in e.extract_skills('Built app.tsx and types.ts with strict TypeScript interfaces and import tests')])
+```
+The results are as described in the issues. The first print statement returns an empty list despite 
+a clear mention of "index.js", "const", "arrow functions", "async/await callbacks". The second print also
+returns only "React" as the detected skill despite the presence of "app.tsx", "types.ts", and 
+"TypeScript interfaces" in the message. This indicates that the skill extractor is unable to parse
+JavaScript and TypeScript related keywords from the text. The third and fourth print statement confirms that
+the `_detect_languages()` is called and can parse if the filename is provided. This shows that
+the extractor is working, but not covering all the extraction cases.
+
+**PLAN.md link:** [link to PLAN.md in your fork]
+
+**Walkthrough video (recommended):** [link to your Loom video, ≤2 min — recommended, not graded]
+
+**Blockers or open questions:**
+[Anything you're still uncertain about going into Week 9, or leave blank]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,23 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/148
+
+**Issue title:** Skill extractor fails to detect JavaScript and TypeScript
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The skill extractor is failing to extract JavaScript and TypeScript in its 
+language detection function. The detector is able to detect some keywords still if
+provided in a certain way, but otherwise it is unable to extract the mentions of
+filenames from the text and is missing some extensions (jsx, tsx). The code resides only within
+`ingestion/parsers/skill_extractor.py` under `extract_skills()` and `_detect_languages()`.
+It is also largely missing a whole lot of JavaScript and TypeScript keywords.
+With a successful fix, the parser should recognize the filenames if mentioned in text,
+and several keywords aside from "import" and "require" should be detected.
+
+**Branch name:** fix/148-javascript-and-typescript-failed-skill-parser
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -57,9 +57,9 @@ JavaScript and TypeScript related keywords from the text. The third and fourth p
 the `_detect_languages()` is called and can parse if the filename is provided. This shows that
 the extractor is working, but not covering all the extraction cases.
 
-**PLAN.md link:** [link to PLAN.md in your fork]
+**PLAN.md link:** [view PLAN.md](./PLAN.md)
 
-**Walkthrough video (recommended):** [link to your Loom video, ≤2 min — recommended, not graded]
+**Walkthrough video (recommended):** Omitted
 
 **Blockers or open questions:**
-[Anything you're still uncertain about going into Week 9, or leave blank]
+N/A

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -6,6 +6,11 @@
 
 **Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
 
+**Tier reasoning:** The issue is localized and seems appropriate for the time frame.
+The issue description is clear with reproducible steps and describe well what "done"
+state looks like. The relevant files are also pointed out along with the unit tests.
+There are quite a few others working on this issue, but it is okay given the time constraints.
+
 **Problem summary:**
 The skill extractor is failing to extract JavaScript and TypeScript in its 
 language detection function. The detector is able to detect some keywords still if

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -29,7 +29,7 @@ and several keywords aside from "import" and "require" should be detected.
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [link to commit documenting the reproduced issue]
+**Reproduction commit link:** [Note and summarize reproduction steps](https://github.com/nathnet/pathreview/commit/3d9f87ad6b215d3dbc393537c7d4d6fc4367ae5d)
 
 **Reproduction summary:**
 I followed the step-by-step production code provided in the issues in my local python interpreter.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -59,7 +59,8 @@ the extractor is working, but not covering all the extraction cases.
 
 **PLAN.md link:** [view PLAN.md](./PLAN.md)
 
-**Walkthrough video (recommended):** Omitted
+**Walkthrough video (recommended):** [Loom video](https://www.loom.com/share/5cd041826f92401cbc701dcc4a884bf1)
 
 **Blockers or open questions:**
-N/A
+- Should the JS/TS keyword only trigger one of the languages or both?
+- Should I implement the minimum keyword matches before we declare a language skill detected?

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -89,7 +89,7 @@ Leading the capstone project effort for WEB103, which includes implementing feat
 
 ### Check-in 2 (end of week)
 
-**PR link:** [link to your submitted pull request]
+**PR link:** [Fix JavaScript and TypeScript skill detection in SkillExtractor](https://github.com/ascherj/pathreview/pull/649)
 
 **Branch:** `fix/148-javascript-and-typescript-failed-skill-parser`
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -120,20 +120,38 @@ No feedback received yet.
 ### Reflection
 
 **What was harder than you expected?**
-[Be specific — what part of the process, codebase, or workflow
-surprised you?]
+The part I found most difficult is trying to make the precommit hook pass 
+so that I could commit my changes, despite the existing check errors. 
+I spent probably almost half of my time trying to identify all the existing
+errors and mitigate some that crossed path with my changes. 
 
 **What did you learn about working in a large codebase?**
-[What's different about contributing to someone else's production code
-vs. building your own project?]
+Since I have worked on larger codebases before, this one is actually smaller.
+But there were still something I got to learn as I see multiple packages
+inside the same repo (core, ingestion, rag, safety, frontend, etc.) and seeing
+how JavaScript frontend project is mixed into the same repo as Python backend.
 
 **How did AI tools help — and where did they fall short?**
-[Where was AI assistance most useful this module? Where did you need
-to go beyond what AI could give you?]
+After the thorough planning, I had the AI generated the code changes based on
+the planned directions. And I got to review the code and adapt certain changes
+while having to reject some others. I also had to catch more missing cases as
+I went and added new action item to the plan for more code fix generation.
 
 **What would you do differently if you started over?**
-[Issue selection, planning, implementation, or process — anything
-you'd change?]
+I would actually start by reading the general architecture of the repo to 
+understand the general flow first before moving on to reading through each
+issue to understand the scope clearer before I decide to pick a specific
+issue to work on. Instead of jumping to the issue to claim it first based
+on my interests solely. And I would like to ensure the issue I take would
+fit into my schedule and other commitments as well.
+
+On the implementation side, I would commit after each step instead of letting
+changes accumulate — this time steps 2 and 3 ended up in the same commit
+because I forgot.
 
 **What are you most proud of from this module?**
-[One thing — it doesn't have to be the PR itself.]
+Well, it might sound odd, but the one thing I'm most proud of is actually
+understanding the scope of the initial tier 3 issue that I was trying to
+take and knowing that I do not have enough capacity to actually finish it.
+That has given me a better judgment exercise and allowed me to downgrade
+the issue tier to balance other courses I am taking and the outside life.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -64,3 +64,41 @@ the extractor is working, but not covering all the extraction cases.
 **Blockers or open questions:**
 - Should the JS/TS keyword only trigger one of the languages or both?
 - Should I implement the minimum keyword matches before we declare a language skill detected?
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Step 1 of the plan is complete. Added regex-based scanning of text content for `.js`, `.jsx`, `.ts`, `.tsx` file extension mentions in `_detect_languages()` (`skill_extractor.py` lines 178-181). Updated the `lang` determination logic to also consider text-based TypeScript signals, not just the `filename` parameter. Added two new tests: `test_js_extension_in_text` and `test_ts_extension_in_text`.
+
+**Next steps:**
+- Step 2: Expand JS/TS keyword detection to use more of `JS_TS_KEYWORDS` (`const`, `let`, `var`, `export`, `function`) and fix the `require` regex from `\s+` to `\b`.
+- Step 3: Add TypeScript-specific text patterns (`typescript`, `interface`, generic types) for text-based TypeScript detection.
+- Step 4: Add Dockerfile keyword and docker-compose detection to `_detect_tools()`.
+- Step 5: Run all four target tests and verify no regressions.
+
+**Blockers:**
+Leading the capstone project effort for WEB103, which includes implementing features, conducting code reviews, and coordinating with teammates to keep the project on track. This is taking up a significant portion of my available time this week.
+
+**Existing failures:**
+- Aside from the targets in `test_skill_extractor.py`, there's one more failing test: `test_database_technology_detection`
+- 19 mypy errors on function missing a type annotation in `test_skill_extractor.py`
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [link to your submitted pull request]
+
+**Branch:** [the branch name you worked on, e.g. `fix/123-short-description`]
+
+**What you built:**
+[1–3 sentences summarizing what your fix does and how it works]
+
+**Tests added or updated:**
+[Which test files did you touch? What do they cover?]
+
+**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+
+**Draft PR feedback received from:** [name or Slack handle, or "none"]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -101,4 +101,4 @@ Added 7 new tests to `tests/unit/test_skill_extractor.py`: `test_js_extension_in
 
 **Self-review confirmation:** [x] make check passes  [x] make test-unit passes
 
-**Draft PR feedback received from:** [name or Slack handle, or "none"]
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -102,3 +102,38 @@ Added 7 new tests to `tests/unit/test_skill_extractor.py`: `test_js_extension_in
 **Self-review confirmation:** [x] make check passes  [x] make test-unit passes
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No review came in.
+
+**How you responded:**
+No feedback received yet.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+[Be specific — what part of the process, codebase, or workflow
+surprised you?]
+
+**What did you learn about working in a large codebase?**
+[What's different about contributing to someone else's production code
+vs. building your own project?]
+
+**How did AI tools help — and where did they fall short?**
+[Where was AI assistance most useful this module? Where did you need
+to go beyond what AI could give you?]
+
+**What would you do differently if you started over?**
+[Issue selection, planning, implementation, or process — anything
+you'd change?]
+
+**What are you most proud of from this module?**
+[One thing — it doesn't have to be the PR itself.]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -91,14 +91,14 @@ Leading the capstone project effort for WEB103, which includes implementing feat
 
 **PR link:** [link to your submitted pull request]
 
-**Branch:** [the branch name you worked on, e.g. `fix/123-short-description`]
+**Branch:** `fix/148-javascript-and-typescript-failed-skill-parser`
 
 **What you built:**
-[1–3 sentences summarizing what your fix does and how it works]
+Extended `_detect_languages()` in `skill_extractor.py` to detect JavaScript and TypeScript from text content — scanning for `.js`/`.jsx`/`.ts`/`.tsx` file extension mentions, JS keywords (`const`, `let`, `var`, `export`, `function`, `class`, `async`, `await`, `require`), and TypeScript-specific patterns (`interface`, type annotations, generic types, the word "typescript"). Also extended `_detect_tools()` to detect Docker from Dockerfile instructions (`FROM`, `RUN`, `EXPOSE`, etc.) and docker-compose structure, without requiring the word "docker" to appear explicitly.
 
 **Tests added or updated:**
-[Which test files did you touch? What do they cover?]
+Added 7 new tests to `tests/unit/test_skill_extractor.py`: `test_js_extension_in_text`, `test_ts_extension_in_text`, `test_js_keywords_in_text`, `test_javascript_keyword_in_prose`, `test_typescript_keyword_in_prose`, `test_typescript_type_annotations`, and `test_docker_filename_in_prose`. All 4 originally failing tests now pass. The only remaining failure is `test_database_technology_detection`, a pre-existing bug in the test itself (references `skill_names` before it's defined).
 
-**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
 
 **Draft PR feedback received from:** [name or Slack handle, or "none"]

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,72 @@
+## Solution plan
+
+**Issue:** [Skill extractor fails to detect JavaScript and TypeScript](https://github.com/ascherj/pathreview/issues/148)
+
+### Understand
+What is the root cause of this issue? What behavior is expected vs. actual?  
+
+The root cause lies in `skill_extractor.py`between line 174-192. The current code for JavaScript and TypeScript filename detection
+only checks for the `filename` parameter. It does not check for the `.js`, `.jsx`, `.ts`, and `.tsx` inside the text itself.
+The user could be casually mentioning their skills and not providing files they have worked on and the current code would miss
+all the mentions of their work. It is also missing other keyword detector listed in `JS_TS_KEYWORDS` like `const`, `let`, `var`, etc.
+
+The expected behavior is the detector should be able to detect more JavaScript and TypeScript related keywords and also able to
+detect filename extensions within the text itself rather than just relying on the user passing in the `filename` parameter. 
+It should also detect Docker keywords and `Dockerfile` and `docker-compose.yml` name.
+
+The current behavior lacks the Docker detector entirely unless the text contains the word `docker`. For JavaScript and TypeScript, 
+the filename detection only works if the user passes in the files themselves, it cannot yet detect the filename mentions in the text.
+For the keyword detection, it can only detects `import`, `require`, and `package.json`. But `require` can still fail since the detector
+expects some whitespaces immediately after the keyword i.e. `require("fs")` would fail to be detected.
+
+### Map
+Which files, functions, or modules are involved?
+List the specific files you expect to touch.
+
+Files: `ingestion/parsers/skill_extractor.py` for code and `tests/unit/test_skill_extractor.py` for tests.
+Functions: 
+  - Code: `extract_skills()` -> `_detect_languages()` and `extract_skills()` -> `_detect_tools()`
+  - Tests: `test_javascript_detection()`, `test_text_with_typescript_files()`, `test_devops_tool_detection()`, `test_docker_compose_detection()`
+Modules: `ingestion/parsers` and `tests/unit`
+
+The code changes would mainly be in `_detect_languages()` line 174-192 and `_detect_tools()` line 267-277.
+
+### Plan
+What are the steps to fix this issue?
+Break it into 3–5 concrete sub-tasks.
+
+1. In `_detect_languages()`, add a regex scan of the text for `.js`, `.jsx`, `.ts`, `.tsx` extensions so filename mentions in text are caught without a `filename` parameter.
+2. In `_detect_languages()`, expand the JS/TS keyword check to use more of `JS_TS_KEYWORDS` — add `const`, `let`, `var`, `export`, `function` alongside `import`/`require`. Also fix the require regex from `\s+` to `\s*` so `require('fs')` matches.
+3. In `_detect_languages()`, add TypeScript-specific text patterns: the word `typescript`, `interface` declarations, and generic type syntax (`: string`, `Promise<`, etc.) so TypeScript can be detected from prose without a `.ts` filename.
+4. In `_detect_tools()`, add Dockerfile keyword detection (`FROM`, `RUN`, `EXPOSE`, `CMD`, `ENTRYPOINT`) and docker-compose indicators (`services:`, `docker-compose`) so Docker is detected without the word "docker" appearing explicitly.
+5. Run the four failing tests to confirm they pass, and verify no existing passing tests regress.
+
+### Inputs & outputs
+What does your fix take as input? What should it produce or change?
+
+Input: A string of text (and an optional `filename` parameter) passed to `extract_skills()`. The text may be prose describing work experience, source code snippets, or configuration file content.
+
+Output: A list of `SkillDetection` objects sorted by confidence. After the fix, text containing JS/TS keywords, `.js`/`.ts`/`.tsx` extension mentions, TypeScript syntax, or Dockerfile/docker-compose content should produce the appropriate `SkillDetection` entries that are currently missing.
+
+What changes: No new inputs or outputs are introduced — the function signature stays the same. Only the detection logic inside `_detect_languages()` and `_detect_tools()` changes to catch more patterns from the existing input.
+
+### Risks & unknowns
+What could go wrong? What are you still unsure about?
+
+Risks:
+- Broadening the JS keyword list (`const`, `let`, `var`) risks false positives — these words appear in plain English and other languages. A sentence like "let me explain" could trigger JavaScript detection.
+- Adding Dockerfile keyword detection (`FROM`, `RUN`) carries the same risk — common English words that could appear in non-code text.
+
+Unknowns:
+- Whether the fix should require a minimum number of keyword matches (2+) before emitting a detection, to guard against false positives from common English words like `let`, `var`, `FROM`, or `RUN`. The current codebase only requires 1 match before emitting the detection.
+- Whether TypeScript and JavaScript should ever be detected simultaneously from the same text, or if detecting TypeScript should suppress JavaScript.
+
+### Edge cases
+What inputs or states should your fix handle gracefully?
+
+- Text containing `let` or `const` in plain English context (e.g. "let me explain the const approach") — should not trigger JavaScript detection.
+- Text mentioning `.ts` in a non-TypeScript context (e.g. "exports.ts" or a timestamp abbreviation "10 ts ago") — should not trigger TypeScript detection.
+- Text that mentions both `.tsx` and TypeScript keywords — should emit TypeScript, not JavaScript (`.tsx` is in `REACT_INDICATORS` and currently only triggers React).
+- Empty string or whitespace-only input — already handled, should continue returning `[]`.
+- Text with mixed JS and TS signals — should emit whichever has stronger evidence, or both if warranted.
+- Dockerfile content passed as text with no `filename` — should detect Docker after the fix.

--- a/PLAN.md
+++ b/PLAN.md
@@ -36,7 +36,7 @@ What are the steps to fix this issue?
 Break it into 3–5 concrete sub-tasks.
 
 1. In `_detect_languages()`, add a regex scan of the text for `.js`, `.jsx`, `.ts`, `.tsx` extensions so filename mentions in text are caught without a `filename` parameter.
-2. In `_detect_languages()`, expand the JS/TS keyword check to use more of `JS_TS_KEYWORDS` — add `const`, `let`, `var`, `export`, `function` alongside `import`/`require`. Also fix the require regex from `\s+` to `\s*` so `require('fs')` matches.
+2. In `_detect_languages()`, expand the JS/TS keyword check to use more of `JS_TS_KEYWORDS` — add `const`, `let`, `var`, `export`, `function` alongside `import`/`require`. Also fix the require regex from `\s+` to `\b` so `require('fs')` matches.
 3. In `_detect_languages()`, add TypeScript-specific text patterns: the word `typescript`, `interface` declarations, and generic type syntax (`: string`, `Promise<`, etc.) so TypeScript can be detected from prose without a `.ts` filename.
 4. In `_detect_tools()`, add Dockerfile keyword detection (`FROM`, `RUN`, `EXPOSE`, `CMD`, `ENTRYPOINT`) and docker-compose indicators (`services:`, `docker-compose`) so Docker is detected without the word "docker" appearing explicitly.
 5. Run the four failing tests to confirm they pass, and verify no existing passing tests regress.
@@ -46,7 +46,7 @@ What does your fix take as input? What should it produce or change?
 
 Input: A string of text (and an optional `filename` parameter) passed to `extract_skills()`. The text may be prose describing work experience, source code snippets, or configuration file content.
 
-Output: A list of `SkillDetection` objects sorted by confidence. After the fix, text containing JS/TS keywords, `.js`/`.ts`/`.tsx` extension mentions, TypeScript syntax, or Dockerfile/docker-compose content should produce the appropriate `SkillDetection` entries that are currently missing.
+Output: A list of `SkillDetection` objects sorted by confidence. After the fix, text containing JS/TS keywords, `.js`/`.jsx`/`.ts`/`.tsx` extension mentions, TypeScript syntax, or Dockerfile/docker-compose content should produce the appropriate `SkillDetection` entries that are currently missing.
 
 What changes: No new inputs or outputs are introduced — the function signature stays the same. Only the detection logic inside `_detect_languages()` and `_detect_tools()` changes to catch more patterns from the existing input.
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -99,7 +99,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -449,7 +448,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -473,7 +471,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1561,7 +1558,6 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1579,7 +1575,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1972,7 +1967,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3507,7 +3501,6 @@
       "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^2.0.1",
         "cssstyle": "^4.0.1",
@@ -4094,7 +4087,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4107,7 +4099,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4771,7 +4762,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/ingestion/parsers/skill_extractor.py
+++ b/ingestion/parsers/skill_extractor.py
@@ -297,3 +297,19 @@ class SkillExtractor:
                         confidence=confidence,
                         evidence=[f"Found '{tool}' reference in content"],
                     )
+
+        docker_evidence = []
+        if re.search(r"\b(FROM|RUN|EXPOSE|CMD|ENTRYPOINT|COPY|ADD)\b", text):
+            docker_evidence.append("Dockerfile instructions detected")
+        if re.search(r"\bservices\s*:", text) and re.search(r"\b(build|image|ports)\s*:", text):
+            docker_evidence.append("docker-compose structure detected")
+        if "dockerfile" in text_lower or "docker-compose" in text_lower:
+            docker_evidence.append("Docker filename reference found")
+
+        if docker_evidence and "Docker" not in skills_dict:
+            skills_dict["Docker"] = SkillDetection(
+                name="Docker",
+                category="Tool",
+                confidence=min(0.95, 0.6 + len(docker_evidence) * 0.1),
+                evidence=docker_evidence,
+            )

--- a/ingestion/parsers/skill_extractor.py
+++ b/ingestion/parsers/skill_extractor.py
@@ -184,8 +184,10 @@ class SkillExtractor:
             js_evidence.append("JavaScript keyword found")
         if re.search(r"\b(import|require)\b", text):
             js_evidence.append("CommonJS or ES6 imports")
-        if re.search(r"\b(const|let|var|export|function)\b", text):
-            js_evidence.append("JavaScript keywords (const/let/var/export/function)")
+        if re.search(r"\b(const|let|var|export|function|class|async|await)\b", text):
+            js_evidence.append(
+                "JavaScript keywords (const/let/var/export/function/class/async/await)"
+            )
         if "package.json" in text_lower:
             js_evidence.append("package.json found")
 

--- a/ingestion/parsers/skill_extractor.py
+++ b/ingestion/parsers/skill_extractor.py
@@ -1,11 +1,11 @@
 import re
 from dataclasses import dataclass
-from typing import Optional
 
 
 @dataclass
 class SkillDetection:
     """Result of detecting a skill."""
+
     name: str
     category: str
     confidence: float
@@ -105,7 +105,7 @@ class SkillExtractor:
         "ansible": 0.85,
     }
 
-    def extract_skills(self, text: str, filename: Optional[str] = None) -> list[SkillDetection]:
+    def extract_skills(self, text: str, filename: str | None = None) -> list[SkillDetection]:
         """
         Extract skills from source code or documentation text.
 
@@ -116,7 +116,7 @@ class SkillExtractor:
         Returns:
             List of detected skills with confidence scores
         """
-        detected_skills = {}
+        detected_skills: dict[str, SkillDetection] = {}
 
         # Detect languages first
         self._detect_languages(text, filename, detected_skills)
@@ -143,7 +143,7 @@ class SkillExtractor:
     def _detect_languages(
         self,
         text: str,
-        filename: Optional[str],
+        filename: str | None,
         skills_dict: dict,
     ) -> None:
         """Detect programming languages."""
@@ -176,6 +176,10 @@ class SkillExtractor:
             js_evidence.append("JavaScript file extension (.js)")
         if ".ts" in str(filename or "").lower():
             js_evidence.append("TypeScript file extension (.ts)")
+        if re.search(r"\w+\.jsx?\b", text):
+            js_evidence.append("JavaScript file reference (.js/.jsx)")
+        if re.search(r"\w+\.tsx?\b", text):
+            js_evidence.append("TypeScript file reference (.ts/.tsx)")
         if re.search(r"\b(import|require)\s+", text):
             js_evidence.append("CommonJS or ES6 imports")
         if "package.json" in text_lower:
@@ -183,7 +187,11 @@ class SkillExtractor:
 
         if js_evidence:
             confidence = min(0.95, 0.6 + len(js_evidence) * 0.1)
-            lang = "TypeScript" if ".ts" in str(filename or "").lower() else "JavaScript"
+            ts_signals = (
+                ".ts" in str(filename or "").lower()
+                or "TypeScript file reference (.ts/.tsx)" in js_evidence
+            )
+            lang = "TypeScript" if ts_signals else "JavaScript"
             skills_dict[lang] = SkillDetection(
                 name=lang,
                 category="Language",

--- a/ingestion/parsers/skill_extractor.py
+++ b/ingestion/parsers/skill_extractor.py
@@ -180,16 +180,31 @@ class SkillExtractor:
             js_evidence.append("JavaScript file reference (.js/.jsx)")
         if re.search(r"\w+\.tsx?\b", text):
             js_evidence.append("TypeScript file reference (.ts/.tsx)")
-        if re.search(r"\b(import|require)\s+", text):
+        if "javascript" in text_lower:
+            js_evidence.append("JavaScript keyword found")
+        if re.search(r"\b(import|require)\b", text):
             js_evidence.append("CommonJS or ES6 imports")
+        if re.search(r"\b(const|let|var|export|function)\b", text):
+            js_evidence.append("JavaScript keywords (const/let/var/export/function)")
         if "package.json" in text_lower:
             js_evidence.append("package.json found")
 
-        if js_evidence:
-            confidence = min(0.95, 0.6 + len(js_evidence) * 0.1)
+        ts_evidence = []
+        if "typescript" in text_lower:
+            ts_evidence.append("TypeScript keyword found")
+        if re.search(r"\binterface\s+\w+", text):
+            ts_evidence.append("TypeScript interface declaration")
+        if re.search(r":\s*(string|number|boolean|void|never|any)\b", text):
+            ts_evidence.append("TypeScript type annotations")
+        if re.search(r"Promise<|Array<|Record<", text):
+            ts_evidence.append("TypeScript generic types")
+
+        if js_evidence or ts_evidence:
+            confidence = min(0.95, 0.6 + len(js_evidence + ts_evidence) * 0.1)
             ts_signals = (
                 ".ts" in str(filename or "").lower()
                 or "TypeScript file reference (.ts/.tsx)" in js_evidence
+                or bool(ts_evidence)
             )
             lang = "TypeScript" if ts_signals else "JavaScript"
             skills_dict[lang] = SkillDetection(

--- a/tests/unit/test_skill_extractor.py
+++ b/tests/unit/test_skill_extractor.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from ingestion.parsers.skill_extractor import SkillExtractor, SkillDetection
+from ingestion.parsers.skill_extractor import SkillDetection, SkillExtractor
 
 
 @pytest.mark.unit
@@ -135,7 +135,7 @@ class TestSkillExtractor:
         """
         result = extractor.extract_skills(text)
 
-        skill_names = [s.name for s in skill_names]
+        skill_names = [s.name for s in result]
         # Should detect PostgreSQL
         assert any("postgres" in s.lower() or "sql" in s.lower() for s in skill_names)
 
@@ -169,6 +169,22 @@ class TestSkillExtractor:
         skill_names = [s.name for s in result]
         # Filename should provide Python hint
         assert any("python" in s.lower() for s in skill_names)
+
+    def test_js_extension_in_text(self, extractor):
+        """Test JavaScript detection from file extension mentions in text."""
+        text = "Wrote index.js and utils.jsx for the frontend components."
+        result = extractor.extract_skills(text)
+
+        skill_names = [s.name for s in result]
+        assert any("javascript" in s.lower() for s in skill_names)
+
+    def test_ts_extension_in_text(self, extractor):
+        """Test TypeScript detection from file extension mentions in text."""
+        text = "Built app.tsx and types.ts for the user interface."
+        result = extractor.extract_skills(text)
+
+        skill_names = [s.name for s in result]
+        assert any("typescript" in s.lower() for s in skill_names)
 
     def test_javascript_detection(self, extractor):
         """Test JavaScript detection."""
@@ -232,10 +248,7 @@ class TestSkillExtractor:
     def test_skill_detection_dataclass(self):
         """Test SkillDetection dataclass structure."""
         skill = SkillDetection(
-            name="Python",
-            category="Language",
-            confidence=0.95,
-            evidence=["import statement"]
+            name="Python", category="Language", confidence=0.95, evidence=["import statement"]
         )
 
         assert skill.name == "Python"

--- a/tests/unit/test_skill_extractor.py
+++ b/tests/unit/test_skill_extractor.py
@@ -186,6 +186,43 @@ class TestSkillExtractor:
         skill_names = [s.name for s in result]
         assert any("typescript" in s.lower() for s in skill_names)
 
+    def test_js_keywords_in_text(self, extractor):
+        """Test JavaScript detection from keywords in prose."""
+        text = "Used const and let declarations with export functions and var assignments."
+        result = extractor.extract_skills(text)
+
+        skill_names = [s.name for s in result]
+        assert any("javascript" in s.lower() for s in skill_names)
+
+    def test_javascript_keyword_in_prose(self, extractor):
+        """Test JavaScript detection from the word 'javascript' in prose."""
+        text = "I have three years of experience with JavaScript development."
+        result = extractor.extract_skills(text)
+
+        skill_names = [s.name for s in result]
+        assert any("javascript" in s.lower() for s in skill_names)
+
+    def test_typescript_keyword_in_prose(self, extractor):
+        """Test TypeScript detection from the word 'typescript' in prose."""
+        text = "Migrated the codebase from JavaScript to TypeScript for better type safety."
+        result = extractor.extract_skills(text)
+
+        skill_names = [s.name for s in result]
+        assert any("typescript" in s.lower() for s in skill_names)
+
+    def test_typescript_type_annotations(self, extractor):
+        """Test TypeScript detection from type annotation syntax."""
+        text = """
+        function greet(name: string): void {
+            console.log(name);
+        }
+        async function fetch(): Promise<string> {}
+        """
+        result = extractor.extract_skills(text)
+
+        skill_names = [s.name for s in result]
+        assert any("typescript" in s.lower() for s in skill_names)
+
     def test_javascript_detection(self, extractor):
         """Test JavaScript detection."""
         text = """

--- a/tests/unit/test_skill_extractor.py
+++ b/tests/unit/test_skill_extractor.py
@@ -250,6 +250,14 @@ class TestSkillExtractor:
         skill_names = [s.name for s in result]
         assert any("docker" in s.lower() for s in skill_names)
 
+    def test_docker_filename_in_prose(self, extractor):
+        """Test Docker detection from Dockerfile or docker-compose mention in prose."""
+        text = "Containerized the app by writing a Dockerfile and a docker-compose.yml."
+        result = extractor.extract_skills(text)
+
+        skill_names = [s.name for s in result]
+        assert any("docker" in s.lower() for s in skill_names)
+
     def test_aws_gcp_azure_detection(self, extractor):
         """Test cloud platform detection."""
         text = """


### PR DESCRIPTION
## Summary
`SkillExtractor._detect_languages()` previously could not detect JavaScript or TypeScript from text content — it only checked the `filename` parameter for `.js`/`.ts` extensions and had a regex that failed on `require('fs')` (no space after `require`). This PR fixes language detection by scanning text for file extension mentions (`.js`, `.jsx`, `.ts`, `.tsx`), expanding keyword coverage to include `const`, `let`, `var`, `export`, `function`, `class`, `async`, `await`, and adding TypeScript-specific patterns (`interface` declarations, type annotations, generic types). It also fixes `_detect_tools()` to detect Docker from Dockerfile instructions and docker-compose structure without requiring the word "docker" to appear explicitly.

## Issue
Closes #148 

## Changes
- Added regex scans in _detect_languages() for .js/.jsx/.ts/.tsx file extension mentions in text content
- Fixed require detection regex from \s+ to \b so require('fs') is matched
- Added JS keyword detection for const, let, var, export, function, class, async, await
- Added TypeScript-specific text detection: interface declarations, type annotations (: string, : number, etc.), generic types (Promise<, Array<, Record<), and the word "typescript"
- Updated lang determination to emit TypeScript when TypeScript signals are found in text, not just when a .ts filename is passed
- Added Dockerfile instruction detection (FROM, RUN, EXPOSE, CMD, ENTRYPOINT, COPY, ADD) and docker-compose structure detection (services: + build:/image:/ports:) to _detect_tools()
- Added 7 new unit tests covering each of the above detection paths

## Testing
- [x] Unit tests pass (`make test-unit`)
- [x] Integration tests pass (`make test-integration`) note: no existing tests
- [x] Linter passes (`make lint`)
- [x] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes

To manually verify, open a Python interpreter from the project root with the virtual environment activated and run the reproduction steps from the issue:
```
from ingestion.parsers.skill_extractor import SkillExtractor
e = SkillExtractor()
print(e.extract_skills('Wrote index.js using const arrow functions and async/await callbacks'))
# Expected: [SkillDetection(name='JavaScript', ...)]
print([d.name for d in e.extract_skills('Built app.tsx and types.ts with strict TypeScript interfaces')])
# Expected: ['TypeScript', 'React']
```

## Screenshots / Demo
<img width="1313" height="245" alt="image" src="https://github.com/user-attachments/assets/c2cb6963-77bf-4543-a9f4-94efab01b8a1" />

## Notes for Reviewers
`test_database_technology_detection` in `tests/unit/test_skill_extractor.py` is a pre-existing failure — line 138 references `skill_names` before it is defined (should be `result`). This failure exists on main and is unrelated to this PR.
