### PR TITLE
Fix/68 health check safety event count

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -43,17 +43,24 @@ hardcoded and never wired up to `SafetyMonitor`.
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** []
+**Reproduction commit link:** https://github.com/Ahmadkarim7/pathreview/commit/ff9e3af
 
 **Reproduction summary:**
-Logged a safety event via SafetyMonitor.log_event() and confirmed /health still
-returns safety_events_last_hour: 0 — the field exists but is hardcoded and was
-never wired up to the actual monitoring data.
+Logged a safety event directly via SafetyMonitor.log_event(), confirmed Redis stored
+the count (2), then immediately hit /health and found safety_events_last_hour still
+returned 0 — proving the field is hardcoded in api/routes/health.py and was never
+wired up to SafetyMonitor.
 
-**PLAN.md link:** [link to PLAN.md in your fork]
+**PLAN.md link:** https://github.com/Ahmadkarim7/pathreview/blob/fix/68-health-check-safety-event-count/PLAN.md
 
+**Walkthrough video (recommended):** (skipped)
 
 **Blockers or open questions:**
 Confirming with mentor whether another contributor (RadRebelSam) already has this
-issue in progress. Also flagged in PLAN.md that a fully accurate hourly count needs
-a bigger Redis storage change than the issue's estimate suggests.
+issue in progress, since they commented on #68 with a nearly identical branch name.
+Also noted in PLAN.md: a fully accurate hourly count needs a bigger Redis storage
+change (sorted sets vs. flat counters) than the issue's 2–4hr estimate suggests.
+Unrelated to this issue but observed during testing: /health's postgres and redis
+dependency checks are currently broken (SQLAlchemy text() issue and a missing
+settings.redis_host attribute) — flagging in case it's relevant, but not touching
+it since it's out of scope for #68.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -64,3 +64,64 @@ Unrelated to this issue but observed during testing: /health's postgres and redi
 dependency checks are currently broken (SQLAlchemy text() issue and a missing
 settings.redis_host attribute) — flagging in case it's relevant, but not touching
 it since it's out of scope for #68.
+
+
+## Week 9 — Implementation, tests, and PR
+
+**PR link:** https://github.com/ascherj/pathreview/pull/674
+
+**Branch name:** fix/68-health-check-safety-event-count
+
+**Summary of changes:**
+Implemented the fix in three commits following PLAN.md:
+
+1. Redesigned the Redis storage in safety/monitoring.py. The old incr/expire
+   counter never enforced window_hours (the docstring admitted it), so I switched
+   to a sorted set per event type (safety:events:{event_type}:zset) with the
+   event timestamp as the score. get_event_count() now prunes entries older than
+   the window with ZREMRANGEBYSCORE and counts with ZCARD, so "last hour" is
+   actually the last hour. Added get_total_event_count(window_hours=1) that sums
+   across all 5 VALID_EVENT_TYPES.
+2. Wired /health to real data. Created core/redis_client.py (shared Redis client
+   built from settings.redis_url, mirroring the get_db pattern in core/database.py)
+   and api/deps.py (a get_safety_monitor dependency). Replaced the hardcoded
+   safety_events_last_hour = 0 in api/routes/health.py with a real call, keeping
+   the existing try/except so Redis failures degrade to 0 instead of failing the
+   endpoint. One catch mypy saved me from: my first version used redis.asyncio,
+   but SafetyMonitor calls Redis synchronously — the async client would have
+   silently returned 0 forever. Switched the shared client to sync redis.
+3. Added tests/unit/test_health.py — 5 tests using an in-memory FakeRedis and
+   FastAPI dependency overrides. Getting these to run took real debugging: the
+   app's startup event calls init_db() against real Postgres, which broke
+   TestClient across multiple tests (event-loop reuse), so I monkeypatch init_db
+   to a no-op. I also had to patch the missing settings.redis_host/redis_port
+   attributes (the pre-existing bug I flagged in Week 8) because that broken
+   check flips /health to 503, which wraps the response in {"detail": ...} and
+   breaks assertions.
+
+**Tests touched:**
+tests/unit/test_health.py (new). Covers: recent events counted, no events
+returns 0, events older than 1 hour excluded (the actual windowing bug), multiple
+event types summed, and Redis-down falls back to 0. All 5 pass.
+
+**Self-review:**
+- make test-unit: my 5 tests pass. The suite has 53 pre-existing failures in
+  unrelated modules (bias detector, PII scrubber, resume parser, review service,
+  etc.). Verified they're pre-existing by running the suite with my changes
+  stashed (git stash) — same 53 failures, so my changes add zero new failures.
+- Pre-commit hooks (ruff, black, mypy) pass on both implementation commits. The
+  test commit was made with --no-verify: mypy follows test_health.py's import of
+  api.main into pre-existing untyped modules (36 errors, none in files this PR
+  touches). test_health.py itself is fully annotated and mypy-clean. Documented
+  in the PR description.
+- Pre-existing /health bugs (raw-SQL postgres check, missing settings.redis_host)
+  left untouched as out of scope, worked around in test fixtures only.
+- Migration note in PR: the storage format change means events logged under the
+  old safety:events:{event_type} counter keys won't be counted after this change.
+  I didn't find any other code reading the old key format.
+
+**Feedback:**
+Mentor confirmed earlier this week that overlap with RadRebelSam on #68 is fine
+for this course repo, so I proceeded. I've requested a review on the draft PR via
+Slack but have not received feedback back yet as of this entry — will incorporate
+any review comments before marking the PR ready for review.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -14,3 +14,46 @@ The `/health` API endpoint currently reports basic service status but has no vis
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+
+## Reproduction — Issue #68
+
+Ran the following to confirm the bug:
+
+    .venv/bin/python -c "
+    import redis
+    from safety.monitoring import SafetyMonitor
+
+    r = redis.Redis(host='localhost', port=6379, db=0, decode_responses=True)
+    monitor = SafetyMonitor(r)
+    monitor.log_event('content_filtered', {'reason': 'manual repro test'})
+    print('Stored count in Redis:', monitor.get_event_count('content_filtered'))
+    "
+
+Output: `Stored count in Redis: 2`
+
+Then immediately: `curl http://localhost:8000/health`
+
+Output: `"safety_events_last_hour":0`
+
+**Confirmed:** a real safety event exists in Redis (count = 2), but `/health` still
+reports `0`. This confirms `safety_events_last_hour` in `api/routes/health.py` is
+hardcoded and never wired up to `SafetyMonitor`.
+
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** []
+
+**Reproduction summary:**
+Logged a safety event via SafetyMonitor.log_event() and confirmed /health still
+returns safety_events_last_hour: 0 — the field exists but is hardcoded and was
+never wired up to the actual monitoring data.
+
+**PLAN.md link:** [link to PLAN.md in your fork]
+
+
+**Blockers or open questions:**
+Confirming with mentor whether another contributor (RadRebelSam) already has this
+issue in progress. Also flagged in PLAN.md that a fully accurate hourly count needs
+a bigger Redis storage change than the issue's estimate suggests.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,16 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/68
+
+**Issue title:** Add a safety event count to the health check endpoint
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The `/health` API endpoint currently reports basic service status but has no visibility into safety system activity. Operators who want to check on safety monitoring have to leave the health check and go query a separate dashboard, which is slow and easy to skip. This issue asks for a new `safety_events_last_hour` field to be added to the health check response, pulling that count from the safety monitoring logic. The fix mainly touches `api/routes/health.py` (the endpoint itself) and `safety/monitoring.py` (where safety event data is tracked). Once done, anyone hitting `/health` will immediately see recent safety event activity alongside normal service status.
+
+**Branch name:** fix/68-health-check-safety-event-count
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -125,3 +125,68 @@ Mentor confirmed earlier this week that overlap with RadRebelSam on #68 is fine
 for this course repo, so I proceeded. I've requested a review on the draft PR via
 Slack but have not received feedback back yet as of this entry — will incorporate
 any review comments before marking the PR ready for review.
+
+
+## Week 10 — Iteration & reflection
+ 
+### Reviewer feedback
+ 
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+ 
+**Summary of feedback:**
+No review has come in yet. I requested a review on the draft PR via Slack back in
+Week 9 and haven't heard back as of this entry.
+ 
+**How you responded:**
+N/A — nothing to respond to yet. If feedback comes in after this entry, I'll
+incorporate it and note the changes, but the PR is currently sitting as-is.
+ 
+---
+ 
+### Reflection
+ 
+**What was harder than you expected?**
+Python was the harder part for me overall — I'm not very familiar with the
+language, so things that probably would've been quick for someone with a Python
+background (the Redis sorted-set rewrite in `safety/monitoring.py`, wiring up
+FastAPI's dependency injection in `api/deps.py`, getting the sync-vs-async Redis
+client distinction right) took real time and trial and error. The mypy catch on
+the async client silently returning 0 forever is a good example — I wouldn't have
+caught that on my own without leaning on the tooling.
+ 
+**What did you learn about working in a large codebase?**
+The biggest difference from building my own project is how much of the work is
+scoping what *not* to touch. I found two real pre-existing bugs in `/health` (the
+broken Postgres check and the missing `settings.redis_host` attribute) while
+testing my fix, and the instinct is to just fix them since I'm already in there.
+But they were out of scope for #68, so I flagged them in the journal and PR
+description and worked around them in test fixtures instead. I also had to deal
+with someone else potentially working the same issue (RadRebelSam's nearly
+identical branch), which isn't something that comes up when you're the only one
+touching your own repo — it added a whole coordination step (checking with a
+mentor) that had nothing to do with the code itself.
+ 
+**How did AI tools help — and where did they fall short?**
+AI tools were most useful for translating what I understood conceptually
+(windowed counts, sorted sets vs. flat counters) into working Python syntax,
+especially early on when I wasn't confident in the language. Where they fell
+short was catching the subtler bugs — the sync/async Redis client issue was
+something mypy caught, not something I'd have thought to ask an AI tool to check
+for, since on the surface the async version looked like it should work fine.
+ 
+**What would you do differently if you started over?**
+I'd pick an issue that touched the RAG system, model tuning, or the multi-agent
+tooling instead of the health check endpoint. The safety/health work was a good
+intro issue for getting comfortable with the codebase and with Python, but it
+didn't get me into the parts of PathReview I'm actually most curious about. If I
+started over, I'd probably spend more time in Week 7 scanning the issue list
+specifically for something in `rag/` or `agent/`, even if it meant a steeper
+learning curve.
+ 
+**What are you most proud of from this module?**
+Getting through the Python unfamiliarity and still landing a real fix — not just
+a patch, but an actual redesign of the storage logic (counter → sorted set) that
+fixed a bug I found through testing (the windowing was never enforced) rather
+than just the bug the issue described. I came out of this wanting to keep doing
+open source contributions regularly, maybe about once a week, which wasn't
+something I expected going in.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,7 +1,7 @@
 ## Solution plan
 
 **Issue:** #68 — Add a safety event count to the health check endpoint
-https://github.com/ascherj/pathreview/issues/68
+https://github.com/Ahmadkarim7/pathreview/issues/68
 
 ### Understand
 The `/health` endpoint already has a `safety_events_last_hour` key in its response, but it's

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,130 @@
+## Solution plan
+
+**Issue:** #68 — Add a safety event count to the health check endpoint
+https://github.com/ascherj/pathreview/issues/68
+
+### Understand
+The `/health` endpoint already has a `safety_events_last_hour` key in its response, but it's
+hardcoded to `0` inside a placeholder try block in `api/routes/health.py`:
+
+```python
+try:
+    # This would be populated by actual safety event logging
+    health_status["safety_events_last_hour"] = 0
+except Exception as exc:
+    log.error("safety_events_check_failed", error=str(exc))
+```
+
+It never calls into `safety/monitoring.py`'s `SafetyMonitor` class. So the field exists but
+is disconnected from the actual safety event data.
+
+`SafetyMonitor.get_event_count(event_type, window_hours=1)` looks like the intended source
+of this data, but there are two problems with it as-is:
+1. It only returns a count for **one** event type at a time. The health check needs a total
+   across all 5 types in `VALID_EVENT_TYPES` (`pii_detected`, `injection_attempt`,
+   `content_filtered`, `bias_detected`, `rate_limited`).
+2. Its `window_hours` parameter is **not enforced** — the docstring says so explicitly.
+   The underlying Redis key (`safety:events:{event_type}`) is incremented with `incr` and
+   given a flat 24-hour expiry (`self.redis.expire(key, 86400)`). There's no per-hour
+   bucketing, so a count returned "for the last hour" could really reflect events from up
+   to 24 hours ago, until the key happens to expire.
+
+**Root cause:** (a) `health.py` was never wired up to `SafetyMonitor`, and (b) even if wired
+up, `SafetyMonitor` doesn't currently track events with real hourly granularity — only a
+rolling 24h counter per event type.
+
+### Map
+Files I expect to touch:
+- `api/routes/health.py` — replace the hardcoded `0` in the `safety_events_last_hour` block
+  with a real call into `SafetyMonitor`. Need to figure out how the endpoint gets access to
+  a Redis client / `SafetyMonitor` instance (it doesn't currently import either) — likely
+  via a new FastAPI dependency, similar to how `db=Depends(get_db)` works.
+- `safety/monitoring.py` — add a method (e.g. `get_total_event_count(window_hours=1)`) that
+  sums across all `VALID_EVENT_TYPES`, and fix the Redis key scheme so `window_hours` is
+  actually enforced (e.g. per-hour bucketed keys like `safety:events:{event_type}:{hour_bucket}`,
+  or a sorted set with timestamps and `ZREMRANGEBYSCORE` to drop entries older than the window).
+- Wherever the app's shared Redis client is created/injected (not yet located — need to
+  search for existing `Depends(...)` patterns near `get_db` in `core/`, since `health.py`
+  currently creates its own throwaway `redis.Redis(...)` instance inline just for the
+  dependency check, rather than reusing a shared client).
+- Test file for the health endpoint (location not yet confirmed — need to check for an
+  existing `tests/.../test_health.py` or equivalent, or create one).
+
+### Plan
+1. Search the codebase for where `SafetyMonitor` is currently instantiated and where
+   `log_event()` is called elsewhere (e.g., in middleware or other routes), to find the
+   existing pattern for getting a Redis client / `SafetyMonitor` instance via dependency
+   injection.
+2. Decide on the Redis key redesign for real hourly windowing. Simplest approach: switch
+   from a single `incr` counter to a Redis sorted set per event type
+   (`safety:events:{event_type}:zset`), storing each event's timestamp as the score, with
+   `ZREMRANGEBYSCORE` to prune anything older than `window_hours` before counting with
+   `ZCARD`. This replaces `incr`/`expire` in `log_event()`.
+3. Add `get_total_event_count(window_hours: int = 1) -> int` to `SafetyMonitor`, summing
+   `get_event_count(event_type, window_hours)` (updated to use the new windowed logic)
+   across all `VALID_EVENT_TYPES`.
+4. Wire up `api/routes/health.py`: add a dependency to inject the shared `SafetyMonitor` (or
+   Redis client), and replace the hardcoded `0` with
+   `safety_monitor.get_total_event_count(window_hours=1)`. Keep the existing try/except so a
+   Redis failure here degrades gracefully to `0` rather than marking the whole endpoint
+   unhealthy — matching the current pattern.
+5. Run existing tests to confirm nothing else breaks: `make test-unit` (or repo equivalent).
+6. Write a new test that logs a safety event via `SafetyMonitor.log_event()`, then hits
+   `/health`, and asserts `safety_events_last_hour` reflects it (see below).
+7. Run `make check` (lint/format/types) if the repo has one.
+
+### Inputs & outputs
+**Function I'm changing:** `SafetyMonitor.get_event_count()` (fixing windowing) and adding
+`SafetyMonitor.get_total_event_count()`; also `health_check()` in `health.py`.
+
+**Existing happy path:** `/health` returns dependency statuses and a hardcoded
+`safety_events_last_hour: 0`.
+
+**New behavior:**
+- Input: one or more safety events logged via `SafetyMonitor.log_event()` within the last
+  hour.
+- Expected output: `/health` response's `safety_events_last_hour` reflects the real count,
+  summed across all event types, only counting events within the last hour.
+
+**Test I'll write (exact location TBD once I find the test directory):**
+```python
+def test_health_reflects_recent_safety_events(client, safety_monitor):
+    safety_monitor.log_event("content_filtered", {"reason": "test"})
+    safety_monitor.log_event("rate_limited", {"reason": "test"})
+
+    response = client.get("/health")
+
+    assert response.json()["safety_events_last_hour"] == 2
+```
+
+### Risks & unknowns
+1. **The `window_hours` fix is bigger than "add a field."** The issue's 2–4 hour estimate
+   assumes the data already exists; enforcing real hourly windowing means redesigning the
+   Redis storage (counter → sorted set), which touches `log_event()` too, not just the
+   getter. I may raise this with a mentor to confirm whether a true rolling-hour count is
+   expected, or whether a documented "approximate, resets every 24h" count is acceptable
+   for this issue's scope.
+2. **I haven't located how `health.py` should get a Redis client / `SafetyMonitor`
+   instance.** It currently instantiates its own local `redis.Redis(...)` just to `.ping()`
+   for the dependency check — I don't yet know if there's a shared client elsewhere I
+   should reuse instead of creating a second connection.
+3. **Someone else may be working this same issue.** I noticed another contributor
+   (RadRebelSam) commented on issue #68 and pushed a branch with a name almost identical to
+   mine. I'll confirm with the instructor/mentor before investing more time to avoid
+   duplicate work.
+4. **Redis sorted-set migration risk.** If `log_event()`'s storage format changes, I need to
+   confirm nothing else in the codebase reads the old `safety:events:{event_type}` counter
+   format directly (e.g., a dashboard or another endpoint), or I'll break it silently.
+
+### Edge cases
+- No safety events ever logged (Redis key doesn't exist) → total count should be `0`, not
+  an error.
+- Redis is down when `/health` is called → `safety_events_last_hour` should gracefully
+  return `0` (matching existing `except` behavior in both `health.py` and
+  `get_event_count`), without marking the whole `/health` response `"unhealthy"`.
+- Events logged more than 1 hour ago but within the old 24h expiry window → must NOT be
+  counted once the windowing fix is in place (this is the actual bug being fixed).
+- Multiple event types logged in the same hour → total must sum across all of them, not
+  just the first type checked.
+- Unknown/invalid event type passed to `log_event()` → already handled upstream (logged as
+  a warning and skipped); not part of this fix.

--- a/api/deps.py
+++ b/api/deps.py
@@ -1,0 +1,16 @@
+"""Shared FastAPI dependencies."""
+
+from typing import Annotated
+
+import redis
+from fastapi import Depends
+
+from core.redis_client import get_redis
+from safety.monitoring import SafetyMonitor
+
+
+def get_safety_monitor(
+    redis_client: Annotated[redis.Redis, Depends(get_redis)],
+) -> SafetyMonitor:
+    """Dependency that provides a SafetyMonitor backed by the shared Redis client."""
+    return SafetyMonitor(redis_client)

--- a/api/routes/health.py
+++ b/api/routes/health.py
@@ -1,8 +1,12 @@
-from fastapi import APIRouter, HTTPException, status, Depends
-import structlog
-from datetime import datetime, timedelta
+from datetime import datetime
+from typing import Annotated, Any
 
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from api.deps import get_safety_monitor
 from core.database import get_db
+from safety.monitoring import SafetyMonitor
 
 log = structlog.get_logger()
 
@@ -10,12 +14,15 @@ router = APIRouter(prefix="/health", tags=["health"])
 
 
 @router.get("")
-async def health_check(db=Depends(get_db)):
+async def health_check(
+    db: Annotated[Any, Depends(get_db)],
+    safety_monitor: Annotated[SafetyMonitor, Depends(get_safety_monitor)],
+) -> dict[str, Any]:
     """
     Check health of PostgreSQL, Redis, and Vector DB.
     Returns 200 if all healthy, 503 if any dependency is down.
     """
-    health_status = {
+    health_status: dict[str, Any] = {
         "status": "healthy",
         "dependencies": {
             "postgres": "unknown",
@@ -39,6 +46,7 @@ async def health_check(db=Depends(get_db)):
     try:
         # Check Redis (if available)
         import redis
+
         from core.config import settings
 
         r = redis.Redis(
@@ -72,10 +80,11 @@ async def health_check(db=Depends(get_db)):
         health_status["dependencies"]["vector_db"] = "unhealthy"
         health_status["status"] = "unhealthy"
 
-    # Count safety events in last hour (placeholder)
+    # Count safety events in last hour
     try:
-        # This would be populated by actual safety event logging
-        health_status["safety_events_last_hour"] = 0
+        health_status["safety_events_last_hour"] = safety_monitor.get_total_event_count(
+            window_hours=1
+        )
     except Exception as exc:
         log.error("safety_events_check_failed", error=str(exc))
 

--- a/core/redis_client.py
+++ b/core/redis_client.py
@@ -1,8 +1,8 @@
 """Shared Redis client for dependency injection."""
 
-from collections.abc import AsyncGenerator
+from collections.abc import Generator
 
-import redis.asyncio as redis
+import redis
 
 from core.config import settings
 
@@ -11,10 +11,10 @@ _redis_pool: redis.ConnectionPool = redis.ConnectionPool.from_url(
 )
 
 
-async def get_redis() -> AsyncGenerator[redis.Redis, None]:
+def get_redis() -> Generator[redis.Redis, None, None]:
     """Dependency for FastAPI that yields a Redis client."""
     client = redis.Redis(connection_pool=_redis_pool)
     try:
         yield client
     finally:
-        await client.close()
+        client.close()

--- a/core/redis_client.py
+++ b/core/redis_client.py
@@ -1,0 +1,20 @@
+"""Shared Redis client for dependency injection."""
+
+from collections.abc import AsyncGenerator
+
+import redis.asyncio as redis
+
+from core.config import settings
+
+_redis_pool: redis.ConnectionPool = redis.ConnectionPool.from_url(
+    settings.redis_url, decode_responses=True
+)
+
+
+async def get_redis() -> AsyncGenerator[redis.Redis, None]:
+    """Dependency for FastAPI that yields a Redis client."""
+    client = redis.Redis(connection_pool=_redis_pool)
+    try:
+        yield client
+    finally:
+        await client.close()

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -99,7 +99,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -449,7 +448,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -473,7 +471,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1561,7 +1558,6 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1579,7 +1575,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1972,7 +1967,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3507,7 +3501,6 @@
       "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^2.0.1",
         "cssstyle": "^4.0.1",
@@ -4094,7 +4087,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4107,7 +4099,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4771,7 +4762,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/safety/monitoring.py
+++ b/safety/monitoring.py
@@ -1,8 +1,9 @@
 """Safety event monitoring."""
 
+import time
+
 import redis
 import structlog
-from datetime import datetime, timedelta
 
 logger = structlog.get_logger()
 
@@ -10,13 +11,12 @@ logger = structlog.get_logger()
 class SafetyMonitor:
     """Monitor and log safety events."""
 
-    # Valid event types
     VALID_EVENT_TYPES = {
         "pii_detected",
         "injection_attempt",
         "content_filtered",
         "bias_detected",
-        "rate_limited"
+        "rate_limited",
     }
 
     def __init__(self, redis_client: redis.Redis):
@@ -38,37 +38,51 @@ class SafetyMonitor:
             logger.warning("unknown_event_type", event_type=event_type)
             return
 
-        timestamp = datetime.utcnow().isoformat()
-
         try:
-            # Log to structlog
             logger.warning("safety_event", event_type=event_type, **details)
 
-            # Store count in Redis for monitoring
-            key = f"safety:events:{event_type}"
-            self.redis.incr(key)
-            # Set expiry to 24 hours
+            key = f"safety:events:{event_type}:zset"
+            now = time.time()
+            # Score = timestamp, member must be unique per event
+            self.redis.zadd(key, {f"{now}:{id(details)}": now})
+            # Keep the key from growing forever even if nobody reads it
             self.redis.expire(key, 86400)
 
         except Exception as e:
             logger.error("safety_monitor_error", error=str(e))
 
     def get_event_count(self, event_type: str, window_hours: int = 1) -> int:
-        """Get count of safety events.
+        """Get count of safety events within a real rolling window.
 
         Args:
             event_type: Type of event
-            window_hours: Time window in hours (not enforced here; for reference)
+            window_hours: Time window in hours, enforced via ZREMRANGEBYSCORE
 
         Returns:
             Count of events in the window
         """
-        key = f"safety:events:{event_type}"
+        key = f"safety:events:{event_type}:zset"
+        cutoff = time.time() - (window_hours * 3600)
 
         try:
-            count = self.redis.get(key)
-            return int(count) if count else 0
+            # Prune anything older than the window, then count what's left
+            self.redis.zremrangebyscore(key, 0, cutoff)
+            return self.redis.zcard(key)
 
         except Exception as e:
             logger.error("event_count_error", event_type=event_type, error=str(e))
             return 0
+
+    def get_total_event_count(self, window_hours: int = 1) -> int:
+        """Get total count of safety events across all event types.
+
+        Args:
+            window_hours: Time window in hours
+
+        Returns:
+            Summed count across all VALID_EVENT_TYPES
+        """
+        total = 0
+        for event_type in self.VALID_EVENT_TYPES:
+            total += self.get_event_count(event_type, window_hours)
+        return total

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -1,0 +1,129 @@
+"""Tests for the /health endpoint safety event count."""
+
+import time
+from collections.abc import Generator
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+import api.main as main_module
+from api.deps import get_safety_monitor
+from api.main import app
+from core.database import get_db
+from safety.monitoring import SafetyMonitor
+
+
+class FakeRedis:
+    """Minimal in-memory stand-in for the sorted-set operations we use."""
+
+    def __init__(self) -> None:
+        self.store: dict[str, dict[str, float]] = {}
+
+    def zadd(self, key: str, mapping: dict[str, float]) -> None:
+        self.store.setdefault(key, {}).update(mapping)
+
+    def zremrangebyscore(self, key: str, min_score: float, max_score: float) -> None:
+        bucket = self.store.get(key, {})
+        self.store[key] = {m: s for m, s in bucket.items() if not (min_score <= s <= max_score)}
+
+    def zcard(self, key: str) -> int:
+        return len(self.store.get(key, {}))
+
+    def expire(self, key: str, seconds: int) -> None:
+        pass
+
+
+@pytest.fixture(autouse=True)
+def skip_real_db_startup(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Prevent the app's real startup event from touching Postgres,
+    and work around the pre-existing missing redis_host/redis_port settings."""
+
+    async def noop() -> None:
+        pass
+
+    monkeypatch.setattr(main_module, "init_db", noop)
+
+    from core.config import settings
+
+    monkeypatch.setattr(type(settings), "redis_host", "localhost", raising=False)
+    monkeypatch.setattr(type(settings), "redis_port", 6379, raising=False)
+
+
+@pytest.fixture
+def fake_redis() -> FakeRedis:
+    return FakeRedis()
+
+
+@pytest.fixture
+def safety_monitor(fake_redis: FakeRedis) -> SafetyMonitor:
+    return SafetyMonitor(fake_redis)  # type: ignore[arg-type]
+
+
+@pytest.fixture
+def client(safety_monitor: SafetyMonitor) -> Generator[TestClient, None, None]:
+    mock_db = AsyncMock()
+    mock_db.execute = AsyncMock(return_value=None)
+
+    async def override_get_db() -> Generator[AsyncMock, None, None]:  # type: ignore[misc]
+        yield mock_db
+
+    app.dependency_overrides[get_safety_monitor] = lambda: safety_monitor
+    app.dependency_overrides[get_db] = override_get_db
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+def test_health_reflects_recent_safety_events(
+    client: TestClient, safety_monitor: SafetyMonitor
+) -> None:
+    safety_monitor.log_event("content_filtered", {"reason": "test"})
+    safety_monitor.log_event("rate_limited", {"reason": "test"})
+
+    response = client.get("/health")
+
+    assert response.json()["safety_events_last_hour"] == 2
+
+
+def test_health_no_events_returns_zero(client: TestClient) -> None:
+    response = client.get("/health")
+    assert response.json()["safety_events_last_hour"] == 0
+
+
+def test_health_events_outside_window_not_counted(
+    safety_monitor: SafetyMonitor, client: TestClient
+) -> None:
+    key = "safety:events:pii_detected:zset"
+    old_timestamp = time.time() - (2 * 3600)  # 2 hours ago
+    safety_monitor.redis.zadd(key, {"old-event": old_timestamp})
+
+    response = client.get("/health")
+
+    assert response.json()["safety_events_last_hour"] == 0
+
+
+def test_health_multiple_event_types_summed(
+    safety_monitor: SafetyMonitor, client: TestClient
+) -> None:
+    safety_monitor.log_event("pii_detected", {})
+    safety_monitor.log_event("injection_attempt", {})
+    safety_monitor.log_event("bias_detected", {})
+
+    response = client.get("/health")
+
+    assert response.json()["safety_events_last_hour"] == 3
+
+
+def test_health_redis_down_falls_back_to_zero(
+    client: TestClient, safety_monitor: SafetyMonitor
+) -> None:
+    def broken_zcard(key: str) -> int:
+        raise ConnectionError("redis down")
+
+    safety_monitor.redis.zcard = broken_zcard  # type: ignore[method-assign, assignment]
+
+    response = client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json()["safety_events_last_hour"] == 0


### PR DESCRIPTION
## Summary
Wires the `/health` endpoint's `safety_events_last_hour` field (previously hardcoded to `0`) to real safety event data from `SafetyMonitor`, and fixes the underlying storage so the 1-hour window is actually enforced — the old `incr`/`expire` Redis counter never honored `window_hours`, so any count could include events up to 24 hours old.

## Issue
Closes #68

## Changes
- `safety/monitoring.py`: Replaced the flat `incr`/`expire` counter with a Redis sorted set per event type (`safety:events:{type}:zset`, timestamp as score). `get_event_count()` now enforces `window_hours` via `ZREMRANGEBYSCORE` + `ZCARD`. Added `get_total_event_count()` summing across all 5 `VALID_EVENT_TYPES`.
- `core/redis_client.py` (new): Shared Redis client dependency built from `settings.redis_url`, mirroring the `get_db` pattern in `core/database.py`.
- `api/deps.py` (new): `get_safety_monitor` FastAPI dependency.
- `api/routes/health.py`: Replaced the hardcoded `0` with a real call to `get_total_event_count(window_hours=1)`, keeping the existing try/except graceful-degradation behavior.
- `tests/unit/test_health.py` (new): 5 tests using an in-memory FakeRedis and dependency overrides.

## Testing
- [x] Unit tests pass (`make test-unit`) — my 5 new tests pass; the suite's ~53 pre-existing failures in unrelated modules (bias detector, PII scrubber, resume parser, etc.) are identical with my changes stashed, verified via `git stash`, so this PR adds no new failures
- [ ] Integration tests pass (`make test-integration`) — not run
- [x] Linter passes (`make lint`) — ruff and black pass on all changed files
- [x] Type checker passes (`make typecheck`) — mypy passes on all implementation files; see note below about the test file
- [x] New/updated tests cover the changes — recent events counted, zero events, events outside the 1-hour window excluded, multiple event types summed, Redis-down falls back to 0

## Screenshots / Demo
N/A

## Notes for Reviewers
- **Pre-existing bugs left untouched (out of scope):** `/health`'s Postgres check uses raw string SQL (SQLAlchemy `text()` issue) and its Redis check references `settings.redis_host`/`redis_port`, which don't exist in `Settings` (only `redis_url` does). Both were failing before this PR; my tests work around them via fixtures.
- **mypy on the test file:** the mypy pre-commit hook fails on `tests/unit/test_health.py` only because importing `api.main` makes mypy follow imports into pre-existing untyped modules (36 errors, none in files this PR touches). `test_health.py` itself is fully annotated and mypy-clean; the test commit used `--no-verify` for this reason.
- **Storage migration note:** the format change means events logged under the old `safety:events:{type}` counter keys won't be counted after this change. I found no other code reading the old key format.