### PR TITLE
fix: handle None context chunk text in faithfulness checker (#153)

### DIFF
--- a/rag/evaluator/faithfulness_checker.py
+++ b/rag/evaluator/faithfulness_checker.py
@@ -1,6 +1,7 @@
 """Check if generated feedback is supported by retrieved context."""
 
 import re
+
 import structlog
 
 logger = structlog.get_logger()
@@ -20,8 +21,11 @@ class FaithfulnessChecker:
             Faithfulness score 0.0-1.0 (ratio of supported claims)
         """
         if not feedback or not context_chunks:
-            logger.info("faithfulness_empty_input", has_feedback=bool(feedback),
-                       has_chunks=bool(context_chunks))
+            logger.info(
+                "faithfulness_empty_input",
+                has_feedback=bool(feedback),
+                has_chunks=bool(context_chunks),
+            )
             return 0.0
 
         # Extract key claims from feedback (sentences)
@@ -30,10 +34,10 @@ class FaithfulnessChecker:
             logger.info("faithfulness_no_claims_extracted")
             return 0.5  # Default to neutral if no extractable claims
 
-        # Concatenate context text
-        context_text = " ".join([
-            chunk.get("text", "") for chunk in context_chunks
-        ])
+        # Concatenate context text. Use ``or ""`` so a chunk whose "text" key is
+        # present but None (not just absent) is treated as empty instead of
+        # crashing " ".join(...) with a TypeError.
+        context_text = " ".join([chunk.get("text") or "" for chunk in context_chunks])
 
         # Check each claim for support
         supported = 0
@@ -43,8 +47,9 @@ class FaithfulnessChecker:
 
         score = supported / len(claims) if claims else 0.0
 
-        logger.info("faithfulness_checked", claims_count=len(claims),
-                   supported_count=supported, score=score)
+        logger.info(
+            "faithfulness_checked", claims_count=len(claims), supported_count=supported, score=score
+        )
 
         return score
 
@@ -59,7 +64,7 @@ class FaithfulnessChecker:
             List of claims (sentences)
         """
         # Split by sentence (simple regex)
-        sentences = re.split(r'[.!?]+', text)
+        sentences = re.split(r"[.!?]+", text)
         claims = [s.strip() for s in sentences if s.strip() and len(s.strip()) > 10]
         return claims[:10]  # Limit to 10 claims for scoring
 
@@ -81,8 +86,25 @@ class FaithfulnessChecker:
         # Require at least some meaningful overlap
         overlap = claim_tokens & context_tokens
         # Filter out common stop words
-        stop_words = {'a', 'an', 'the', 'is', 'are', 'was', 'were', 'be', 'been',
-                     'and', 'or', 'but', 'in', 'of', 'to', 'for', 'that'}
+        stop_words = {
+            "a",
+            "an",
+            "the",
+            "is",
+            "are",
+            "was",
+            "were",
+            "be",
+            "been",
+            "and",
+            "or",
+            "but",
+            "in",
+            "of",
+            "to",
+            "for",
+            "that",
+        }
         meaningful_overlap = overlap - stop_words
 
         return len(meaningful_overlap) >= 2


### PR DESCRIPTION
## Summary

The faithfulness checker crashes with a `TypeError` when a retrieved context chunk has its `text` key present but set to `None`. This PR makes `FaithfulnessChecker.check()` treat a `None` (or missing) text value as an empty string so it returns a score instead of crashing.

## Issue

Closes #153

## Changes

- `rag/evaluator/faithfulness_checker.py`: in `check()`, changed the context concatenation from `chunk.get("text", "")` to `chunk.get("text") or ""`. `dict.get(key, default)` only returns the default when the key is **absent** — when the key exists with value `None`, it returns `None`, which then reaches `" ".join(...)` and raises `TypeError: sequence item 0: expected str instance, NoneType found`. Using `or ""` coerces both a `None` value and an absent key to `""`.
- The file was also normalized by the repo's `black`/`ruff` pre-commit hooks; those changes are style-only and unrelated to the logic fix.

## Testing

- [ ] Unit tests pass (`make test-unit`) — see pre-existing failures note below
- [ ] Integration tests pass (`make test-integration`) — not run locally (require DB/Redis services); this change is isolated to a pure function and does not touch integration paths
- [x] Linter passes (`make lint`) — the changed file passes `ruff`
- [x] Type checker passes (`make typecheck`) — the changed file passes `mypy`
- [x] New/updated tests cover the changes — the existing regression test `test_none_context_chunk_text` fails before this change and passes after it

**Pre-existing failures (documented per contribution guidance):** Before this change the unit suite reported **53 failed / 375 passed**. Those failures are unrelated to #153 (in `resume_parser`, `review_service`, `skill_extractor`, `tech_detector`, etc., plus 3 *scoring-logic* failures inside the faithfulness checker itself, which fail with `AssertionError`, not the `TypeError` this PR fixes). After this change the suite reports **52 failed / 376 passed** — this PR fixes exactly one test (`test_none_context_chunk_text`) and introduces **no new failures**.

## Notes for Reviewers

- The same `chunk.get("text", "")` pattern also appears in `rag/evaluator/relevance_scorer.py:32` and `rag/generator/review_generator.py:157` and carries the same latent risk, but I scoped this PR to the faithfulness checker (#153). Happy to open a follow-up if you'd like those addressed too.
- The 3 pre-existing scoring failures in `test_faithfulness_checker.py` are a separate keyword-overlap issue and are intentionally left untouched.
