### PR TITLE
fix(api): use SQLAlchemy text for health check probe

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -69,3 +69,45 @@ I added `tests/unit/test_health.py` with two async unit tests. The tests confirm
 The repository retains its documented pre-existing failures. The full unit-test result remained at 53 failures while passing tests increased from 375 to 377, confirming that both new tests pass and no new failures were introduced. Repository-wide linting reports pre-existing errors outside the changed files, while both changed files pass targeted Ruff and Black checks.
 
 **Draft PR feedback received from:** none
+
+
+## Week 10 - Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes [x] No - still awaiting review
+
+**Summary of feedback:**
+No reviewer or maintainer feedback had been received at the time of submission. Reviewer feedback was not provided as a course feature for the Summer 2026 cohort.
+
+**How you responded:**
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+
+At first, the hardest part was understanding the true scale of the issue and separating my small fix from the wider state of the repository. When I saw dozens of failing tests, my first reaction was to worry that I had broken something. I had to slow down, compare the results with the baseline, and confirm that those failures already existed and were unrelated to the health-check issue.
+
+It was also challenging to create tests that isolated PostgreSQL from the separate Redis and configuration problems. I wanted to fix only issue #154, not accidentally expand the scope or change unrelated parts of the codebase. This made me more careful about mocking dependencies, documenting pre-existing failures, and confirming that my contribution introduced no new problems.
+
+**What did you learn about working in a large codebase?**
+
+I learned that contributing to a large codebase requires much more caution than working on my own projects. In my personal projects, I often wait until I have finished a large amount of work before committing. During this contribution, I had to make smaller, more intentional commits so that each stage of the work was visible and easier to review.
+
+I also learned that testing is not only about proving that a new change works. It is also about confirming that I did not make an existing problem worse or affect another part of the application. Because the repository already had unrelated failures, I had to understand the existing baseline, keep the scope of my fix narrow, and verify that my changes introduced no new failures.
+
+**How did AI tools help, and where did they fall short?**
+
+AI tools were especially useful when I was designing the tests and trying to understand what evidence I needed to prove that the fix worked. They helped me identify what to check, such as confirming that the database probe received a SQLAlchemy `TextClause` and that a genuine database failure still returned HTTP 503. They also helped me interpret errors and work through the Git and pull-request process step by step.
+
+Where AI fell short was in making judgment calls. Sometimes a suggestion did not fit the codebase, the scope of the issue, or the way I wanted to approach the work. In those moments, I had to review the actual code, decide what should and should not be changed, make corrections myself, and then continue the conversation with AI. The process worked best when I treated AI as a guide rather than assuming every suggestion was automatically correct.
+
+**What would you do differently if you started over?**
+
+I am satisfied with most of the decisions I made during this project. I took time to understand the issue, kept the scope focused, and tested the change carefully. The main thing I would do differently is open the draft pull request much earlier. That would have created more time for classmates or mentors to review the work and give feedback before the final submission. Even though reviewer feedback was not provided as a course feature for Summer 2026, I would still have valued another perspective on the implementation and tests.
+
+**What are you most proud of from this module?**
+
+I am most proud of how comfortable I became with Git. Before this module, I often forgot commands and had to look them up, especially when pushing, pulling, checking the branch status, reviewing changes, and committing work. After using the commands repeatedly throughout the four-week contribution process, they began to feel natural. I can now move through the Git workflow with much more confidence, and that feels like a skill I will continue using beyond this project.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -52,3 +52,20 @@ I will update the PostgreSQL probe in `api/routes/health.py`, create focused reg
 **Blockers:**
 
 ---
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/656
+
+**Branch:** `fix/154-health-check-db-probe`
+
+**What you built:**
+I updated the PostgreSQL health probe to execute `SELECT 1` using SQLAlchemy's supported `text()` construct. This prevents SQLAlchemy 2.x from rejecting the query and falsely reporting a reachable PostgreSQL database as unhealthy, while preserving the existing HTTP 503 behavior for genuine database failures.
+
+**Tests added or updated:**
+I added `tests/unit/test_health.py` with two async unit tests. The tests confirm that the database probe receives a SQLAlchemy `TextClause` containing `SELECT 1` and that a genuine database execution failure still marks PostgreSQL as unhealthy and returns HTTP 503.
+
+**Self-review confirmation:** [x] make check passes [x] make test-unit passes
+
+The repository retains its documented pre-existing failures. The full unit-test result remained at 53 failures while passing tests increased from 375 to 377, confirming that both new tests pass and no new failures were introduced. Repository-wide linting reports pre-existing errors outside the changed files, while both changed files pass targeted Ruff and Black checks.
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -27,3 +27,15 @@ The database health check in `api/routes/health.py` sends `"SELECT 1"` to SQLAlc
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 - Reproduction & solution planning
+
+**Reproduction commit link:** Pending until the reproduction commit is pushed
+
+**Reproduction summary:**
+I confirmed that the PostgreSQL Docker service was healthy, then executed the same raw `"SELECT 1"` string used by `health_check()` through the project's real SQLAlchemy `AsyncSession`. SQLAlchemy 2.0.51 raised an `ArgumentError` for the raw string, while `text("SELECT 1")` succeeded through the same session and returned `1`, confirming that the failure is caused by the query format rather than an unavailable database.
+
+**PLAN.md link:** Pending
+
+**Blockers or open questions:**
+The complete `/health` route also contains an unrelated Redis configuration mismatch because `health.py` refers to `redis_host` and `redis_port`, while the settings object defines `redis_url`. This is outside issue #154, so the planned regression test should isolate the PostgreSQL probe without expanding the scope of this contribution.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -39,3 +39,16 @@ I confirmed that the PostgreSQL Docker service was healthy, then executed the sa
 
 **Blockers or open questions:**
 
+## Week 9 - Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+I reproduced issue #154 using SQLAlchemy 2.0.51 and the project's real `AsyncSession`, documented the reproduction, and completed `PLAN.md`. I also ran the existing unit-test suite and recorded a baseline of 375 passing tests and 53 pre-existing failures so I can identify whether my changes introduce any new failures.
+
+**Next steps:**
+I will update the PostgreSQL probe in `api/routes/health.py`, create focused regression tests in `tests/unit/test_health.py`, run the new tests directly, run `make check`, and compare the full unit-test results against the existing baseline. I will then open a draft pull request and request feedback before marking it ready for review.
+
+**Blockers:**
+
+---

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -6,6 +6,19 @@
 
 **Tier:** [x] Tier 1 [ ] Tier 2 [ ] Tier 3
 
+**"Is this issue right for me?" checklist reasoning:**
+
+- **Understanding the issue:** I can explain the problem and expected behavior in my own words. The health endpoint is incorrectly reporting PostgreSQL as unavailable because its database probe uses a raw SQL string that SQLAlchemy 2.x rejects.
+- **Affected area:** The issue is contained in the API layer, primarily in the `health_check` route in `api/routes/health.py`. I located the route and read the surrounding PostgreSQL, Redis, and vector database checks.
+- **Definition of done:** Before the fix, a reachable PostgreSQL database may be reported as unhealthy and `/health` may return a failure response. After the fix, the probe should use SQLAlchemy's supported textual SQL format, report PostgreSQL as healthy when it is reachable, and continue reporting genuine database failures correctly.
+- **Tier fit:** This is my first contribution to this codebase, so Tier 1 is an appropriate choice for me. The expected change is localized to one route and its related tests and should not require changes to the frontend, database schema, RAG pipeline, or agent system.
+- **Codebase readiness:** I found the specific function referenced by the issue and reviewed enough surrounding code to understand how an exception changes the dependency status and causes the endpoint to return an unhealthy response.
+- **Test readiness:** Before implementing the change, I will find and read the existing API test patterns and add a regression test that confirms the database probe succeeds when SQLAlchemy receives a valid textual SQL expression.
+- **Other contributors:** I checked the issue comments and cohort ledger. When i signed up there were only about 4 people working on it but I understand that multiple students can work on the same issue.
+- **Time and scope:** Tier 1 issues are expected to be achievable within approximately 3-6 hours of focused work so it is realistic for me to complete before the Week 9 deadline.
+- **Blockers:** The issue does not list any unresolved blocker or dependency that must be completed first.
+- **Verdict:** This issue is a realistic fit for my current experience, available time, and the Module 3 contribution requirements.
+
 **Problem summary:**
 The database health check in `api/routes/health.py` sends `"SELECT 1"` to SQLAlchemy as a plain string. Under SQLAlchemy 2.x, textual SQL has to be explicitly declared, so the database probe raises an `ArgumentError` even when PostgreSQL is available. This causes the `/health` endpoint to report that the database is down even though it is reachable. A successful fix will execute the probe using the supported SQLAlchemy format and verify the corrected behavior with an appropriate test.
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,16 @@
+## Week 7 - Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/154
+
+**Issue title:** Health check DB probe passes a raw SQL string, which fails under SQLAlchemy 2.x
+
+**Tier:** [x] Tier 1 [ ] Tier 2 [ ] Tier 3
+
+**Problem summary:**
+The database health check in `api/routes/health.py` sends `"SELECT 1"` to SQLAlchemy as a plain string. Under SQLAlchemy 2.x, textual SQL has to be explicitly declared, so the database probe raises an `ArgumentError` even when PostgreSQL is available. This causes the `/health` endpoint to report that the database is down even though it is reachable. A successful fix will execute the probe using the supported SQLAlchemy format and verify the corrected behavior with an appropriate test.
+
+**Branch name:** `fix/154-health-check-db-probe`
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -30,12 +30,12 @@ The database health check in `api/routes/health.py` sends `"SELECT 1"` to SQLAlc
 
 ## Week 8 - Reproduction & solution planning
 
-**Reproduction commit link:** Pending until the reproduction commit is pushed
+**Reproduction commit link:** https://github.com/DuBaem/pathreview/commit/ed8e1a5
 
 **Reproduction summary:**
 I confirmed that the PostgreSQL Docker service was healthy, then executed the same raw `"SELECT 1"` string used by `health_check()` through the project's real SQLAlchemy `AsyncSession`. SQLAlchemy 2.0.51 raised an `ArgumentError` for the raw string, while `text("SELECT 1")` succeeded through the same session and returned `1`, confirming that the failure is caused by the query format rather than an unavailable database.
 
-**PLAN.md link:** Pending
+**PLAN.md link:** https://github.com/DuBaem/pathreview/blob/fix/154-health-check-db-probe/PLAN.md
 
 **Blockers or open questions:**
-The complete `/health` route also contains an unrelated Redis configuration mismatch because `health.py` refers to `redis_host` and `redis_port`, while the settings object defines `redis_url`. This is outside issue #154, so the planned regression test should isolate the PostgreSQL probe without expanding the scope of this contribution.
+

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,93 @@
+## Solution plan
+
+**Issue:** #154 - Health check DB probe passes a raw SQL string, which fails under SQLAlchemy 2.x  
+https://github.com/ascherj/pathreview/issues/154
+
+### Understand
+The PostgreSQL probe in `api/routes/health.py` calls `await db.execute("SELECT 1")`, which passes textual SQL to SQLAlchemy as a plain Python string. The project uses SQLAlchemy 2.x, which requires textual SQL to be explicitly wrapped with `sqlalchemy.text()` before it is passed to `AsyncSession.execute()`.
+
+I reproduced the issue locally using SQLAlchemy 2.0.51 and the project's real `AsyncSession`. The raw `"SELECT 1"` string raised `sqlalchemy.exc.ArgumentError`, while `text("SELECT 1")` succeeded through the same database session and returned `1`. Docker also reported the PostgreSQL service as healthy, confirming that the failure was caused by the query format rather than an unavailable database.
+
+Inside `health_check()`, the exception is caught by the PostgreSQL probe's exception handler. The route then marks PostgreSQL and the overall health status as `"unhealthy"`. This causes the route to raise an HTTPException, which FastAPI returns as an HTTP 503 response even though PostgreSQL is reachable.
+
+The expected behavior is that a reachable PostgreSQL database is reported as `"healthy"`. The route should continue to report PostgreSQL as `"unhealthy"` when the database execute operation fails because the database is genuinely unavailable.
+
+**Root cause:** The PostgreSQL health probe does not wrap the textual SQL statement with SQLAlchemy's `text()` construct before passing it to `AsyncSession.execute()`.
+
+### Map
+
+- `api/routes/health.py`
+  - Relevant function: `health_check()`
+  - This file contains the PostgreSQL probe that currently calls `await db.execute("SELECT 1")`.
+  - I expect to import SQLAlchemy's `text()` function and wrap the query before passing it to `db.execute()`.
+
+- `tests/unit/test_health.py`
+  - This file does not currently exist, so I expect to create it.
+  - It will contain regression tests for the PostgreSQL portion of `health_check()`.
+  - The tests will follow the project's existing async unit-test conventions using `pytest.mark.unit`, `pytest.mark.asyncio`, and `AsyncMock`.
+
+### Plan
+
+1. Update `api/routes/health.py` to import SQLAlchemy's `text()` function and replace `await db.execute("SELECT 1")` with `await db.execute(text("SELECT 1"))`. Keep the existing logging, dependency status updates, and HTTP 503 behavior unchanged.
+
+2. Create `tests/unit/test_health.py` using the repository's existing async test conventions: `pytest.mark.unit`, `pytest.mark.asyncio`, and `AsyncMock`. Mock the Redis check so that unrelated Redis configuration behavior does not affect the PostgreSQL tests.
+
+3. Add a regression test for the successful database path. The test should call `health_check()` with a mock database session whose `execute()` method succeeds, then verify that `execute()` receives a SQLAlchemy textual SQL object and that PostgreSQL is reported as `"healthy"`.
+
+4. Add a test for the database failure path. Configure the mock session's `execute()` method to raise an exception, then verify that the route still marks PostgreSQL as `"unhealthy"` and raises an HTTP 503 response with the existing health-status structure.
+
+5. Run the new health tests directly, then run `make check`. Run `make test-unit` afterward and compare the results with the existing baseline of 53 failures and 375 passing tests to confirm that the change introduces no additional failures.
+
+### Inputs & outputs
+
+**Function involved:** `health_check(db)`
+
+**Current input to the PostgreSQL probe:**
+- A database session provided by FastAPI through `get_db()`.
+- The plain Python string `"SELECT 1"` passed to `db.execute()`.
+
+**Current output:**
+- SQLAlchemy 2.x raises `sqlalchemy.exc.ArgumentError` before the query reaches PostgreSQL.
+- `health_check()` catches the exception and marks PostgreSQL and the overall health status as `"unhealthy"`.
+- The route raises an HTTP 503 response even when PostgreSQL is running and reachable.
+
+**Expected input after the fix:**
+- The same database session.
+- A SQLAlchemy textual SQL object created with `text("SELECT 1")`.
+
+**Expected output after the fix:**
+- When PostgreSQL is reachable, `db.execute(text("SELECT 1"))` completes successfully and PostgreSQL is marked as `"healthy"`.
+- The existing health-response structure, logging, and handling of the other dependencies remain unchanged.
+- When the database execution genuinely fails, PostgreSQL is still marked as `"unhealthy"` and the route still raises HTTP 503.
+
+**Regression tests:**
+- A successful database probe should verify that `db.execute()` receives a SQLAlchemy `TextClause` containing `"SELECT 1"` rather than a plain string.
+- A failed database probe should verify that an exception from `db.execute()` still produces the existing unhealthy PostgreSQL status and HTTP 503 behavior.
+
+### Risks & unknowns
+
+1. **The PostgreSQL test could be affected by unrelated dependency checks.**  
+   `health_check()` continues to check Redis and the vector database after the PostgreSQL probe. The route currently refers to `settings.redis_host` and `settings.redis_port`, but `core/config.py` only defines `redis_url`. The health tests will need to isolate or mock the Redis check so that this separate configuration issue does not cause a false failure or expand the scope of issue #154.
+
+2. **The success test could become too dependent on SQLAlchemy internals.**  
+   A newly created `text("SELECT 1")` object may not compare directly with another `text("SELECT 1")` object. Instead of relying on object identity, the test should inspect the argument passed to `db.execute()`, confirm that it is a SQLAlchemy textual SQL object, and confirm that its SQL content is `"SELECT 1"`.
+
+3. **The failure-path test must preserve the existing response behavior.**  
+   When `db.execute()` raises, `health_check()` should still mark PostgreSQL and the overall status as `"unhealthy"` and raise `HTTPException` with status code 503. The test setup must prevent unrelated Redis or vector database behavior from changing the response being asserted.
+
+4. **The repository already has unrelated unit-test failures.**  
+   The baseline `make test-unit` run produced 53 failures and 375 passing tests in modules unrelated to the health route. I should not attempt to fix those failures as part of issue #154. I will validate the new health tests directly, run `make check`, and compare the full unit-test result with the baseline to confirm that my change does not add new failures.
+
+### Edge cases
+
+- **PostgreSQL is reachable:** The wrapped `text("SELECT 1")` query should execute successfully, and the PostgreSQL dependency should be reported as `"healthy"`.
+
+- **PostgreSQL is unavailable or the query execution raises:** The existing exception handler should still mark PostgreSQL and the overall health status as `"unhealthy"` and raise an HTTP 503 response.
+
+- **PostgreSQL is healthy but Redis is unavailable:** The PostgreSQL result should remain `"healthy"`, while the route may still return an unhealthy overall status because another dependency failed. The fix should not change how dependency results are recorded separately.
+
+- **The vector database URL is missing:** The existing behavior should remain unchanged, with the vector database reported as `"unavailable"` without altering the PostgreSQL result.
+
+- **The database execute call succeeds but returns no meaningful row data:** The health probe only needs successful query execution. It should not depend on processing or storing the returned result.
+
+- **The health response structure must remain stable:** The fix should not remove or rename the existing `status`, `dependencies`, `safety_events_last_hour`, or `timestamp` fields.

--- a/api/routes/health.py
+++ b/api/routes/health.py
@@ -1,6 +1,8 @@
-from fastapi import APIRouter, HTTPException, status, Depends
+from datetime import datetime
+
 import structlog
-from datetime import datetime, timedelta
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import text
 
 from core.database import get_db
 
@@ -10,7 +12,7 @@ router = APIRouter(prefix="/health", tags=["health"])
 
 
 @router.get("")
-async def health_check(db=Depends(get_db)):
+async def health_check(db=Depends(get_db)):  # noqa: B008
     """
     Check health of PostgreSQL, Redis, and Vector DB.
     Returns 200 if all healthy, 503 if any dependency is down.
@@ -28,7 +30,7 @@ async def health_check(db=Depends(get_db)):
 
     try:
         # Check PostgreSQL
-        await db.execute("SELECT 1")
+        await db.execute(text("SELECT 1"))
         health_status["dependencies"]["postgres"] = "healthy"
         log.debug("postgres_health_check_passed")
     except Exception as exc:
@@ -39,6 +41,7 @@ async def health_check(db=Depends(get_db)):
     try:
         # Check Redis (if available)
         import redis
+
         from core.config import settings
 
         r = redis.Redis(

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -1,0 +1,75 @@
+"""Unit tests for the health check route."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy.sql.elements import TextClause
+
+from api.routes.health import health_check
+
+
+@pytest.mark.unit
+class TestHealthCheck:
+    """Tests for the health check endpoint."""
+
+    @pytest.fixture
+    def mock_db_session(self) -> AsyncMock:
+        """Create a mock asynchronous database session."""
+        session = AsyncMock()
+        session.execute = AsyncMock()
+        return session
+
+    @pytest.fixture
+    def mock_settings(self) -> SimpleNamespace:
+        """Provide the settings used by the other dependency checks."""
+        return SimpleNamespace(
+            redis_host="localhost",
+            redis_port=6379,
+            vector_db_url="http://localhost:8001",
+        )
+
+    @pytest.mark.asyncio
+    async def test_postgres_probe_uses_text_clause(
+        self,
+        mock_db_session: AsyncMock,
+        mock_settings: SimpleNamespace,
+    ) -> None:
+        """The PostgreSQL probe should execute SELECT 1 as a TextClause."""
+        with (
+            patch("core.config.settings", mock_settings),
+            patch("redis.Redis") as mock_redis,
+        ):
+            mock_redis.return_value.ping.return_value = True
+            result = await health_check(mock_db_session)
+
+        mock_db_session.execute.assert_awaited_once()
+        statement = mock_db_session.execute.await_args.args[0]
+
+        assert isinstance(statement, TextClause)
+        assert str(statement) == "SELECT 1"
+        assert result["status"] == "healthy"
+        assert result["dependencies"]["postgres"] == "healthy"
+
+    @pytest.mark.asyncio
+    async def test_postgres_failure_returns_503(
+        self,
+        mock_db_session: AsyncMock,
+        mock_settings: SimpleNamespace,
+    ) -> None:
+        """A genuine PostgreSQL failure should still return a 503 response."""
+        mock_db_session.execute.side_effect = RuntimeError("database unavailable")
+
+        with (
+            patch("core.config.settings", mock_settings),
+            patch("redis.Redis") as mock_redis,
+        ):
+            mock_redis.return_value.ping.return_value = True
+
+            with pytest.raises(HTTPException) as exc_info:
+                await health_check(mock_db_session)
+
+        assert exc_info.value.status_code == 503
+        assert exc_info.value.detail["status"] == "unhealthy"
+        assert exc_info.value.detail["dependencies"]["postgres"] == "unhealthy"


### PR DESCRIPTION
## Summary

Updates the PostgreSQL health check to execute `SELECT 1` as a SQLAlchemy `TextClause` by wrapping it with `text()`. SQLAlchemy 2.x rejects raw textual SQL strings, which caused the health endpoint to report PostgreSQL as unhealthy even when the database was reachable.

## Issue

Closes #154

## Changes

- Import `text` from SQLAlchemy in `api/routes/health.py`
- Execute the PostgreSQL probe with `text("SELECT 1")`
- Add unit coverage for the successful PostgreSQL probe
- Confirm genuine database failures still return HTTP 503

## Testing

- [ ] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`)
- [ ] Linter passes (`make lint`)
- [ ] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes

Focused verification:

- `tests/unit/test_health.py`: 2 passed
- Targeted Ruff checks passed for `api/routes/health.py` and `tests/unit/test_health.py`
- Black passed for both changed files

Repository-wide unit-test comparison:

- Before: 53 failed, 375 passed
- After: 53 failed, 377 passed
- The same 53 unrelated failures remain, and both new tests pass
- No new unit-test failures were introduced

Repository-wide `make lint` reports 178 pre-existing errors outside the changed files. Both changed files pass targeted Ruff checks.

The type checker remains blocked by pre-existing Redis configuration errors involving `redis_host` and `redis_port`, as well as a local Python 3.12 and NumPy stub compatibility issue while the project targets Python 3.11.

## Screenshots / Demo

Not applicable. This is a backend health-check fix.

## Notes for Reviewers

The regression tests verify that the PostgreSQL probe receives a SQLAlchemy `TextClause` containing `SELECT 1` and that genuine database failures continue to return HTTP 503.

The mypy pre-commit hook was skipped for the implementation and test commits because of the unrelated type-checking issues documented above. Ruff and Black passed.