### PR TITLE
fix(tests): lengthen readme_scorer fixture to satisfy word-count assertion

### DIFF
--- a/tests/unit/test_readme_scorer.py
+++ b/tests/unit/test_readme_scorer.py
@@ -15,37 +15,115 @@ class TestReadmeScorer:
         return ReadmeScorer()
 
     def test_readme_with_all_quality_signals(self, scorer):
-        """Test README with all quality signals returns high score."""
+        """Test README with all quality signals returns high score.
+
+        The fixture is intentionally 500+ words so that it lands in the
+        ``comprehensive`` word-count category (the scorer classifies >= 500
+        words as comprehensive). It also embeds every quality signal the test
+        name promises -- installation, usage, badges, a demo link, and a tech
+        stack -- so the assertions below pass for the right reason rather than
+        by weakening the expectations.
+        """
         readme = """
         # Project Name
-        A comprehensive project description.
-
-        ## Installation
-        ```bash
-        pip install package
-        ```
-
-        ## Usage
-        ```python
-        import package
-        package.run()
-        ```
-
-        ## Features
-        - Feature 1
-        - Feature 2
-        - Feature 3
-
-        ## Tech Stack
-        - Python 3.9
-        - FastAPI
-        - PostgreSQL
 
         ![Build Status](https://example.com/badge.svg)
         ![Coverage](https://example.com/coverage.svg)
+        ![License](https://example.com/license.svg)
+
+        A comprehensive project description that explains what this tool does,
+        who it is for, and why someone would want to use it. This project helps
+        early-career developers automate a tedious task so they can focus on the
+        work that actually matters to them. It is designed to be approachable
+        for newcomers while remaining powerful enough for experienced engineers
+        who need to extend it. The goal of this document is to give a reader
+        everything they need to install, configure, run, and contribute to the
+        project without having to read the source code first.
 
         ## Live Demo
-        [Try it here](https://demo.example.com)
+
+        You can see it in action without installing anything locally.
+        [Try it here](https://demo.example.com) and explore the hosted example
+        environment. The live demo is reset every night, so feel free to create
+        sample data and experiment with every feature described below.
+
+        ## Installation
+
+        The project supports Python 3.9 and newer. Getting started only takes a
+        couple of minutes on most systems. First, create and activate a virtual
+        environment so your dependencies stay isolated from the rest of your
+        machine. Then install the package from the Python Package Index:
+
+        ```bash
+        python -m venv .venv
+        source .venv/bin/activate
+        pip install package
+        ```
+
+        If you plan to contribute, install the development extras instead. These
+        pull in the test runner, the linter, and the type checker that the
+        continuous integration pipeline runs on every pull request:
+
+        ```bash
+        pip install "package[dev]"
+        ```
+
+        ## Usage
+
+        Once the package is installed, importing and running it is
+        straightforward. The example below shows the most common workflow, which
+        is loading the library, configuring it with sensible defaults, and
+        executing the main entry point. Most users will only ever need these few
+        lines to get real results:
+
+        ```python
+        import package
+
+        client = package.Client()
+        client.configure(verbose=True)
+        client.run()
+        ```
+
+        For more advanced scenarios you can pass additional options to customize
+        the behavior. Each option is documented in the reference guide, and the
+        library ships with sensible defaults so that the common case stays
+        simple while the complex case remains possible.
+
+        ## Features
+
+        - Fast, dependency-light core that runs anywhere Python runs
+        - A friendly command line interface for interactive use
+        - A stable programmatic API for embedding in larger systems
+        - Structured logging so failures are easy to diagnose in production
+        - Extensive automated tests covering both the happy path and edge cases
+
+        ## Tech Stack
+
+        This project is built with a small, well-understood set of technologies
+        so that new contributors can be productive quickly. The backend is
+        written in Python and exposes a web API using FastAPI. Persistent data
+        is stored in PostgreSQL, and background coordination is handled through
+        a lightweight queue. The full technology stack is:
+
+        - Python 3.9 or newer as the primary implementation language
+        - FastAPI for the HTTP layer and automatic API documentation
+        - PostgreSQL for durable relational storage
+        - Redis for caching and lightweight coordination
+        - pytest for the automated test suite
+
+        ## Contributing
+
+        Contributions are welcome and appreciated. Please open an issue before
+        starting significant work so we can discuss the approach together. When
+        you submit a pull request, make sure the tests pass, the linter is
+        clean, and any new behavior is covered by a test. We try to review new
+        contributions within a few days and are happy to help first-time
+        contributors through the process from start to finish.
+
+        ## License
+
+        This project is released under the MIT License. See the LICENSE file in
+        the repository root for the full text and details about permitted use.
         """
 
         result = scorer.execute({"readme_content": readme})


### PR DESCRIPTION
## Summary
`test_readme_with_all_quality_signals` asserted `word_count > 100` and
`word_count_category == "comprehensive"`, but its inline fixture README was only 51 words.
`ReadmeScorer` classifies `< 100` words as `"minimal"` and only assigns `"comprehensive"` at
`>= 500` words, so the test failed on every run (`assert 51 > 100`) despite the production scorer
logic being correct. This PR lengthens the fixture to a genuine 583-word README so the test passes
because the input is truly comprehensive — not by weakening its assertions.

## Issue
Closes #156

## Changes
- Lengthen the fixture in `test_readme_with_all_quality_signals` from 51 to ~583 words so it lands
  in the `comprehensive` category (`>= 500` words).
- Keep every quality signal the test name promises in the new fixture: installation, usage, badges,
  demo link, and tech stack — so the boolean assertions still pass for the right reason.
- Add a docstring explaining why the fixture must stay `500+` words, to prevent future drift back
  under the threshold.
- No production code changed; the scorer thresholds in `agent/tools/readme_scorer.py` were already
  correct.

## Testing
- [x] Unit tests pass (`make test-unit`) — `test_readme_scorer.py`: 23 passed (previously
  `test_readme_with_all_quality_signals` failed with `assert 51 > 100`)
- [ ] Integration tests pass (`make test-integration`) — not run; this is a pure unit test with an
  inline fixture (no DB/services), so integration coverage is not affected
- [x] Linter passes (`make lint`) — `ruff` clean on the changed code
- [ ] Type checker passes (`make typecheck`) — not verified locally (unrelated env issue); no type
  surface changed, will run in CI
- [x] New/updated tests cover the changes — the change fixes the test itself

## Screenshots / Demo
N/A — test-only change.

## Notes for Reviewers
- Scoped deliberately to the single fixture. I did **not** touch the pre-existing `black`
  formatting nit in `test_setup_keyword_counts_as_installation` (it also fails on `main`), to keep
  this PR focused on #156.
- The fix intentionally lengthens the fixture rather than relaxing the assertions, so the test
  keeps verifying the `"comprehensive"` path for real.