### PR TITLE
Fix #153: Handle None context chunk text

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -24,12 +24,12 @@ This issue has a clearly defined bug, a known failing test, and a limited scope,
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [add after committing]
+**Reproduction commit link:** https://github.com/ascherj/pathreview/commit/06f132bf497e1620de48d64fe8d0edd282257369 
 
 **Reproduction summary:**
 I reproduced the issue by running the existing unit test `test_none_context_chunk_text` in `tests/unit/test_faithfulness_checker.py`. The test failed because the faithfulness checker attempted to join a `None` value with strings, confirming that context chunks with `text: None` cause a `TypeError`.
 
-**PLAN.md link:** [add after pushing]
+**PLAN.md link:** https://github.com/ashna2007/pathreview/blob/fix/153-faithfulness-none-context/PLAN.md
 
 **Walkthrough video (recommended):** Not recorded
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,23 @@
+# PathReview Development Journal
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/153
+
+**Issue title:** Faithfulness checker crashes when a context chunk has `text: None`
+
+**Tier:** [ ] Tier 1  [X] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The faithfulness checker combines retrieved context into a single string before evaluating responses. If one of the context chunks contains a `text` field with the value `None`, the checker crashes because it attempts to join a non-string value. A successful fix will safely handle missing or `None` text values so the evaluation can continue without raising an error.
+
+**Branch name:** `fix/153-faithfulness-none-context`
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [X] Issue added to cohort ledger
+
+### Is this issue right for me? 
+Yes! I chose this issue because it is a manageable first open-source contribution that still requires real debugging and testing. Although the fix appears relatively small, I will need to understand how the faithfulness checker processes context and why the crash occurs before implementing a solution. This issue fits my current Python experience and will help me become more comfortable working in a larger codebase.
+
+This issue has a clearly defined bug, a known failing test, and a limited scope, making it a good first open-source contribution. It requires debugging an existing codebase, understanding the cause of the crash, implementing a safe fix, and verifying it with automated tests. Since it is a Tier 1 issue, it is an appropriate starting point while still providing experience working with a larger project.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -67,3 +67,37 @@ No new tests were added. The existing unit test `test_none_context_chunk_text` n
 
 **Draft PR feedback received from:**
 none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [X] No — still awaiting review
+
+**Summary of feedback:**
+[What did reviewers comment on? Or note that no review came in.]
+No review came in.
+
+**How you responded:**
+[What changes did you make, or what did you reply? If no feedback,
+leave blank.]
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Trying to understand how my issues fits into the codebase was very difficult. It took the longest amount of time, considering the fact that there were multiple failing tests, yet there was only one relevant to mine. I thought that because it was a small issue, it would be easy to follow and find, and as a result, underestimated how much time it would take to find that issue and understand what was going on. 
+
+**What did you learn about working in a large codebase?**
+One of the most significant things I learned from this entire process is that even as something small as a tier one issue, a single line code change, can be so important. When building your own project, you don't pay attention to the single line changes, but with a large codebase, since every little thing is very significant to the entire functionality, it's more important even though it may not feel like it.
+
+**How did AI tools help — and where did they fall short?**
+AI assistance was the most useful when trying to understand the codebase. It is a very large codebase, and my contribution was so small, so locating where my issue was and understanding where to start was crucial. Claude helped me intially navigate what I was working with, and it made my life much easier. However, it did fall short when it came to locating the specific test I needed, so prompting that a little bit more and replicating the issue were the steps I had to take to fix that.
+
+
+**What would you do differently if you started over?**
+I think planning would be the biggest change I would make. This issue was interesting and significant, but I overestimated the amount of time it would take. If I started again, I would've completed this issue much quicker and tried completing another one as well.
+
+**What are you most proud of from this module?**
+I think the fact that I was able to understand how relevant a simple fix can be to fixing the entire issue is the thing I am most proud of. Without my fix, the RAG would not be able to work, eventually propagating into a bigger issue that hinders the functionality of the app. Open source contributions, big or small, make huge changes overall, and that's what made me proud of the small yet mighty work I did.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -48,3 +48,22 @@ Push my branch, open a draft pull request, complete the PR template, request pee
 
 **Blockers:**
 None.
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/665
+
+**Branch:** `fix/153-faithfulness-none-context`
+
+**What you built:**
+Implemented a fix for Issue #153 by updating the faithfulness checker to safely handle context chunks whose `"text"` field is `None`. This prevents a `TypeError` during context concatenation while preserving the existing behavior for valid text.
+
+**Tests added or updated:**
+No new tests were added. The existing unit test `test_none_context_chunk_text` now passes after the fix. I also verified that `make test-unit` improved from 53 failed / 375 passed to 52 failed / 376 passed.
+
+**Self-review confirmation:**
+- [x] `make check` introduces no new failures (182 pre-existing errors remain)
+- [x] `make test-unit` introduces no new failures (improved from 53 failed to 52 failed)
+
+**Draft PR feedback received from:**
+none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -21,3 +21,17 @@ The faithfulness checker combines retrieved context into a single string before 
 Yes! I chose this issue because it is a manageable first open-source contribution that still requires real debugging and testing. Although the fix appears relatively small, I will need to understand how the faithfulness checker processes context and why the crash occurs before implementing a solution. This issue fits my current Python experience and will help me become more comfortable working in a larger codebase.
 
 This issue has a clearly defined bug, a known failing test, and a limited scope, making it a good first open-source contribution. It requires debugging an existing codebase, understanding the cause of the crash, implementing a safe fix, and verifying it with automated tests. Since it is a Tier 1 issue, it is an appropriate starting point while still providing experience working with a larger project.
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [add after committing]
+
+**Reproduction summary:**
+I reproduced the issue by running the existing unit test `test_none_context_chunk_text` in `tests/unit/test_faithfulness_checker.py`. The test failed because the faithfulness checker attempted to join a `None` value with strings, confirming that context chunks with `text: None` cause a `TypeError`.
+
+**PLAN.md link:** [add after pushing]
+
+**Walkthrough video (recommended):** Not recorded
+
+**Blockers or open questions:**
+I still need to confirm whether the intended behavior is to skip chunks with `None` text or treat them as empty strings, although the issue description suggests safely converting them to empty strings.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -35,3 +35,16 @@ I reproduced the issue by running the existing unit test `test_none_context_chun
 
 **Blockers or open questions:**
 I still need to confirm whether the intended behavior is to skip chunks with `None` text or treat them as empty strings, although the issue description suggests safely converting them to empty strings.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the fix for Issue #153 by updating the faithfulness checker to safely handle context chunks whose `"text"` field is `None`. I verified that the previously failing test now passes, and the full unit test results improved from 53 failures and 375 passes to 52 failures and 376 passes.
+
+**Next steps:**
+Push my branch, open a draft pull request, complete the PR template, request peer or mentor feedback, address any feedback I receive, and finalize the pull request.
+
+**Blockers:**
+None.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,43 @@
+# Solution Plan
+
+**Issue:** Faithfulness checker crashes when a context chunk has `text: None`
+https://github.com/ascherj/pathreview/issues/153
+
+## Understand
+
+The faithfulness checker combines the text from retrieved context chunks into a single string before evaluating whether the model's response is supported by the retrieved evidence. When one of the chunks contains `text: None`, Python raises a TypeError because `join()` expects strings, causing the evaluation to fail.
+
+## Map
+
+Files involved:
+
+- `rag/evaluator/faithfulness_checker.py`
+- `tests/unit/test_faithfulness_checker.py`
+
+## Plan
+
+1. Inspect the failing unit test to understand the expected behavior.
+2. Locate where context chunk text is combined in the faithfulness checker.
+3. Update the code to safely handle `None` values by treating them as empty strings.
+4. Re-run the failing test to verify the crash is resolved.
+5. Run the broader faithfulness test suite to ensure no existing behavior is broken.
+
+## Inputs & outputs
+
+**Input:**
+A list of retrieved context chunks, where one or more chunks may contain `"text": None`.
+
+**Output:**
+The faithfulness checker should ignore or safely handle missing text values instead of crashing.
+
+## Risks & unknowns
+
+I need to confirm whether other parts of the codebase also expect `text` to always be a string. I also want to verify that treating `None` as an empty string matches the intended behavior for the evaluator.
+
+## Edge cases
+
+- Context chunk contains `text: None`
+- Context chunk contains an empty string
+- Context chunk is missing the `text` field entirely
+- Multiple invalid chunks appear in the same request
+- All chunks are valid strings (existing behavior should remain unchanged)

--- a/rag/evaluator/faithfulness_checker.py
+++ b/rag/evaluator/faithfulness_checker.py
@@ -1,6 +1,7 @@
 """Check if generated feedback is supported by retrieved context."""
 
 import re
+
 import structlog
 
 logger = structlog.get_logger()
@@ -20,8 +21,11 @@ class FaithfulnessChecker:
             Faithfulness score 0.0-1.0 (ratio of supported claims)
         """
         if not feedback or not context_chunks:
-            logger.info("faithfulness_empty_input", has_feedback=bool(feedback),
-                       has_chunks=bool(context_chunks))
+            logger.info(
+                "faithfulness_empty_input",
+                has_feedback=bool(feedback),
+                has_chunks=bool(context_chunks),
+            )
             return 0.0
 
         # Extract key claims from feedback (sentences)
@@ -31,9 +35,7 @@ class FaithfulnessChecker:
             return 0.5  # Default to neutral if no extractable claims
 
         # Concatenate context text
-        context_text = " ".join([
-            chunk.get("text", "") for chunk in context_chunks
-        ])
+        context_text = " ".join([chunk.get("text") or "" for chunk in context_chunks])
 
         # Check each claim for support
         supported = 0
@@ -43,8 +45,9 @@ class FaithfulnessChecker:
 
         score = supported / len(claims) if claims else 0.0
 
-        logger.info("faithfulness_checked", claims_count=len(claims),
-                   supported_count=supported, score=score)
+        logger.info(
+            "faithfulness_checked", claims_count=len(claims), supported_count=supported, score=score
+        )
 
         return score
 
@@ -59,7 +62,7 @@ class FaithfulnessChecker:
             List of claims (sentences)
         """
         # Split by sentence (simple regex)
-        sentences = re.split(r'[.!?]+', text)
+        sentences = re.split(r"[.!?]+", text)
         claims = [s.strip() for s in sentences if s.strip() and len(s.strip()) > 10]
         return claims[:10]  # Limit to 10 claims for scoring
 
@@ -81,8 +84,25 @@ class FaithfulnessChecker:
         # Require at least some meaningful overlap
         overlap = claim_tokens & context_tokens
         # Filter out common stop words
-        stop_words = {'a', 'an', 'the', 'is', 'are', 'was', 'were', 'be', 'been',
-                     'and', 'or', 'but', 'in', 'of', 'to', 'for', 'that'}
+        stop_words = {
+            "a",
+            "an",
+            "the",
+            "is",
+            "are",
+            "was",
+            "were",
+            "be",
+            "been",
+            "and",
+            "or",
+            "but",
+            "in",
+            "of",
+            "to",
+            "for",
+            "that",
+        }
         meaningful_overlap = overlap - stop_words
 
         return len(meaningful_overlap) >= 2


### PR DESCRIPTION
## Summary

This pull request fixes Issue #153 by updating the `FaithfulnessChecker` to safely handle context chunks whose `"text"` field is `None`. Previously, attempting to concatenate context text would raise a `TypeError`. The change treats `None` values as empty strings while preserving the existing behavior for valid text.

## Issue

Closes #153

## Changes

- Updated `FaithfulnessChecker.check()` to treat `None` context chunk text as an empty string.
- Preserved the existing behavior for valid context chunks.
- Verified that the existing unit test for this edge case now passes.

## Testing

- [x] Unit tests pass (`pytest tests/unit/test_faithfulness_checker.py -k none_context_chunk_text -vv`)
- [ ] Integration tests pass (`make test-integration`) *(not run)*
- [ ] Linter passes (`make lint`) *(project has pre-existing lint failures)*
- [x] Type checker passes (`mypy`)
- [x] New/updated tests cover the changes

**Baseline before changes**
- `make test-unit`: **53 failed, 375 passed, 1 warning**
- `make check`: **182 pre-existing errors**

**After this change**
- `make test-unit`: **52 failed, 376 passed, 1 warning**
- `make check`: **182 errors (no new lint issues introduced)**

## Screenshots / Demo

N/A

## Notes for Reviewers

This is a minimal fix for the `None` context chunk edge case. The change only affects how `None` values are handled during context concatenation and does not alter behavior for valid text.