### PR TITLE
fix: scope ContextManager to a single review to prevent stale cache reuse (#43)

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -16,3 +16,17 @@ This bug is about the AI reviewer "remembering" things it shouldn't. When a user
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/rehanNY06/pathreview-RB/commit/302e4de
+
+**Reproduction summary:**
+I wrote a standalone script that creates an Orchestrator with a fake tool that counts how many times it actually runs, then calls `.run()` twice for the same profile. The logs confirmed a "tool_result_cache_hit" on the second call, and the tool only executed once across both calls — proving the second review silently reused the first review's cached result instead of running fresh.
+
+**PLAN.md link:** https://github.com/rehanNY06/pathreview-RB/blob/fix/43-agent-session-state-not-cleared/PLAN.md
+
+**Walkthrough video (recommended):** (skipped, optional)
+
+**Blockers or open questions:**
+The real orchestration logic isn't wired into the live API yet — `_run_agent_orchestration()` in `review_service.py` is currently a placeholder that returns hardcoded data. I reproduced the bug directly against the `Orchestrator` class instead. I'm not yet sure if wiring the real orchestrator into the API is in scope for my fix, or a separate issue — planning to ask in Slack/office hours.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,16 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/43
+
+**Issue title:** Agent session state is not cleared between reviews for the same user
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+This bug is about the AI reviewer "remembering" things it shouldn't. When a user asks for a review, the system saves the results from the tools it ran and links them to that user's ID so it can reuse them later. The problem is that this saved information never gets cleared out. So if a user updates their portfolio and asks for a second review, the system just reuses its old saved results instead of actually re-checking the new version of their portfolio. That means the user could get feedback about problems they already fixed, because the AI never really looked again. The fix needs to happen in agent/memory/session_store.py, the file responsible for storing this session information, by making sure it clears out old data before starting a new review.
+
+**Branch name:** fix/43-agent-session-state-not-cleared
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -9,6 +9,8 @@
 **Problem summary:**
 This bug is about the AI reviewer "remembering" things it shouldn't. When a user asks for a review, the system saves the results from the tools it ran and links them to that user's ID so it can reuse them later. The problem is that this saved information never gets cleared out. So if a user updates their portfolio and asks for a second review, the system just reuses its old saved results instead of actually re-checking the new version of their portfolio. That means the user could get feedback about problems they already fixed, because the AI never really looked again. The fix needs to happen in agent/memory/session_store.py, the file responsible for storing this session information, by making sure it clears out old data before starting a new review.
 
+**Selection notes:** I chose this as a Tier 1 issue since it's my first time contributing to a large codebase, and a single-file, well-scoped bug felt like the right level of difficulty to start with. Before committing, I checked the issue comments and the cohort ledger — a couple of other students had also expressed interest in this issue, but the assignment clarified that claims are non-exclusive, so I was comfortable moving forward. The estimated 3–4 hours fits well within my available time before the Week 9 deadline given my other coursework, and there were no blockers or dependencies noted on the issue.
+
 **Branch name:** fix/43-agent-session-state-not-cleared
 
 **Setup confirmation:** [x] App runs locally at localhost:5173

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -30,3 +30,16 @@ I wrote a standalone script that creates an Orchestrator with a fake tool that c
 
 **Blockers or open questions:**
 The real orchestration logic isn't wired into the live API yet — `_run_agent_orchestration()` in `review_service.py` is currently a placeholder that returns hardcoded data. I reproduced the bug directly against the `Orchestrator` class instead. I'm not yet sure if wiring the real orchestrator into the API is in scope for my fix, or a separate issue — planning to ask in Slack/office hours.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+I implemented the core fix for issue #43: `Orchestrator` was creating a single `ContextManager` in `__init__`, which lived for the entire lifetime of the Orchestrator instance and let cached tool results leak across separate review requests. I changed it so a fresh `ContextManager` is created at the start of every `run()` call instead, guaranteeing no tool result can survive from one review into the next. This covers sub-tasks 1-3 from my PLAN.md.
+
+**Next steps:**
+I wrote unit tests (`tests/unit/test_orchestrator.py`) covering the fix, confirmed `make test-unit` shows no new failures compared to before my change, and confirmed `make check` is clean on my two files. Still need to open a draft PR for peer/mentor feedback and write the final PR description documenting the pre-existing, unrelated test/lint failures I found in the codebase.
+
+**Blockers:**
+None blocking right now. One open question I still want feedback on: whether wiring the real `Orchestrator` into the live API (`review_service.py` currently uses a placeholder) is in scope for this issue, or a separate concern -- I reproduced and fixed the bug directly against the `Orchestrator` class itself.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -43,3 +43,20 @@ I wrote unit tests (`tests/unit/test_orchestrator.py`) covering the fix, confirm
 
 **Blockers:**
 None blocking right now. One open question I still want feedback on: whether wiring the real `Orchestrator` into the live API (`review_service.py` currently uses a placeholder) is in scope for this issue, or a separate concern -- I reproduced and fixed the bug directly against the `Orchestrator` class itself.
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/663
+
+**Branch:** fix/43-agent-session-state-not-cleared
+
+**What you built:**
+Fixed issue #43 by changing `Orchestrator` to create a fresh `ContextManager` at the start of every `run()` call instead of storing one on `self` for the whole lifetime of the orchestrator. This preserves memoization within a single review while guaranteeing tool results can never leak into a later, separate review request.
+
+**Tests added or updated:**
+Added `tests/unit/test_orchestrator.py` with 5 tests: re-execution across separate reviews for the same profile, no cache sharing between different profiles, intra-review memoization still working, `run()`'s return shape, and graceful handling of an unknown tool in the plan.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+(Both commands were run and confirmed to introduce zero new failures compared to the pre-fix code -- the pre-existing failures/errors in unrelated files are documented in my PR description.)
+
+**Draft PR feedback received from:** none (posted in Slack, but no responses came in before the deadline)

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -60,3 +60,35 @@ Added `tests/unit/test_orchestrator.py` with 5 tests: re-execution across separa
 (Both commands were run and confirmed to introduce zero new failures compared to the pre-fix code -- the pre-existing failures/errors in unrelated files are documented in my PR description.)
 
 **Draft PR feedback received from:** none (posted in Slack, but no responses came in before the deadline)
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+(Note: reviewer feedback is not a feature in Summer 2026, per course announcement.)
+
+**Summary of feedback:**
+No review came in on PR #663 by the end of the module. I posted the draft PR in Slack asking for early feedback, but no one responded before the deadline.
+
+**How you responded:**
+N/A -- no feedback was received to respond to.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Getting my local environment running reliably was a bigger time sink than the actual bug fix. I hit a Docker container (`vector-db` / ChromaDB) that crashed on every startup due to a `numpy` version incompatibility baked into the image itself -- nothing I could fix by restarting or rebuilding, since the issue was internal to the pinned image version. I also kept running commands in PowerShell instead of Git Bash out of habit, which broke `make` repeatedly until I got in the habit of checking which shell I was in. Tracing the actual bug was harder than I expected too -- the issue title pointed at `session_store.py`, but that file turned out to be completely correct on its own. The real bug was two layers away, in how `Orchestrator` instantiated `ContextManager` in `__init__` instead of scoping it to a single `run()` call. I had to read through `orchestrator.py`, `context_manager.py`, and trace the call chain from `main.py` through `reviews.py` through `review_service.py` before I found where the actual orchestration logic lived (and even then, found out it was just a placeholder that isn't wired into the live API yet).
+
+**What did you learn about working in a large codebase?**
+The bug wasn't where the issue title said it would be. That was the biggest lesson -- issue titles and docstrings point you in a direction, but the actual root cause can be one or two layers removed from where you start looking. I also learned that a codebase can have pre-existing, unrelated failures (53 failing tests, 179 lint/type errors) that have nothing to do with what you're working on, and that's normal -- the standard isn't "leave the codebase perfect," it's "don't make it worse." Documenting that clearly in a PR description, backed by a before/after comparison (I used `git stash` to prove the same 53 failures existed before and after my change), felt like a more honest and useful contribution than silently ignoring them or trying to fix everything at once.
+
+**How did AI tools help — and where did they fall short?**
+AI assistance was most useful for reading and tracing code I didn't write -- following the chain from the API route through the service layer to the actual orchestrator, and spotting that `ContextManager`'s own docstring ("within-session memoization") directly contradicted how it was being used (stored for the lifetime of the Orchestrator instance). It was also useful for quickly explaining unfamiliar tooling errors (Docker Compose output, pre-commit hook failures, mypy error messages) in plain language when I didn't recognize them. Where it fell short: it couldn't actually run commands on my machine, so every fix still required me to manually copy files, run terminal commands, and report back results -- which meant a lot of back-and-forth for things that would have been one step if I'd had direct file access. It also couldn't diagnose the Docker/numpy issue with certainty since it couldn't execute anything inside the container itself; we could only reason about it from the log output.
+
+**What would you do differently if you started over?**
+I'd read the full call chain (API route -> service -> orchestrator -> memory) before writing any reproduction code, instead of starting with the file the issue title pointed at. I'd also set up my environment more carefully at the start -- confirming Git Bash vs PowerShell early, and checking `docker compose ps -a` (not just `ps`) from the very first setup so I'd have caught the vector-db crash sooner instead of discovering it mid-restart.
+
+**What are you most proud of from this module?**
+Proving the bug was real before writing any fix. Instead of guessing at the cause and patching something, I wrote a standalone script with a fake tool that counted its own executions, which gave me clear, undeniable log output (`tool_result_cache_hit`) showing the exact mechanism of the bug. That same script became the basis for my actual regression test, so the proof-of-bug and the safety-net-against-regression were the same piece of work.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,100 @@
+## Solution plan
+ 
+**Issue:** Agent session state is not cleared between reviews for the same user
+https://github.com/ascherj/pathreview/issues/43
+ 
+### Understand
+ 
+The `Orchestrator` class (`agent/orchestrator.py`) caches individual tool
+results in a `ContextManager` instance (`self.context_manager`), keyed only
+by a hash of the tool's input parameters (`_execute_tool`). This cache has
+no expiration (TTL) and nothing ever clears it between review requests.
+ 
+Expected behavior: when a user requests a second review of their profile
+(for example, after updating their portfolio), each tool should be re-run
+so the review reflects current, real data.
+ 
+Actual behavior: if a tool's input parameters look the same across two
+review requests (e.g. the same `github_repo` name, even though the repo's
+contents may have changed since), `_execute_tool` finds a cache hit and
+returns the old result without executing the tool again. The user's second
+review can silently reuse data from their first review.
+ 
+I confirmed this locally with a standalone script (see reproduction commit)
+that shows a tool's `execute()` method is only called once even when the
+orchestrator processes two separate "review" requests for the same profile.
+ 
+### Map
+ 
+Files I expect to touch:
+- `agent/orchestrator.py` — contains `Orchestrator._execute_tool` (the
+  caching logic itself) and `Orchestrator.run` (where session state is
+  loaded/saved via `SessionStore`, currently without any explicit clearing
+  step for a new review request).
+- `agent/memory/context_manager.py` — the `ContextManager` class that
+  performs the actual caching; likely needs either a TTL, a way to be reset,
+  or to be scoped per-review instead of per-orchestrator-instance.
+- `agent/memory/session_store.py` — not itself buggy, but I may need to add
+  a `delete()` call somewhere in the review flow if session state should be
+  explicitly cleared at the start of a new review.
+- Possibly a test file, e.g. `tests/agent/test_orchestrator.py` (need to
+  confirm exact test directory structure), to add a regression test based
+  on my reproduction script.
+### Plan
+ 
+1. Confirm exactly how `ContextManager` stores and looks up cached results
+   (read `agent/memory/context_manager.py` in full) to understand whether
+   the cleanest fix is a TTL, an instance-per-request pattern, or an
+   explicit cache-clearing call.
+2. Decide on the fix approach: most likely, make `ContextManager`'s cache
+   scoped to a single `run()` call (e.g. create a fresh `ContextManager` at
+   the start of `run()`, or accept one as a constructor/parameter) rather
+   than living for the whole lifetime of the `Orchestrator` instance.
+3. Update `Orchestrator.run()` and/or `_execute_tool()` so that a new review
+   request cannot see cached tool results from a previous, separate review.
+4. Add/expand the `SessionStore` interaction if needed, so that stored
+   session state is explicitly cleared or replaced (not just merged) at the
+   start of a new review for the same profile.
+5. Convert my standalone reproduction script into an automated regression
+   test (e.g. using pytest) that fails on the current code and passes once
+   the fix is in place.
+### Inputs & outputs
+ 
+- **Input:** two (or more) calls to `Orchestrator.run(profile_id, profile_data)`
+  for the same `profile_id`, where `profile_data` may or may not have
+  changed between calls.
+- **Output (after fix):** each call to `run()` executes its planned tools
+  fresh, so the returned `tool_results` always reflect the current
+  `profile_data` and current external state, never a previous review's
+  cached results.
+### Risks & unknowns
+ 
+- I don't yet know whether removing/scoping the cache will cause a
+  performance regression (the cache may have been added intentionally to
+  avoid redundant, costly calls like GitHub API requests within a single
+  review). I need to make sure my fix only prevents cross-review staleness,
+  not intra-review memoization of genuinely repeated calls.
+- I haven't yet confirmed whether `Orchestrator` instances are created
+  fresh per API request or reused as a long-lived singleton in production
+  — `_run_agent_orchestration()` in `core/services/review_service.py` is
+  currently a placeholder/stub and doesn't call the real `Orchestrator` at
+  all, so I can't observe this directly from the live app yet. I'll need to
+  ask in Slack or check with a mentor whether wiring up the real
+  orchestrator is in scope for this issue or a separate concern.
+- Unsure whether `SessionStore.set()`'s use of `session_state.update(results)`
+  (merging old and new state) is itself intentional behavior I need to
+  preserve for some other feature, or whether it's part of the bug.
+### Edge cases
+ 
+- A profile with no meaningful changes between reviews (should still behave
+  correctly, i.e. no crash, even if the "fresh" result happens to match the
+  old one).
+- A profile where only some tools are affected by the update (e.g. resume
+  text changed but GitHub repo didn't) — the fix shouldn't force unrelated,
+  genuinely-unchanged tool calls to error out, just ensure they're not
+  incorrectly cached long-term.
+- Concurrent reviews for two different profiles happening at the same time
+  should never share cached state with each other.
+- A `SessionStore` that is unavailable/`None` (the code already supports
+  this) should continue to work without crashing.
+ 

--- a/agent/orchestrator.py
+++ b/agent/orchestrator.py
@@ -1,12 +1,13 @@
 """Plan-execute orchestrator for agent tools."""
 
 import time
-import structlog
-from typing import Optional
+from typing import Any
 
-from .memory.session_store import SessionStore
-from .memory.context_manager import ContextManager
+import structlog
+
 from .error_handling import retry_with_backoff
+from .memory.context_manager import ContextManager
+from .memory.session_store import SessionStore
 
 logger = structlog.get_logger()
 
@@ -14,8 +15,9 @@ logger = structlog.get_logger()
 class Orchestrator:
     """Orchestrate tool execution with planning and memoization."""
 
-    def __init__(self, tools: dict, session_store: Optional[SessionStore] = None,
-                 tool_timeout: float = 30.0):
+    def __init__(
+        self, tools: dict, session_store: SessionStore | None = None, tool_timeout: float = 30.0
+    ) -> None:
         """Initialize orchestrator.
 
         Args:
@@ -26,7 +28,6 @@ class Orchestrator:
         self.tools = tools
         self.session_store = session_store
         self.tool_timeout = tool_timeout
-        self.context_manager = ContextManager()
 
     def run(self, profile_id: str, profile_data: dict) -> dict:
         """Execute analysis plan for a profile.
@@ -40,6 +41,8 @@ class Orchestrator:
         """
         logger.info("orchestrator_start", profile_id=profile_id)
 
+        context_manager = ContextManager()
+
         # Build execution plan
         plan = self._build_plan(profile_data)
 
@@ -52,8 +55,8 @@ class Orchestrator:
         results = {}
         for tool_name, tool_input in plan:
             try:
-                result = self._execute_tool(tool_name, tool_input)
-                results[tool_name] = result.data if hasattr(result, 'data') else result
+                result = self._execute_tool(tool_name, tool_input, context_manager)
+                results[tool_name] = result.data if hasattr(result, "data") else result
 
                 logger.info("tool_executed", tool=tool_name, success=True)
 
@@ -66,13 +69,12 @@ class Orchestrator:
             session_state.update(results)
             self.session_store.set(profile_id, session_state)
 
-        logger.info("orchestrator_complete", profile_id=profile_id,
-                   tools_executed=len(results))
+        logger.info("orchestrator_complete", profile_id=profile_id, tools_executed=len(results))
 
         return {
             "profile_id": profile_id,
             "tool_results": results,
-            "cached_results": self.context_manager.get_all_results()
+            "cached_results": context_manager.get_all_results(),
         }
 
     def _build_plan(self, profile_data: dict) -> list[tuple[str, dict]]:
@@ -90,55 +92,55 @@ class Orchestrator:
         if profile_data.get("github_username"):
             for project in profile_data.get("projects", []):
                 if project.get("github_repo"):
-                    plan.append((
-                        "github_tool",
-                        {
-                            "github_username": profile_data["github_username"],
-                            "repo_name": project["github_repo"]
-                        }
-                    ))
+                    plan.append(
+                        (
+                            "github_tool",
+                            {
+                                "github_username": profile_data["github_username"],
+                                "repo_name": project["github_repo"],
+                            },
+                        )
+                    )
                     break  # Only process first repo for now
 
         # Tech detector (if files available)
         if profile_data.get("files"):
-            plan.append((
-                "tech_detector",
-                {"files": profile_data["files"]}
-            ))
+            plan.append(("tech_detector", {"files": profile_data["files"]}))
 
         # README scorer
         if profile_data.get("readme_content"):
-            plan.append((
-                "readme_scorer",
-                {"readme_content": profile_data["readme_content"]}
-            ))
+            plan.append(("readme_scorer", {"readme_content": profile_data["readme_content"]}))
 
         # Skill extractor
         if profile_data.get("resume_text"):
-            plan.append((
-                "skill_extractor",
-                {
-                    "resume_text": profile_data["resume_text"],
-                    "repo_metadata": profile_data.get("repo_metadata", {})
-                }
-            ))
+            plan.append(
+                (
+                    "skill_extractor",
+                    {
+                        "resume_text": profile_data["resume_text"],
+                        "repo_metadata": profile_data.get("repo_metadata", {}),
+                    },
+                )
+            )
 
         # Market analyzer (if skills detected)
         if plan:  # Only if other tools executed
-            plan.append((
-                "market_analyzer",
-                {"detected_skills": {}}  # Will be populated by context
-            ))
+            plan.append(
+                ("market_analyzer", {"detected_skills": {}})  # Will be populated by context
+            )
 
         logger.info("plan_built", plan_size=len(plan))
         return plan
 
-    def _execute_tool(self, tool_name: str, tool_input: dict):
+    def _execute_tool(
+        self, tool_name: str, tool_input: dict, context_manager: ContextManager
+    ) -> Any:
         """Execute a single tool with retry and memoization.
 
         Args:
             tool_name: Name of tool to execute
             tool_input: Input dict for tool
+            context_manager: Context manager scoped to the current run() call
 
         Returns:
             Tool result
@@ -148,7 +150,7 @@ class Orchestrator:
 
         # Check context cache
         input_hash = ContextManager.hash_input(tool_input)
-        cached_result = self.context_manager.get_tool_result(tool_name, input_hash)
+        cached_result = context_manager.get_tool_result(tool_name, input_hash)
 
         if cached_result:
             logger.info("tool_cache_hit", tool=tool_name)
@@ -161,7 +163,7 @@ class Orchestrator:
             result = self._execute_with_timeout(tool, tool_input)
 
             # Cache result
-            self.context_manager.store_tool_result(tool_name, input_hash, result)
+            context_manager.store_tool_result(tool_name, input_hash, result)
 
             return result
 
@@ -172,7 +174,9 @@ class Orchestrator:
             logger.error("tool_execution_error", tool=tool_name, error=str(e))
             raise
 
-    def _execute_with_timeout(self, tool, tool_input: dict, timeout: Optional[float] = None):
+    def _execute_with_timeout(
+        self, tool: Any, tool_input: dict, timeout: float | None = None
+    ) -> Any:
         """Execute tool with timeout.
 
         Args:
@@ -189,7 +193,7 @@ class Orchestrator:
         timeout = timeout or self.tool_timeout
 
         @retry_with_backoff(max_retries=2, backoff_factor=1.5)
-        def _execute():
+        def _execute() -> Any:
             return tool.execute(tool_input)
 
         start = time.time()

--- a/reproduce_issue_43.py
+++ b/reproduce_issue_43.py
@@ -1,0 +1,79 @@
+"""
+Reproduction script for issue #43:
+"Agent session state is not cleared between reviews for the same user"
+
+Run with:
+    python reproduce_issue_43.py
+
+What this shows:
+    The Orchestrator's per-tool result cache (ContextManager) is keyed only
+    on a hash of the tool's input parameters, with no TTL and no way to
+    force a refresh. If the same Orchestrator instance handles a second
+    review request for the same profile -- and the tool's input parameters
+    look the same as last time (e.g. same github_repo name) -- the cached
+    result from the FIRST review is returned instead of re-running the tool.
+
+    This is a problem because tools like github_tool or market_analyzer can
+    produce different real-world output over time even when called with the
+    exact same input parameters (e.g. the user pushed new commits, or the
+    job market data changed) -- but the cache has no way to know that and
+    will happily serve stale data forever.
+
+Expected (correct) behavior:
+    The tool should execute once per review request, so review #2 reflects
+    current reality.
+
+Actual (buggy) behavior:
+    The tool executes once total. Review #2 silently reuses review #1's
+    result.
+"""
+
+from agent.orchestrator import Orchestrator
+
+
+class CountingTool:
+    """A fake tool that tracks how many times it was actually executed."""
+
+    name = "tech_detector"
+
+    def __init__(self) -> None:
+        self.call_count = 0
+
+    def execute(self, tool_input: dict) -> dict:
+        self.call_count += 1
+        return {
+            "call_number": self.call_count,
+            "note": f"This is the result from execution #{self.call_count}",
+        }
+
+
+def main() -> None:
+    tool = CountingTool()
+    orchestrator = Orchestrator(tools={"tech_detector": tool}, session_store=None)
+
+    profile_id = "profile-123"
+    profile_data = {"files": ["main.py"]}  # unchanged between "reviews"
+
+    print("=== Review request #1 (user's first review) ===")
+    result_1 = orchestrator.run(profile_id, profile_data)
+    print("tech_detector result:", result_1["tool_results"]["tech_detector"])
+    print(f"Tool has actually been executed {tool.call_count} time(s) so far.\n")
+
+    print("=== User asks for a second review (e.g. re-checks their profile) ===")
+    result_2 = orchestrator.run(profile_id, profile_data)
+    print("tech_detector result:", result_2["tool_results"]["tech_detector"])
+    print(f"Tool has actually been executed {tool.call_count} time(s) so far.\n")
+
+    if tool.call_count == 1:
+        print(
+            "BUG REPRODUCED: the tool was only executed once, even though "
+            "the orchestrator ran twice. The second review silently reused "
+            "the first review's cached result instead of generating a "
+            "fresh one."
+        )
+    else:
+        print("Tool executed fresh each time -- bug not present in this run.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -1,0 +1,87 @@
+"""Tests for orchestrator.py"""
+
+import pytest
+
+from agent.memory.context_manager import ContextManager
+from agent.orchestrator import Orchestrator
+
+
+class CountingTool:
+    """Fake tool that tracks how many times it was actually executed."""
+
+    name = "tech_detector"
+
+    def __init__(self) -> None:
+        self.call_count = 0
+
+    def execute(self, tool_input: dict) -> dict:
+        self.call_count += 1
+        return {"call_number": self.call_count}
+
+
+@pytest.mark.unit
+class TestOrchestrator:
+    """Test suite for Orchestrator."""
+
+    @pytest.fixture
+    def tool(self) -> CountingTool:
+        """Create a fake tool that counts real executions."""
+        return CountingTool()
+
+    @pytest.fixture
+    def orchestrator(self, tool: CountingTool) -> Orchestrator:
+        """Create an Orchestrator wired up with the fake tool."""
+        return Orchestrator(tools={"tech_detector": tool}, session_store=None)
+
+    def test_second_review_reexecutes_tools(
+        self, orchestrator: Orchestrator, tool: CountingTool
+    ) -> None:
+        """A second review for the same profile must not reuse a previous
+        review's cached tool result (issue #43)."""
+        profile_id = "profile-123"
+        profile_data = {"files": ["main.py"]}
+
+        orchestrator.run(profile_id, profile_data)
+        orchestrator.run(profile_id, profile_data)
+
+        assert tool.call_count == 2
+
+    def test_different_profiles_do_not_share_cache(
+        self, orchestrator: Orchestrator, tool: CountingTool
+    ) -> None:
+        """Reviewing two different profiles must not share cached results."""
+        profile_data = {"files": ["main.py"]}
+
+        orchestrator.run("profile-a", profile_data)
+        orchestrator.run("profile-b", profile_data)
+
+        assert tool.call_count == 2
+
+    def test_memoizes_within_a_single_review(
+        self, orchestrator: Orchestrator, tool: CountingTool
+    ) -> None:
+        """Within one review (same ContextManager), repeated calls for the
+        same tool+input should still be memoized."""
+        context_manager = ContextManager()
+        tool_input = {"files": ["main.py"]}
+
+        orchestrator._execute_tool("tech_detector", tool_input, context_manager)
+        orchestrator._execute_tool("tech_detector", tool_input, context_manager)
+
+        assert tool.call_count == 1
+
+    def test_run_returns_tool_results(self, orchestrator: Orchestrator) -> None:
+        """run() should return the tool's result under tool_results."""
+        result = orchestrator.run("profile-123", {"files": ["main.py"]})
+
+        assert "tool_results" in result
+        assert "tech_detector" in result["tool_results"]
+
+    def test_unknown_tool_in_plan_is_handled_gracefully(self) -> None:
+        """A planned tool with no matching entry in `tools` should be
+        recorded as a failed result, not raise or crash the whole review."""
+        orchestrator = Orchestrator(tools={}, session_store=None)
+
+        result = orchestrator.run("profile-123", {"files": ["main.py"]})
+
+        assert result["tool_results"]["tech_detector"]["success"] is False


### PR DESCRIPTION
### What
Closes #43.

`Orchestrator` was creating a single `ContextManager` instance in `__init__`, which lived for the entire lifetime of the `Orchestrator` object. Since `ContextManager` is documented as "within-session memoization," this meant cached tool results from one review request could be silently returned during a completely separate, later review request for the same (or a different) profile -- even if the underlying data had changed.

### Why
If a user updates their portfolio and requests a second review, the review should reflect their current data. Instead, if a tool's input parameters happened to look the same as a previous review (e.g. same `github_repo` name), `_execute_tool` would return the old cached result instead of re-running the tool, silently serving stale feedback.

### How
- A fresh `ContextManager` is now created at the top of every `Orchestrator.run()` call instead of being stored on `self` in `__init__`.
- `_execute_tool` now receives the `ContextManager` for the current review as a parameter instead of reading `self.context_manager`.
- This preserves memoization *within* a single review (repeated calls to the same tool+input inside one `run()` are still deduplicated) while guaranteeing nothing survives *between* separate reviews.

### Testing
- Added `tests/unit/test_orchestrator.py` with 5 tests covering: re-execution across separate reviews for the same profile, no cache sharing between different profiles, intra-review memoization still working, `run()`'s return shape, and graceful handling of an unknown tool in the plan.
- `make test-unit`: all 5 new tests pass. Total suite: 380 passed, 53 failed -- the same 53 failures exist on `main` before this change and are unrelated to this fix (they're in modules like `bias_detector`, `pii_scrubber`, `resume_parser`, `tech_detector`, `review_service`, none of which this PR touches). Confirmed via `git stash` comparison against the pre-fix code.
- `make check`: both files I added/modified (`agent/orchestrator.py`, `tests/unit/test_orchestrator.py`) are fully clean (no ruff, black, or mypy errors). The remaining mypy errors in the codebase (`agent/error_handling.py`, `agent/memory/context_manager.py`, `agent/memory/session_store.py`) are pre-existing and unrelated to this change -- they're missing type annotations that existed before this PR.

### Reproduction
See `reproduce_issue_43.py` (added in an earlier commit) for a standalone script demonstrating the bug before this fix.

### Note / open question
The real `Orchestrator` isn't currently wired into the live API -- `core/services/review_service.py`'s `_run_agent_orchestration()` is a placeholder that returns hardcoded data. I reproduced and fixed this bug directly against the `Orchestrator` class. Happy to take on wiring the real orchestrator into the API as a follow-up if that's useful, but wanted to flag it's out of scope for this PR.