### PR TITLE
Add test coverage for review_service.py (#109)

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -22,3 +22,24 @@ changes to the pipeline don't silently break review processing.
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [we'll fill this in after committing]
+
+**Reproduction summary:**
+Ran `pytest tests/unit/test_review_service.py --cov=core.services.review_service --cov-report=term-missing`
+and confirmed 22% coverage, below the 40% threshold in the issue. Coverage report shows
+`process_review` (lines 98-194) and its helper functions `_run_ingestion_pipeline`,
+`_run_agent_orchestration`, `_run_rag_retrieval_generation` (lines 202-279), and
+`_run_safety_checks` (lines 369-390) are almost entirely untested. Also discovered
+13 pre-existing tests for `get_review`/`list_reviews` are currently failing due to
+an unrelated AsyncMock setup bug — noted as a blocker/observation, not part of this issue's scope.
+
+**PLAN.md link:** [we'll fill this in next]
+
+**Walkthrough video (recommended):** 
+
+**Blockers or open questions:**
+The 13 failing pre-existing tests are a separate bug (broken AsyncMock setup for db.execute).
+Need to decide whether to leave them as-is or flag separately, since fixing them isn't part of issue #109's scope.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -36,7 +36,7 @@ and confirmed 22% coverage, below the 40% threshold in the issue. Coverage repor
 13 pre-existing tests for `get_review`/`list_reviews` are currently failing due to
 an unrelated AsyncMock setup bug — noted as a blocker/observation, not part of this issue's scope.
 
-**PLAN.md link:** [we'll fill this in next]
+**PLAN.md link:** https://github.com/namitalamichhane/pathreview/blob/test/109-review-service-coverage/PLAN.md
 
 **Walkthrough video (recommended):** 
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -25,7 +25,7 @@ changes to the pipeline don't silently break review processing.
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [we'll fill this in after committing]
+**Reproduction commit link:** https://github.com/namitalamichhane/pathreview/commit/cb51d7f
 
 **Reproduction summary:**
 Ran `pytest tests/unit/test_review_service.py --cov=core.services.review_service --cov-report=term-missing`

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,24 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/109
+
+**Issue title:** Test coverage for core/services/review_service.py is below 40%
+
+**Tier:** [x] Tier 2  [ ] Tier 1  [ ] Tier 3
+
+**Problem summary:**
+The `review_service.py` module orchestrates the entire review pipeline — fetching
+a user's profile, running ingestion (GitHub, portfolio, resume), agent analysis,
+RAG generation, and safety checks — but most of this logic currently has no unit
+tests. This matters because `process_review` has several distinct outcomes (full
+success, a missing profile, a failed safety check, and an unhandled exception
+mid-pipeline) that each set the review's status differently, and none of that
+branching logic is currently verified. A successful fix adds unit tests in
+tests/unit/test_review_service.py that exercise each of these paths so future
+changes to the pipeline don't silently break review processing.
+
+**Branch name:** test/109-review-service-coverage
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -43,3 +43,26 @@ an unrelated AsyncMock setup bug — noted as a blocker/observation, not part of
 **Blockers or open questions:**
 The 13 failing pre-existing tests are a separate bug (broken AsyncMock setup for db.execute).
 Need to decide whether to leave them as-is or flag separately, since fixing them isn't part of issue #109's scope.
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/695
+
+**Branch:** `test/109-review-service-coverage`
+
+**What you built:**
+Added unit tests for `core/services/review_service.py`, focusing on `process_review`,
+`_run_ingestion_pipeline`, and `_run_safety_checks`, which previously had almost no
+coverage. Coverage for this file went from 22% to 90%.
+
+**Tests added or updated:**
+Added 15 new tests to `tests/unit/test_review_service.py`: 6 covering `process_review`
+(success path and 5 failure/edge-case branches), 3 covering `_run_ingestion_pipeline`
+(success, empty profile, partial source failure), and 6 covering `_run_safety_checks`
+(valid output, missing sections, missing name/content, and confidence boundary values).
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+(13 pre-existing failures in `get_review`/`list_reviews` documented as out of scope;
+confirmed no new failures or lint errors introduced by this change)
+
+**Draft PR feedback received from:** [fill in once you hear back, or "none" if you submit before getting any]

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,104 +1,47 @@
-\## Solution plan
+## Solution plan
 
-
-
-\*\*Issue:\*\* Test coverage for core/services/review\_service.py is below 40% (#109)
-
+**Issue:** Test coverage for core/services/review_service.py is below 40% (#109)
 https://github.com/ascherj/pathreview/issues/109
 
-
-
-\### Understand
-
-`review\_service.py` currently has 22% test coverage. The main orchestration function,
-
-`process\_review`, and its helper functions (`\_run\_ingestion\_pipeline`,
-
-`\_run\_agent\_orchestration`, `\_run\_rag\_retrieval\_generation`, `\_run\_safety\_checks`)
-
-have almost no tests. Expected behavior: process\_review should reliably set the review's
-
+### Understand
+review_service.py currently has 22% test coverage. The main orchestration function,
+process_review, and its helper functions (_run_ingestion_pipeline,
+_run_agent_orchestration, _run_rag_retrieval_generation, _run_safety_checks)
+have almost no tests. Expected behavior: process_review should reliably set the review's
 status to "complete" on success, "failed" on a safety check rejection, and "failed" on
-
 any unhandled exception, while ingestion errors for individual sources (GitHub, portfolio,
-
 resume) should be logged but not crash the whole pipeline. None of this branching is
-
 currently verified by tests.
 
-
-
-\### Map
-
+### Map
 Files I expect to touch:
-
-\- `tests/unit/test\_review\_service.py` (primary file — adding new test cases)
-
-\- Possibly `core/services/review\_service.py` (only if a test reveals an actual bug,
-
-&#x20; not just a coverage gap)
-
-
+- tests/unit/test_review_service.py (primary file, adding new test cases)
+- Possibly core/services/review_service.py (only if a test reveals an actual bug, not just a coverage gap)
 
 Functions to cover:
+- process_review (lines 98-194): success path, safety-check-failure path, profile-not-found path, unhandled-exception path
+- _run_ingestion_pipeline (lines 202-230): success case, and case where one source (e.g. GitHub) throws but others still process
+- _run_agent_orchestration / _run_rag_retrieval_generation (lines 230-279): basic output shape validation
+- _run_safety_checks (lines 369-390): passing case, missing-sections case, invalid-confidence case
 
-\- `process\_review` (lines 98-194): success path, safety-check-failure path, profile-not-found path, unhandled-exception path
+### Plan
+1. Write tests for process_review success path (mock all helper functions to return valid data, assert status becomes "complete")
+2. Write tests for process_review failure paths (profile not found, safety check fails, unhandled exception raised mid-pipeline)
+3. Write tests for _run_ingestion_pipeline covering partial failure (one source fails, others still return data)
+4. Write tests for _run_safety_checks covering all three validation branches (missing sections, missing name or content, invalid confidence range)
+5. Run full coverage report again and confirm we have crossed the 40 percent threshold, targeting closer to 70-80 percent for this file
 
-\- `\_run\_ingestion\_pipeline` (lines 202-\~230): success case, and case where one source (e.g. GitHub) throws but others still process
+### Inputs and outputs
+Input: a review_id and profile_id (UUIDs), plus a mocked db session and mocked profile data.
+Output: assertions on the Review object's status field, and on what gets passed to db.commit().
 
-\- `\_run\_agent\_orchestration` / `\_run\_rag\_retrieval\_generation` (lines \~230-279): basic output shape validation
+### Risks and unknowns
+- The 13 pre-existing failing tests (AsyncMock misconfiguration for get_review and list_reviews) are NOT part of this issue's scope, but they run in the same file, so I need to make sure my new tests don't accidentally depend on shared broken fixtures.
+- Not yet sure how the shared mock_db_session fixture is defined at the top of test_review_service.py, need to check whether I can reuse it as-is or need my own mocking pattern for process_review's multiple db.execute calls.
+- process_review calls multiple helper functions in sequence, mocking all of them correctly without conflicting patches could get fiddly.
 
-\- `\_run\_safety\_checks` (lines 369-390): passing case, missing-sections case, invalid-confidence case
-
-
-
-\### Plan
-
-1\. Write tests for `process\_review` success path (mock all helper functions to return valid data, assert status becomes "complete")
-
-2\. Write tests for `process\_review` failure paths (profile not found, safety check fails, unhandled exception raised mid-pipeline)
-
-3\. Write tests for `\_run\_ingestion\_pipeline` covering partial failure (one source fails, others still return data)
-
-4\. Write tests for `\_run\_safety\_checks` covering all three validation branches (missing sections, missing name/content, invalid confidence range)
-
-5\. Run full coverage report again and confirm we've crossed the 40% threshold, targeting closer to 70-80% for this file
-
-
-
-\### Inputs \& outputs
-
-Input: a `review\_id` and `profile\_id` (UUIDs), plus a mocked `db` session and mocked profile data.
-
-Output: assertions on the `Review` object's `status` field, and on what gets passed to `db.commit()`.
-
-
-
-\### Risks \& unknowns
-
-\- The 13 pre-existing failing tests (AsyncMock misconfiguration for `get\_review`/`list\_reviews`)
-
-&#x20; are NOT part of this issue's scope, but they run in the same file — need to make sure my new
-
-&#x20; tests don't accidentally depend on shared broken fixtures.
-
-\- Not yet sure how the shared `mock\_db\_session` fixture is defined at the top of
-
-&#x20; `test\_review\_service.py` — need to check whether I can reuse it as-is or need my own mocking pattern for `process\_review`'s multiple `db.execute` calls.
-
-\- `process\_review` calls multiple helper functions in sequence — mocking all of them correctly
-
-&#x20; without conflicting patches could get fiddly.
-
-
-
-\### Edge cases
-
-\- Profile has no GitHub username, no portfolio URL, and no resume text at all (empty ingestion)
-
-\- Safety check returns exactly 0 or exactly 1 for confidence (boundary values)
-
-\- `review` is None when `process\_review` starts (already-deleted review)
-
-\- Exception raised inside the outer `except` block itself (the fallback status update fails too)
-
+### Edge cases
+- Profile has no GitHub username, no portfolio URL, and no resume text at all (empty ingestion)
+- Safety check returns exactly 0 or exactly 1 for confidence (boundary values)
+- review is None when process_review starts (already-deleted review)
+- Exception raised inside the outer except block itself (the fallback status update fails too)

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,104 @@
+\## Solution plan
+
+
+
+\*\*Issue:\*\* Test coverage for core/services/review\_service.py is below 40% (#109)
+
+https://github.com/ascherj/pathreview/issues/109
+
+
+
+\### Understand
+
+`review\_service.py` currently has 22% test coverage. The main orchestration function,
+
+`process\_review`, and its helper functions (`\_run\_ingestion\_pipeline`,
+
+`\_run\_agent\_orchestration`, `\_run\_rag\_retrieval\_generation`, `\_run\_safety\_checks`)
+
+have almost no tests. Expected behavior: process\_review should reliably set the review's
+
+status to "complete" on success, "failed" on a safety check rejection, and "failed" on
+
+any unhandled exception, while ingestion errors for individual sources (GitHub, portfolio,
+
+resume) should be logged but not crash the whole pipeline. None of this branching is
+
+currently verified by tests.
+
+
+
+\### Map
+
+Files I expect to touch:
+
+\- `tests/unit/test\_review\_service.py` (primary file — adding new test cases)
+
+\- Possibly `core/services/review\_service.py` (only if a test reveals an actual bug,
+
+&#x20; not just a coverage gap)
+
+
+
+Functions to cover:
+
+\- `process\_review` (lines 98-194): success path, safety-check-failure path, profile-not-found path, unhandled-exception path
+
+\- `\_run\_ingestion\_pipeline` (lines 202-\~230): success case, and case where one source (e.g. GitHub) throws but others still process
+
+\- `\_run\_agent\_orchestration` / `\_run\_rag\_retrieval\_generation` (lines \~230-279): basic output shape validation
+
+\- `\_run\_safety\_checks` (lines 369-390): passing case, missing-sections case, invalid-confidence case
+
+
+
+\### Plan
+
+1\. Write tests for `process\_review` success path (mock all helper functions to return valid data, assert status becomes "complete")
+
+2\. Write tests for `process\_review` failure paths (profile not found, safety check fails, unhandled exception raised mid-pipeline)
+
+3\. Write tests for `\_run\_ingestion\_pipeline` covering partial failure (one source fails, others still return data)
+
+4\. Write tests for `\_run\_safety\_checks` covering all three validation branches (missing sections, missing name/content, invalid confidence range)
+
+5\. Run full coverage report again and confirm we've crossed the 40% threshold, targeting closer to 70-80% for this file
+
+
+
+\### Inputs \& outputs
+
+Input: a `review\_id` and `profile\_id` (UUIDs), plus a mocked `db` session and mocked profile data.
+
+Output: assertions on the `Review` object's `status` field, and on what gets passed to `db.commit()`.
+
+
+
+\### Risks \& unknowns
+
+\- The 13 pre-existing failing tests (AsyncMock misconfiguration for `get\_review`/`list\_reviews`)
+
+&#x20; are NOT part of this issue's scope, but they run in the same file — need to make sure my new
+
+&#x20; tests don't accidentally depend on shared broken fixtures.
+
+\- Not yet sure how the shared `mock\_db\_session` fixture is defined at the top of
+
+&#x20; `test\_review\_service.py` — need to check whether I can reuse it as-is or need my own mocking pattern for `process\_review`'s multiple `db.execute` calls.
+
+\- `process\_review` calls multiple helper functions in sequence — mocking all of them correctly
+
+&#x20; without conflicting patches could get fiddly.
+
+
+
+\### Edge cases
+
+\- Profile has no GitHub username, no portfolio URL, and no resume text at all (empty ingestion)
+
+\- Safety check returns exactly 0 or exactly 1 for confidence (boundary values)
+
+\- `review` is None when `process\_review` starts (already-deleted review)
+
+\- Exception raised inside the outer `except` block itself (the fallback status update fails too)
+

--- a/tests/unit/test_review_service.py
+++ b/tests/unit/test_review_service.py
@@ -1,14 +1,17 @@
 """Tests for review_service.py"""
 
-import pytest
-from uuid import uuid4
 from unittest.mock import AsyncMock, Mock, patch
-import asyncio
+from uuid import uuid4
+
+import pytest
 
 from core.services.review_service import (
+    _run_ingestion_pipeline,
+    _run_safety_checks,
     create_review,
     get_review,
     list_reviews,
+    process_review,
 )
 
 
@@ -45,7 +48,9 @@ class TestReviewService:
         return profile
 
     @pytest.mark.asyncio
-    async def test_create_review_returns_review_with_pending_status(self, mock_db_session, mock_review):
+    async def test_create_review_returns_review_with_pending_status(
+        self, mock_db_session, mock_review
+    ):
         """Test create_review returns Review with status='pending'."""
         profile_id = uuid4()
         user_id = uuid4()
@@ -55,7 +60,7 @@ class TestReviewService:
         mock_db_session.commit = AsyncMock()
         mock_db_session.refresh = AsyncMock()
 
-        with patch('core.services.review_service.Review') as MockReview:
+        with patch("core.services.review_service.Review") as MockReview:
             mock_instance = MockReview.return_value
             mock_instance.status = "pending"
             mock_instance.sections = None
@@ -66,7 +71,7 @@ class TestReviewService:
             # Check that Review was instantiated
             MockReview.assert_called()
             call_kwargs = MockReview.call_args[1]
-            assert call_kwargs['status'] == "pending"
+            assert call_kwargs["status"] == "pending"
 
     @pytest.mark.asyncio
     async def test_get_review_returns_review_for_correct_owner(self, mock_db_session):
@@ -133,9 +138,7 @@ class TestReviewService:
         mock_result.scalars.return_value.all.return_value = []
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
-        reviews, total = await list_reviews(
-            mock_db_session, user_id, page=2, page_size=page_size
-        )
+        reviews, total = await list_reviews(mock_db_session, user_id, page=2, page_size=page_size)
 
         # Second call should pass offset for page 2
         calls = mock_db_session.execute.call_args_list
@@ -165,7 +168,7 @@ class TestReviewService:
         profile_id = uuid4()
         user_id = uuid4()
 
-        with patch('core.services.review_service.Review'):
+        with patch("core.services.review_service.Review"):
             await create_review(mock_db_session, profile_id, user_id)
 
             mock_db_session.add.assert_called_once()
@@ -176,7 +179,7 @@ class TestReviewService:
         profile_id = uuid4()
         user_id = uuid4()
 
-        with patch('core.services.review_service.Review'):
+        with patch("core.services.review_service.Review"):
             await create_review(mock_db_session, profile_id, user_id)
 
             mock_db_session.commit.assert_called_once()
@@ -187,7 +190,7 @@ class TestReviewService:
         profile_id = uuid4()
         user_id = uuid4()
 
-        with patch('core.services.review_service.Review'):
+        with patch("core.services.review_service.Review"):
             await create_review(mock_db_session, profile_id, user_id)
 
             mock_db_session.refresh.assert_called_once()
@@ -244,13 +247,13 @@ class TestReviewService:
         profile_id = uuid4()
         user_id = uuid4()
 
-        with patch('core.services.review_service.Review') as MockReview:
+        with patch("core.services.review_service.Review") as MockReview:
             MockReview.return_value = Mock()
             await create_review(mock_db_session, profile_id, user_id)
 
             call_kwargs = MockReview.call_args[1]
-            assert 'profile_id' in call_kwargs
-            assert 'status' in call_kwargs
+            assert "profile_id" in call_kwargs
+            assert "status" in call_kwargs
 
     @pytest.mark.asyncio
     async def test_get_review_verifies_ownership(self, mock_db_session):
@@ -287,7 +290,7 @@ class TestReviewService:
         """Test list_reviews returns list of Review objects."""
         user_id = uuid4()
 
-        mock_reviews = [Mock(spec=['id', 'status']) for _ in range(3)]
+        mock_reviews = [Mock(spec=["id", "status"]) for _ in range(3)]
         mock_result = AsyncMock()
         mock_result.scalars.return_value.all.return_value = mock_reviews
         mock_db_session.execute = AsyncMock(return_value=mock_result)
@@ -302,13 +305,13 @@ class TestReviewService:
         profile_id = uuid4()
         user_id = uuid4()
 
-        with patch('core.services.review_service.Review') as MockReview:
+        with patch("core.services.review_service.Review") as MockReview:
             MockReview.return_value = Mock()
             await create_review(mock_db_session, profile_id, user_id)
 
             call_kwargs = MockReview.call_args[1]
-            assert call_kwargs['sections'] is None
-            assert call_kwargs['overall_score'] is None
+            assert call_kwargs["sections"] is None
+            assert call_kwargs["overall_score"] is None
 
     @pytest.mark.asyncio
     async def test_get_review_with_valid_uuid(self, mock_db_session):
@@ -338,3 +341,255 @@ class TestReviewService:
 
         # Should order by created_at descending
         mock_db_session.execute.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch("core.services.review_service._run_safety_checks")
+    @patch("core.services.review_service._run_rag_retrieval_generation")
+    @patch("core.services.review_service._run_agent_orchestration")
+    @patch("core.services.review_service._run_ingestion_pipeline")
+    async def test_process_review_success_sets_status_complete(
+        self,
+        mock_ingestion,
+        mock_agent,
+        mock_rag,
+        mock_safety,
+        mock_db_session,
+        mock_review,
+        mock_profile,
+    ):
+        """Test process_review sets status='complete' and stores sections on success."""
+        review_result = Mock()
+        review_result.scalars.return_value.first.return_value = mock_review
+        profile_result = Mock()
+        profile_result.scalars.return_value.first.return_value = mock_profile
+        mock_db_session.execute = AsyncMock(side_effect=[review_result, profile_result])
+
+        mock_ingestion.return_value = [{"source_type": "github", "data": "some data"}]
+        mock_agent.return_value = {"sections": [], "overall_score": 0.75}
+        mock_rag.return_value = {
+            "sections": [
+                {
+                    "section_name": "Technical Skills",
+                    "content": "Great skills",
+                    "confidence": 0.9,
+                    "suggestions": ["Add more detail"],
+                }
+            ],
+            "overall_score": 0.85,
+        }
+        mock_safety.return_value = True
+
+        await process_review(mock_db_session, mock_review.id, mock_profile.id)
+
+        assert mock_review.status == "complete"
+        assert mock_review.overall_score == 0.85
+        assert mock_review.sections is not None
+        assert len(mock_review.sections) == 1
+
+    @pytest.mark.asyncio
+    async def test_process_review_returns_early_when_review_not_found(self, mock_db_session):
+        """Test process_review exits quietly (no commit) when review doesn't exist."""
+        review_result = Mock()
+        review_result.scalars.return_value.first.return_value = None
+        mock_db_session.execute = AsyncMock(return_value=review_result)
+
+        result = await process_review(mock_db_session, uuid4(), uuid4())
+
+        assert result is None
+        mock_db_session.commit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_process_review_sets_failed_when_profile_not_found(
+        self,
+        mock_db_session,
+        mock_review,
+    ):
+        """Test process_review sets status='failed' when the profile can't be found."""
+        review_result = Mock()
+        review_result.scalars.return_value.first.return_value = mock_review
+        profile_result = Mock()
+        profile_result.scalars.return_value.first.return_value = None
+        mock_db_session.execute = AsyncMock(side_effect=[review_result, profile_result])
+
+        await process_review(mock_db_session, mock_review.id, uuid4())
+
+        assert mock_review.status == "failed"
+        mock_db_session.commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch("core.services.review_service._run_safety_checks")
+    @patch("core.services.review_service._run_rag_retrieval_generation")
+    @patch("core.services.review_service._run_agent_orchestration")
+    @patch("core.services.review_service._run_ingestion_pipeline")
+    async def test_process_review_sets_failed_when_safety_checks_fail(
+        self,
+        mock_ingestion,
+        mock_agent,
+        mock_rag,
+        mock_safety,
+        mock_db_session,
+        mock_review,
+        mock_profile,
+    ):
+        """Test process_review sets status='failed' when safety checks reject the output."""
+        review_result = Mock()
+        review_result.scalars.return_value.first.return_value = mock_review
+        profile_result = Mock()
+        profile_result.scalars.return_value.first.return_value = mock_profile
+        mock_db_session.execute = AsyncMock(side_effect=[review_result, profile_result])
+
+        mock_ingestion.return_value = []
+        mock_agent.return_value = {"sections": [], "overall_score": 0.5}
+        mock_rag.return_value = {"sections": [], "overall_score": 0.5}
+        mock_safety.return_value = False
+
+        await process_review(mock_db_session, mock_review.id, mock_profile.id)
+
+        assert mock_review.status == "failed"
+        assert mock_review.sections is None
+
+    @pytest.mark.asyncio
+    @patch("core.services.review_service._run_ingestion_pipeline")
+    async def test_process_review_sets_failed_on_unhandled_exception(
+        self,
+        mock_ingestion,
+        mock_db_session,
+        mock_review,
+        mock_profile,
+    ):
+        """Test process_review catches a mid-pipeline exception and marks the review failed."""
+        review_result = Mock()
+        review_result.scalars.return_value.first.return_value = mock_review
+        profile_result = Mock()
+        profile_result.scalars.return_value.first.return_value = mock_profile
+        review_result_again = Mock()
+        review_result_again.scalars.return_value.first.return_value = mock_review
+        mock_db_session.execute = AsyncMock(
+            side_effect=[review_result, profile_result, review_result_again]
+        )
+
+        mock_ingestion.side_effect = Exception("ingestion exploded")
+
+        await process_review(mock_db_session, mock_review.id, mock_profile.id)
+
+        assert mock_review.status == "failed"
+
+    @pytest.mark.asyncio
+    @patch("core.services.review_service._run_ingestion_pipeline")
+    async def test_process_review_does_not_raise_when_failure_handler_itself_fails(
+        self,
+        mock_ingestion,
+        mock_db_session,
+        mock_review,
+        mock_profile,
+    ):
+        """Test process_review swallows errors even if the fallback status update fails too."""
+        review_result = Mock()
+        review_result.scalars.return_value.first.return_value = mock_review
+        profile_result = Mock()
+        profile_result.scalars.return_value.first.return_value = mock_profile
+        mock_db_session.execute = AsyncMock(
+            side_effect=[review_result, profile_result, Exception("db is down")]
+        )
+
+        mock_ingestion.side_effect = Exception("ingestion exploded")
+
+        await process_review(mock_db_session, mock_review.id, mock_profile.id)
+
+    @pytest.mark.asyncio
+    async def test_run_ingestion_pipeline_success_all_sources(self, mock_db_session):
+        """Test ingestion pipeline processes github, portfolio, and resume sources."""
+        profile = Mock(
+            id=uuid4(),
+            github_username="octocat",
+            portfolio_url="https://example.com/portfolio",
+            resume_text="Experienced engineer...",
+            resume_filename="resume.pdf",
+        )
+        with patch("core.services.review_service.IngestedSource"):
+            results = await _run_ingestion_pipeline(mock_db_session, profile)
+
+        assert len(results) == 3
+        assert mock_db_session.add.call_count == 3
+        mock_db_session.commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_run_ingestion_pipeline_empty_profile_returns_empty_list(self, mock_db_session):
+        """Test ingestion pipeline handles a profile with no sources at all (edge case)."""
+        profile = Mock(
+            id=uuid4(),
+            github_username=None,
+            portfolio_url=None,
+            resume_text=None,
+            resume_filename=None,
+        )
+        with patch("core.services.review_service.IngestedSource"):
+            results = await _run_ingestion_pipeline(mock_db_session, profile)
+
+        assert results == []
+        mock_db_session.add.assert_not_called()
+        mock_db_session.commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_run_ingestion_pipeline_continues_after_github_failure(self, mock_db_session):
+        """Test that a failure ingesting GitHub doesn't stop portfolio/resume from processing."""
+        profile = Mock(
+            id=uuid4(),
+            github_username="octocat",
+            portfolio_url="https://example.com/portfolio",
+            resume_text="Experienced engineer...",
+            resume_filename="resume.pdf",
+        )
+        with patch(
+            "core.services.review_service.IngestedSource",
+            side_effect=[Exception("github ingestion failed"), Mock(), Mock()],
+        ):
+            results = await _run_ingestion_pipeline(mock_db_session, profile)
+
+        assert len(results) == 3
+        assert mock_db_session.add.call_count == 2
+        mock_db_session.commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_run_safety_checks_passes_valid_output(self):
+        """Test safety checks pass for a well-formed section."""
+        output = {
+            "sections": [
+                {"section_name": "Technical Skills", "content": "Solid", "confidence": 0.5}
+            ]
+        }
+        assert await _run_safety_checks(output) is True
+
+    @pytest.mark.asyncio
+    async def test_run_safety_checks_fails_when_no_sections(self):
+        """Test safety checks fail when sections are missing or empty."""
+        assert await _run_safety_checks({"sections": []}) is False
+        assert await _run_safety_checks({}) is False
+
+    @pytest.mark.asyncio
+    async def test_run_safety_checks_fails_when_section_missing_name_or_content(self):
+        """Test safety checks fail when a section is missing its name or content."""
+        missing_name = {
+            "sections": [{"section_name": "", "content": "Some content", "confidence": 0.5}]
+        }
+        missing_content = {
+            "sections": [{"section_name": "Technical Skills", "content": "", "confidence": 0.5}]
+        }
+        assert await _run_safety_checks(missing_name) is False
+        assert await _run_safety_checks(missing_content) is False
+
+    @pytest.mark.asyncio
+    async def test_run_safety_checks_boundary_confidence_values_pass(self):
+        """Test confidence of exactly 0 and exactly 1 are valid (inclusive boundaries)."""
+        zero_confidence = {"sections": [{"section_name": "X", "content": "Y", "confidence": 0}]}
+        one_confidence = {"sections": [{"section_name": "X", "content": "Y", "confidence": 1}]}
+        assert await _run_safety_checks(zero_confidence) is True
+        assert await _run_safety_checks(one_confidence) is True
+
+    @pytest.mark.asyncio
+    async def test_run_safety_checks_fails_invalid_confidence_out_of_range(self):
+        """Test confidence outside [0, 1] fails safety checks."""
+        too_high = {"sections": [{"section_name": "X", "content": "Y", "confidence": 1.5}]}
+        too_low = {"sections": [{"section_name": "X", "content": "Y", "confidence": -0.1}]}
+        assert await _run_safety_checks(too_high) is False
+        assert await _run_safety_checks(too_low) is False


### PR DESCRIPTION
## Summary
Adds unit test coverage for `core/services/review_service.py`, focused on
`process_review`, `_run_ingestion_pipeline`, and `_run_safety_checks`, which
previously had almost no test coverage (22%).

Closes #109

## What was tested
- `process_review`: success path, review-not-found, profile-not-found,
  safety-check-failure, unhandled mid-pipeline exception, and exception
  during the fallback failure-handler itself
- `_run_ingestion_pipeline`: success with all sources, empty profile
  (no sources), and partial failure (one source fails, others still process)
- `_run_safety_checks`: valid output, missing sections, missing name/content,
  and confidence boundary values (0 and 1 inclusive, out-of-range rejected)

## Coverage
`core/services/review_service.py` coverage: 22% → 90% (target was 40%)

## Tests
- 15 new tests added to `tests/unit/test_review_service.py`, all passing
- `make test-unit` and `make check` both run clean relative to baseline

## Pre-existing failures (not in scope for this PR)
13 pre-existing test failures exist in this same file, in `get_review` and
`list_reviews` tests, due to an AsyncMock misconfiguration (`mock_result`
is mocked as `AsyncMock` when `result.scalars()` should be sync). These are
unrelated to this issue and are not fixed here. Confirmed via `make check`
diff that this PR introduces zero new lint errors, and via `make test-unit`
that no new test failures were introduced — the same 13 failures exist
before and after this change.