### PR TITLE
fix: build Redis health-check client from redis_url (#155)

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,47 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/155
+
+**Issue title:** Health check references settings.redis_host, which does not exist on Settings
+
+**Tier:** [ X ] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The `/health` endpoint (`api/routes/health.py`) checks Redis by building a client
+with `redis.Redis(host=settings.redis_host, port=settings.redis_port, ...)`. But the
+`Settings` class in `core/config.py` never defines `redis_host` or `redis_port` — it
+exposes a single `redis_url` instead. So the attribute lookup raises
+`AttributeError: 'Settings' object has no attribute 'redis_host'` before a connection
+is ever attempted. The surrounding `try/except` swallows that error, marks Redis
+`"unhealthy"`, and the endpoint returns 503 regardless of whether Redis is actually
+up — which defeats the point of a health check. A successful fix rebuilds the client
+from the attribute that actually exists (`redis.Redis.from_url(settings.redis_url,
+...)`), so `/health` reports Redis's real state instead of failing on a bad config
+reference.
+
+**Branch name:** fix/155-health-check-redis-host
+
+**Setup confirmation:** [ X ] App runs locally at localhost:5173
+
+**Cohort ledger:** [ X ] Issue added to cohort ledger
+
+---
+
+### Selection notes — "Is this right for me?" checklist reasoning
+
+- **Scope is bounded and understood.** The bug lives in one function in one file
+  (`api/routes/health.py`). I traced it end to end with the VS Code debugger: sent a
+  `GET /health`, hit a breakpoint in the Redis block, and read the caught exception
+  in Locals — `AttributeError("'Settings' object has no attribute 'redis_host'")`.
+  I can explain both the cause (attribute doesn't exist) and the effect (`except`
+  swallows it, so the endpoint always returns 503).
+- **The fix is small and low-risk.** Replace the `host=/port=` construction with
+  `redis.Redis.from_url(settings.redis_url, ...)`, matching the attribute the
+  `Settings` class already exposes. No schema, migration, or API-contract change.
+- **I can verify it.** I have the backend running locally and a saved request that
+  reproduces the 503, so I can confirm the Redis dependency flips to `"healthy"`
+  (with Redis up) once the fix lands.
+- **Out of scope, deliberately.** While reproducing this I noticed `/health` also
+  reports Postgres unhealthy — but for a different reason (`db.execute("SELECT 1")`
+  needs SQLAlchemy's `text()` wrapper). That is not issue #155. I'm leaving it
+  untouched to keep this branch to one intent; it belongs in its own issue/PR.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -96,3 +96,36 @@ Added `tests/unit/test_health.py` — the project's first health-endpoint tests:
 _Pre-existing failures note:_ On the base commit (`main`), `make test-unit` reports **53 failing tests** (e.g. `test_tech_detector`, `test_skill_extractor`, `test_structural_chunker`) and `make check` reports pre-existing lint/type errors — all unrelated to issue #155. After my changes the count is unchanged (**53 pre-existing failures, +3 new passing tests**); my change introduces no new failures. My new test file passes lint cleanly, and the 4 lint hits in `health.py` are pre-existing in-function imports present identically on `main`. "Passes" here means my changes introduce no new failures.
 
 **Draft PR feedback received from:** none
+
+---
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [ X ] No — still awaiting review
+
+**Summary of feedback:**
+No review has come in yet. As of the Week 10 deadline, PR [#670](https://github.com/ascherj/pathreview/pull/670) is open with status `REVIEW_REQUIRED` and has zero reviews and zero comments from maintainers. The PR is not a draft and the template is fully filled in, so it's ready whenever a maintainer picks it up.
+
+**How you responded:**
+Nothing to respond to yet. If feedback arrives after the deadline I'll engage with it on the PR — my most likely follow-ups would be adding a short module-level docstring to `tests/unit/test_health.py` if asked, or splitting the Postgres `text()` bug I flagged into its own issue if a maintainer wants it addressed. I kept the PR scoped to one intent specifically so it's easy to review.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Separating my change from the codebase's noise was harder than the fix itself. The actual code change was three lines, but `make test-unit` showed 53 pre-existing failures and `make check` reported a wall of lint/type errors that had nothing to do with my issue. The hard part was proving my change was clean: I had to check out `main`, capture a baseline (53 failing / 375 passing), then confirm my branch produced exactly the same 53 failures plus my 3 new passing tests. Without that baseline I couldn't have honestly claimed "no new failures" — and it would have been easy to panic and think I'd broken something. A related surprise: `pytest` wasn't even installed in the venv, so the Makefile's `$(PYTEST)` path didn't exist until I ran `uv pip install -e ".[dev]"`.
+
+**What did you learn about working in a large codebase?**
+That a "passing" bar means something different in someone else's production code. In my own projects, green means everything is green. Here, the responsible standard was "don't make it worse" — my contribution had to introduce no *new* failures, not fix a codebase I didn't break. I also learned to respect scope: while reproducing #155 I found a second real bug (`/health`'s Postgres check needs SQLAlchemy's `text()` wrapper), and the disciplined move was to document it and leave it alone rather than fold it into the same PR. One branch, one intent makes the change reviewable. Tracing the bug also meant reading code I'd never see in my own work — following `settings.redis_host` back to `core/config.py` to prove the attribute genuinely didn't exist, rather than assuming.
+
+**How did AI tools help — and where did they fall short?**
+AI was most useful for navigation and scaffolding: quickly locating every `redis` reference across `api/`, `safety/`, and `agent/`, matching the existing test conventions (the `Mock()`-based Redis pattern in `test_rate_limiter.py`), and drafting the `from_url` fix and the `TestClient` + `dependency_overrides` test harness. Where it fell short was judgment calls that needed the real repo state: deciding what was in vs. out of scope, and — most importantly — the pre-existing-failure analysis. AI could run the commands, but *I* had to decide that the 53 failures were legitimately not mine to fix and that documenting them in the PR was the honest thing to do. It also couldn't run `git push` for me — my SSH key is passphrase-protected, so every push was a manual, interactive step.
+
+**What would you do differently if you started over?**
+I'd capture the `make check` / `make test-unit` baseline in Week 8 during reproduction, not Week 9 during implementation. Knowing the pre-existing failure count up front would have removed all the "did I break this?" doubt when I ran the suite after my change. I'd also open the PR as a draft earlier in Week 9 to leave more room for peer feedback, instead of going straight to ready-for-review close to the deadline.
+
+**What are you most proud of from this module?**
+Not the three-line fix — the honesty around it. The `/health` endpoint had never had a single test; my PR adds the project's first health-endpoint tests, including a regression guard that fails if anyone reintroduces the `redis_host`/`redis_port` reference. And I documented the pre-existing failures transparently in the PR instead of quietly checking every box, which is the kind of contribution I'd actually want to receive as a maintainer.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -45,3 +45,54 @@ reference.
   reports Postgres unhealthy — but for a different reason (`db.execute("SELECT 1")`
   needs SQLAlchemy's `text()` wrapper). That is not issue #155. I'm leaving it
   untouched to keep this branch to one intent; it belongs in its own issue/PR.
+
+---
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [`5b12f9f`](https://github.com/tmayush/pathreview/commit/5b12f9f) — the added `tests/unit/test_health.py` encodes the reproduction: `test_health_check_does_not_reference_redis_host` asserts `settings` has no `redis_host`/`redis_port`, and before the fix the Redis block reported `"unhealthy"` because the attribute lookup raised `AttributeError`.
+
+**Reproduction summary:**
+I ran the backend and sent `GET /health` with a VS Code breakpoint in the Redis block. The caught exception was `AttributeError("'Settings' object has no attribute 'redis_host'")` — raised before any connection was attempted, then swallowed by the `except`, so the endpoint returned 503 with Redis marked `"unhealthy"` even though Redis was up.
+
+**PLAN.md link:** [PLAN.md](https://github.com/tmayush/pathreview/blob/fix/155-health-check-redis-host/PLAN.md)
+
+**Walkthrough video (recommended):** not recorded.
+
+**Blockers or open questions:**
+None. The fix is a bounded, one-function change; the only care needed is separating it from the codebase's documented pre-existing test/lint failures.
+
+---
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the fix in `api/routes/health.py` (sub-task 1) — the Redis client is now built with `redis.Redis.from_url(settings.redis_url, decode_responses=True)`. Added `tests/unit/test_health.py` (sub-task 2) with three passing tests.
+
+**Next steps:**
+Run the full `make check` / `make test-unit` baseline comparison (sub-task 3), finalize the journal, and open the PR (sub-task 4).
+
+**Blockers:**
+None.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** _to be added once the PR is opened_
+
+**Branch:** `fix/155-health-check-redis-host`
+
+**What you built:**
+The `/health` endpoint built its Redis client from `settings.redis_host`/`settings.redis_port`, attributes that don't exist on `Settings` — the lookup raised `AttributeError`, which was swallowed so Redis was always reported unhealthy and `/health` returned 503 even when Redis was up. The fix builds the client from the `settings.redis_url` that actually exists (via `redis.Redis.from_url`), so the check reports Redis's real state.
+
+**Tests added or updated:**
+Added `tests/unit/test_health.py` — the project's first health-endpoint tests: Redis reported healthy on a successful ping; reported unhealthy (503) on a real connection failure; and a regression guard confirming the client is built from `redis_url` and that `redis_host`/`redis_port` are never referenced.
+
+**Self-review confirmation:** [ X ] make check passes  [ X ] make test-unit passes
+
+_Pre-existing failures note:_ On the base commit (`main`), `make test-unit` reports **53 failing tests** (e.g. `test_tech_detector`, `test_skill_extractor`, `test_structural_chunker`) and `make check` reports pre-existing lint/type errors — all unrelated to issue #155. After my changes the count is unchanged (**53 pre-existing failures, +3 new passing tests**); my change introduces no new failures. My new test file passes lint cleanly, and the 4 lint hits in `health.py` are pre-existing in-function imports present identically on `main`. "Passes" here means my changes introduce no new failures.
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -81,7 +81,7 @@ None.
 
 ### Check-in 2 (end of week)
 
-**PR link:** _to be added once the PR is opened_
+**PR link:** https://github.com/ascherj/pathreview/pull/670
 
 **Branch:** `fix/155-health-check-redis-host`
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -50,17 +50,17 @@ reference.
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [`5b12f9f`](https://github.com/tmayush/pathreview/commit/5b12f9f) — the added `tests/unit/test_health.py` encodes the reproduction: `test_health_check_does_not_reference_redis_host` asserts `settings` has no `redis_host`/`redis_port`, and before the fix the Redis block reported `"unhealthy"` because the attribute lookup raised `AttributeError`.
+**Reproduction commit link:** [`5b12f9f`](https://github.com/tmayush/pathreview/commit/5b12f9f). The added `tests/unit/test_health.py` encodes the reproduction. `test_health_check_does_not_reference_redis_host` asserts that `settings` has no `redis_host` or `redis_port`, and before the fix the Redis block reported `"unhealthy"` because the attribute lookup raised `AttributeError`.
 
 **Reproduction summary:**
-I ran the backend and sent `GET /health` with a VS Code breakpoint in the Redis block. The caught exception was `AttributeError("'Settings' object has no attribute 'redis_host'")` — raised before any connection was attempted, then swallowed by the `except`, so the endpoint returned 503 with Redis marked `"unhealthy"` even though Redis was up.
+I ran the backend and sent `GET /health` with a VS Code breakpoint in the Redis block. The caught exception was `AttributeError("'Settings' object has no attribute 'redis_host'")`. It fired before any connection was attempted, the `except` swallowed it, and the endpoint returned 503 with Redis marked `"unhealthy"` even though Redis was up.
 
 **PLAN.md link:** [PLAN.md](https://github.com/tmayush/pathreview/blob/fix/155-health-check-redis-host/PLAN.md)
 
 **Walkthrough video (recommended):** not recorded.
 
 **Blockers or open questions:**
-None. The fix is a bounded, one-function change; the only care needed is separating it from the codebase's documented pre-existing test/lint failures.
+None. The fix is a bounded, one-function change. The only care needed is keeping it separate from the codebase's documented pre-existing test and lint failures.
 
 ---
 
@@ -69,7 +69,7 @@ None. The fix is a bounded, one-function change; the only care needed is separat
 ### Check-in 1 (mid-week)
 
 **Current progress:**
-Implemented the fix in `api/routes/health.py` (sub-task 1) — the Redis client is now built with `redis.Redis.from_url(settings.redis_url, decode_responses=True)`. Added `tests/unit/test_health.py` (sub-task 2) with three passing tests.
+Implemented the fix in `api/routes/health.py` (sub-task 1). The Redis client is now built with `redis.Redis.from_url(settings.redis_url, decode_responses=True)`. Added `tests/unit/test_health.py` (sub-task 2) with three passing tests.
 
 **Next steps:**
 Run the full `make check` / `make test-unit` baseline comparison (sub-task 3), finalize the journal, and open the PR (sub-task 4).
@@ -86,14 +86,14 @@ None.
 **Branch:** `fix/155-health-check-redis-host`
 
 **What you built:**
-The `/health` endpoint built its Redis client from `settings.redis_host`/`settings.redis_port`, attributes that don't exist on `Settings` — the lookup raised `AttributeError`, which was swallowed so Redis was always reported unhealthy and `/health` returned 503 even when Redis was up. The fix builds the client from the `settings.redis_url` that actually exists (via `redis.Redis.from_url`), so the check reports Redis's real state.
+The `/health` endpoint built its Redis client from `settings.redis_host` and `settings.redis_port`. Those attributes don't exist on `Settings`, so the lookup raised `AttributeError`. The `except` swallowed it, Redis was always reported unhealthy, and `/health` returned 503 even when Redis was up. The fix builds the client from `settings.redis_url`, which does exist, using `redis.Redis.from_url`, so the check reports Redis's real state.
 
 **Tests added or updated:**
-Added `tests/unit/test_health.py` — the project's first health-endpoint tests: Redis reported healthy on a successful ping; reported unhealthy (503) on a real connection failure; and a regression guard confirming the client is built from `redis_url` and that `redis_host`/`redis_port` are never referenced.
+Added `tests/unit/test_health.py`, the project's first tests for the health endpoint. They cover three cases: Redis reported healthy on a successful ping, Redis reported unhealthy (503) on a real connection failure, and a regression guard that fails if the client is ever built from `redis_host` or `redis_port` again instead of `redis_url`.
 
 **Self-review confirmation:** [ X ] make check passes  [ X ] make test-unit passes
 
-_Pre-existing failures note:_ On the base commit (`main`), `make test-unit` reports **53 failing tests** (e.g. `test_tech_detector`, `test_skill_extractor`, `test_structural_chunker`) and `make check` reports pre-existing lint/type errors — all unrelated to issue #155. After my changes the count is unchanged (**53 pre-existing failures, +3 new passing tests**); my change introduces no new failures. My new test file passes lint cleanly, and the 4 lint hits in `health.py` are pre-existing in-function imports present identically on `main`. "Passes" here means my changes introduce no new failures.
+_Pre-existing failures note:_ On the base commit (`main`), `make test-unit` reports **53 failing tests** (for example `test_tech_detector`, `test_skill_extractor`, `test_structural_chunker`) and `make check` reports pre-existing lint and type errors. None of them relate to issue #155. After my changes the count is unchanged: the same 53 failures plus my 3 new passing tests. My change introduces no new failures. My new test file passes lint cleanly, and the 4 lint hits in `health.py` are pre-existing in-function imports that appear identically on `main`. So "passes" here means my changes introduce no new failures.
 
 **Draft PR feedback received from:** none
 
@@ -106,26 +106,26 @@ _Pre-existing failures note:_ On the base commit (`main`), `make test-unit` repo
 **Feedback received:** [ ] Yes  [ X ] No — still awaiting review
 
 **Summary of feedback:**
-No review has come in yet. As of the Week 10 deadline, PR [#670](https://github.com/ascherj/pathreview/pull/670) is open with status `REVIEW_REQUIRED` and has zero reviews and zero comments from maintainers. The PR is not a draft and the template is fully filled in, so it's ready whenever a maintainer picks it up.
+No review has come in yet. At the Week 10 deadline, PR [#670](https://github.com/ascherj/pathreview/pull/670) is open with status `REVIEW_REQUIRED` and has no reviews or comments from maintainers. It isn't a draft and the template is filled in, so it's ready whenever a maintainer picks it up.
 
 **How you responded:**
-Nothing to respond to yet. If feedback arrives after the deadline I'll engage with it on the PR — my most likely follow-ups would be adding a short module-level docstring to `tests/unit/test_health.py` if asked, or splitting the Postgres `text()` bug I flagged into its own issue if a maintainer wants it addressed. I kept the PR scoped to one intent specifically so it's easy to review.
+There's nothing to respond to yet. If feedback shows up after the deadline I'll answer it on the PR. The most likely follow-ups I can think of are adding a short module docstring to `tests/unit/test_health.py` if someone asks, or opening a separate issue for the Postgres `text()` bug I flagged if a maintainer wants it fixed. I kept the PR to one change on purpose so it stays easy to review.
 
 ---
 
 ### Reflection
 
 **What was harder than you expected?**
-Separating my change from the codebase's noise was harder than the fix itself. The actual code change was three lines, but `make test-unit` showed 53 pre-existing failures and `make check` reported a wall of lint/type errors that had nothing to do with my issue. The hard part was proving my change was clean: I had to check out `main`, capture a baseline (53 failing / 375 passing), then confirm my branch produced exactly the same 53 failures plus my 3 new passing tests. Without that baseline I couldn't have honestly claimed "no new failures" — and it would have been easy to panic and think I'd broken something. A related surprise: `pytest` wasn't even installed in the venv, so the Makefile's `$(PYTEST)` path didn't exist until I ran `uv pip install -e ".[dev]"`.
+The fix was three lines. Proving it was clean took longer than writing it. `make test-unit` came back with 53 failures and `make check` printed a wall of lint and type errors, none of it mine. To claim my change was safe I had to check out `main`, record a baseline (53 failing, 375 passing), then confirm my branch produced the same 53 plus my 3 new passing tests. Without that baseline I'd have had no honest way to say I hadn't broken anything, and it would have been easy to see red output and assume I had. A smaller surprise: `pytest` wasn't installed in the venv at all, so the Makefile's test command pointed at a binary that didn't exist until I ran `uv pip install -e ".[dev]"`.
 
 **What did you learn about working in a large codebase?**
-That a "passing" bar means something different in someone else's production code. In my own projects, green means everything is green. Here, the responsible standard was "don't make it worse" — my contribution had to introduce no *new* failures, not fix a codebase I didn't break. I also learned to respect scope: while reproducing #155 I found a second real bug (`/health`'s Postgres check needs SQLAlchemy's `text()` wrapper), and the disciplined move was to document it and leave it alone rather than fold it into the same PR. One branch, one intent makes the change reviewable. Tracing the bug also meant reading code I'd never see in my own work — following `settings.redis_host` back to `core/config.py` to prove the attribute genuinely didn't exist, rather than assuming.
+That "passing" means something different in code you didn't write. In my own projects, green means green. Here the honest bar was "don't make it worse." I only had to avoid adding new failures, not repair a codebase I hadn't broken. I also learned to hold scope. While reproducing #155 I found a second real bug: the Postgres check in `/health` calls `db.execute("SELECT 1")` without SQLAlchemy's `text()` wrapper. The right move was to write it down and leave it for its own issue, not fold it into this PR. Tracing the original bug also meant reading files I'd never touch in my own work, following `settings.redis_host` back to `core/config.py` to confirm the attribute genuinely wasn't there instead of taking the error message on faith.
 
 **How did AI tools help — and where did they fall short?**
-AI was most useful for navigation and scaffolding: quickly locating every `redis` reference across `api/`, `safety/`, and `agent/`, matching the existing test conventions (the `Mock()`-based Redis pattern in `test_rate_limiter.py`), and drafting the `from_url` fix and the `TestClient` + `dependency_overrides` test harness. Where it fell short was judgment calls that needed the real repo state: deciding what was in vs. out of scope, and — most importantly — the pre-existing-failure analysis. AI could run the commands, but *I* had to decide that the 53 failures were legitimately not mine to fix and that documenting them in the PR was the honest thing to do. It also couldn't run `git push` for me — my SSH key is passphrase-protected, so every push was a manual, interactive step.
+AI was best at getting around the codebase and setting up scaffolding. It found every `redis` reference across `api/`, `safety/`, and `agent/` fast, pointed me at the existing `Mock()` Redis pattern in `test_rate_limiter.py` so my test matched the house style, and drafted both the `from_url` fix and the `TestClient` plus `dependency_overrides` harness. It was weaker on judgment. Deciding what belonged in scope, and reading the pre-existing failures for what they were, came down to me. The tool could run the commands, but I had to decide those 53 failures weren't mine to fix and that saying so plainly in the PR was the right call. It also couldn't push for me. My SSH key has a passphrase, so every push was a manual step I ran myself.
 
 **What would you do differently if you started over?**
-I'd capture the `make check` / `make test-unit` baseline in Week 8 during reproduction, not Week 9 during implementation. Knowing the pre-existing failure count up front would have removed all the "did I break this?" doubt when I ran the suite after my change. I'd also open the PR as a draft earlier in Week 9 to leave more room for peer feedback, instead of going straight to ready-for-review close to the deadline.
+I'd take the `make check` and `make test-unit` baseline in Week 8 while reproducing, not in Week 9 while coding. Having the failure count in hand from the start would have killed the "did I break this?" doubt the first time I ran the suite. I'd also open the PR as a draft earlier in the week. I went straight to ready-for-review close to the deadline and left almost no room for peer feedback.
 
 **What are you most proud of from this module?**
-Not the three-line fix — the honesty around it. The `/health` endpoint had never had a single test; my PR adds the project's first health-endpoint tests, including a regression guard that fails if anyone reintroduces the `redis_host`/`redis_port` reference. And I documented the pre-existing failures transparently in the PR instead of quietly checking every box, which is the kind of contribution I'd actually want to receive as a maintainer.
+Not the three-line fix. The honesty around it. The `/health` endpoint had never had a single test, and my PR adds the first ones, including a guard that breaks the build if anyone puts the `redis_host` or `redis_port` reference back. And I wrote the pre-existing failures into the PR openly instead of quietly ticking every checkbox. That's the kind of PR I'd want to get if I were the maintainer.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,33 +1,33 @@
 ## Solution plan
 
-**Issue:** [Health check references `settings.redis_host`, which does not exist on Settings — #155](https://github.com/ascherj/pathreview/issues/155)
+**Issue:** [Health check references settings.redis_host, which does not exist on Settings (#155)](https://github.com/ascherj/pathreview/issues/155)
 
 ### Understand
 
 The `/health` endpoint (`api/routes/health.py`) builds its Redis client with
 `redis.Redis(host=settings.redis_host, port=settings.redis_port, ...)`. The
-`Settings` class in `core/config.py` never defines `redis_host` or `redis_port`
-— it exposes a single `redis_url` field (default `redis://localhost:6379/0`).
+`Settings` class in `core/config.py` never defines `redis_host` or `redis_port`.
+It exposes a single `redis_url` field (default `redis://localhost:6379/0`).
 
 - **Expected:** `/health` connects to Redis and reports its real state
   (`"healthy"` when reachable, `"unhealthy"` when the connection fails).
 - **Actual:** `settings.redis_host` raises
-  `AttributeError: 'Settings' object has no attribute 'redis_host'` *before any
-  connection is attempted*. The surrounding `try/except` swallows the error,
-  marks Redis `"unhealthy"`, and the endpoint returns **503 unconditionally** —
+  `AttributeError: 'Settings' object has no attribute 'redis_host'` before any
+  connection is attempted. The surrounding `try/except` swallows the error,
+  marks Redis `"unhealthy"`, and the endpoint returns **503 unconditionally**,
   even when Redis is up. The health check can never report Redis healthy.
 
 **Root cause:** the endpoint references configuration attributes that don't
-exist on `Settings`; it should build the client from the `redis_url` that does.
+exist on `Settings`. It should build the client from the `redis_url` that does.
 
 ### Map
 
-- `api/routes/health.py` — the Redis check block (the only production code
-  change). Swap the `host=/port=` construction for `redis.Redis.from_url`.
-- `core/config.py` — read-only reference; confirms `redis_url` is the real
-  attribute and `redis_host`/`redis_port` do not exist. No change needed.
-- `tests/unit/test_health.py` — **new** test file (no health tests exist today).
-- `safety/rate_limiter.py`, `agent/memory/session_store.py` — reviewed to
+- `api/routes/health.py`: the Redis check block, and the only production code
+  change. Swap the `host=/port=` construction for `redis.Redis.from_url`.
+- `core/config.py`: read-only reference. Confirms `redis_url` is the real
+  attribute and that `redis_host`/`redis_port` do not exist. No change needed.
+- `tests/unit/test_health.py`: **new** test file (no health tests exist today).
+- `safety/rate_limiter.py`, `agent/memory/session_store.py`: reviewed to
   confirm the rest of the app already receives a Redis client by injection and
   does not depend on the removed attributes. No change needed.
 
@@ -37,40 +37,43 @@ exist on `Settings`; it should build the client from the `redis_url` that does.
    `redis.Redis(host=settings.redis_host, port=settings.redis_port, db=0, decode_responses=True)`
    with `redis.Redis.from_url(settings.redis_url, decode_responses=True)`
    (the URL already encodes host, port, and db).
-2. Add `tests/unit/test_health.py` covering: Redis reported healthy on a
-   successful ping; reported unhealthy (503) on a real connection failure; and a
-   regression guard asserting the client is built from `redis_url` and that
-   `settings` has no `redis_host`/`redis_port`.
-3. Run `make test-unit` and `make check`; record pre-existing failures vs. new
-   ones (the codebase has documented pre-existing failures unrelated to #155).
-4. Update `JOURNAL.md` (Week 8 + Week 9 check-ins) and open the PR.
+2. Add `tests/unit/test_health.py` covering three cases: Redis reported healthy
+   on a successful ping, reported unhealthy (503) on a real connection failure,
+   and a regression guard asserting the client is built from `redis_url` and
+   that `settings` has no `redis_host`/`redis_port`.
+3. Run `make test-unit` and `make check`, and record pre-existing failures
+   against new ones (the codebase has documented pre-existing failures
+   unrelated to #155).
+4. Update `JOURNAL.md` (Week 8 and Week 9 check-ins) and open the PR.
 
 ### Inputs & outputs
 
 - **Input:** `settings.redis_url` (str, from env/.env, default
   `redis://localhost:6379/0`).
-- **Output:** a working Redis client; the `dependencies.redis` field in the
+- **Output:** a working Redis client. The `dependencies.redis` field in the
   `/health` JSON reflects Redis's true state, and the endpoint returns 200 when
   all dependencies are healthy instead of always 503.
 
 ### Risks & unknowns
 
 - **`from_url` argument parity:** `db=0` is dropped because it's already encoded
-  in the URL's path (`/0`). Low risk — the default URL uses db 0. Verified
-  against `core/config.py`.
+  in the URL's path (`/0`). This is low risk, since the default URL uses db 0.
+  Verified against `core/config.py`.
 - **Pre-existing failures:** `make check` and `make test-unit` already report
-  unrelated failures (e.g. `test_tech_detector`, `test_skill_extractor`) and
-  lint errors on the base commit. Risk is misattributing them to this change —
-  mitigated by capturing a baseline on `main` before/after.
-- **Out of scope:** `/health`'s Postgres check (`db.execute("SELECT 1")` needs
-  SQLAlchemy's `text()` wrapper) is a separate bug; deliberately not touched to
-  keep this branch to one intent.
+  unrelated failures (for example `test_tech_detector`, `test_skill_extractor`)
+  and lint errors on the base commit. The risk is misattributing them to this
+  change. I mitigate it by capturing a baseline on `main` before and after.
+- **Out of scope:** the Postgres check in `/health` (`db.execute("SELECT 1")`
+  needs SQLAlchemy's `text()` wrapper) is a separate bug. I deliberately leave
+  it untouched to keep this branch to one intent.
 
 ### Edge cases
 
-- Redis is down / unreachable → `ping()` raises → reported `"unhealthy"`, 503
-  (the intended behavior, now reachable instead of masked by the config bug).
-- A non-default `redis_url` (different host/port/db via env) → honored, because
-  the client is built from the URL rather than hard-coded pieces.
-- `settings.redis_url` malformed → `from_url` raises inside the `try`, caught and
-  reported `"unhealthy"` — a real signal, not a silent config crash.
+- Redis is down or unreachable: `ping()` raises, so Redis is reported
+  `"unhealthy"` with a 503. That is the intended behavior, now reachable instead
+  of masked by the config bug.
+- A non-default `redis_url` (different host, port, or db via env) is honored,
+  because the client is built from the URL rather than hard-coded pieces.
+- A malformed `redis_url` makes `from_url` raise inside the `try`, which is
+  caught and reported `"unhealthy"`. That is a real signal, not a silent config
+  crash.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,76 @@
+## Solution plan
+
+**Issue:** [Health check references `settings.redis_host`, which does not exist on Settings — #155](https://github.com/ascherj/pathreview/issues/155)
+
+### Understand
+
+The `/health` endpoint (`api/routes/health.py`) builds its Redis client with
+`redis.Redis(host=settings.redis_host, port=settings.redis_port, ...)`. The
+`Settings` class in `core/config.py` never defines `redis_host` or `redis_port`
+— it exposes a single `redis_url` field (default `redis://localhost:6379/0`).
+
+- **Expected:** `/health` connects to Redis and reports its real state
+  (`"healthy"` when reachable, `"unhealthy"` when the connection fails).
+- **Actual:** `settings.redis_host` raises
+  `AttributeError: 'Settings' object has no attribute 'redis_host'` *before any
+  connection is attempted*. The surrounding `try/except` swallows the error,
+  marks Redis `"unhealthy"`, and the endpoint returns **503 unconditionally** —
+  even when Redis is up. The health check can never report Redis healthy.
+
+**Root cause:** the endpoint references configuration attributes that don't
+exist on `Settings`; it should build the client from the `redis_url` that does.
+
+### Map
+
+- `api/routes/health.py` — the Redis check block (the only production code
+  change). Swap the `host=/port=` construction for `redis.Redis.from_url`.
+- `core/config.py` — read-only reference; confirms `redis_url` is the real
+  attribute and `redis_host`/`redis_port` do not exist. No change needed.
+- `tests/unit/test_health.py` — **new** test file (no health tests exist today).
+- `safety/rate_limiter.py`, `agent/memory/session_store.py` — reviewed to
+  confirm the rest of the app already receives a Redis client by injection and
+  does not depend on the removed attributes. No change needed.
+
+### Plan
+
+1. In `api/routes/health.py`, replace
+   `redis.Redis(host=settings.redis_host, port=settings.redis_port, db=0, decode_responses=True)`
+   with `redis.Redis.from_url(settings.redis_url, decode_responses=True)`
+   (the URL already encodes host, port, and db).
+2. Add `tests/unit/test_health.py` covering: Redis reported healthy on a
+   successful ping; reported unhealthy (503) on a real connection failure; and a
+   regression guard asserting the client is built from `redis_url` and that
+   `settings` has no `redis_host`/`redis_port`.
+3. Run `make test-unit` and `make check`; record pre-existing failures vs. new
+   ones (the codebase has documented pre-existing failures unrelated to #155).
+4. Update `JOURNAL.md` (Week 8 + Week 9 check-ins) and open the PR.
+
+### Inputs & outputs
+
+- **Input:** `settings.redis_url` (str, from env/.env, default
+  `redis://localhost:6379/0`).
+- **Output:** a working Redis client; the `dependencies.redis` field in the
+  `/health` JSON reflects Redis's true state, and the endpoint returns 200 when
+  all dependencies are healthy instead of always 503.
+
+### Risks & unknowns
+
+- **`from_url` argument parity:** `db=0` is dropped because it's already encoded
+  in the URL's path (`/0`). Low risk — the default URL uses db 0. Verified
+  against `core/config.py`.
+- **Pre-existing failures:** `make check` and `make test-unit` already report
+  unrelated failures (e.g. `test_tech_detector`, `test_skill_extractor`) and
+  lint errors on the base commit. Risk is misattributing them to this change —
+  mitigated by capturing a baseline on `main` before/after.
+- **Out of scope:** `/health`'s Postgres check (`db.execute("SELECT 1")` needs
+  SQLAlchemy's `text()` wrapper) is a separate bug; deliberately not touched to
+  keep this branch to one intent.
+
+### Edge cases
+
+- Redis is down / unreachable → `ping()` raises → reported `"unhealthy"`, 503
+  (the intended behavior, now reachable instead of masked by the config bug).
+- A non-default `redis_url` (different host/port/db via env) → honored, because
+  the client is built from the URL rather than hard-coded pieces.
+- `settings.redis_url` malformed → `from_url` raises inside the `try`, caught and
+  reported `"unhealthy"` — a real signal, not a silent config crash.

--- a/api/routes/health.py
+++ b/api/routes/health.py
@@ -41,10 +41,8 @@ async def health_check(db=Depends(get_db)):
         import redis
         from core.config import settings
 
-        r = redis.Redis(
-            host=settings.redis_host,
-            port=settings.redis_port,
-            db=0,
+        r = redis.Redis.from_url(
+            settings.redis_url,
             decode_responses=True,
         )
         r.ping()

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -1,0 +1,83 @@
+"""Tests for the /health endpoint (api/routes/health.py).
+
+Focus: issue #155 — the Redis check must build its client from
+``settings.redis_url`` (via ``redis.Redis.from_url``) rather than the
+non-existent ``settings.redis_host`` / ``settings.redis_port`` attributes.
+Before the fix, the attribute lookup raised ``AttributeError`` inside the
+``try`` block, which was swallowed and always reported Redis ``"unhealthy"``.
+"""
+
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.main import app
+from core.database import get_db
+
+
+@pytest.fixture
+def healthy_db():
+    """Override get_db with a session whose ``execute`` succeeds."""
+    db = Mock()
+    db.execute = AsyncMock(return_value=None)
+
+    async def _override():
+        yield db
+
+    app.dependency_overrides[get_db] = _override
+    yield db
+    app.dependency_overrides.pop(get_db, None)
+
+
+@pytest.fixture
+def client(healthy_db):
+    return TestClient(app)
+
+
+@pytest.mark.unit
+class TestHealthRedisCheck:
+    """Redis dependency reporting in the /health endpoint."""
+
+    def test_redis_reported_healthy_when_ping_succeeds(self, client):
+        """When Redis pings successfully, it is reported healthy (not swallowed)."""
+        mock_client = Mock()
+        mock_client.ping = Mock(return_value=True)
+
+        with patch("redis.Redis.from_url", return_value=mock_client) as from_url:
+            resp = client.get("/health")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["dependencies"]["redis"] == "healthy"
+        # Regression guard for #155: the client is built from redis_url,
+        # never from the non-existent redis_host/redis_port attributes.
+        from_url.assert_called_once()
+        assert from_url.call_args.args[0].startswith("redis://")
+
+    def test_redis_reported_unhealthy_when_ping_fails(self, client):
+        """A real connection failure (not a config bug) surfaces as 503."""
+        mock_client = Mock()
+        mock_client.ping = Mock(side_effect=ConnectionError("connection refused"))
+
+        with patch("redis.Redis.from_url", return_value=mock_client):
+            resp = client.get("/health")
+
+        assert resp.status_code == 503
+        body = resp.json()["detail"]
+        assert body["dependencies"]["redis"] == "unhealthy"
+
+    def test_health_check_does_not_reference_redis_host(self, client):
+        """The endpoint must not touch settings.redis_host (the #155 bug)."""
+        from core.config import settings
+
+        assert not hasattr(settings, "redis_host")
+        assert not hasattr(settings, "redis_port")
+
+        mock_client = Mock()
+        mock_client.ping = Mock(return_value=True)
+        with patch("redis.Redis.from_url", return_value=mock_client):
+            resp = client.get("/health")
+
+        # No AttributeError leaked through as an unhealthy Redis status.
+        assert resp.json()["dependencies"]["redis"] == "healthy"


### PR DESCRIPTION
## Summary
The `/health` endpoint built its Redis client from `settings.redis_host` and `settings.redis_port`, which do not exist on the `Settings` class (`core/config.py` exposes a single `redis_url`). The attribute lookup raised `AttributeError` inside the Redis `try` block before any connection was attempted. The `except` swallowed it, marked Redis `"unhealthy"`, and the endpoint returned 503 unconditionally, even when Redis was up. This PR builds the client from the `redis_url` that actually exists, so `/health` reports Redis's real state.

## Issue
Closes #155

## Changes
- `api/routes/health.py`: replace `redis.Redis(host=settings.redis_host, port=settings.redis_port, db=0, decode_responses=True)` with `redis.Redis.from_url(settings.redis_url, decode_responses=True)`. The URL already encodes host, port, and db.
- `tests/unit/test_health.py` (new): the project's first tests for the health endpoint. They cover Redis healthy on a successful ping, Redis unhealthy (503) on a real connection failure, and a regression guard that `settings` never exposes `redis_host`/`redis_port` and that the client is built from `redis_url`.
- `PLAN.md` (new): solution plan for the issue.

## Testing
- [x] Unit tests pass (`make test-unit`), with the note on pre-existing failures below
- [ ] Integration tests pass (`make test-integration`)
- [ ] Linter passes (`make lint`), with the note on pre-existing failures below
- [ ] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes

**Pre-existing failures (unrelated to this issue):** On the base commit (`main`), `make test-unit` already reports 53 failing tests (for example `test_tech_detector`, `test_skill_extractor`, `test_structural_chunker`), and `make lint` and `make typecheck` already report errors. After this change the failure count is unchanged: this PR adds 3 new passing tests and introduces no new failures. The new test file passes `ruff` cleanly, and the only lint hits in `health.py` are pre-existing in-function imports that appear identically on `main`.

## Screenshots / Demo
N/A. The behavior is covered by the new unit tests.

## Notes for Reviewers
- `db=0` is intentionally dropped because it is already encoded in the default `redis_url` path (`redis://localhost:6379/0`).
- Out of scope: while reproducing this I noticed the Postgres check in `/health` (`db.execute("SELECT 1")`) needs SQLAlchemy's `text()` wrapper. That is a separate bug, left untouched to keep this PR to one intent.
