### PR TITLE
fix/153 faithfulness checker none text

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -14,10 +14,10 @@ The `FaithfulnessChecker().check()` method builds context string by joining the 
 
 - **Understanding:** I can descrive this issue in such way: `check()` builds a context string from chunk using `chunk.get("text", "")`, but this only defaults when the key is "missing". If "text" is present and would be set to `None` then `.get()` returns `None`, and the later `" ".join(...)` call would crash the code with `TypeError` message.
 - **Affected area:** The issue is in `FaithfulnessChecker.check()`. The failing test `test_none_context_chunk_text` in `tests/unit/test_faithfulness_checker.py` confirms it.
-- **Definition of done:** Before the fix: passing a chunk like `{"text": None}` crashes with a `TypeError` message. After the fix: `check()` should treat that chunk's text as empty or missing one and still return a correct score feedback. 
+- **Definition of done:** Before the fix: passing a chunk like `{"text": None}` crashes with a `TypeError` message. After the fix: `check()` should treat that chunk's text as empty or missing one and still return a correct score feedback.
 - **Tier fit:** This is a Tier 1 issue because it requires one or two line fix that isolated to a single method, fully covered by an existing test and with no cross-module dependencies. This is my first contribution to a large codebase, which is why Tier 1 would be my starting point.
 - **Codebase readiness:** I've located `check()` through `tests/unit/test_faithfulness_checker.py` and the surrounding context-building logic, and read `test_none_context_chunk_text` from start to finish in the test file.
-- **Scope/time:** Based on the issue, I estimate 3-6 hours (Tier 1 estimate for Week 8-9) since it looks look like a 1-2 line fix with verifying the existing test passes. 
+- **Scope/time:** Based on the issue, I estimate 3-6 hours (Tier 1 estimate for Week 8-9) since it looks look like a 1-2 line fix with verifying the existing test passes.
 - **Blockers:** No open blockers or dependencies are noted in the issue.
 
 **Branch name:** fix/153-faithfulness-checker-none-text
@@ -25,3 +25,24 @@ The `FaithfulnessChecker().check()` method builds context string by joining the 
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [link to commit documenting the reproduced issue]
+
+**Reproduction summary:**
+
+Ran `pytest tests/unit/test_faithfulness_checker.py::TestFaithfulnessChecker::test_none_context_chunk_text -v` and confirmed that test fails with `TypeError` message: `sequence item 0: expected str instance, NoneType found` that was raised when `.check()` tries to join chunk's `None` "text" value into the context
+string.
+
+**PLAN.md link:** [link to PLAN.md in your fork]
+
+**Walkthrough video (recommended):** [link to your Loom video, ≤2 min — recommended, not graded]
+
+**Blockers or open questions:**
+
+Uncertain for the one instruction:
+
+`Request peer or mentor feedback on a draft PR` :
+
+Where do I get PR link and how do I need to contact to instructor. Do I need to choose own instructor or I need to choose certain instructor

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -28,14 +28,14 @@ The `FaithfulnessChecker().check()` method builds context string by joining the 
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [link to commit documenting the reproduced issue]
+**Reproduction commit link:** https://github.com/ascherj/pathreview/commit/7e4a2dbf591dc0453c592645c05d158f53ba52e1
 
 **Reproduction summary:**
 
 Ran `pytest tests/unit/test_faithfulness_checker.py::TestFaithfulnessChecker::test_none_context_chunk_text -v` and confirmed that test fails with `TypeError` message: `sequence item 0: expected str instance, NoneType found` that was raised when `.check()` tries to join chunk's `None` "text" value into the context
 string.
 
-**PLAN.md link:** [link to PLAN.md in your fork]
+**PLAN.md link:** https://github.com/DanyloBatrak/pathreview/blob/fix/153-faithfulness-checker-none-text/PLAN.md
 
 **Walkthrough video (recommended):** [link to your Loom video, ≤2 min — recommended, not graded]
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -10,6 +10,16 @@
 
 The `FaithfulnessChecker().check()` method builds context string by joining the "text" field from each context chank. The issue is that when chank's "text" set to `None`, `.get("text", "")` returns `None` instead of default and crash the code with `TypeError` message by joining to `None`. This bug affects on faithfullness-checking logic in `tests/unit/test_faithfulness_checker.py` where `test_none_context_chunk_text()` method fails because `.check()` not handled this case. The successful outcome would be to make context-building step treat "text" value set to `None` in same way as empty or missing one, so that checker can score feedback correctly even if chunk's input is distorted.
 
+**Selection notes ("Is this right for me?" checklist):**
+
+- **Understanding:** I can descrive this issue in such way: `check()` builds a context string from chunk using `chunk.get("text", "")`, but this only defaults when the key is "missing". If "text" is present and would be set to `None` then `.get()` returns `None`, and the later `" ".join(...)` call would crash the code with `TypeError` message.
+- **Affected area:** The issue is in `FaithfulnessChecker.check()`. The failing test `test_none_context_chunk_text` in `tests/unit/test_faithfulness_checker.py` confirms it.
+- **Definition of done:** Before the fix: passing a chunk like `{"text": None}` crashes with a `TypeError` message. After the fix: `check()` should treat that chunk's text as empty or missing one and still return a correct score feedback. 
+- **Tier fit:** This is a Tier 1 issue because it requires one or two line fix that isolated to a single method, fully covered by an existing test and with no cross-module dependencies. This is my first contribution to a large codebase, which is why Tier 1 would be my starting point.
+- **Codebase readiness:** I've located `check()` through `tests/unit/test_faithfulness_checker.py` and the surrounding context-building logic, and read `test_none_context_chunk_text` from start to finish in the test file.
+- **Scope/time:** Based on the issue, I estimate 3-6 hours (Tier 1 estimate for Week 8-9) since it looks look like a 1-2 line fix with verifying the existing test passes. 
+- **Blockers:** No open blockers or dependencies are noted in the issue.
+
 **Branch name:** fix/153-faithfulness-checker-none-text
 
 **Setup confirmation:** [x] App runs locally at localhost:5173

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -67,3 +67,41 @@ Verified `test_none_context_chunk_text` in `tests/unit/test_faithfulness_checker
 (Note: Both checks pass according to the project's pre-existing failures policy. My changes introduced no new failures. `ruff check` on the modified file passes with no errors. Baseline `make test-unit` had 53 failures, after my fix - 52 failures, with the only change being `test_none_context_chunk_text` changing from failed to passed.)
 
 **Draft PR feedback received from:** none (yet to be reviewed)
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes [X] No — still awaiting review
+
+**Summary of feedback:**
+
+No review came in
+
+**How you responded:**
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+
+Finding out the part where `.get("text", "")` doesn't work with the `None` case took much longer than expected to be for Tier 1 because the default-value argument in `chunk.get()` only activates when the key is missing, not when text set to `None` value. That distinction is easy to miss when scanning code, and it's the kind of bug that only shows with a specific data shape (e.g. a chunk that has a `"text"` key but no content), which is the reason why it slipped through originally.
+
+**What did you learn about working in a large codebase?**
+
+I learned that this codebase had 53 pre-existing failing tests and 181 pre-existing lint errors across the codebase which are been not related to my changes.When I first joined to this project, I thought that this codebase would have a clean baseline. However, I now understand that when I woek in shared codebase I would have to separate "failure that I caused" from "failure that were already there".
+
+This meant that by running `make test-unit` I need to check result before and after I did change rather than to just checking if my one new test passed.
+
+**How did AI tools help — and where did they fall short?**
+
+AI was most useful when I had hard time to with running tests and in explaining the difference between `chunk.get()` default value and the "or" fallbacks. However, it fall short when it came to telling me which of 53 failing tests were safe to ignore and what are related to my change. Because of that I had to read the test output and issue tracker by myself to find exact issue that related to my change.
+
+**What would you do differently if you started over?**
+
+If I started over, I would run the full baseline test before I touch any code rather than after I make the fix, so that I had a clear view of how many tests and lint errors were failling from the beginning. That way I could see the difference from the start instead of rebuilding it later.
+
+**What are you most proud of from this module?**
+
+I most pround of that, while working on Tier 1 problem I improved my project management skills. I noticed three other failling tests in same file that looked related to my fix. I investigated them and confirmed that they are not related to my fix. Instead of fixing them umpropted or ignoring them completely, I called them out in my PR as "pre-existing failing tests in `test_faithfulness_checker.py`." This taught me of importance of staying on track while still documenting other issues I discovered along the way.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -46,3 +46,21 @@ Uncertain for the one instruction:
 `Request peer or mentor feedback on a draft PR` :
 
 Where do I get PR link and how do I need to contact to instructor. Do I need to choose own instructor or I need to choose certain instructor
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 2 (end of week)
+
+**PR link:** [link to your submitted pull request]
+
+**Branch:** [the branch name you worked on, e.g. `fix/123-short-description`]
+
+**What you built:**
+[1–3 sentences summarizing what your fix does and how it works]
+
+**Tests added or updated:**
+[Which test files did you touch? What do they cover?]
+
+**Self-review confirmation:** [ ] make check passes [ ] make test-unit passes
+
+**Draft PR feedback received from:** [name or Slack handle, or "none"]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -51,16 +51,19 @@ Where do I get PR link and how do I need to contact to instructor. Do I need to 
 
 ### Check-in 2 (end of week)
 
-**PR link:** [link to your submitted pull request]
+**PR link:** https://github.com/ascherj/pathreview/pull/666#issue-5046789813
 
-**Branch:** [the branch name you worked on, e.g. `fix/123-short-description`]
+**Branch:** `fix/153-faithfulness-checker-none-text`
 
 **What you built:**
-[1–3 sentences summarizing what your fix does and how it works]
+
+Fixed a bug in `FaithfulnessChecker.check()` where context chunks with a `None` value for `"text"` caused a `TypeError` during string concatenation, since `.get("text", "")` only uses the default value when the "text" key is missing, but not when key exists and its value equals to `None`. Changed the pattern to `.get("text") or ""` so missing, `None`, and empty text are all treated consistently as empty strings.
 
 **Tests added or updated:**
-[Which test files did you touch? What do they cover?]
 
-**Self-review confirmation:** [ ] make check passes [ ] make test-unit passes
+Verified `test_none_context_chunk_text` in `tests/unit/test_faithfulness_checker.py` now passes, covering context chunks with `{"text": None}.`
 
-**Draft PR feedback received from:** [name or Slack handle, or "none"]
+**Self-review confirmation:** [x] make check passes [x] make test-unit passes
+(Note: Both checks pass according to the project's pre-existing failures policy. My changes introduced no new failures. `ruff check` on the modified file passes with no errors. Baseline `make test-unit` had 53 failures, after my fix - 52 failures, with the only change being `test_none_context_chunk_text` changing from failed to passed.)
+
+**Draft PR feedback received from:** none (yet to be reviewed)

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,17 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/153
+
+**Issue title:** Faithfulness checker crashes when a context chunk has text: None
+
+**Tier:** [x] Tier 1 [ ] Tier 2 [ ] Tier 3
+
+**Problem summary:**
+
+The `FaithfulnessChecker().check()` method builds context string by joining the "text" field from each context chank. The issue is that when chank's "text" set to `None`, `.get("text", "")` returns `None` instead of default and crash the code with `TypeError` message by joining to `None`. This bug affects on faithfullness-checking logic in `tests/unit/test_faithfulness_checker.py` where `test_none_context_chunk_text()` method fails because `.check()` not handled this case. The successful outcome would be to make context-building step treat "text" value set to `None` in same way as empty or missing one, so that checker can score feedback correctly even if chunk's input is distorted.
+
+**Branch name:** fix/153-faithfulness-checker-none-text
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,52 @@
+## Solution plan
+
+**Issue:** Faithfulness checker crashes when a context chunk has text: None
+https://github.com/ascherj/pathreview/issues/153
+
+### Understand
+
+The root cause is in `FaithfulnessChecker().check()` method which builds context string via `.get("text", "")` for each context chank. `.get()`'s default applies only if key is missing and not when key is exist but its value is `None`. When we passed chunk `{"text": None}` then `.get("text", "")` would return `None`, instead of empty string and later via `.join(...)` we get `TypeError` message because `join()` requires all inputs to be strings.
+
+#### Expected Behavior
+
+`.check()` should treat a `None` as empty string or missing one so that checker sent valid score output.
+
+#### Actual Behavior
+
+`.check()` crashes the code with `TypeError` message: `sequence item 0: expected str instance, NoneType found`
+
+### Map
+
+- `rag/evaluator/faithfulness_checker.py` which contains `FaithfullnessChecker.check()` and its buggy context-building logic
+- `tests/unit/test_faithfulness_checker.py` which contains `test_none_context_chunk_text` test that currently fails
+
+### Plan
+
+1. Find exact line in `.check()` (in `rag/evaluator/faithfulness_checker.py`) where `chunk.get("text" "")` is called.
+2. Replace it with the version that also catches a `None` such as `.get("text")` or ""
+3. Check the rest of the file for having same `.get("text", "")` pattern in case if the same bug happened elsewhere in the class
+4. Run `test_none_context_chunk_text` and see if it passes or not.
+5. Run the full test (a.k.a. `pytest tests/unit/test_faithfulness_checker.py -v`) file to confirm that we don't have deterioated existing tests.
+
+### Inputs & outputs
+
+#### Input
+
+The list of context string, where each chunk may have missing "text", empty string "" or "None"
+
+#### Output
+
+The context string that was built from all valid chunks (with missing "text" / "" / "None") would be treated as empty strings without calling `TypeError`. The `.check()` method should return correct score feedback from 0.0 to 1.0, even if chunk's input is distorted
+
+### Risks & unknowns
+
+- Unsure, whether on the same class file we have other methods that have identical `.get("text" "")` pattern.
+- Unsure, whether we need a separate handling when "text" is a number because issue only mentions about `None`
+- Unsure, whether the fix would change score behavior for chunks that have already valid text
+
+### Edge cases
+
+`{"text": None}` - should be treated as empty string or missing one
+`{}` - should work through `.get()` default and treated as having empty text.
+`{"text" ""}` - already empty string and should be uneffected by fix
+A entirely empty `context_chunks` list - `.check()` confirms succefully and returns a valid score

--- a/rag/evaluator/faithfulness_checker.py
+++ b/rag/evaluator/faithfulness_checker.py
@@ -1,6 +1,7 @@
 """Check if generated feedback is supported by retrieved context."""
 
 import re
+
 import structlog
 
 logger = structlog.get_logger()
@@ -20,8 +21,11 @@ class FaithfulnessChecker:
             Faithfulness score 0.0-1.0 (ratio of supported claims)
         """
         if not feedback or not context_chunks:
-            logger.info("faithfulness_empty_input", has_feedback=bool(feedback),
-                       has_chunks=bool(context_chunks))
+            logger.info(
+                "faithfulness_empty_input",
+                has_feedback=bool(feedback),
+                has_chunks=bool(context_chunks),
+            )
             return 0.0
 
         # Extract key claims from feedback (sentences)
@@ -31,9 +35,7 @@ class FaithfulnessChecker:
             return 0.5  # Default to neutral if no extractable claims
 
         # Concatenate context text
-        context_text = " ".join([
-            chunk.get("text", "") for chunk in context_chunks
-        ])
+        context_text = " ".join([chunk.get("text") or "" for chunk in context_chunks])
 
         # Check each claim for support
         supported = 0
@@ -43,8 +45,9 @@ class FaithfulnessChecker:
 
         score = supported / len(claims) if claims else 0.0
 
-        logger.info("faithfulness_checked", claims_count=len(claims),
-                   supported_count=supported, score=score)
+        logger.info(
+            "faithfulness_checked", claims_count=len(claims), supported_count=supported, score=score
+        )
 
         return score
 
@@ -59,7 +62,7 @@ class FaithfulnessChecker:
             List of claims (sentences)
         """
         # Split by sentence (simple regex)
-        sentences = re.split(r'[.!?]+', text)
+        sentences = re.split(r"[.!?]+", text)
         claims = [s.strip() for s in sentences if s.strip() and len(s.strip()) > 10]
         return claims[:10]  # Limit to 10 claims for scoring
 
@@ -81,8 +84,25 @@ class FaithfulnessChecker:
         # Require at least some meaningful overlap
         overlap = claim_tokens & context_tokens
         # Filter out common stop words
-        stop_words = {'a', 'an', 'the', 'is', 'are', 'was', 'were', 'be', 'been',
-                     'and', 'or', 'but', 'in', 'of', 'to', 'for', 'that'}
+        stop_words = {
+            "a",
+            "an",
+            "the",
+            "is",
+            "are",
+            "was",
+            "were",
+            "be",
+            "been",
+            "and",
+            "or",
+            "but",
+            "in",
+            "of",
+            "to",
+            "for",
+            "that",
+        }
         meaningful_overlap = overlap - stop_words
 
         return len(meaningful_overlap) >= 2


### PR DESCRIPTION
## Summary
Fixes the bug in `FaithfulnessChecker.check()`  where context chunks with a `None` value for `"text"` caused a `TypeError` during string concatenation. The expression .get("text", "") only uses the default value when the "text" key is missing. If the key exists and its value equals to `None`, then a chunk like `{"text": None}` passed `None` straight through to `" ".join(...)`, which requires all items to be strings. Updated the logic to treat missing, `None`, and empty "text" as empty strings.

## Issue
Closes #153

## Changes
Changed `chunk.get("text", "")` to `chunk.get("text") or ""` in `rag/evaluator/faithfulness_checker.py` so `None` values would be treated as empty strings, matching the existing behavior for missing keys and empty strings.

## Testing
- [x] Unit tests pass (`make test-unit`)
- [] Integration tests pass (`make test-integration`) - no integration tests exist in the repo currently (`collected 0 items`); nothing to run
- [x] Linter passes (`make lint`)  - confirmed that ruff check passes for the modified file (`rag/evaluator/faithfulness_checker.py`); repo-wide lint has 181 pre-existing errors unrelated to this change, see notes below.
- [x] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes - — `test_none_context_chunk_text` in `tests/unit/test_faithfulness_checker.py`

## Pre-existing failures (documented, not introduced by this PR)
- Baseline `make test-unit` run: 53 failed, 375 passed. After this fix: 52 failed, 376 passed. The only change is `test_none_context_chunk_text` flipping from failed to passed. There are no new failures introduced  and it is confirmed via diff of failure lists before/after
- `make check` reports 181 pre-existing lint errors across the codebase, which are unrelated to this PR's scope. `ruff check` on the only file modified in this PR (`rag/evaluator/faithfulness_checker.py`) passes with zero errors.

## Screenshots / Demo
N/A — only backend logic fix, no UI change.

## Notes for Reviewers
This is a small, isolated fix (`.get("text", "")` → `.get("text") or ""`), focused exclusively on the None-text bug described in issue #153. 
There are three other pre-existing failing tests in `test_faithfulness_checker.py` (`test_partial_support_returns_middle_score`, `test_multiple_context_chunks`, `test_multiple_claims_varying_support`). These failures are unrelated to the issue #153 and are intentionally out of scope for this PR.
