### PR TITLE
Fix Issue #152: Improve faithfulness claim support checking

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -37,3 +37,18 @@ Not recorded.
 
 **Blockers or open questions:**
 None at this time.
+
+## Week 9
+### Check-in 1 (mid-week)
+
+**Current progress:**
+
+I implemented the fix for Issue #152, which addresses the faithfulness checker incorrectly marking short supported claims as unsupported. I updated the matching logic to better handle short factual claims and added handling for `None` values in context chunks to prevent runtime errors. I verified the changes by running the unit tests and confirmed that the previously failing tests now pass.
+
+**Next steps:**
+
+I will run the full project validation commands (`make check` and `make test-unit`), review the implementation for code quality, push the latest changes to my GitHub branch, and open a pull request for review. After that, I will complete the Week 9 Check-in 2 section with the PR link.
+
+**Blockers:**
+
+None at this time.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -23,14 +23,14 @@ This issue is labeled Tier 1 and has a focused scope in one main component of th
 ## Week 8 – Reproduction & solution planning
 
 **Reproduction commit link:**
-[to be added after pushing]
+[\[link\]](https://github.com/winniehappi1/pathreview/blob/fix/152-short-claim-support/JOURNAL.md)
 
 **Reproduction summary:**
 
 I reproduced Issue #152 by running the faithfulness checker unit tests locally using pytest. The tests showed that short supported claims were incorrectly scored as unsupported, and a None value in a context chunk caused a TypeError.
 
 **PLAN.md link:**
-[to be added after pushing]
+[\[link\]](https://github.com/winniehappi1/pathreview/blob/fix/152-short-claim-support/PLAN.md)
 
 **Walkthrough video:**
 Not recorded.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -19,3 +19,21 @@ This issue is labeled Tier 1 and has a focused scope in one main component of th
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 – Reproduction & solution planning
+
+**Reproduction commit link:**
+[to be added after pushing]
+
+**Reproduction summary:**
+
+I reproduced Issue #152 by running the faithfulness checker unit tests locally using pytest. The tests showed that short supported claims were incorrectly scored as unsupported, and a None value in a context chunk caused a TypeError.
+
+**PLAN.md link:**
+[to be added after pushing]
+
+**Walkthrough video:**
+Not recorded.
+
+**Blockers or open questions:**
+None at this time.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -8,7 +8,11 @@
 
 **Problem summary:**
 
-The faithfulness checker currently requires at least two meaningful overlapping words between a claim and the retrieved context before marking the claim as supported. This causes short factual claims, such as "Knows Python.", to be incorrectly classified as unsupported even when the context clearly contains supporting information. The issue affects the `rag/evaluator/faithfulness_checker.py` component. A successful fix will allow short claims to be recognized as supported while preserving stricter matching for longer, more detailed claims.
+The faithfulness checker currently requires at least two meaningful overlapping words between a claim and the retrieved context before it marks the claim as supported. Because of this rule, short factual claims such as “Knows Python” are incorrectly scored as unsupported even when the context clearly mentions Python experience. The issue affects the claim-support logic in `rag/evaluator/faithfulness_checker.py`. A successful fix should allow short claims to be recognized from one meaningful keyword while still keeping stronger matching requirements for longer claims.
+
+**Is this right for me? Selection notes:**
+
+This issue is labeled Tier 1 and has a focused scope in one main component of the codebase. The issue description includes a clear example, identifies the relevant file, and lists related tests, so I can reproduce the problem and verify the fix. The work involves Python, string processing, and unit testing, which are skills I am comfortable using. I also confirmed that the issue was open and not assigned before claiming it.
 
 **Branch name:** `fix/152-short-claim-support`
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,17 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/jamjamgobambam/pathreview/issues/152
+
+**Issue title:** Faithfulness checker can never mark short claims as supported
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+
+The faithfulness checker currently requires at least two meaningful overlapping words between a claim and the retrieved context before marking the claim as supported. This causes short factual claims, such as "Knows Python.", to be incorrectly classified as unsupported even when the context clearly contains supporting information. The issue affects the `rag/evaluator/faithfulness_checker.py` component. A successful fix will allow short claims to be recognized as supported while preserving stricter matching for longer, more detailed claims.
+
+**Branch name:** `fix/152-short-claim-support`
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -52,3 +52,23 @@ I will run the full project validation commands (`make check` and `make test-uni
 **Blockers:**
 
 None at this time.
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/651
+
+**Branch:** `fix/152-short-claim-support`
+
+**What you built:**
+
+I updated the faithfulness checker so short factual claims can be recognized as supported when they share a meaningful keyword with the retrieved context. I also improved claim extraction for compound sentences, normalized tokenization to remove punctuation, and made context processing handle missing or `None` text safely.
+
+**Tests added or updated:**
+
+I did not modify the test file. I used the existing tests in `tests/unit/test_faithfulness_checker.py` to validate the implementation, including short-claim support, multiple context chunks, partial support, and `None` context text handling. All 22 tests in that file passed.
+
+**Self-review confirmation:**  
+[x] `make check` completed with no new failures introduced  
+[x] `make test-unit` completed with no new failures introduced
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -72,3 +72,42 @@ I did not modify the test file. I used the existing tests in `tests/unit/test_fa
 [x] `make test-unit` completed with no new failures introduced
 
 **Draft PR feedback received from:** none
+
+
+## Week 10 – Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No – still awaiting review
+
+**Summary of feedback:**
+
+No reviewer feedback was received during the Summer 2026 session. My pull request remained open without maintainer comments.
+
+**How you responded:**
+
+No action was required because no review comments were provided.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+
+The hardest part was understanding an unfamiliar production codebase instead of writing code from scratch. Before making any changes, I had to understand how the faithfulness checker fit into the overall retrieval-augmented generation pipeline, identify where to implement the fix, and make sure my changes matched the project's coding style. I also spent a significant amount of time dealing with Git, pull requests, pre-commit hooks, formatting, and type-checking issues before I could successfully submit my work.
+
+**What did you learn about working in a large codebase?**
+
+I learned that contributing to a production repository requires much more than writing working code. It is important to read existing code patterns, follow contribution guidelines, write changes that are consistent with the rest of the project, and ensure tests and formatting tools pass. I also learned to make small, focused changes instead of trying to redesign the entire implementation.
+
+**How did AI tools help — and where did they fall short?**
+
+AI was very helpful for understanding unfamiliar code, explaining Git commands, suggesting implementations, debugging errors, and helping me interpret the issue requirements. However, AI could not determine exactly what the project maintainers expected or guarantee that a solution would satisfy the issue. I still had to read the issue carefully, compare my implementation with the existing codebase, run the tests myself, and make decisions about which suggestions were appropriate.
+
+**What would you do differently if you started over?**
+
+I would spend more time reading the repository before writing code and create my pull request earlier so I would have more time to receive feedback. I would also make smaller commits throughout the process instead of waiting until multiple changes had accumulated, making it easier to track my progress and debug problems.
+
+**What are you most proud of from this module?**
+
+I am most proud that I successfully completed my first contribution to a real open-source project. From selecting an issue and reproducing it to creating a feature branch, implementing a solution, working through Git and pre-commit issues, and submitting a pull request, I gained practical experience with a professional software development workflow that I had never completed before.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,70 @@
+# Solution Plan
+
+**Issue:**
+Faithfulness checker can never mark short claims as supported (#152)
+
+## Understand
+
+The faithfulness checker currently requires at least two overlapping meaningful tokens between a claim and the retrieved context. Very short factual claims often contain only one important keyword, causing correctly supported claims to be marked unsupported.
+
+Expected:
+Short factual claims should be marked as supported when the context clearly contains the same concept.
+
+Actual:
+Claims like "Knows Python." always receive an unsupported score even when the context contains "Python expert."
+
+---
+
+## Map
+
+Files involved:
+
+- rag/evaluator/faithfulness_checker.py
+- tests/unit/test_faithfulness_checker.py
+
+Functions involved:
+
+- FaithfulnessChecker.check()
+- FaithfulnessChecker._is_supported()
+
+---
+
+## Plan
+
+1. Reproduce the failing tests.
+2. Handle None values safely when building the context text.
+3. Improve token matching for short factual claims.
+4. Keep existing behavior for unsupported claims.
+5. Run all unit tests to confirm the fix.
+
+---
+
+## Inputs & Outputs
+
+Input:
+
+- feedback string
+- context chunks
+
+Output:
+
+- faithfulness score between 0.0 and 1.0
+
+---
+
+## Risks & Unknowns
+
+Changing the overlap logic may accidentally increase false positives.
+
+Need to preserve behavior for unsupported claims while improving short supported claims.
+
+---
+
+## Edge Cases
+
+- Empty feedback
+- Empty context
+- None context text
+- Missing text key
+- Single-word claims
+- Multiple context chunks

--- a/rag/evaluator/faithfulness_checker.py
+++ b/rag/evaluator/faithfulness_checker.py
@@ -1,6 +1,7 @@
 """Check if generated feedback is supported by retrieved context."""
 
 import re
+
 import structlog
 
 logger = structlog.get_logger()
@@ -9,80 +10,122 @@ logger = structlog.get_logger()
 class FaithfulnessChecker:
     """Verify that feedback claims are supported by context."""
 
-    def check(self, feedback: str, context_chunks: list[dict]) -> float:
+    def check(
+        self,
+        feedback: str,
+        context_chunks: list[dict[str, str | None]],
+    ) -> float:
         """Check faithfulness of feedback to context.
 
         Args:
-            feedback: Generated feedback text
-            context_chunks: Retrieved context chunks
+            feedback: Generated feedback text.
+            context_chunks: Retrieved context chunks.
 
         Returns:
-            Faithfulness score 0.0-1.0 (ratio of supported claims)
+            Faithfulness score from 0.0 to 1.0.
         """
         if not feedback or not context_chunks:
-            logger.info("faithfulness_empty_input", has_feedback=bool(feedback),
-                       has_chunks=bool(context_chunks))
+            logger.info(
+                "faithfulness_empty_input",
+                has_feedback=bool(feedback),
+                has_chunks=bool(context_chunks),
+            )
             return 0.0
 
-        # Extract key claims from feedback (sentences)
         claims = self._extract_claims(feedback)
+
         if not claims:
             logger.info("faithfulness_no_claims_extracted")
-            return 0.5  # Default to neutral if no extractable claims
+            return 0.5
 
-        # Concatenate context text
-        context_text = " ".join([
-            chunk.get("text", "") for chunk in context_chunks
-        ])
+        context_text = " ".join(chunk.get("text") or "" for chunk in context_chunks)
 
-        # Check each claim for support
-        supported = 0
-        for claim in claims:
-            if self._is_supported(claim, context_text):
-                supported += 1
+        supported_count = sum(self._is_supported(claim, context_text) for claim in claims)
 
-        score = supported / len(claims) if claims else 0.0
+        score = supported_count / len(claims)
 
-        logger.info("faithfulness_checked", claims_count=len(claims),
-                   supported_count=supported, score=score)
+        logger.info(
+            "faithfulness_checked",
+            claims_count=len(claims),
+            supported_count=supported_count,
+            score=score,
+        )
 
         return score
 
     @staticmethod
     def _extract_claims(text: str) -> list[str]:
-        """Extract key claims from feedback text.
+        """Extract individual claims from feedback text.
 
         Args:
-            text: Feedback text
+            text: Feedback text.
 
         Returns:
-            List of claims (sentences)
+            A list of individual claims.
         """
-        # Split by sentence (simple regex)
-        sentences = re.split(r'[.!?]+', text)
-        claims = [s.strip() for s in sentences if s.strip() and len(s.strip()) > 10]
-        return claims[:10]  # Limit to 10 claims for scoring
+        sentences = re.split(r"[.!?]+", text)
+        claims: list[str] = []
+
+        for sentence in sentences:
+            sentence = sentence.strip()
+
+            if not sentence:
+                continue
+
+            parts = re.split(r"\s*(?:,|\band\b)\s*", sentence)
+
+            claims.extend(part.strip() for part in parts if part.strip())
+
+        return claims[:10]
 
     @staticmethod
     def _is_supported(claim: str, context: str) -> bool:
-        """Check if a claim is supported by context.
+        """Check whether a claim is supported by the context.
 
         Args:
-            claim: Claim text
-            context: Context text
+            claim: Claim text.
+            context: Context text.
 
         Returns:
-            True if claim is supported
+            True when the claim has enough meaningful overlap with the context.
         """
-        # Tokenize and check for keyword overlap
-        claim_tokens = set(claim.lower().split())
-        context_tokens = set(context.lower().split())
+        claim_tokens = set(re.findall(r"\b\w+\b", claim.lower()))
+        context_tokens = set(re.findall(r"\b\w+\b", context.lower()))
 
-        # Require at least some meaningful overlap
-        overlap = claim_tokens & context_tokens
-        # Filter out common stop words
-        stop_words = {'a', 'an', 'the', 'is', 'are', 'was', 'were', 'be', 'been',
-                     'and', 'or', 'but', 'in', 'of', 'to', 'for', 'that'}
-        meaningful_overlap = overlap - stop_words
+        stop_words = {
+            "a",
+            "an",
+            "the",
+            "is",
+            "are",
+            "was",
+            "were",
+            "be",
+            "been",
+            "and",
+            "or",
+            "but",
+            "in",
+            "of",
+            "to",
+            "for",
+            "that",
+            "has",
+            "have",
+            "had",
+            "shows",
+            "show",
+            "demonstrates",
+            "demonstrated",
+        }
 
-        return len(meaningful_overlap) >= 2
+        meaningful_claim_tokens = claim_tokens - stop_words
+
+        if not meaningful_claim_tokens:
+            return False
+
+        meaningful_overlap = meaningful_claim_tokens & context_tokens
+
+        required_overlap = 1 if len(meaningful_claim_tokens) <= 4 else 2
+
+        return len(meaningful_overlap) >= required_overlap


### PR DESCRIPTION
## Summary
This PR improves the faithfulness checker by splitting generated feedback into individual claims and checking whether each claim is supported by the retrieved context using meaningful token overlap.

## Changes
- Improved claim extraction
- Improved claim support matching
- Added handling for compound sentences
- Updated JOURNAL.md for Week 9

## Testing
- ✅ make test-unit
- ✅ make check (or no new failures introduced)

## Related Issue
Fixes #152