### PR TITLE
Fix# 148: skill extractor function extracting js ts format

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,36 @@
+# Journal
+
+## Week 7 - Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/148
+
+**Issue title:** Skill extractor fails to detect JavaScript and TypeScript
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Why I picked this issue:**
+I switched to this issue after my original pick, issue #130, got closed by the professor for being based on a false premise. It turned out docker-compose.yml never actually had the LLM proxy service that issue described, so there was nothing real to fix. This time I wanted to make sure my pick was a real, reproducible bug before committing to it, and #148 fit that. The issue gives two concrete examples of text that should trigger skill detection but doesn't, so I can run those same inputs through extract_skills() myself and see the bug instead of just taking the report at face value. It's also tagged tier-1, which felt like the right move after a tier-3 issue turned into a dead end, and it's scoped to one function in the ingestion pipeline instead of spreading across a bunch of files.
+
+**Problem summary:**
+extract_skills() is supposed to detect programming languages and frameworks mentioned in text, but right now it basically can't see JavaScript or TypeScript. The issue gives two examples: text about writing index.js with arrow functions and async/await comes back with zero detected skills, and text mentioning app.tsx and types.ts with TypeScript interfaces only detects React while missing TypeScript and JavaScript entirely. Detection for Python, DevOps, and database skills works fine, so this looks like a gap specific to how the JS/TS family gets matched rather than a problem with the whole function. Four test cases in the test suite are currently failing because of this. Fixing it means extract_skills() needs to reliably pick up JavaScript and TypeScript the same way it already handles those other languages.
+
+**Branch name:** fix/148-skill-extractor-js-ts
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 - Reproduction
+
+**What I did to reproduce this:**
+The repo already has a test file for this function, tests/unit/test_skill_extractor.py, so I ran it directly instead of writing new tests from scratch: `pytest tests/unit/test_skill_extractor.py -v -m unit`. That gave me 5 failing tests, not the 4 the issue mentions, so I read through each failure instead of assuming they were all the same bug. Two of them line up exactly with the issue:
+
+- `test_javascript_detection` feeds in `const fs = require('fs');` and expects a JavaScript skill to be detected. Nothing gets detected.
+- `test_text_with_typescript_files` feeds in text using `export interface User {...}` and `export class UserService {...}`, no filename. It only expects TypeScript, but nothing gets detected either.
+
+The other 3 failures (`test_database_technology_detection`, `test_devops_tool_detection`, `test_docker_compose_detection`) are unrelated pre-existing bugs, not JS/TS detection issues, so I am not treating those as part of this issue's scope.
+
+**What this confirms:**
+I traced both real failures to `_detect_languages()` in ingestion/parsers/skill_extractor.py (around line 173). The JS/TS evidence check only runs `re.search(r"\b(import|require)\s+", text)`, which requires a space right after `require`. `require('fs')` has no space before the `(`, so it never matches. The same block never checks for `export`, `interface`, or `class`, so TypeScript-style module code with no filename is invisible too. There is also a `JS_TS_KEYWORDS` set defined earlier in the file that would cover this, but it is never actually referenced anywhere in the detection logic, so it is dead code sitting right next to the bug.
+
+I added a comment directly above that regex in skill_extractor.py pointing at issue #148 and the two failing tests, so the exact location is documented in the code, not just in this journal.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -68,3 +68,35 @@ Added 4 new tests to tests/unit/test_skill_extractor.py: `test_issue_148_javascr
 **Self-review confirmation:** [x] make check passes for the files I touched (ruff, black, mypy all clean on skill_extractor.py and my new tests; the full repo-wide `make check` still fails from unrelated pre-existing lint errors in files I never touched)  [x] make test-unit passes for the tests this issue covers (ran the full suite before and after: 53 failed/375 passed before any of my changes, 51 failed/381 passed after, so 6 more tests pass overall with zero new failures anywhere)
 
 **Draft PR feedback received from:** none yet
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+As of 08/07/2026 There has been no feedback yet on my PR. 
+
+**How you responded:**
+[What changes did you make, or what did you reply? If no feedback,
+leave blank.]
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The hardest part of this entire pull request was not solving the bug itself, but following the practices of a industry standard PR. Throughout all my academic career, I have been used to writing code and tests, then submitting them with a single commit and a brief description. In this module, it emphasized how intricate and important the PR process is. Getting familiar with maneuvering through the Github interface, writing a detailed PR description, and following the review process was more time-consuming than I expected. I also had to learn how to write tests that accurately reflect the issue's examples, which required careful reading and understanding of the problem.
+
+**What did you learn about working in a large codebase?**
+The biggest difference between contributing to a large codebase and writing my own code is the importance of understanding the existing structure and conventions. Jumping into a large codebase practically highlighted how a small change that you are contributing on can have an impact on other parts of the system. When working on your own project, you understand the entire codebase and can make changes without worrying about any large scale issues as much due to your familiarity with the code making and decisions from scratch.
+
+**How did AI tools help — and where did they fall short?**
+AI was imperative in helping me understand the existing codebase and the problem at hand. To me, that was the main premise of this module and where AI is most effective. I prompted claude to narrow down the relevant files and functions to understand the bug and understand the existing test and any other relevant code associated with the issue. After familiarizing myself with the issue and codebase, I just followed the usual effective prompting procedures to get the AI to help me write the code and tests eventually fixing the bug. Where it may fell short was missing some of the nuances of the existing codebase and the problem at hand, which required me to read and understand the codebase myself. A few draft fixes didn't immediately work and resulted in some new problems, and I had to iterate on them to get the final solution.
+
+**What would you do differently if you started over?**
+If I were to start over, I would spend more time upfront understanding the existing codebase as a whole. To be completely transparent, I spent a lot of time understanding the specific function and test files related to the issue, but I did not spend as much time understanding the overall structure of the codebase. Not to say I did not spend enough time on that, but in a real world scenario, I would have spent more time understanding the overall structure of the codebase and how the different components interact with each other to fully immerse myself into the project. This would have helped me to understand the bigger picture and how my changes fit into it.
+
+**What are you most proud of from this module?**
+I am most proud of my ability to adapt to the PR process and the review process. That essentially was the main goal of this module. I'm proud to have had an actual practical experience of contributing to a large codebase from beginning to end. Learning how to select an issue, understanding the process of reproducing it, building a solution, writing tests, and submitting a PR for review was a very valuable experience. 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -53,7 +53,7 @@ Running `make check` on the whole repo still fails, but it is 180 pre-existing l
 
 ### Check-in 2 (end of week)
 
-**PR link:** not submitted yet, want to commit and push first
+**PR link:** https://github.com/ascherj/pathreview/pull/697
 
 **Branch:** fix/148-skill-extractor-js-ts
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -34,3 +34,37 @@ The other 3 failures (`test_database_technology_detection`, `test_devops_tool_de
 I traced both real failures to `_detect_languages()` in ingestion/parsers/skill_extractor.py (around line 173). The JS/TS evidence check only runs `re.search(r"\b(import|require)\s+", text)`, which requires a space right after `require`. `require('fs')` has no space before the `(`, so it never matches. The same block never checks for `export`, `interface`, or `class`, so TypeScript-style module code with no filename is invisible too. There is also a `JS_TS_KEYWORDS` set defined earlier in the file that would cover this, but it is never actually referenced anywhere in the detection logic, so it is dead code sitting right next to the bug.
 
 I added a comment directly above that regex in skill_extractor.py pointing at issue #148 and the two failing tests, so the exact location is documented in the code, not just in this journal.
+
+
+## Week 9 - Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+I finished steps 2 through 4 from PLAN.md. In `_detect_languages()` I widened the import/require check so it also catches `require('fs')` style calls with no space before the parenthesis, added evidence checks for `export`, arrow functions, and async/await, and added a separate TypeScript-specific check (looking for `interface` and TS-style type annotations like `: string`) so the TypeScript vs JavaScript label no longer depends only on the filename. Both `test_javascript_detection` and `test_text_with_typescript_files` pass now. I also ran the full unit suite before and after my change to check for regressions, went from 53 failing to 51 failing, so exactly the 2 tests I meant to fix and nothing else broke.
+
+**Next steps:**
+I still need to add 1 or 2 of my own test cases based on the issue's exact examples (arrow function and async/await text with no require at all, and a `.tsx` filename with no matching text in the body), since the existing tests use slightly different sample text than what the issue itself gave. After that I want to commit, push, and open the PR.
+
+**Blockers:**
+Running `make check` on the whole repo still fails, but it is 180 pre-existing lint errors in files I never touched (mostly unused variables in test_tech_detector.py and similar). I checked just my file with ruff, black, and mypy directly and it passes all three on its own, so I do not think this blocks my PR, but I wanted to note it here in case it comes up in review.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** not submitted yet, want to commit and push first
+
+**Branch:** fix/148-skill-extractor-js-ts
+
+**What you built:**
+I fixed `extract_skills()` so it actually detects JavaScript and TypeScript from real code content instead of relying mostly on filenames. It now looks for `require(`, `export`, arrow functions, and async/await as JavaScript evidence, and separately checks for `interface` (including the plural "interfaces") and TypeScript-style type annotations to decide whether to label something TypeScript, instead of only checking for a `.ts` filename.
+
+While testing, I ran the two exact examples straight from the issue body and found my first pass at the fix still missed the TypeScript one, since it was written as plain description text ("Built app.tsx and types.ts with strict TypeScript interfaces") instead of real code, with no filename passed in at all. So I added a second layer of evidence: checking for the literal words "javascript" and "typescript" in the text, and checking for `.js`/`.jsx`/`.ts`/`.tsx` mentioned inside the text itself, not just in the filename argument. I also had to tighten my own async/await check, since a bare "await" check I wrote first would have falsely flagged plain English like "I await your reply."
+
+**Tests added or updated:**
+Added 4 new tests to tests/unit/test_skill_extractor.py: `test_issue_148_javascript_description` and `test_issue_148_typescript_description` use the issue's exact wording with no filename, `test_js_ts_keywords_do_not_false_positive_on_prose` checks that ordinary English sentences with words like "class," "let," and "await" don't get flagged as code, and `test_tsx_file_detects_both_react_and_typescript` checks that a real `.tsx` component is picked up as both React and TypeScript together. The existing `test_javascript_detection` and `test_text_with_typescript_files` also now pass.
+
+**Self-review confirmation:** [x] make check passes for the files I touched (ruff, black, mypy all clean on skill_extractor.py and my new tests; the full repo-wide `make check` still fails from unrelated pre-existing lint errors in files I never touched)  [x] make test-unit passes for the tests this issue covers (ran the full suite before and after: 53 failed/375 passed before any of my changes, 51 failed/381 passed after, so 6 more tests pass overall with zero new failures anywhere)
+
+**Draft PR feedback received from:** none yet

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,53 @@
+## Solution plan
+
+**Issue:** Skill extractor fails to detect JavaScript and TypeScript ([#148](https://github.com/ascherj/pathreview/issues/148))
+
+### Understand
+
+What is the root cause of this issue? What behavior is expected vs. actual?
+
+- The root cause lives in `_detect_languages()` in `ingestion/parsers/skill_extractor.py` (around line 173). The JS/TS evidence check relies on a single regex, `re.search(r"\b(import|require)\s+", text)`, which only matches `import`/`require` when followed by whitespace. It never checks for `export`, `interface`, `class`, `const`, `let`, or `function`, even though a `JS_TS_KEYWORDS` set covering those exact terms is already defined earlier in the file and never used anywhere.
+- Expected behavior: text that clearly describes JavaScript or TypeScript work (arrow functions, async/await, `require(...)`, `export interface`, `.tsx`/`.ts` file mentions) should produce a JavaScript or TypeScript `SkillDetection`, the same way Python, DevOps, and database content already gets picked up by their own detection paths.
+- Actual behavior: `require('fs')` (no space before the parenthesis) never matches the regex, so no evidence is collected at all. Content that uses `export`/`interface`/`class` without a `.ts` filename is also invisible, since the language label itself is picked by a ternary on `.ts in filename`, not on anything in the text. Confirmed by running `pytest tests/unit/test_skill_extractor.py -v -m unit`: `test_javascript_detection` and `test_text_with_typescript_files` both fail with zero skills detected.
+
+### Map
+
+Which files, functions, or modules are involved?
+
+- `ingestion/parsers/skill_extractor.py` - `_detect_languages()` is where the fix goes. This is also where the unused `JS_TS_KEYWORDS` set and `REACT_INDICATORS` set already live, so I can reuse the existing pattern the file uses for other languages instead of inventing a new one.
+- `tests/unit/test_skill_extractor.py` - already has `test_javascript_detection` and `test_text_with_typescript_files`, which are the tests I need to make pass. I don't expect to need new test files, though I may add one or two more cases (e.g. `import`/`export` with no trailing space, arrow functions alone with no `require`/`import` at all) if the fix doesn't already cover them.
+
+### Plan
+
+What are the steps to fix this issue?
+
+1. Reproduce and confirm scope (done - see JOURNAL.md Week 8). Only `test_javascript_detection` and `test_text_with_typescript_files` are actually about JS/TS; the other 3 failing tests in the same file are pre-existing bugs unrelated to this issue and out of scope here.
+2. Widen the JS/TS evidence regex so it matches `require`/`import` regardless of what follows (`require(`, `require '...'`, `import {`, `import x from`), instead of requiring a literal space.
+3. Add evidence checks for `export`, `interface`, `class`, and the other `JS_TS_KEYWORDS` terms that are currently defined but unused, so content-only samples (no filename) can still be detected the same way the issue's TypeScript example expects.
+4. Reconsider the `TypeScript` vs `JavaScript` label logic so it isn't based solely on `.ts` in the filename. If `interface` or type-annotation-style TS syntax appears in the text itself, that should be enough to label it TypeScript even with no filename, mirroring how Python type annotations already contribute evidence for Python.
+5. Run `pytest tests/unit/test_skill_extractor.py -v -m unit` again to confirm both target tests pass, and check that the 3 unrelated failing tests are still failing for their original, unrelated reasons (not newly broken by this change).
+6. Add 1-2 additional test cases of my own (arrow function + async/await with no `require`, and `.tsx` filename with no matching text) to cover the two examples given directly in the issue body, since the existing tests use slightly different sample text than the issue's own examples.
+
+### Inputs & outputs
+
+- Input: arbitrary text passed to `extract_skills(text, filename=None)`, sometimes with a filename, sometimes without, as shown by the issue's two examples (plain `.js`-style code with no filename, and `.tsx`/`.ts` filenames with TypeScript-flavored text).
+- Output: `_detect_languages()` populates `skills_dict` with a `JavaScript` or `TypeScript` `SkillDetection` (name, category, confidence, evidence list) whenever the text or filename gives real evidence of either language, following the same shape already used for Python.
+
+### Risks & unknowns
+
+Unknowns:
+
+- How much evidence is "enough" to call something TypeScript vs JavaScript when there's no filename at all. I want to avoid making the regex so broad that plain English text mentioning words like "class" or "export" (in a non-code sense) gets falsely flagged. I'll check confidence scoring and maybe require at least two independent signals before labeling, similar to how Python already accumulates multiple evidence items before reporting.
+- Whether fixing this regex could change results for the 3 unrelated failing tests. I don't expect overlap since those are about Docker/database detection, not language detection, but I'll rerun the full file, not just the two target tests, to be sure I haven't shifted anything unexpected.
+
+Risks:
+
+- Overly broad keyword matching could introduce false positives on non-code text (e.g. a resume that says "I exported reports as PDF" containing the word "export"). I'll keep matches anchored to code-like syntax (e.g. `export\s+(default\s+)?(class|interface|function|const)`) rather than bare keyword substrings, to avoid this.
+- `JS_TS_KEYWORDS` was defined but never wired in for a reason I don't know yet; it's possible an earlier version of this code intentionally avoided it because it was too noisy. I'll test with real-sounding non-JS text as a sanity check before relying on it directly.
+
+### Edge cases
+
+- Text with `require`/`import` immediately followed by a parenthesis or quote and no space (e.g. `require('fs')`, `import('./thing')`), which is what the existing failing test already covers.
+- Text with no filename at all that still clearly reads as TypeScript because of `interface`/`export class`/type annotations, matching the issue's second example.
+- Text that mentions React (`.tsx`, `useState`) which already gets detected correctly today, I need to make sure my change doesn't accidentally duplicate or conflict with the existing `_detect_react()` logic, since a `.tsx` file is arguably both React and TypeScript.
+- Plain-English text that happens to contain common-English words that overlap with JS keywords (e.g. "class," "let," "const" used outside of code), which should not falsely trigger a JavaScript/TypeScript detection.

--- a/ingestion/parsers/skill_extractor.py
+++ b/ingestion/parsers/skill_extractor.py
@@ -1,11 +1,11 @@
 import re
 from dataclasses import dataclass
-from typing import Optional
 
 
 @dataclass
 class SkillDetection:
     """Result of detecting a skill."""
+
     name: str
     category: str
     confidence: float
@@ -105,7 +105,7 @@ class SkillExtractor:
         "ansible": 0.85,
     }
 
-    def extract_skills(self, text: str, filename: Optional[str] = None) -> list[SkillDetection]:
+    def extract_skills(self, text: str, filename: str | None = None) -> list[SkillDetection]:
         """
         Extract skills from source code or documentation text.
 
@@ -116,7 +116,7 @@ class SkillExtractor:
         Returns:
             List of detected skills with confidence scores
         """
-        detected_skills = {}
+        detected_skills: dict[str, SkillDetection] = {}
 
         # Detect languages first
         self._detect_languages(text, filename, detected_skills)
@@ -143,7 +143,7 @@ class SkillExtractor:
     def _detect_languages(
         self,
         text: str,
-        filename: Optional[str],
+        filename: str | None,
         skills_dict: dict,
     ) -> None:
         """Detect programming languages."""
@@ -171,6 +171,11 @@ class SkillExtractor:
             )
 
         # JavaScript/TypeScript detection
+        # BUG (#148): this regex requires whitespace right after import/require, so it
+        # misses `require('fs')` and never checks export/interface/class, so content-only
+        # TS/JS (no filename) is invisible. JS_TS_KEYWORDS above is never used here.
+        # Reproduced by tests/unit/test_skill_extractor.py::test_javascript_detection and
+        # ::test_text_with_typescript_files.
         js_evidence = []
         if ".js" in str(filename or "").lower():
             js_evidence.append("JavaScript file extension (.js)")

--- a/ingestion/parsers/skill_extractor.py
+++ b/ingestion/parsers/skill_extractor.py
@@ -171,29 +171,49 @@ class SkillExtractor:
             )
 
         # JavaScript/TypeScript detection
-        # BUG (#148): this regex requires whitespace right after import/require, so it
-        # misses `require('fs')` and never checks export/interface/class, so content-only
-        # TS/JS (no filename) is invisible. JS_TS_KEYWORDS above is never used here.
-        # Reproduced by tests/unit/test_skill_extractor.py::test_javascript_detection and
-        # ::test_text_with_typescript_files.
         js_evidence = []
         if ".js" in str(filename or "").lower():
             js_evidence.append("JavaScript file extension (.js)")
         if ".ts" in str(filename or "").lower():
             js_evidence.append("TypeScript file extension (.ts)")
-        if re.search(r"\b(import|require)\s+", text):
+        if re.search(r"\bimport\s+[\w{]", text) or re.search(r"\b(import|require)\s*\(", text):
             js_evidence.append("CommonJS or ES6 imports")
+        if re.search(r"\bexport\s+(default\s+)?(class|function|const|interface)\b", text):
+            js_evidence.append("ES module export statements")
+        if (
+            re.search(r"=>\s*[{(]", text)
+            or re.search(r"\basync\s+\w+\s*\(", text)
+            or re.search(r"\basync\s*/\s*await\b", text_lower)
+        ):
+            js_evidence.append("arrow functions or async/await")
+        if re.search(r"\.jsx?\b", text_lower):
+            js_evidence.append("JavaScript file extension mentioned in text")
+        if "javascript" in text_lower:
+            js_evidence.append("mentions 'JavaScript'")
         if "package.json" in text_lower:
             js_evidence.append("package.json found")
 
-        if js_evidence:
-            confidence = min(0.95, 0.6 + len(js_evidence) * 0.1)
-            lang = "TypeScript" if ".ts" in str(filename or "").lower() else "JavaScript"
+        # TypeScript-specific evidence, used to pick the label even with no filename
+        ts_evidence = []
+        if ".ts" in str(filename or "").lower():
+            ts_evidence.append("TypeScript file extension (.ts)")
+        if re.search(r"\binterfaces?\b", text_lower):
+            ts_evidence.append("TypeScript interface declaration")
+        if re.search(r":\s*(string|number|boolean|void|any|unknown)\b", text):
+            ts_evidence.append("TypeScript type annotations")
+        if re.search(r"\.tsx?\b", text_lower):
+            ts_evidence.append("TypeScript file extension mentioned in text")
+        if "typescript" in text_lower:
+            ts_evidence.append("mentions 'TypeScript'")
+
+        if js_evidence or ts_evidence:
+            confidence = min(0.95, 0.6 + (len(js_evidence) + len(ts_evidence)) * 0.1)
+            lang = "TypeScript" if ts_evidence else "JavaScript"
             skills_dict[lang] = SkillDetection(
                 name=lang,
                 category="Language",
                 confidence=confidence,
-                evidence=js_evidence,
+                evidence=js_evidence + ts_evidence,
             )
 
         # Other languages by extension

--- a/tests/unit/test_skill_extractor.py
+++ b/tests/unit/test_skill_extractor.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from ingestion.parsers.skill_extractor import SkillExtractor, SkillDetection
+from ingestion.parsers.skill_extractor import SkillDetection, SkillExtractor
 
 
 @pytest.mark.unit
@@ -10,11 +10,11 @@ class TestSkillExtractor:
     """Test suite for SkillExtractor."""
 
     @pytest.fixture
-    def extractor(self):
+    def extractor(self) -> SkillExtractor:
         """Create a SkillExtractor instance."""
         return SkillExtractor()
 
-    def test_text_with_python_imports(self, extractor):
+    def test_text_with_python_imports(self, extractor: SkillExtractor) -> None:
         """Test detection of Python from import statements."""
         text = """
         import os
@@ -28,7 +28,7 @@ class TestSkillExtractor:
         # Should detect Python
         assert any("python" in s.lower() for s in skill_names), f"Got skills: {skill_names}"
 
-    def test_text_with_python_type_annotations(self, extractor):
+    def test_text_with_python_type_annotations(self, extractor: SkillExtractor) -> None:
         """Test that Python is detected from type annotations alone."""
         text = """
         def process_data(items: List[str]) -> Dict[str, int]:
@@ -43,7 +43,7 @@ class TestSkillExtractor:
         # Should still detect Python despite no imports
         assert any("python" in s.lower() for s in skill_names)
 
-    def test_text_with_typescript_files(self, extractor):
+    def test_text_with_typescript_files(self, extractor: SkillExtractor) -> None:
         """Test TypeScript detection."""
         text = """
         export interface User {
@@ -61,7 +61,7 @@ class TestSkillExtractor:
         # Should detect TypeScript
         assert any("typescript" in s.lower() for s in skill_names)
 
-    def test_jupyter_ipynb_detection(self, extractor):
+    def test_jupyter_ipynb_detection(self, extractor: SkillExtractor) -> None:
         """Test Python/Jupyter detection from .ipynb reference."""
         text = """
         This notebook (analysis.ipynb) contains:
@@ -73,7 +73,7 @@ class TestSkillExtractor:
         skill_names = [s.name for s in result]
         assert any("python" in s.lower() or "jupyter" in s.lower() for s in skill_names)
 
-    def test_mixed_language_text(self, extractor):
+    def test_mixed_language_text(self, extractor: SkillExtractor) -> None:
         """Test detection of multiple languages with confidence scores."""
         text = """
         // JavaScript code
@@ -106,7 +106,7 @@ class TestSkillExtractor:
         # Should detect multiple languages
         assert len(skill_names) > 1
 
-    def test_frameworks_detected_with_high_confidence(self, extractor):
+    def test_frameworks_detected_with_high_confidence(self, extractor: SkillExtractor) -> None:
         """Test that known frameworks are detected with high confidence."""
         text = "import django; from django.db import models"
         result = extractor.extract_skills(text)
@@ -116,7 +116,7 @@ class TestSkillExtractor:
         if django_skills:
             assert django_skills[0].confidence > 0.8
 
-    def test_react_detection(self, extractor):
+    def test_react_detection(self, extractor: SkillExtractor) -> None:
         """Test React detection from imports."""
         text = """
         import React, { useState, useEffect } from 'react';
@@ -127,7 +127,7 @@ class TestSkillExtractor:
         skill_names = [s.name for s in result]
         assert any("react" in s.lower() for s in skill_names)
 
-    def test_database_technology_detection(self, extractor):
+    def test_database_technology_detection(self, extractor: SkillExtractor) -> None:
         """Test database technology detection."""
         text = """
         import psycopg2
@@ -135,11 +135,11 @@ class TestSkillExtractor:
         """
         result = extractor.extract_skills(text)
 
-        skill_names = [s.name for s in skill_names]
+        skill_names = [s.name for s in result]
         # Should detect PostgreSQL
         assert any("postgres" in s.lower() or "sql" in s.lower() for s in skill_names)
 
-    def test_devops_tool_detection(self, extractor):
+    def test_devops_tool_detection(self, extractor: SkillExtractor) -> None:
         """Test DevOps tool detection."""
         text = """
         FROM python:3.9
@@ -152,7 +152,7 @@ class TestSkillExtractor:
         # Should detect Docker
         assert any("docker" in s.lower() for s in skill_names)
 
-    def test_skill_has_evidence_list(self, extractor):
+    def test_skill_has_evidence_list(self, extractor: SkillExtractor) -> None:
         """Test that detected skills include evidence."""
         text = "import numpy; import pandas"
         result = extractor.extract_skills(text)
@@ -161,7 +161,7 @@ class TestSkillExtractor:
             assert hasattr(skill, "evidence")
             assert isinstance(skill.evidence, list)
 
-    def test_filename_based_detection(self, extractor):
+    def test_filename_based_detection(self, extractor: SkillExtractor) -> None:
         """Test detection based on filename extension."""
         text = "Some code content"
         result = extractor.extract_skills(text, filename="script.py")
@@ -170,7 +170,7 @@ class TestSkillExtractor:
         # Filename should provide Python hint
         assert any("python" in s.lower() for s in skill_names)
 
-    def test_javascript_detection(self, extractor):
+    def test_javascript_detection(self, extractor: SkillExtractor) -> None:
         """Test JavaScript detection."""
         text = """
         const fs = require('fs');
@@ -182,7 +182,49 @@ class TestSkillExtractor:
         skill_names = [s.name for s in result]
         assert any("javascript" in s.lower() or "js" in s.lower() for s in skill_names)
 
-    def test_docker_compose_detection(self, extractor):
+    def test_issue_148_javascript_description(self, extractor: SkillExtractor) -> None:
+        """Test the exact JavaScript example from issue #148 (no filename)."""
+        text = "Wrote index.js using const arrow functions and async/await callbacks"
+        result = extractor.extract_skills(text)
+
+        skill_names = [s.name for s in result]
+        assert any("javascript" in s.lower() for s in skill_names), f"Got skills: {skill_names}"
+
+    def test_issue_148_typescript_description(self, extractor: SkillExtractor) -> None:
+        """Test the exact TypeScript example from issue #148 (no filename)."""
+        text = "Built app.tsx and types.ts with strict TypeScript interfaces"
+        result = extractor.extract_skills(text)
+
+        skill_names = [s.name for s in result]
+        assert any("typescript" in s.lower() for s in skill_names), f"Got skills: {skill_names}"
+
+    def test_js_ts_keywords_do_not_false_positive_on_prose(self, extractor: SkillExtractor) -> None:
+        """Test that plain English sentences with JS/TS-adjacent words aren't misdetected."""
+        text = "I await your reply, take this master class, and let me know."
+        result = extractor.extract_skills(text)
+
+        skill_names = [s.name for s in result]
+        assert not any(
+            "javascript" in s.lower() or "typescript" in s.lower() for s in skill_names
+        ), f"Got skills: {skill_names}"
+
+    def test_tsx_file_detects_both_react_and_typescript(self, extractor: SkillExtractor) -> None:
+        """Test that a real .tsx component is detected as both React and TypeScript."""
+        text = """
+        import { useState } from 'react';
+
+        export function Counter(): JSX.Element {
+            const [count, setCount] = useState<number>(0);
+            return null;
+        }
+        """
+        result = extractor.extract_skills(text, filename="Counter.tsx")
+
+        skill_names = [s.name for s in result]
+        assert any("react" in s.lower() for s in skill_names), f"Got skills: {skill_names}"
+        assert any("typescript" in s.lower() for s in skill_names), f"Got skills: {skill_names}"
+
+    def test_docker_compose_detection(self, extractor: SkillExtractor) -> None:
         """Test Docker and Docker Compose detection."""
         text = """
         version: '3.8'
@@ -197,7 +239,7 @@ class TestSkillExtractor:
         skill_names = [s.name for s in result]
         assert any("docker" in s.lower() for s in skill_names)
 
-    def test_aws_gcp_azure_detection(self, extractor):
+    def test_aws_gcp_azure_detection(self, extractor: SkillExtractor) -> None:
         """Test cloud platform detection."""
         text = """
         import boto3
@@ -208,19 +250,19 @@ class TestSkillExtractor:
         skill_names = [s.name for s in result]
         assert any("aws" in s.lower() or "python" in s.lower() for s in skill_names)
 
-    def test_empty_text(self, extractor):
+    def test_empty_text(self, extractor: SkillExtractor) -> None:
         """Test handling of empty text."""
         result = extractor.extract_skills("")
         assert isinstance(result, list)
 
-    def test_unrecognized_language(self, extractor):
+    def test_unrecognized_language(self, extractor: SkillExtractor) -> None:
         """Test handling of unrecognized language."""
         text = "This is just plain English text with no code."
         result = extractor.extract_skills(text)
         # Should return list (possibly empty)
         assert isinstance(result, list)
 
-    def test_confidence_scores_are_floats(self, extractor):
+    def test_confidence_scores_are_floats(self, extractor: SkillExtractor) -> None:
         """Test that all confidence scores are floats between 0 and 1."""
         text = "import django; import numpy; from flask import Flask"
         result = extractor.extract_skills(text)
@@ -229,13 +271,10 @@ class TestSkillExtractor:
             assert isinstance(skill.confidence, float)
             assert 0.0 <= skill.confidence <= 1.0
 
-    def test_skill_detection_dataclass(self):
+    def test_skill_detection_dataclass(self) -> None:
         """Test SkillDetection dataclass structure."""
         skill = SkillDetection(
-            name="Python",
-            category="Language",
-            confidence=0.95,
-            evidence=["import statement"]
+            name="Python", category="Language", confidence=0.95, evidence=["import statement"]
         )
 
         assert skill.name == "Python"


### PR DESCRIPTION
## Summary
extract_skills() was supposed to detect programming languages and frameworks from text, but it was basically blind to JavaScript and TypeScript specifically, even though Python, DevOps, and database detection all worked fine. The root problem was a single narrow regex that only matched import/require when followed by whitespace, so it missed common syntax like require('fs'), and it never checked for export, interface, arrow functions, or async/await at all. It also only labeled something TypeScript if a .ts filename was passed in, so content-only TypeScript code with no filename was invisible too. This PR widens that detection so it picks up real JS/TS syntax and also literal mentions of "javascript"/"typescript" or .js/.ts/.tsx in plain description text, since the issue's own examples described files instead of showing real code.

## Issue
Closes #148

## Changes
* Widened the JS/TS import check in _detect_languages() so it also catches require('fs') style calls with no space before the parenthesis, not just import x from 'y'
Added checks for export, arrow functions, and async/await as JavaScript evidence, since none of these were being checked before

* Added a separate TypeScript specific check (interface, TypeScript type annotations) so the TypeScript vs JavaScript label does not depend only on a .ts filename anymore
Added checks for the literal words "javascript" and "typescript" and for .js/.jsx/.ts/.tsx mentioned inside the text itself, since the issue's own example describes a file instead of showing real code

* Added 4 new tests in tests/unit/test_skill_extractor.py: the issue's exact two examples, a test that plain English sentences with words like "class" and "let" don't get flagged as code, and a test that a real .tsx file gets detected as both React and TypeScript

* Fixed an unrelated typo in test_database_technology_detection that was crashing the test outright, and added missing type annotations across the test file so mypy's disallow_untyped_defs setting is satisfied

## Testing

[x] Unit tests pass (make test-unit) - ran the full suite before and after: went from 53 failed/375 passed to 51 failed/381 passed, so 6 more tests pass and nothing new broke.
[ ] Integration tests pass (make test-integration) - not run, this issue is unit level only.
[ ] Linter passes (make lint) - the files I touched pass ruff cleanly on their own, the full repo-wide make lint still fails from about 177 pre-existing errors in files I never touched.
[ ] Type checker passes (make typecheck) - same story, ingestion/parsers/skill_extractor.py passes mypy on its own, the repo-wide command fails from pre-existing missing type stubs and a numpy/mypy version conflict unrelated to this fix
[x] New/updated tests cover the changes
To see the fix work directly, run this from the repo root:

python3 -c "
from ingestion.parsers.skill_extractor import SkillExtractor
e = SkillExtractor()
print(e.extract_skills('Wrote index.js using const arrow functions and async/await callbacks'))
print(e.extract_skills('Built app.tsx and types.ts with strict TypeScript interfaces'))
"
Before this fix, both calls returned nothing useful (the first came back empty, the second only returned React). After this fix, the first call returns JavaScript and the second returns both React and TypeScript.

You can also just run the two tests that reproduce the issue's own examples directly:

pytest tests/unit/test_skill_extractor.py::TestSkillExtractor::test_issue_148_javascript_description -v
pytest tests/unit/test_skill_extractor.py::TestSkillExtractor::test_issue_148_typescript_description -v


## Screenshots / Demo
<!-- If applicable, add screenshots or a link to a demo video -->
N/A

## Notes for Reviewers
While testing my first attempt at the fix, I ran the issue's own two examples through extract_skills() directly and found the TypeScript one still failed, since it was written as a plain description ("Built app.tsx and types.ts with strict TypeScript interfaces") instead of actual code, with no filename passed in. That is why I added the extra literal word and text based extension checks on top of the code syntax checks. More detail on this is in JOURNAL.md under Week 8 and Week 9 if you want the full walkthrough.
