### PR TITLE
test(api): reject POST /reviews when profile has no content

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -7,10 +7,21 @@
 **Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
 
 **Problem summary:**
-The `POST /reviews` API route is missing a test for the case where a profile exists but has no ingested documents. Without that coverage, the endpoint could crash or return an unclear error and nobody would catch it. A successful fix adds a unit test in `tests/unit/test_review_routes.py` that confirms the endpoint returns an appropriate error instead of failing unexpectedly.
+The `POST /reviews` API route is missing a test for the case where a profile exists but has no ingested documents. Without that coverage, the endpoint could crash or return an unclear error and nobody would catch it. A successful fix adds a unit test (likely in `tests/unit/test_review_routes.py` or the existing review test files) that confirms the endpoint returns an appropriate error instead of failing unexpectedly. Scope is focused on tests for one edge case on the API layer, not a full feature rewrite.
 
 **Branch name:** test/88-reviews-no-ingested-documents
 
-**Setup confirmation:** [x] App runs locally at localhost:5173
+**Setup confirmation:** [ ] App runs locally at localhost:5173
 
-**Cohort ledger:** [x] Issue added to cohort ledger
+**Cohort ledger:** [ ] Issue added to cohort ledger
+
+### Selection notes — "Is this right for me?" checklist
+
+| Check | Notes |
+|---|---|
+| Can I explain the bug in my own words? | Yes — profile exists, no ingested docs, review endpoint should error cleanly, and we need a test for that path. |
+| Do I know which area of the codebase it touches? | Yes — API review routes + unit tests under `tests/unit/` (issue points at `test_review_routes.py`). |
+| Is the scope small enough for Module 3? | Yes — Tier 1 / good first issue; estimated 2–3 hours; mostly adding one test case, not redesigning the review pipeline. |
+| Do my skills match? | Yes — writing/asserting API unit tests is a good fit; I don't need deep RAG/agent work for this issue. |
+| Is it still available / claimed? | I commented on the issue to claim it (AI 201 section 2a). Several others also commented, so I'll coordinate if needed and keep the work clearly scoped to the missing test. |
+| Why this issue over others? | Clear acceptance criteria, named files, Tier 1, and it strengthens error-path coverage on a real API endpoint. |

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -28,7 +28,7 @@ The `POST /reviews` API route is missing a test for the case where a profile exi
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** empty
+**Reproduction commit link:** https://github.com/kevin-luk-3/pathreview/commit/ab95557f99c6f5bca735433f795af50ac638ef38
 
 **Reproduction summary:**
 Confirmed the gap locally: `tests/unit/test_review_routes.py` does not exist, and no unit test covers `POST /reviews` when a profile has no ingested content. `create_review` / `create_review_endpoint` never check for `IngestedSource` rows (or empty ingestible profile fields) before creating a `pending` review, so the empty-content path is untested and has no intentional 4xx error contract yet.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -11,7 +11,7 @@ The `POST /reviews` API route is missing a test for the case where a profile exi
 
 **Branch name:** test/88-reviews-no-ingested-documents
 
-**Setup confirmation:** [ ] App runs locally at localhost:5173
+**Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [ ] Issue added to cohort ledger
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -25,3 +25,16 @@ The `POST /reviews` API route is missing a test for the case where a profile exi
 | Do my skills match? | Yes — writing/asserting API unit tests is a good fit; I don't need deep RAG/agent work for this issue. |
 | Is it still available / claimed? | I commented on the issue to claim it (AI 201 section 2a). Several others also commented, so I'll coordinate if needed and keep the work clearly scoped to the missing test. |
 | Why this issue over others? | Clear acceptance criteria, named files, Tier 1, and it strengthens error-path coverage on a real API endpoint. |
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** empty
+
+**Reproduction summary:**
+Confirmed the gap locally: `tests/unit/test_review_routes.py` does not exist, and no unit test covers `POST /reviews` when a profile has no ingested content. `create_review` / `create_review_endpoint` never check for `IngestedSource` rows (or empty ingestible profile fields) before creating a `pending` review, so the empty-content path is untested and has no intentional 4xx error contract yet.
+
+**PLAN.md link:** https://github.com/kevin-luk-3/pathreview/blob/test/88-reviews-no-ingested-documents/PLAN.md
+
+
+**Blockers or open questions:**
+Still need to decide exact error contract (400 vs 404) and whether “no ingested content” means zero `IngestedSource` rows at POST time vs. a profile with no resume/github/portfolio fields. May need a small validation change in the route/service so the new test asserts real behavior, not only mocks.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,16 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/88
+
+**Issue title:** `POST /reviews` endpoint has no test for when the profile has no ingested documents
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The `POST /reviews` API route is missing a test for the case where a profile exists but has no ingested documents. Without that coverage, the endpoint could crash or return an unclear error and nobody would catch it. A successful fix adds a unit test in `tests/unit/test_review_routes.py` that confirms the endpoint returns an appropriate error instead of failing unexpectedly.
+
+**Branch name:** test/88-reviews-no-ingested-documents
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -76,3 +76,34 @@ Baseline comparison (stash our changes → run → restore → run again):
 - `ruff check .`: **182 errors** before and after (unchanged).
 - `mypy` (paths from Makefile): **5 errors** before and after (unchanged; further checking blocked by pre-existing issues).
 Our contribution does not introduce new failures. "Passes" here means no new failures beyond that pre-existing baseline.
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No reviewer or maintainer comments on [PR #704](https://github.com/ascherj/pathreview/pull/704) by the end of Week 10 (no review comments, issue comments, or formal reviews). Per Su26 guidance, that’s okay — documenting the absence counts.
+
+**How you responded:**
+
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The hardest part wasn’t writing the empty-content check itself — it was figuring out what “no ingested documents” actually meant in this codebase. Issue #88 sounded like counting `IngestedSource` rows, but those rows are created later inside `process_review`, so checking row count at `POST /reviews` time would reject almost every first review. Landing on “blank github/resume/portfolio fields” took reading `PLAN.md`, `_run_ingestion_pipeline`, and the route carefully. Pre-commit also blocked the commit with pre-existing ruff/mypy noise in `reviews.py` and imported services, which I didn’t expect on a Tier 1 test issue.
+
+**What did you learn about working in a large codebase?**
+In your own project you can rewrite freely; here a small issue still forces you to respect existing patterns and keep the diff tiny. My first attempt over-edited `test_review_service.py` (~200 lines of churn) when #88 only needed a route guard plus `tests/unit/test_review_routes.py`. Peer PRs and the issue’s “Relevant files” line made it clear: leave unrelated tests alone, put validation in `create_review_endpoint`, and don’t “fix” the whole suite. Also learned that `make format` / black on the whole repo can accidentally dirty dozens of files — restore those before committing.
+
+**How did AI tools help — and where did they fall short?**
+AI was useful for exploring `api/routes/reviews.py`, drafting the FastAPI `TestClient` test, and writing the PR/journal scaffolding. It fell short when it “helpfully” rewrote lots of existing service tests and suggested a bigger service-layer redesign than a good-first-issue needed — I had to push back, reset those files, and slim to ~20 lines in the route plus one new test file. It also couldn’t decide the product meaning of “ingested content” without me verifying against the live ingestion flow. AI drafts still needed a human scope check against CONTRIBUTING.md and the rubric.
+
+**What would you do differently if you started over?**
+I’d lock the empty-content definition in Week 8 (fields vs `IngestedSource`) before writing code, and I’d open a draft PR earlier instead of doing plan + implement + submit in a rush. I’d also run `make lint` / pre-commit on just the touched files first so I wasn’t surprised by B008/`Depends` and mypy failures that already existed in `reviews.py`. Finally I’d keep the first implementation minimal from day one instead of building a large service+test rewrite and then cutting it down.
+
+**What are you most proud of from this module?**
+I’m most proud of catching the overbuilt first approach and cutting it back to a reviewable Tier 1 PR: one validation block in `create_review_endpoint`, one unit test in `test_review_routes.py`, and a clear baseline note that we didn’t add to the 53 pre-existing unit failures. Shipping [PR #704](https://github.com/ascherj/pathreview/pull/704) with a small, intentional diff felt more like real open-source contribution than just getting something to pass locally.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -38,3 +38,41 @@ Confirmed the gap locally: `tests/unit/test_review_routes.py` does not exist, an
 
 **Blockers or open questions:**
 Still need to decide exact error contract (400 vs 404) and whether “no ingested content” means zero `IngestedSource` rows at POST time vs. a profile with no resume/github/portfolio fields. May need a small validation change in the route/service so the new test asserts real behavior, not only mocks.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Added a small empty-content check in `create_review_endpoint` (`api/routes/reviews.py`): load the profile with `get_profile`, return 404 if missing/not owned, return 400 if github/resume/portfolio are all empty. Added `tests/unit/test_review_routes.py` with one unit test for that 400 path. Left `review_service.py` / existing service tests unchanged.
+
+**Next steps:**
+Self-review against CONTRIBUTING.md, open a draft PR for peer/mentor feedback, then mark ready for review and paste the PR link into Check-in 2.
+
+**Blockers:**
+none
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** 
+
+**Branch:** `test/88-reviews-no-ingested-documents`
+
+**What you built:**
+`POST /reviews` now returns 400 `"Profile has no ingested content to review"` when the profile has no github username, resume text, or portfolio URL, instead of creating a pending review. Missing/unowned profiles still get 404.
+
+**Tests added or updated:**
+- `tests/unit/test_review_routes.py` — asserts POST `/reviews` returns 400 when the profile has no ingestible content.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+**Draft PR feedback received from:** none
+
+**Notes for checkboxes above:**
+Baseline comparison (stash our changes → run → restore → run again):
+- `make test-unit`: before **53 failed / 375 passed**; after **53 failed / 376 passed** (same failures + our new passing test).
+- `ruff check .`: **182 errors** before and after (unchanged).
+- `mypy` (paths from Makefile): **5 errors** before and after (unchanged; further checking blocked by pre-existing issues).
+Our contribution does not introduce new failures. "Passes" here means no new failures beyond that pre-existing baseline.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -56,7 +56,7 @@ none
 
 ### Check-in 2 (end of week)
 
-**PR link:** 
+**PR link:** https://github.com/ascherj/pathreview/pull/704
 
 **Branch:** `test/88-reviews-no-ingested-documents`
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,98 @@
+## Solution plan
+
+**Issue:** [#88 — `POST /reviews` endpoint has no test for when the profile has no ingested documents](https://github.com/ascherj/pathreview/issues/88)
+
+### Understand
+
+`POST /reviews` is handled by `create_review_endpoint()` in `api/routes/reviews.py` (lines 22–62). It always calls `create_review()` then queues `process_review()` as a background task. There is **no check** that the target profile has anything to review.
+
+`create_review()` in `core/services/review_service.py` (lines 15–32) only builds a `Review` with `status="pending"` and commits it. It does not:
+- load the `Profile`
+- verify the profile belongs to `current_user`
+- check for existing `IngestedSource` rows
+- check whether the profile has any ingestible fields (`github_username`, `resume_text`, `portfolio_url`)
+
+Background processing in `_run_ingestion_pipeline()` (lines 197–279) only appends sources when those profile fields are set. If all are missing/empty, it returns `[]`. `_run_agent_orchestration()` (lines 282–304) is a **placeholder** that still returns fake sections even when `ingestion_results` is empty — so the empty path does not currently raise; it can look “successful” with made-up feedback.
+
+There is also **no** `tests/unit/test_review_routes.py` (the file named in the issue). `tests/unit/test_review_service.py` only covers happy-path service helpers — nothing for “profile exists, nothing to ingest.”
+
+**Expected behavior:** `POST /reviews` for a profile that exists but has no content to ingest should return a clear **4xx** error and must **not** create a pending review / start `process_review`.
+
+**Root cause:** Missing precondition validation in the create-review path (`create_review_endpoint` / `create_review`), plus missing route-level test coverage for that path.
+
+### Map
+
+Files I expect to touch:
+
+- `api/routes/reviews.py` — `create_review_endpoint()` (lines 22–62): add validation **before** `create_review()` / `background_tasks.add_task(...)`, raise `HTTPException`, rely on existing `except HTTPException: raise` (lines 54–55).
+- `core/services/review_service.py` — either extend `create_review()` (lines 15–32) to load the profile + enforce the empty-content rule, **or** add a small helper (e.g. `assert_profile_ready_for_review`) used by the route. Prefer putting the rule in the service so it stays testable without HTTP.
+- `core/models/profile.py` — fields `github_username`, `resume_text`, `portfolio_url` (lines 30–33): these are what `_run_ingestion_pipeline` actually uses.
+- `core/models/ingested_source.py` — `IngestedSource` model: useful for understanding “ingested content,” but see Risks — rows are usually created *during* `process_review`, not before `POST`.
+- `api/schemas/review.py` — `ReviewCreate` only has `profile_id`; no schema change expected.
+- `tests/unit/test_review_routes.py` — **new file** (named by the issue): route test for the empty-content case.
+- `tests/unit/test_review_service.py` — existing AsyncMock / `@pytest.mark.unit` / `@pytest.mark.asyncio` patterns to mirror (e.g. `test_create_review_returns_review_with_pending_status` around line 48).
+
+### Inputs & outputs
+
+**Endpoint:** `POST /reviews`  
+**Handler:** `create_review_endpoint(data: ReviewCreate, ...)`  
+**Body:** `{ "profile_id": "<uuid>" }`
+
+**Existing happy path (keep working):**
+- Input: authenticated user + owned profile that has at least one of `github_username` / `resume_text` / `portfolio_url`
+- Output: `200` + `ReviewResponse` with `status="pending"`; `process_review` is queued
+
+**New behavior (empty content case):**
+- Input: authenticated user + owned profile where `github_username`, `resume_text`, and `portfolio_url` are all missing/empty (nothing `_run_ingestion_pipeline` can ingest)
+- Expected output: `HTTP 400` with detail like `"Profile has no ingested content to review"` (exact string locked in the test)
+- Does **not** call `db.add(Review)` / does **not** queue `process_review`
+
+**Status-code choice:** Use **400** (bad request / invalid state for this operation), matching client-error style in `api/routes/auth.py` (e.g. email-already-registered). **404** stays reserved for “profile not found / not owned,” same pattern as `get_profile_endpoint` in `api/routes/profiles.py` (lines 130–133).
+
+**Test I'll write** (in new `tests/unit/test_review_routes.py`):
+
+```python
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_create_review_profile_with_no_ingested_content_returns_400():
+    """POST /reviews should return 400 when the profile has nothing to ingest."""
+    # Arrange: authenticated user; profile exists and is owned; all ingestible fields empty;
+    # override get_current_user + get_db / service deps as needed (no route-test helpers exist yet).
+
+    response = await client.post(
+        "/reviews",
+        json={"profile_id": str(empty_profile.id)},
+        headers={"Authorization": "Bearer ..."},
+    )
+
+    assert response.status_code == 400
+    assert "no ingested content" in response.json()["detail"].lower()
+```
+
+I'll follow FastAPI `dependency_overrides` for `get_current_user` / `get_db`, and match pytest markers from `test_review_service.py`. If pure route testing is too heavy for Tier 1, fall back to a service-level test that asserts `create_review` (or the new helper) raises `HTTPException(400)` for an empty profile — still add `test_review_routes.py` as the issue asks, even if thin and calling the endpoint function with mocks.
+
+### Plan
+
+1. Confirm empty-content definition against the live flow: at `POST` time, `IngestedSource` rows usually do **not** exist yet because ingestion runs inside `process_review` (`review_service.py` ~127–128). So the precondition should be “profile has no ingestible fields,” not “zero `IngestedSource` rows.” Update this plan if investigation proves reviews are only created after a separate ingest step.
+2. Add profile lookup + ownership check if missing (today `create_review` ignores `user_id` entirely). Reuse the same ownership idea as `get_review()` / `get_profile()` — unknown profile or wrong owner → **404** `"Profile not found"`.
+3. Add empty-content check after the profile is loaded: if not (`github_username` or `resume_text` or `portfolio_url`), raise `HTTPException(status_code=400, detail="Profile has no ingested content to review")` **before** creating the `Review`.
+4. Wire that raise so `create_review_endpoint` surfaces it via the existing `except HTTPException: raise` block (lines 54–55) — do not let it fall into the generic 500 handler (lines 56–62).
+5. Create `tests/unit/test_review_routes.py` with the test drafted above (and optionally a happy-path smoke assert if cheap).
+6. Run `make test-unit` focusing on the new file, then full unit suite.
+7. Run `make check` (lint / format / types) before PR week.
+
+### Risks & unknowns
+
+1. **“Ingested content” vs ingestible profile fields.** The issue says “no associated ingested content,” which sounds like `IngestedSource` rows — but those are written *during* `_run_ingestion_pipeline`, after `POST` already returned `pending`. Checking row count at `POST` would reject almost every first review. I’ll treat empty ingestible profile fields as the intended signal unless the product flow shows a prior ingest API.
+2. **No route tests exist in this repo.** There is no `tests/unit/test_*routes*.py` to copy. Building FastAPI `TestClient` / `AsyncClient` + `dependency_overrides` is new ground here — risk of a flaky or overbuilt test. Mitigation: start from how `api/main.py` mounts routers and how `get_current_user` is defined in `api/middleware/auth.py`.
+3. **`create_review` currently ignores `user_id`.** Adding ownership + empty checks changes more than “just a test.” Stay minimal: only what’s required for a correct 400/404 contract.
+4. **Placeholder agent hides the bug.** `_run_agent_orchestration` returns fake sections even when `ingestion_results == []`, so a live empty profile may not “crash” today — it fails silently with nonsense output. The explicit 400 is what makes the behavior correct and testable.
+5. **`IngestedSource(...)` in `_run_ingestion_pipeline` passes `raw_data=...`, but `core/models/ingested_source.py` has no `raw_data` column.** That’s outside #88 scope, but it means I should not rely on that path for the empty-content test setup.
+
+### Edge cases
+
+- Profile missing or not owned by caller → **404** `"Profile not found"` (same as profiles route); distinct from empty-content **400**
+- Profile with only `github_username` set (resume/portfolio null) → **allowed** (happy path); ingestion has something to run
+- Profile with whitespace-only `resume_text` → treat as empty (use `.strip()`); should **400**
+- Profile that already has `IngestedSource` rows from a prior run but cleared profile fields → still **400** under the field-based rule (document; don’t special-case unless product requires it)
+- Unauthenticated request → still **401** from auth middleware; don’t break `get_current_user` when overriding deps in tests

--- a/api/routes/reviews.py
+++ b/api/routes/reviews.py
@@ -1,12 +1,13 @@
-from fastapi import APIRouter, Depends, HTTPException, status, BackgroundTasks
 from uuid import UUID
-import structlog
 
-from api.schemas.review import ReviewCreate, ReviewResponse, ReviewListResponse
+import structlog
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
+
 from api.middleware.auth import get_current_user
-from core.models.user import User
-from core.models.review import Review
+from api.schemas.review import ReviewCreate, ReviewListResponse, ReviewResponse
 from core.database import get_db
+from core.models.user import User
+from core.services.profile_service import get_profile
 from core.services.review_service import (
     create_review,
     get_review,
@@ -32,6 +33,26 @@ async def create_review_endpoint(
     Returns review with status="pending" immediately.
     """
     try:
+        profile = await get_profile(db=db, profile_id=data.profile_id, user_id=current_user.id)
+        if not profile:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Profile not found",
+            )
+
+        has_content = any(
+            [
+                (profile.github_username or "").strip(),
+                (profile.resume_text or "").strip(),
+                (profile.portfolio_url or "").strip(),
+            ]
+        )
+        if not has_content:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Profile has no ingested content to review",
+            )
+
         # Create review with status="pending"
         review = await create_review(
             db=db,

--- a/tests/unit/test_review_routes.py
+++ b/tests/unit/test_review_routes.py
@@ -1,0 +1,48 @@
+"""Tests for api/routes/reviews.py"""
+
+from unittest.mock import AsyncMock, Mock
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.middleware.auth import get_current_user
+from api.routes import reviews
+from core.database import get_db
+
+
+@pytest.mark.unit
+def test_create_review_profile_with_no_ingested_content_returns_400(monkeypatch):
+    """POST /reviews should return 400 when the profile has nothing to ingest."""
+    user = Mock()
+    user.id = uuid4()
+    empty_profile = Mock(
+        id=uuid4(),
+        user_id=user.id,
+        github_username=None,
+        resume_text=None,
+        portfolio_url=None,
+    )
+
+    async def fake_get_profile(db, profile_id, user_id):
+        return empty_profile
+
+    monkeypatch.setattr(reviews, "get_profile", fake_get_profile)
+
+    app = FastAPI()
+    app.include_router(reviews.router)
+    app.dependency_overrides[get_current_user] = lambda: user
+
+    async def override_db():
+        yield AsyncMock()
+
+    app.dependency_overrides[get_db] = override_db
+
+    response = TestClient(app).post(
+        "/reviews",
+        json={"profile_id": str(empty_profile.id)},
+    )
+
+    assert response.status_code == 400
+    assert "no ingested content" in response.json()["detail"].lower()


### PR DESCRIPTION
## Summary
POST /reviews now returns 400 when a profile has no github username, resume text, or portfolio URL, instead of creating a pending review with nothing to ingest.

## Issue
Closes #88

## Changes
- Validate profile ownership/content in `create_review_endpoint` before creating a review
- Add `tests/unit/test_review_routes.py` for the empty-content 400 case

## Testing
Manual:
1. Login as user1@example.com / password1
2. Create/use a profile with no github, resume, or portfolio
3. POST /reviews with that profile_id → expect 400 and detail containing "no ingested content"
4. Set github_username on a profile and POST again → still 200 pending

Automated: `.venv/bin/pytest tests/unit/test_review_routes.py -v -m unit`

Pre-existing baseline (unchanged by this PR):
- test-unit: 53 failed / 375 passed → after: 53 failed / 376 passed
- ruff: 182 errors before and after
- mypy: 5 errors before and after

## Notes for Reviewers
Empty content = blank ingestible profile fields at POST time (not IngestedSource rows, which are created later during process_review).