### PR TITLE
fix: Route structlog through stdlib logging in tests so caplog captures logs

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,19 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/159
+
+**Issue title:** structlog output is not captured by pytest caplog — log assertions fail suite-wide
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+Structlog is not configured to propgate into the stdlib logging system in tests. Each test fails when asserting on caplog, even though the code itself runs fine.
+The test_batch_processor.py unit test is currently broken. A fix would include configuring the structlog so caplog-based assertions work and these tests pass.
+
+
+
+**Branch name:** bug/159-structlog-output-not-captured-by-pytest-caplog
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -33,3 +33,5 @@ The test_batch_processor.py unit test is currently broken. A fix would include c
 
 **Reproduction summary:**
 `test_empty_chunks_list_returns_empty` fails with `AssertionError: assert ('Empty chunks list' in '' or False)` — `caplog.text` is empty and `caplog.records` is empty. The captured stdout shows the warning *was* emitted (`[warning  ] Empty chunks list provided to BatchEmbeddingProcessor`), but structlog uses its default configuration (`structlog.get_logger()` in `batch_processor.py:7`) which prints straight to stdout instead of propagating through Python's stdlib `logging`. Since pytest's `caplog` fixture only captures stdlib `logging` output, the log record never reaches `caplog`, so the assertion fails even though the code runs correctly.
+
+**PLAN.md link:** https://github.com/Nexus-00/pathreview/blob/bug/159-structlog-output-not-captured-by-pytest-caplog/PLAN.md

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -10,8 +10,6 @@
 Structlog is not configured to propgate into the stdlib logging system in tests. Each test fails when asserting on caplog, even though the code itself runs fine.
 The test_batch_processor.py unit test is currently broken. A fix would include configuring the structlog so caplog-based assertions work and these tests pass.
 
-
-
 **Branch name:** bug/159-structlog-output-not-captured-by-pytest-caplog
 
 **Setup confirmation:** [x] App runs locally at localhost:5173
@@ -19,8 +17,6 @@ The test_batch_processor.py unit test is currently broken. A fix would include c
 **Cohort ledger:** [x] Issue added to cohort ledger
 
 ## Week 8 — Reproduction & solution planning
-
-**Reproduction commit link:** [link to commit documenting the reproduced issue]
 
 **Failing test:** `tests/unit/test_batch_processor.py::TestBatchEmbeddingProcessor::test_empty_chunks_list_returns_empty`
 
@@ -35,3 +31,38 @@ The test_batch_processor.py unit test is currently broken. A fix would include c
 `test_empty_chunks_list_returns_empty` fails with `AssertionError: assert ('Empty chunks list' in '' or False)` — `caplog.text` is empty and `caplog.records` is empty. The captured stdout shows the warning *was* emitted (`[warning  ] Empty chunks list provided to BatchEmbeddingProcessor`), but structlog uses its default configuration (`structlog.get_logger()` in `batch_processor.py:7`) which prints straight to stdout instead of propagating through Python's stdlib `logging`. Since pytest's `caplog` fixture only captures stdlib `logging` output, the log record never reaches `caplog`, so the assertion fails even though the code runs correctly.
 
 **PLAN.md link:** https://github.com/Nexus-00/pathreview/blob/bug/159-structlog-output-not-captured-by-pytest-caplog/PLAN.md
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+1. The autouse configure_structlog_for_tests fixture in tests/conftest.py configures structlog with stdlib.LoggerFactory(), cache_logger_on_first_use=False, and a plain ConsoleRenderer(colors=False).
+
+2. The fixture sets the root logger to DEBUG so WARNING-level records propagate to caplog's handler. I verified via the target test, which asserts on both caplog.text and caplog.records[*].message — both are populated, and it passes.
+
+**Next steps:**
+Implementing the rest of the plan, through steps 3 to 5: Run the target test, run the full suite, commit, then submit the PR.
+
+**Blockers:**
+Time management is an issue. I've been busy throughout the entire week, and did not make as much progress as I wanted to in the middle of the week.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [link to your submitted pull request]
+
+**Branch:** bug/159-structlog-output-not-captured-by-pytest-caplog
+
+**What you built:**
+Added an autouse fixture in `tests/conftest.py` that reconfigures structlog to route events through Python's stdlib `logging` (via `structlog.stdlib.LoggerFactory()` with `cache_logger_on_first_use=False` and a plain, non-ANSI `ConsoleRenderer(colors=False)`) and raises the root logger to `DEBUG` so WARNING records reach pytest's caplog handler. Because structlog config is process-global, every module using `structlog.get_logger()` now has its logs captured by caplog during tests, and the fixture calls `structlog.reset_defaults()` on teardown to avoid config bleed.
+
+**Tests added or updated:**
+`tests/conftest.py` — added the `configure_structlog_for_tests` autouse fixture; no test assertions were changed. This unblocks the existing failing test `tests/unit/test_batch_processor.py::TestBatchEmbeddingProcessor::test_empty_chunks_list_returns_empty` (which asserts on both `caplog.text` and `caplog.records`) and enables caplog-based assertions suite-wide.
+
+**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+- `make test-unit`: the fix takes the unit suite from 53 failing to 52 (fixes the target test, zero new failures). The remaining 52 failures are pre-existing and unrelated to #159 (async-mock setup and domain-logic issues in `review_service`, `resume_parser`, `tech_detector`, etc.).
+- `make check`: `tests/conftest.py` is clean under `ruff` and `black`; `mypy`'s `typecheck` target does not cover `tests/`. The 182 `make check` errors are all pre-existing and outside the scope of this issue.
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -66,3 +66,36 @@ Added an autouse fixture in `tests/conftest.py` that reconfigures structlog to r
 - `make check`: `tests/conftest.py` is clean under `ruff` and `black`; `mypy`'s `typecheck` target does not cover `tests/`. The 182 `make check` errors are all pre-existing and outside the scope of this issue.
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No review came in for my Pull Request.
+
+**How you responded:**
+I did not receive feedback.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+What was harder than I expected was the workflow process of finding the offending part of the codebase, then ensuring that I understood why it was a problem in the issue on GitHub, before then having to understand how to implement a fix in the way that meets Contributor standards.
+
+**What did you learn about working in a large codebase?**
+When I'm building my own project, I know what I want, and I am free to implement changes as I see fit, I have an easier time remembering which parts of the codebase correspond to which module, I am familiar with libraries that I use, and I don't have to wait for pull requests to make progress in the project.
+
+When contributing to someone else's production code, I have very limited insight of the codebase. I feel like that unless I use the project frequently in my day-to-day work, I don't have as much of an incentive or project-wide knowledge to make meaningful contributions to someone else's codebase. ALso having to follow their conventions is expected, but I think community code contributions have multiple layers of friction: making the right changes, following conventions, understanding the relevant parts of the codebase, determining if it is even worth contributing, etc.
+
+**How did AI tools help — and where did they fall short?**
+For this module, AI assistance was the most useful in gaining the understanding of the codebase. I understood what test_batch_processor.py was meant to do, and I was able to make targeted changes that fixed a bug and made one more test pass. For my intervention, I still needed to direct Claude Code to make sure contributor guidelines were met, and I ran the tests myself.
+
+**What would you do differently if you started over?**
+One thing that I would do differently, is picking a different, more difficult issue that doesn't involve the test case itself, but rather some implementation that has a test case. I feel like with so many different issues to take on for Pathreview, it's hard to say that seeing test cases would be useful if I only expect a few of them to fail, not many of them at once.
+
+**What are you most proud of from this module?**
+I'm most proud of practicing on making my first pull request on a somewhat real codebase. With the current hiring environment, I'm not too sure if hiring managers or recruiters pay attention to contributions made on GitHub, or work past the resume. With AI being able to fill out resumes and submit them, I'm not too sure if credentials on my Resume or contributions on GitHub would matter as much as before AI.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -51,7 +51,7 @@ Time management is an issue. I've been busy throughout the entire week, and did 
 
 ### Check-in 2 (end of week)
 
-**PR link:** [link to your submitted pull request]
+**PR link:** https://github.com/ascherj/pathreview/pull/672
 
 **Branch:** bug/159-structlog-output-not-captured-by-pytest-caplog
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -17,3 +17,19 @@ The test_batch_processor.py unit test is currently broken. A fix would include c
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [link to commit documenting the reproduced issue]
+
+**Failing test:** `tests/unit/test_batch_processor.py::TestBatchEmbeddingProcessor::test_empty_chunks_list_returns_empty`
+
+**Steps to reproduce:**
+1. From the repo root, run the batch processor unit tests:
+   ```
+   python -m pytest tests/unit/test_batch_processor.py -v
+   ```
+2. Observe the result: `1 failed, 10 passed`.
+
+**Reproduction summary:**
+`test_empty_chunks_list_returns_empty` fails with `AssertionError: assert ('Empty chunks list' in '' or False)` — `caplog.text` is empty and `caplog.records` is empty. The captured stdout shows the warning *was* emitted (`[warning  ] Empty chunks list provided to BatchEmbeddingProcessor`), but structlog uses its default configuration (`structlog.get_logger()` in `batch_processor.py:7`) which prints straight to stdout instead of propagating through Python's stdlib `logging`. Since pytest's `caplog` fixture only captures stdlib `logging` output, the log record never reaches `caplog`, so the assertion fails even though the code runs correctly.

--- a/PLAN.md
+++ b/PLAN.md
@@ -3,7 +3,6 @@
 **Issue:** https://github.com/ascherj/pathreview/issues/159
 
 ### Understand
-What is the root cause of this issue? What behavior is expected vs. actual?
 
 **Root cause:** structlog is left at its *default* configuration during test runs. The default uses `structlog.PrintLogger`, which writes rendered events straight to `stdout` and never propagates them through Python's stdlib `logging` system. pytest's `caplog` fixture only captures records that flow through stdlib `logging`, so `caplog.text` and `caplog.records` are always empty.
 
@@ -22,7 +21,6 @@ The project already has correct routing in `core/logging.py::configure_logging()
 
 ### Plan
 
-
 1. **Add a structlog test fixture** in `tests/conftest.py`: an `autouse=True` fixture that calls `structlog.configure(...)` with `logger_factory=structlog.stdlib.LoggerFactory()`, `cache_logger_on_first_use=False`, and a plain (non-ANSI) renderer chain ending in `structlog.stdlib.ProcessorFormatter.wrap_for_formatter` / `ConsoleRenderer(colors=False)` so the event text lands in `caplog` cleanly.
 2. **Ensure caplog visibility:** confirm the fixture (or the test) sets the capture level so WARNING-level records propagate to `caplog` (the default caplog handler captures propagated records; set `caplog.set_level`/root level if needed).
 3. **Run the target test:** `python -m pytest tests/unit/test_batch_processor.py -v` and expect `11 passed`.
@@ -30,13 +28,11 @@ The project already has correct routing in `core/logging.py::configure_logging()
 5. **Commit** the reproduction and fix, then link the commit in `JOURNAL.md`.
 
 ### Inputs & outputs
-What does your fix take as input? What should it produce or change?
 
 - **Input:** the current pytest environment with structlog unconfigured.
 - **Output/change:** a new fixture in `tests/conftest.py`. After the change, structlog log calls made anywhere in the codebase during tests are routed through stdlib `logging` and captured by `caplog`. `test_empty_chunks_list_returns_empty` passes, and all other `caplog`-based assertions across the suite work.
 
 ### Risks & unknowns
-What could go wrong? What are you still unsure about?
 
 - **Global config bleed:** `structlog.configure()` is process-global. An `autouse` session fixture makes it deterministic, and using `cache_logger_on_first_use=False` avoids stale cached loggers from module-import time.
 - **Renderer format:** if the renderer emits ANSI color codes, `caplog.text` substring checks could break, so use `colors=False` or a plain renderer in tests.
@@ -44,7 +40,6 @@ What could go wrong? What are you still unsure about?
 - **Unknown:** whether any existing passing test relies on the *default* stdout behavior. The full-suite run in step 4 will surface this.
 
 ### Edge cases
-What inputs or states should your fix handle gracefully?
 
 - Loggers created at module import time (before the fixture runs), handled by disabling logger caching so config is picked up on first log call.
 - Log records at various levels (debug/info/warning/error). The batch processor emits all of these, and the config should route each to stdlib logging without dropping the message text.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,52 @@
+## Solution plan
+
+**Issue:** https://github.com/ascherj/pathreview/issues/159
+
+### Understand
+What is the root cause of this issue? What behavior is expected vs. actual?
+
+**Root cause:** structlog is left at its *default* configuration during test runs. The default uses `structlog.PrintLogger`, which writes rendered events straight to `stdout` and never propagates them through Python's stdlib `logging` system. pytest's `caplog` fixture only captures records that flow through stdlib `logging`, so `caplog.text` and `caplog.records` are always empty.
+
+The project already has correct routing in `core/logging.py::configure_logging()`. That function calls `structlog.configure(..., logger_factory=structlog.stdlib.LoggerFactory())`, which sends events through stdlib `logging`. The problem is that **nothing calls `configure_logging()` during tests** (there is no structlog setup in `tests/conftest.py`), so the default config is what's active.
+
+- **Expected:** A `logger.warning(...)` emitted by application code is captured by `caplog`, so `"Empty chunks list" in caplog.text` is `True`.
+- **Actual:** The warning is printed to stdout (visible in pytest's "Captured stdout"), but `caplog.text == ''`, so the assertion fails with `AssertionError: assert ('Empty chunks list' in '' or False)`.
+
+### Map
+
+- `tests/conftest.py`: **primary change.** Add an `autouse`, session-scoped fixture that configures structlog to route through stdlib `logging` before any test logs.
+- `core/logging.py::configure_logging()`: existing reference implementation. The fixture will reuse its `LoggerFactory()` approach (or call it directly with a test-appropriate renderer).
+- `ingestion/embeddings/batch_processor.py:7`: the module under test. It uses `logger = structlog.get_logger()` and needs **no change**, since it already goes through the global structlog config.
+- `tests/unit/test_batch_processor.py:36-44`: the failing test. It needs **no change** once routing is fixed.
+- The 30+ other modules using `structlog.get_logger()` benefit automatically, with no per-module changes.
+
+### Plan
+
+
+1. **Add a structlog test fixture** in `tests/conftest.py`: an `autouse=True` fixture that calls `structlog.configure(...)` with `logger_factory=structlog.stdlib.LoggerFactory()`, `cache_logger_on_first_use=False`, and a plain (non-ANSI) renderer chain ending in `structlog.stdlib.ProcessorFormatter.wrap_for_formatter` / `ConsoleRenderer(colors=False)` so the event text lands in `caplog` cleanly.
+2. **Ensure caplog visibility:** confirm the fixture (or the test) sets the capture level so WARNING-level records propagate to `caplog` (the default caplog handler captures propagated records; set `caplog.set_level`/root level if needed).
+3. **Run the target test:** `python -m pytest tests/unit/test_batch_processor.py -v` and expect `11 passed`.
+4. **Run the full suite:** `python -m pytest` to confirm no regressions from changing the global structlog config (watch for tests that assert on raw stdout instead of caplog).
+5. **Commit** the reproduction and fix, then link the commit in `JOURNAL.md`.
+
+### Inputs & outputs
+What does your fix take as input? What should it produce or change?
+
+- **Input:** the current pytest environment with structlog unconfigured.
+- **Output/change:** a new fixture in `tests/conftest.py`. After the change, structlog log calls made anywhere in the codebase during tests are routed through stdlib `logging` and captured by `caplog`. `test_empty_chunks_list_returns_empty` passes, and all other `caplog`-based assertions across the suite work.
+
+### Risks & unknowns
+What could go wrong? What are you still unsure about?
+
+- **Global config bleed:** `structlog.configure()` is process-global. An `autouse` session fixture makes it deterministic, and using `cache_logger_on_first_use=False` avoids stale cached loggers from module-import time.
+- **Renderer format:** if the renderer emits ANSI color codes, `caplog.text` substring checks could break, so use `colors=False` or a plain renderer in tests.
+- **Level filtering:** `structlog.stdlib.filter_by_level` plus caplog's default level must allow WARNING through. Verify this with the full-suite run.
+- **Unknown:** whether any existing passing test relies on the *default* stdout behavior. The full-suite run in step 4 will surface this.
+
+### Edge cases
+What inputs or states should your fix handle gracefully?
+
+- Loggers created at module import time (before the fixture runs), handled by disabling logger caching so config is picked up on first log call.
+- Log records at various levels (debug/info/warning/error). The batch processor emits all of these, and the config should route each to stdlib logging without dropping the message text.
+- Tests that assert on `caplog.records[*].message` versus `caplog.text`. Both must be populated, so the message string emitted to the stdlib logger must contain the event text.
+- Exception logging (`logger.error(..., error=str(e))`) paths in `batch_processor.process`, which should still render and be capturable.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,42 @@
 """Shared test fixtures for PathReview."""
 
+import logging
+from collections.abc import Iterator
+
 import pytest
+import structlog
+
+
+@pytest.fixture(autouse=True)
+def configure_structlog_for_tests() -> Iterator[None]:
+    """Route structlog events through stdlib ``logging`` so pytest's ``caplog``
+    can capture them.
+
+    By default structlog uses ``PrintLogger``, which writes rendered events
+    straight to stdout and never touches stdlib ``logging``. Since ``caplog``
+    only sees records that flow through stdlib ``logging``, log-based
+    assertions would always fail. Configuring a ``stdlib.LoggerFactory`` with a
+    plain (non-ANSI) renderer fixes this for every test.
+    """
+    structlog.configure(
+        processors=[
+            structlog.stdlib.filter_by_level,
+            structlog.stdlib.add_logger_name,
+            structlog.stdlib.add_log_level,
+            structlog.stdlib.PositionalArgumentsFormatter(),
+            structlog.processors.StackInfoRenderer(),
+            structlog.processors.format_exc_info,
+            structlog.processors.UnicodeDecoder(),
+            structlog.dev.ConsoleRenderer(colors=False),
+        ],
+        context_class=dict,
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        cache_logger_on_first_use=False,
+    )
+    # Ensure WARNING-level records propagate to caplog's handler.
+    logging.getLogger().setLevel(logging.DEBUG)
+    yield
+    structlog.reset_defaults()
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
structlog was left at its default configuration during test runs, where `PrintLogger` writes rendered events straight to stdout without passing through Python's stdlib `logging`. Because pytest's `caplog` fixture only captures records that flow through stdlib `logging`, `caplog.text` and `caplog.records` were always empty and every log-based assertion failed. This PR adds an autouse pytest fixture that reconfigures structlog to route through stdlib `logging` for the duration of the test session, so caplog captures log output as expected.

## Issue
Closes #159

## Changes
- Added an autouse `configure_structlog_for_tests` fixture in `tests/conftest.py` that calls `structlog.configure(...)` with `logger_factory=structlog.stdlib.LoggerFactory()`, `cache_logger_on_first_use=False`, and a plain non-ANSI `ConsoleRenderer(colors=False)`.
- Raised the root logger level to `DEBUG` in the fixture so WARNING-level records propagate to caplog's handler.
- Reset structlog to its defaults on fixture teardown to avoid process-global config bleed between test sessions.
- No application code or test assertions were changed; the fix is test-infrastructure only.

## Testing
- [ ] Unit tests pass (`make test-unit`): target test `test_empty_chunks_list_returns_empty` now passes; the suite goes from 53 to 52 failures with **zero new failures**. The remaining 52 are pre-existing and unrelated to this issue (async-mock setup and domain-logic issues in `review_service`, `resume_parser`, `tech_detector`, etc.).
- [ ] Integration tests pass (`make test-integration`): N/A. The repo has no integration tests yet (`tests/integration/` contains only `__init__.py`), so the target collects 0 tests (pytest exit code 5).
- [ ] Linter passes (`make lint`): `tests/conftest.py` is clean under `ruff`; the 182 repo-wide errors are pre-existing and outside this issue's scope.
- [ ] Type checker passes (`make typecheck`): the `typecheck` target does not cover `tests/`; `tests/conftest.py` carries a full return-type annotation (`-> Iterator[None]`).
- [x] New/updated tests cover the changes: the fixture unblocks the existing failing test, which asserts on both `caplog.text` and `caplog.records`.

## Screenshots / Demo
None

## Notes for Reviewers
- The fix is process-global by nature (`structlog.configure()` affects the whole process). The autouse plus session determinism and `cache_logger_on_first_use=False` are deliberate so module-import-time loggers still pick up the config on first log call.
- The pre-existing suite failures are not touched by this change; see the baseline comparison in the Testing section. Verified by stashing the fixture and re-running: identical failure set minus the one this PR fixes.