### PR TITLE
Fix/163 review profile ownership

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,27 @@
+# AI-201 Open Source Journal
+
+## Repository
+https://github.com/Damola-png/pathreview
+
+## Week 7 - Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/163
+
+**Issue title:** Review creation does not verify profile ownership
+
+**Tier:** [ ] Tier 1  [x] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The `POST /reviews` flow passes the authenticated `user_id` into `create_review`, but the service currently creates a review from the provided `profile_id` without confirming that profile belongs to the same user. This creates an authorization gap where a user could potentially create reviews for another user's profile if they know the profile UUID. In contrast, `get_review` and `list_reviews` already scope access through `Profile.user_id`, so the write path is inconsistent with the read path. A successful fix should enforce ownership before review creation and add a test that covers the cross-user case.
+
+**Is this right for me? checklist reasoning:**
+- I can reproduce and explain the bug path across API route and service layers (`api/routes/reviews.py` -> `core/services/review_service.py`).
+- Scope is bounded to one endpoint behavior plus test coverage, which is realistic for this module timeline.
+- The acceptance criteria are clear: reject cross-user profile access on review creation and keep behavior consistent with existing ownership checks in read endpoints.
+- Risk is moderate (authorization logic), but contained to review creation and should be validated with targeted tests.
+
+**Branch name:** fix/163-review-profile-ownership
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -65,19 +65,33 @@ Open a draft PR, request peer/mentor feedback in Slack, and finalize the PR desc
 
 ### Check-in 2 (end of week)
 
-**PR link:** [add your submitted PR link]
+**PR link:** [https://github.com/ascherj/pathreview/pull/699]
+
+**PR status:** Draft (work in progress), awaiting reviewer approval and maintainer workflow approval
 
 **Branch:** fix/163-review-profile-ownership
 
 **What you built:**
 Added an authorization guard in the review creation service that checks `(profile_id, user_id)` ownership before constructing a `Review`. This closes the cross-user creation gap by rejecting inaccessible profiles with a 404 response and preventing any database writes for unauthorized requests.
 
+**PR description summary (submitted):**
+- Summary: Fixes Issue #163 by verifying requested profile ownership before review creation.
+- Issue closure: Closes #163.
+- Behavior changes: rejects non-owner access, rejects missing profiles, and blocks unauthorized `db.add()`/`db.commit()` writes.
+- Test updates: unit tests updated for authorized and unauthorized review creation paths; ownership regression test passes.
+- Scope note: any remaining unrelated repository-wide failures were pre-existing and not introduced by this PR.
+
 **Tests added or updated:**
 Updated `tests/unit/test_review_service.py` to cover the ownership rejection path (`test_create_review_rejects_profile_owned_by_another_user`) and to keep the review service suite stable with SQLAlchemy execute-result mocks. Focused run: `pytest tests/unit/test_review_service.py -v -m unit` (20 passed).
 
-**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+**Self-review confirmation:** [x] `make check` equivalent executed in PowerShell (`ruff`, `black --check`, `mypy`) and results documented below  [x] `make test-unit` equivalent executed in PowerShell (`pytest tests/unit -v -m unit`) and results documented below
 
 **Draft PR feedback received from:** none
 
+**PR readiness notes:**
+- Review required: at least 1 approving review from a maintainer/write-access reviewer.
+- CI gate: 1 workflow run is awaiting maintainer approval.
+- Merge state: PR remains draft until ready-for-review is submitted.
+
 **Pre-existing failures observed:**
-Project-wide `check` and `test-unit` equivalents still report existing unrelated failures in other modules (for example: safety, parsing, scoring, and detector tests). After this fix, the previously failing `tests/unit/test_review_service.py` cases related to Issue #163 are now passing, and no new failures were introduced in the touched review service scope.
+Project-wide `check` and `test-unit` equivalents still report existing unrelated baseline failures in other modules (for example: safety, parsing, scoring, and detector tests). For this issue scope, the focused review service run passes: `pytest tests/unit/test_review_service.py -v -m unit` (20 passed). This change did not introduce any new failures in the touched review service code path.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -25,3 +25,23 @@ The `POST /reviews` flow passes the authenticated `user_id` into `create_review`
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [ ] Issue added to cohort ledger
+
+
+
+
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:**
+[https://github.com/Damola-png/pathreview/commit/13aa66480b8fd02bed5ed4e4a26f43efc2a7306e]
+
+**Reproduction summary:**
+I reproduced Issue#163 by adding a targeted unit test where the authenticated user attempts to create a review for a profile owned by another user. The test failed because `create_review()` still called `db.add()` and created a pending review instead of rejecting the unauthorized request, confirming that profile ownership is not currently checked during review creation.
+
+**PLAN.md link:**
+https://github.com/Damola-png/pathreview/blob/fix/163-review-profile-ownership/PLAN.md
+
+
+
+**Blockers or open questions:**
+I still need to confirm the expected error response when a profile does not exist or belongs to another user. The existing read endpoints use ownership filtering and return a 404 when the requested resource cannot be accessed, so I will determine whether review creation should follow the same behavior. There are also unrelated existing `AsyncMock` failures in some review service tests, so I will use targeted tests for Issue #163 while implementing and validating the fix.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -45,3 +45,39 @@ https://github.com/Damola-png/pathreview/blob/fix/163-review-profile-ownership/P
 
 **Blockers or open questions:**
 I still need to confirm the expected error response when a profile does not exist or belongs to another user. The existing read endpoints use ownership filtering and return a 404 when the requested resource cannot be accessed, so I will determine whether review creation should follow the same behavior. There are also unrelated existing `AsyncMock` failures in some review service tests, so I will use targeted tests for Issue #163 while implementing and validating the fix.
+
+
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented Issue #163 by adding profile ownership validation inside `create_review()` so review creation only succeeds when the requested profile belongs to the authenticated user. Unauthorized or non-existent profiles now return a `404 Profile not found` before any review is added or committed. Updated `tests/unit/test_review_service.py` with ownership-aware setup and verification for both allowed and rejected creation paths.
+
+**Next steps:**
+Open a draft PR, request peer/mentor feedback in Slack, and finalize the PR description with baseline vs post-change check/test results. Re-run project checks before marking the PR ready and update this journal with the submitted PR link.
+
+**Blockers:**
+`make` is not available in this Windows PowerShell environment, so I ran equivalent commands via `.venv\\Scripts` (`ruff`, `black --check`, `mypy`, and `pytest`) to validate behavior.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [add your submitted PR link]
+
+**Branch:** fix/163-review-profile-ownership
+
+**What you built:**
+Added an authorization guard in the review creation service that checks `(profile_id, user_id)` ownership before constructing a `Review`. This closes the cross-user creation gap by rejecting inaccessible profiles with a 404 response and preventing any database writes for unauthorized requests.
+
+**Tests added or updated:**
+Updated `tests/unit/test_review_service.py` to cover the ownership rejection path (`test_create_review_rejects_profile_owned_by_another_user`) and to keep the review service suite stable with SQLAlchemy execute-result mocks. Focused run: `pytest tests/unit/test_review_service.py -v -m unit` (20 passed).
+
+**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+
+**Draft PR feedback received from:** none
+
+**Pre-existing failures observed:**
+Project-wide `check` and `test-unit` equivalents still report existing unrelated failures in other modules (for example: safety, parsing, scoring, and detector tests). After this fix, the previously failing `tests/unit/test_review_service.py` cases related to Issue #163 are now passing, and no new failures were introduced in the touched review service scope.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -95,3 +95,34 @@ Updated `tests/unit/test_review_service.py` to cover the ownership rejection pat
 
 **Pre-existing failures observed:**
 Project-wide `check` and `test-unit` equivalents still report existing unrelated baseline failures in other modules (for example: safety, parsing, scoring, and detector tests). For this issue scope, the focused review service run passes: `pytest tests/unit/test_review_service.py -v -m unit` (20 passed). This change did not introduce any new failures in the touched review service code path.
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No reviewer feedback was provided during the Summer 2026 cycle. The module notes that reviewer feedback is not a standard feature for this term, so there were no maintainer comments to address for this issue.
+
+**How you responded:**
+No direct review comments were available, so there were no code or documentation changes to make in response to reviewer feedback. I used the time to finalize the implementation record, confirm the working branch state, and write the reflection below.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The hardest part was not writing the ownership check itself; it was validating the behavior in a way that matched the project's existing authorization patterns. I had to trace the read path and compare it to the create path, then make sure the fix was consistent without widening the scope or introducing a different failure mode. The repository also had unrelated failing tests and baseline noise, which made it easy to second-guess whether a problem was caused by my change or by pre-existing state.
+
+**What did you learn about working in a large codebase?**
+I learned that production code is less about writing a clever solution and more about matching an existing design language. In a larger codebase, the important work is often understanding the access patterns, conventions, and failure semantics already used by the team. A small change like enforcing profile ownership sounds straightforward, but it matters whether the app treats unauthorized access as a 404, a 403, or a silent rejection, and those conventions are shaped by the broader codebase rather than by any single function.
+
+**How did AI tools help — and where did they fall short?**
+AI was especially useful for narrowing the issue quickly: it helped me trace the create-review flow, identify the missing ownership guard, and draft a focused regression test. It also helped me reason about likely side effects and suggest a path that kept the patch minimal. The limitations showed up when I needed to validate against the actual repository semantics and non-obvious conventions, especially around error handling and existing test patterns. In other words, AI accelerated the initial investigation, but the final judgment still had to come from reading the relevant service and route behavior and confirming the expected contract with the codebase itself.
+
+**What would you do differently if you started over?**
+I would spend a bit more time upfront checking the surrounding ownership conventions and the exact error contract before implementing the fix. That would reduce the back-and-forth of confirming whether a missing profile or cross-user access should raise the same error as the read endpoints. I would also isolate the regression test even more aggressively and run the smallest relevant suite earlier, so I could tell more quickly whether the fix was behaving correctly without being distracted by unrelated repo-level failures.
+
+**What are you most proud of from this module?**
+I am most proud of the fact that the fix addressed a real authorization gap in the service layer and was supported by a targeted regression test. It was a useful reminder that secure behavior is sometimes about preventing the wrong action before a write happens, not just responding to it afterward. The final patch was small but meaningful, and it confirmed that careful reasoning can improve safety without overcomplicating the code.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,64 @@
+# Solution plan
+
+**Issue:** [#163 — Review creation does not verify profile ownership](https://github.com/ascherj/pathreview/issues/163)
+
+### Understand
+
+The `POST /reviews` endpoint passes both the requested `profile_id` and the authenticated user's `user_id` to `create_review()`. However, `create_review()` currently uses the `profile_id` to create the review without checking whether that profile belongs to the authenticated user. This means a user who knows another user's profile UUID could potentially create a review for that profile.
+
+The expected behavior is that a review should only be created when the requested profile belongs to the authenticated user. If the profile does not exist or belongs to another user, review creation should be rejected before anything is added to the database.
+
+I reproduced the issue with a unit test that supplies a profile owned by a different user. The test fails because `create_review()` still calls `db.add()` and creates the review.
+
+### Map
+
+The main files involved are:
+
+* `api/routes/reviews.py` — handles `POST /reviews`, gets the authenticated user, and passes `current_user.id` to the service.
+* `core/services/review_service.py` — contains `create_review()`, where the ownership validation is currently missing.
+* `tests/unit/test_review_service.py` — contains the review service tests and will contain coverage for the cross-user ownership case.
+
+The existing `get_review()` and `list_reviews()` functions in `core/services/review_service.py` already use `Profile.user_id` to scope review access to the authenticated user. I can use these functions as references for how ownership is handled elsewhere in the service.
+
+### Plan
+
+1. Update `create_review()` in `core/services/review_service.py` to query for the requested profile and verify that its `user_id` matches the authenticated `user_id`.
+2. If the profile does not exist or is not owned by the current user, stop review creation before calling `db.add()` or committing a review.
+3. Preserve the existing review creation behavior for profiles that are owned by the authenticated user, including the initial `"pending"` status.
+4. Update `tests/unit/test_review_service.py` so the cross-user case verifies that unauthorized review creation is rejected.
+5. Add or update test coverage for the valid-owner case and run the targeted review service tests to confirm the ownership check works without breaking normal review creation.
+
+### Inputs & outputs
+
+**Inputs:**
+
+* `profile_id` — UUID of the profile that the user wants reviewed.
+* `user_id` — UUID of the currently authenticated user.
+* Database session used to look up the profile and create the review.
+
+**Expected output for a valid profile:**
+
+* A new `Review` associated with the requested profile.
+* The review begins with a `"pending"` status and is committed to the database.
+
+**Expected output for an unauthorized or unavailable profile:**
+
+* Review creation is rejected.
+* No `Review` is added or committed to the database.
+* The API should return an appropriate error rather than creating a review.
+
+### Risks & unknowns
+
+One decision I need to confirm is which error response the project expects when the profile does not exist or belongs to another user. The existing read endpoints use a `404 Not Found` response when a review cannot be accessed by the current user, so I will investigate whether review creation should follow the same pattern.
+
+There are also existing unrelated failures in `tests/unit/test_review_service.py` involving the setup of `AsyncMock` results. I will keep the Issue #163 tests targeted so those existing failures are not confused with failures caused by my ownership change.
+
+I also need to make sure the ownership validation happens before the review is added or committed so an unauthorized request cannot leave database changes behind.
+
+### Edge cases
+
+* The profile exists and belongs to the authenticated user — review creation should succeed normally.
+* The profile exists but belongs to another user — review creation should be rejected.
+* The supplied `profile_id` does not match any profile — review creation should be rejected.
+* A valid UUID is supplied for a profile that the current user cannot access — it should not reveal or create data for that profile.
+* The ownership check succeeds but a later database operation fails — existing error handling and rollback behavior should continue to work.

--- a/core/services/review_service.py
+++ b/core/services/review_service.py
@@ -1,13 +1,15 @@
-from uuid import UUID
-import structlog
 import json
 from datetime import datetime
-from sqlalchemy import select, and_
+from uuid import UUID
 
-from core.models.review import Review
-from core.models.profile import Profile
-from core.models.ingested_source import IngestedSource
+import structlog
+from fastapi import HTTPException, status
+from sqlalchemy import and_, select
+
 from api.schemas.review import FeedbackSection
+from core.models.ingested_source import IngestedSource
+from core.models.profile import Profile
+from core.models.review import Review
 
 log = structlog.get_logger()
 
@@ -19,7 +21,19 @@ async def create_review(
 ) -> Review:
     """
     Create a new review with status="pending".
+
+    The requested profile must belong to the authenticated user.
     """
+    stmt = select(Profile).where(Profile.id == profile_id)
+    result = await db.execute(stmt)
+    profile = result.scalars().first()
+
+    if profile is None or profile.user_id != user_id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Profile not found",
+        )
+
     review = Review(
         profile_id=profile_id,
         status="pending",
@@ -40,8 +54,8 @@ async def get_review(
     """
     Get a review by ID, checking that it belongs to the user's profile.
     """
-    stmt = select(Review).join(Profile).where(
-        and_(Review.id == review_id, Profile.user_id == user_id)
+    stmt = (
+        select(Review).join(Profile).where(and_(Review.id == review_id, Profile.user_id == user_id))
     )
     result = await db.execute(stmt)
     return result.scalars().first()

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -99,7 +99,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -449,7 +448,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -473,7 +471,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1561,7 +1558,6 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1579,7 +1575,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1972,7 +1967,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3507,7 +3501,6 @@
       "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^2.0.1",
         "cssstyle": "^4.0.1",
@@ -4094,7 +4087,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4107,7 +4099,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4771,7 +4762,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -99,6 +99,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -448,6 +449,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -471,6 +473,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1558,6 +1561,7 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1575,6 +1579,7 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1967,6 +1972,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3501,6 +3507,7 @@
       "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^2.0.1",
         "cssstyle": "^4.0.1",
@@ -4087,6 +4094,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4099,6 +4107,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4762,6 +4771,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/tests/unit/test_review_service.py
+++ b/tests/unit/test_review_service.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, Mock, patch
 from uuid import uuid4
 
 import pytest
+from fastapi import HTTPException
 
 from core.services.review_service import (
     create_review,
@@ -15,6 +16,15 @@ from core.services.review_service import (
 @pytest.mark.unit
 class TestReviewService:
     """Test suite for review_service module."""
+
+    def _mock_execute_result(self, first=None, all_items=None):
+        """Build a SQLAlchemy-like execute() result object for tests."""
+        result = Mock()
+        scalar_result = Mock()
+        scalar_result.first.return_value = first
+        scalar_result.all.return_value = all_items or []
+        result.scalars.return_value = scalar_result
+        return result
 
     @pytest.fixture
     def mock_db_session(self):
@@ -56,23 +66,24 @@ class TestReviewService:
         mock_db_session.add = Mock()
         mock_db_session.commit = AsyncMock()
         mock_db_session.refresh = AsyncMock()
+        mock_db_session.execute = AsyncMock(return_value=self._mock_execute_result(first=Mock()))
 
-        with patch("core.services.review_service.Review") as MockReview:
-            mock_instance = MockReview.return_value
+        with patch("core.services.review_service.Review") as mock_review_cls:
+            mock_instance = mock_review_cls.return_value
             mock_instance.status = "pending"
             mock_instance.sections = None
             mock_instance.overall_score = None
 
-            result = await create_review(mock_db_session, profile_id, user_id)
+            await create_review(mock_db_session, profile_id, user_id)
 
             # Check that Review was instantiated
-            MockReview.assert_called()
-            call_kwargs = MockReview.call_args[1]
+            mock_review_cls.assert_called()
+            call_kwargs = mock_review_cls.call_args[1]
             assert call_kwargs["status"] == "pending"
 
     @pytest.mark.asyncio
     async def test_create_review_rejects_profile_owned_by_another_user(self, mock_db_session):
-        """Reproduce #163: a user must not create a review for another user's profile."""
+        """Reject review creation when another user owns the profile."""
         profile_id = uuid4()
         current_user_id = uuid4()
         other_user_id = uuid4()
@@ -81,17 +92,25 @@ class TestReviewService:
         mock_profile.id = profile_id
         mock_profile.user_id = other_user_id
 
+        mock_scalars = Mock()
+        mock_scalars.first.return_value = mock_profile
+
         mock_result = Mock()
-        mock_result.scalars.return_value.first.return_value = mock_profile
+        mock_result.scalars.return_value = mock_scalars
+
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
-        await create_review(
-            mock_db_session,
-            profile_id,
-            current_user_id,
-        )
+        with pytest.raises(HTTPException) as exc_info:
+            await create_review(
+                mock_db_session,
+                profile_id,
+                current_user_id,
+            )
 
+        assert exc_info.value.status_code == 404
+        assert exc_info.value.detail == "Profile not found"
         mock_db_session.add.assert_not_called()
+        mock_db_session.commit.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_get_review_returns_review_for_correct_owner(self, mock_db_session):
@@ -103,9 +122,9 @@ class TestReviewService:
         mock_review.id = review_id
 
         # Setup mock execute to return review
-        mock_result = AsyncMock()
-        mock_result.scalars.return_value.first.return_value = mock_review
-        mock_db_session.execute = AsyncMock(return_value=mock_result)
+        mock_db_session.execute = AsyncMock(
+            return_value=self._mock_execute_result(first=mock_review)
+        )
 
         result = await get_review(mock_db_session, review_id, user_id)
 
@@ -116,13 +135,10 @@ class TestReviewService:
     async def test_get_review_returns_none_for_wrong_user(self, mock_db_session):
         """Test get_review returns None when user_id doesn't match."""
         review_id = uuid4()
-        user_id = uuid4()
         wrong_user_id = uuid4()
 
         # Setup mock to return None
-        mock_result = AsyncMock()
-        mock_result.scalars.return_value.first.return_value = None
-        mock_db_session.execute = AsyncMock(return_value=mock_result)
+        mock_db_session.execute = AsyncMock(return_value=self._mock_execute_result(first=None))
 
         result = await get_review(mock_db_session, review_id, wrong_user_id)
 
@@ -137,9 +153,9 @@ class TestReviewService:
         mock_reviews = [Mock() for _ in range(5)]
 
         # Setup execute mock to return reviews
-        mock_result = AsyncMock()
-        mock_result.scalars.return_value.all.return_value = mock_reviews
-        mock_db_session.execute = AsyncMock(return_value=mock_result)
+        mock_db_session.execute = AsyncMock(
+            return_value=self._mock_execute_result(all_items=mock_reviews)
+        )
 
         reviews, total = await list_reviews(mock_db_session, user_id, page=1, page_size=20)
 
@@ -154,9 +170,7 @@ class TestReviewService:
         page_size = 20
 
         # Setup mock
-        mock_result = AsyncMock()
-        mock_result.scalars.return_value.all.return_value = []
-        mock_db_session.execute = AsyncMock(return_value=mock_result)
+        mock_db_session.execute = AsyncMock(return_value=self._mock_execute_result(all_items=[]))
 
         reviews, total = await list_reviews(mock_db_session, user_id, page=2, page_size=page_size)
 
@@ -170,9 +184,7 @@ class TestReviewService:
         """Test list_reviews returns (reviews, total) tuple."""
         user_id = uuid4()
 
-        mock_result = AsyncMock()
-        mock_result.scalars.return_value.all.return_value = []
-        mock_db_session.execute = AsyncMock(return_value=mock_result)
+        mock_db_session.execute = AsyncMock(return_value=self._mock_execute_result(all_items=[]))
 
         result = await list_reviews(mock_db_session, user_id)
 
@@ -187,6 +199,7 @@ class TestReviewService:
         """Test create_review calls db.add()."""
         profile_id = uuid4()
         user_id = uuid4()
+        mock_db_session.execute = AsyncMock(return_value=self._mock_execute_result(first=Mock()))
 
         with patch("core.services.review_service.Review"):
             await create_review(mock_db_session, profile_id, user_id)
@@ -198,6 +211,7 @@ class TestReviewService:
         """Test create_review calls db.commit()."""
         profile_id = uuid4()
         user_id = uuid4()
+        mock_db_session.execute = AsyncMock(return_value=self._mock_execute_result(first=Mock()))
 
         with patch("core.services.review_service.Review"):
             await create_review(mock_db_session, profile_id, user_id)
@@ -209,6 +223,7 @@ class TestReviewService:
         """Test create_review calls db.refresh()."""
         profile_id = uuid4()
         user_id = uuid4()
+        mock_db_session.execute = AsyncMock(return_value=self._mock_execute_result(first=Mock()))
 
         with patch("core.services.review_service.Review"):
             await create_review(mock_db_session, profile_id, user_id)
@@ -221,9 +236,7 @@ class TestReviewService:
         review_id = uuid4()
         user_id = uuid4()
 
-        mock_result = AsyncMock()
-        mock_result.scalars.return_value.first.return_value = None
-        mock_db_session.execute = AsyncMock(return_value=mock_result)
+        mock_db_session.execute = AsyncMock(return_value=self._mock_execute_result(first=None))
 
         await get_review(mock_db_session, review_id, user_id)
 
@@ -235,9 +248,7 @@ class TestReviewService:
         """Test list_reviews uses default pagination."""
         user_id = uuid4()
 
-        mock_result = AsyncMock()
-        mock_result.scalars.return_value.all.return_value = []
-        mock_db_session.execute = AsyncMock(return_value=mock_result)
+        mock_db_session.execute = AsyncMock(return_value=self._mock_execute_result(all_items=[]))
 
         reviews, total = await list_reviews(mock_db_session, user_id)
 
@@ -251,9 +262,7 @@ class TestReviewService:
         user_id = uuid4()
         custom_page_size = 50
 
-        mock_result = AsyncMock()
-        mock_result.scalars.return_value.all.return_value = []
-        mock_db_session.execute = AsyncMock(return_value=mock_result)
+        mock_db_session.execute = AsyncMock(return_value=self._mock_execute_result(all_items=[]))
 
         reviews, total = await list_reviews(
             mock_db_session, user_id, page=1, page_size=custom_page_size
@@ -266,12 +275,13 @@ class TestReviewService:
         """Test create_review handles UUID objects correctly."""
         profile_id = uuid4()
         user_id = uuid4()
+        mock_db_session.execute = AsyncMock(return_value=self._mock_execute_result(first=Mock()))
 
-        with patch("core.services.review_service.Review") as MockReview:
-            MockReview.return_value = Mock()
+        with patch("core.services.review_service.Review") as mock_review_cls:
+            mock_review_cls.return_value = Mock()
             await create_review(mock_db_session, profile_id, user_id)
 
-            call_kwargs = MockReview.call_args[1]
+            call_kwargs = mock_review_cls.call_args[1]
             assert "profile_id" in call_kwargs
             assert "status" in call_kwargs
 
@@ -281,9 +291,7 @@ class TestReviewService:
         review_id = uuid4()
         user_id = uuid4()
 
-        mock_result = AsyncMock()
-        mock_result.scalars.return_value.first.return_value = None
-        mock_db_session.execute = AsyncMock(return_value=mock_result)
+        mock_db_session.execute = AsyncMock(return_value=self._mock_execute_result(first=None))
 
         await get_review(mock_db_session, review_id, user_id)
 
@@ -296,9 +304,9 @@ class TestReviewService:
         user_id = uuid4()
 
         mock_reviews = [Mock() for _ in range(5)]
-        mock_result = AsyncMock()
-        mock_result.scalars.return_value.all.return_value = mock_reviews
-        mock_db_session.execute = AsyncMock(return_value=mock_result)
+        mock_db_session.execute = AsyncMock(
+            return_value=self._mock_execute_result(all_items=mock_reviews)
+        )
 
         reviews, total = await list_reviews(mock_db_session, user_id)
 
@@ -311,9 +319,9 @@ class TestReviewService:
         user_id = uuid4()
 
         mock_reviews = [Mock(spec=["id", "status"]) for _ in range(3)]
-        mock_result = AsyncMock()
-        mock_result.scalars.return_value.all.return_value = mock_reviews
-        mock_db_session.execute = AsyncMock(return_value=mock_result)
+        mock_db_session.execute = AsyncMock(
+            return_value=self._mock_execute_result(all_items=mock_reviews)
+        )
 
         reviews, total = await list_reviews(mock_db_session, user_id)
 
@@ -324,12 +332,13 @@ class TestReviewService:
         """Test review has None for sections and overall_score initially."""
         profile_id = uuid4()
         user_id = uuid4()
+        mock_db_session.execute = AsyncMock(return_value=self._mock_execute_result(first=Mock()))
 
-        with patch("core.services.review_service.Review") as MockReview:
-            MockReview.return_value = Mock()
+        with patch("core.services.review_service.Review") as mock_review_cls:
+            mock_review_cls.return_value = Mock()
             await create_review(mock_db_session, profile_id, user_id)
 
-            call_kwargs = MockReview.call_args[1]
+            call_kwargs = mock_review_cls.call_args[1]
             assert call_kwargs["sections"] is None
             assert call_kwargs["overall_score"] is None
 
@@ -339,9 +348,7 @@ class TestReviewService:
         review_id = uuid4()
         user_id = uuid4()
 
-        mock_result = AsyncMock()
-        mock_result.scalars.return_value.first.return_value = None
-        mock_db_session.execute = AsyncMock(return_value=mock_result)
+        mock_db_session.execute = AsyncMock(return_value=self._mock_execute_result(first=None))
 
         # Should not raise
         result = await get_review(mock_db_session, review_id, user_id)
@@ -353,11 +360,9 @@ class TestReviewService:
         """Test list_reviews returns results ordered by created_at desc."""
         user_id = uuid4()
 
-        mock_result = AsyncMock()
-        mock_result.scalars.return_value.all.return_value = []
-        mock_db_session.execute = AsyncMock(return_value=mock_result)
+        mock_db_session.execute = AsyncMock(return_value=self._mock_execute_result(all_items=[]))
 
         reviews, total = await list_reviews(mock_db_session, user_id)
 
         # Should order by created_at descending
-        mock_db_session.execute.assert_called_once()
+        assert mock_db_session.execute.call_count == 2

--- a/tests/unit/test_review_service.py
+++ b/tests/unit/test_review_service.py
@@ -1,9 +1,9 @@
 """Tests for review_service.py"""
 
-import pytest
-from uuid import uuid4
 from unittest.mock import AsyncMock, Mock, patch
-import asyncio
+from uuid import uuid4
+
+import pytest
 
 from core.services.review_service import (
     create_review,
@@ -45,7 +45,9 @@ class TestReviewService:
         return profile
 
     @pytest.mark.asyncio
-    async def test_create_review_returns_review_with_pending_status(self, mock_db_session, mock_review):
+    async def test_create_review_returns_review_with_pending_status(
+        self, mock_db_session, mock_review
+    ):
         """Test create_review returns Review with status='pending'."""
         profile_id = uuid4()
         user_id = uuid4()
@@ -55,7 +57,7 @@ class TestReviewService:
         mock_db_session.commit = AsyncMock()
         mock_db_session.refresh = AsyncMock()
 
-        with patch('core.services.review_service.Review') as MockReview:
+        with patch("core.services.review_service.Review") as MockReview:
             mock_instance = MockReview.return_value
             mock_instance.status = "pending"
             mock_instance.sections = None
@@ -66,7 +68,30 @@ class TestReviewService:
             # Check that Review was instantiated
             MockReview.assert_called()
             call_kwargs = MockReview.call_args[1]
-            assert call_kwargs['status'] == "pending"
+            assert call_kwargs["status"] == "pending"
+
+    @pytest.mark.asyncio
+    async def test_create_review_rejects_profile_owned_by_another_user(self, mock_db_session):
+        """Reproduce #163: a user must not create a review for another user's profile."""
+        profile_id = uuid4()
+        current_user_id = uuid4()
+        other_user_id = uuid4()
+
+        mock_profile = Mock()
+        mock_profile.id = profile_id
+        mock_profile.user_id = other_user_id
+
+        mock_result = Mock()
+        mock_result.scalars.return_value.first.return_value = mock_profile
+        mock_db_session.execute = AsyncMock(return_value=mock_result)
+
+        await create_review(
+            mock_db_session,
+            profile_id,
+            current_user_id,
+        )
+
+        mock_db_session.add.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_get_review_returns_review_for_correct_owner(self, mock_db_session):
@@ -133,9 +158,7 @@ class TestReviewService:
         mock_result.scalars.return_value.all.return_value = []
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
-        reviews, total = await list_reviews(
-            mock_db_session, user_id, page=2, page_size=page_size
-        )
+        reviews, total = await list_reviews(mock_db_session, user_id, page=2, page_size=page_size)
 
         # Second call should pass offset for page 2
         calls = mock_db_session.execute.call_args_list
@@ -165,7 +188,7 @@ class TestReviewService:
         profile_id = uuid4()
         user_id = uuid4()
 
-        with patch('core.services.review_service.Review'):
+        with patch("core.services.review_service.Review"):
             await create_review(mock_db_session, profile_id, user_id)
 
             mock_db_session.add.assert_called_once()
@@ -176,7 +199,7 @@ class TestReviewService:
         profile_id = uuid4()
         user_id = uuid4()
 
-        with patch('core.services.review_service.Review'):
+        with patch("core.services.review_service.Review"):
             await create_review(mock_db_session, profile_id, user_id)
 
             mock_db_session.commit.assert_called_once()
@@ -187,7 +210,7 @@ class TestReviewService:
         profile_id = uuid4()
         user_id = uuid4()
 
-        with patch('core.services.review_service.Review'):
+        with patch("core.services.review_service.Review"):
             await create_review(mock_db_session, profile_id, user_id)
 
             mock_db_session.refresh.assert_called_once()
@@ -244,13 +267,13 @@ class TestReviewService:
         profile_id = uuid4()
         user_id = uuid4()
 
-        with patch('core.services.review_service.Review') as MockReview:
+        with patch("core.services.review_service.Review") as MockReview:
             MockReview.return_value = Mock()
             await create_review(mock_db_session, profile_id, user_id)
 
             call_kwargs = MockReview.call_args[1]
-            assert 'profile_id' in call_kwargs
-            assert 'status' in call_kwargs
+            assert "profile_id" in call_kwargs
+            assert "status" in call_kwargs
 
     @pytest.mark.asyncio
     async def test_get_review_verifies_ownership(self, mock_db_session):
@@ -287,7 +310,7 @@ class TestReviewService:
         """Test list_reviews returns list of Review objects."""
         user_id = uuid4()
 
-        mock_reviews = [Mock(spec=['id', 'status']) for _ in range(3)]
+        mock_reviews = [Mock(spec=["id", "status"]) for _ in range(3)]
         mock_result = AsyncMock()
         mock_result.scalars.return_value.all.return_value = mock_reviews
         mock_db_session.execute = AsyncMock(return_value=mock_result)
@@ -302,13 +325,13 @@ class TestReviewService:
         profile_id = uuid4()
         user_id = uuid4()
 
-        with patch('core.services.review_service.Review') as MockReview:
+        with patch("core.services.review_service.Review") as MockReview:
             MockReview.return_value = Mock()
             await create_review(mock_db_session, profile_id, user_id)
 
             call_kwargs = MockReview.call_args[1]
-            assert call_kwargs['sections'] is None
-            assert call_kwargs['overall_score'] is None
+            assert call_kwargs["sections"] is None
+            assert call_kwargs["overall_score"] is None
 
     @pytest.mark.asyncio
     async def test_get_review_with_valid_uuid(self, mock_db_session):


### PR DESCRIPTION
## Summary

Fixes Issue #163 by verifying that the requested profile belongs to the authenticated user before creating a review.

## Issue

Closes #163

## Changes

- Added ownership validation in `create_review()`.
- Rejects review creation for profiles owned by another user.
- Rejects review creation when the profile does not exist.
- Prevents unauthorized requests from calling `db.add()` or `db.commit()`.
- Updated unit tests for authorized and unauthorized review creation.

## Testing

- Updated `tests/unit/test_review_service.py`
- Ran targeted review service tests.
- Confirmed the ownership regression test passes.

## Notes

Any remaining unrelated repository-wide failures (if applicable) were present before this change and were not introduced by this PR.