### PR TITLE
test(rag): correct partial-overlap fixture

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,16 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/157
+
+**Issue title:** Relevance scorer “partial overlap” test fixture actually has full query overlap
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The partial-overlap unit test in `tests/unit/test_relevance_scorer.py` uses a query and chunk that share every query term. Because the relevance scorer measures query-token coverage, it correctly returns `1.0`, contradicting the test's expectation of a middle-range score. The fixture needs to omit some query terms while retaining others so it represents genuine partial overlap. A successful fix makes the test exercise the intended behavior without changing the correct scoring implementation.
+
+**Branch name:** test/157-partial-overlap-fixture
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -13,4 +13,4 @@ The partial-overlap unit test in `tests/unit/test_relevance_scorer.py` uses a qu
 
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
-**Cohort ledger:** [ ] Issue added to cohort ledger
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -14,3 +14,17 @@ The partial-overlap unit test in `tests/unit/test_relevance_scorer.py` uses a qu
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/xyin20/pathreview/commit/fac1dda72ac9ca4ab6a91ec808d66f7de0f73129
+
+**Reproduction summary:**
+I restored the original all-four-term fixture and ran the focused relevance scorer tests. The scorer correctly returned `1.0`, producing `assert 1.0 < 0.9` and a result of `1 failed, 18 passed`.
+
+**PLAN.md link:** https://github.com/xyin20/pathreview/blob/test/157-partial-overlap-fixture/PLAN.md
+
+**Walkthrough video (recommended):** Not recorded
+
+**Blockers or open questions:**
+None.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -28,3 +28,36 @@ I restored the original all-four-term fixture and ran the focused relevance scor
 
 **Blockers or open questions:**
 None.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+I completed all five sub-tasks from `PLAN.md`: retained the four-token query, revised the chunk to a genuine two-of-four-term overlap, confirmed the score is `0.5`, ran the focused scorer suite, and verified that no production scoring code changed. The focused `tests/unit/test_relevance_scorer.py` suite passes all 19 tests.
+
+**Next steps:**
+Run the repository-wide unit and contribution checks, compare any failures with `origin/main`, open a draft PR, and request feedback before final submission.
+
+**Blockers:**
+The repository has numerous pre-existing lint, formatting, type-checking, and unit-test failures outside the relevance scorer.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/694
+
+**Branch:** `test/157-partial-overlap-fixture`
+
+**What you built:**
+I corrected the partial-overlap test fixture so the chunk matches only `Python` and `Django` from the four-term query. The unchanged scorer now returns the intended `0.5` coverage score instead of the correct-but-unexpected full-coverage score of `1.0`.
+
+**Tests added or updated:**
+Updated `tests/unit/test_relevance_scorer.py` so `test_query_with_partial_overlap` exercises genuine partial coverage. The focused file passes 19 tests; compared with `origin/main`, the full suite improves from 52 failures/345 passes/31 errors to 51 failures/346 passes/31 errors with no new failures.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+**Verification note:** Per the documented pre-existing-failure policy, the checked boxes mean this contribution introduces no new failures. GNU Make was unavailable on this Windows host, so I ran its exact underlying commands: Ruff reports 182 pre-existing errors, Black would reformat 52 pre-existing files, and mypy reports five pre-existing dependency/type errors. The full unit-suite baseline comparison confirms this branch removes issue #157's one failure and otherwise matches `origin/main`.
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -61,3 +61,34 @@ Updated `tests/unit/test_relevance_scorer.py` so `test_query_with_partial_overla
 **Verification note:** Per the documented pre-existing-failure policy, the checked boxes mean this contribution introduces no new failures. GNU Make was unavailable on this Windows host, so I ran the target commands directly, using Black's non-mutating `--check` mode to avoid rewriting unrelated files: Ruff reports 182 pre-existing errors, Black would reformat 52 pre-existing files, and mypy reports five pre-existing dependency/type errors. The full unit-suite baseline comparison confirms this branch removes issue #157's one failure and otherwise matches `origin/main`.
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No reviewer or maintainer feedback had arrived by August 6, 2026. I checked PR #694's conversation comments, submitted reviews, and inline review threads; all three were empty, which is consistent with the Summer 2026 note that reviewer feedback is not provided.
+
+**How you responded:**
+No response or code change was necessary because no feedback was received.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The code change itself was only one line, but proving that it was the correct one-line change took more work than expected. The failing assertion initially made the scorer look suspicious, yet tracing `RelevanceScorer.score()` showed that it correctly computes matched unique query tokens divided by total unique query tokens, so four matches out of four must return `1.0`. The harder part was separating that narrow fixture bug from the repository's much larger set of unrelated failures. Windows setup added friction as well: GNU Make was unavailable, the full dependency install encountered a long-running pip process and file lock, and I had to run the Makefile targets directly without allowing Black to rewrite dozens of unrelated files.
+
+**What did you learn about working in a large codebase?**
+I learned that a failing test does not automatically mean production code is wrong; the test data and the assertion must be checked against the implementation's contract. Scope discipline matters more in someone else's codebase because an apparently helpful cleanup can turn a focused contribution into a risky, difficult-to-review change. The baseline comparison was especially useful: `origin/main` had 52 failures, 345 passes, and 31 errors, while my branch had 51 failures, 346 passes, and the same 31 errors. That evidence showed that the branch fixed exactly issue #157 without making unrelated areas worse.
+
+**How did AI tools help — and where did they fall short?**
+AI assistance was most useful for navigating the repository, locating the scorer and contribution rules, translating the scoring logic into the expected `0.5` result, and keeping the branch, commits, journal, and PR consistent. It also helped automate repetitive verification, including temporarily restoring the original fixture, reproducing `assert 1.0 < 0.9`, and comparing the full suite against `origin/main`. AI could not replace judgment about whether the implementation or fixture was conceptually wrong, and tool assumptions sometimes failed in the real environment: Make was missing, package installation hit Windows locking behavior, and the review-thread helper queried the fork instead of the upstream cross-fork PR. Those cases required reading the actual errors, choosing safer fallbacks, and documenting limitations rather than claiming a clean result.
+
+**What would you do differently if you started over?**
+I would establish the full baseline before editing anything: install the declared development environment, run the focused test, run the repository-wide checks, and record the exact results immediately. I would also use Python 3.11 and install GNU Make at the start to match the project's documented setup more closely. Finally, I would create and push the reproduction commit before implementing the fixture fix, rather than reconstructing the original failing state afterward for the Week 8 record. That sequence would make the history easier for a reviewer to follow and reduce environment work late in the contribution cycle.
+
+**What are you most proud of from this module?**
+I am most proud of resisting the temptation to change a correct scorer merely to satisfy a failing assertion. The final contribution changes only the misleading fixture, produces the intended `0.5` partial-coverage score, and leaves production behavior untouched. I also built a traceable record—from reproduction through planning, testing, baseline comparison, and PR submission—that explains not just what changed, but why the change is correct.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -58,6 +58,6 @@ Updated `tests/unit/test_relevance_scorer.py` so `test_query_with_partial_overla
 
 **Self-review confirmation:** [x] make check passes  [x] make test-unit passes
 
-**Verification note:** Per the documented pre-existing-failure policy, the checked boxes mean this contribution introduces no new failures. GNU Make was unavailable on this Windows host, so I ran its exact underlying commands: Ruff reports 182 pre-existing errors, Black would reformat 52 pre-existing files, and mypy reports five pre-existing dependency/type errors. The full unit-suite baseline comparison confirms this branch removes issue #157's one failure and otherwise matches `origin/main`.
+**Verification note:** Per the documented pre-existing-failure policy, the checked boxes mean this contribution introduces no new failures. GNU Make was unavailable on this Windows host, so I ran the target commands directly, using Black's non-mutating `--check` mode to avoid rewriting unrelated files: Ruff reports 182 pre-existing errors, Black would reformat 52 pre-existing files, and mypy reports five pre-existing dependency/type errors. The full unit-suite baseline comparison confirms this branch removes issue #157's one failure and otherwise matches `origin/main`.
 
 **Draft PR feedback received from:** none

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,58 @@
+## Solution plan
+
+**Issue:** [Relevance scorer “partial overlap” test fixture actually has full query overlap](https://github.com/ascherj/pathreview/issues/157)
+
+### Understand
+
+`RelevanceScorer.score()` tokenizes the query and each chunk, then divides the
+number of matching unique query tokens by the number of unique query tokens.
+The query in `test_query_with_partial_overlap` contains four tokens, and the
+original chunk contains all four, so the actual and correct score is `1.0`.
+The test expects a partial-match score between `0.3` and `0.9`, so the fixture—not
+the scoring implementation—is the root cause. The expected behavior is for the
+chunk to contain only some of the query tokens and produce a middle-range score.
+
+### Map
+
+Files involved:
+
+- `tests/unit/test_relevance_scorer.py`
+  - `TestRelevanceScorer.test_query_with_partial_overlap`
+- `rag/evaluator/relevance_scorer.py`
+  - `RelevanceScorer.score()` provides the behavior being tested but should not
+    require modification.
+
+### Plan
+
+1. Preserve the four-token query so the test remains easy to understand.
+2. Change the chunk fixture to retain `Python` and `Django` while omitting the
+   query terms `web` and `framework`.
+3. Confirm the scorer returns `0.5`, representing two matching tokens out of
+   four unique query tokens.
+4. Run `pytest tests/unit/test_relevance_scorer.py -q` and confirm the partial
+   overlap assertion and the rest of the scorer tests pass.
+5. Review the diff to ensure no production scoring behavior changed.
+
+### Inputs & outputs
+
+The test passes the query `"Python Django web framework"` and a single chunk
+dictionary containing natural-language text. The revised fixture should match
+exactly two of the four unique query tokens, causing `score()` to return `0.5`.
+The test file should pass without changes to `RelevanceScorer`.
+
+### Risks & unknowns
+
+- Adding either `web` or `framework` back to the chunk would raise the score to
+  `0.75`, which still passes but makes the intended 50% overlap less explicit.
+- Punctuation is not stripped by `_tokenize()`, so punctuation attached to a
+  query word could accidentally turn an intended match into a non-match.
+- The focused test requires `pytest` and `structlog` in the local environment.
+- No production-code changes are expected; a production change would expand
+  the issue beyond its stated scope.
+
+### Edge cases
+
+- The revised chunk should continue to demonstrate case-insensitive matching.
+- Extra non-query words in the chunk must not affect the coverage calculation.
+- Empty queries and chunks, zero overlap, full overlap, and multiple chunks are
+  already covered by neighboring tests and should remain unchanged.

--- a/REPRODUCTION.md
+++ b/REPRODUCTION.md
@@ -1,0 +1,47 @@
+# Issue #157 reproduction
+
+Issue: [Relevance scorer “partial overlap” test fixture actually has full query overlap](https://github.com/ascherj/pathreview/issues/157)
+
+## Environment
+
+- Reproduced on Windows with Python 3.14.4
+- Focused dependencies: `pytest` and `structlog`
+- Reproduction date: 2026-07-28
+
+## Steps
+
+1. Use the original `test_query_with_partial_overlap` fixture in
+   `tests/unit/test_relevance_scorer.py`:
+
+   ```python
+   query = "Python Django web framework"
+   chunks = [
+       {
+           "text": "Django is a Python web framework for rapid development"
+       },
+   ]
+   ```
+
+2. Run:
+
+   ```powershell
+   .\.venv\Scripts\python.exe -m pytest tests/unit/test_relevance_scorer.py -q
+   ```
+
+## Observed result
+
+The focused test file reports `1 failed, 18 passed`. The failing assertion is:
+
+```text
+assert 0.3 < score < 0.9
+E       assert 1.0 < 0.9
+```
+
+All four unique query tokens—`python`, `django`, `web`, and `framework`—also
+occur in the chunk. `RelevanceScorer.score()` therefore computes `4 / 4` and
+correctly returns `1.0`; the fixture does not represent partial overlap.
+
+## Expected result
+
+The partial-overlap fixture should contain some, but not all, query tokens so
+the score falls strictly between the test's `0.3` and `0.9` bounds.

--- a/tests/unit/test_relevance_scorer.py
+++ b/tests/unit/test_relevance_scorer.py
@@ -49,7 +49,7 @@ class TestRelevanceScorer:
         query = "Python Django web framework"
         chunks = [
             {
-                "text": "Django is a Python web framework for rapid development"
+                "text": "Django is a popular Python tool for rapid development"
             },
         ]
 


### PR DESCRIPTION
## Summary

Correct the relevance scorer's partial-overlap unit-test fixture so it matches only two of four query terms. The scorer now returns `0.5` for this case, exercising the intended middle-range assertion without changing correct production scoring behavior. The branch also includes the required reproduction record, solution plan, and weekly journal.

## Issue

Closes #157

## Changes

- Replace the misleading full-overlap chunk in `test_query_with_partial_overlap` with a genuine two-of-four-term overlap.
- Document the original `assert 1.0 < 0.9` reproduction in `REPRODUCTION.md`.
- Add the scoped implementation approach and risk analysis in `PLAN.md`.
- Record Weeks 7–9 progress and verification in `JOURNAL.md`.

## Testing

- [x] Issue-specific unit tests pass (`19 passed` in `tests/unit/test_relevance_scorer.py`).
- [x] Full unit-suite baseline compared: `origin/main` has 52 failures, 345 passes, and 31 errors; this branch has 51 failures, 346 passes, and 31 errors. The only improvement is issue #157, and no new failures were introduced.
- [x] Linter and formatter baseline reviewed; repository-wide pre-existing failures remain unrelated to this fixture-only change.
- [x] Type checker baseline reviewed; five pre-existing dependency/type errors are unrelated to this fixture-only change.
- [ ] Integration tests were not run because this change only corrects isolated unit-test data.
- [x] The updated unit test covers the change.

## Screenshots / Demo

Not applicable; this change affects unit-test data only.

## Notes for Reviewers

The repository-wide checks do not currently pass on `origin/main`: Ruff reports 182 errors, Black would reformat 52 files, mypy stops on five dependency/type issues, and the unit suite has 52 failures plus 31 errors. This branch does not modify production code or those unrelated areas. Compared with `origin/main`, it removes only the known relevance-scorer failure and introduces no new failures.
