### PR TITLE
fix(rag): handle None context chunk text

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -17,3 +17,23 @@ The bug has a narrow scope in `rag/evaluator/faithfulness_checker.py`, includes 
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [ ] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [cf3b1be — fix(rag): handle None context chunk text](https://github.com/yifanliu0108/pathreview/commit/cf3b1be46ca58416f2aacd2dfcd0a731faf6dbb0)
+
+**Reproduction summary:**
+I ran `FaithfulnessChecker().check("Knows Python.", [{"text": None}])` against the
+upstream implementation and reliably reproduced `TypeError: sequence item 0:
+expected str instance, NoneType found` while the context strings were joined. On
+this branch, the same input completes without an exception and returns `0.0`.
+
+**PLAN.md link:** [PLAN.md on the working branch](https://github.com/yifanliu0108/pathreview/blob/fix/153-none-context-chunk-text/PLAN.md)
+
+**Walkthrough video (recommended):** Not recorded (optional and not graded).
+
+**Blockers or open questions:**
+The issue-specific null-text and missing-key tests pass. Three existing assertions
+in the complete faithfulness-checker test module still fail because its current
+token-overlap scoring returns `0.0` where those tests expect partial support; they
+are unrelated to the `None`-handling crash and are outside issue #153.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,19 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/153
+
+**Issue title:** Faithfulness checker crashes when a context chunk has `text: None`
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The RAG faithfulness checker combines the `text` values from retrieved context chunks before scoring generated feedback. When a chunk contains the `text` key with a value of `None`, `dict.get("text", "")` returns `None` instead of the empty-string default, and `str.join` raises a `TypeError`. This prevents the checker from returning a score for otherwise valid input. A successful fix will normalize a missing or `None` text value to an empty string so faithfulness evaluation continues without crashing.
+
+**Selection notes — “Is this right for me?” checklist:**
+The bug has a narrow scope in `rag/evaluator/faithfulness_checker.py`, includes clear reproduction steps, and already has a focused failing unit test. The expected behavior is explicit, the change does not require an API or database migration, and it can be verified with the targeted test plus the repository's standard checks. These constraints make the issue realistic to complete as a Tier 1 contribution without expanding its scope.
+
+**Branch name:** `fix/153-none-context-chunk-text`
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -61,7 +61,7 @@ focused tests introduce no new failures and documenting the baseline below.
 
 ### Check-in 2 (end of week)
 
-**PR link:** [To be added after the pull request is opened]
+**PR link:** https://github.com/ascherj/pathreview/pull/657
 
 **Branch:** `fix/153-none-context-chunk-text`
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -37,3 +37,52 @@ The issue-specific null-text and missing-key tests pass. Three existing assertio
 in the complete faithfulness-checker test module still fail because its current
 token-overlap scoring returns `0.0` where those tests expect partial support; they
 are unrelated to the `None`-handling crash and are outside issue #153.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented null-safe context concatenation in `FaithfulnessChecker.check()` and
+verified the focused `None` and missing-key regression cases. The reproduction,
+code mapping, risks, and edge cases in `PLAN.md` are complete.
+
+**Next steps:**
+Strengthen the regression coverage for mixed valid, missing, and null context
+chunks; run the repository checks; self-review the final diff; and submit the pull
+request.
+
+**Blockers:**
+The repository has broad pre-existing lint and unit-test failures unrelated to
+issue #153. Per the course guidance, I am verifying that the changed files and
+focused tests introduce no new failures and documenting the baseline below.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [To be added after the pull request is opened]
+
+**Branch:** `fix/153-none-context-chunk-text`
+
+**What you built:**
+Updated the faithfulness checker so retrieved chunks with missing or `None` text
+contribute an empty string instead of crashing `str.join()`. Valid text from other
+chunks remains available for scoring.
+
+**Tests added or updated:**
+Updated `tests/unit/test_faithfulness_checker.py` to assert the exact score for an
+all-null context and added coverage for a mixed list containing valid, missing,
+and null chunk text.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+Here, “passes” follows the course definition for a codebase with documented
+pre-existing failures: the contribution introduces no new failures. On August 3,
+2026, `make check` reported 181 existing repository-wide Ruff errors. `make
+test-unit` completed with 346 passing tests, 51 existing failures, and 31 errors;
+the errors came from chunker tests attempting to download a tokenizer while
+network access was unavailable. The focused null/missing-text tests pass, and the
+changed Python files pass focused Ruff, Black, and mypy checks.
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -86,3 +86,52 @@ network access was unavailable. The focused null/missing-text tests pass, and th
 changed Python files pass focused Ruff, Black, and mypy checks.
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No reviewer feedback was provided. Reviewer feedback is not part of the Summer
+2026 course process, so my pull request remains open without maintainer comments.
+
+**How you responded:**
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The hardest part was separating problems caused by my change from failures that
+already existed in the repository. The full test suite contained unrelated
+scoring failures, lint errors, and tests that tried to download a tokenizer while
+the network was unavailable. I had to reproduce issue #153 directly and run
+focused tests to prove that my fix handled `None` without introducing a new
+failure.
+
+**What did you learn about working in a large codebase?**
+I learned that a small code change still requires understanding the surrounding
+data flow, existing tests, and project conventions. In my own projects I can
+change several components at once, but in someone else's codebase I need to keep
+the scope narrow and avoid fixing unrelated problems. Clear notes about the test
+baseline also make the contribution easier for a maintainer to evaluate.
+
+**How did AI tools help — and where did they fall short?**
+AI tools helped me trace the `TypeError` to `str.join()`, compare possible fixes,
+and identify useful edge cases such as missing, null, and mixed chunk text. They
+also helped me organize the implementation plan and journal. However, AI could
+not decide whether a failure was pre-existing just from the error message. I
+still had to inspect the code, reproduce the bug, run the focused tests, and
+compare those results with the repository-wide test output.
+
+**What would you do differently if you started over?**
+I would run the full checks before changing any code so I had a clear baseline
+from the beginning. I would also submit the pull request earlier, leaving more
+time to review the final diff and respond if a maintainer commented.
+
+**What are you most proud of from this module?**
+I am most proud that I turned a specific crash into a small, tested fix without
+expanding the issue's scope. The added tests cover null, missing, and mixed text
+values, and the checker now returns a valid score instead of crashing.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,76 @@
+## Solution plan
+
+**Issue:** [Faithfulness checker crashes when a context chunk has `text: None` (#153)](https://github.com/ascherj/pathreview/issues/153)
+
+### Understand
+
+`FaithfulnessChecker.check()` builds one context string by joining the value returned
+by `chunk.get("text", "")` for every retrieved chunk. The default only applies when
+the `text` key is absent; when the key exists and its value is `None`, the generator
+passes `None` to `str.join()`, which raises `TypeError` before any claims can be
+scored.
+
+Expected behavior: a chunk with missing or `None` text should contribute an empty
+string, allowing the checker to continue and return a score between `0.0` and `1.0`.
+Actual behavior: `FaithfulnessChecker().check("Knows Python.", [{"text": None}])`
+raises `TypeError: sequence item 0: expected str instance, NoneType found`.
+
+### Map
+
+- `rag/evaluator/faithfulness_checker.py`
+  - `FaithfulnessChecker.check()` extracts and joins context chunk text.
+- `tests/unit/test_faithfulness_checker.py`
+  - `test_none_context_chunk_text` is the focused regression test.
+  - `test_missing_text_key_in_chunk` protects the related missing-key case.
+
+No API route, database model, migration, frontend component, or LLM integration is
+involved in this fix.
+
+### Plan
+
+1. Reproduce issue #153 with a context list containing `{"text": None}` and confirm
+   the failure occurs while `check()` constructs `context_text`.
+2. Normalize each retrieved `text` value in
+   `rag/evaluator/faithfulness_checker.py` so both a missing key and an explicit
+   `None` become an empty string before `str.join()` runs.
+3. Run `test_none_context_chunk_text` and `test_missing_text_key_in_chunk` to verify
+   both nullable-input paths return a valid numeric score without an exception.
+4. Run the complete faithfulness-checker test module and the repository quality
+   checks, separating any pre-existing failures from regressions caused by this
+   focused change.
+
+### Inputs & outputs
+
+The input is generated feedback as a string and retrieved context as a
+`list[dict]`. Each dictionary may have a string `text` value, a missing `text` key,
+or `text: None`.
+
+The fix does not change the public method signature or return type. For valid
+feedback and a non-empty chunk list, `check()` should continue to produce a
+faithfulness score from `0.0` to `1.0`; null or missing chunk text simply contributes
+no supporting words.
+
+### Risks & unknowns
+
+- Using a broad truthiness fallback would also normalize other falsey values such
+  as `0` or `False`. Retrieved chunk text is typed and produced as text in normal
+  operation, but an explicit `None` check could be preferable if non-string values
+  become supported later.
+- Normalizing invalid text prevents the crash but can lower the score because that
+  chunk supplies no evidence. This is preferable to inventing context, but upstream
+  retrieval or ingestion may still need separate validation if null text becomes
+  common.
+- The full `tests/unit/test_faithfulness_checker.py` module currently contains
+  unrelated scoring-expectation failures. The issue-specific regression test must
+  pass independently, and those baseline failures should not be hidden or expanded
+  into issue #153.
+
+### Edge cases
+
+- A single chunk with `text: None`.
+- A chunk with no `text` key.
+- A mixture of valid text, missing text, and `None` text across several chunks.
+- All chunks containing unusable text, which should yield a valid low score rather
+  than an exception.
+- Empty feedback or an empty context list, which should retain the existing `0.0`
+  early-return behavior.

--- a/rag/evaluator/faithfulness_checker.py
+++ b/rag/evaluator/faithfulness_checker.py
@@ -1,6 +1,7 @@
 """Check if generated feedback is supported by retrieved context."""
 
 import re
+
 import structlog
 
 logger = structlog.get_logger()
@@ -20,8 +21,11 @@ class FaithfulnessChecker:
             Faithfulness score 0.0-1.0 (ratio of supported claims)
         """
         if not feedback or not context_chunks:
-            logger.info("faithfulness_empty_input", has_feedback=bool(feedback),
-                       has_chunks=bool(context_chunks))
+            logger.info(
+                "faithfulness_empty_input",
+                has_feedback=bool(feedback),
+                has_chunks=bool(context_chunks),
+            )
             return 0.0
 
         # Extract key claims from feedback (sentences)
@@ -31,9 +35,7 @@ class FaithfulnessChecker:
             return 0.5  # Default to neutral if no extractable claims
 
         # Concatenate context text
-        context_text = " ".join([
-            chunk.get("text", "") for chunk in context_chunks
-        ])
+        context_text = " ".join([chunk.get("text") or "" for chunk in context_chunks])
 
         # Check each claim for support
         supported = 0
@@ -43,8 +45,9 @@ class FaithfulnessChecker:
 
         score = supported / len(claims) if claims else 0.0
 
-        logger.info("faithfulness_checked", claims_count=len(claims),
-                   supported_count=supported, score=score)
+        logger.info(
+            "faithfulness_checked", claims_count=len(claims), supported_count=supported, score=score
+        )
 
         return score
 
@@ -59,7 +62,7 @@ class FaithfulnessChecker:
             List of claims (sentences)
         """
         # Split by sentence (simple regex)
-        sentences = re.split(r'[.!?]+', text)
+        sentences = re.split(r"[.!?]+", text)
         claims = [s.strip() for s in sentences if s.strip() and len(s.strip()) > 10]
         return claims[:10]  # Limit to 10 claims for scoring
 
@@ -81,8 +84,25 @@ class FaithfulnessChecker:
         # Require at least some meaningful overlap
         overlap = claim_tokens & context_tokens
         # Filter out common stop words
-        stop_words = {'a', 'an', 'the', 'is', 'are', 'was', 'were', 'be', 'been',
-                     'and', 'or', 'but', 'in', 'of', 'to', 'for', 'that'}
+        stop_words = {
+            "a",
+            "an",
+            "the",
+            "is",
+            "are",
+            "was",
+            "were",
+            "be",
+            "been",
+            "and",
+            "or",
+            "but",
+            "in",
+            "of",
+            "to",
+            "for",
+            "that",
+        }
         meaningful_overlap = overlap - stop_words
 
         return len(meaningful_overlap) >= 2

--- a/tests/unit/test_faithfulness_checker.py
+++ b/tests/unit/test_faithfulness_checker.py
@@ -18,9 +18,7 @@ class TestFaithfulnessChecker:
         """Test feedback fully supported by context returns score close to 1.0."""
         feedback = "The developer has strong Python skills and experience with Django."
         context_chunks = [
-            {
-                "text": "The portfolio shows Python expertise and Django framework experience."
-            },
+            {"text": "The portfolio shows Python expertise and Django framework experience."},
         ]
 
         score = checker.check(feedback, context_chunks)
@@ -34,9 +32,7 @@ class TestFaithfulnessChecker:
         """Test feedback with no support in context returns score close to 0.0."""
         feedback = "This developer is an expert in Rust systems programming."
         context_chunks = [
-            {
-                "text": "The developer has Python and JavaScript experience."
-            },
+            {"text": "The developer has Python and JavaScript experience."},
         ]
 
         score = checker.check(feedback, context_chunks)
@@ -48,9 +44,7 @@ class TestFaithfulnessChecker:
         """Test partial support returns score between 0 and 1."""
         feedback = "The developer shows Python expertise and Kubernetes knowledge."
         context_chunks = [
-            {
-                "text": "Strong Python programming skills demonstrated in projects."
-            },
+            {"text": "Strong Python programming skills demonstrated in projects."},
         ]
 
         score = checker.check(feedback, context_chunks)
@@ -63,9 +57,7 @@ class TestFaithfulnessChecker:
     def test_empty_feedback_returns_zero(self, checker):
         """Test empty feedback returns 0.0."""
         feedback = ""
-        context_chunks = [
-            {"text": "Some context"}
-        ]
+        context_chunks = [{"text": "Some context"}]
 
         score = checker.check(feedback, context_chunks)
 
@@ -155,15 +147,11 @@ class TestFaithfulnessChecker:
         """Test that score varies with input, never hardcoded 1.0 or 0.0."""
         # First test: fully supported
         score1 = checker.check(
-            "Python and JavaScript skills",
-            [{"text": "Expert in Python and JavaScript"}]
+            "Python and JavaScript skills", [{"text": "Expert in Python and JavaScript"}]
         )
 
         # Second test: no support
-        score2 = checker.check(
-            "Rust expertise",
-            [{"text": "Java programming background"}]
-        )
+        score2 = checker.check("Rust expertise", [{"text": "Java programming background"}])
 
         # Scores should be different
         assert score1 != score2
@@ -173,9 +161,7 @@ class TestFaithfulnessChecker:
     def test_multiple_claims_varying_support(self, checker):
         """Test scoring with multiple claims of varying support."""
         feedback = "Python expert. Knows Rust. Skilled with Docker."
-        context_chunks = [
-            {"text": "Python and Docker expertise shown in projects."}
-        ]
+        context_chunks = [{"text": "Python and Docker expertise shown in projects."}]
 
         score = checker.check(feedback, context_chunks)
 
@@ -186,9 +172,7 @@ class TestFaithfulnessChecker:
     def test_very_long_feedback(self, checker):
         """Test handling of very long feedback text."""
         feedback = "The developer. " * 100
-        context_chunks = [
-            {"text": "Developer portfolio content"}
-        ]
+        context_chunks = [{"text": "Developer portfolio content"}]
 
         score = checker.check(feedback, context_chunks)
 
@@ -198,9 +182,7 @@ class TestFaithfulnessChecker:
     def test_very_long_context(self, checker):
         """Test handling of very long context."""
         feedback = "The developer has Python skills."
-        context_chunks = [
-            {"text": "Python " * 1000}
-        ]
+        context_chunks = [{"text": "Python " * 1000}]
 
         score = checker.check(feedback, context_chunks)
 
@@ -215,8 +197,7 @@ class TestFaithfulnessChecker:
 
         supported = checker._is_supported(claim, context)
 
-        # Despite word overlap, should look for meaningful overlap (not stop words)
-        # This depends on implementation
+        assert supported is True
 
     def test_minimum_overlap_required(self, checker):
         """Test that minimum meaningful overlap is required for support."""
@@ -231,22 +212,29 @@ class TestFaithfulnessChecker:
     def test_none_context_chunk_text(self, checker):
         """Test handling of None in context chunk text."""
         feedback = "Has Python skills"
+        context_chunks = [{"text": None}]
+
+        score = checker.check(feedback, context_chunks)
+
+        assert score == 0.0
+
+    def test_none_and_missing_text_do_not_discard_valid_context(self, checker):
+        """Test unusable chunks are ignored while valid context is retained."""
+        feedback = "The developer has Python skills."
         context_chunks = [
-            {"text": None}
+            {"text": None},
+            {"content": "This chunk uses the wrong key."},
+            {"text": "Python skills are demonstrated in the portfolio."},
         ]
 
         score = checker.check(feedback, context_chunks)
 
-        # Should handle gracefully
-        assert isinstance(score, float)
-        assert 0.0 <= score <= 1.0
+        assert score == 1.0
 
     def test_missing_text_key_in_chunk(self, checker):
         """Test handling of missing 'text' key in context chunk."""
         feedback = "Has Python skills"
-        context_chunks = [
-            {"content": "Python skills"}  # Wrong key
-        ]
+        context_chunks = [{"content": "Python skills"}]  # Wrong key
 
         score = checker.check(feedback, context_chunks)
 


### PR DESCRIPTION
## Summary

Prevents `FaithfulnessChecker.check()` from crashing when a retrieved context chunk contains `text: None`. Null or missing text now contributes an empty string while valid text remains available for scoring.

## Issue

Closes #153

## Changes

- Normalize missing or null context text before joining chunks.
- Strengthen the null-text regression test.
- Add coverage for mixed valid, missing, and null chunks.
- Add the Week 9 check-ins to `JOURNAL.md`.

## Testing

- [x] Unit tests pass (`make test-unit`)*
- [ ] Integration tests pass (`make test-integration`) — not applicable
- [x] Linter passes (`make lint`)*
- [x] Type checker passes (`make typecheck`)*
- [x] New/updated tests cover the changes

Focused validation: 4 issue-related tests pass. Ruff, Black, and mypy pass for the changed production code.

*The repository has pre-existing failures documented in `JOURNAL.md`. This contribution introduces no new failures, following the course definition of “passes.”

## Screenshots / Demo

Not applicable; this backend fix has no UI changes.

## Notes for Reviewers

This PR intentionally does not alter the checker’s existing token-overlap scoring behavior.