### PR TITLE
fix: redact parenthesized US phone numbersFix/146 redact parenthesized phone numbers

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -43,3 +43,57 @@ Not recorded.
 
 **Blockers or open questions:**
 The backend setup exposed startup issues in the provided starter repository. Although the frontend and Docker services were configured successfully, the backend initialization encountered database startup issues. While waiting for guidance from the course staff, I continued analyzing the relevant code and prepared a detailed implementation plan for the assigned issue.
+
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+
+- Investigated the PII scrubber implementation.
+- Identified the phone-number regular expression causing the issue.
+- Planned the implementation.
+- Updated the regex.
+- Verified issue-specific tests.
+
+**Next steps:**
+
+Open the pull request, request review, and complete final testing.
+
+**Blockers:**
+
+The backend setup exposed unrelated startup issues in the starter repository, but they did not prevent implementation of Issue #146.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:**
+
+<GitHub PR URL>
+
+**Branch:**
+
+fix/146-redact-parenthesized-phone-numbers
+
+**What you built:**
+
+Updated the US phone-number detection logic so that phone numbers written with parentheses around the area code are correctly detected and redacted. Existing supported US phone-number formats continue to work.
+
+**Tests added or updated:**
+
+Updated:
+
+- tests/unit/test_pii_scrubber.py
+
+Verified phone-number detection and redaction behavior.
+
+**Self-review confirmation:**
+
+- [ ] make check passes
+- [ ] make test-unit passes
+
+**Draft PR feedback received from:**
+
+None

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -97,3 +97,39 @@ Verified phone-number detection and redaction behavior.
 **Draft PR feedback received from:**
 
 None
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No reviewer feedback was provided during Summer 2026. I completed the contribution and submitted my pull request, but there were no maintainer review comments to respond to during this module.
+
+**How you responded:**
+No response or additional code changes were required because no reviewer feedback was received.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+
+The local development environment was more difficult to set up than I expected. I encountered several issues involving Python versions, Docker, PostgreSQL, and database initialization before I could focus on my selected issue. I also learned that debugging a failure in an unfamiliar repository requires separating problems caused by my own changes from problems that already exist in the codebase. During implementation, even a small regex change required careful testing because a pattern that fixes one input can potentially create false positives or affect other formats.
+
+**What did you learn about working in a large codebase?**
+
+I learned that contributing to an existing codebase is very different from building a project from scratch. Before changing anything, I needed to understand the repository structure, locate the relevant module, inspect existing tests, follow the project's contribution conventions, and keep my change narrowly scoped. For Issue #146, the actual implementation was relatively small, but understanding how `safety/pii_scrubber.py` interacted with the existing tests in `tests/unit/test_pii_scrubber.py` was an important part of making the change safely. I also learned the importance of recognizing unrelated or pre-existing failures rather than expanding the scope of a pull request to fix every problem encountered.
+
+**How did AI tools help — and where did they fall short?**
+
+I used ChatGPT throughout the contribution process to help navigate the unfamiliar repository, interpret error messages, reason about the phone-number regular expression, plan debugging steps, and organize my PLAN.md and JOURNAL.md documentation. AI was especially useful for explaining why the original regular expression could fail on a parenthesized phone number and for suggesting focused tests and edge cases. However, AI suggestions still had to be verified against the actual repository and test results. For example, running the full PII scrubber tests exposed an unrelated failure involving the street-address pattern, and I had to use the real test output to distinguish that existing behavior from the phone-number issue I was fixing. This reinforced that AI can accelerate investigation, but the codebase, tests, and observed behavior remain the source of truth.
+
+**What would you do differently if you started over?**
+
+I would spend less time trying to solve unrelated environment and starter-code problems before narrowing my attention to the specific issue I selected. I would also run the smallest relevant unit tests earlier instead of depending on the entire application to run end-to-end. For Issue #146, the behavior could be investigated directly through `PIIScrubber` and its unit tests without requiring every backend service to be operational. I would establish a baseline of relevant test failures first, make the smallest possible change, rerun the same tests, and only then expand to the broader test suite.
+
+**What are you most proud of from this module?**
+
+I am most proud of continuing through the full contribution workflow despite the setup and debugging challenges. I went from selecting an unfamiliar issue to locating the relevant implementation, reproducing and understanding the behavior, creating a structured solution plan, modifying the PII detection logic, testing the change, and preparing a pull request. More importantly, I became more comfortable working incrementally in someone else's codebase instead of treating every unexpected failure as something my contribution needed to fix.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -9,14 +9,37 @@
 **Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
 
 **Problem summary:**
-This issue affects the safety layer, specifically the PII scrubber. The current scrubber can redact some phone number formats, but it fails when a US phone number uses parentheses around the area code, such as `(415) 555-1234`. A successful fix would update the phone-number detection logic so parenthesized US phone numbers are also redacted consistently without breaking existing redaction behavior. I chose this issue because it has a clear scope and is a manageable first contribution.
+This issue affects the safety layer of the application, specifically the PII scrubber that is responsible for detecting and redacting sensitive information. Currently, phone numbers written with parentheses around the area code, such as `(415) 555-1234`, are not detected and therefore remain visible. A successful fix will update the detection logic so these phone numbers are redacted while preserving the existing behavior for other supported phone number formats. I chose this issue because it has a well-defined scope and is a good first contribution to the project.
 
 **Branch name:** fix/146-redact-parenthesized-phone-numbers
 
-**Setup confirmation:** [x] Frontend runs locally at localhost:5173  
-Backend setup was partially completed. Docker, PostgreSQL, Redis, and the frontend were configured, but backend startup exposed duplicate SQLAlchemy index issues in the starter project.
+**Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
 
-**Selection notes:**
-I chose a Tier 1 safety issue because it appears focused on one behavior in the PII scrubber rather than requiring broad architectural changes. The expected fix should likely involve updating a regex or detection pattern and adding a focused test case.
+### Selection notes ("Is this right for me?" checklist)
+
+- [x] The issue has a clearly defined problem statement.
+- [x] The expected behavior is easy to understand.
+- [x] The issue appears to be limited to a small part of the safety layer.
+- [x] I expect the fix to involve updating the phone-number detection logic and adding or updating tests rather than making large architectural changes.
+- [x] I selected this issue because it is a Tier 1 issue and is appropriate for a first contribution to a larger codebase.
+
+---
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:**
+https://github.com/hemasribavisetty/pathreview/commit/99e431f
+
+**Reproduction summary:**
+I reproduced the issue by locating the PII scrubber implementation in `safety/pii_scrubber.py` and reviewing the current phone number detection logic. I confirmed that the issue is related to the regular expression used for US phone numbers, which does not reliably handle phone numbers written with parentheses around the area code, such as `(415) 555-1234`. I also identified the related unit tests in `tests/unit/test_pii_scrubber.py` that will be used to validate the fix.
+
+**PLAN.md link:**
+https://github.com/hemasribavisetty/pathreview/blob/fix/146-redact-parenthesized-phone-numbers/PLAN.md
+
+**Walkthrough video (recommended):**
+Not recorded.
+
+**Blockers or open questions:**
+The backend setup exposed startup issues in the provided starter repository. Although the frontend and Docker services were configured successfully, the backend initialization encountered database startup issues. While waiting for guidance from the course staff, I continued analyzing the relevant code and prepared a detailed implementation plan for the assigned issue.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,22 @@
+# JOURNAL
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/146
+
+**Issue title:** PII scrubber fails to redact parenthesized US phone numbers
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+This issue affects the safety layer, specifically the PII scrubber. The current scrubber can redact some phone number formats, but it fails when a US phone number uses parentheses around the area code, such as `(415) 555-1234`. A successful fix would update the phone-number detection logic so parenthesized US phone numbers are also redacted consistently without breaking existing redaction behavior. I chose this issue because it has a clear scope and is a manageable first contribution.
+
+**Branch name:** fix/146-redact-parenthesized-phone-numbers
+
+**Setup confirmation:** [x] Frontend runs locally at localhost:5173  
+Backend setup was partially completed. Docker, PostgreSQL, Redis, and the frontend were configured, but backend startup exposed duplicate SQLAlchemy index issues in the starter project.
+
+**Cohort ledger:** [ ] Issue added to cohort ledger
+
+**Selection notes:**
+I chose a Tier 1 safety issue because it appears focused on one behavior in the PII scrubber rather than requiring broad architectural changes. The expected fix should likely involve updating a regex or detection pattern and adding a focused test case.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -16,7 +16,7 @@ This issue affects the safety layer, specifically the PII scrubber. The current 
 **Setup confirmation:** [x] Frontend runs locally at localhost:5173  
 Backend setup was partially completed. Docker, PostgreSQL, Redis, and the frontend were configured, but backend startup exposed duplicate SQLAlchemy index issues in the starter project.
 
-**Cohort ledger:** [ ] Issue added to cohort ledger
+**Cohort ledger:** [x] Issue added to cohort ledger
 
 **Selection notes:**
 I chose a Tier 1 safety issue because it appears focused on one behavior in the PII scrubber rather than requiring broad architectural changes. The expected fix should likely involve updating a regex or detection pattern and adding a focused test case.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,87 @@
+# PLAN
+
+# Solution plan
+
+**Issue:** PII scrubber fails to redact parenthesized US phone numbers  
+**Issue Link:** https://github.com/ascherj/pathreview/issues/146
+
+---
+
+## Understand
+
+This issue affects the safety layer of the application, specifically the PII scrubber responsible for detecting and redacting personally identifiable information. The current implementation is intended to detect several US phone number formats, but numbers written with parentheses around the area code, such as `(415) 555-1234`, are not consistently detected and therefore are not redacted. The expected behavior is for these phone numbers to be replaced with `[REDACTED]` while maintaining support for all currently supported phone number formats.
+
+---
+
+## Map
+
+The primary files involved are:
+
+- `safety/pii_scrubber.py`
+  - Contains the `PIIScrubber` class.
+  - Defines the `phone_us` regular expression.
+  - Implements the `scrub()` and `detect()` methods.
+
+- `tests/unit/test_pii_scrubber.py`
+  - Contains unit tests for phone-number detection and redaction.
+  - Will be used to verify that parenthesized phone numbers are correctly handled.
+
+---
+
+## Plan
+
+1. Review the current `phone_us` regular expression in `safety/pii_scrubber.py`.
+2. Reproduce the issue using the existing unit tests and confirm the current behavior.
+3. Update the regular expression so that phone numbers with parenthesized area codes are detected correctly.
+4. Verify that existing supported phone number formats continue to pass.
+5. Run the relevant unit tests and confirm that no regressions have been introduced.
+
+---
+
+## Inputs & outputs
+
+### Input
+
+```
+Please call me at (415) 555-1234.
+```
+
+### Current Output
+
+```
+Please call me at (415) 555-1234.
+```
+
+### Expected Output
+
+```
+Please call me at [REDACTED].
+```
+
+The `detect()` method should also return a detection of type `phone_us` for the phone number.
+
+---
+
+## Risks & unknowns
+
+- Updating the regular expression could accidentally affect detection of other supported phone number formats.
+- A broader regex may introduce false positives by matching numeric strings that are not phone numbers.
+- The interaction between the US phone pattern and the international phone pattern should be verified to avoid overlapping matches.
+- Additional edge cases may already exist in the test suite that need to continue passing after the change.
+
+---
+
+## Edge cases
+
+The updated solution should correctly handle:
+
+- `(415) 555-1234`
+- `(415)555-1234`
+- `(415)-555-1234`
+- `415-555-1234`
+- `415.555.1234`
+- `+1 (415) 555-1234`
+- Multiple phone numbers within the same document.
+- Phone numbers surrounded by punctuation.
+- Existing supported phone number formats should continue to work without modification.
+- Numeric strings that are not valid phone numbers should not be falsely redacted.

--- a/safety/pii_scrubber.py
+++ b/safety/pii_scrubber.py
@@ -12,7 +12,11 @@ class PIIScrubber:
     # Regex patterns for common PII
     PII_PATTERNS = {
         "email": r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b",
-        "phone_us": r"\b(?:\+?1[-.]?)?\(?([0-9]{3})\)?[-.]?([0-9]{3})[-.]?([0-9]{4})\b",
+        "phone_us": (
+            r"(?<!\w)(?:\+?1[\s.-]?)?"
+            r"(?:\([0-9]{3}\)|[0-9]{3})"
+            r"[\s.-]?[0-9]{3}[\s.-]?[0-9]{4}(?!\w)"
+        ),
         "phone_intl": r"\+[0-9]{1,3}[-.]?[0-9]{1,14}",
         "ssn": r"\b(?!000|666)[0-9]{3}-(?!00)[0-9]{2}-(?!0000)[0-9]{4}\b",
         "street_address": r"\b\d+\s+[A-Za-z\s]+(?:Street|St|Avenue|Ave|Road|Rd|Boulevard|Blvd|Drive|Dr|Lane|Ln|Court|Ct|Circle|Cir|Park|Pl|Plaza|Place|Drive|Dr|Way|Parkway|Pkwy|Point|Pt|Pike|Run|Summit|Summit|Terrace|Ter|Trail|Trl|Tunnel|Turnpike|View|Vista|Vlg|Village|Vly|Valley)",

--- a/tests/unit/test_pii_scrubber.py
+++ b/tests/unit/test_pii_scrubber.py
@@ -31,13 +31,15 @@ class TestPIIScrubber:
         assert "alice@example.com" not in scrubbed
         assert "bob@company.org" not in scrubbed
 
-    def test_us_phone_number_redaction(self, scrubber):
-        """Test US phone number is redacted."""
-        text = "Call me at (555) 123-4567"
-        scrubbed = scrubber.scrub(text)
+    def test_detect_phone_pii(self, scrubber):
+        """Test detect() finds a parenthesized US phone number."""
+        text = "Phone: (555) 123-4567"
+        detected = scrubber.detect(text)
 
-        assert "[REDACTED]" in scrubbed
-        assert "555" not in scrubbed or "1234567" not in scrubbed
+        phone_detections = [d for d in detected if d["type"] == "phone_us"]
+
+        assert len(phone_detections) == 1
+        assert phone_detections[0]["value"] == "(555) 123-4567"
 
     def test_us_phone_formats(self, scrubber):
         """Test various US phone number formats."""

--- a/tests/unit/test_pii_scrubber.py
+++ b/tests/unit/test_pii_scrubber.py
@@ -252,3 +252,9 @@ class TestPIIScrubber:
 
         # Should be minimal or no detections
         # (version number shouldn't be flagged as SSN)
+    def test_scrub_parenthesized_us_phone_number(self, scrubber):
+        text = "Call me at (415) 555-1234."
+        result = scrubber.scrub(text)
+
+        assert "(415) 555-1234" not in result
+        assert "[REDACTED]" in result   


### PR DESCRIPTION
## Summary

This pull request fixes Issue #146 by updating the US phone-number detection pattern in the PII scrubber.

The previous implementation failed to detect phone numbers written with parentheses around the area code, such as `(555) 123-4567`. The updated regular expression now supports both parenthesized and non-parenthesized US phone numbers while preserving support for existing formats.

## Changes

- Updated the `phone_us` regular expression in `safety/pii_scrubber.py`
- Verified support for:
  - `(555) 123-4567`
  - `555-123-4567`
  - `555.123.4567`
  - `+1 555 123 4567`
- Updated and verified unit tests in `tests/unit/test_pii_scrubber.py`

## Testing

Commands executed:

```bash
python3 -m pytest tests/unit/test_pii_scrubber.py -v
```

Issue-specific tests passed successfully.

### Pre-existing issue

While running the complete PII scrubber test suite, an unrelated failure remains in:

```
test_mixed_pii_and_text
```

This failure is caused by the existing `street_address` regular expression matching part of the phrase "Python applications". It is unrelated to the phone-number fix implemented in this PR, and this change does not introduce that failure.