### PR TITLE
test: restore basic_profile.json test fixture (#106)

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -26,7 +26,7 @@ Issue #106 addresses a missing shared test fixture: `tests/fixtures/sample_profi
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** https://github.com/michellejtan/pathreview/commit/7301bcdc4ebb6bb816b98b3c75319cabc849bd20
+**Reproduction commit link:** https://github.com/michellejtan/pathreview/commit/ae1dde81f3ef04a4d660c08fbc644f05b2b701af
 
 **Reproduction summary:**
 Ran `ls tests/fixtures` and `find tests -iname "*profile*"` — confirmed the
@@ -36,9 +36,14 @@ remaining reference is a TODO comment in `scripts/run_evals.py` pointing at
 that path, suggesting the fixture was removed (or never committed) at some
 point and the reference was left behind.
 
-**PLAN.md link:** [link to PLAN.md in your fork]
+**PLAN.md link:** https://github.com/michellejtan/pathreview/blob/test/106-restore-basic-profile-fixture/PLAN.md
 
-**Walkthrough video (recommended):** [link to your Loom video, ≤2 min — recommended, not graded]
+**Walkthrough video (recommended):** Not recorded.
 
 **Blockers or open questions:**
-[Anything you're still uncertain about going into Week 9, or leave blank]
+No existing test or code consumes `basic_profile.json` today, so there's no schema to match
+exactly — I derived the shape from the `Profile` model fields and the issue's "GitHub
+username, resume, two repos" wording, but a reviewer may expect different field names.
+Separately, `IngestedSource` (the model repos map to) has no `name`/`description` fields, so
+my `repos` shape doesn't correspond 1:1 to any existing DB model — flagging this in case it
+should be reconciled before merging.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -23,3 +23,22 @@ Issue #106 addresses a missing shared test fixture: `tests/fixtures/sample_profi
 **Setup confirmation:** [X] App runs locally at localhost:5173
 
 **Cohort ledger:** [X] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [link to commit documenting the reproduced issue]
+
+**Reproduction summary:**
+Ran `ls tests/fixtures` and `find tests -iname "*profile*"` — confirmed the
+`tests/fixtures/sample_profiles/basic_profile.json` file and its parent folder
+do not exist anywhere in the repo, and no test currently imports it. The only
+remaining reference is a TODO comment in `scripts/run_evals.py` pointing at
+that path, suggesting the fixture was removed (or never committed) at some
+point and the reference was left behind.
+
+**PLAN.md link:** [link to PLAN.md in your fork]
+
+**Walkthrough video (recommended):** [link to your Loom video, ≤2 min — recommended, not graded]
+
+**Blockers or open questions:**
+[Anything you're still uncertain about going into Week 9, or leave blank]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,25 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/106
+
+**Issue title:** Shared test fixture for a sample user profile is missing from `tests/fixtures/`
+
+**Tier:** [X] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+Issue #106 addresses a missing shared test fixture: `tests/fixtures/sample_profiles/basic_profile.json`. The fixture was removed, causing tests that depend on reusable sample profile data to lack a consistent input containing GitHub information, resume details, and repository examples. I verified that the `tests/fixtures/` directory is missing and that `tests/conftest.py` currently only provides resume and README fixtures. The fix will restore a standard sample profile fixture so tests can use consistent data and avoid duplicated setup.
+
+### Is This Issue Right for Me?
+
+- **Understanding** — I verified the missing fixture issue by inspecting the test structure and confirmed that shared sample profile data needs to be restored.
+- **Tier Fit** — This is a Tier 1 issue that matches my current experience because it is a focused test infrastructure change involving adding missing fixture data rather than modifying production behavior.
+- **Scope** — Small and well-bounded: restore one shared sample profile fixture (`tests/fixtures/sample_profiles/basic_profile.json`). No production code changes are required.
+- **Effort (Time)** — Reasonable for Weeks 8–9. The work involves creating realistic sample data, matching the expected profile structure, and running the test suite.
+- **Dependencies** — None external. The fixture uses static test data and does not require database changes, API keys, or external services.
+- **Verification** — I can validate the change by running `make test-unit` and confirming the related tests pass.
+
+**Branch name:** `test/106-restore-basic-profile-fixture`
+
+**Setup confirmation:** [X] App runs locally at localhost:5173
+
+**Cohort ledger:** [X] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -26,7 +26,7 @@ Issue #106 addresses a missing shared test fixture: `tests/fixtures/sample_profi
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [link to commit documenting the reproduced issue]
+**Reproduction commit link:** https://github.com/michellejtan/pathreview/commit/7301bcdc4ebb6bb816b98b3c75319cabc849bd20
 
 **Reproduction summary:**
 Ran `ls tests/fixtures` and `find tests -iname "*profile*"` — confirmed the

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -105,3 +105,29 @@ top-level profile fields and exactly two repo entries, each with `name`, `html_u
 before/after comparison.)
 
 **Draft PR feedback received from:** none [to be filled in after peer review, posted in Slack already]
+
+**PR description (copy, for offline verification):**
+
+> **Summary**
+> The PR restores a missing test fixture file at `tests/fixtures/sample_profiles/basic_profile.json` that is referenced by `scripts/run_evals.py` and `scripts/issues_manifest.json`. The fixture contains realistic fake portfolio data (GitHub username, resume text, two repository entries) structured to match what the actual ingestion parsers consume.
+>
+> **Issue**
+> Closes #106
+>
+> **Changes**
+> - Introduces `tests/fixtures/sample_profiles/basic_profile.json` containing fake profile data with fields like `github_username`, `resume_filename`, `resume_text` (with section headers such as Summary, Technical Skills, Experience, Education), `portfolio_url`, and two `repos` entries patterned after GitHub API metadata
+> - Adds a `sample_profile_data` fixture to `tests/conftest.py` following established patterns for loading sample data
+> - Creates `tests/unit/test_fixtures.py` with a test that validates the fixture loads properly and contains expected structure (profile fields present, exactly two repos, each containing `name`/`html_url`/`readme_content`)
+>
+> **Testing**
+> Unit tests pass with 53 pre-existing failures remaining unchanged; new test passes. Integration tests not applicable. Linting produces no new errors (182 pre-existing unchanged). Type checking passes. Manual verification involves confirming the JSON fixture contains appropriate fields and running the new test.
+>
+> **Screenshots / Demo**
+> N/A — test fixture only, no UI change.
+>
+> **Notes for Reviewers**
+> No integration test currently uses this fixture. The two repository entries mirror raw GitHub API metadata rather than the `IngestedSource` database model, as that represents the layer where parsing occurs before database mapping.
+
+(Note: as of this writing the PR is still in Draft and the Testing section above still needs
+the concrete manual-verification steps promised — this copy will be refreshed once those
+edits land on GitHub.)

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -131,3 +131,69 @@ before/after comparison.)
 (Note: as of this writing the PR is still in Draft and the Testing section above still needs
 the concrete manual-verification steps promised — this copy will be refreshed once those
 edits land on GitHub.)
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [X] No — still awaiting review
+
+**Summary of feedback:**
+[What did reviewers comment on? Or note that no review came in.]
+No review came in.
+
+**How you responded:**
+[What changes did you make, or what did you reply? If no feedback,
+leave blank.]
+no feedback
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+[Be specific — what part of the process, codebase, or workflow
+surprised you?]
+The fixture itself was trivial to write, but figuring out the *right* shape for it wasn't.
+Since no test or production code currently imports `basic_profile.json`, there was no
+existing schema to match — just a TODO comment and the issue's loose "GitHub username,
+resume, two repos" description. I initially guessed at field names, then realized partway
+through that I should reverse-engineer the shape from what `ResumeParser` and
+`RepoAnalyzer` actually consume (section headers, GitHub API-style repo fields) instead of
+inventing something arbitrary. That revision cost more time than the original write-up, and
+it surprised me that a "just add a missing file" issue turned out to be way more ambiguous than I expected
+
+**What did you learn about working in a large codebase?**
+[What's different about contributing to someone else's production code
+vs. building your own project?]
+In my own projects I'd never think twice about picking field names for test data. 
+The names in the project are implicitly a contract with parsing code I didn't write and couldn't fully
+predict from the issue alone. I also got into the habit of leaning on make check / make test-unit as a baseline. Running them first showed there were already 53 test failures and 182 lint errors, so I could compare against that and know my changes weren’t adding anything new. It was a lot better than just eyeballing things and thinking they “looked fine.” That kind of before-and-after checking feels like a habit you really need in a large codebase, and I had to keep that habit  of checking pre-existing failures before touching any codes.
+
+**How did AI tools help — and where did they fall short?**
+[Where was AI assistance most useful this module? Where did you need
+to go beyond what AI could give you?]
+AI was most useful for the mechanical parts — scaffolding the JSON fixture, the
+`sample_profile_data` conftest fixture, and the test asserting on its shape once I knew what
+shape I wanted. It fell short on the actual judgment call of *what* that shape should be:
+figuring out that I needed to go read `ResumeParser.SECTION_HEADERS` and
+`RepoAnalyzer.parse()` directly, rather than trust a plausible-looking guess, was something I
+had to push for myself. It also didn't catch the `mypy` `disallow_untyped_defs` gap in my new
+test code — that only surfaced when the pre-commit hook ran at commit time, since `make
+check`'s typecheck target doesn't cover `tests/`.
+
+**What would you do differently if you started over?**
+[Issue selection, planning, implementation, or process — anything
+you'd change?]
+I'd go straight to reading the parser code before writing the first draft of the fixture,
+instead of writing a plausible-looking version first and revising it once I realized it
+didn't match what was actually consumed downstream. I'd also open the draft PR and post to
+Slack earlier in the week rather than at the very end, since as of this reflection I'm still
+waiting on review and lost the chance to iterate on feedback within the module.
+
+**What are you most proud of from this module?**
+[One thing — it doesn't have to be the PR itself.]
+Catching that my `repos` shape didn't correspond 1:1 to the `IngestedSource` DB model and
+flagging it explicitly in both PLAN.md and the PR notes, instead of quietly shipping a
+mismatch. It would have been easy to call the fixture "done" once the JSON looked
+reasonable; verifying it against the actual parsing code and Calling out the one place where it still didn’t line up felt more honest.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -47,3 +47,61 @@ username, resume, two repos" wording, but a reviewer may expect different field 
 Separately, `IngestedSource` (the model repos map to) has no `name`/`description` fields, so
 my `repos` shape doesn't correspond 1:1 to any existing DB model — flagging this in case it
 should be reconciled before merging.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the full solution from PLAN.md. Restored
+`tests/fixtures/sample_profiles/basic_profile.json` with a fake portfolio (GitHub username,
+resume text, two repos), but revised the shape partway through to match what the ingestion
+parsers actually consume rather than an arbitrary guess: resume text now uses section
+headings (`Summary`, `Technical Skills`, `Experience`, `Education`) matching
+`ResumeParser.SECTION_HEADERS`, and each repo entry uses GitHub API-style fields
+(`html_url`, `language`, `stargazers_count`, `forks_count`, `open_issues_count`, `pushed_at`,
+`readme_content`) matching what `RepoAnalyzer.parse()` reads. Added a `sample_profile_data`
+fixture to `tests/conftest.py` and a new test file, `tests/unit/test_fixtures.py`, that loads
+the fixture and asserts on its shape.
+
+Before starting, I ran `make test-unit` and `make check` on `main` to record a baseline: 53
+pre-existing test failures (376 passing) and 182 pre-existing lint errors, all unrelated to
+this issue. After my changes, both commands show the same pre-existing counts plus my new
+test passing — confirmed by stashing my changes and re-running both commands to verify the
+baseline numbers matched exactly.
+
+**Next steps:**
+Open a draft PR using the repo's PR template, share it in the cohort Slack channel for peer
+review, and address any feedback before marking it ready for review.
+
+**Blockers:**
+None currently. (One snag along the way: the local pre-commit hook's `mypy` check caught two
+missing type annotations — `disallow_untyped_defs = true` — in the new test function and the
+`sample_profile_data` fixture. `make check`'s `typecheck` target doesn't cover `tests/`, so
+this wasn't visible until commit time; fixed by adding explicit annotations.)
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/669
+
+**Branch:** `test/106-restore-basic-profile-fixture`
+
+**What you built:**
+Restored the missing `basic_profile.json` test fixture with a realistic fake portfolio shaped
+to match the actual ingestion parsers (resume section headers, GitHub-style repo metadata),
+and wired it up via a `sample_profile_data` pytest fixture plus a test proving it loads
+correctly.
+
+**Tests added or updated:**
+`tests/unit/test_fixtures.py` (new) — asserts `sample_profile_data` has the expected
+top-level profile fields and exactly two repo entries, each with `name`, `html_url`, and
+`readme_content`.
+
+**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+(Both pass in the sense that my changes introduce zero new failures beyond the documented
+53 pre-existing test failures and 182 pre-existing lint errors — see PR description for the
+before/after comparison.)
+
+**Draft PR feedback received from:** none [to be filled in after peer review, posted in Slack already]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -99,7 +99,7 @@ correctly.
 top-level profile fields and exactly two repo entries, each with `name`, `html_url`, and
 `readme_content`.
 
-**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+**Self-review confirmation:** [X] make check passes  [X] make test-unit passes
 (Both pass in the sense that my changes introduce zero new failures beyond the documented
 53 pre-existing test failures and 182 pre-existing lint errors — see PR description for the
 before/after comparison.)

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,121 @@
+## Solution plan
+
+**Issue:** #106 — Shared test fixture for a sample user profile is missing from `tests/fixtures/`
+https://github.com/ascherj/pathreview/issues/106
+
+### Understand
+The repo is missing the entire `tests/fixtures/` directory. The fixture it should contain,
+`tests/fixtures/sample_profiles/basic_profile.json`, doesn't exist and has no history in
+`git log --all -- tests/fixtures`, so it was either never committed or removed before this
+history began. `scripts/run_evals.py` still has a TODO comment (line 8) pointing at
+`tests/fixtures/sample_profiles/` as the source of "benchmark portfolios," so the path is a
+real, expected convention — just never fulfilled.
+
+Right now `tests/conftest.py` only defines two fixtures, `sample_resume_text` and
+`sample_readme_text`, both plain inline strings (no file loading anywhere in the test suite
+yet). The `Profile` model (`core/models/profile.py`) has fields `github_username`,
+`resume_filename`, `resume_text`, and `portfolio_url`. There's no `Repo`/`repository` model —
+repos are represented as `IngestedSource` rows with `source_type="repo"`, `filename`, and
+`source_url` (`core/models/ingested_source.py`). So "a realistic sample portfolio (GitHub
+username, resume, two repos)" maps to: one profile-shaped object plus a list of two
+repo-shaped objects with a name, description, URL, and README-style text.
+
+**Root cause:** The fixture file (and its parent folder) simply doesn't exist in the repo.
+This is missing test data, not a code bug — no production code needs to change.
+
+### Map
+Files I expect to touch:
+- `tests/fixtures/sample_profiles/basic_profile.json` (new file) — the restored fixture
+  itself.
+- `tests/conftest.py` — add a `sample_profile_data` fixture that loads the JSON file, so
+  tests can request it the same way they request `sample_resume_text` today.
+- `tests/unit/test_conftest_fixtures.py` or similar (new, small test) — a basic test proving
+  the fixture loads and has the expected keys, so this isn't dead weight sitting unused.
+
+Files I looked at but won't touch:
+- `scripts/run_evals.py` — only has a TODO comment referencing the path; implementing the
+  eval runner itself is out of scope for this issue.
+- `core/models/profile.py`, `core/models/ingested_source.py` — read for field names only, no
+  model changes needed.
+
+### Plan
+1. Create the directory `tests/fixtures/sample_profiles/`.
+2. Write `basic_profile.json` with a realistic profile: `github_username`, `resume_filename`,
+   `resume_text` (short realistic resume, following the tone of `sample_resume_text` in
+   conftest.py), `portfolio_url`, and a `repos` list of exactly two entries, each with `name`,
+   `description`, `url`, and `readme_text`.
+3. Add a `sample_profile_data` fixture to `tests/conftest.py` that opens the JSON file
+   (path relative to the fixture file via `Path(__file__).parent`) and returns the parsed
+   dict, following the docstring style of the existing fixtures.
+4. Write one small unit test that requests `sample_profile_data` and asserts the expected
+   top-level keys exist and `len(repos) == 2` — proof the fixture is wired up correctly, not
+   just sitting on disk unused.
+5. Run `make test-unit` to confirm the new test passes and nothing else breaks.
+6. Run `make check` (lint/format/types) to confirm the new JSON and Python files are clean.
+
+### Inputs & outputs
+**New fixture file:** `tests/fixtures/sample_profiles/basic_profile.json`
+
+```json
+{
+  "github_username": "janedoe",
+  "resume_filename": "jane_doe_resume.pdf",
+  "resume_text": "Jane Doe\nSoftware Engineer\n...",
+  "portfolio_url": "https://janedoe.dev",
+  "repos": [
+    {
+      "name": "weather-app",
+      "description": "A weather forecasting app built with React and OpenWeatherMap API.",
+      "url": "https://github.com/janedoe/weather-app",
+      "readme_text": "# Weather App\n..."
+    },
+    {
+      "name": "task-tracker-api",
+      "description": "A REST API for managing tasks, built with FastAPI and PostgreSQL.",
+      "url": "https://github.com/janedoe/task-tracker-api",
+      "readme_text": "# Task Tracker API\n..."
+    }
+  ]
+}
+```
+
+**New fixture function (`tests/conftest.py`):**
+- Input: none (reads from disk)
+- Output: the parsed dict above, available to any test via `sample_profile_data` parameter
+
+**Test I'll write:**
+```python
+def test_sample_profile_data_has_expected_shape(sample_profile_data):
+    """sample_profile_data fixture should load with expected top-level keys."""
+    assert sample_profile_data["github_username"]
+    assert sample_profile_data["resume_text"]
+    assert len(sample_profile_data["repos"]) == 2
+```
+
+### Risks & unknowns
+1. **I'm guessing the exact JSON shape.** Nothing in the current codebase consumes this file,
+   so there's no existing schema to match exactly. I'm basing the shape on the `Profile`
+   model's fields plus the "GitHub username, resume, two repos" wording from the issue. If a
+   reviewer expects different field names, I'll adjust.
+2. **Should repos be modeled after `IngestedSource` fields instead?** I chose `name`/
+   `description`/`url`/`readme_text` because that's what a "repo" conceptually needs for RAG
+   ingestion, but `IngestedSource` doesn't have a `name` or `description` field — those live
+   on GitHub's API response shape, not in our DB model. I'll note this mismatch in my PR
+   description rather than guess further.
+3. **Decision: include the conftest fixture, not just the JSON file.** The issue text says
+   the fixture is needed so "tests that depend on reusable sample profile data" can use it —
+   that implies it should be consumable via pytest, not just sit on disk. A JSON file with no
+   wiring would be dead weight and likely bounce back in review asking how it's meant to be
+   used. Adding `sample_profile_data` to `tests/conftest.py` (a few lines, following the
+   existing pattern) plus a test proving it loads keeps this in Tier-1 scope while making the
+   restored fixture actually usable.
+
+### Edge cases
+- Fixture file is valid JSON but a test imports it expecting a `list` at the top level
+  instead of a `dict` — not applicable here since I'm defining the shape myself, but I'll
+  keep the fixture function's return type explicit (`dict`) so misuse fails fast with a clear
+  type error.
+- `resume_text` containing special characters (quotes, newlines) — need to make sure the
+  JSON is valid (I'll validate with `python -m json.tool` before committing).
+- Two repos is a hard requirement per the issue text — I will not add a third "for realism,"
+  to keep the fixture matching exactly what's asked.

--- a/PLAN.md
+++ b/PLAN.md
@@ -8,48 +8,83 @@ The repo is missing the entire `tests/fixtures/` directory. The fixture it shoul
 `tests/fixtures/sample_profiles/basic_profile.json`, doesn't exist and has no history in
 `git log --all -- tests/fixtures`, so it was either never committed or removed before this
 history began. `scripts/run_evals.py` still has a TODO comment (line 8) pointing at
-`tests/fixtures/sample_profiles/` as the source of "benchmark portfolios," so the path is a
-real, expected convention — just never fulfilled.
+`tests/fixtures/sample_profiles/` as the source of "benchmark portfolios," and the issue itself
+is defined in `scripts/issues_manifest.json` (lines 1612-1620), which names this exact path.
 
-Right now `tests/conftest.py` only defines two fixtures, `sample_resume_text` and
-`sample_readme_text`, both plain inline strings (no file loading anywhere in the test suite
-yet). The `Profile` model (`core/models/profile.py`) has fields `github_username`,
-`resume_filename`, `resume_text`, and `portfolio_url`. There's no `Repo`/`repository` model —
-repos are represented as `IngestedSource` rows with `source_type="repo"`, `filename`, and
-`source_url` (`core/models/ingested_source.py`). So "a realistic sample portfolio (GitHub
-username, resume, two repos)" maps to: one profile-shaped object plus a list of two
-repo-shaped objects with a name, description, URL, and README-style text.
+There are no active integration tests currently referencing `basic_profile.json`,
+`sample_profiles`, or `fixtures` anywhere in `tests/` — this is a from-scratch restoration, not
+a case of matching an existing consumer's expectations exactly.
+
+`tests/conftest.py` currently defines two fixtures, `sample_resume_text()` (lines 6-22) and
+`sample_readme_text()` (lines 25-42), both plain inline strings. They set the project's style
+for fake data: `sample_resume_text` uses name, role, contact line, experience, education, and
+skills sections; `sample_readme_text` uses title, summary, features, and tech stack sections.
+`basic_profile.json` should read as a natural extension of that same style, but as a JSON file
+with a profile plus two repo objects instead of a single Python string.
+
+Rather than inventing an arbitrary shape, the fixture should mirror what the ingestion/schema
+layer actually expects, so it's realistic and immediately useful if a future test wires it up:
+- `api/schemas/profile.py`: `ProfileCreate`/`ProfileUpdate` use `github_username` and
+  `portfolio_url`; `ProfileResponse` adds `id`, `user_id`, `created_at`, `resume_filename`.
+- `core/models/profile.py` (`Profile`, lines 19-56): stored fields are `github_username`,
+  `resume_filename`, `resume_text`, `portfolio_url` (lines 30-33).
+- `ingestion/pipeline.py`: `ingest_resume()` (55-124) takes resume `content`/`filename` and
+  parses `resume_text`; `ingest_readme()` (126-199) takes a repo's README content;
+  `ingest_repo_metadata()` (201-260) takes a full repo metadata dict and passes it to
+  `RepoAnalyzer.parse()`.
+- `ingestion/parsers/resume_parser.py`: `SECTION_HEADERS` (9-23) detects sections like
+  `Summary`, `Technical Skills`, `Projects`, `Experience`, `Education` — the fixture's
+  `resume_text` should use these headings so it looks like real parser input.
+- `ingestion/parsers/repo_analyzer.py`: `RepoAnalyzer.parse()` (29-48) reads GitHub-shaped repo
+  fields directly — `stargazers_count`, `forks_count`, `open_issues_count`, `readme_content`,
+  `language`, `pushed_at`, plus `name`, `description`, `html_url`. Tech-stack detection (133-184)
+  keys off `language` and config files like `package.json`, `requirements.txt`, `Dockerfile`.
+- `ingestion/parsers/readme_parser.py`: expects markdown headings (`#`, `##`) in
+  `readme_content`.
 
 **Root cause:** The fixture file (and its parent folder) simply doesn't exist in the repo.
 This is missing test data, not a code bug — no production code needs to change.
 
 ### Map
-Files I expect to touch:
-- `tests/fixtures/sample_profiles/basic_profile.json` (new file) — the restored fixture
-  itself.
-- `tests/conftest.py` — add a `sample_profile_data` fixture that loads the JSON file, so
-  tests can request it the same way they request `sample_resume_text` today.
-- `tests/unit/test_conftest_fixtures.py` or similar (new, small test) — a basic test proving
-  the fixture loads and has the expected keys, so this isn't dead weight sitting unused.
+Files to touch:
+- `tests/fixtures/sample_profiles/basic_profile.json` (new file) — the restored fixture, one
+  realistic fake portfolio with top-level profile fields, resume content, and two GitHub-style
+  repo objects.
+- `tests/conftest.py` — add a `sample_profile_data` fixture that loads the JSON file, so tests
+  can request it the same way they request `sample_resume_text` today.
+- `tests/unit/test_fixtures.py` (new, already stubbed in working tree) — a basic test proving
+  the fixture loads, has the expected profile fields, and has exactly two repo entries.
 
-Files I looked at but won't touch:
-- `scripts/run_evals.py` — only has a TODO comment referencing the path; implementing the
-  eval runner itself is out of scope for this issue.
-- `core/models/profile.py`, `core/models/ingested_source.py` — read for field names only, no
-  model changes needed.
+Files inspected but not changed (read for field/shape reference only):
+- `scripts/run_evals.py` — only has a TODO comment referencing the path; implementing the eval
+  runner itself is out of scope for this issue.
+- `scripts/issues_manifest.json` (lines 1612-1620) — issue definition/source of truth for scope.
+- `api/schemas/profile.py`, `core/models/profile.py` — field names for the profile portion.
+- `ingestion/pipeline.py`, `ingestion/parsers/resume_parser.py`,
+  `ingestion/parsers/repo_analyzer.py`, `ingestion/parsers/readme_parser.py` — shape reference
+  so the repo objects and text bodies look like real parser input, not arbitrary strings.
+- `core/models/ingested_source.py` — confirms there's no `Repo` model; repos are represented as
+  ingested-source rows at the DB layer, but the fixture should still mirror GitHub API shape
+  since that's what `RepoAnalyzer.parse()` and `ingest_repo_metadata()` actually consume.
 
 ### Plan
 1. Create the directory `tests/fixtures/sample_profiles/`.
-2. Write `basic_profile.json` with a realistic profile: `github_username`, `resume_filename`,
-   `resume_text` (short realistic resume, following the tone of `sample_resume_text` in
-   conftest.py), `portfolio_url`, and a `repos` list of exactly two entries, each with `name`,
-   `description`, `url`, and `readme_text`.
-3. Add a `sample_profile_data` fixture to `tests/conftest.py` that opens the JSON file
-   (path relative to the fixture file via `Path(__file__).parent`) and returns the parsed
-   dict, following the docstring style of the existing fixtures.
-4. Write one small unit test that requests `sample_profile_data` and asserts the expected
-   top-level keys exist and `len(repos) == 2` — proof the fixture is wired up correctly, not
-   just sitting on disk unused.
+2. Write `basic_profile.json` with:
+   - Top-level profile fields: `github_username`, `resume_filename`, `resume_text`,
+     `portfolio_url`.
+   - `resume_text` written with clear section headings (`Summary`, `Technical Skills`,
+     `Experience`, `Education`) so it exercises `ResumeParser._detect_sections()` realistically,
+     following the tone of `sample_resume_text` in conftest.py.
+   - A `repos` list of exactly two entries, each shaped like GitHub repo metadata so it can
+     feed `RepoAnalyzer.parse()` directly: `name`, `description`, `html_url`, `language`,
+     `stargazers_count`, `forks_count`, `open_issues_count`, `pushed_at`, and `readme_content`
+     (markdown with `#`/`##` headings, following the tone of `sample_readme_text`).
+3. Add a `sample_profile_data` fixture to `tests/conftest.py` that opens the JSON file (path
+   relative to the fixture file via `Path(__file__).parent`) and returns the parsed dict,
+   following the docstring style of the existing fixtures.
+4. Fill in `tests/unit/test_fixtures.py` (already present as an empty/stub file) with a test
+   that requests `sample_profile_data` and asserts the expected top-level keys exist and
+   `len(repos) == 2` — proof the fixture is wired up correctly, not just sitting on disk unused.
 5. Run `make test-unit` to confirm the new test passes and nothing else breaks.
 6. Run `make check` (lint/format/types) to confirm the new JSON and Python files are clean.
 
@@ -60,20 +95,30 @@ Files I looked at but won't touch:
 {
   "github_username": "janedoe",
   "resume_filename": "jane_doe_resume.pdf",
-  "resume_text": "Jane Doe\nSoftware Engineer\n...",
+  "resume_text": "Jane Doe\nSoftware Engineer\n\nSummary\n...\n\nTechnical Skills\n...\n\nExperience\n...\n\nEducation\n...",
   "portfolio_url": "https://janedoe.dev",
   "repos": [
     {
       "name": "weather-app",
-      "description": "A weather forecasting app built with React and OpenWeatherMap API.",
-      "url": "https://github.com/janedoe/weather-app",
-      "readme_text": "# Weather App\n..."
+      "description": "A weather forecasting app built with React and the OpenWeatherMap API.",
+      "html_url": "https://github.com/janedoe/weather-app",
+      "language": "TypeScript",
+      "stargazers_count": 12,
+      "forks_count": 3,
+      "open_issues_count": 1,
+      "pushed_at": "2026-05-10T14:22:00Z",
+      "readme_content": "# Weather App\n\n## Features\n...\n\n## Tech Stack\n..."
     },
     {
       "name": "task-tracker-api",
       "description": "A REST API for managing tasks, built with FastAPI and PostgreSQL.",
-      "url": "https://github.com/janedoe/task-tracker-api",
-      "readme_text": "# Task Tracker API\n..."
+      "html_url": "https://github.com/janedoe/task-tracker-api",
+      "language": "Python",
+      "stargazers_count": 5,
+      "forks_count": 1,
+      "open_issues_count": 0,
+      "pushed_at": "2026-04-02T09:10:00Z",
+      "readme_content": "# Task Tracker API\n\n## Features\n...\n\n## Tech Stack\n..."
     }
   ]
 }
@@ -83,39 +128,43 @@ Files I looked at but won't touch:
 - Input: none (reads from disk)
 - Output: the parsed dict above, available to any test via `sample_profile_data` parameter
 
-**Test I'll write:**
+**Test I'll write (`tests/unit/test_fixtures.py`):**
 ```python
 def test_sample_profile_data_has_expected_shape(sample_profile_data):
     """sample_profile_data fixture should load with expected top-level keys."""
     assert sample_profile_data["github_username"]
     assert sample_profile_data["resume_text"]
     assert len(sample_profile_data["repos"]) == 2
+    for repo in sample_profile_data["repos"]:
+        assert repo["name"]
+        assert repo["readme_content"]
 ```
 
 ### Risks & unknowns
-1. **I'm guessing the exact JSON shape.** Nothing in the current codebase consumes this file,
-   so there's no existing schema to match exactly. I'm basing the shape on the `Profile`
-   model's fields plus the "GitHub username, resume, two repos" wording from the issue. If a
-   reviewer expects different field names, I'll adjust.
-2. **Should repos be modeled after `IngestedSource` fields instead?** I chose `name`/
-   `description`/`url`/`readme_text` because that's what a "repo" conceptually needs for RAG
-   ingestion, but `IngestedSource` doesn't have a `name` or `description` field — those live
-   on GitHub's API response shape, not in our DB model. I'll note this mismatch in my PR
-   description rather than guess further.
-3. **Decision: include the conftest fixture, not just the JSON file.** The issue text says
-   the fixture is needed so "tests that depend on reusable sample profile data" can use it —
-   that implies it should be consumable via pytest, not just sit on disk. A JSON file with no
-   wiring would be dead weight and likely bounce back in review asking how it's meant to be
-   used. Adding `sample_profile_data` to `tests/conftest.py` (a few lines, following the
-   existing pattern) plus a test proving it loads keeps this in Tier-1 scope while making the
-   restored fixture actually usable.
+1. **No existing consumer to match exactly.** I confirmed via search that nothing in `tests/`
+   currently references this file, so there's no schema to match byte-for-byte. I'm shaping the
+   fixture to mirror what `RepoAnalyzer.parse()` and `ResumeParser` actually read (GitHub-style
+   repo metadata, section-headed resume text) rather than an arbitrary shape, so it stays useful
+   if/when a real test wires it up.
+2. **Repo shape choice: GitHub API-style, not `IngestedSource`-style.** `IngestedSource` doesn't
+   have `name`/`description`/`language`/etc. — those live on GitHub's API response shape, which
+   is what `ingest_repo_metadata()` and `RepoAnalyzer.parse()` consume before mapping into DB
+   rows. I chose to model the fixture after the API/parser input shape since that's the layer
+   this fixture would actually feed in a future test.
+3. **Decision: include the conftest fixture, not just the JSON file.** The issue implies the
+   fixture should be consumable via pytest, not just sit on disk. A JSON file with no wiring
+   would be dead weight. Adding `sample_profile_data` to `tests/conftest.py` plus a test proving
+   it loads keeps this in scope while making the restored fixture actually usable.
 
 ### Edge cases
-- Fixture file is valid JSON but a test imports it expecting a `list` at the top level
-  instead of a `dict` — not applicable here since I'm defining the shape myself, but I'll
-  keep the fixture function's return type explicit (`dict`) so misuse fails fast with a clear
-  type error.
-- `resume_text` containing special characters (quotes, newlines) — need to make sure the
-  JSON is valid (I'll validate with `python -m json.tool` before committing).
-- Two repos is a hard requirement per the issue text — I will not add a third "for realism,"
-  to keep the fixture matching exactly what's asked.
+- Fixture file is valid JSON but a test imports it expecting a `list` at the top level instead
+  of a `dict` — not applicable here since I'm defining the shape myself, but I'll keep the
+  fixture function's return type explicit (`dict`) so misuse fails fast with a clear type error.
+- `resume_text`/`readme_content` containing special characters (quotes, newlines) — need to
+  make sure the JSON is valid (I'll validate with `python -m json.tool` before committing).
+- Two repos is a hard requirement per the issue text — I will not add a third "for realism," to
+  keep the fixture matching exactly what's asked.
+- `readme_content` must use real markdown headings (`#`, `##`) rather than plain text, since
+  `ReadmeParser._extract_heading_hierarchy()` and `_detect_ci()`/`_detect_tests()` in
+  `RepoAnalyzer` key off structural markers — flat text would make the fixture look
+  unrealistic if ever run through the real parsers.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,11 @@
 """Shared test fixtures for PathReview."""
 
+import json
+from pathlib import Path
+
 import pytest
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
 
 @pytest.fixture
@@ -40,3 +45,11 @@ def sample_readme_text() -> str:
     - Tailwind CSS
     - OpenWeatherMap API
     """
+
+
+@pytest.fixture
+def sample_profile_data() -> dict:
+    """Return a sample portfolio profile (GitHub username, resume, two repos) for testing."""
+    fixture_path = FIXTURES_DIR / "sample_profiles" / "basic_profile.json"
+    data: dict = json.loads(fixture_path.read_text())
+    return data

--- a/tests/fixtures/sample_profiles/basic_profile.json
+++ b/tests/fixtures/sample_profiles/basic_profile.json
@@ -1,0 +1,30 @@
+{
+  "github_username": "janedoe",
+  "resume_filename": "jane_doe_resume.pdf",
+  "resume_text": "Jane Doe\nSoftware Engineer\njane.doe@example.com | github.com/janedoe\n\nSummary\nBackend-focused software engineer with two years of experience building REST APIs and data pipelines.\n\nTechnical Skills\nPython, JavaScript, React, PostgreSQL, Docker\n\nExperience\n- Software Engineer at TechCorp (2022-2024)\n  Built REST APIs using Python and FastAPI.\n\nEducation\n- B.S. Computer Science, State University (2022)",
+  "portfolio_url": "https://janedoe.dev",
+  "repos": [
+    {
+      "name": "weather-app",
+      "description": "A weather forecasting app built with React and OpenWeatherMap API.",
+      "html_url": "https://github.com/janedoe/weather-app",
+      "language": "TypeScript",
+      "stargazers_count": 12,
+      "forks_count": 3,
+      "open_issues_count": 1,
+      "pushed_at": "2026-05-10T14:22:00Z",
+      "readme_content": "# Weather App\nA weather forecasting application built with React and OpenWeatherMap API.\n\n## Features\n- Current weather display\n- 5-day forecast\n- Location search\n\n## Tech Stack\n- React 18\n- TypeScript\n- Tailwind CSS\n- OpenWeatherMap API"
+    },
+    {
+      "name": "task-tracker-api",
+      "description": "A REST API for managing tasks, built with FastAPI and PostgreSQL.",
+      "html_url": "https://github.com/janedoe/task-tracker-api",
+      "language": "Python",
+      "stargazers_count": 5,
+      "forks_count": 1,
+      "open_issues_count": 0,
+      "pushed_at": "2026-04-02T09:10:00Z",
+      "readme_content": "# Task Tracker API\nA REST API for managing tasks, built with FastAPI and PostgreSQL.\n\n## Features\n- CRUD endpoints for tasks\n- User authentication\n- Task filtering and sorting\n\n## Tech Stack\n- FastAPI\n- PostgreSQL\n- SQLAlchemy\n- Docker"
+    }
+  ]
+}

--- a/tests/unit/test_fixtures.py
+++ b/tests/unit/test_fixtures.py
@@ -1,0 +1,15 @@
+"""Tests for shared test fixtures defined in tests/conftest.py."""
+
+import pytest
+
+
+@pytest.mark.unit
+def test_sample_profile_data_has_expected_shape(sample_profile_data: dict) -> None:
+    """sample_profile_data fixture should load with expected top-level keys."""
+    assert sample_profile_data["github_username"]
+    assert sample_profile_data["resume_text"]
+    assert len(sample_profile_data["repos"]) == 2
+    for repo in sample_profile_data["repos"]:
+        assert repo["name"]
+        assert repo["html_url"]
+        assert repo["readme_content"]


### PR DESCRIPTION
## Summary
Restores the missing `tests/fixtures/sample_profiles/basic_profile.json` test fixture referenced by `scripts/run_evals.py` and `scripts/issues_manifest.json` (#106). The fixture is a realistic fake portfolio (GitHub username, resume text, two repos) shaped to match what the ingestion parsers (`ResumeParser`, `RepoAnalyzer`, `ReadmeParser`) actually consume, so it's immediately useful if a future test wires it up rather than an arbitrary shape.

## Issue
Closes #106

## Changes
- Add `tests/fixtures/sample_profiles/basic_profile.json` — a fake profile with `github_username`, `resume_filename`, `resume_text` (using section headings like `Summary`/`Technical Skills`/`Experience`/`Education` so it exercises `ResumeParser`'s section detection), `portfolio_url`, and exactly two `repos` entries shaped like GitHub API metadata (`name`, `description`, `html_url`, `language`, `stargazers_count`, `forks_count`, `open_issues_count`, `pushed_at`, `readme_content` with real markdown headings).
- Add a `sample_profile_data` fixture to `tests/conftest.py` that loads the JSON file, following the existing pattern of `sample_resume_text`/`sample_readme_text`.
- Add `tests/unit/test_fixtures.py` with a test proving the fixture loads correctly and has the expected shape (profile fields present, exactly two repos, each repo has `name`/`html_url`/`readme_content`).

## Testing
- [x] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`) — not applicable, no integration tests reference this fixture yet
- [x] Linter passes (`make lint`)
- [x] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes

All checks passed locally:
- Unit tests: 53 pre-existing failures remain unchanged; new test in
  `tests/unit/test_fixtures.py` passes
- Integration tests: Not applicable
- Linting: No new errors introduced (182 pre-existing errors unchanged)
- Type checking: Passes

**To manually verify:**
1. Check out this branch and run `pytest tests/unit/test_fixtures.py -v` —
   confirm `test_sample_profile_data_shape` (or your actual test name) passes.
2. Open `tests/fixtures/sample_profiles/basic_profile.json` and confirm it
   contains a GitHub username, resume text with section headings (Summary,
   Technical Skills, Experience, Education), and exactly two repo entries
   with GitHub API-style fields (`html_url`, `language`, `stargazers_count`,
   etc.).
3. Run `python -c "import json; d = json.load(open('tests/fixtures/sample_profiles/basic_profile.json')); print(d.keys())"`
   to confirm the top-level keys match what `sample_profile_data` in
   `tests/conftest.py` expects.

### Pre-existing failures (unrelated to this change)
Before starting, I ran `make test-unit` and `make check` on `main` to establish a baseline:
- `make test-unit`: 53 pre-existing failures (e.g. `test_bias_detector.py`, `test_pii_scrubber.py`, `test_review_service.py`, `test_resume_parser.py`, `test_readme_parser.py`, `test_tech_detector.py`, and others), 376 passing.
- `make check`: 182 pre-existing lint errors, none in files this PR touches.

I verified these are unrelated to this fix by stashing my changes and re-running both commands — the failure/error counts were identical with and without my changes applied.

After my changes:
- `make test-unit`: same 53 pre-existing failures, plus my new test passes.
- `make check`: still exactly 182 pre-existing lint errors — zero new errors introduced. `tests/conftest.py` and `tests/unit/test_fixtures.py` pass lint, format, and mypy individually.

This PR does not fix these pre-existing issues (out of scope for #106) but does not introduce any new failures either.

## Screenshots / Demo
N/A — test fixture only, no UI change.

## Notes for Reviewers
- No integration test currently consumes this fixture — `scripts/run_evals.py` has a TODO referencing `tests/fixtures/sample_profiles/` for future benchmark portfolios, but wiring that up is out of scope here.
- I chose to shape the two repo entries like raw GitHub API metadata (`html_url`, `stargazers_count`, etc.) rather than matching the `IngestedSource` DB model, since that's the layer `RepoAnalyzer.parse()` and `ingest_repo_metadata()` actually consume before mapping into DB rows. Flagging in case a different shape is expected.
