### PR TITLE
test(rag): add versioned prompt template snapshots

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,40 @@
+# PathReview Contribution Journal
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/37  
+**Issue title:** Add snapshot tests for prompt templates to catch accidental changes  
+**Tier:** [x] Tier 1 [ ] Tier 2 [ ] Tier 3  
+
+**Problem summary:** PathReview's prompt templates directly shape the feedback produced by the review pipeline, but the existing test only checks that a generated MD5 value has the right type and length. That assertion still passes when template wording changes, so accidental edits can silently alter review behavior without requiring a new template version. The work is localized to `tests/unit/test_prompt_templates.py` and the versioned templates in `rag/generator/prompt_templates.py`. A successful change will store deterministic expectations for each named template version and fail when an existing version's content changes, making intentional prompt changes require an explicit version bump and reviewed snapshot update.
+
+**Branch name:** `test/37-prompt-template-snapshots`  
+**Setup confirmation:** [x] App runs locally at localhost:5173  
+**Cohort ledger:** [x] Issue added to cohort ledger (Section 1B, row 33)
+
+### "Is this right for me?" selection notes
+
+#### Part 1 — Understanding the issue
+
+- [x] I can explain the problem and expected behavior: the current hash test does not compare against a saved value, so it cannot detect prompt changes; version-keyed snapshots should make same-version edits fail.
+- [x] I located the affected files: `tests/unit/test_prompt_templates.py` contains the ineffective snapshot assertion, and `rag/generator/prompt_templates.py` contains the versioned prompt strings.
+- [x] I understand what done looks like: tests pass for the current templates, fail if any existing version is edited, and make an intentional prompt change visible as a new version and snapshot.
+
+#### Part 2 — Tier fit
+
+- [x] Issue #37 is labeled Tier 1 and is a realistic fit because the change is self-contained in the prompt-template unit tests, with at most a small supporting snapshot fixture.
+- [x] The task does not require a cross-module feature, database change, API change, or redesign of the RAG pipeline.
+
+#### Part 3 — Codebase readiness
+
+- [x] I read the relevant implementation, including the nested `PROMPT_TEMPLATES` name/version mapping and `get_template()` lookup behavior.
+- [x] I read `tests/unit/test_prompt_templates.py` end-to-end and confirmed the current `test_template_snapshot_content_hash` assertion cannot catch content changes.
+- [x] My implementation plan is to create deterministic, version-keyed snapshots, compare the current template/version inventory and content against those snapshots, and add a regression test that demonstrates a same-version mutation is rejected.
+
+#### Part 4 — Scope and time
+
+- [x] I reviewed the issue comments and understand that claims are non-exclusive; multiple students may work on the same issue.
+- [x] The issue estimate is 3–5 hours, which is realistic within the Week 8–9 implementation window.
+- [x] The issue lists no blockers or dependencies on unresolved work.
+
+**Verdict:** Issue #37 is well understood, appropriately scoped, and ready for implementation on this branch.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -41,11 +41,15 @@
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** Pending until this reproduction note is committed and pushed  
-**Reproduction summary:** I ran the existing snapshot test, changed `skills_feedback/v1` in an isolated Python process by appending `ACCIDENTAL SAME-VERSION EDIT`, and ran the assertion again. The test still passed while the template remained at version `v1`, confirming that the current MD5 type-and-length checks do not detect accidental prompt changes.  
-**PLAN.md link:** Pending until the solution plan is committed and pushed  
-**Walkthrough video (recommended):** Not recorded (optional and not graded)  
-**Blockers or open questions:** No blockers; the plan will decide how to store version-keyed expected hashes so additions and intentional version changes remain explicit.
+**Reproduction commit link:** https://github.com/neonforestmist/pathreview/commit/f3f028851e87f0095f512160bd9d976d433a6943
+
+**Reproduction summary:** I ran the existing snapshot test, changed `skills_feedback/v1` in an isolated Python process by appending `ACCIDENTAL SAME-VERSION EDIT`, and ran the assertion again. The test still passed while the template remained at version `v1`, confirming that the current MD5 type-and-length checks do not detect accidental prompt changes.
+
+**PLAN.md link:** https://github.com/neonforestmist/pathreview/blob/b7c4ac11a45e75b2fceb68244ceb3a3f565c8ded/PLAN.md
+
+**Walkthrough video (recommended):** Not recorded (optional and not graded)
+
+**Blockers or open questions:** No blockers. The plan uses inline, version-keyed SHA-256 hashes so prompt additions and intentional version changes remain explicit in code review.
 
 ### Reproduction steps
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -45,7 +45,7 @@
 
 **Reproduction summary:** I ran the existing snapshot test, changed `skills_feedback/v1` in an isolated Python process by appending `ACCIDENTAL SAME-VERSION EDIT`, and ran the assertion again. The test still passed while the template remained at version `v1`, confirming that the current MD5 type-and-length checks do not detect accidental prompt changes.
 
-**PLAN.md link:** https://github.com/neonforestmist/pathreview/blob/b7c4ac11a45e75b2fceb68244ceb3a3f565c8ded/PLAN.md
+**PLAN.md link:** https://github.com/neonforestmist/pathreview/blob/test/37-prompt-template-snapshots/PLAN.md
 
 **Walkthrough video (recommended):** Not recorded (optional and not graded)
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -38,3 +38,36 @@
 - [x] The issue lists no blockers or dependencies on unresolved work.
 
 **Verdict:** Issue #37 is well understood, appropriately scoped, and ready for implementation on this branch.
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** Pending until this reproduction note is committed and pushed  
+**Reproduction summary:** I ran the existing snapshot test, changed `skills_feedback/v1` in an isolated Python process by appending `ACCIDENTAL SAME-VERSION EDIT`, and ran the assertion again. The test still passed while the template remained at version `v1`, confirming that the current MD5 type-and-length checks do not detect accidental prompt changes.  
+**PLAN.md link:** Pending until the solution plan is committed and pushed  
+**Walkthrough video (recommended):** Not recorded (optional and not graded)  
+**Blockers or open questions:** No blockers; the plan will decide how to store version-keyed expected hashes so additions and intentional version changes remain explicit.
+
+### Reproduction steps
+
+1. Confirm the current test passes:
+
+   ```bash
+   .venv/bin/pytest tests/unit/test_prompt_templates.py::TestPromptTemplates::test_template_snapshot_content_hash -q
+   ```
+
+2. In an isolated Python process, append text to an existing version and invoke the same test:
+
+   ```python
+   from tests.unit.test_prompt_templates import TestPromptTemplates
+   from rag.generator.prompt_templates import PROMPT_TEMPLATES
+
+   original = PROMPT_TEMPLATES["skills_feedback"]["v1"]
+   PROMPT_TEMPLATES["skills_feedback"]["v1"] = (
+       original + "\nACCIDENTAL SAME-VERSION EDIT"
+   )
+   TestPromptTemplates().test_template_snapshot_content_hash()
+   ```
+
+**Observed result:** Both runs pass. `test_template_snapshot_content_hash` computes an MD5 digest but only checks that the result is a 32-character string, which is true for every MD5 digest regardless of the prompt content.
+
+**Expected result:** A content change to an existing `(template name, version)` pair should fail the snapshot test and direct the contributor to add a new prompt version and its reviewed snapshot.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -104,3 +104,37 @@
 - [x] `make test-unit` introduces no new failures. Untouched `upstream/main` reports 53 failed and 375 passed; this branch reports the same 53 failed and 377 passed, including both new regression tests.
 
 **Draft PR feedback received from:** None. The implementation was completed after the scheduled deadline, so no peer review was received before submission.
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:** No reviewer or maintainer feedback has arrived on [PR #698](https://github.com/ascherj/pathreview/pull/698). The pull request remains open and ready for review, so there were no requested changes to evaluate or implement during Week 10.
+
+**How you responded:** No response or follow-up commit was needed because no feedback was received. I will respond to any later review by confirming the requested behavior, making focused changes on this branch, and documenting the verification results in the pull request.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+
+The hardest part was recognizing that `test_template_snapshot_content_hash` looked meaningful without actually protecting the prompts: it calculated an MD5 digest but only checked that the digest was a 32-character string. Reproducing that weakness safely required mutating `skills_feedback/v1` in an isolated process, proving the test still passed, and then separating failures caused by my branch from the 53 unit-test failures and lint findings already present on `upstream/main`.
+
+**What did you learn about working in a large codebase?**
+
+I learned that a focused change still has to be understood in the context of the repository's conventions, existing test health, and review expectations. Instead of changing production prompt text in `rag/generator/prompt_templates.py`, I kept the implementation in `tests/unit/test_prompt_templates.py`, followed the `test/37-prompt-template-snapshots` branch convention, and compared my results with an untouched upstream checkout so I could show that the branch introduced no new failures.
+
+**How did AI tools help — and where did they fall short?**
+
+AI tools helped me trace the prompt-template structure, turn issue #37 into a concrete reproduction, design the version-keyed SHA-256 assertions, and check the journal and pull request against the course rubrics. They could not decide whether a future prompt edit is intentional, automatically make the repository's pre-existing failures relevant to my change, or replace my review of the generated hashes and failure messages; I still had to verify the original prompt content, run the focused tests, and interpret the branch-versus-upstream results.
+
+**What would you do differently if you started over?**
+
+I would run both the focused prompt tests and the repository-wide checks immediately after setup, before implementation, so the upstream baseline was documented from the beginning. I would also prepare the reproduction and request feedback earlier, which would leave more time to discuss whether the snapshots should remain inline in the test module or move to dedicated fixture files as the prompt inventory grows.
+
+**What are you most proud of from this module?**
+
+I am most proud that the final tests replace a false sense of safety with a precise, reviewable contract for every `(template name, version)` pair. All 39 focused prompt-template tests pass, and the two new regression cases demonstrate that both an accidental same-version edit and an unreviewed `v2` addition now fail with messages that identify exactly what a contributor needs to address.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -90,7 +90,7 @@
 
 ### Check-in 2 (end of week)
 
-**PR link:** Pending final PR submission
+**PR link:** https://github.com/ascherj/pathreview/pull/698
 
 **Branch:** `test/37-prompt-template-snapshots`
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -75,3 +75,32 @@
 **Observed result:** Both runs pass. `test_template_snapshot_content_hash` computes an MD5 digest but only checks that the result is a 32-character string, which is true for every MD5 digest regardless of the prompt content.
 
 **Expected result:** A content change to an existing `(template name, version)` pair should fail the snapshot test and direct the contributor to add a new prompt version and its reviewed snapshot.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:** I completed all five subtasks from `PLAN.md`: added the five reviewed `v1` SHA-256 snapshots, implemented version-keyed hashing and inventory validation, replaced the ineffective MD5 shape check, and added regression tests for same-version edits and unreviewed versions. The changed test module passes Ruff, Black, the repository's pre-commit mypy check, and all 39 focused tests.
+
+**Next steps:** Complete the final self-review, open the upstream pull request with full verification instructions, add its link to this journal and the cohort ledger, and submit the working branch through the course portal.
+
+**Blockers:** No blocker affects issue #37. Untouched `upstream/main` already has repository-wide lint findings and 53 failing unit tests; the branch has the same 53 failures while adding two passing prompt-snapshot regression tests.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** Pending final PR submission
+
+**Branch:** `test/37-prompt-template-snapshots`
+
+**What you built:** I replaced the aggregate MD5 type-and-length assertion with reviewed SHA-256 snapshots keyed by prompt name and version. The new assertions identify inventory changes and same-version content edits, while leaving production prompt text and runtime behavior unchanged.
+
+**Tests added or updated:** Updated `tests/unit/test_prompt_templates.py`. `test_template_snapshot_content_hash` now validates the complete prompt-version inventory and every reviewed digest; `test_template_snapshot_rejects_same_version_content_change` proves an edit to `skills_feedback/v1` fails; and `test_template_snapshot_rejects_unreviewed_version` proves a new `v2` cannot pass without an explicit snapshot.
+
+**Self-review confirmation:**
+
+- [x] `make check` introduces no new failures. The changed file passes Ruff, Black, and pre-commit mypy; the repository-wide command remains blocked by unrelated lint findings already present on `upstream/main`.
+- [x] `make test-unit` introduces no new failures. Untouched `upstream/main` reports 53 failed and 375 passed; this branch reports the same 53 failed and 377 passed, including both new regression tests.
+
+**Draft PR feedback received from:** None. The implementation was completed after the scheduled deadline, so no peer review was received before submission.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,14 +1,14 @@
-# Solution plan
+## Solution plan
 
 **Issue:** [Add snapshot tests for prompt templates to catch accidental changes](https://github.com/ascherj/pathreview/issues/37)
 
-## Understand
+### Understand
 
 `PROMPT_TEMPLATES` stores prompt text in a nested mapping keyed first by template name and then by version, such as `PROMPT_TEMPLATES["skills_feedback"]["v1"]`. The current `TestPromptTemplates.test_template_snapshot_content_hash` test concatenates every prompt, computes an MD5 digest, and only asserts that the digest is a 32-character string. Because every MD5 digest has that shape, the assertion still passes after an existing prompt version is edited.
 
 The expected behavior is for the test to compare every `(template name, version)` pair with a reviewed, deterministic snapshot. An accidental edit to an existing version must fail, while an intentional prompt change must be represented by an explicit new version and a corresponding reviewed snapshot update.
 
-## Map
+### Map
 
 - `tests/unit/test_prompt_templates.py`
   - Replace the ineffective `test_template_snapshot_content_hash` assertion.
@@ -21,7 +21,7 @@ The expected behavior is for the test to compare every `(template name, version)
 - `JOURNAL.md`
   - Preserve the Week 8 reproduction evidence and link to this plan and the reproduction commit.
 
-## Plan
+### Plan
 
 1. Add an `EXPECTED_TEMPLATE_HASHES` mapping in `tests/unit/test_prompt_templates.py`, keyed by `(template_name, version)`, with a SHA-256 digest for each of the five current `v1` prompts.
 2. Add a helper that accepts a nested prompt mapping and returns the same version-keyed digest mapping using each raw UTF-8 prompt string. Keeping snapshots separate avoids aggregate-hash ambiguity and makes failures identify the exact prompt version that changed.
@@ -29,7 +29,7 @@ The expected behavior is for the test to compare every `(template name, version)
 4. Add regression tests using a copied prompt mapping to prove that a same-version content mutation fails without modifying the module-level `PROMPT_TEMPLATES`. Also cover a newly added version so an unreviewed inventory change cannot pass silently.
 5. Run the complete prompt-template unit-test module and the repository's standard formatting/type/test checks. Review the diff to ensure the production prompts are unchanged and snapshot values are deterministic across repeated runs.
 
-## Inputs & outputs
+### Inputs & outputs
 
 **Input:** The nested `PROMPT_TEMPLATES` mapping from `rag/generator/prompt_templates.py`, where each leaf is the exact prompt string for one `(template name, version)` key.
 
@@ -37,7 +37,7 @@ The expected behavior is for the test to compare every `(template name, version)
 
 **Output:** Passing unit tests when both the prompt-version inventory and every current prompt string match their reviewed snapshots. A changed, removed, or newly added prompt version produces a focused assertion failure identifying the affected key. Runtime prompt lookup and generated review behavior remain unchanged.
 
-## Risks & unknowns
+### Risks & unknowns
 
 - A contributor could update an expected hash while editing `rag/generator/prompt_templates.py` without adding a version. Tests cannot infer intent, so the failure message and code review must reinforce the version-bump rule.
 - Hashing the raw prompt text intentionally treats whitespace and line-ending edits as content changes. This is desirable for strict snapshots, but the test message must make that sensitivity clear so the failure is not mistaken for nondeterminism.
@@ -45,7 +45,7 @@ The expected behavior is for the test to compare every `(template name, version)
 - When a legitimate `v2` is added, the old `v1` snapshot should remain unless that version is deliberately removed. The tests must not assume that every template will always have only one version.
 - The initial expected digests must be generated from the unmodified upstream prompts and reviewed before being committed; generating them after an accidental local edit would bless the wrong baseline.
 
-## Edge cases
+### Edge cases
 
 - Existing content changes while its key remains `("skills_feedback", "v1")`; the digest comparison must fail.
 - A new version such as `("skills_feedback", "v2")` is added without an expected snapshot; the inventory comparison must fail and name the unexpected key.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,55 @@
+# Solution plan
+
+**Issue:** [Add snapshot tests for prompt templates to catch accidental changes](https://github.com/ascherj/pathreview/issues/37)
+
+## Understand
+
+`PROMPT_TEMPLATES` stores prompt text in a nested mapping keyed first by template name and then by version, such as `PROMPT_TEMPLATES["skills_feedback"]["v1"]`. The current `TestPromptTemplates.test_template_snapshot_content_hash` test concatenates every prompt, computes an MD5 digest, and only asserts that the digest is a 32-character string. Because every MD5 digest has that shape, the assertion still passes after an existing prompt version is edited.
+
+The expected behavior is for the test to compare every `(template name, version)` pair with a reviewed, deterministic snapshot. An accidental edit to an existing version must fail, while an intentional prompt change must be represented by an explicit new version and a corresponding reviewed snapshot update.
+
+## Map
+
+- `tests/unit/test_prompt_templates.py`
+  - Replace the ineffective `test_template_snapshot_content_hash` assertion.
+  - Add a small helper that produces a stable SHA-256 digest for each `(template name, version)` pair.
+  - Store the expected version-keyed hashes close to the test so changes are visible in code review.
+  - Add focused regression coverage for content and inventory changes.
+- `rag/generator/prompt_templates.py`
+  - Read the `PROMPT_TEMPLATES` structure and `get_template()` behavior as the source of truth.
+  - No production change is expected; this file should only change in a separate, intentional prompt-version update.
+- `JOURNAL.md`
+  - Preserve the Week 8 reproduction evidence and link to this plan and the reproduction commit.
+
+## Plan
+
+1. Add an `EXPECTED_TEMPLATE_HASHES` mapping in `tests/unit/test_prompt_templates.py`, keyed by `(template_name, version)`, with a SHA-256 digest for each of the five current `v1` prompts.
+2. Add a helper that accepts a nested prompt mapping and returns the same version-keyed digest mapping using each raw UTF-8 prompt string. Keeping snapshots separate avoids aggregate-hash ambiguity and makes failures identify the exact prompt version that changed.
+3. Replace `test_template_snapshot_content_hash` with assertions that first compare the actual and expected key inventories and then compare each digest. Include failure messages that name the affected template/version and explain that an intentional content change needs a new version and reviewed snapshot.
+4. Add regression tests using a copied prompt mapping to prove that a same-version content mutation fails without modifying the module-level `PROMPT_TEMPLATES`. Also cover a newly added version so an unreviewed inventory change cannot pass silently.
+5. Run the complete prompt-template unit-test module and the repository's standard formatting/type/test checks. Review the diff to ensure the production prompts are unchanged and snapshot values are deterministic across repeated runs.
+
+## Inputs & outputs
+
+**Input:** The nested `PROMPT_TEMPLATES` mapping from `rag/generator/prompt_templates.py`, where each leaf is the exact prompt string for one `(template name, version)` key.
+
+**Transformation:** Encode each prompt string as UTF-8 and calculate its SHA-256 digest independently. Compare the resulting key set and digests with the checked-in `EXPECTED_TEMPLATE_HASHES` mapping.
+
+**Output:** Passing unit tests when both the prompt-version inventory and every current prompt string match their reviewed snapshots. A changed, removed, or newly added prompt version produces a focused assertion failure identifying the affected key. Runtime prompt lookup and generated review behavior remain unchanged.
+
+## Risks & unknowns
+
+- A contributor could update an expected hash while editing `rag/generator/prompt_templates.py` without adding a version. Tests cannot infer intent, so the failure message and code review must reinforce the version-bump rule.
+- Hashing the raw prompt text intentionally treats whitespace and line-ending edits as content changes. This is desirable for strict snapshots, but the test message must make that sensitivity clear so the failure is not mistaken for nondeterminism.
+- An aggregate digest would hide which prompt changed and could depend on iteration order. The implementation should use a key-to-digest mapping and compare the key inventory separately.
+- When a legitimate `v2` is added, the old `v1` snapshot should remain unless that version is deliberately removed. The tests must not assume that every template will always have only one version.
+- The initial expected digests must be generated from the unmodified upstream prompts and reviewed before being committed; generating them after an accidental local edit would bless the wrong baseline.
+
+## Edge cases
+
+- Existing content changes while its key remains `("skills_feedback", "v1")`; the digest comparison must fail.
+- A new version such as `("skills_feedback", "v2")` is added without an expected snapshot; the inventory comparison must fail and name the unexpected key.
+- A template or version is removed; the inventory comparison must report the missing expected key.
+- Dictionary insertion order changes while names, versions, and content stay identical; version-keyed comparisons must continue to pass.
+- A whitespace-only or newline-only edit occurs inside a prompt; the raw-content digest must treat it as a change.
+- Two different template names contain identical prompt text; each key must still have its own independently checked snapshot entry.

--- a/PLAN.md
+++ b/PLAN.md
@@ -23,11 +23,13 @@ The expected behavior is for the test to compare every `(template name, version)
 
 ### Plan
 
-1. Add an `EXPECTED_TEMPLATE_HASHES` mapping in `tests/unit/test_prompt_templates.py`, keyed by `(template_name, version)`, with a SHA-256 digest for each of the five current `v1` prompts.
-2. Add a helper that accepts a nested prompt mapping and returns the same version-keyed digest mapping using each raw UTF-8 prompt string. Keeping snapshots separate avoids aggregate-hash ambiguity and makes failures identify the exact prompt version that changed.
-3. Replace `test_template_snapshot_content_hash` with assertions that first compare the actual and expected key inventories and then compare each digest. Include failure messages that name the affected template/version and explain that an intentional content change needs a new version and reviewed snapshot.
-4. Add regression tests using a copied prompt mapping to prove that a same-version content mutation fails without modifying the module-level `PROMPT_TEMPLATES`. Also cover a newly added version so an unreviewed inventory change cannot pass silently.
-5. Run the complete prompt-template unit-test module and the repository's standard formatting/type/test checks. Review the diff to ensure the production prompts are unchanged and snapshot values are deterministic across repeated runs.
+1. [x] Add an `EXPECTED_TEMPLATE_HASHES` mapping in `tests/unit/test_prompt_templates.py`, keyed by `(template_name, version)`, with a SHA-256 digest for each of the five current `v1` prompts.
+2. [x] Add a helper that accepts a nested prompt mapping and returns the same version-keyed digest mapping using each raw UTF-8 prompt string. Keeping snapshots separate avoids aggregate-hash ambiguity and makes failures identify the exact prompt version that changed.
+3. [x] Replace `test_template_snapshot_content_hash` with assertions that first compare the actual and expected key inventories and then compare each digest. Include failure messages that name the affected template/version and explain that an intentional content change needs a new version and reviewed snapshot.
+4. [x] Add regression tests using a copied prompt mapping to prove that a same-version content mutation fails without modifying the module-level `PROMPT_TEMPLATES`. Also cover a newly added version so an unreviewed inventory change cannot pass silently.
+5. [x] Run the complete prompt-template unit-test module and the repository's standard formatting/type/test checks. Review the diff to ensure the production prompts are unchanged and snapshot values are deterministic across repeated runs.
+
+**Implementation verification:** All 39 tests in `tests/unit/test_prompt_templates.py` pass, and the changed file passes Ruff, Black, and the repository's pre-commit mypy check. The repository-wide commands retain the same pre-existing failures as untouched `upstream/main`: `make test-unit` reports 53 failures while the branch adds two passing regression tests, and `make check` remains blocked by unrelated existing lint findings.
 
 ### Inputs & outputs
 

--- a/tests/unit/test_prompt_templates.py
+++ b/tests/unit/test_prompt_templates.py
@@ -1,16 +1,67 @@
 """Tests for prompt_templates.py - Snapshot tests"""
 
-import pytest
 import hashlib
+import re
+from collections.abc import Mapping
+from unittest.mock import patch
+
+import pytest
 
 from rag.generator.prompt_templates import PROMPT_TEMPLATES, get_template
+
+EXPECTED_TEMPLATE_HASHES = {
+    ("first_impression", "v1"): (
+        "9e7697ff3efd892c82c63ffcc8365690685fb1c29f79d45d84e057b2d0672dd0"
+    ),
+    ("gaps_feedback", "v1"): ("b2673a1a1f018f2f2fdf37b2dfb6b30634404ba7bb2c241cc01b6240b9097950"),
+    ("presentation_feedback", "v1"): (
+        "87230b7045d66a1fae7d06e2509c6fae31046e0c4e8d30a3c3d6fe9ad2a7a3d7"
+    ),
+    ("projects_feedback", "v1"): (
+        "7e53575582f45389e4a3e4f93c7c137da629d3a14809e16f746732b9a06740d1"
+    ),
+    ("skills_feedback", "v1"): ("a24d6d717d4f365c28a686f28b3e77f47204c325ce892fc32d68eb82259f6816"),
+}
+
+
+def _template_hashes(
+    templates: Mapping[str, Mapping[str, str]],
+) -> dict[tuple[str, str], str]:
+    """Return a SHA-256 digest keyed by template name and version."""
+    return {
+        (name, version): hashlib.sha256(template.encode("utf-8")).hexdigest()
+        for name, versions in templates.items()
+        for version, template in versions.items()
+    }
+
+
+def _assert_prompt_snapshots(
+    templates: Mapping[str, Mapping[str, str]],
+    expected_hashes: Mapping[tuple[str, str], str] = EXPECTED_TEMPLATE_HASHES,
+) -> None:
+    """Assert that the prompt inventory and content match reviewed snapshots."""
+    actual_hashes = _template_hashes(templates)
+    actual_keys = set(actual_hashes)
+    expected_keys = set(expected_hashes)
+
+    assert actual_keys == expected_keys, (
+        "Prompt template versions changed. "
+        f"Unexpected versions without snapshots: {sorted(actual_keys - expected_keys)}; "
+        f"snapshot versions missing from templates: {sorted(expected_keys - actual_keys)}."
+    )
+
+    for name, version in sorted(expected_keys):
+        assert actual_hashes[(name, version)] == expected_hashes[(name, version)], (
+            f"Prompt template {name} {version} changed without a reviewed snapshot. "
+            "For an intentional prompt change, add a new version and its expected hash."
+        )
 
 
 @pytest.mark.unit
 class TestPromptTemplates:
     """Test suite for prompt templates."""
 
-    def test_all_5_templates_exist(self):
+    def test_all_5_templates_exist(self) -> None:
         """Test all 5 templates exist in PROMPT_TEMPLATES."""
         expected_templates = {
             "skills_feedback",
@@ -23,38 +74,40 @@ class TestPromptTemplates:
         actual_templates = set(PROMPT_TEMPLATES.keys())
         assert actual_templates == expected_templates
 
-    def test_skills_feedback_template_exists(self):
+    def test_skills_feedback_template_exists(self) -> None:
         """Test skills_feedback template exists."""
         assert "skills_feedback" in PROMPT_TEMPLATES
         assert "v1" in PROMPT_TEMPLATES["skills_feedback"]
 
-    def test_projects_feedback_template_exists(self):
+    def test_projects_feedback_template_exists(self) -> None:
         """Test projects_feedback template exists."""
         assert "projects_feedback" in PROMPT_TEMPLATES
         assert "v1" in PROMPT_TEMPLATES["projects_feedback"]
 
-    def test_presentation_feedback_template_exists(self):
+    def test_presentation_feedback_template_exists(self) -> None:
         """Test presentation_feedback template exists."""
         assert "presentation_feedback" in PROMPT_TEMPLATES
         assert "v1" in PROMPT_TEMPLATES["presentation_feedback"]
 
-    def test_gaps_feedback_template_exists(self):
+    def test_gaps_feedback_template_exists(self) -> None:
         """Test gaps_feedback template exists."""
         assert "gaps_feedback" in PROMPT_TEMPLATES
         assert "v1" in PROMPT_TEMPLATES["gaps_feedback"]
 
-    def test_first_impression_template_exists(self):
+    def test_first_impression_template_exists(self) -> None:
         """Test first_impression template exists."""
         assert "first_impression" in PROMPT_TEMPLATES
         assert "v1" in PROMPT_TEMPLATES["first_impression"]
 
-    def test_each_template_contains_context_placeholder(self):
+    def test_each_template_contains_context_placeholder(self) -> None:
         """Test each template contains {context} placeholder."""
         for template_name, versions in PROMPT_TEMPLATES.items():
             for version, template_text in versions.items():
-                assert "{context}" in template_text, f"{template_name} v{version} missing {{context}}"
+                assert (
+                    "{context}" in template_text
+                ), f"{template_name} v{version} missing {{context}}"
 
-    def test_each_template_contains_github_username_placeholder(self):
+    def test_each_template_contains_github_username_placeholder(self) -> None:
         """Test each template contains {github_username} placeholder."""
         for template_name, versions in PROMPT_TEMPLATES.items():
             for version, template_text in versions.items():
@@ -62,7 +115,7 @@ class TestPromptTemplates:
                     "{github_username}" in template_text
                 ), f"{template_name} v{version} missing {{github_username}}"
 
-    def test_each_template_contains_project_count_placeholder(self):
+    def test_each_template_contains_project_count_placeholder(self) -> None:
         """Test each template contains {project_count} placeholder."""
         for template_name, versions in PROMPT_TEMPLATES.items():
             for version, template_text in versions.items():
@@ -70,7 +123,7 @@ class TestPromptTemplates:
                     "{project_count}" in template_text
                 ), f"{template_name} v{version} missing {{project_count}}"
 
-    def test_get_template_returns_correct_template(self):
+    def test_get_template_returns_correct_template(self) -> None:
         """Test get_template() returns correct template."""
         template = get_template("skills_feedback", "v1")
 
@@ -78,182 +131,204 @@ class TestPromptTemplates:
         assert "{context}" in template
         assert "skills" in template.lower()
 
-    def test_get_template_projects_feedback(self):
+    def test_get_template_projects_feedback(self) -> None:
         """Test get_template for projects_feedback."""
         template = get_template("projects_feedback", "v1")
 
         assert isinstance(template, str)
         assert "project" in template.lower()
 
-    def test_get_template_presentation_feedback(self):
+    def test_get_template_presentation_feedback(self) -> None:
         """Test get_template for presentation_feedback."""
         template = get_template("presentation_feedback", "v1")
 
         assert isinstance(template, str)
         assert "presentation" in template.lower() or "readme" in template.lower()
 
-    def test_get_template_gaps_feedback(self):
+    def test_get_template_gaps_feedback(self) -> None:
         """Test get_template for gaps_feedback."""
         template = get_template("gaps_feedback", "v1")
 
         assert isinstance(template, str)
         assert "gap" in template.lower() or "skill" in template.lower()
 
-    def test_get_template_first_impression(self):
+    def test_get_template_first_impression(self) -> None:
         """Test get_template for first_impression."""
         template = get_template("first_impression", "v1")
 
         assert isinstance(template, str)
         assert "impression" in template.lower() or "summary" in template.lower()
 
-    def test_get_template_unknown_name_raises_error(self):
+    def test_get_template_unknown_name_raises_error(self) -> None:
         """Test get_template() raises KeyError/ValueError for unknown template."""
         with pytest.raises((KeyError, ValueError)):
             get_template("nonexistent_template")
 
-    def test_get_template_unknown_version_raises_error(self):
+    def test_get_template_unknown_version_raises_error(self) -> None:
         """Test get_template() raises KeyError/ValueError for unknown version."""
         with pytest.raises((KeyError, ValueError)):
             get_template("skills_feedback", "v999")
 
-    def test_all_templates_have_v1(self):
+    def test_all_templates_have_v1(self) -> None:
         """Test all templates have v1 version."""
-        for template_name in PROMPT_TEMPLATES.keys():
+        for template_name in PROMPT_TEMPLATES:
             assert "v1" in PROMPT_TEMPLATES[template_name]
 
-    def test_templates_are_strings(self):
+    def test_templates_are_strings(self) -> None:
         """Test all templates are strings."""
-        for template_name, versions in PROMPT_TEMPLATES.items():
-            for version, template_text in versions.items():
+        for _template_name, versions in PROMPT_TEMPLATES.items():
+            for _version, template_text in versions.items():
                 assert isinstance(template_text, str)
                 assert len(template_text) > 0
 
-    def test_templates_have_reasonable_length(self):
+    def test_templates_have_reasonable_length(self) -> None:
         """Test templates have reasonable length."""
         for template_name, versions in PROMPT_TEMPLATES.items():
             for version, template_text in versions.items():
                 # Templates should be at least 100 chars
                 assert len(template_text) > 100, f"{template_name} v{version} too short"
 
-    def test_skills_feedback_mentions_technical_skills(self):
+    def test_skills_feedback_mentions_technical_skills(self) -> None:
         """Test skills_feedback template mentions technical skills."""
         template = PROMPT_TEMPLATES["skills_feedback"]["v1"]
 
         assert "skill" in template.lower()
 
-    def test_projects_feedback_mentions_code_quality(self):
+    def test_projects_feedback_mentions_code_quality(self) -> None:
         """Test projects_feedback template mentions code quality."""
         template = PROMPT_TEMPLATES["projects_feedback"]["v1"]
 
         assert "project" in template.lower() or "quality" in template.lower()
 
-    def test_gaps_feedback_mentions_missing_skills(self):
+    def test_gaps_feedback_mentions_missing_skills(self) -> None:
         """Test gaps_feedback template mentions missing/gap concepts."""
         template = PROMPT_TEMPLATES["gaps_feedback"]["v1"]
 
-        assert "gap" in template.lower() or "missing" in template.lower() or "demand" in template.lower()
+        assert (
+            "gap" in template.lower()
+            or "missing" in template.lower()
+            or "demand" in template.lower()
+        )
 
-    def test_presentation_feedback_mentions_readme(self):
+    def test_presentation_feedback_mentions_readme(self) -> None:
         """Test presentation_feedback template mentions README or presentation."""
         template = PROMPT_TEMPLATES["presentation_feedback"]["v1"]
 
-        assert "readme" in template.lower() or "presentation" in template.lower() or "organization" in template.lower()
+        assert (
+            "readme" in template.lower()
+            or "presentation" in template.lower()
+            or "organization" in template.lower()
+        )
 
-    def test_first_impression_is_concise(self):
+    def test_first_impression_is_concise(self) -> None:
         """Test first_impression template instructs concise output."""
         template = PROMPT_TEMPLATES["first_impression"]["v1"]
 
-        assert "2" in template or "3" in template or "sentence" in template.lower() or "summary" in template.lower()
+        assert (
+            "2" in template
+            or "3" in template
+            or "sentence" in template.lower()
+            or "summary" in template.lower()
+        )
 
-    def test_get_template_default_version(self):
+    def test_get_template_default_version(self) -> None:
         """Test get_template() defaults to v1 when version not specified."""
         template_default = get_template("skills_feedback")
         template_v1 = get_template("skills_feedback", "v1")
 
         assert template_default == template_v1
 
-    def test_template_snapshot_content_hash(self):
-        """Snapshot test: verify template content hash."""
-        # Create hash of all template content
-        template_content = ""
-        for name in sorted(PROMPT_TEMPLATES.keys()):
-            for version in sorted(PROMPT_TEMPLATES[name].keys()):
-                template_content += PROMPT_TEMPLATES[name][version]
+    def test_template_snapshot_content_hash(self) -> None:
+        """Verify every prompt version matches its reviewed content snapshot."""
+        _assert_prompt_snapshots(PROMPT_TEMPLATES)
 
-        content_hash = hashlib.md5(template_content.encode()).hexdigest()
+    def test_template_snapshot_rejects_same_version_content_change(self) -> None:
+        """Reject content edits that reuse an existing prompt version."""
+        mutated_templates = {name: versions.copy() for name, versions in PROMPT_TEMPLATES.items()}
+        mutated_templates["skills_feedback"]["v1"] += "\nACCIDENTAL SAME-VERSION EDIT"
 
-        # Expected hash - update if templates intentionally change
-        # This helps detect unintended changes to templates
-        assert isinstance(content_hash, str)
-        assert len(content_hash) == 32  # MD5 hash length
+        with pytest.raises(AssertionError, match="skills_feedback v1 changed"):
+            _assert_prompt_snapshots(mutated_templates)
 
-    def test_skills_feedback_requests_json_format(self):
+    def test_template_snapshot_rejects_unreviewed_version(self) -> None:
+        """Reject new prompt versions until an expected snapshot is reviewed."""
+        mutated_templates = {name: versions.copy() for name, versions in PROMPT_TEMPLATES.items()}
+        mutated_templates["skills_feedback"]["v2"] = mutated_templates["skills_feedback"]["v1"]
+
+        with pytest.raises(AssertionError, match="Unexpected versions without snapshots"):
+            _assert_prompt_snapshots(mutated_templates)
+
+    def test_skills_feedback_requests_json_format(self) -> None:
         """Test skills_feedback requests JSON output."""
         template = PROMPT_TEMPLATES["skills_feedback"]["v1"]
 
         assert "json" in template.lower()
 
-    def test_projects_feedback_requests_json_format(self):
+    def test_projects_feedback_requests_json_format(self) -> None:
         """Test projects_feedback requests JSON output."""
         template = PROMPT_TEMPLATES["projects_feedback"]["v1"]
 
         assert "json" in template.lower()
 
-    def test_presentation_feedback_requests_json_format(self):
+    def test_presentation_feedback_requests_json_format(self) -> None:
         """Test presentation_feedback requests JSON output."""
         template = PROMPT_TEMPLATES["presentation_feedback"]["v1"]
 
         assert "json" in template.lower()
 
-    def test_gaps_feedback_requests_json_format(self):
+    def test_gaps_feedback_requests_json_format(self) -> None:
         """Test gaps_feedback requests JSON output."""
         template = PROMPT_TEMPLATES["gaps_feedback"]["v1"]
 
         assert "json" in template.lower()
 
-    def test_first_impression_plain_text(self):
+    def test_first_impression_plain_text(self) -> None:
         """Test first_impression may request plain text."""
         template = PROMPT_TEMPLATES["first_impression"]["v1"]
 
         # Should specify format (JSON or plain text)
-        assert "json" in template.lower() or "text" in template.lower() or "summary" in template.lower()
+        assert (
+            "json" in template.lower()
+            or "text" in template.lower()
+            or "summary" in template.lower()
+        )
 
-    def test_templates_have_portfolio_context(self):
+    def test_templates_have_portfolio_context(self) -> None:
         """Test templates mention portfolio or context."""
-        for name in PROMPT_TEMPLATES.keys():
+        for name in PROMPT_TEMPLATES:
             template = PROMPT_TEMPLATES[name]["v1"]
             # All should have context mention or portfolio mention
             assert "{context}" in template or "portfolio" in template.lower()
 
-    def test_template_get_logs_retrieval(self):
+    def test_template_get_logs_retrieval(self) -> None:
         """Test that get_template logs retrieval."""
-        # Import logger to verify it's used
-        with pytest.MonkeyPatch.context() as mp:
-            from unittest.mock import patch
-            with patch('rag.generator.prompt_templates.logger') as mock_logger:
-                get_template("skills_feedback")
-                # Should log template retrieval
+        with patch("rag.generator.prompt_templates.logger") as mock_logger:
+            get_template("skills_feedback")
 
-    def test_each_template_name_is_valid_identifier(self):
+        mock_logger.info.assert_called_once_with(
+            "template_retrieved", name="skills_feedback", version="v1"
+        )
+
+    def test_each_template_name_is_valid_identifier(self) -> None:
         """Test template names are valid Python identifiers."""
-        for name in PROMPT_TEMPLATES.keys():
+        for name in PROMPT_TEMPLATES:
             assert name.isidentifier()
             assert "_" in name  # Should use snake_case
 
-    def test_template_versions_are_strings(self):
+    def test_template_versions_are_strings(self) -> None:
         """Test template version keys are strings."""
-        for template_name, versions in PROMPT_TEMPLATES.items():
+        for _template_name, versions in PROMPT_TEMPLATES.items():
             assert isinstance(versions, dict)
-            for version_key in versions.keys():
+            for version_key in versions:
                 assert isinstance(version_key, str)
                 assert version_key.startswith("v")
 
-    def test_no_hardcoded_usernames_in_templates(self):
+    def test_no_hardcoded_usernames_in_templates(self) -> None:
         """Test templates don't contain hardcoded test usernames."""
         forbidden = ["john", "jane", "test", "demo"]
 
-        for name, versions in PROMPT_TEMPLATES.items():
-            for version, template_text in versions.items():
+        for _name, versions in PROMPT_TEMPLATES.items():
+            for _version, template_text in versions.items():
                 for forbidden_word in forbidden:
                     # Should use {github_username} placeholder instead
                     assert not (
@@ -261,13 +336,12 @@ class TestPromptTemplates:
                         and "{github_username}" not in template_text
                     )
 
-    def test_templates_use_consistent_placeholders(self):
+    def test_templates_use_consistent_placeholders(self) -> None:
         """Test all templates use consistent placeholder syntax."""
-        for name, versions in PROMPT_TEMPLATES.items():
-            for version, template_text in versions.items():
+        for _name, versions in PROMPT_TEMPLATES.items():
+            for _version, template_text in versions.items():
                 # All placeholders should use {name} syntax
-                import re
-                placeholders = re.findall(r'\{(\w+)\}', template_text)
+                placeholders = re.findall(r"\{(\w+)\}", template_text)
                 assert "context" in placeholders
                 assert "github_username" in placeholders
                 assert "project_count" in placeholders


### PR DESCRIPTION
## Summary

Adds deterministic, version-keyed snapshot protection for all prompt templates. The previous test computed an MD5 digest but only checked its type and length, so every prompt edit still passed; this change compares each prompt version with a reviewed SHA-256 digest and reports the exact version that changed.

## Issue

Closes #37

## Changes

- Add an inline `EXPECTED_TEMPLATE_HASHES` baseline for all five current `v1` prompts.
- Hash each `(template name, version)` independently so failures identify the affected prompt and do not depend on dictionary order.
- Validate both the prompt-version inventory and every reviewed digest with actionable failure messages.
- Add regressions proving same-version content edits and unreviewed new versions are rejected.
- Bring the touched test module into Ruff, Black, and mypy compliance without changing production prompt content.

## Testing

- [x] Focused unit tests pass: `.venv/bin/pytest tests/unit/test_prompt_templates.py -q` (39 passed).
- [x] Changed file passes `ruff` and `black --check`.
- [x] Repository pre-commit Ruff, Black, and mypy hooks pass.
- [x] New/updated tests cover the snapshot behavior.
- [x] Repository-wide `make test-unit` introduces no new failures: untouched `upstream/main` reports 53 failed / 375 passed, while this branch reports the same 53 failed / 377 passed.
- [x] Repository-wide `make check` introduces no new failures; it remains blocked by unrelated lint findings already present on `upstream/main`.
- [ ] Integration tests were not run because this is an isolated unit-test-only change with no production runtime changes.

## Screenshots / Demo

Not applicable; this change only strengthens prompt-template unit tests.

## Notes for Reviewers

The expected hashes are kept next to the assertions so any snapshot update is explicit in code review. Production content in `rag/generator/prompt_templates.py` is unchanged.

Manual verification:

1. Run `.venv/bin/pytest tests/unit/test_prompt_templates.py -q` and confirm all 39 tests pass.
2. Temporarily append text to `PROMPT_TEMPLATES["skills_feedback"]["v1"]` in a local checkout.
3. Run `.venv/bin/pytest tests/unit/test_prompt_templates.py::TestPromptTemplates::test_template_snapshot_content_hash -q` and confirm it fails with `skills_feedback v1 changed without a reviewed snapshot`.
4. Revert the temporary prompt edit.