### PR TITLE
Fix/163 review profile ownership

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -29,3 +29,27 @@ Added test `test_create_review_missing_ownership_check()` documenting the vulner
 **Blockers or open questions:**
 - Clarify if non-existent profile should return 403 or 404
 - Check if background task `process_review()` needs ownership verification too
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+- ✅ Sub-task 1: Added ownership verification to `create_review()` service function
+  - Queries Profile by id and verifies `profile.user_id == user_id`
+  - Returns None if ownership check fails
+- ✅ Sub-task 2: Updated `create_review_endpoint()` to handle ownership verification
+  - Checks if `create_review()` returns None
+  - Raises HTTPException with 403 Forbidden status code
+- ✅ Sub-task 3 (partial): Added comprehensive tests
+  - `test_create_review_rejects_wrong_owner`: Verifies ownership check blocks attacker
+  - `test_create_review_allows_owner`: Verifies owner can create reviews
+  - `test_create_review_returns_none_for_nonexistent_profile`: Verifies non-existent profile handling
+
+**Next steps:**
+- Run make check and make test-unit to verify all tests pass
+- Get peer/mentor feedback on draft PR
+- Finalize PR and submit
+
+**Blockers:**
+None - implementation on track

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -17,7 +17,7 @@ The POST /reviews endpoint accepts an authenticated user's request but doesn't v
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** https://github.com/ascherj/pathreview/commit/6171fe1
+**Reproduction commit link:** https://github.com/AdetayoKalejaiye/pathreview/commit/6171fe1
 
 **Reproduction summary:**
 Added test `test_create_review_missing_ownership_check()` documenting the vulnerability: `create_review()` service accepts any `profile_id` without verifying it belongs to the current user. Unlike `get_review()` and `list_reviews()` which join with Profile and filter by user ownership, `create_review()` has no ownership check.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -53,3 +53,26 @@ Added test `test_create_review_missing_ownership_check()` documenting the vulner
 
 **Blockers:**
 None - implementation on track
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/703
+
+**Branch:** fix/163-review-profile-ownership
+
+**What you built:**
+Added profile ownership verification to the review creation endpoint (issue #163). The `create_review()` service now queries the Profile table to verify the profile belongs to the requesting user before creating a review. If ownership verification fails, the endpoint returns 403 Forbidden, preventing unauthorized users from creating reviews on other users' profiles.
+
+**Tests added or updated:**
+Updated `tests/unit/test_review_service.py` with three new tests:
+- `test_create_review_rejects_wrong_owner`: Verifies attacker cannot create reviews on others' profiles
+- `test_create_review_allows_owner`: Verifies owner can successfully create reviews on their profile
+- `test_create_review_returns_none_for_nonexistent_profile`: Verifies proper handling of non-existent profiles
+
+**Self-review confirmation:** 
+- [ ] make check passes
+- [ ] make test-unit passes
+
+**Draft PR feedback received from:** None (PR opened as draft for early feedback)

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,16 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/163
+
+**Issue title:** Review creation does not verify profile ownership
+
+**Tier:** [x] Tier 2
+
+**Problem summary:**
+The POST /reviews endpoint accepts an authenticated user's request but doesn't verify that the profile belongs to that user. An attacker can create reviews on any profile by supplying another user's profile ID. The fix should add ownership checks to create_review(), matching the scoping already used in get_review() and list_reviews().
+
+**Branch name:** fix/163-review-profile-ownership
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -76,3 +76,34 @@ Updated `tests/unit/test_review_service.py` with three new tests:
 - [ ] make test-unit passes
 
 **Draft PR feedback received from:** None (PR opened as draft for early feedback)
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [x] No — still awaiting review
+
+**Summary of feedback:**
+No review feedback received during Summer 2026 (reviewer feedback not available this session). PR remains open awaiting maintainer review.
+
+**How you responded:**
+N/A
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The hardest part was understanding the scope of the ownership check. Initially, I wasn't sure whether the fix should only be in the service layer or also in the endpoint. I also had to think carefully about UUID type conversions (the database stores UUIDs as strings while the endpoint passes UUID objects), which required careful handling in the comparison logic. Additionally, understanding how SQLAlchemy handles type coercion between different UUID representations took time to get right. Finally, getting the gh CLI tool to work for creating the PR was unexpectedly difficult — ended up needing to manually create the PR through the web interface.
+
+**What did you learn about working in a large codebase?**
+Working in PathReview taught me that consistency and patterns matter tremendously. The existing `get_review()` and `list_reviews()` functions already had the right security pattern (joining with Profile and filtering by user_id), and my job was to apply that same pattern to `create_review()`. In a large codebase, you're not inventing solutions — you're reading existing code to find the established patterns and replicating them. I also learned that every change needs tests, and those tests should match existing test patterns in the same module. Large codebases enforce conventions through their structure and test suite, and that's actually helpful for maintaining consistency.
+
+**How did AI tools help — and where did they fall short?**
+AI was invaluable for exploring the codebase quickly — when I needed to understand the Review and Profile models, their relationships, and how authentication worked, I could ask targeted questions and get code references with line numbers. AI also helped me understand the existing patterns in `get_review()` and `list_reviews()` so I could replicate them correctly. However, AI fell short on two things: (1) Understanding the specific type conversions needed between UUID objects and string UUIDs stored in the database — I had to debug that myself by reasoning through the SQLAlchemy mapping, and (2) Creating a proper PR through the gh CLI — after several attempts failed, I had to fall back to manual creation. AI is great at pattern recognition and code navigation, but less reliable for tool-specific operations and subtle type system details.
+
+**What would you do differently if you started over?**
+I would fetch the upstream repository earlier so that git and gh have the proper remote setup. I spent time debugging why gh wouldn't create the PR when the real issue was that upstream wasn't configured yet. I'd also spend more time reading CONTRIBUTING.md upfront to understand the exact testing and linting requirements before starting implementation. Finally, I would test the UUID type conversion issue more carefully earlier on — I almost implemented a solution that wouldn't have worked due to type mismatches. Testing assumptions about types earlier would have saved iteration time.
+
+**What are you most proud of from this module?**
+I'm most proud of how thoroughly I documented the vulnerability and my solution approach in PLAN.md. Even though the actual code change was relatively small (adding a profile ownership check), understanding why it was needed, where it belonged, what could go wrong, and what edge cases to handle required real thought. The planning discipline — writing out the Understand/Map/Plan/Inputs/Risks/EdgeCases structure before touching code — forced me to think deeply about the problem and catch issues (like the UUID type handling) that I might have missed otherwise. That structured planning approach is something I'll carry forward to future contributions.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -14,3 +14,18 @@ The POST /reviews endpoint accepts an authenticated user's request but doesn't v
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/ascherj/pathreview/commit/6171fe1
+
+**Reproduction summary:**
+Added test `test_create_review_missing_ownership_check()` documenting the vulnerability: `create_review()` service accepts any `profile_id` without verifying it belongs to the current user. Unlike `get_review()` and `list_reviews()` which join with Profile and filter by user ownership, `create_review()` has no ownership check.
+
+**PLAN.md link:** [PLAN.md](./PLAN.md)
+
+**Walkthrough video (recommended):** (Not recorded)
+
+**Blockers or open questions:**
+- Clarify if non-existent profile should return 403 or 404
+- Check if background task `process_review()` needs ownership verification too

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,64 @@
+## Solution plan
+
+**Issue:** [#163 - Review creation does not verify profile ownership](https://github.com/ascherj/pathreview/issues/163)
+
+### Understand
+
+**Root cause:** The `POST /reviews` endpoint accepts an authenticated user's request but doesn't verify that the profile belongs to that user. An attacker can create reviews on any profile by supplying another user's profile ID in the request.
+
+**Expected behavior:** Only the owner of a profile should be able to create reviews for that profile.
+
+**Actual behavior:** Any authenticated user can create a review for any profile, regardless of ownership.
+
+**Comparison with other endpoints:**
+- `get_review()` joins with Profile and filters by `Profile.user_id == user_id` ✓
+- `list_reviews()` joins with Profile and filters by `Profile.user_id == user_id` ✓
+- `create_review()` accepts profile_id without ownership verification ✗
+
+### Map
+
+**Files to touch:**
+1. `core/services/review_service.py` - Update `create_review()` function to verify ownership
+2. `api/routes/reviews.py` - Update `create_review_endpoint()` to handle ownership check or raise 403
+3. `tests/unit/test_review_service.py` - Add test documenting the vulnerability (already added)
+
+### Plan
+
+**Sub-tasks:**
+
+1. **Add ownership check to `create_review()` service**
+   - Modify `create_review()` to accept `user_id` parameter (already does)
+   - Query Profile by id and verify `profile.user_id == user_id`
+   - Return None if ownership verification fails (or raise appropriate exception)
+   - Match the pattern used in `get_review()` with SQL join and filter
+
+2. **Update `create_review_endpoint()` to handle verification failure**
+   - Check if `create_review()` returns None (indicating ownership check failed)
+   - Raise `HTTPException(status_code=403, detail="Cannot create review on this profile")`
+   - Ensure error is logged appropriately
+
+3. **Test the fix**
+   - Verify test `test_create_review_missing_ownership_check()` now fails/passes appropriately
+   - Confirm that create_review with wrong user_id returns None
+   - Confirm endpoint returns 403 when profile doesn't belong to user
+
+### Inputs & outputs
+
+**Input:** `POST /reviews` with `profile_id` in request body from authenticated user
+
+**Output:** 
+- Success (201): Review created if `profile_id` belongs to current user
+- Forbidden (403): Error response if `profile_id` belongs to different user
+
+### Risks & unknowns
+
+1. **Risk: Cascade behavior** - Deleting a profile cascades to reviews; ensure cascade still works after ownership check
+2. **Risk: Background task** - `process_review()` background task doesn't verify ownership; may need to add check there too
+3. **Unknown: Transaction isolation** - Profile could be deleted between ownership check and review creation; SQL should handle this
+
+### Edge cases
+
+1. **Non-existent profile** - User supplies valid UUID for profile that doesn't exist → 403 or 404?
+2. **Deleted profile** - Profile was deleted after user obtained ID → cascading delete handles it
+3. **Concurrent requests** - Multiple requests creating reviews simultaneously on same profile → should all succeed if user owns profile
+4. **User_id mismatch** - Endpoint receives profile_id and current_user.id, but are they the same type? Check UUID handling

--- a/api/routes/reviews.py
+++ b/api/routes/reviews.py
@@ -28,6 +28,7 @@ async def create_review_endpoint(
 ):
     """
     Create a new review for a profile.
+    Verifies profile ownership before creation.
     Triggers ingestion pipeline and agent orchestration asynchronously.
     Returns review with status="pending" immediately.
     """
@@ -38,6 +39,17 @@ async def create_review_endpoint(
             profile_id=data.profile_id,
             user_id=current_user.id,
         )
+
+        if not review:
+            log.warning(
+                "review_creation_forbidden",
+                profile_id=str(data.profile_id),
+                user_id=str(current_user.id),
+            )
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Cannot create review on this profile",
+            )
 
         # Add background task for processing
         background_tasks.add_task(process_review, db, review.id, data.profile_id)

--- a/core/services/review_service.py
+++ b/core/services/review_service.py
@@ -16,10 +16,19 @@ async def create_review(
     db,
     profile_id: UUID,
     user_id: UUID,
-) -> Review:
+) -> Review | None:
     """
     Create a new review with status="pending".
+    Verifies that profile_id belongs to user_id before creating.
+    Returns None if profile doesn't exist or doesn't belong to user.
     """
+    stmt = select(Profile).where(Profile.id == profile_id)
+    result = await db.execute(stmt)
+    profile = result.scalars().first()
+
+    if not profile or profile.user_id != str(user_id):
+        return None
+
     review = Review(
         profile_id=profile_id,
         status="pending",

--- a/tests/unit/test_review_service.py
+++ b/tests/unit/test_review_service.py
@@ -338,3 +338,32 @@ class TestReviewService:
 
         # Should order by created_at descending
         mock_db_session.execute.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_create_review_missing_ownership_check(self, mock_db_session):
+        """VULNERABILITY: create_review does not verify profile belongs to user.
+
+        Issue #163: An attacker can create reviews on any profile by supplying
+        another user's profile_id. Unlike get_review() and list_reviews() which
+        join with Profile and filter by Profile.user_id, create_review() accepts
+        any profile_id without ownership verification.
+
+        This test documents that profile ownership should be checked before
+        allowing review creation.
+        """
+        attacker_user_id = uuid4()
+        victim_profile_id = uuid4()
+
+        with patch('core.services.review_service.Review') as MockReview:
+            mock_instance = MockReview.return_value
+            mock_instance.id = uuid4()
+            mock_db_session.add = Mock()
+            mock_db_session.commit = AsyncMock()
+            mock_db_session.refresh = AsyncMock()
+
+            # Attacker can create review on any profile without ownership check
+            result = await create_review(mock_db_session, victim_profile_id, attacker_user_id)
+
+            # Currently succeeds because create_review doesn't verify profile ownership
+            assert result is not None
+            # After fix: should be None or raise exception if profile doesn't belong to user

--- a/tests/unit/test_review_service.py
+++ b/tests/unit/test_review_service.py
@@ -340,19 +340,45 @@ class TestReviewService:
         mock_db_session.execute.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_create_review_missing_ownership_check(self, mock_db_session):
-        """VULNERABILITY: create_review does not verify profile belongs to user.
+    async def test_create_review_rejects_wrong_owner(self, mock_db_session):
+        """Test create_review rejects profile that doesn't belong to user.
 
-        Issue #163: An attacker can create reviews on any profile by supplying
-        another user's profile_id. Unlike get_review() and list_reviews() which
-        join with Profile and filter by Profile.user_id, create_review() accepts
-        any profile_id without ownership verification.
-
-        This test documents that profile ownership should be checked before
-        allowing review creation.
+        Issue #163: create_review should verify profile ownership before creation.
+        If profile_id doesn't belong to user_id, return None.
         """
         attacker_user_id = uuid4()
+        victim_user_id = uuid4()
         victim_profile_id = uuid4()
+
+        # Mock Profile query to return a profile owned by a different user
+        mock_profile = Mock()
+        mock_profile.id = victim_profile_id
+        mock_profile.user_id = victim_user_id  # Different from attacker_user_id
+
+        mock_result = AsyncMock()
+        mock_result.scalars.return_value.first.return_value = mock_profile
+        mock_db_session.execute = AsyncMock(return_value=mock_result)
+
+        # Attacker attempts to create review on victim's profile
+        result = await create_review(mock_db_session, victim_profile_id, attacker_user_id)
+
+        # Should return None (ownership verification failed)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_create_review_allows_owner(self, mock_db_session):
+        """Test create_review allows profile owner to create reviews."""
+        user_id = uuid4()
+        profile_id = uuid4()
+
+        # Mock Profile query to return a profile owned by the user
+        mock_profile = Mock()
+        mock_profile.id = profile_id
+        mock_profile.user_id = user_id
+
+        mock_result = AsyncMock()
+        mock_result.scalars.return_value.first.return_value = mock_profile
+        mock_db_session.execute = AsyncMock(return_value=mock_result)
 
         with patch('core.services.review_service.Review') as MockReview:
             mock_instance = MockReview.return_value
@@ -361,9 +387,23 @@ class TestReviewService:
             mock_db_session.commit = AsyncMock()
             mock_db_session.refresh = AsyncMock()
 
-            # Attacker can create review on any profile without ownership check
-            result = await create_review(mock_db_session, victim_profile_id, attacker_user_id)
+            result = await create_review(mock_db_session, profile_id, user_id)
 
-            # Currently succeeds because create_review doesn't verify profile ownership
+            # Should succeed because ownership verified
             assert result is not None
-            # After fix: should be None or raise exception if profile doesn't belong to user
+
+    @pytest.mark.asyncio
+    async def test_create_review_returns_none_for_nonexistent_profile(self, mock_db_session):
+        """Test create_review returns None if profile doesn't exist."""
+        user_id = uuid4()
+        nonexistent_profile_id = uuid4()
+
+        # Mock Profile query to return None (profile not found)
+        mock_result = AsyncMock()
+        mock_result.scalars.return_value.first.return_value = None
+        mock_db_session.execute = AsyncMock(return_value=mock_result)
+
+        result = await create_review(mock_db_session, nonexistent_profile_id, user_id)
+
+        # Should return None (profile not found)
+        assert result is None


### PR DESCRIPTION
## Summary
Add ownership verification to the review creation endpoint to prevent users from creating reviews on other users' profiles.

## Issue
Closes #163

## Changes
- Add ownership check to `create_review()` service function in `core/services/review_service.py`
  - Queries Profile by id and verifies `profile.user_id == user_id`
  - Returns None if profile doesn't exist or doesn't belong to user
- Update `create_review_endpoint()` in `api/routes/reviews.py` to handle ownership verification
  - Raises HTTPException with 403 Forbidden status if ownership check fails
  - Adds appropriate logging for security events
- Add comprehensive unit tests to verify ownership enforcement

## Testing
- [ ] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`)
- [ ] Linter passes (`make lint`)
- [ ] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes

## Notes for Reviewers
This fix ensures that only profile owners can create reviews on their profiles, matching the security pattern already used in `get_review()` and `list_reviews()`. The solution returns 403 Forbidden when a non-owner attempts to create a review.
