### PR TITLE
Fix/147 resume whitespace

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -37,3 +37,15 @@ I will need to understand the current logic for removing the whitespace and find
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/LaurenM64/pathreview/tree/fix/147-resume-whitespace
+
+**Reproduction summary:**
+I created a test in test_resume_parser.py that had extra whitespace added in a variety of cases.  Running the tests created the specified error where the resume parser could not parse those cases and failed.  
+
+**PLAN.md link:** https://github.com/LaurenM64/pathreview/blob/fix/147-resume-whitespace/PLAN.md
+

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,39 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/147
+**Issue title:** Resume section detection fails on text with leading whitespace
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:** The ingestion pipeline currently fails to correctly identify resume sections if the text contains leading whitespace before the headers. This bug prevents those specific resumes from being properly chunked, analyzed, and scored by the RAG system. A successful fix will likely involve stripping whitespace during the parsing step so the system can reliably recognize headers regardless of minor formatting quirks.
+
+**Is this right for me reasoning:** 
+[x]I can explain the problem and the expected behavior in 2–3 sentences without reading the issue. (summary above)
+[x]I've located the relevant files and confirmed they exist in the codebase. 
+resume_parser.py within the parsers folder.
+
+[x] I can describe a concrete before-and-after: what the user sees before the fix and what they see after. 
+Before: empty text in detected_sections outputs.  After: should be full with the content in the header.
+
+
+[x]The tier is a realistic match for where I am right now (tier 1)
+
+[x] I've found and read the specific code the issue references (not just the file — the function or section). _detect_sections() in resume_parser.py specifically lines 122/123: 
+"# Remove extra whitespace
+text = re.sub(r"\n{3,}", "\n\n", text)"
+
+
+[x]I've read enough surrounding context that I can write a rough plan for the fix without looking anything up. 
+I will need to understand the current logic for removing the whitespace and find what is causing the bug. It is likely within lines 122/123 as those are the lines handling whitespace removal but I will investigate the other calls to "text" as well. 
+
+[x]I've found the test file for my module and read at least one test end-to-end.
+
+[x]I've checked the issue comments and the ledger's Claims count, and I'm fine with how many others are on this issue.
+
+[x]I've estimated the time this will take and I'm confident I can complete it before the Week 9 deadline.
+[x]This issue has no open blockers or dependencies on other unresolved issues.
+
+**Branch name:** fix/147-resume-whitespace
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -49,3 +49,21 @@ I created a test in test_resume_parser.py that had extra whitespace added in a v
 
 **PLAN.md link:** https://github.com/LaurenM64/pathreview/blob/fix/147-resume-whitespace/PLAN.md
 
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+**Current progress:** Implemented the fix for Issue #147 in `resume_parser.py`. I updated the regular expressions in both `_detect_sections()` and `_strip_markdown()` to include `[ \t]*`, allowing the parser to correctly identify headers and markdown syntax even if they are indented with spaces or tabs.
+**Next steps:** Run the test suite to confirm the fix, check for linting errors, and open a pull request.
+**Blockers:** None.
+
+---
+
+### Check-in 2 (end of week)
+**PR link:** https://github.com/ascherj/pathreview/pull/690
+**Branch:** `fix/147-resume-whitespace`
+**What you built:** I updated the regex patterns in the resume parser to tolerate leading spaces and tabs. This ensures that sections like "Experience:" or "Education:" are still detected and properly parsed even if the text extraction includes random indentation formatting.
+**Tests added or updated:** I updated `tests/unit/test_resume_parser.py` by adding `test_detect_sections_with_leading_whitespace` to reproduce the bug. My fix caused this test, and 5 other pre-existing tests in that file, to turn green.
+**Self-review confirmation:** 
+[x] `make check` passes (Note: Pre-existing failures exist in unrelated modules)
+[x] `make test-unit` passes (Note: Pre-existing failures exist in unrelated modules)
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -67,3 +67,37 @@ I created a test in test_resume_parser.py that had extra whitespace added in a v
 [x] `make check` passes (Note: Pre-existing failures exist in unrelated modules)
 [x] `make test-unit` passes (Note: Pre-existing failures exist in unrelated modules)
 **Draft PR feedback received from:** none
+
+
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+N/A
+
+**How you responded:**
+[What changes did you make, or what did you reply? If no feedback,
+leave blank.]
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Dealing with setting up the project in the first place was difficult, as there were a lot of moving parts including figuring out how to install Docker.  Additionally, getting used to the codebase itself was tricky, although the earlier project had helped with that.  
+
+**What did you learn about working in a large codebase?**
+Getting used to someone else's syntax and code organization strategy is difficult at first.  However, using techniques from earlier projects helped to find where I need to enter the codebase and how to go between the files to get the full story.  
+
+**How did AI tools help — and where did they fall short?**
+AI assistance helped me understand specific files that I was unfamiliar with, especially ones involving databases.  It helped me to also talk through my ideas and understand where specifically my knowledge was falling short.  However, I still had to identify what files to pass into the AI, as I could not just shove the entire project into AI to determine that.  
+
+**What would you do differently if you started over?**
+Now that I have a better idea on the whole process, I would choose a different issue that was more difficult.  I would approach it with less AI guidance since I feel more confident with identifying where in the codebase and file the issue may me,  
+
+**What are you most proud of from this module?**
+Being able to go through a difficult codebase and successfully finding a bug, this is something I definitely would have struggled with earlier on.  

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,36 @@
+## Solution plan
+
+**Issue:** [#147 Resume section detection fails on text with leading whitespace](https://github.com/ascherj/pathreview/issues/147)
+
+### Understand
+What is the root cause of this issue? What behavior is expected vs. actual?
+- **Root Cause:** The regular expressions used in the parser to identify headers and markdown syntax likely start strictly to the beginning of a line without accounting for leading spaces or tabs.
+- **Expected:** The parser should correctly identify headers even if they are indented with spaces or tabs.
+- **Actual:** The parser returns an empty list for sections, and fails to strip markdown headers if leading whitespace exists.
+
+### Map
+Which files, functions, or modules are involved?
+- `ingestion/parsers/resume_parser.py`
+  - Function: `_detect_sections()`
+  - Function: `_strip_markdown()` (also failing due to the same root cause)
+
+### Plan
+What are the steps to fix this issue?
+1. Open `resume_parser.py` and locate the regex patterns used to match sections and markdown headers.
+2. Update the regex patterns to allow for optional leading whitespace. Reseaching solutions shows this typically involves adding `^[ \t]*` or `^\s*` before the header keyword match.
+3. Apply the same whitespace-tolerant logic to the `_strip_markdown()` function.
+4. Run the test suite (`pytest tests/unit/test_resume_parser.py`) to verify that all 6 currently failing tests turn green.
+
+### Inputs & outputs
+What does your fix take as input? What should it produce or change?
+- **Input:** Raw string text extracted from PDFs or Markdown files containing headers preceded by spaces/tabs.
+- **Output:** A properly populated list of strings (e.g., `['Experience', 'Education', 'Skills']`) extracted and assigned to `result.metadata["detected_sections"]`.
+
+### Risks & unknowns
+What could go wrong? What are you still unsure about?
+- **Risk:** If we make the regex *too* loose by using generic whitespace matching like `\s*`, it might accidentally match multi-line text artifacts or bullet points mid-sentence that happen to look like headers. We need to be careful to only target spaces and tabs (`[ \t]*`) at the start of a line.
+
+### Edge cases
+What inputs or states should your fix handle gracefully?
+- Mixed spaces and tabs used for indentation.
+- Headers that have trailing whitespace before the colon (e.g., `Experience :`).

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -99,7 +99,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -449,7 +448,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -473,7 +471,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1561,7 +1558,6 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1579,7 +1575,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1972,7 +1967,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3507,7 +3501,6 @@
       "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^2.0.1",
         "cssstyle": "^4.0.1",
@@ -4094,7 +4087,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4107,7 +4099,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4771,7 +4762,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/ingestion/parsers/resume_parser.py
+++ b/ingestion/parsers/resume_parser.py
@@ -98,8 +98,8 @@ class ResumeParser(BaseParser):
 
     def _strip_markdown(self, content: str) -> str:
         """Remove markdown syntax from content."""
-        # Remove markdown headers
-        text = re.sub(r"^#+\s+", "", content, flags=re.MULTILINE)
+        # Remove markdown headers (now tolerates leading spaces/tabs)
+        text = re.sub(r"^[ \t]*#+\s+", "", content, flags=re.MULTILINE)
 
         # Remove markdown links [text](url)
         text = re.sub(r"\[([^\]]+)\]\(([^\)]+)\)", r"\1", text)
@@ -130,12 +130,12 @@ class ResumeParser(BaseParser):
         text_lower = text.lower()
 
         for section in SECTION_HEADERS:
-            # Look for section header patterns
+            # Look for section header patterns (now tolerating leading spaces/tabs)
             patterns = [
-                rf"^{re.escape(section)}\s*$",
-                rf"^{re.escape(section)}\s*[:|-]",
-                rf"\n{re.escape(section)}\s*$",
-                rf"\n{re.escape(section)}\s*[:|-]",
+                rf"^[ \t]*{re.escape(section)}\s*$",
+                rf"^[ \t]*{re.escape(section)}\s*[:|-]",
+                rf"\n[ \t]*{re.escape(section)}\s*$",
+                rf"\n[ \t]*{re.escape(section)}\s*[:|-]",
             ]
 
             for pattern in patterns:

--- a/tests/unit/test_resume_parser.py
+++ b/tests/unit/test_resume_parser.py
@@ -181,3 +181,26 @@ class TestResumeParser:
         assert "John Doe" in result.text
         assert "Software Engineer" in result.text
         assert "Python" in result.text
+
+    def test_detect_sections_with_leading_whitespace(self, parser):
+        """Test section detection handles headers with leading whitespace (Issue #147)."""
+        text = """
+            Experience:
+            Senior Developer at TechCorp
+
+              Education:
+            BS Computer Science
+
+         Skills: Python, JavaScript
+        """
+        sections = parser._detect_sections(text)
+
+        assert isinstance(sections, list)
+        assert len(sections) > 0, "Bug #147: No sections detected due to leading whitespace"
+        
+        sections_lower = [s.lower() for s in sections]
+        assert any("experience" in s for s in sections_lower), "Failed to detect Experience section"
+        assert any("education" in s for s in sections_lower), "Failed to detect Education section"
+        assert any("skills" in s for s in sections_lower), "Failed to detect Skills section"
+
+

--- a/tests/unit/test_resume_parser.py
+++ b/tests/unit/test_resume_parser.py
@@ -1,11 +1,11 @@
 """Tests for resume_parser.py"""
 
-import pytest
-from unittest.mock import Mock, patch, MagicMock
-from io import BytesIO
+from unittest.mock import Mock, patch
 
-from ingestion.parsers.resume_parser import ResumeParser
+import pytest
+
 from ingestion.parsers.base import ParseResult
+from ingestion.parsers.resume_parser import ResumeParser
 
 
 @pytest.mark.unit
@@ -197,10 +197,8 @@ class TestResumeParser:
 
         assert isinstance(sections, list)
         assert len(sections) > 0, "Bug #147: No sections detected due to leading whitespace"
-        
+
         sections_lower = [s.lower() for s in sections]
         assert any("experience" in s for s in sections_lower), "Failed to detect Experience section"
         assert any("education" in s for s in sections_lower), "Failed to detect Education section"
         assert any("skills" in s for s in sections_lower), "Failed to detect Skills section"
-
-


### PR DESCRIPTION
## Summary
Implemented the fix for Issue #147 in `resume_parser.py`. I updated the regular expressions in both `_detect_sections()` and `_strip_markdown()` to include `[ \t]*`, allowing the parser to correctly identify headers and markdown syntax even if they are indented with spaces or tabs.

## Issue
Closes #147 

## Changes
- Strip Markdown changed regex
- Detect Sections changed regex

## Testing
<!-- How did you verify your changes? -->
- [x] Unit tests pass (`make test-unit`)
- [x] Integration tests pass (`make test-integration`)
- [x] Linter passes (`make lint`)
- [x] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes

