### PR TITLE
fix(api): reject review creation for profiles with no ingested content

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -15,4 +15,4 @@ The review routes have basically no test coverage right now. The file the issue 
 
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
-**Cohort ledger:** [ ] Issue added to cohort ledger
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -11,6 +11,9 @@
 **Problem summary:**
 The review routes have basically no test coverage right now. The file the issue points to, tests/unit/test_review_routes.py, does not even exist in the repo. The closest thing we have is tests/unit/test_review_service.py, and that file only tests create_review, get_review, and list_reviews against a mocked DB session. It never spins up the actual POST /reviews endpoint and never touches process_review, which is the background task that actually runs the ingestion pipeline. So right now nothing proves what happens when someone creates a review for a profile that has no github username, portfolio url, or resume text on file. A fix here means adding a test that hits the endpoint with that kind of empty profile and confirms we get back a sane error instead of a crash or a silent pending review that never resolves.
 
+**Scope/fit reasoning:**
+I picked this one as my first issue because it's tagged tier 1 and good first issue, it's unassigned, and I checked issue #88 directly and confirmed it says no pull requests yet. The maintainer estimated 2 to 3 hours for it too. It stays contained to one endpoint and one new test file, so I don't need to fully understand the AI internals fully in depth, just enough to know what should happen when there are no ingested documents. I also noticed a bunch of other tier 1 issues like issue #149 already have open PRs from other students, so that's why I also decided on this one.
+
 **Branch name:** test/88-review-no-ingested-content
 
 **Setup confirmation:** [x] App runs locally at localhost:5173

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,18 @@
+# Journal
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/88
+
+**Issue title:** POST /reviews endpoint has no test for when the profile has no ingested documents
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The review routes have basically no test coverage right now. The file the issue points to, tests/unit/test_review_routes.py, does not even exist in the repo. The closest thing we have is tests/unit/test_review_service.py, and that file only tests create_review, get_review, and list_reviews against a mocked DB session. It never spins up the actual POST /reviews endpoint and never touches process_review, which is the background task that actually runs the ingestion pipeline. So right now nothing proves what happens when someone creates a review for a profile that has no github username, portfolio url, or resume text on file. A fix here means adding a test that hits the endpoint with that kind of empty profile and confirms we get back a sane error instead of a crash or a silent pending review that never resolves.
+
+**Branch name:** test/88-review-no-ingested-content
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -19,3 +19,23 @@ I picked this one as my first issue because it's tagged tier 1 and good first is
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/Anthony-Jerez/pathreview/commit/4b19bf2
+
+**Reproduction summary:**
+I wrote a test that POSTs to /reviews for a profile with no github username, portfolio url, or resume text, and expects a 422 back. Running it against the current code shows the endpoint always returns 200 instead, which confirms there is no validation anywhere in the request path for a profile with no ingested content.
+
+**Reproduction Steps:**
+1. Traced the full review creation flow through api/routes/reviews.py and core/services/review_service.py.
+2. Found that create_review_endpoint and create_review never check whether a profile has any ingested content, or even whether the profile exists, before creating the review and scheduling the background processing task.
+3. Wrote tests/unit/test_review_routes.py using FastAPI's TestClient, with get_current_user and get_db overridden and the background process_review task mocked out, so the test only exercises the endpoint's own logic.
+4. Ran pytest tests/unit/test_review_routes.py -v -m unit and got a failure: the response came back 200 instead of the 422 I asserted, which reproduces the exact gap issue 88 describes.
+
+**PLAN.md link:** https://github.com/Anthony-Jerez/pathreview/blob/test/88-review-no-ingested-content/PLAN.md
+
+**Walkthrough video (recommended):**
+
+**Blockers or open questions:**
+Still deciding whether "no ingested content" should be checked off the three profile fields directly or by counting IngestedSource rows for the profile. They're equivalent today but might not stay that way if ingestion changes later. Also haven't checked yet whether the frontend assumes review creation always succeeds, that needs a look before the actual fix goes in during week 9.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -73,3 +73,34 @@ tests/unit/test_review_routes.py now has three tests instead of the one reproduc
 Note on what "passes" means here: this codebase already has pre-existing failures unrelated to my change. make lint has 180 pre-existing errors repo wide (my two files went from 14 to 12 since I cleaned up an unused import and import ordering along the way), make typecheck fails early because of a numpy stub compatibility issue in this environment that happens with or without my change, and make test-unit already had 53 failing tests before I touched anything. I confirmed none of that is new. Before my fix, running the full suite gave 54 failed and 375 passed. After my fix it's 53 failed and 378 passed, so the one test I expected to flip did, two more tests got added, and nothing else changed. Scoped mypy on api/ and core/ with --ignore-missing-imports also stayed at exactly 62 errors before and after.
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No feedback yet on PR #673. It's still sitting open and unreviewed as of this check in.
+
+**How you responded:**
+
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Getting onboarded to the codebase was harder than I expected. Before I could even think about the fix, I had to spend real time just reading through api/routes/reviews.py and core/services/review_service.py to understand how a review actually gets created and processed. On top of that I had to make sure I had the right dependencies set up for the project to even run locally, and this was also my first real exposure to pytest, so fixtures, mocks, and the whole testing setup took some getting used to before I felt comfortable writing my own tests.
+
+**What did you learn about working in a large codebase?**
+Working in a codebase like this takes a lot more time up front than working on my own project would. I can't just start typing, I have to get familiar with how things are organized and how existing pieces already solve similar problems before I add anything new. That extra time is what keeps me from introducing bugs I didn't mean to, and it also makes sure whatever I write is something another contributor could actually follow and understand later. I saw this play out directly with my own fix. My first plan assumed checking IngestedSource rows would tell me whether a profile had content, but once I got into the actual implementation I realized that check was circular, since those rows only get created after a review already exists. I also ran into a good amount of pre-existing lint, type, and test failures in the repo that had nothing to do with my change, and I had to learn how to tell those apart from anything I introduced myself.
+
+**How did AI tools help — and where did they fall short?**
+AI tools were most helpful for understanding the codebase itself, explaining what functions did, walking me through unfamiliar syntax, and pointing me toward where the actual gap in the code was. Once it came to figuring out which edge cases actually mattered to test though, like the missing profile case, the no content case, and making sure the normal case still worked, I wanted to think through those myself instead of letting that get decided for me. That part felt like something I needed to reason through on my own to actually understand the issue.
+
+**What would you do differently if you started over?**
+I would spend more time in the planning step before jumping into implementation. My PLAN.md draft going into week 9 assumed the IngestedSource row count was a safe way to check for content, and that only got caught once I was actually writing the fix. If I had sat with the plan a little longer and traced through when those rows actually get created, I probably would have caught that circular logic earlier instead of correcting it mid implementation.
+
+**What are you most proud of from this module?**
+I'm most proud of getting to go through something that actually resembles a real open source contribution from start to finish. Picking an issue, reproducing it, writing an actual plan, implementing the fix, and opening a PR against it feels a lot more meaningful than just building something on my own from scratch, since it forced me to work within someone else's codebase and conventions the whole way through.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -81,7 +81,7 @@ Note on what "passes" means here: this codebase already has pre-existing failure
 **Feedback received:** [ ] Yes  [x] No — still awaiting review
 
 **Summary of feedback:**
-No feedback yet on PR #673. It's still sitting open and unreviewed as of this check in.
+No feedback yet on [PR #673](https://github.com/ascherj/pathreview/pull/673). It's still open and unreviewed as of this check in.
 
 **How you responded:**
 
@@ -91,16 +91,21 @@ No feedback yet on PR #673. It's still sitting open and unreviewed as of this ch
 ### Reflection
 
 **What was harder than you expected?**
+
 Getting onboarded to the codebase was harder than I expected. Before I could even think about the fix, I had to spend real time just reading through api/routes/reviews.py and core/services/review_service.py to understand how a review actually gets created and processed. On top of that I had to make sure I had the right dependencies set up for the project to even run locally, and this was also my first real exposure to pytest, so fixtures, mocks, and the whole testing setup took some getting used to before I felt comfortable writing my own tests.
 
 **What did you learn about working in a large codebase?**
-Working in a codebase like this takes a lot more time up front than working on my own project would. I can't just start typing, I have to get familiar with how things are organized and how existing pieces already solve similar problems before I add anything new. That extra time is what keeps me from introducing bugs I didn't mean to, and it also makes sure whatever I write is something another contributor could actually follow and understand later. I saw this play out directly with my own fix. My first plan assumed checking IngestedSource rows would tell me whether a profile had content, but once I got into the actual implementation I realized that check was circular, since those rows only get created after a review already exists. I also ran into a good amount of pre-existing lint, type, and test failures in the repo that had nothing to do with my change, and I had to learn how to tell those apart from anything I introduced myself.
+
+Working in a codebase like this takes a lot more time up front than working on my own project would. I can't just go straight into coding, I have to get familiar with how things are organized and how existing pieces already solve similar problems before I add anything new. That extra time is what keeps me from introducing bugs I didn't mean to, and it also makes sure whatever I write is something another contributor could actually follow and understand later. I saw this play out directly with my own fix. My first plan assumed checking IngestedSource rows would tell me whether a profile had content, but once I got into the actual implementation I realized that check was circular, since those rows only get created after a review already exists. I also ran into a good amount of pre-existing lint, type, and test failures in the repo that had nothing to do with my change, and I had to learn how to tell those apart from anything I introduced myself.
 
 **How did AI tools help — and where did they fall short?**
+
 AI tools were most helpful for understanding the codebase itself, explaining what functions did, walking me through unfamiliar syntax, and pointing me toward where the actual gap in the code was. Once it came to figuring out which edge cases actually mattered to test though, like the missing profile case, the no content case, and making sure the normal case still worked, I wanted to think through those myself instead of letting that get decided for me. That part felt like something I needed to reason through on my own to actually understand the issue.
 
 **What would you do differently if you started over?**
+
 I would spend more time in the planning step before jumping into implementation. My PLAN.md draft going into week 9 assumed the IngestedSource row count was a safe way to check for content, and that only got caught once I was actually writing the fix. If I had sat with the plan a little longer and traced through when those rows actually get created, I probably would have caught that circular logic earlier instead of correcting it mid implementation.
 
 **What are you most proud of from this module?**
-I'm most proud of getting to go through something that actually resembles a real open source contribution from start to finish. Picking an issue, reproducing it, writing an actual plan, implementing the fix, and opening a PR against it feels a lot more meaningful than just building something on my own from scratch, since it forced me to work within someone else's codebase and conventions the whole way through.
+
+I'm most proud of getting to go through something that actually resembles a real open source contribution from start to finish. Picking an issue, reproducing it, writing an actual plan, implementing the fix, and opening a PR for it feels a lot more meaningful than just building something on my own from scratch, since it forced me to work within someone else's codebase and conventions which is something I don't often have the chance to do.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -39,3 +39,37 @@ I wrote a test that POSTs to /reviews for a profile with no github username, por
 
 **Blockers or open questions:**
 Still deciding whether "no ingested content" should be checked off the three profile fields directly or by counting IngestedSource rows for the profile. They're equivalent today but might not stay that way if ingestion changes later. Also haven't checked yet whether the frontend assumes review creation always succeeds, that needs a look before the actual fix goes in during week 9.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+- I reviewed the tests/unit/ files to understand the pytest structure. I noticed standard patterns like prefixing names with "test", tagging classes with @pytest.mark.unit, and using @pytest.fixture for reusable setup and mocks.
+- I started creating fixtures and getting a better handle on how mocking is implemented while working on test_review_routes.py.
+
+**Next steps:**
+- I have to work on finalizing the test file to ensure all edge cases associated with this issue are covered.
+
+**Blockers:**
+- I'm still getting used to mocks, fixtures, and syntax.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** (to be filled in once I open the PR myself, see the title and description I've drafted in my notes)
+
+**Branch:** test/88-review-no-ingested-content
+
+**What you built:**
+POST /reviews now looks up the profile before creating anything, using the existing get_profile service. If the profile doesn't exist or isn't owned by the current user it returns 404, and if the profile exists but has no github username, portfolio url, or resume text, it returns 422 with a message explaining why. Only after both checks pass does it go on to create the review and schedule the background processing like before.
+
+**Tests added or updated:**
+tests/unit/test_review_routes.py now has three tests instead of the one reproduction test from week 8. One confirms 422 for a profile with no content, one confirms 404 for a profile that doesn't exist, and one is a regression check confirming a profile that does have content still gets back a 200 with status pending.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+Note on what "passes" means here: this codebase already has pre-existing failures unrelated to my change. make lint has 180 pre-existing errors repo wide (my two files went from 14 to 12 since I cleaned up an unused import and import ordering along the way), make typecheck fails early because of a numpy stub compatibility issue in this environment that happens with or without my change, and make test-unit already had 53 failing tests before I touched anything. I confirmed none of that is new. Before my fix, running the full suite gave 54 failed and 375 passed. After my fix it's 53 failed and 378 passed, so the one test I expected to flip did, two more tests got added, and nothing else changed. Scoped mypy on api/ and core/ with --ignore-missing-imports also stayed at exactly 62 errors before and after.
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -58,7 +58,7 @@ Still deciding whether "no ingested content" should be checked off the three pro
 
 ### Check-in 2 (end of week)
 
-**PR link:** (to be filled in once I open the PR myself, see the title and description I've drafted in my notes)
+**PR link:** https://github.com/ascherj/pathreview/pull/673
 
 **Branch:** test/88-review-no-ingested-content
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,38 @@
+# Solution plan
+
+**Issue:** POST /reviews endpoint has no test for when the profile has no ingested documents ([#88](https://github.com/ascherj/pathreview/issues/88))
+
+### Understand
+
+This isn't actually a crash bug. It's a missing validation gap. `create_review_endpoint` in api/routes/reviews.py and `create_review` in core/services/review_service.py never check whether a profile has any ingested content, or even whether the profile exists, before creating a Review row and kicking off the background processing task. Expected behavior is that a profile with no github_username, portfolio_url, or resume_text (and therefore no IngestedSource rows) should get a clear error back. Actual behavior is the endpoint always returns 200 with status "pending," and the background process_review task later marks it "complete" using hardcoded placeholder feedback sections that ignore whether any real content was ever ingested. I confirmed this with a reproduction test in tests/unit/test_review_routes.py that currently fails, since it expects a 422 and gets a 200 instead.
+
+### Map
+
+- api/routes/reviews.py, create_review_endpoint. This is where the validation needs to get added before the review gets scheduled.
+- core/services/review_service.py, create_review and _run_ingestion_pipeline. create_review is where the profile and its ingested content should get checked. _run_ingestion_pipeline is where the empty case is currently silently swallowed.
+- core/models/ingested_source.py and core/models/profile.py. These define what "has content" actually means right now: github_username, portfolio_url, resume_text on Profile, or rows in IngestedSource.
+- tests/unit/test_review_routes.py. This has the reproduction test and will need updating once the fix is in, plus a new regression test for the happy path.
+- api/schemas/review.py. Review already has an error_message field, so the response shape probably doesn't need to change much.
+
+### Plan
+
+1. Add a lookup in create_review (or right in the endpoint) that checks the profile exists and has at least one of github_username, portfolio_url, resume_text set, or has IngestedSource rows.
+2. If the profile doesn't exist or doesn't belong to the current user, return 404. If it exists but has no ingested content, return 422 with a clear detail message explaining why.
+3. Leave process_review defensive too, so if it ever gets called directly outside the endpoint it still fails safely instead of completing with fake content.
+4. Update the reproduction test in tests/unit/test_review_routes.py so it asserts the new passing behavior, and add a second test confirming a profile that does have content still returns 200 with status "pending" like before.
+5. Check frontend/src/pages/ReviewPage.tsx and frontend/src/hooks/useReviewStatus.ts to see if they assume review creation always succeeds, and update them to handle the new error response if needed.
+
+### Inputs & outputs
+
+Input stays the same, just profile_id on POST /reviews. What changes is the output: a profile with no ingested content now gets a 422 with an explanation instead of a silent 200. A missing or not-owned profile now gets a 404 instead of being allowed through. The happy path response shape doesn't change at all.
+
+### Risks & unknowns
+
+I'm still not sure whether "has content" should be based on the three profile fields directly or on actually counting IngestedSource rows for that profile. Right now they're equivalent since _run_ingestion_pipeline is the only thing that ever creates IngestedSource rows, but ingestion/pipeline.py has placeholder logic hinting at a bigger real ingestion pipeline down the line, so checking IngestedSource directly is probably more future proof. I also don't know if the frontend assumes POST /reviews always succeeds, that needs a quick look before shipping this. And there's no existing DB backed integration test pattern in this repo, everything so far is mocked sessions, so a more realistic end to end test isn't something I can model off an existing example yet.
+
+### Edge cases
+
+- Profile ID doesn't exist at all, should be 404.
+- Profile has resume_filename set but resume_text is empty or null, that's a partial upload and probably still counts as no content.
+- A future ingestion path creates IngestedSource rows without ever touching the three profile text fields, the check should hold up against that by counting IngestedSource rows instead of only checking the profile fields.
+- Someone uploads content to their profile while a review request for that same profile is already in flight, this is a race condition I'm noting but not planning to handle in this fix.

--- a/PLAN.md
+++ b/PLAN.md
@@ -18,9 +18,9 @@ This isn't actually a crash bug. It's a missing validation gap. `create_review_e
 
 1. Add a lookup in create_review (or right in the endpoint) that checks the profile exists and has at least one of github_username, portfolio_url, resume_text set, or has IngestedSource rows.
 2. If the profile doesn't exist or doesn't belong to the current user, return 404. If it exists but has no ingested content, return 422 with a clear detail message explaining why.
-3. Leave process_review defensive too, so if it ever gets called directly outside the endpoint it still fails safely instead of completing with fake content.
-4. Update the reproduction test in tests/unit/test_review_routes.py so it asserts the new passing behavior, and add a second test confirming a profile that does have content still returns 200 with status "pending" like before.
-5. Check frontend/src/pages/ReviewPage.tsx and frontend/src/hooks/useReviewStatus.ts to see if they assume review creation always succeeds, and update them to handle the new error response if needed.
+3. ~~Leave process_review defensive too~~ Decided against this. Since the endpoint now blocks the request before process_review is ever scheduled for these cases, adding a second defensive check deeper in the pipeline would be speculative, unreachable code. Kept the fix to the one place it's actually needed.
+4. Update the reproduction test in tests/unit/test_review_routes.py so it asserts the new passing behavior, and add a second test confirming a profile that does have content still returns 200 with status "pending" like before. Done, plus a third test for the 404 case.
+5. ~~Check frontend/src/pages/ReviewPage.tsx and frontend/src/hooks/useReviewStatus.ts~~ Checked, no changes needed (see Risks & unknowns).
 
 ### Inputs & outputs
 
@@ -28,7 +28,11 @@ Input stays the same, just profile_id on POST /reviews. What changes is the outp
 
 ### Risks & unknowns
 
-I'm still not sure whether "has content" should be based on the three profile fields directly or on actually counting IngestedSource rows for that profile. Right now they're equivalent since _run_ingestion_pipeline is the only thing that ever creates IngestedSource rows, but ingestion/pipeline.py has placeholder logic hinting at a bigger real ingestion pipeline down the line, so checking IngestedSource directly is probably more future proof. I also don't know if the frontend assumes POST /reviews always succeeds, that needs a quick look before shipping this. And there's no existing DB backed integration test pattern in this repo, everything so far is mocked sessions, so a more realistic end to end test isn't something I can model off an existing example yet.
+Resolved: I went with checking the three profile fields directly instead of counting IngestedSource rows. Counting IngestedSource rows turned out to be circular, those rows only ever get created during process_review, which only runs after a review already exists. So a brand new profile would always show zero IngestedSource rows even if it's about to get real content ingested. The profile fields are the actual raw input the user provided, so that's the right thing to check before a review is ever created.
+
+Resolved: the frontend does not assume POST /reviews always succeeds. frontend/src/services/api.ts already throws on any non 2xx response using the server's error detail, and frontend/src/pages/NewProfilePage.tsx already catches that and redirects to the dashboard. No frontend changes were needed.
+
+Still true: there's no existing DB backed integration test pattern in this repo, everything so far is mocked sessions, so a more realistic end to end test isn't something I could model off an existing example. I stuck with the mocked TestClient approach for consistency with the rest of tests/unit/.
 
 ### Edge cases
 

--- a/api/routes/reviews.py
+++ b/api/routes/reviews.py
@@ -1,12 +1,13 @@
-from fastapi import APIRouter, Depends, HTTPException, status, BackgroundTasks
 from uuid import UUID
-import structlog
 
-from api.schemas.review import ReviewCreate, ReviewResponse, ReviewListResponse
+import structlog
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
+
 from api.middleware.auth import get_current_user
-from core.models.user import User
-from core.models.review import Review
+from api.schemas.review import ReviewCreate, ReviewListResponse, ReviewResponse
 from core.database import get_db
+from core.models.user import User
+from core.services.profile_service import get_profile
 from core.services.review_service import (
     create_review,
     get_review,
@@ -32,6 +33,23 @@ async def create_review_endpoint(
     Returns review with status="pending" immediately.
     """
     try:
+        profile = await get_profile(
+            db=db, profile_id=data.profile_id, user_id=UUID(current_user.id)
+        )
+
+        if not profile:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Profile not found",
+            )
+
+        if not any([profile.github_username, profile.portfolio_url, profile.resume_text]):
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="Profile has no ingested content. Add a GitHub username, "
+                "portfolio URL, or resume before requesting a review.",
+            )
+
         # Create review with status="pending"
         review = await create_review(
             db=db,

--- a/tests/unit/test_review_routes.py
+++ b/tests/unit/test_review_routes.py
@@ -1,0 +1,90 @@
+"""Tests for reviews routes - issue #88 reproduction."""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, Mock, patch
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.main import app
+from api.middleware.auth import get_current_user
+from core.database import get_db
+from core.models.profile import Profile
+from core.models.user import User
+
+
+@pytest.mark.unit
+class TestCreateReviewNoIngestedContent:
+    """Reproduction test suite for issue #88."""
+
+    @pytest.fixture
+    def mock_user(self):
+        """Create a mock authenticated User."""
+        user = Mock(spec=User)
+        user.id = str(uuid4())
+        return user
+
+    @pytest.fixture
+    def mock_profile_no_content(self):
+        """A profile that exists but has no github/portfolio/resume data."""
+        profile = Mock(spec=Profile)
+        profile.id = str(uuid4())
+        profile.github_username = None
+        profile.portfolio_url = None
+        profile.resume_text = None
+        return profile
+
+    @pytest.fixture
+    def client(self, mock_user):
+        """TestClient with get_db/get_current_user overridden and DB startup mocked."""
+
+        async def _override_get_db():
+            session = AsyncMock()
+            session.add = Mock()
+            session.commit = AsyncMock()
+            session.refresh = AsyncMock()
+            yield session
+
+        app.dependency_overrides[get_current_user] = lambda: mock_user
+        app.dependency_overrides[get_db] = _override_get_db
+
+        with patch("api.main.init_db", new=AsyncMock()):
+            with TestClient(app) as test_client:
+                yield test_client
+
+        app.dependency_overrides.clear()
+
+    def test_create_review_for_profile_with_no_ingested_content_returns_error(
+        self, client, mock_profile_no_content
+    ):
+        """POST /reviews for a profile with no ingested content should return an error, not 200.
+
+        Reproduction of issue #88: create_review_endpoint currently has no
+        check for missing ingested content, so this assertion fails today
+        (actual response is 200) instead of the expected 422.
+        """
+        now = datetime.now(UTC)
+        mock_review = Mock()
+        mock_review.id = uuid4()
+        mock_review.profile_id = UUID(mock_profile_no_content.id)
+        mock_review.status = "pending"
+        mock_review.sections = None
+        mock_review.overall_score = None
+        mock_review.error_message = None
+        mock_review.created_at = now
+        mock_review.updated_at = now
+
+        with (
+            patch("core.services.review_service.Review", return_value=mock_review),
+            patch("api.routes.reviews.process_review", new=AsyncMock()),
+        ):
+            response = client.post(
+                "/reviews",
+                json={"profile_id": mock_profile_no_content.id},
+            )
+
+        assert response.status_code == 422, (
+            "Expected the endpoint to reject a profile with no ingested "
+            f"content, but got {response.status_code}: {response.text}"
+        )

--- a/tests/unit/test_review_routes.py
+++ b/tests/unit/test_review_routes.py
@@ -1,4 +1,4 @@
-"""Tests for reviews routes - issue #88 reproduction."""
+"""Tests for reviews routes - issue #88."""
 
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, Mock, patch
@@ -14,9 +14,21 @@ from core.models.profile import Profile
 from core.models.user import User
 
 
+def _mock_profile_lookup(mock_db_session, profile):
+    """Configure mock_db_session.execute so get_profile() returns the given profile (or None).
+
+    db.execute() is the only async part of SQLAlchemy's async API; the returned
+    Result object's .scalars()/.first() are synchronous, so the result itself
+    must be a plain Mock, not an AsyncMock.
+    """
+    mock_result = Mock()
+    mock_result.scalars.return_value.first.return_value = profile
+    mock_db_session.execute = AsyncMock(return_value=mock_result)
+
+
 @pytest.mark.unit
-class TestCreateReviewNoIngestedContent:
-    """Reproduction test suite for issue #88."""
+class TestCreateReviewEndpoint:
+    """Test suite for POST /reviews, covering issue #88 (no ingested content)."""
 
     @pytest.fixture
     def mock_user(self):
@@ -24,6 +36,15 @@ class TestCreateReviewNoIngestedContent:
         user = Mock(spec=User)
         user.id = str(uuid4())
         return user
+
+    @pytest.fixture
+    def mock_db_session(self):
+        """Create a mock async database session."""
+        session = AsyncMock()
+        session.add = Mock()
+        session.commit = AsyncMock()
+        session.refresh = AsyncMock()
+        return session
 
     @pytest.fixture
     def mock_profile_no_content(self):
@@ -36,38 +57,65 @@ class TestCreateReviewNoIngestedContent:
         return profile
 
     @pytest.fixture
-    def client(self, mock_user):
+    def mock_profile_with_content(self):
+        """A profile with a github username set."""
+        profile = Mock(spec=Profile)
+        profile.id = str(uuid4())
+        profile.github_username = "octocat"
+        profile.portfolio_url = None
+        profile.resume_text = None
+        return profile
+
+    @pytest.fixture
+    def client(self, mock_user, mock_db_session):
         """TestClient with get_db/get_current_user overridden and DB startup mocked."""
 
         async def _override_get_db():
-            session = AsyncMock()
-            session.add = Mock()
-            session.commit = AsyncMock()
-            session.refresh = AsyncMock()
-            yield session
+            yield mock_db_session
 
         app.dependency_overrides[get_current_user] = lambda: mock_user
         app.dependency_overrides[get_db] = _override_get_db
 
-        with patch("api.main.init_db", new=AsyncMock()):
-            with TestClient(app) as test_client:
-                yield test_client
+        with patch("api.main.init_db", new=AsyncMock()), TestClient(app) as test_client:
+            yield test_client
 
         app.dependency_overrides.clear()
 
-    def test_create_review_for_profile_with_no_ingested_content_returns_error(
-        self, client, mock_profile_no_content
+    def test_create_review_for_profile_with_no_ingested_content_returns_422(
+        self, client, mock_db_session, mock_profile_no_content
     ):
-        """POST /reviews for a profile with no ingested content should return an error, not 200.
+        """POST /reviews for a profile with no ingested content returns 422, not a crash."""
+        _mock_profile_lookup(mock_db_session, mock_profile_no_content)
 
-        Reproduction of issue #88: create_review_endpoint currently has no
-        check for missing ingested content, so this assertion fails today
-        (actual response is 200) instead of the expected 422.
-        """
+        response = client.post(
+            "/reviews",
+            json={"profile_id": mock_profile_no_content.id},
+        )
+
+        assert response.status_code == 422
+        assert "ingested content" in response.json()["detail"].lower()
+
+    def test_create_review_for_missing_profile_returns_404(self, client, mock_db_session):
+        """POST /reviews for a profile_id that doesn't exist (or isn't owned) returns 404."""
+        _mock_profile_lookup(mock_db_session, None)
+
+        response = client.post(
+            "/reviews",
+            json={"profile_id": str(uuid4())},
+        )
+
+        assert response.status_code == 404
+
+    def test_create_review_for_profile_with_content_returns_pending(
+        self, client, mock_db_session, mock_profile_with_content
+    ):
+        """POST /reviews for a profile with content still returns 200 with status pending."""
+        _mock_profile_lookup(mock_db_session, mock_profile_with_content)
+
         now = datetime.now(UTC)
         mock_review = Mock()
         mock_review.id = uuid4()
-        mock_review.profile_id = UUID(mock_profile_no_content.id)
+        mock_review.profile_id = UUID(mock_profile_with_content.id)
         mock_review.status = "pending"
         mock_review.sections = None
         mock_review.overall_score = None
@@ -81,10 +129,8 @@ class TestCreateReviewNoIngestedContent:
         ):
             response = client.post(
                 "/reviews",
-                json={"profile_id": mock_profile_no_content.id},
+                json={"profile_id": mock_profile_with_content.id},
             )
 
-        assert response.status_code == 422, (
-            "Expected the endpoint to reject a profile with no ingested "
-            f"content, but got {response.status_code}: {response.text}"
-        )
+        assert response.status_code == 200
+        assert response.json()["status"] == "pending"


### PR DESCRIPTION
## Summary

POST /reviews accepted any profile_id, including profiles with no github_username, portfolio_url, or resume_text, and always returned 200 with status "pending." The background processing task would later mark it "complete" using hardcoded placeholder feedback, regardless of whether any real content existed. The endpoint now validates the profile before creating a review and returns a clear error instead.

## Issue

Closes #88

## Changes

Root cause: create_review_endpoint and create_review never checked whether a profile exists or has any content before scheduling a review. This wasn't a crash, it was a silent success on bad input.

- `api/routes/reviews.py` - create_review_endpoint now looks up the profile with the existing get_profile service before creating a review. Returns 404 if the profile doesn't exist or isn't owned by the current user, and 422 if the profile exists but has no github_username, portfolio_url, or resume_text
- Reused core/services/profile_service.py's get_profile, which already does an ownership-checked lookup. No new exception classes or service-layer changes were needed
- `tests/unit/test_review_routes.py` - added test_create_review_for_profile_with_no_ingested_content_returns_422, test_create_review_for_missing_profile_returns_404, and a regression test test_create_review_for_profile_with_content_returns_pending confirming the happy path still returns 200

## Testing

- [x] Unit tests pass (`make test-unit`) - 378 passed, 53 failed. The 53 failures are pre-existing and unrelated to this change (see Notes for Reviewers)
- [x] New/updated tests cover the changes

**Reproduce the original bug (before the fix):**
1. Check out `main`
2. Run `make run`
3. Create a profile with no github username, portfolio url, or resume (e.g. via POST /profiles with all fields empty)
4. POST /reviews with that profile's id
5. Observe: response is 200 OK with status "pending," even though the profile has nothing to review

**Verify the fix (on this branch):**
1. Check out `test/88-review-no-ingested-content`
2. Run `make run`
3. Repeat the same empty-profile POST /reviews request
4. Expected: response is 422 with body:
   `{"detail": "Profile has no ingested content. Add a GitHub username, portfolio URL, or resume before requesting a review."}`
5. A POST /reviews for a profile_id that doesn't exist now returns 404 instead of silently succeeding

## Screenshots / Demo

## Notes for Reviewers

This repo has pre-existing issues unrelated to this PR:
- `make test-unit` has 53 failing tests before this change (confirmed by running against `main`). This PR doesn't touch any of those files.
- `make lint` reports 180 pre-existing errors repo-wide. The two files this PR touches actually went from 14 to 12 ruff errors (cleaned up an unused import and import ordering as a drive-by), no new categories introduced.
- `make typecheck` fails early in this environment due to a numpy/mypy stub compatibility issue unrelated to any code change. Running mypy scoped to `api/ core/` with `--ignore-missing-imports` (bypassing that environment issue) shows exactly 62 pre-existing errors both before and after this change.

See PLAN.md on this branch for the full reasoning, including why I checked the profile's own fields instead of counting IngestedSource rows (checking IngestedSource would be circular, since those rows are only created by the review process itself).