### PR TITLE
Fix/147 resume section detection fails on text with leading whitespace

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,25 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/147
+
+**Issue title:** Resume section detection fails on text with leading whitespace
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+In `ingestion/parsers/resume_parser.py`, `_detect_sections()` builds its header
+patterns with `^` and `\n` anchors immediately followed by the section name,
+allowing no leading whitespace. PDF text extraction frequently preserves
+indentation before each line, so headers like `    Experience` never match any
+of the four patterns and `detected_sections` is returned as an empty list,
+losing all structural metadata for the resume. The same rigid anchoring also
+affects `_strip_markdown()`, where `^#+\s+` fails to strip indented markdown
+headers. A successful fix inserts `\s*` after each `^`/`\n` anchor (and in the
+markdown-header regex) so indented headers are recognized, restoring accurate
+section detection for PDF-sourced resumes.
+
+**Branch name:** fix/147-resume-section-detection-fails-on-text-with-leading-whitespace
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -23,3 +23,20 @@ section detection for PDF-sourced resumes.
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/ZhangChengX/pathreview/commit/b68caadebfe7175293fc0abb8cad885ac00723a8
+
+**Reproduction summary:**
+I parsed indented resume text with `ResumeParser().parse('\n    Education:\n    - B.S.\n\n    Skills: Python\n')`
+and printed `res.metadata['detected_sections']`. It returned an empty list `[]` instead
+of `["Education", "Skills"]`, confirming that leading whitespace breaks section detection.
+
+**PLAN.md link:** https://github.com/ZhangChengX/pathreview/blob/fix/147-resume-section-detection-fails-on-text-with-leading-whitespace/PLAN.md
+
+**Walkthrough video (recommended):** N/A
+
+**Blockers or open questions:**
+None. The root cause and fix are clear: the header regex patterns did not allow leading
+whitespace, so adding `\s*` after each `^`/`\n` anchor solves it.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -84,3 +84,48 @@ detection works on indented resume text and that no other tests break.
 **Self-review confirmation:** [x] make check passes  [x] make test-unit passes
 
 **Draft PR feedback received from:** Charlie
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No maintainer review or comments have come in yet. 
+
+**How you responded:**
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The code change was small, but defining its boundaries took more care than I
+expected. I had to trace both PDF and Markdown parsing paths, identify all four
+section-header patterns, and notice that `_strip_markdown()` had the same
+leading-whitespace assumption. I also needed tests for spaces, tabs, and
+indented Markdown headers without changing the parser's public behavior.
+
+**What did you learn about working in a large codebase?**
+I learned to start from the reported behavior, follow the existing call path,
+and make the smallest change that fits the project's conventions. In someone
+else's codebase, a locally correct fix is not enough: it needs focused regression
+coverage, must preserve existing APIs, and has to pass the repository's unit,
+integration, lint, and type-check workflows before it is ready for review.
+
+**How did AI tools help — and where did they fall short?**
+AI tools helped me locate the related regex patterns, reason about the anchors,
+draft a reproduction plan, and identify useful edge cases for the regression
+tests. They could not replace checking the actual parser flow, repository
+conventions, test output, and final diff. I still had to verify that the proposed
+regex change solved the real failure without expanding the scope unnecessarily.
+
+**What would you do differently if you started over?**
+I would add the focused failing tests for space-indented, tab-indented, and
+Markdown headers before changing the implementation, then use those tests to
+drive the fix. 
+
+**What are you most proud of from this module?**
+I am most proud of turning a real PDF-text parsing edge case into a narrow fix
+with regression coverage while keeping the public API and return shape unchanged.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -40,3 +40,47 @@ of `["Education", "Skills"]`, confirming that leading whitespace breaks section 
 **Blockers or open questions:**
 None. The root cause and fix are clear: the header regex patterns did not allow leading
 whitespace, so adding `\s*` after each `^`/`\n` anchor solves it.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+All PLAN.md sub-tasks are done. I reproduced the bug (indented text returned an
+empty `detected_sections`), added `\s*` right after each `^`/`\n` anchor in the
+four header patterns inside `_detect_sections()`, and updated `_strip_markdown()`
+so its header regex `^#+\s+` became `^\s*#+\s+`. The fix is committed as
+`b68caad` ("fix: detect resume sections with leading whitespace").
+
+**Next steps:**
+Run the unit tests and `make check`, open the pull request, and collect draft PR
+feedback.
+
+**Blockers:**
+None.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/681
+
+**Branch:** `fix/147-resume-section-detection-fails-on-text-with-leading-whitespace`
+
+**What you built:**
+The fix inserts `\s*` after each `^`/`\n` anchor in the four section-header
+patterns in `_detect_sections()` and changes the `_strip_markdown()` header regex
+to `^\s*#+\s+`, so indented headers from PDF-extracted text are recognized. As a
+result `detect_sections` returns the correct section names (e.g. Experience,
+Education, Skills) regardless of leading whitespace, and indented markdown headers
+are stripped. No change to the public API or return shape.
+
+**Tests added or updated:**
+`tests/unit/test_resume_parser.py` — `test_detect_sections` (covers indented
+`Experience`/`Education`/`Skills` headers), `test_parse_single_column_resume_text`,
+and `test_parse_resume_no_work_experience`, which together confirm section
+detection works on indented resume text and that no other tests break.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+**Draft PR feedback received from:** Charlie

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,70 @@
+## Solution plan
+
+**Issue:** https://github.com/ascherj/pathreview/issues/147
+
+### Understand
+What is the root cause of this issue? What behavior is expected vs. actual?
+
+The root cause is in `ingestion/parsers/resume_parser.py`. The `_detect_sections()`
+function looks for section headers (like "Experience" or "Education") using regex
+patterns that expect the header to start right at the beginning of a line, with no
+space in front. PDF text extraction often keeps the original indentation, so a header
+like `    Education` has leading spaces and matches none of the patterns.
+
+- **Expected:** The parser finds sections such as "Education" and "Skills" even when
+  the lines are indented.
+- **Actual:** `detected_sections` comes back as an empty list whenever the text is
+  indented, so all section info for the resume is lost.
+
+The same problem exists in `_strip_markdown()`, whose header regex `^#+\s+` cannot
+strip an indented markdown header like `    # Summary`.
+
+### Map
+Which files, functions, or modules are involved?
+
+- `ingestion/parsers/resume_parser.py`
+  - `_detect_sections()` — the four header regex patterns
+  - `_strip_markdown()` — the markdown-header regex
+- `tests/unit/test_resume_parser.py` — the failing tests that confirm the fix
+  (`test_parse_single_column_resume_text`, `test_parse_resume_no_work_experience`,
+  `test_detect_sections`)
+
+### Plan
+What are the steps to fix this issue? Break it into 3–5 concrete sub-tasks.
+
+1. Reproduce the bug by parsing indented resume text and confirming
+   `detected_sections` is empty.
+2. Add `\s*` right after each `^` and `\n` anchor in the four patterns inside
+   `_detect_sections()` so leading whitespace is allowed.
+3. Do the same in `_strip_markdown()`: change `^#+\s+` to `^\s*#+\s+` so indented
+   markdown headers are stripped.
+4. Run the failing tests and confirm they now pass, and that no other tests break.
+
+### Inputs & outputs
+What does your fix take as input? What should it produce or change?
+
+- **Input:** Resume text (from a PDF or markdown) that may have leading whitespace
+  in front of section headers.
+- **Output / change:** `_detect_sections()` returns the correct list of section names
+  (e.g. `["Education", "Skills"]`) regardless of indentation, and `_strip_markdown()`
+  removes indented markdown headers. No change to the public API or return shape.
+
+### Risks & unknowns
+What could go wrong? What are you still unsure about?
+
+- Adding `\s*` makes the patterns a bit looser, so an indented line that happens to
+  equal a section word could now be detected as a header. In practice this is fine
+  because the patterns still require the header to be alone on the line or followed
+  by `:`, `|`, or `-`.
+- The fix does not handle headers written in mixed order or with extra characters;
+  it only addresses leading whitespace, which is what the issue asks for.
+
+### Edge cases
+What inputs or states should your fix handle gracefully?
+
+- Headers indented with spaces or tabs (`    Education`, `\tSkills`).
+- Headers at the very start of the text vs. after a newline.
+- Headers followed by `:`, `|`, or `-`, or standing alone on a line.
+- Markdown headers that are indented (`   ## Summary`).
+- Text with no section headers at all — should still return an empty list without
+  errors.

--- a/ingestion/parsers/resume_parser.py
+++ b/ingestion/parsers/resume_parser.py
@@ -99,7 +99,7 @@ class ResumeParser(BaseParser):
     def _strip_markdown(self, content: str) -> str:
         """Remove markdown syntax from content."""
         # Remove markdown headers
-        text = re.sub(r"^#+\s+", "", content, flags=re.MULTILINE)
+        text = re.sub(r"^\s*#+\s+", "", content, flags=re.MULTILINE)
 
         # Remove markdown links [text](url)
         text = re.sub(r"\[([^\]]+)\]\(([^\)]+)\)", r"\1", text)
@@ -132,10 +132,10 @@ class ResumeParser(BaseParser):
         for section in SECTION_HEADERS:
             # Look for section header patterns
             patterns = [
-                rf"^{re.escape(section)}\s*$",
-                rf"^{re.escape(section)}\s*[:|-]",
-                rf"\n{re.escape(section)}\s*$",
-                rf"\n{re.escape(section)}\s*[:|-]",
+                rf"^\s*{re.escape(section)}\s*$",
+                rf"^\s*{re.escape(section)}\s*[:|-]",
+                rf"\n\s*{re.escape(section)}\s*$",
+                rf"\n\s*{re.escape(section)}\s*[:|-]",
             ]
 
             for pattern in patterns:

--- a/tests/unit/test_resume_parser.py
+++ b/tests/unit/test_resume_parser.py
@@ -13,11 +13,13 @@ class TestResumeParser:
     """Test suite for ResumeParser."""
 
     @pytest.fixture
-    def parser(self):
+    def parser(self) -> ResumeParser:
         """Create a ResumeParser instance."""
         return ResumeParser()
 
-    def test_parse_single_column_resume_text(self, parser, sample_resume_text):
+    def test_parse_single_column_resume_text(
+        self, parser: ResumeParser, sample_resume_text: str
+    ) -> None:
         """Test parsing a standard single-column resume text."""
         result = parser.parse(sample_resume_text)
 
@@ -33,7 +35,7 @@ class TestResumeParser:
             "skills" in s for s in detected_lower
         )
 
-    def test_parse_resume_no_work_experience(self, parser):
+    def test_parse_resume_no_work_experience(self, parser: ResumeParser) -> None:
         """Test parsing a resume with no work experience section - handles gracefully."""
         resume_no_work = """
         John Smith
@@ -54,7 +56,7 @@ class TestResumeParser:
         detected_lower = [s.lower() for s in result.metadata["detected_sections"]]
         assert any("education" in s for s in detected_lower)
 
-    def test_parse_multipage_pdf(self, parser):
+    def test_parse_multipage_pdf(self, parser: ResumeParser) -> None:
         """Test parsing a multi-page PDF resume."""
         # Create a mock PDF with multiple pages
         with patch("ingestion.parsers.resume_parser.PdfReader") as mock_pdf_reader:
@@ -81,7 +83,7 @@ class TestResumeParser:
             assert "Page 2 Content" in result.text
             assert "Page 3 Content" in result.text
 
-    def test_parse_markdown_resume(self, parser):
+    def test_parse_markdown_resume(self, parser: ResumeParser) -> None:
         """Test parsing a Markdown resume."""
         markdown_resume = """
         # Jane Doe
@@ -105,25 +107,25 @@ class TestResumeParser:
         assert "#" not in result.text or result.text.count("#") < markdown_resume.count("#")
         assert "Jane Doe" in result.text
 
-    def test_parse_invalid_content_type(self, parser):
+    def test_parse_invalid_content_type(self, parser: ResumeParser) -> None:
         """Test that invalid content type raises ValueError with clear message."""
         with pytest.raises(ValueError) as exc_info:
-            parser.parse(12345)  # Invalid: integer
+            parser.parse(12345)  # type: ignore[arg-type]  # Invalid: integer
 
         assert "Content must be bytes" in str(exc_info.value) or "Content must be" in str(
             exc_info.value
         )
 
-    def test_parse_invalid_list_content(self, parser):
+    def test_parse_invalid_list_content(self, parser: ResumeParser) -> None:
         """Test that list content raises ValueError."""
         with pytest.raises(ValueError) as exc_info:
-            parser.parse(["not", "valid"])
+            parser.parse(["not", "valid"])  # type: ignore[arg-type]
 
         assert "Content must be bytes" in str(exc_info.value) or "Content must be" in str(
             exc_info.value
         )
 
-    def test_detect_sections(self, parser):
+    def test_detect_sections(self, parser: ResumeParser) -> None:
         """Test section detection in resume text."""
         text = """
         Experience:
@@ -143,7 +145,40 @@ class TestResumeParser:
         assert any("education" in s for s in sections_lower)
         assert any("skills" in s for s in sections_lower)
 
-    def test_strip_markdown_syntax(self, parser):
+    def test_detect_sections_with_leading_whitespace(self, parser: ResumeParser) -> None:
+        """Regression test for issue #147: headers with leading indentation.
+
+        Section headers preceded by spaces or tabs must be detected exactly
+        the same as headers flush against the start of the line. Before the
+        fix, the ``^``-anchored patterns required the header to be the very
+        first character on the line, so indented headers were silently missed.
+        """
+        # Same headers, one flush against column 0, one indented.
+        flush = "Experience\nSenior Dev\n\nEducation\nBS CS\n\nSkills\nPython"
+        space_indented = (
+            "    Experience\n    Senior Dev\n\n"
+            "    Education\n    BS CS\n\n    Skills\n    Python"
+        )
+        tab_indented = "\tExperience\n\tSenior Dev\n\n\tEducation\n\tSkills: Python"
+
+        flush_sections = sorted(parser._detect_sections(flush))
+
+        # The indented input must not silently drop sections...
+        assert flush_sections, "sanity: flush input should detect sections"
+        # ...and must detect exactly the same set as the flush input.
+        assert sorted(parser._detect_sections(space_indented)) == flush_sections
+        assert set(parser._detect_sections(space_indented)) == {
+            "Experience",
+            "Education",
+            "Skills",
+        }
+        # Tabs count as leading whitespace too.
+        tab_sections = [s.lower() for s in parser._detect_sections(tab_indented)]
+        assert any("experience" in s for s in tab_sections)
+        assert any("education" in s for s in tab_sections)
+        assert any("skills" in s for s in tab_sections)
+
+    def test_strip_markdown_syntax(self, parser: ResumeParser) -> None:
         """Test markdown syntax stripping."""
         markdown_text = """
         # Header
@@ -163,7 +198,24 @@ class TestResumeParser:
         # But actual text content should remain
         assert "Header" in stripped or "Bold text" in stripped
 
-    def test_pdf_parsing_error_handling(self, parser):
+    def test_strip_markdown_headers_with_leading_whitespace(self, parser: ResumeParser) -> None:
+        """Regression test for issue #147: indented markdown headers.
+
+        The header-stripping pattern must tolerate leading indentation, so an
+        indented ``## Experience`` still has its ``#`` markers removed. Before
+        the fix the ``^#+`` pattern only matched at column 0.
+        """
+        indented = "    # Jane Doe\n    ## Experience\n    - Built APIs\n    ## Skills"
+        stripped = parser._strip_markdown(indented)
+
+        # No markdown header markers should survive.
+        assert "#" not in stripped
+        # The header text itself must be preserved.
+        assert "Jane Doe" in stripped
+        assert "Experience" in stripped
+        assert "Skills" in stripped
+
+    def test_pdf_parsing_error_handling(self, parser: ResumeParser) -> None:
         """Test graceful error handling for invalid PDF."""
         with patch("ingestion.parsers.resume_parser.PdfReader") as mock_pdf_reader:
             mock_pdf_reader.side_effect = Exception("Invalid PDF format")
@@ -173,7 +225,7 @@ class TestResumeParser:
 
             assert "Failed to parse PDF" in str(exc_info.value)
 
-    def test_parse_preserves_text_content(self, parser):
+    def test_parse_preserves_text_content(self, parser: ResumeParser) -> None:
         """Test that parsing preserves actual content text."""
         original_text = "John Doe\nSoftware Engineer\nPython, JavaScript, React"
         result = parser.parse(original_text)


### PR DESCRIPTION
## Summary
<!-- One paragraph describing what this PR does and why -->
In `ingestion/parsers/resume_parser.py`, `_detect_sections()` builds its header
patterns with `^` and `\n` anchors immediately followed by the section name,
allowing no leading whitespace. PDF text extraction frequently preserves
indentation before each line, so headers like `    Experience` never match any
of the four patterns and `detected_sections` is returned as an empty list,
losing all structural metadata for the resume. The same rigid anchoring also
affects `_strip_markdown()`, where `^#+\s+` fails to strip indented markdown
headers. A successful fix inserts `\s*` after each `^`/`\n` anchor (and in the
markdown-header regex) so indented headers are recognized, restoring accurate
section detection for PDF-sourced resumes.

## Issue
Closes #147 

## Changes
<!-- Bullet list of the specific changes made -->
The fix inserts `\s*` after each `^`/`\n` anchor in the four section-header
patterns in `_detect_sections()` and changes the `_strip_markdown()` header regex
to `^\s*#+\s+`, so indented headers from PDF-extracted text are recognized. As a
result `detect_sections` returns the correct section names (e.g. Experience,
Education, Skills) regardless of leading whitespace, and indented markdown headers
are stripped. No change to the public API or return shape.

## Testing
<!-- How did you verify your changes? -->
- [x] Unit tests pass (`make test-unit`)
- [x] Integration tests pass (`make test-integration`)
- [x] Linter passes (`make lint`)
- [x] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes

## Screenshots / Demo
<!-- If applicable, add screenshots or a link to a demo video -->

## Notes for Reviewers
<!-- Anything the reviewer should pay particular attention to -->
