### PR TITLE
docs(api): add POST /profiles request body schema

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,28 @@
+# Journal
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/89
+
+**Issue title:** API reference doc is missing the `POST /profiles` request body schema
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The API reference file, `docs/API.md`, lists the `POST /profiles` endpoint but
+only gives it a one-line description. It never explains what you have to send in
+the request, so anyone calling the API has to read the source code or open the
+Swagger page to figure it out. The missing detail matters here because this
+endpoint is not a normal JSON request — it takes a multipart form with three
+optional fields: a GitHub username, a portfolio URL, and a resume file upload
+(which must be a PDF or Markdown/plain-text file). A successful fix adds a clear
+request body section for this endpoint — a table of the fields with their types
+and rules, plus a short example request — so the doc on its own is enough to call
+the endpoint correctly. The change only touches the documentation in `docs/API.md`
+and does not change how the application behaves.
+
+**Branch name:** docs/89-post-profiles-request-body
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -26,3 +26,13 @@ and does not change how the application behaves.
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction and plan
+
+**Issue:** #89 — API reference doc is missing the `POST /profiles` request body schema
+(https://github.com/ascherj/pathreview/issues/89)
+
+**Walkthrough video:** https://www.loom.com/share/a59ceea3be4d433d99066c6a4cdd3843
+
+**What I did this week:** reproduced the problem on my own machine, then wrote a
+structured plan for the fix in `PLAN.md`.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -36,3 +36,25 @@ and does not change how the application behaves.
 
 **What I did this week:** reproduced the problem on my own machine, then wrote a
 structured plan for the fix in `PLAN.md`.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the fix from `PLAN.md`. Completed sub-tasks 1–4: added a request body
+section for `POST /profiles` to `docs/API.md` — a `multipart/form-data` + Bearer
+auth note, a field table (`github_username`, `portfolio_url`, `resume_file` with
+types, length limits, and allowed file types), the resume file-type rule with its
+exact `422` message, and a runnable `curl` example. Also added a doc-regression
+unit test at `tests/unit/test_api_docs.py` (7 tests, all passing) that guards the
+documented schema. Committed the doc fix and the test separately.
+
+**Next steps:**
+Do the final `make check` / `make test-unit` verification, fill in the PR template,
+and open the pull request into `ascherj/main`, then record the link in Check-in 2.
+
+**Blockers:**
+None. Note: the repo has pre-existing `make check` (182 ruff errors) and
+`make test-unit` (53 failing tests) issues unrelated to this change — I recorded the
+baseline first and confirmed my change adds none. This will be documented in the PR.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -88,3 +88,59 @@ clean and my 7 new tests pass; the pre-existing 182 ruff / 5 mypy / 53 test fail
 documented in the PR and unchanged by this PR.)
 
 **Draft PR feedback received from:** none (opened ready for review)
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No reviewer or maintainer comments had arrived on PR #659 yet, and
+the PR is still open with review requested (0 comments, 0 reviews). I'll respond
+within 48 hours if feedback comes in, per the CONTRIBUTING guidelines.
+
+**How you responded:**
+N/A — no feedback yet.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+
+The setup was the hardest part. I expected to spend the module on the issue itself, but
+the first stretch went to getting a working Python at all: my python3 was still the
+system 3.9 even after a Homebrew upgrade (a PATH-ordering problem), and then Homebrew's
+3.12/3.14 couldn't even run pip because of a macOS libexpat/pyexpat symbol
+mismatch that only cleared after an OS update. None of that was "the work," but it
+blocked all of it. The other surprise was conceptual: "reproducing" a *documentation*
+bug isn't a crash that I could trigger, it's proving the doc is incomplete against the running
+API, which took a while to reframe.
+
+**What did you learn about working in a large codebase?**
+
+That we inherit the codebase's existing state instead of a clean slate. This repo was
+already with several errors and failing unit tests — and the skill
+was separating *my* responsibility (introduce no new failures) from pre-existing debt,
+then documenting that honestly rather than pretending everything was green. I also
+learned the source of truth is the code, not the docs or even Swagger: the OpenAPI
+schema itself omitted the length limits, the allowed file types, and the error
+messages, so I had to read `api/routes/profiles.py` directly. And the enforced
+convention lives in tooling — the pre-commit mypy hook demanded return-type annotations
+on my new test even though older test files skip them, because it only re-checks
+changed files.
+
+**How did AI tools help — and where did they fall short?**
+
+AI was strongest at finding info and making drafts. Like locating the endpoint and schema, drafting the plan/journal/PR, and doing the mechanical git and verification work quickly. 
+
+Where it fell short: it first tried to "reproduce" the bug by dumping the OpenAPI schema offline instead of actually running the app. I had to insist on a real, runnable reproduction, which is what surfaced the useful surprises (an over-long username returns 500, not 422; `/health` is broken by its own bugs). It also couldn't make the judgment calls that were actually mine: which issue to take, whether to fix tempting out-of-scope bugs (I didn't), whether a docs-only change even warrants a test, and how much to trust a green checkmark in a red repo. The environment fix needed a real-world OS update no tool could do for me.
+
+**What would you do differently if you started over?**
+
+I'd actually run the app end-to-end before choosing an issue, so setup pain wouldn't spill over into the work and I'd know the reproduction path from day one. I'd reproduce in the running app immediately instead of reasoning from source. I might pick an issue that already has a test file, so the testing approach isn't something I have to invent. And I'd file the two out-of-scope bugs as their own issues the moment I found them, instead of only noting them in the PR.
+
+**What are you most proud of?**
+
+Avoiding scope creep. It was tempting to "fix" the 500 bug or the broken `/health` check while I was in there, but I kept the PR to exactly what issue #89 asked for and logged the rest as follow-ups. And instead of quietly checking "tests pass" in a repo that's clearly failing, I measured the baseline first and wrote a PR that's transparent about what was already broken and proves my change added nothing new, and a small regression test so the documented schema can't silently disappear again.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -58,3 +58,33 @@ and open the pull request into `ascherj/main`, then record the link in Check-in 
 None. Note: the repo has pre-existing `make check` (182 ruff errors) and
 `make test-unit` (53 failing tests) issues unrelated to this change — I recorded the
 baseline first and confirmed my change adds none. This will be documented in the PR.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/659
+
+**Branch:** `docs/89-post-profiles-request-body`
+
+**What you built:**
+A request body section for `POST /profiles` in `docs/API.md`. It documents that the
+endpoint takes a `multipart/form-data` upload with three optional fields
+(`github_username`, `portfolio_url`, `resume_file`), their length limits and accepted
+resume file types, the required Bearer token (`401` if missing), the `422` returned for
+an invalid file type, and a runnable `curl` example — so the doc alone is enough to call
+the endpoint correctly.
+
+**Tests added or updated:**
+Added `tests/unit/test_api_docs.py` — 7 unit tests that read `docs/API.md` and assert it
+documents the `multipart/form-data` content type, all three request fields, the
+Bearer-auth/`401` requirement, the accepted resume MIME types (including `text/plain`),
+the exact `422` detail message, and a `curl` example. This guards the #89 fix so the
+schema can't silently disappear again.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+(In this repo "passes" means *no new failures*: my changed files are ruff/black/mypy
+clean and my 7 new tests pass; the pre-existing 182 ruff / 5 mypy / 53 test failures are
+documented in the PR and unchanged by this PR.)
+
+**Draft PR feedback received from:** none (opened ready for review)

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,127 @@
+# PLAN — Issue #89: Document the `POST /profiles` request body
+
+## What needs to change
+
+The API reference `docs/API.md` documents `POST /profiles` (line 18) as a single
+sentence with **no request body schema**. A developer reading only this doc cannot
+build a valid request: they don't know it is a `multipart/form-data` upload, which
+fields exist, the field constraints, the allowed resume file types, or that a Bearer
+token is required.
+
+**A correct fix** adds a request body section for `POST /profiles` to `docs/API.md`
+that states the content type, the auth requirement, a field-by-field table (name,
+type, required, constraints), the resume file-type rule, and a runnable `curl`
+example — so the doc alone is enough to call the endpoint correctly. This is a
+documentation-only change; no application code changes.
+
+## Reproduction (confirmed in the local environment)
+
+Brought the stack up: `docker compose up -d` (Postgres + Redis healthy; Chroma not
+needed here), `alembic upgrade head`, seeded users, then `uvicorn api.main:app` on
+:8000. Exercised the real endpoint with `curl`, using a token from `POST /auth/login`
+(seeded `user1@example.com` / `password1`):
+
+| Request | Result | Confirms |
+| --- | --- | --- |
+| No token | `401` | Auth (Bearer token) is required |
+| Token + `.png` file | `422` `{"detail":"Resume must be a PDF or Markdown file"}` | File-type rule + exact error message |
+| Token + `github_username` = 300 chars | `500` `{"detail":"Failed to create profile"}` | Over-length is not a clean 422 (see risks) |
+| Token + valid `github_username` + `portfolio_url` | `200` + profile JSON | Happy path |
+
+The live OpenAPI (`/openapi.json`) declares the body as `multipart/form-data` with
+`github_username`, `portfolio_url`, `resume_file`, and `security: OAuth2PasswordBearer`
+— none of which appears in `docs/API.md`. The OpenAPI is itself thin: it omits the
+length limits, the allowed file types, and the exact error messages, so the written
+doc adds real value over "just read Swagger."
+
+## Files involved
+
+**Changed by the fix (one file):**
+- `docs/API.md` — add the request body section under the `POST /profiles` line (line 18).
+
+**Read-only, source of truth (not changed):**
+- `api/routes/profiles.py` — `create_profile_endpoint` (lines 23–108); the
+  `Form(...)`/`File(...)` signature (lines 24–30) and the file-type check (lines 42–53).
+- `api/schemas/profile.py` — `ProfileCreate` (lines 7–9, the `max_length` limits) and
+  `ProfileResponse` (lines 17–25, the success payload).
+
+## Inputs and outputs (the contract being documented)
+
+The fix does not change these — it documents them accurately.
+
+**Inputs** — `multipart/form-data`, all fields optional, plus an auth header:
+| Field | Type | Required | Constraint |
+| --- | --- | --- | --- |
+| `github_username` | string (form) | No | max 255 chars |
+| `portfolio_url` | string (form) | No | max 500 chars |
+| `resume_file` | file upload | No | must be `application/pdf`, `text/markdown`, or `text/plain` |
+| `Authorization` header | `Bearer <token>` | Yes | from `POST /auth/login` |
+
+**Outputs:**
+- `200 OK` → `ProfileResponse` JSON: `id` (UUID), `user_id` (UUID),
+  `github_username` (string\|null), `portfolio_url` (string\|null),
+  `created_at` (datetime), `resume_filename` (string\|null).
+- `401 Unauthorized` → missing/invalid token.
+- `422 Unprocessable Entity` → disallowed resume file type, detail
+  `"Resume must be a PDF or Markdown file"`.
+
+## Sub-tasks (in order)
+
+1. In `docs/API.md`, under the `POST /profiles` line, add a note: content type is
+   `multipart/form-data` and a Bearer token is required (401 if missing).
+2. Add the request field table (`github_username`, `portfolio_url`, `resume_file`)
+   with columns Field / Type / Required / Description, including the length limits
+   and allowed file types.
+3. Add a one-line note on the resume file rule: the accepted types and the exact
+   `422` detail returned for anything else.
+4. Add a copy-pasteable `curl` example: base URL `http://localhost:8000`, a
+   `Authorization: Bearer <token>` header, and `-F` form fields including a file upload.
+5. Leave every other endpoint untouched and keep the file's existing terse style.
+6. Run the verification steps below, then commit and push.
+
+## Edge cases the documentation must cover
+
+1. **Disallowed resume type** (e.g. `.png`, `.docx`): endpoint returns `422` with
+   detail `"Resume must be a PDF or Markdown file"` — the doc must state the accepted
+   types and this response.
+2. **No fields at all / a single field**: every field is optional, so a request with
+   only `github_username` (or nothing) still returns `200` — the doc must mark each
+   field optional, not imply any is required.
+3. **Missing or expired token**: returns `401` — the doc must state auth is required
+   and point to `POST /auth/login`.
+4. **`text/plain` resume**: accepted even though the error message names only "PDF or
+   Markdown" — the doc must list plain text as an accepted type.
+
+## Risks / unknowns (each tied to a concrete location)
+
+- **Over-length values return 500, not 422.** `max_length` (255/500) is declared on
+  `ProfileCreate` in `api/schemas/profile.py:7-9`, but the model is constructed
+  *after* form parsing in `api/routes/profiles.py:79-82`, so an over-long value throws
+  and surfaces as `500 {"detail":"Failed to create profile"}`. Decision: document the
+  limits as the intended constraints, but do **not** claim a 422 for exceeding them.
+  This is a latent bug, **out of scope for #89** — raise a separate issue.
+- **File-type message is narrower than the rule.** The check in
+  `api/routes/profiles.py:42-53` accepts `text/plain`, but its message says only
+  "PDF or Markdown." Document the true accepted set and quote the exact message.
+- **Scope creep.** The manifest E-14 text also names `POST /reviews`, but issue #89's
+  title is `POST /profiles` only (see `docs/API.md:24` for the reviews line). Plan
+  stays profiles-only; a reviewer may ask for reviews too — easy to add later.
+- **New formatting convention.** This is the first request-body block in `docs/API.md`;
+  keep it clean so it can be reused for other endpoints.
+
+## Incidental findings (NOT part of this issue)
+
+- `GET /health` returns `503` due to bugs in the health-check code itself, not real
+  outages: the Postgres check uses a bare `SELECT 1` (SQLAlchemy 2.x needs
+  `text('SELECT 1')`) and the Redis check reads a non-existent `settings.redis_host`.
+  The app otherwise runs fine. Worth a separate issue; not touching here.
+
+## Verification
+
+- Re-read `docs/API.md`; confirm the table and `curl` block render as valid GitHub markdown.
+- Cross-check every documented field, constraint, and status code against the
+  reproduction table above and `api/routes/profiles.py`.
+- With the app running at `http://localhost:8000`, open `/docs` and confirm the
+  Swagger `POST /profiles` body matches the doc.
+- Commit the fix as `docs(api): add POST /profiles request body schema` with
+  `Fixes #89` in the body; push to `origin`; open a PR into `ascherj/main`.

--- a/docs/API.md
+++ b/docs/API.md
@@ -16,6 +16,30 @@ Base URL: `http://localhost:8000`
 ### Profiles
 
 `POST /profiles` — Create a profile with resume and GitHub username.
+
+Send as `multipart/form-data` with a Bearer token
+(`Authorization: Bearer <token>`, obtained from `POST /auth/login`); requests
+without a valid token return `401`. All fields are optional.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `github_username` | string | No | GitHub username. Max 255 characters. |
+| `portfolio_url` | string | No | Portfolio URL. Max 500 characters. |
+| `resume_file` | file | No | Resume upload. Must be PDF, Markdown, or plain text (`application/pdf`, `text/markdown`, `text/plain`); any other type returns `422` with `{"detail": "Resume must be a PDF or Markdown file"}`. |
+
+Example:
+
+```bash
+curl -X POST http://localhost:8000/profiles \
+  -H "Authorization: Bearer <token>" \
+  -F "github_username=octocat" \
+  -F "portfolio_url=https://octo.dev" \
+  -F "resume_file=@resume.pdf"
+```
+
+On success, returns `200` with the created profile (`id`, `user_id`,
+`github_username`, `portfolio_url`, `created_at`, `resume_filename`).
+
 `GET /profiles/{profile_id}` — Retrieve a profile.
 `DELETE /profiles/{profile_id}` — Delete a profile and associated data.
 

--- a/tests/unit/test_api_docs.py
+++ b/tests/unit/test_api_docs.py
@@ -1,0 +1,60 @@
+"""Tests for the API reference documentation (docs/API.md).
+
+Guards issue #89: the API reference must document the POST /profiles request
+body so the doc alone is enough to call the endpoint. These tests fail if that
+schema is removed or drifts from the actual endpoint contract.
+"""
+
+from pathlib import Path
+
+import pytest
+
+API_DOC = Path(__file__).resolve().parents[2] / "docs" / "API.md"
+
+
+@pytest.mark.unit
+class TestApiDocsProfilesRequestBody:
+    """Test suite ensuring docs/API.md documents the POST /profiles request body."""
+
+    def _doc_text(self) -> str:
+        """Read the API reference doc as text."""
+        return API_DOC.read_text(encoding="utf-8")
+
+    def test_api_doc_exists(self) -> None:
+        """docs/API.md exists and is not empty."""
+        assert API_DOC.is_file()
+        assert self._doc_text().strip()
+
+    def test_documents_multipart_content_type(self) -> None:
+        """The request body is documented as multipart/form-data."""
+        assert "multipart/form-data" in self._doc_text()
+
+    def test_documents_all_request_fields(self) -> None:
+        """All three request body fields are documented."""
+        doc = self._doc_text()
+        for field in ("github_username", "portfolio_url", "resume_file"):
+            assert field in doc
+
+    def test_documents_auth_requirement(self) -> None:
+        """The Bearer-token requirement and 401 response are documented."""
+        doc = self._doc_text()
+        assert "Bearer" in doc
+        assert "401" in doc
+
+    def test_documents_allowed_resume_types(self) -> None:
+        """All accepted resume MIME types, including plain text, are documented."""
+        doc = self._doc_text()
+        for mime in ("application/pdf", "text/markdown", "text/plain"):
+            assert mime in doc
+
+    def test_documents_invalid_file_type_response(self) -> None:
+        """The 422 response and its exact detail message are documented."""
+        doc = self._doc_text()
+        assert "422" in doc
+        assert "Resume must be a PDF or Markdown file" in doc
+
+    def test_documents_curl_example(self) -> None:
+        """A runnable curl example for POST /profiles is documented."""
+        doc = self._doc_text()
+        assert "curl" in doc
+        assert "/profiles" in doc


### PR DESCRIPTION
## Summary

The API reference (`docs/API.md`) documented `POST /profiles` with only a one-line
description and no request body schema. A developer reading the doc could not build a
valid request: it does not mention that the endpoint takes a `multipart/form-data`
upload, which fields exist, their length limits, the accepted resume file types, or
that a Bearer token is required. This PR adds a complete request body section so the
doc alone is enough to call the endpoint, plus a unit test that guards the documented
schema against regression. This is a documentation change — no application code is
modified.

## Issue

Closes #89

## Changes

- **`docs/API.md`** — added a `POST /profiles` request body section: a
  `multipart/form-data` + Bearer-auth note (`401` if the token is missing/invalid), a
  field table (`github_username` ≤255, `portfolio_url` ≤500, `resume_file` with its
  accepted types), the resume file-type rule and its exact `422` message, a runnable
  `curl` example, and the `200` success shape.
- **`tests/unit/test_api_docs.py`** — new doc-regression unit test (7 cases) asserting
  the doc documents the content type, all three fields, the auth/`401` requirement, the
  accepted MIME types (including `text/plain`), the exact `422` detail, and a `curl`
  example.

## Testing

Before writing the doc I reproduced the real behavior locally (Postgres/Redis via
`docker compose`, migrations, seeded users, `uvicorn` on :8000) and exercised the
endpoint with `curl` using a token from `POST /auth/login`:

- No token → `401`
- Wrong file type (`.png`) → `422` `{"detail":"Resume must be a PDF or Markdown file"}`
- Valid `github_username` + `portfolio_url` → `200` with the created profile

The documented schema matches the live OpenAPI at `/docs`.

- [x] Unit tests pass (`make test-unit`) — the 7 new `test_api_docs` tests pass. ⚠️ The
  repo has **53 pre-existing unit-test failures** (`test_skill_extractor`,
  `test_tech_detector`, `test_structural_chunker`, …) unrelated to this change; this PR
  introduces **no new failures** (verified by diffing the failure set before/after).
- [ ] Integration tests pass (`make test-integration`) — not run; this is a
  documentation change and integration tests require the DB/Redis services. No
  integration behavior is affected.
- [x] Linter passes (`make lint`) — the changed files are ruff-clean. ⚠️ The repo has
  **182 pre-existing ruff errors** unrelated to this change; none added.
- [x] Type checker passes (`make typecheck`) — the new test file is mypy-clean (enforced
  by the pre-commit hook). ⚠️ The repo has **5 pre-existing mypy errors** (missing
  third-party stubs: `PyPDF2`, `jose`, `passlib`) unrelated to this change; none added.
- [x] New/updated tests cover the changes — `tests/unit/test_api_docs.py`.

**How to manually verify:**

1. Render `docs/API.md` and read the **Profiles** section — `POST /profiles` now shows
   the content type, auth note, field table, file-type rule, `curl` example, and success shape.
2. Cross-check against the live API: `docker compose up -d`, `alembic upgrade head`,
   `python scripts/seed_db.py`, then `uvicorn api.main:app --port 8000`. Open
   `http://localhost:8000/docs`, expand `POST /profiles`, and confirm the
   `multipart/form-data` body (`github_username`, `portfolio_url`, `resume_file`) and the
   auth requirement match the doc.
3. Reproduce the documented responses (token from `POST /auth/login` as
   `user1@example.com` / `password1`):
   - No token → `401`
   - `-F "resume_file=@x.png;type=image/png"` → `422` with `{"detail":"Resume must be a PDF or Markdown file"}`
   - `-F "github_username=octocat"` → `200`
4. Run the guard test: `make test-unit` (or `pytest tests/unit/test_api_docs.py -m unit`) —
   the 7 `test_api_docs` tests pass.

## Screenshots / Demo

Walkthrough video: https://www.loom.com/share/a59ceea3be4d433d99066c6a4cdd3843

## Notes for Reviewers

- Scope is intentionally limited to `POST /profiles` per issue #89. (The original issue
  manifest text also mentioned `POST /reviews`; happy to add it in a follow-up.)
- Reproduction surfaced two **pre-existing, out-of-scope** bugs worth separate issues:
  (1) an over-long `github_username` (>255) returns `500` instead of a clean `422`,
  because the length limit is enforced on an internal model built *after* form parsing
  (`api/schemas/profile.py` + `api/routes/profiles.py`); (2) `GET /health` returns `503`
  due to bugs in the health-check code itself (a bare `SELECT 1` needs `text(...)`; the
  Redis check reads a non-existent `settings.redis_host`). I documented the intended
  length limits but deliberately did **not** claim a `422` for over-length, to keep the
  doc accurate.
- Pre-existing `make check` / `make test-unit` failures are documented above; this PR
  adds none.
