### PR TITLE
Fix/86 api rate limiting header

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -8,7 +8,7 @@
 **Problem summary:**
 Currently there is no rate limiting implemented on the API endpoint, the only limiter is the mocked Redis one that shows why the unit test passed rather than the live program. When I, the user tried to make many requests they were all 200 ok which shows why I was not able to get 429. I will need to add the middle ware of the rate limiting along with the headers to notify the users how many requests. Since its a middle ware, I dont need to go implement it for all routes as all responses will need to go through my middle ware.
 
-**Branch name:** `fix/86/api-rate-limiting-header`
+**Branch name:** `fix/86-api-rate-limiting-header`
 
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
@@ -45,3 +45,28 @@ wired in.
 **Scope:**
 
 I have worked with other large codebases before like Thonny and Idle Python Editors, so I believe this issue will be addressed within the next couple of weeks.
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [link to commit documenting the reproduced issue]
+
+**Reproduction summary:**
+I went to `http://localhost:8000/docs#/reviews/list_reviews_endpoint_reviews_get` and logged in with `user1.example.com` on the lock icon to generate a curl command of the reviews. Then I used the terminal with the following commands. Where the key is the token generated with the curl command.
+``` bash
+TOKEN=<Key>
+
+for i in {1..1000}; do
+  code=$(curl -s -o /dev/null -w "%{http_code}" \
+    "http://localhost:8000/reviews?page=1&page_size=20" \
+    -H "Authorization: Bearer $TOKEN")
+  echo "$code"
+done > status_code.log
+```
+Once it's done running, I ran `sort status_code.log | uniq -c` and it showed `1000 200` in the terminal.
+
+These commands prints the status codes of 1000 GET requests made for the reviews page and prints it out to a `status_code.log` file then the `sort status_code.log | uniq -c` finds different instances of status codes. `1000 200` means that there are 1000 instances of 200 status codes and shows no 429 meaning a rate limiter has not been implemented for the API. I also ran the test suite for `tests/unit/test_rate_limiter.py`, it shows that all tests passed, but upon further inspection, it only tests on a mocked Redis rather than actual requests from the API.
+
+**PLAN.md link:** [link to PLAN.md in your fork]
+
+**Blockers or open questions:**
+[Anything you're still uncertain about going into Week 9, or leave blank]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -69,4 +69,57 @@ These commands prints the status codes of 1000 GET requests made for the reviews
 **PLAN.md link:** [PLAN.md](PLAN.md)
 
 **Blockers or open questions:**
-[Anything you're still uncertain about going into Week 9, or leave blank]
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+So far, the JWT rate limiter and the tests for the JWT are implemented along with the headers that were needed from the issue. X-RateLimit-Limit and X-RateLimit-Remaining headers are added to every API response.
+
+**Next steps:**
+Implement the IP ratelimiting as the fallback when JWT tokens are malformed or expired. Unit testing will are also needed to verify that it reaches to the IP fall back or manual testing.
+
+**Blockers:**
+When implementing the IP rate-limit, how would it limit requests from the login or register pages?
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [link to your submitted pull request]
+
+**Branch:** `fix/86-api-rate-limiting-header`
+
+**What you built:**
+Added `RateLimitMiddleware` (`api/middleware/rate_limiter.py`), which wires 
+the existing (previously unused) `RateLimiter` class into every API request. It resolves a rate-limiting identifier from the JWT's `sub` claim when a valid bearer token is present, falling back to the client's IP address for unauthenticated or invalid/expired tokens. It attaches `X-RateLimit-Limit` and `X-RateLimit-Remaining` headers to every response, and returns a 429 with those same headers once the caller exceeds `rate_limit_per_minute` within the rolling 60-second window.
+
+**Tests added or updated:**
+`tests/unit/test_rate_limiter_middleware.py` (new file, 11 tests): covers 
+valid-JWT requests under/over the limit, remaining-count decrementing 
+across repeated calls, per-user identifier isolation, IP fallback for 
+missing/malformed/non-Bearer/invalid Authorization headers, IP-based 
+isolation across different clients, IP-path over-limit denial, and JWT 
+taking priority over IP when both are available. `RateLimiter`'s own 
+internal logic (rolling window, per-identifier isolation, fail-open on 
+Redis error) is unchanged and already covered by the existing 
+`tests/unit/test_rate_limiter.py`, so this suite mocks `RateLimiter` 
+directly rather than re-testing it.
+
+**Self-review confirmation:** 
+* [x] make check passes  
+
+make check` (lint) introduces zero new errors — confirmed the same 
+182 pre-existing errors present on a fresh clean pull remain unchanged 
+after my changes; my two new files pass `ruff check` cleanly on their own
+
+* [x] make test-unit passes
+
+`python -m pytest tests/unit/test_rate_limiter_middleware.py 
+tests/unit/test_rate_limiter.py`, 30 passed  
+Prior to changes was 53 failed, 375 passed, 1 warnings in 5.00s
+After Changes was 53 failed, 386 passed, 2 warnings in 5.00s 
+As a result no changes caused pre-existing tests to fail. 
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -48,7 +48,7 @@ I have worked with other large codebases before like Thonny and Idle Python Edit
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [link to commit documenting the reproduced issue]
+**Reproduction commit link:** [Link to Commit Documenting the Reproduced Issue](https://github.com/ascherj/pathreview/commit/cc6aa2d6556f14164dedfd9f994bd92b8dcf7655)
 
 **Reproduction summary:**
 I went to `http://localhost:8000/docs#/reviews/list_reviews_endpoint_reviews_get` and logged in with `user1.example.com` on the lock icon to generate a curl command of the reviews. Then I used the terminal with the following commands. Where the key is the token generated with the curl command.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -87,7 +87,7 @@ When implementing the IP rate-limit, how would it limit requests from the login 
 
 ### Check-in 2 (end of week)
 
-**PR link:** [link to your submitted pull request]
+**PR link:** [Link to pull request](https://github.com/ascherj/pathreview/compare/main...kevku:pathreview:fix/86-api-rate-limiting-header?expand=1)
 
 **Branch:** `fix/86-api-rate-limiting-header`
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -66,7 +66,7 @@ Once it's done running, I ran `sort status_code.log | uniq -c` and it showed `10
 
 These commands prints the status codes of 1000 GET requests made for the reviews page and prints it out to a `status_code.log` file then the `sort status_code.log | uniq -c` finds different instances of status codes. `1000 200` means that there are 1000 instances of 200 status codes and shows no 429 meaning a rate limiter has not been implemented for the API. I also ran the test suite for `tests/unit/test_rate_limiter.py`, it shows that all tests passed, but upon further inspection, it only tests on a mocked Redis rather than actual requests from the API.
 
-**PLAN.md link:** [link to PLAN.md in your fork]
+**PLAN.md link:** [PLAN.md](PLAN.md)
 
 **Blockers or open questions:**
 [Anything you're still uncertain about going into Week 9, or leave blank]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,47 @@
+## Week 7 — Issue selection
+
+**Issue link:** [Issue](https://github.com/ascherj/pathreview/issues/86)
+**Issue title:** Add an API rate limiting header (X-RateLimit-Remaining) to responses
+
+**Tier:** [ ] Tier 1  [x] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+Currently there is no rate limiting implemented on the API endpoint, the only limiter is the mocked Redis one that shows why the unit test passed rather than the live program. When I, the user tried to make many requests they were all 200 ok which shows why I was not able to get 429. I will need to add the middle ware of the rate limiting along with the headers to notify the users how many requests. Since its a middle ware, I dont need to go implement it for all routes as all responses will need to go through my middle ware.
+
+**Branch name:** `fix/86/api-rate-limiting-header`
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger
+
+### **Selection Notes:**
+
+**Do I understand which part of the app is affected?**
+
+Yes. This touches `api/middleware/` (currently only `request_id.py` and an 
+auth middleware exist — no rate limiting middleware), `safety/rate_limiter.py` 
+(the unused `RateLimiter` class), and `core/config.py` (unused 
+`rate_limit_per_minute` setting). I confirmed all three files exist and read 
+their contents directly.
+
+**Do I understand what "done" looks like?**
+
+Yes. Before: authenticated requests to any endpoint always return 200, no 
+matter how many are sent in a short window, and no response includes rate 
+limit information. After: once a client exceeds [X] requests in [window], 
+they receive a 429 response; every response (whether allowed or blocked) 
+includes `X-RateLimit-Limit` and `X-RateLimit-Remaining` headers so clients 
+can proactively back off before hitting the limit.
+
+**Can I find the relevant code?**
+
+Yes. I read `RateLimiter.check_rate_limit()` in full, including its Redis 
+sorted-set logic and fail-open behavior on Redis errors. I also read 
+`RequestIDMiddleware` in `api/middleware/request_id.py` as the structural 
+template for how middleware is written and registered in this app, and 
+traced `main.py` to see exactly where and how `add_middleware()` calls are 
+wired in.
+
+**Scope:**
+
+I have worked with other large codebases before like Thonny and Idle Python Editors, so I believe this issue will be addressed within the next couple of weeks.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -123,3 +123,34 @@ After Changes was 53 failed, 386 passed, 2 warnings in 5.00s
 As a result no changes caused pre-existing tests to fail. 
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [x] Yes  [ ] No — still awaiting review
+
+**Summary of feedback:**
+The feedback that was provided said that I properly recognized that there were components in the codebase that were not utilized for example the config settings for the RateLimiter and the RateLimiter class itself. It said utilizing JWT and IP as a fallback was a thoughtful design choice and keeping my scope related to the issue. What I could have improve on was running the entire test-suite and adding more tests to the pre-exisiting RateLimiter as the Middleware relies on that component to be working properly.
+
+**How you responded:**
+I think I remembered running the entire test-suite before and after the implementation of the RateLimit Middleware, but I did not mention it in the `JOURNAL.md` or my PR. Additionally, I provided Claude the tests for the RateLimiter and it thought that the tests were pretty comprehensive during a prompt. I think next time I should have confirmed it myself and try to think of more edge cases to test the limits of the RateLimiter.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+I thought that having a week to decide on what issues to work on made a huge impact on the scope of the project. I was either deciding from choosing tier 1 or tier 2 issues from GitHub since I've never contributed to an open source repo, but I've taken a class that worked with large codebases that taught me how to navigate the project. Since many of the tier 1 seemed really simple I went with tier 2. I was originally worried that the issue can easily extend out of scope and I was worrying too many cases that were not originally part of the issue. After tracing what components were related to the RateLimiter, I realized that majority of the RateLimiter was already implemented, but the middleware was not created that uses the RateLimiter. Using AI to help me understand how to implement a middleware and having it explain some ways to approach this problem, it made decision making a lot easier. For example I asked how should I track per user for managing the limits and it provided some options that reused pre-exisiting tools like the JWT per user.
+
+**What did you learn about working in a large codebase?**
+I learned that there's a specific format for commit messages and it helped me realize that the messages and specifying each commits helps organize the iterative changes and provides useful information to the developer or AI that can be working in a large codebase.
+
+**How did AI tools help — and where did they fall short?**
+AI helped provide options of implemenations, help me reason through pros and cons, and help me use code functions that I've never knew about or unfamiliar with. The main part that can fall short is that AI tends to do more than asked to, so sometimes I may need to tell it to focus on a certain implementation before continuing. Additionally there were times where I had to correct on some hallucinations when the chat goes long. I think with each commit of a certain implementation and then testing it with another commits help me iteratively build the overall function and ensures that I will run into less issues later on.
+
+**What would you do differently if you started over?**
+If I were to start over, I think I would like to use AI to do a complete scan of the codebase and summarize of what it can do, then use the summary as a context of what the codebase is and prevent it from rescanning the codebase multiple times. This would overall reduce the token usage. 
+
+**What are you most proud of from this module?**
+I am most proud of the iterative implementation of the RateLimiting Middleware because it helps me develop better coding styles when working with AI. I tend to commit and push an entire feature and trying to get AI to one-shot the implementation. This tend to lead me to undo some features that AI tries to add. The iterative commits allows me to go back to code that was working originally and slowly build the feature.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,36 @@
+## Solution plan
+
+**Issue title:** Add an API rate limiting header (X-RateLimit-Remaining) to responses
+**Issue link:** [Issue](https://github.com/ascherj/pathreview/issues/86)
+
+### Understand
+What was expected was the API already have a rate limiting feature implemented. The issue wanted to add headers to the responses so the users can know how much requests they can make before recieving a 429 status code. Since there is no rate limiting feature the headers cannot be implemented.
+
+### Map
+Related Files:
+- `api/main.py`
+- `core/config.py`
+- `safety/rate_limiter.py`
+Creating Files:
+- `api/middleware/rate_limiter.py`
+
+### Plan
+1. Create a `rate_limiter.py` in the `api/middleware` directory and use `safety/rate_limiter.py`
+  - Keep track of number of requests per minute and ensure user does not exceed `core/config.py` limits
+    - Use both IP and JWT to keep track of requests. JWT as the main tracker, while IP as a fallback
+  - Add `X-RateLimit-Remaining` and `X-RateLimit-Limit` as a response header
+  - Once it exceeds the limit, return the user a 429 status code
+2. Register the middleware in the app in `main.py`
+  - Register `RateLimitMiddleware` before `RequestIDMiddleware` in `main.py`, so `request_id` is available when the rate limiter logs events
+3. Test different types of requests to see if we can get the remaining number of requests
+4. Test different types of requests to see if we can get 429 status code
+
+### Inputs & outputs
+Instead of having inputs, we keep track of how many requests a user makes per minute. Our output would be adding the counter/remaining requests the user has left before reaching the 429 status code as a response header. Our counter of requests should reset with a rolling window model and the response header should reflect the updates.
+
+### Risks & unknowns
+Currently, I may not know whether there are bugs or know whether the `safety/rate_limiter.py` works completely without bugs. I know that there are tests for it with a mock, but not sure whether they are compatiable with the API.
+
+### Edge cases
+Using both JWT as the main identifier to keep track of requests from a user, it can account for multiple instances logged in to the same account to limit requests. For the sessions that JWT is not available or for those who are not logged in, IP will be the fall back identifier to limit requests.
+It will handle malformed/expired JWTs by falling back to IP (auth/authorization itself is unaffected — still enforced by the existing get_current_user dependency downstream)

--- a/api/main.py
+++ b/api/main.py
@@ -1,12 +1,16 @@
+import redis
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from fastapi.openapi.utils import get_openapi
 import structlog
 
+from api.middleware.rate_limiter import RateLimiterMiddleware
 from api.middleware.request_id import RequestIDMiddleware
 from api.routes import auth, profiles, reviews, health
+from core.config import settings
 from core.database import init_db
+from safety.rate_limiter import RateLimiter
 
 log = structlog.get_logger()
 
@@ -40,6 +44,16 @@ def custom_openapi():
 
 app.openapi = custom_openapi
 
+
+# Add rate limit middleware (registered before CORS so CORS wraps it and
+# still attaches Access-Control-* headers to 429 responses)
+redis_client = redis.Redis.from_url(settings.redis_url)
+rate_limiter = RateLimiter(redis_client)
+app.add_middleware(
+    RateLimiterMiddleware,
+    rate_limiter=rate_limiter,
+    limit=settings.rate_limit_per_minute,
+)
 
 # Add CORS middleware
 app.add_middleware(

--- a/api/middleware/rate_limiter.py
+++ b/api/middleware/rate_limiter.py
@@ -1,0 +1,56 @@
+from fastapi import Request
+from fastapi.responses import JSONResponse
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import Response
+
+from core.security import decode_access_token
+from safety.rate_limiter import RateLimiter
+
+
+class RateLimiterMiddleware(BaseHTTPMiddleware):
+    """
+    Enforces a per-user rolling-window rate limit for authenticated requests
+    and attaches X-RateLimit-Limit / X-RateLimit-Remaining headers to every
+    response.
+    """
+
+    def __init__(self, app, rate_limiter: RateLimiter, limit: int):
+        super().__init__(app)
+        self.rate_limiter = rate_limiter
+        self.limit = limit
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        identifier = None
+        auth_header = request.headers.get("Authorization")
+
+        if auth_header and auth_header.startswith("Bearer "):
+            token = auth_header.split(" ")[1]
+            payload = decode_access_token(token)
+            if payload:
+                identifier = payload.get("sub")
+
+        if identifier is None:
+            # JWT-only first pass: unauthenticated requests aren't rate
+            # limited yet (IP fallback to be added later).
+            return await call_next(request)
+
+        allowed, remaining = self.rate_limiter.check_rate_limit(
+            identifier=identifier,
+            limit=self.limit,
+            window_seconds=60,
+        )
+
+        if not allowed:
+            return JSONResponse(
+                status_code=429,
+                content={"detail": "Rate limit exceeded"},
+                headers={
+                    "X-RateLimit-Limit": str(self.limit),
+                    "X-RateLimit-Remaining": "0",
+                },
+            )
+
+        response = await call_next(request)
+        response.headers["X-RateLimit-Limit"] = str(self.limit)
+        response.headers["X-RateLimit-Remaining"] = str(remaining)
+        return response

--- a/api/middleware/rate_limiter.py
+++ b/api/middleware/rate_limiter.py
@@ -1,6 +1,6 @@
-from fastapi import Request
+from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
-from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.responses import Response
 
 from core.security import decode_access_token
@@ -14,12 +14,12 @@ class RateLimiterMiddleware(BaseHTTPMiddleware):
     response.
     """
 
-    def __init__(self, app, rate_limiter: RateLimiter, limit: int):
+    def __init__(self, app: FastAPI, rate_limiter: RateLimiter, limit: int) -> None:
         super().__init__(app)
         self.rate_limiter = rate_limiter
         self.limit = limit
 
-    async def dispatch(self, request: Request, call_next) -> Response:
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
         identifier = None
         auth_header = request.headers.get("Authorization")
 

--- a/api/middleware/rate_limiter.py
+++ b/api/middleware/rate_limiter.py
@@ -30,9 +30,12 @@ class RateLimiterMiddleware(BaseHTTPMiddleware):
                 identifier = payload.get("sub")
 
         if identifier is None:
-            # JWT-only first pass: unauthenticated requests aren't rate
-            # limited yet (IP fallback to be added later).
-            return await call_next(request)
+            # Note: uses request.client.host directly. Does not inspect
+            # X-Forwarded-For or similar proxy headers — if this app is ever
+            # deployed behind a reverse proxy/load balancer, this would
+            # report the proxy's IP rather than the real client IP. Out of
+            # scope for this issue; flagging for future consideration.
+            identifier = request.client.host
 
         allowed, remaining = self.rate_limiter.check_rate_limit(
             identifier=identifier,

--- a/tests/unit/test_rate_limiter_middleware.py
+++ b/tests/unit/test_rate_limiter_middleware.py
@@ -27,8 +27,8 @@ class TestRateLimiterMiddleware:
         return MagicMock()
 
     @pytest.fixture
-    def client(self, mock_rate_limiter: MagicMock) -> TestClient:
-        """Create a TestClient wrapping a minimal app with only the rate limiter middleware."""
+    def app(self, mock_rate_limiter: MagicMock) -> FastAPI:
+        """Create a minimal app with only the rate limiter middleware."""
         app = FastAPI()
         app.add_middleware(RateLimiterMiddleware, rate_limiter=mock_rate_limiter, limit=60)
 
@@ -36,6 +36,11 @@ class TestRateLimiterMiddleware:
         def ping() -> dict[str, bool]:
             return {"ok": True}
 
+        return app
+
+    @pytest.fixture
+    def client(self, app: FastAPI) -> TestClient:
+        """Create a TestClient wrapping the minimal app, using TestClient's default client host."""
         return TestClient(app)
 
     def test_valid_token_under_limit_allowed(
@@ -100,38 +105,95 @@ class TestRateLimiterMiddleware:
         ]
         assert identifiers == ["user_a", "user_b"]
 
-    def test_malformed_jwt_not_rate_limited(
+    def test_malformed_jwt_falls_back_to_ip(
         self, client: TestClient, mock_rate_limiter: MagicMock
     ) -> None:
-        """Test a malformed/invalid JWT falls through unrestricted (no IP fallback yet)."""
+        """Test a malformed/invalid JWT falls back to rate limiting by client IP."""
+        mock_rate_limiter.check_rate_limit.return_value = (True, 59)
+
         response = client.get("/ping", headers={"Authorization": "Bearer not.a.valid.jwt"})
 
         assert response.status_code == 200
-        mock_rate_limiter.check_rate_limit.assert_not_called()
+        mock_rate_limiter.check_rate_limit.assert_called_once_with(
+            identifier="testclient", limit=60, window_seconds=60
+        )
 
-    def test_no_authorization_header_not_rate_limited(
+    def test_no_authorization_header_falls_back_to_ip(
         self, client: TestClient, mock_rate_limiter: MagicMock
     ) -> None:
-        """Test a request with no Authorization header falls through unrestricted."""
+        """Test a request with no Authorization header falls back to rate limiting by client IP."""
+        mock_rate_limiter.check_rate_limit.return_value = (True, 59)
+
         response = client.get("/ping")
 
         assert response.status_code == 200
-        mock_rate_limiter.check_rate_limit.assert_not_called()
+        mock_rate_limiter.check_rate_limit.assert_called_once_with(
+            identifier="testclient", limit=60, window_seconds=60
+        )
 
-    def test_non_bearer_scheme_not_rate_limited(
+    def test_non_bearer_scheme_falls_back_to_ip(
         self, client: TestClient, mock_rate_limiter: MagicMock
     ) -> None:
-        """Test an Authorization header using a non-Bearer scheme falls through unrestricted."""
+        """Test a non-Bearer Authorization scheme falls back to IP-based rate limiting."""
+        mock_rate_limiter.check_rate_limit.return_value = (True, 59)
+
         response = client.get("/ping", headers={"Authorization": "Basic dXNlcjpwYXNz"})
 
         assert response.status_code == 200
-        mock_rate_limiter.check_rate_limit.assert_not_called()
+        mock_rate_limiter.check_rate_limit.assert_called_once_with(
+            identifier="testclient", limit=60, window_seconds=60
+        )
 
-    def test_authorization_header_without_bearer_prefix_not_rate_limited(
+    def test_authorization_header_without_bearer_prefix_falls_back_to_ip(
         self, client: TestClient, mock_rate_limiter: MagicMock
     ) -> None:
-        """Test an Authorization header with no scheme prefix at all falls through unrestricted."""
+        """Test an Authorization header with no scheme prefix falls back to rate limiting by IP."""
+        mock_rate_limiter.check_rate_limit.return_value = (True, 59)
+
         response = client.get("/ping", headers={"Authorization": "sometoken123"})
 
         assert response.status_code == 200
-        mock_rate_limiter.check_rate_limit.assert_not_called()
+        mock_rate_limiter.check_rate_limit.assert_called_once_with(
+            identifier="testclient", limit=60, window_seconds=60
+        )
+
+    def test_ip_fallback_denies_over_limit(
+        self, client: TestClient, mock_rate_limiter: MagicMock
+    ) -> None:
+        """Test an unauthenticated request over the limit is denied same as the JWT path."""
+        mock_rate_limiter.check_rate_limit.return_value = (False, 0)
+
+        response = client.get("/ping")
+
+        assert response.status_code == 429
+        assert response.headers["X-RateLimit-Remaining"] == "0"
+
+    def test_different_client_ips_use_distinct_identifiers(
+        self, app: FastAPI, mock_rate_limiter: MagicMock
+    ) -> None:
+        """Test unauthenticated requests from different IPs are isolated, like the JWT case."""
+        mock_rate_limiter.check_rate_limit.return_value = (True, 59)
+        client_a = TestClient(app, client=("1.2.3.4", 12345))
+        client_b = TestClient(app, client=("5.6.7.8", 54321))
+
+        client_a.get("/ping")
+        client_b.get("/ping")
+
+        identifiers = [
+            call.kwargs["identifier"] for call in mock_rate_limiter.check_rate_limit.call_args_list
+        ]
+        assert identifiers == ["1.2.3.4", "5.6.7.8"]
+
+    def test_valid_jwt_takes_priority_over_ip(
+        self, app: FastAPI, mock_rate_limiter: MagicMock
+    ) -> None:
+        """Test a valid JWT's sub claim is used over client IP when both are available."""
+        mock_rate_limiter.check_rate_limit.return_value = (True, 59)
+        token = create_access_token({"sub": "user123"})
+        client = TestClient(app, client=("9.9.9.9", 12345))
+
+        client.get("/ping", headers={"Authorization": f"Bearer {token}"})
+
+        mock_rate_limiter.check_rate_limit.assert_called_once_with(
+            identifier="user123", limit=60, window_seconds=60
+        )

--- a/tests/unit/test_rate_limiter_middleware.py
+++ b/tests/unit/test_rate_limiter_middleware.py
@@ -1,0 +1,137 @@
+"""Tests for api/middleware/rate_limiter.py"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.middleware.rate_limiter import RateLimiterMiddleware
+from core.security import create_access_token
+
+
+@pytest.mark.unit
+class TestRateLimiterMiddleware:
+    """Test suite for RateLimiterMiddleware.
+
+    RateLimiter's own internal correctness (rolling window, per-identifier
+    isolation, fail-open behavior) is covered by test_rate_limiter.py.
+    This suite mocks RateLimiter directly and is scoped to the middleware's
+    own responsibilities: token parsing, identifier extraction, and relaying
+    check_rate_limit's output into response status/headers.
+    """
+
+    @pytest.fixture
+    def mock_rate_limiter(self) -> MagicMock:
+        """Create a mock RateLimiter."""
+        return MagicMock()
+
+    @pytest.fixture
+    def client(self, mock_rate_limiter: MagicMock) -> TestClient:
+        """Create a TestClient wrapping a minimal app with only the rate limiter middleware."""
+        app = FastAPI()
+        app.add_middleware(RateLimiterMiddleware, rate_limiter=mock_rate_limiter, limit=60)
+
+        @app.get("/ping")
+        def ping() -> dict[str, bool]:
+            return {"ok": True}
+
+        return TestClient(app)
+
+    def test_valid_token_under_limit_allowed(
+        self, client: TestClient, mock_rate_limiter: MagicMock
+    ) -> None:
+        """Test valid JWT under the limit returns 200 with correct rate limit headers."""
+        mock_rate_limiter.check_rate_limit.return_value = (True, 59)
+        token = create_access_token({"sub": "user123"})
+
+        response = client.get("/ping", headers={"Authorization": f"Bearer {token}"})
+
+        assert response.status_code == 200
+        assert response.headers["X-RateLimit-Limit"] == "60"
+        assert response.headers["X-RateLimit-Remaining"] == "59"
+
+    def test_remaining_decrements_across_requests(
+        self, client: TestClient, mock_rate_limiter: MagicMock
+    ) -> None:
+        """Test X-RateLimit-Remaining reflects each call's return value across repeated requests."""
+        mock_rate_limiter.check_rate_limit.side_effect = [
+            (True, 59),
+            (True, 58),
+            (True, 57),
+        ]
+        token = create_access_token({"sub": "user123"})
+
+        remaining_values = []
+        for _ in range(3):
+            response = client.get("/ping", headers={"Authorization": f"Bearer {token}"})
+            assert response.status_code == 200
+            remaining_values.append(response.headers["X-RateLimit-Remaining"])
+
+        assert remaining_values == ["59", "58", "57"]
+
+    def test_valid_token_over_limit_denied(
+        self, client: TestClient, mock_rate_limiter: MagicMock
+    ) -> None:
+        """Test valid JWT at/over the limit returns 429 with X-RateLimit-Remaining: 0."""
+        mock_rate_limiter.check_rate_limit.return_value = (False, 0)
+        token = create_access_token({"sub": "user123"})
+
+        response = client.get("/ping", headers={"Authorization": f"Bearer {token}"})
+
+        assert response.status_code == 429
+        assert response.headers["X-RateLimit-Limit"] == "60"
+        assert response.headers["X-RateLimit-Remaining"] == "0"
+        assert response.json() == {"detail": "Rate limit exceeded"}
+
+    def test_different_users_use_distinct_identifiers(
+        self, client: TestClient, mock_rate_limiter: MagicMock
+    ) -> None:
+        """Test each user's JWT sub claim is passed as a distinct identifier to check_rate_limit."""
+        mock_rate_limiter.check_rate_limit.return_value = (True, 59)
+        token_a = create_access_token({"sub": "user_a"})
+        token_b = create_access_token({"sub": "user_b"})
+
+        client.get("/ping", headers={"Authorization": f"Bearer {token_a}"})
+        client.get("/ping", headers={"Authorization": f"Bearer {token_b}"})
+
+        identifiers = [
+            call.kwargs["identifier"] for call in mock_rate_limiter.check_rate_limit.call_args_list
+        ]
+        assert identifiers == ["user_a", "user_b"]
+
+    def test_malformed_jwt_not_rate_limited(
+        self, client: TestClient, mock_rate_limiter: MagicMock
+    ) -> None:
+        """Test a malformed/invalid JWT falls through unrestricted (no IP fallback yet)."""
+        response = client.get("/ping", headers={"Authorization": "Bearer not.a.valid.jwt"})
+
+        assert response.status_code == 200
+        mock_rate_limiter.check_rate_limit.assert_not_called()
+
+    def test_no_authorization_header_not_rate_limited(
+        self, client: TestClient, mock_rate_limiter: MagicMock
+    ) -> None:
+        """Test a request with no Authorization header falls through unrestricted."""
+        response = client.get("/ping")
+
+        assert response.status_code == 200
+        mock_rate_limiter.check_rate_limit.assert_not_called()
+
+    def test_non_bearer_scheme_not_rate_limited(
+        self, client: TestClient, mock_rate_limiter: MagicMock
+    ) -> None:
+        """Test an Authorization header using a non-Bearer scheme falls through unrestricted."""
+        response = client.get("/ping", headers={"Authorization": "Basic dXNlcjpwYXNz"})
+
+        assert response.status_code == 200
+        mock_rate_limiter.check_rate_limit.assert_not_called()
+
+    def test_authorization_header_without_bearer_prefix_not_rate_limited(
+        self, client: TestClient, mock_rate_limiter: MagicMock
+    ) -> None:
+        """Test an Authorization header with no scheme prefix at all falls through unrestricted."""
+        response = client.get("/ping", headers={"Authorization": "sometoken123"})
+
+        assert response.status_code == 200
+        mock_rate_limiter.check_rate_limit.assert_not_called()


### PR DESCRIPTION
## Summary

API clients previously had no way to know how many requests they had left 
before hitting a rate limit - there was no rate limiting enforcement at all 
in the live application, even though a fully-implemented, unit-tested 
`RateLimiter` class existed unused in `safety/rate_limiter.py`. This PR 
wires that class into the app via a new middleware, adds `X-RateLimit-Limit` 
and `X-RateLimit-Remaining` headers to every response, and returns 429 once 
a caller exceeds the configured limit within a rolling 60-second window. 
The rate-limit identifier is the authenticated user's ID (from their JWT) 
when available, falling back to client IP for unauthenticated or 
invalid/expired-token requests.

## Issue

Closes #86

## Changes

- Add `RateLimitMiddleware` (`api/middleware/rate_limiter.py`), registered 
  globally in `main.py`, so every route is covered without modifying 
  individual endpoint files
- Instantiate a Redis client from `settings.redis_url` and wrap it in the 
  existing `RateLimiter` (`safety/rate_limiter.py`) once at app startup
- Resolve the rate-limit identifier from the JWT's `sub` claim (via the 
  existing `decode_access_token()` helper in `core/security.py`) when a 
  valid bearer token is present
- Fall back to `request.client.host` (client IP) when no valid JWT is 
  available — covers missing Authorization header, non-Bearer schemes, and 
  malformed/expired tokens (does not inspect `X-Forwarded-For` or other 
  proxy-forwarded headers; out of scope for this issue)
- Attach `X-RateLimit-Limit` / `X-RateLimit-Remaining` headers to every 
  response, including error responses (e.g. 401s from downstream auth 
  checks), since the middleware wraps the full request/response cycle
- Return 429 with `{"detail": "Rate limit exceeded"}` and the same headers 
  once the identifier's limit (`settings.rate_limit_per_minute`, default 60) 
  is exceeded
- Add `tests/unit/test_rate_limiter_middleware.py` (11 tests) covering the 
  JWT path, IP fallback path, per-identifier isolation for both paths, and 
  JWT-over-IP priority when both are available; `RateLimiter`'s own internal 
  logic is unchanged and already covered by the existing 
  `tests/unit/test_rate_limiter.py`, so this suite mocks `RateLimiter` 
  directly rather than re-testing it

## Testing

- [x] Unit tests pass (`make test-unit`)
- [x] Integration tests pass (`make test-integration`)
- [x] Linter passes (`make lint`)
- [x] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes

## Screenshots / Demo
### Pre and Post Functions of make test-unit
Images show that the functions added did not affect the values and pre-existing errors for make check, make test-integrations, make lint, and make typecheck:
<img width="1512" height="440" alt="Pre-make_test-unit" src="https://github.com/user-attachments/assets/033748ea-9399-4873-bdb7-bfd0f57903cf" />
<img width="1508" height="426" alt="Post-make_test-unit" src="https://github.com/user-attachments/assets/743d75db-a51b-4f37-8014-f283ae1a759c" />
### Pre and Post Functions of make check
<img width="1509" height="446" alt="Pre-make_check" src="https://github.com/user-attachments/assets/6fbbe855-0b90-49f3-acf9-966950e32db2" />
<img width="1512" height="441" alt="Post-make_check" src="https://github.com/user-attachments/assets/9a7d83e9-ed6f-4ebf-849b-c65257a15eec" />
<img width="1508" height="155" alt="Pre-make_typecheck" src="https://github.com/user-attachments/assets/1b94f77f-0728-4623-b213-0aa9ba7adce2" />
<img width="1507" height="128" alt="Post-make_typecheck" src="https://github.com/user-attachments/assets/1e5b8472-1bca-4145-bbbe-3acdd0876a68" />
### Pre and Post Implementation Live Site Testing with Status Codes
Script provided in the `JOURNAL.md` to print 1000 request status codes to the API, then `sort <logfile name> | uniq -c` grabs unique status codes to show whether a rate limit has been reached:
1.`pre_rate_limit_jwt.log` is the status codes prior to any implementation
2.`pre_rate_limit_ip.log` is the status codes post JWT rate limiting implementation, but prior to IP rate limiting
3. `post_rate_limit_jwt.log` is the status codes after JWT rate limiting
4. `post_rate_limit_ip.log` is the status codes after JWT & IP rate limiting
<img width="673" height="175" alt="Status Codes" src="https://github.com/user-attachments/assets/0b855d90-b8b3-4f94-8768-00edb65d74bc" />

## Notes for Reviewers
This applies a single global rate limit (via `settings.rate_limit_per_minute`) 
to every API endpoint, including auth/login — there's no per-route or 
per-endpoint-type limit tuning yet (e.g. a stricter limit specifically for 
`/auth/login` to slow brute-force attempts more aggressively than general 
API usage). That kind of per-route configuration would be a reasonable 
follow-up but is out of scope for this issue.

The IP fallback uses `request.client.host` directly and does not inspect 
`X-Forwarded-For` or similar proxy-forwarded headers — if this app is ever 
deployed behind a reverse proxy or load balancer, this would report the 
proxy's IP rather than the real client IP.

Unrelated to this change: a fresh, unmodified pull of `main` currently has 
182 pre-existing `make check` lint errors and 53 pre-existing 
`make test-unit` failures. This PR introduces zero new errors/failures on 
top of that baseline — verified by comparing before/after on a clean pull.
