### PR TITLE
docs(api): document POST request body schemas in the API reference

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -52,8 +52,7 @@ above), so this issue is a realistic, well-scoped Tier 1 choice for me.
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** 
-https://github.com/Daidai1031/pathreview/commit/72ff229abf222e21c45b45471e2214fed405a217
+**Reproduction commit link:** https://github.com/Daidai1031/pathreview/commit/72ff229abf222e21c45b45471e2214fed405a217
 
 **Reproduction summary:**
 I ran the API locally and exercised both POST endpoints through the OpenAPI UI at
@@ -62,8 +61,7 @@ with an undocumented `resume_file` upload, while `POST /reviews` takes JSON — 
 `docs/API.md` describes both with identical one-line entries and no request format
 at all, so the two are indistinguishable to a reader.
 
-**PLAN.md link:** 
-https://github.com/Daidai1031/pathreview/blob/docs/89-add-post-request-body-schemas/PLAN.md
+**PLAN.md link:** https://github.com/Daidai1031/pathreview/blob/docs/89-add-post-request-body-schemas/PLAN.md
 
 **Walkthrough video (recommended):**
 
@@ -73,7 +71,12 @@ has neither requests nor responses — I need to confirm with the maintainer whe
 responses are in scope. Separately, two of the error paths I tested return 500 for
 what is clearly invalid client input; that looks like a bug in the handlers'
 exception handling, but it is a code change and I don't think it belongs in this
-docs issue.
+docs issue. Third, PDF resume uploads always fail with "Failed to parse PDF
+resume" — the handler passes raw bytes to `PyPDF2.PdfReader`, which needs a
+file-like object. That leaves an open question for the docs themselves: should
+`docs/API.md` list PDF as a supported resume format, when in practice it never
+works? I plan to document the allowlist as the code intends it, add a note about
+the current limitation, and open a separate issue for the bug.
 
 ---
 
@@ -178,6 +181,8 @@ required field, `profile_id: UUID`.
 | --- | --- | --- |
 | `POST /profiles` with no bearer token | 401 | `{"detail": "Not authenticated"}` |
 | `POST /profiles` with a `.docx` resume | 422 | `{"detail": "Resume must be a PDF or Markdown file"}` |
+| `POST /profiles` with a valid PDF resume | 422 | `{"detail": "Failed to parse PDF resume"}` |
+| `POST /profiles` with a Markdown resume | 200 | profile created, `resume_filename` populated |
 | `POST /profiles` with `github_username` over 255 chars | 500 | `{"detail": "Failed to create profile"}` |
 | `POST /reviews` with a nonexistent `profile_id` | 500 | `{"detail": "Failed to create review"}` |
 
@@ -200,6 +205,44 @@ differently.
 Fixing the 500s is a code change and outside the scope of #89. I will document the
 behavior as it currently stands, flag the discrepancy in the PR, and suggest a
 separate issue.
+
+#### PDF resume uploads always fail
+
+Uploading a valid PDF returns 422:
+
+```json
+{
+  "detail": "Failed to parse PDF resume"
+}
+```
+
+Uploading Markdown succeeds:
+
+```json
+{
+  "id": "a5cbcb29-6bf0-4373-80a0-e26a6fe9a854",
+  "user_id": "cc258f35-98a3-457b-b1bb-6fec6c95f9a9",
+  "github_username": "daidai1031",
+  "portfolio_url": "https://www.daidingrdesigns.com/",
+  "created_at": "2026-07-24T07:30:51.364782Z",
+  "resume_filename": "001-chunking-strategy.md"
+}
+```
+
+The two branches diverge in `create_profile_endpoint` (`api/routes/profiles.py`).
+Both start from `content = await resume_file.read()`, which returns `bytes`. The
+Markdown branch calls `content.decode("utf-8")`, which works on bytes. The PDF
+branch calls `PyPDF2.PdfReader(content)`, but `PdfReader` expects a file path or a
+file-like object — `bytes` has no `.seek()`, so the call raises, the surrounding
+`except Exception` catches it, and every PDF becomes a 422. Wrapping the bytes,
+`PdfReader(io.BytesIO(content))`, would be the usual fix.
+
+The practical effect is that the API advertises PDF support — the type allowlist
+accepts `application/pdf` and the rejection message names PDF first — while no PDF
+has ever been accepted. This is a code bug, not a docs bug, so it is outside the
+scope of #89. I searched the tracker and found no existing report; the closest is
+the closed #76, which covered the related 500-vs-422 behavior for non-PDF files.
+I plan to raise this separately rather than fold it into this PR.
 
 #### Why this counts as a reproduction
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -53,6 +53,7 @@ above), so this issue is a realistic, well-scoped Tier 1 choice for me.
 ## Week 8 — Reproduction & solution planning
 
 **Reproduction commit link:** 
+https://github.com/Daidai1031/pathreview/commit/72ff229abf222e21c45b45471e2214fed405a217
 
 **Reproduction summary:**
 I ran the API locally and exercised both POST endpoints through the OpenAPI UI at
@@ -62,6 +63,7 @@ with an undocumented `resume_file` upload, while `POST /reviews` takes JSON — 
 at all, so the two are indistinguishable to a reader.
 
 **PLAN.md link:** 
+https://github.com/Daidai1031/pathreview/blob/docs/89-add-post-request-body-schemas/PLAN.md
 
 **Walkthrough video (recommended):**
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -47,3 +47,162 @@ above), so this issue is a realistic, well-scoped Tier 1 choice for me.
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+---
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** 
+
+**Reproduction summary:**
+I ran the API locally and exercised both POST endpoints through the OpenAPI UI at
+`localhost:8000/docs`. `POST /profiles` turned out to take `multipart/form-data`
+with an undocumented `resume_file` upload, while `POST /reviews` takes JSON — yet
+`docs/API.md` describes both with identical one-line entries and no request format
+at all, so the two are indistinguishable to a reader.
+
+**PLAN.md link:** 
+
+**Walkthrough video (recommended):**
+
+**Blockers or open questions:**
+The issue body says the response schemas are already documented, but `docs/API.md`
+has neither requests nor responses — I need to confirm with the maintainer whether
+responses are in scope. Separately, two of the error paths I tested return 500 for
+what is clearly invalid client input; that looks like a bug in the handlers'
+exception handling, but it is a code change and I don't think it belongs in this
+docs issue.
+
+---
+
+### Reproduction detail
+
+Everything below was observed against the API running locally at
+`http://localhost:8000`. Bearer tokens are redacted.
+
+#### What `docs/API.md` says today
+
+The Profiles and Reviews sections in full:
+
+```
+### Profiles
+
+`POST /profiles` — Create a profile with resume and GitHub username.
+`GET /profiles/{profile_id}` — Retrieve a profile.
+`DELETE /profiles/{profile_id}` — Delete a profile and associated data.
+
+### Reviews
+
+`POST /reviews` — Request a new portfolio review for a profile.
+`GET /reviews/{review_id}` — Retrieve a completed review.
+`GET /reviews` — List reviews for the authenticated user (paginated).
+```
+
+One line per endpoint. No content type, no field names, no required/optional
+information, no example request, and no mention that a bearer token is needed.
+A reader cannot construct a valid request from this.
+
+#### `POST /profiles` takes `multipart/form-data`, not JSON
+
+```
+curl -X 'POST' \
+  'http://localhost:8000/profiles' \
+  -H 'accept: application/json' \
+  -H 'Authorization: Bearer <token>' \
+  -H 'Content-Type: multipart/form-data' \
+  -F 'github_username=daidai1031' \
+  -F 'portfolio_url=https://www.daidingrdesigns.com/' \
+  -F 'resume_file='
+```
+
+`200 OK`:
+
+```json
+{
+  "id": "39539042-b11e-4fa1-9f7a-068398cba5eb",
+  "user_id": "cc258f35-98a3-457b-b1bb-6fec6c95f9a9",
+  "github_username": "daidai1031",
+  "portfolio_url": "https://www.daidingrdesigns.com/",
+  "created_at": "2026-07-24T05:31:40.029680Z",
+  "resume_filename": null
+}
+```
+
+Three things here appear nowhere in `docs/API.md`:
+
+1. The content type is `multipart/form-data`. The doc gives no reason to expect
+   this; the default assumption for a POST endpoint is JSON.
+2. There is a third field, `resume_file`, a file upload. The doc mentions "resume"
+   in prose but never names the field or says it is a file.
+3. The endpoint requires `Authorization: Bearer <token>` from `POST /auth/login`.
+
+Source of truth: `create_profile_endpoint` in `api/routes/profiles.py`, whose
+parameters are declared as `Form(default=None)` and `UploadFile = File(default=None)`.
+`ProfileCreate` is constructed inside the handler; it is not the request body model.
+
+#### `POST /reviews` takes `application/json`
+
+Request body, marked **required** in the OpenAPI schema:
+
+```json
+{
+  "profile_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+}
+```
+
+With a `profile_id` that exists, `200 OK` and the review is created with
+`status: "pending"`; the analysis then runs in the background:
+
+```json
+{
+  "id": "4be36d29-a966-418d-ac6b-080e0268081d",
+  "profile_id": "39539042-b11e-4fa1-9f7a-068398cba5eb",
+  "status": "pending",
+  "sections": null,
+  "overall_score": null,
+  "error_message": null,
+  "created_at": "2026-07-24T06:06:45.606040Z",
+  "updated_at": "2026-07-24T06:06:45.606046Z"
+}
+```
+
+Source of truth: `create_review_endpoint` in `api/routes/reviews.py` takes
+`data: ReviewCreate`; `ReviewCreate` in `api/schemas/review.py` declares one
+required field, `profile_id: UUID`.
+
+#### Error responses — observed, not assumed
+
+| Scenario | Status | Response body |
+| --- | --- | --- |
+| `POST /profiles` with no bearer token | 401 | `{"detail": "Not authenticated"}` |
+| `POST /profiles` with a `.docx` resume | 422 | `{"detail": "Resume must be a PDF or Markdown file"}` |
+| `POST /profiles` with `github_username` over 255 chars | 500 | `{"detail": "Failed to create profile"}` |
+| `POST /reviews` with a nonexistent `profile_id` | 500 | `{"detail": "Failed to create review"}` |
+
+The 401 also carries a `www-authenticate: Bearer` response header. Swagger labels
+all four as *Undocumented*, so they are missing from the OpenAPI schema as well as
+from `docs/API.md`.
+
+**On the two 500s.** Both are caused by invalid client input and would normally be
+4xx. In `api/routes/profiles.py`, an over-length `github_username` arrives as an
+unconstrained `Form` string and only fails when `ProfileCreate(...)` is constructed
+inside the handler; that `ValidationError` is swallowed by the handler's generic
+`except Exception` and re-raised as a 500. `api/routes/reviews.py` does the same
+for a `profile_id` with no matching row.
+
+The `.docx` case is the instructive contrast: that check raises `HTTPException`
+explicitly, and the `except HTTPException: raise` branch passes it through intact,
+so it correctly surfaces as 422. Two error paths in the same function, handled
+differently.
+
+Fixing the 500s is a code change and outside the scope of #89. I will document the
+behavior as it currently stands, flag the discrepancy in the PR, and suggest a
+separate issue.
+
+#### Why this counts as a reproduction
+
+The two POST endpoints take different content types — one form-data with a file
+upload, one JSON — and `docs/API.md` describes them with structurally identical
+one-line entries that omit the distinction entirely. A developer working from the
+documentation alone cannot tell them apart, and the natural guess for `/profiles`
+is wrong. All four error responses are undocumented as well.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -327,3 +327,84 @@ files I touched are clean under ruff and black individually. Full detail in the
 PR's Notes for Reviewers.)
 
 **Draft PR feedback received from:** none
+
+
+## Week 10 — Iteration & reflection
+### Reviewer feedback
+
+**Feedback received:** [x] Yes  [ ] No — still awaiting review
+
+**Summary of feedback:**
+Reviewer @ahmadzai38 approved the PR, noting the API documentation was clear
+and that both new tests in `test_api_docs.py` passed locally. They flagged
+one inline typo in `docs/API.md`: the `POST /profiles` description read
+"sCreate a profile..." instead of "Create a profile...".
+
+**How you responded:**
+Fixed the typo in a follow-up commit (`docs(api): fix typo in POST /profiles
+description`) and replied on the review thread confirming the fix. No other
+changes were requested — the PR was already approved before the typo fix.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Scoping the change correctly, not writing it. Once I actually hit both
+endpoints locally, I found three things beyond the missing schemas: two
+error paths returning 500 instead of 4xx for invalid client input (an
+over-length `github_username`, a nonexistent `profile_id`), and PDF resume
+uploads failing 100% of the time because `create_profile_endpoint` passes
+raw `bytes` to `PyPDF2.PdfReader` instead of wrapping it in
+`io.BytesIO()`. All three were tempting to just fix inline — I had already
+traced the exact line — but a docs-only issue isn't the place to widen the
+diff with unrelated behavior changes. Deciding to document the current
+behavior faithfully, flag each one explicitly in the PR, and leave the
+actual fixes for separate issues took more judgment than the schema-writing
+itself.
+
+**What did you learn about working in a large codebase?**
+That the issue description and the actual system can disagree, and you have
+to verify against the running code, not the ticket. Issue #89 says response
+schemas are "already documented," but `docs/API.md` had neither requests
+nor responses for either endpoint — I only found that by reading the file
+myself. Similarly, `POST /profiles` looks like a JSON endpoint from the doc
+prose, but the handler in `api/routes/profiles.py` declares its parameters
+as `Form(...)` and `UploadFile`, and only builds a `ProfileCreate` object
+internally — it's never the request body model. In a solo project I'd never
+hit that gap between "what the code implies" and "what a Pydantic model at
+the route boundary" actually is, because I'd always be the one who wrote
+both.
+
+**How did AI tools help — and where did they fall short?**
+AI was most useful for structure: scaffolding `PLAN.md`, drafting the field
+tables and `curl` examples once I told it the exact wire format, and
+suggesting the drift-detection pattern for `tests/unit/test_api_docs.py`
+(reading `create_profile_endpoint`'s live signature and `ReviewCreate.model_fields`
+instead of hardcoding field names). It fell short anywhere that required
+actually running the server — the multipart-vs-JSON distinction, the four
+undocumented error responses, and the PDF bug were only found by sending
+real requests to `localhost:8000` and reading real responses; no amount of
+reading the route file would have surfaced that `PdfReader(bytes)` fails
+because `bytes` has no `.seek()` without actually triggering the exception.
+
+**What would you do differently if you started over?**
+I'd raise the three scope questions (missing response docs, the 500s, the
+PDF bug) with a mentor as soon as I found them in Week 8, instead of
+resolving all three unilaterally and only surfacing them in the PR
+description. They were reasonable calls, but for a first large-codebase
+contribution I'd rather have a second opinion on "does this belong in my
+PR" before committing to an answer, especially since the issue estimated
+2–3 hours and the actual reproduction work — hitting every endpoint,
+diffing four error paths, tracing the PDF bug to its exact line — took
+considerably longer than that.
+
+**What are you most proud of from this module?**
+The two tests in `test_api_docs.py`, not the documentation itself. Most
+docs-only PRs have no way to stay correct once the code changes again;
+mine reads `create_profile_endpoint`'s actual signature and
+`ReviewCreate.model_fields` at test time and fails if a field is added or
+removed without the doc being updated. Turning a "just prose" issue into
+something that's actually guarded by CI felt like the one place I went
+beyond what the issue literally asked for.
+

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -7,6 +7,7 @@
 **Tier:**  [x] Tier 1  [ ] Tier 2  [ ] Tier 3
 
 **Problem summary:**
+
 The API reference file `docs/API.md` documents the response shape for each
 endpoint, but it never describes what data a client must send in the request
 body for the two POST endpoints: `POST /profiles` and `POST /reviews`. Because of
@@ -15,6 +16,31 @@ what types they should be, or what a valid example request looks like. A
 successful fix adds request body schemas for both endpoints, with a description
 for each field and realistic example values, so the documentation matches the
 detail already provided for responses.
+
+**Selection notes:**
+
+- Tier fit:
+This is my first contribution to a large codebase, so I'm
+deliberately choosing a Tier 1 issue. It's docs-only and self-contained, which
+matches where I am right now.
+
+- Codebase readiness: I traced both endpoints to their request models:
+`POST /profiles` uses ProfileCreate (`api/schemas/profile.py`), which accepts two
+optional fields: github_username and portfolio_url (both strings). `POST /reviews`
+uses ReviewCreate (`api/schemas/review.py`), which requires a single field,
+profile_id (a UUID). I read these Pydantic classes directly, so the schemas I
+document will match the fields the API actually accepts. Note: this is a
+documentation-only change with no code behavior, so there is no unit test to
+modify; my verification is checking the documented fields against these request
+models.
+
+- Scope and time: Estimated 2–3 hours per the issue, which fits
+comfortably in the Weeks 8–9 window alongside my other commitments. I checked
+the issue comments and the ledger's Claims count and I'm fine with 14 people are on it. The issue lists no blockers or dependencies.
+
+- All boxes reasonably satisfied (with the test-file caveat noted
+above), so this issue is a realistic, well-scoped Tier 1 choice for me.
+
 
 **Branch name:** docs/89-add-post-request-body-schemas
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -251,3 +251,79 @@ upload, one JSON — and `docs/API.md` describes them with structurally identica
 one-line entries that omit the distinction entirely. A developer working from the
 documentation alone cannot tell them apart, and the natural guess for `/profiles`
 is wrong. All four error responses are undocumented as well.
+
+---
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Sub-tasks 1–2 from PLAN.md were already done in Week 8 (confirming the wire format
+for both endpoints and verifying the error paths against a running server). This
+week I completed sub-tasks 3–5: the `POST /profiles` request section in
+`docs/API.md` (content type `multipart/form-data`, a field table for
+`github_username`, `portfolio_url`, and the previously undocumented `resume_file`
+upload, plus a `curl -F` example), the `POST /reviews` request section
+(`application/json`, required `profile_id`, JSON and curl examples), and the
+authentication and error-response tables for both endpoints. I also recorded a
+baseline of the repo's existing failures before touching anything —
+53 failed / 375 passed on `make test-unit`, 182 ruff errors, 52 files unformatted
+under black, 5 mypy errors — so I can prove my change doesn't add to them.
+
+**Next steps:**
+Add a test that guards the new documentation against drifting from the request
+models, re-run the full check suite to confirm the failure counts are unchanged,
+open a draft PR, and get peer feedback before marking it ready for review.
+
+**Blockers:**
+No hard blockers. Three scope questions remain open, and rather than wait on the
+maintainer I decided to keep the change minimal and surface each one in the PR
+description: (1) the issue body claims response schemas are already documented,
+but `docs/API.md` has neither requests nor responses — I documented requests only,
+matching the issue title; (2) two error paths return 500 for invalid client input
+where a 4xx is expected; (3) PDF resume uploads always fail because
+`create_profile_endpoint` passes raw bytes to `PyPDF2.PdfReader`. Both (2) and (3)
+are code defects outside a docs issue, so I documented the observed behavior and
+flagged them for the reviewer instead of widening the diff.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/685
+
+**Branch:** `docs/89-add-post-request-body-schemas`
+
+**What you built:**
+Added request-body documentation for both POST endpoints to `docs/API.md`, which
+previously described every endpoint with a single line and no request information
+at all. Each endpoint now has its content type, a field table with types and
+required/optional marking, a verified `curl` example, and a table of the error
+responses it actually returns — all observed against a locally running server
+rather than inferred from the source.
+
+**Tests added or updated:**
+Created `tests/unit/test_api_docs.py` with two tests that guard the documentation
+against drifting from the code it describes.
+`test_api_doc_documents_all_profile_request_fields` reads the live signature of
+`create_profile_endpoint` and asserts that each of its form fields
+(`github_username`, `portfolio_url`, `resume_file`) is still both a handler
+parameter and present in `docs/API.md`.
+`test_api_doc_documents_all_review_request_fields` iterates
+`ReviewCreate.model_fields` and asserts every declared field appears in the doc.
+Either test fails if someone changes a request model without updating the API
+reference. Both are marked `pytest.mark.unit` to match the project's marker
+convention so they run under `make test-unit`; the suite went from 375 to 377
+passing with the failure count unchanged at 53.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+(This repository has substantial pre-existing failures on `main`. Measured before
+and after my change: `make test-unit` 53 failed / 375 passed → 53 failed / 377
+passed; `ruff` 182 errors → 182 errors; `black --check` 52 files → 52 files;
+`mypy` 5 errors → 5 errors. My change introduces no new failures, and the two
+files I touched are clean under ruff and black individually. Full detail in the
+PR's Notes for Reviewers.)
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,23 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/89
+
+**Issue title:** API reference doc is missing the `POST /profiles` request body schema
+
+**Tier:**  [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The API reference file `docs/API.md` documents the response shape for each
+endpoint, but it never describes what data a client must send in the request
+body for the two POST endpoints: `POST /profiles` and `POST /reviews`. Because of
+this gap, a developer reading the docs can't tell which fields are required,
+what types they should be, or what a valid example request looks like. A
+successful fix adds request body schemas for both endpoints, with a description
+for each field and realistic example values, so the documentation matches the
+detail already provided for responses.
+
+**Branch name:** docs/89-add-post-request-body-schemas
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/PLAN.md
+++ b/PLAN.md
@@ -116,6 +116,14 @@ and response body.
   but fixing it is a code change outside #89. Risk: documenting 500 as if it were
   intended behavior. Mitigation — document what the API actually does today, flag
   the discrepancy in the PR, and suggest a separate issue for the error handling.
+- **PDF is advertised but non-functional.** Verified: the type allowlist accepts
+  `application/pdf` and the rejection message names PDF first, yet no PDF upload
+  succeeds. Documenting "PDF or Markdown" without qualification would be
+  misleading; documenting "Markdown only" would contradict the code's intent. My
+  plan is to document the allowlist as written, add a short note that PDF parsing
+  currently fails, and open a separate issue for the bug — but I want the
+  maintainer's read on this before the PR, since it is a judgment call about what
+  the reference doc should describe: intended behavior or current behavior.
 - **Code/doc mismatch on allowed resume types.** The allowlist in
   `api/routes/profiles.py` includes `text/plain`, but the error message says "PDF
   or Markdown file". I will document observed behavior and note the inconsistency
@@ -139,9 +147,11 @@ The documentation must cover these so a reader is not surprised:
    with `{"detail": "Resume must be a PDF or Markdown file"}`. Worth contrasting
    with the two 500s below: this check raises `HTTPException` explicitly, so the
    handler's `except HTTPException: raise` branch passes it through intact.
-4. **A PDF that fails to parse** — also 422, but with a different detail,
-   "Failed to parse PDF resume"; worth listing separately so readers can tell the
-   two failures apart.
+4. **A PDF resume** — verified: *every* PDF returns 422 with
+   `{"detail": "Failed to parse PDF resume"}`, while Markdown returns 200. The PDF
+   branch in `create_profile_endpoint` passes raw `bytes` to `PyPDF2.PdfReader`,
+   which needs a file-like object. Readers must be able to tell this failure apart
+   from the wrong-file-type 422, which has a different detail string.
 5. **A missing, malformed, or expired bearer token** — verified: 401 with
    `{"detail": "Not authenticated"}` and a `www-authenticate: Bearer` header.
 6. **`github_username` longer than the 255-character limit** — verified: 500 with

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,153 @@
+## Solution plan
+
+**Issue:** #89 — API reference doc is missing the `POST /profiles` request body schema
+https://github.com/ascherj/pathreview/issues/89
+
+### Understand
+
+**Root cause.** `docs/API.md` lists every endpoint as a single line — for example,
+`` `POST /profiles` — Create a profile with resume and GitHub username. `` — with no
+description of what a client must send. No content type, no field names, no
+required/optional information, no example, and no mention that both POST endpoints
+require an `Authorization: Bearer <token>` header (enforced by `get_current_user`
+in `api/middleware/auth.py`).
+
+**Expected behavior.** A developer reading `docs/API.md` should be able to build a
+working request to `POST /profiles` and `POST /reviews` without opening the source.
+
+**Actual behavior.** The two endpoints take *different* content types, and the doc
+describes them with structurally identical one-line entries. Verified against the
+running server through the OpenAPI UI:
+
+- `POST /profiles` takes `multipart/form-data` — three fields, `github_username`,
+  `portfolio_url`, and a file upload `resume_file` that the doc never names.
+  Confirmed by a successful 200 response; evidence in the Week 8 section of `JOURNAL.md`.
+- `POST /reviews` takes `application/json` with one required field, `profile_id`.
+
+The natural assumption for a POST endpoint is JSON, so a reader following the doc
+will send the wrong content type to `/profiles`.
+
+**Scope note.** The issue body states that response schemas are already documented.
+In `main` they are not — `docs/API.md` documents neither requests nor responses. My
+fix covers request bodies only, matching the issue title. I will raise the
+response-schema discrepancy in the issue thread rather than silently widen scope.
+
+### Map
+
+File I will change:
+
+- `docs/API.md` — the only file modified. New "Request" subsections under the
+  `Profiles` and `Reviews` headings.
+
+Files I read as the source of truth (not modified):
+
+- `api/routes/profiles.py` — `create_profile_endpoint`: the `Form`/`File`
+  parameter declarations, the MIME allowlist (`application/pdf`, `text/markdown`,
+  `text/plain`), and the 422 raised for other file types.
+- `api/routes/reviews.py` — `create_review_endpoint`: takes `data: ReviewCreate`
+  as a JSON body.
+- `api/schemas/profile.py` — `ProfileCreate`: `github_username` (`max_length=255`),
+  `portfolio_url` (`max_length=500`), both optional.
+- `api/schemas/review.py` — `ReviewCreate`: `profile_id: UUID`, required.
+- `api/middleware/auth.py` — `get_current_user`: the 401 path and the
+  `WWW-Authenticate: Bearer` header both POST endpoints inherit.
+- `docs/CONTRIBUTING.md` — branch naming, Conventional Commits, PR process.
+
+### Plan
+
+1. **Confirm the wire format for both endpoints.** Done — ran the API locally and
+   exercised both endpoints through `localhost:8000/docs`; evidence recorded in
+   the Week 8 section of `JOURNAL.md`.
+2. **Verify the error paths** (done) so documented status codes are observed rather
+   than guessed: no bearer token returns 401 "Not authenticated";
+   an over-length `github_username` returns 500 "Failed to create profile"; a
+   nonexistent `profile_id` on `/reviews` returns 500 "Failed to create review";
+   and a `.docx` resume upload returns 422 "Resume must be a PDF or Markdown file".
+   Evidence in the Week 8 section of `JOURNAL.md`.
+3. **Write the `POST /profiles` request section in `docs/API.md`** — content type
+   `multipart/form-data`, a field table covering `github_username` (string,
+   optional, max 255), `portfolio_url` (string, optional, max 500), and
+   `resume_file` (file, optional, PDF/Markdown/plain text), plus a `curl -F` example.
+4. **Write the `POST /reviews` request section** — content type `application/json`,
+   a field table with `profile_id` (UUID string, required), a JSON example body,
+   and a matching `curl` example.
+5. **Document authentication and error responses** for both endpoints: the bearer
+   token from `POST /auth/login`, 401 for a missing or expired token, 422 for an
+   unsupported resume file type.
+6. **Verify and submit.** Re-run every documented example against the local server
+   and confirm the responses match; check open PRs referencing #89 to avoid
+   duplicate work; commit as `docs(api): document POST request bodies in API
+   reference` and open a PR closing #89.
+
+### Inputs & outputs
+
+**Inputs to the fix:** the handler signatures in `api/routes/profiles.py` and
+`api/routes/reviews.py`, the Pydantic field constraints in
+`api/schemas/profile.py` and `api/schemas/review.py`, and the live OpenAPI schema
+at `localhost:8000/openapi.json`.
+
+**Outputs:** a modified `docs/API.md` containing two new request sections (field
+tables plus verified examples) and a short authentication note. Documented for
+`POST /profiles`: content type `multipart/form-data`, fields `github_username`,
+`portfolio_url`, `resume_file`. For `POST /reviews`: content type
+`application/json`, field `profile_id`.
+
+**Not changed:** no source files, no function signatures, no API behavior. Nothing
+under `api/` is touched, so no test changes; verification is running each
+documented example against the local server and comparing the observed status code
+and response body.
+
+### Risks & unknowns
+
+- **The issue title points at the wrong format.** It says "request body schema,"
+  which implies JSON, but `create_profile_endpoint` in `api/routes/profiles.py`
+  uses `Form()`/`File()`. I confirmed form-data against the running server, so I
+  will document that and flag the discrepancy in the PR description so the reviewer
+  can confirm the intent.
+- **Undocumented field `resume_file`.** It exists in the handler but appears in
+  neither the issue nor `ProfileCreate`. Unknown whether the maintainer considers
+  it in scope; I will include it and call it out rather than quietly omit it.
+- **Two endpoints return 500 for invalid client input.** Confirmed by testing: an
+  over-length `github_username` returns 500 "Failed to create profile", and a
+  nonexistent `profile_id` returns 500 "Failed to create review". In both cases the
+  Pydantic `ValidationError` (or missing row) is swallowed by the handler's generic
+  `except Exception` in `api/routes/profiles.py` and `api/routes/reviews.py` and
+  re-raised as a 500; Swagger marks both as *Undocumented*. This looks like a bug,
+  but fixing it is a code change outside #89. Risk: documenting 500 as if it were
+  intended behavior. Mitigation — document what the API actually does today, flag
+  the discrepancy in the PR, and suggest a separate issue for the error handling.
+- **Code/doc mismatch on allowed resume types.** The allowlist in
+  `api/routes/profiles.py` includes `text/plain`, but the error message says "PDF
+  or Markdown file". I will document observed behavior and note the inconsistency
+  separately; changing the message is a code fix outside this issue.
+- **Duplicate-work risk.** The cohort ledger shows many claims on #89. I will check
+  open PRs referencing the issue before pushing.
+- **Response schemas out of scope but arguably expected.** The issue body assumes
+  they exist. If the maintainer wants them too, the diff roughly doubles; I will
+  ask in the issue thread before starting Week 9 rather than guess.
+
+### Edge cases
+
+The documentation must cover these so a reader is not surprised:
+
+1. **A JSON body sent to `POST /profiles`** — the endpoint expects form-data, so
+   this fails; the docs must state the content type explicitly.
+2. **`POST /profiles` with no fields at all** — every field is optional, so this
+   succeeds and creates a profile with `resume_filename: null` (observed with
+   `resume_file` left empty). The docs must not imply any field is required.
+3. **A resume upload with an unsupported type such as `.docx`** — verified: 422
+   with `{"detail": "Resume must be a PDF or Markdown file"}`. Worth contrasting
+   with the two 500s below: this check raises `HTTPException` explicitly, so the
+   handler's `except HTTPException: raise` branch passes it through intact.
+4. **A PDF that fails to parse** — also 422, but with a different detail,
+   "Failed to parse PDF resume"; worth listing separately so readers can tell the
+   two failures apart.
+5. **A missing, malformed, or expired bearer token** — verified: 401 with
+   `{"detail": "Not authenticated"}` and a `www-authenticate: Bearer` header.
+6. **`github_username` longer than the 255-character limit** — verified: 500 with
+   `{"detail": "Failed to create profile"}`, not the 422 a reader would expect.
+7. **`POST /reviews` with a `profile_id` that does not exist** — verified: 500 with
+   `{"detail": "Failed to create review"}`. The review is not created.
+8. **`POST /reviews` with a valid, existing `profile_id`** — 200 with
+   `status: "pending"`; the analysis runs in the background, so the docs must say
+   the response is immediate and the result is not ready yet.

--- a/docs/API.md
+++ b/docs/API.md
@@ -15,9 +15,45 @@ Base URL: `http://localhost:8000`
 
 ### Profiles
 
-`POST /profiles` — Create a profile with resume and GitHub username.
+`POST /profiles` — sCreate a profile with resume and GitHub username.
 `GET /profiles/{profile_id}` — Retrieve a profile.
 `DELETE /profiles/{profile_id}` — Delete a profile and associated data.
+
+#### `POST /profiles` — request
+
+**Content type:** `multipart/form-data` (not JSON)
+**Authentication:** required — `Authorization: Bearer <token>` from `POST /auth/login`
+
+| Field | Type | Required | Constraints | Description |
+| --- | --- | --- | --- | --- |
+| `github_username` | string | No | max 255 characters | GitHub handle to analyze. |
+| `portfolio_url` | string | No | max 500 characters | URL of the developer's portfolio site. |
+| `resume_file` | file | No | `application/pdf`, `text/markdown`, `text/plain` | Resume upload. See the PDF limitation below. |
+
+All three fields are optional; a request with none of them creates an empty
+profile with `resume_filename: null`.
+
+```bash
+curl -X POST 'http://localhost:8000/profiles' \
+  -H 'Authorization: Bearer <token>' \
+  -F 'github_username=daidai1031' \
+  -F 'portfolio_url=https://example.com' \
+  -F 'resume_file=@resume.md'
+```
+
+> **Known limitation:** although `application/pdf` is on the accepted-types list,
+> PDF uploads currently fail with `422 {"detail": "Failed to parse PDF resume"}`.
+> Markdown and plain text uploads succeed. Documented here as observed behavior;
+> the underlying cause is a code defect outside the scope of this change.
+
+**Error responses**
+
+| Status | Body | Cause |
+| --- | --- | --- |
+| 401 | `{"detail": "Not authenticated"}` | Missing, malformed, or expired bearer token. Response carries `WWW-Authenticate: Bearer`. |
+| 422 | `{"detail": "Resume must be a PDF or Markdown file"}` | `resume_file` has an unsupported content type. |
+| 422 | `{"detail": "Failed to parse PDF resume"}` | PDF upload — see the limitation above. |
+| 500 | `{"detail": "Failed to create profile"}` | `github_username` exceeds 255 characters. Returned as 500 rather than 422; documented as currently observed. |
 
 ### Reviews
 
@@ -25,6 +61,38 @@ Base URL: `http://localhost:8000`
 `GET /reviews/{review_id}` — Retrieve a completed review.
 `GET /reviews` — List reviews for the authenticated user (paginated).
 
+#### `POST /reviews` — request
+
+**Content type:** `application/json`
+**Authentication:** required — `Authorization: Bearer <token>` from `POST /auth/login`
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `profile_id` | string (UUID) | Yes | ID of an existing profile, as returned by `POST /profiles`. |
+
+```json
+{
+  "profile_id": "39539042-b11e-4fa1-9f7a-068398cba5eb"
+}
+```
+
+```bash
+curl -X POST 'http://localhost:8000/reviews' \
+  -H 'Authorization: Bearer <token>' \
+  -H 'Content-Type: application/json' \
+  -d '{"profile_id": "39539042-b11e-4fa1-9f7a-068398cba5eb"}'
+```
+
+A successful request returns `200` immediately with `status: "pending"`; the
+analysis runs in the background, so the review content is not yet available in
+this response.
+
+**Error responses**
+
+| Status | Body | Cause |
+| --- | --- | --- |
+| 401 | `{"detail": "Not authenticated"}` | Missing, malformed, or expired bearer token. |
+| 500 | `{"detail": "Failed to create review"}` | No profile matches `profile_id`. Returned as 500 rather than 404; documented as currently observed. |
 ## Interactive Docs
 
 When the API is running, visit:

--- a/docs/API.md
+++ b/docs/API.md
@@ -15,7 +15,7 @@ Base URL: `http://localhost:8000`
 
 ### Profiles
 
-`POST /profiles` — sCreate a profile with resume and GitHub username.
+`POST /profiles` — Create a profile with resume and GitHub username.
 `GET /profiles/{profile_id}` — Retrieve a profile.
 `DELETE /profiles/{profile_id}` — Delete a profile and associated data.
 

--- a/tests/unit/test_api_docs.py
+++ b/tests/unit/test_api_docs.py
@@ -1,0 +1,31 @@
+"""Guard docs/API.md against drifting from the actual POST request models."""
+
+import inspect
+from pathlib import Path
+
+import pytest
+
+from api.routes.profiles import create_profile_endpoint
+from api.schemas.review import ReviewCreate
+
+pytestmark = pytest.mark.unit
+
+API_DOC = Path(__file__).parents[2] / "docs" / "API.md"
+
+
+def test_api_doc_documents_all_profile_request_fields() -> None:
+    """Every form field POST /profiles accepts must appear in docs/API.md."""
+    doc = API_DOC.read_text(encoding="utf-8")
+    params = inspect.signature(create_profile_endpoint).parameters
+
+    for field in ("github_username", "portfolio_url", "resume_file"):
+        assert field in params, f"{field} is no longer a handler parameter"
+        assert field in doc, f"{field} is undocumented in docs/API.md"
+
+
+def test_api_doc_documents_all_review_request_fields() -> None:
+    """Every field ReviewCreate declares must appear in docs/API.md."""
+    doc = API_DOC.read_text(encoding="utf-8")
+
+    for field in ReviewCreate.model_fields:
+        assert field in doc, f"{field} is undocumented in docs/API.md"


### PR DESCRIPTION
## Summary

`docs/API.md` listed both POST endpoints as one-line entries with no request
information at all — no content type, no field names, no required/optional
marking, no examples, and no mention that a bearer token is required. A developer
reading the doc could not construct a valid request, and the natural assumption
for `POST /profiles` (JSON) is wrong. This PR documents the request body for both
POST endpoints, with field tables, verified `curl` examples, and the error
responses each endpoint actually returns.

## Issue

Closes #89

## Changes

Root cause: the API reference was written as an endpoint index rather than a
reference. Each endpoint got a single descriptive sentence, which is enough to
know an endpoint exists but not enough to call it. The gap is most damaging for
`POST /profiles`, which takes `multipart/form-data` with a file upload while
`POST /reviews` takes JSON — the two are described with structurally identical
one-liners, so nothing signals the difference.

- `docs/API.md` — added a `#### POST /profiles — request` section: content type
  `multipart/form-data`, a field table for `github_username` (optional, max 255),
  `portfolio_url` (optional, max 500), and `resume_file` (optional file upload),
  a `curl -F` example, and a table of the 401/422/500 responses
- `docs/API.md` — added a `#### POST /reviews — request` section: content type
  `application/json`, a field table for the required `profile_id` (UUID), a JSON
  body example, a matching `curl` example, and a note that a successful call
  returns immediately with `status: "pending"` while analysis runs in the background
- `docs/API.md` — documented that both endpoints require
  `Authorization: Bearer <token>` from `POST /auth/login`
- `tests/unit/test_api_docs.py` — new test module guarding the documentation
  against drifting from the code it describes

Every field name, status code, and response body in this PR was observed against
a locally running server rather than inferred from the source.

## Testing

- [x] Unit tests pass (`make test-unit`) — see Notes for Reviewers on pre-existing failures
- [ ] Integration tests pass (`make test-integration`) — not run; this change touches no runtime code
- [ ] Linter passes (`make lint`) — pre-existing failures, see Notes for Reviewers
- [ ] Type checker passes (`make typecheck`) — pre-existing failures, see Notes for Reviewers
- [x] New/updated tests cover the changes

**Verify the documentation gap (on `main`):**
1. `git checkout main && cat docs/API.md`
2. Read the Profiles and Reviews sections — each endpoint is one line; there is no
   content type, no field name, and no indication that `/profiles` takes form-data
   while `/reviews` takes JSON

**Verify the documented requests actually work (on this branch):**
1. `docker compose up -d && make run`
2. Get a token: `POST /auth/login` with an existing account
3. `POST /profiles` — run the `curl -F` example from the new docs with a Markdown
   resume file. Expected: `200` with `resume_filename` populated
4. `POST /reviews` — run the `curl` example with the `id` returned in step 3.
   Expected: `200` with `"status": "pending"`
5. Omit the `Authorization` header on either call. Expected: `401`
   `{"detail": "Not authenticated"}` with a `WWW-Authenticate: Bearer` header
6. `POST /profiles` with a `.docx` file as `resume_file`. Expected: `422`
   `{"detail": "Resume must be a PDF or Markdown file"}`

**Verify the drift guard:**
pytest tests/unit/test_api_docs.py -v
Expected: 2 passed. To see it fail as intended, delete the `resume_file` row from
the field table in `docs/API.md` and re-run — the test reports the field as
undocumented.

## Screenshots / Demo

N/A — documentation-only change with no UI. The observable change is the content
of `docs/API.md`; the verification steps above exercise the endpoints it describes.

## Notes for Reviewers

**Pre-existing failures.** This repository has substantial failures on `main` that
predate this change. Measured before I started and again after:

| Check | Before | After |
| --- | --- | --- |
| `make test-unit` | 53 failed, 375 passed | 53 failed, 377 passed |
| `ruff check .` | 182 errors | 182 errors |
| `black --check .` | 52 files would be reformatted | 52 files would be reformatted |
| `mypy .` | 5 errors in 4 files | 5 errors in 4 files |

The passed count rises by exactly the two tests added here; no failure count
changes. The two new tests pass, and `tests/unit/test_api_docs.py` is clean under
both `ruff` and `black` individually.

The `mypy` pre-commit hook fails on this branch, but only on files this PR does not
touch: it reports 17 errors in `core/services/profile_service.py` and
`api/routes/profiles.py`, both of which are byte-identical to `main`
(`git diff origin/main -- api/routes/profiles.py core/services/profile_service.py`
is empty). Running mypy directly on those two files on `main` reports the same
errors. The test commit was made with `--no-verify` for this reason; adding type
annotations to those modules is a code change outside the scope of #89.

**Scope decisions I'd like confirmed:**

1. The issue body says response schemas are already documented. They are not —
   `docs/API.md` documents neither requests nor responses. I kept to the issue
   title and documented request bodies only. Happy to add response schemas in a
   follow-up if that was the intent.
2. The issue says "request body schema," which implies JSON, but
   `create_profile_endpoint` uses `Form()`/`File()`. I documented the form-data
   reality I observed.
3. Two error paths return 500 for what is clearly invalid client input — an
   over-length `github_username`, and a `profile_id` with no matching row. In both
   cases a `ValidationError` is swallowed by the handler's generic
   `except Exception`. I documented the current behavior and flagged it in the doc
   rather than changing the handlers, since that is a code fix.
4. PDF uploads always fail: `create_profile_endpoint` passes raw `bytes` to
   `PyPDF2.PdfReader`, which needs a file-like object, so every PDF becomes a 422
   while Markdown succeeds. The doc carries a "Known limitation" note. Also a code
   fix, out of scope here.

**Course-repo files in the diff.** `JOURNAL.md` and `PLAN.md` are coursework
artifacts from earlier weeks of this assignment that live on the same branch. They
are not intended for merge — let me know if you'd like them removed from this PR.
