### PR TITLE
Test/88 review endpoint test

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -14,3 +14,39 @@ The /reviews endpoint currently assumes a profile will already have some documen
 **Setup confirmation:** [X] App runs locally at localhost:5173
 
 **Cohort ledger:** [X] Issue added to cohort ledger
+
+**Reproduction steps:**
+
+Root cause traced to `process_review()` in [core/services/review_service.py:82](core/services/review_service.py#L82). `POST /reviews` ([api/routes/reviews.py:22](api/routes/reviews.py#L22)) never checks for ingested documents — it creates the review with `status="pending"` and hands the real work to a background task. Inside that task, `_run_ingestion_pipeline()` ([core/services/review_service.py:197](core/services/review_service.py#L197)) correctly returns `[]` when a profile has no `github_username`, `portfolio_url`, or `resume_text`. But `_run_agent_orchestration()` ([:282](core/services/review_service.py#L282)) and `_run_rag_retrieval_generation()` ([:307](core/services/review_service.py#L307)) are hardcoded placeholders that ignore the (empty) ingestion results entirely, and `_run_safety_checks()` ([:357](core/services/review_service.py#L357)) only validates shape, not provenance. Net effect: **no crash, no 4xx** — a documentless profile silently reaches `status="complete"` with fabricated feedback.
+
+Steps to reproduce against a local server (`make run`, API at `localhost:8000`):
+
+1. Register a fresh user:
+   ```bash
+   curl -s -X POST http://localhost:8000/auth/register \
+     -H "Content-Type: application/json" \
+     -d '{"email": "empty-profile-test@example.com", "password": "testpass123"}'
+   ```
+   Extract `access_token` as `$TOKEN`.
+
+2. Create a profile with no fields set (all optional per `ProfileCreate`):
+   ```bash
+   curl -s -X POST http://localhost:8000/profiles -H "Authorization: Bearer $TOKEN"
+   ```
+   Confirmed profile `349cc633-fc7a-4178-9207-7283dab27943` created with `github_username`, `portfolio_url`, `resume_text` all null and zero `ingested_sources` rows.
+
+3. Trigger a review for that profile:
+   ```bash
+   curl -s -X POST http://localhost:8000/reviews \
+     -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+     -d '{"profile_id": "349cc633-fc7a-4178-9207-7283dab27943"}'
+   ```
+   Returns `201` with `status: "pending"`, review id `72a8a928-ed09-43be-879e-128bc03e142f`.
+
+4. Poll the review after the background task runs:
+   ```bash
+   curl -s http://localhost:8000/reviews/72a8a928-ed09-43be-879e-128bc03e142f -H "Authorization: Bearer $TOKEN"
+   ```
+   **Actual result:** `status: "complete"`, `overall_score: 0.81`, `error_message: null`, and three fully-populated feedback sections ("Technical Skills", "Project Experience", "Career Growth") — none of which reflect real analysis, since nothing was ever ingested.
+
+**Expected behavior (not yet implemented):** the review should end in `status="failed"` with a descriptive `error_message` (the column already exists on `Review` but is never set on this path), rather than fabricating a successful result. No test currently exists for this path (`process_review`, `_run_ingestion_pipeline`, and this scenario are entirely uncovered in `tests/unit/test_review_service.py`).

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -50,3 +50,15 @@ Steps to reproduce against a local server (`make run`, API at `localhost:8000`):
    **Actual result:** `status: "complete"`, `overall_score: 0.81`, `error_message: null`, and three fully-populated feedback sections ("Technical Skills", "Project Experience", "Career Growth") — none of which reflect real analysis, since nothing was ever ingested.
 
 **Expected behavior (not yet implemented):** the review should end in `status="failed"` with a descriptive `error_message` (the column already exists on `Review` but is never set on this path), rather than fabricating a successful result. No test currently exists for this path (`process_review`, `_run_ingestion_pipeline`, and this scenario are entirely uncovered in `tests/unit/test_review_service.py`).
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [962e503](https://github.com/asnts18/pathreview/commit/962e503)
+
+**Reproduction summary:**
+Created a fresh user, then a profile with no `github_username`, `portfolio_url`, or `resume_text` set, then triggered `POST /reviews` against it. The review reached `status: "complete"` with a fabricated `overall_score: 0.81` and three canned feedback sections, instead of failing — confirming that `process_review()` never checks whether ingestion actually produced anything before generating feedback.
+
+**PLAN.md link:** [PLAN.md](https://github.com/asnts18/pathreview/blob/test/88-review-endpoint-test/PLAN.md)
+
+**Blockers or open questions:**
+Still deciding whether "no documents ingested" should be judged from the profile's own fields (`github_username`/`portfolio_url`/`resume_text`) or from the `ingested_sources` table directly — these should normally agree, but could diverge if a profile has stale `IngestedSource` rows from a prior partial run. See Risks & unknowns in `PLAN.md` for details.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,16 @@
+## Week 7 — Issue selection
+
+**Issue link:** [[paste link here]](https://github.com/ascherj/pathreview/issues/88)
+
+**Issue title:** POST /reviews endpoint has no test for when the profile has no ingested documents #88
+
+**Tier:** [X] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The /reviews endpoint currently assumes a profile will already have some documents ingested before a review is requested, and that assumption is never checked in the test suite. If someone triggers a review for a profile that exists but hasn't had anything ingested yet, it's unclear whether the endpoint fails gracefully or throws an unhandled exception, since no test exists to pin down the expected behavior. This is a gap in edge-case coverage rather than a confirmed bug — the fix is really about writing a regression test that calls the endpoint under this specific condition and asserts a clean, well-formed error response (e.g. a 4xx with a descriptive message) instead of a server crash. A successful fix gives the team confidence that this edge case is handled predictably and prevents future changes from silently reintroducing a crash for profiles with no ingested content.
+
+**Branch name:** test/88-review-endpoint-test
+
+**Setup confirmation:** [X] App runs locally at localhost:5173
+
+**Cohort ledger:** [X] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -62,3 +62,20 @@ Created a fresh user, then a profile with no `github_username`, `portfolio_url`,
 
 **Blockers or open questions:**
 Still deciding whether "no documents ingested" should be judged from the profile's own fields (`github_username`/`portfolio_url`/`resume_text`) or from the `ingested_sources` table directly — these should normally agree, but could diverge if a profile has stale `IngestedSource` rows from a prior partial run. See Risks & unknowns in `PLAN.md` for details.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the fix from `PLAN.md` step 1: `process_review()` in `core/services/review_service.py` now checks whether `_run_ingestion_pipeline()` returned any results, and if not, sets `status="failed"` with a descriptive `error_message` instead of continuing on to the placeholder agent/RAG/safety steps. Also completed step 2 — confirmed `error_message` is already exposed on `ReviewResponse` for `GET /reviews/{id}`, and added it to the lighter `GET /reviews/{id}/status` payload too, since that's the endpoint clients poll while a review is processing. Wrote both regression tests from steps 3–4 in `tests/unit/test_review_service.py`: one asserting a documentless profile ends in `status="failed"` with a non-null `error_message`, and a companion happy-path test asserting a profile with at least one source still reaches `status="complete"`. Re-ran the original curl reproduction from Week 8 against a live local server (Postgres via `docker compose up -d`) — confirmed the same profile shape now returns `status: "failed"` with the descriptive message on both endpoints, and confirmed a profile with `github_username` set is unaffected and still completes normally.
+
+Resolved the open question from Week 8: went with checking `_run_ingestion_pipeline()`'s return value (the profile's own fields) rather than querying `ingested_sources` directly, since that function is the sole writer of those rows and is already re-run fresh on every `process_review()` call.
+
+Verified no regressions: `make test-unit` still shows the same 53 pre-existing failures (all pre-existing mock-configuration bugs in unrelated test files) plus 377 passing (up from 375 — the 2 new tests). `make lint` (182 errors) and `make typecheck` (103 errors) are both unchanged from the pre-existing baseline I recorded before starting.
+
+**Next steps:**
+Finish filling out the PR template, double-check branch name and commit messages against `docs/CONTRIBUTING.md` conventions, and open the PR.
+
+**Blockers:**
+None.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -95,3 +95,34 @@ None.
 - [x] `make test-unit` passes — with caveats: 53 pre-existing test failures in unrelated files (mock-configuration bugs), unchanged by this change. 377 tests pass (up from 375 baseline — the 2 new tests added here, both green).
 
 **Draft PR feedback received from:** none.
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [X] No — still awaiting review
+
+**Summary of feedback:**
+Reviewer feedback is not a feature in Summer 2026.
+
+**How you responded:**
+N/A
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Figuring out what the bug actually *was* took longer than fixing it. Issue #88 was filed as a missing-test-coverage gap, so I expected the endpoint to either 500 or return a clean 4xx once I poked at it — instead, tracing the async flow from `POST /reviews` into the `process_review()` background task revealed there was no error path at all. A documentless profile sailed through to `status="complete"` with confident, fabricated feedback sections, because the agent/RAG steps are still hardcoded placeholders that ignore their inputs. That's a much sneakier failure mode than a crash, and I wouldn't have caught it without actually reproducing it end-to-end with curl rather than just reading the code. The other surprise was hitting a hard wall on `git commit`: this repo's mypy pre-commit hook has no baseline mode, so it fails on any pre-existing type error in a file I touched, whether or not I caused it. I hadn't budgeted time for a tooling problem that had nothing to do with my actual fix.
+
+**What did you learn about working in a large codebase?**
+The biggest shift was learning to tell "my change broke this" apart from "this was already broken," and proving it instead of assuming it. I ran `make check` and `make test-unit` before touching anything specifically so I'd have a baseline to diff against later — without that, I couldn't have confidently said the 53 failing tests and 182 lint errors were pre-existing rather than something I introduced. I also learned to resist the urge to clean up what I saw along the way. It would have been easy to "fix" the unsorted imports or add type annotations while I was in `review_service.py`, but that inflates the diff and makes the actual change harder to review. Scoping the fix to exactly one `if not ingestion_results:` block, and pushing back on my own instinct to auto-format the whole file, felt like the real skill being tested here.
+
+**How did AI tools help — and where did they fall short?**
+AI was strongest at the mechanical tracing work — following the call chain from the route handler through the background task through each placeholder helper function, and spotting that `_run_agent_orchestration()` and `_run_rag_retrieval_generation()` silently ignore their `ingestion_results` argument. That's the kind of thing that's easy to miss skimming and tedious to verify by hand across five files. It also made the reproduction loop fast — spinning up Docker, registering a user, creating an empty profile, and curling the review into existence, all scripted rather than clicked through manually. Where it fell short was exactly the judgment calls: whether "no documents" should be judged from the profile's own fields or the `ingested_sources` table, whether to bypass the pre-commit hook with `--no-verify`, how strict to be about the checkboxes in the PR template given the pre-existing failures. Those needed an actual decision from me, not just information — the AI could lay out the tradeoffs clearly, but I had to be the one to pick.
+
+**What would you do differently if you started over?**
+I'd check the repo's pre-commit config before writing any code, not after trying to commit. Knowing upfront that mypy has no baseline mode would have changed how I planned my time — I'd have either budgeted for the `--no-verify` conversation earlier or picked a smaller, more isolated file to touch. I'd also push back sooner on my own default of committing frequently; bundling the fix and its tests into one commit up front would have meant hitting the hook wall once instead of losing time re-doing the same edit after `git checkout` accidentally reverted more than I meant it to.
+
+**What are you most proud of from this module?**
+The reproduction, not the fix. Anyone can read `process_review()` and guess it might not handle an empty profile well — proving it, live, with a real curl request against a real running server, and getting back an actual fabricated `overall_score: 0.81` for a profile with zero ingested documents, is what turned "this looks like a gap" into "this is definitely broken, and here's exactly what it does instead." That evidence is what made the fix itself almost mechanical.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -79,3 +79,19 @@ Finish filling out the PR template, double-check branch name and commit messages
 
 **Blockers:**
 None.
+
+### Check-in 2 (end of week)
+
+**PR link:** [#707](https://github.com/ascherj/pathreview/pull/707)
+
+**Branch:** `test/88-review-endpoint-test`
+
+**What you built:** `process_review()` now checks whether the ingestion pipeline actually produced any sources for a profile, and if not, sets the review to `status="failed"` with a descriptive `error_message` instead of letting the (hardcoded, placeholder) agent/RAG generation steps fabricate a fake "complete" review. The failure reason is also surfaced on the lightweight `/reviews/{id}/status` polling endpoint, not just the full review fetch.
+
+**Tests added or updated:** `tests/unit/test_review_service.py` — added `TestProcessReviewNoIngestedDocuments` with two tests: one confirms a profile with no `github_username`/`portfolio_url`/`resume_text` ends in `status="failed"` with a non-null `error_message`; the other confirms a profile with at least one source (e.g. `github_username` set) still reaches `status="complete"`, guarding against the new check rejecting valid profiles.
+
+**Self-review confirmation:**
+- [x] `make check` passes — with caveats: 182 pre-existing lint errors and 103 pre-existing mypy errors in the repo, confirmed identical in count and content before and after this change (verified via `git stash` diff on the touched files). No new lint or type errors introduced by this fix.
+- [x] `make test-unit` passes — with caveats: 53 pre-existing test failures in unrelated files (mock-configuration bugs), unchanged by this change. 377 tests pass (up from 375 baseline — the 2 new tests added here, both green).
+
+**Draft PR feedback received from:** none.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,45 @@
+## Solution plan
+
+**Issue:** [POST /reviews endpoint has no test for when the profile has no ingested documents #88](https://github.com/ascherj/pathreview/issues/88)
+
+### Understand
+
+**Expected behavior:** Requesting a review for a profile that has no ingested documents (no GitHub username, portfolio URL, or resume) should fail in a clean, well-formed way — e.g. `status="failed"` with a descriptive `error_message` — so the client can tell the user to add content before requesting a review.
+
+**Actual behavior (confirmed via reproduction, see `JOURNAL.md`):** No such check exists anywhere in the pipeline. `POST /reviews` ([api/routes/reviews.py:22](api/routes/reviews.py#L22)) creates the review with `status="pending"` and hands processing to a background task, `process_review()` ([core/services/review_service.py:82](core/services/review_service.py#L82)). Inside that task, `_run_ingestion_pipeline()` correctly returns `[]` for a documentless profile, but the downstream placeholder steps — `_run_agent_orchestration()` and `_run_rag_retrieval_generation()` — ignore the (empty) ingestion results and always return hardcoded, canned sections and a fixed `overall_score`. `_run_safety_checks()` only validates structural shape, not whether the content reflects real input. Net result: the review silently reaches `status="complete"` with fabricated feedback instead of failing — no crash, no error, nothing to catch the case. Root cause is a missing guard: nothing in `process_review()` checks "did ingestion actually produce anything?" before proceeding to generate feedback.
+
+### Map
+
+- [core/services/review_service.py](core/services/review_service.py) — `process_review()` (orchestration/guard logic goes here, right after the ingestion step); `_run_ingestion_pipeline()` (already returns the empty-list signal we need, no change expected)
+- [tests/unit/test_review_service.py](tests/unit/test_review_service.py) — currently has zero coverage of `process_review()`; needs new tests for both the no-documents-fails case and the happy path (has documents → proceeds normally)
+- [core/models/review.py](core/models/review.py) — no schema change needed; `error_message: Mapped[str | None]` already exists on `Review` and is simply unused today
+- [api/schemas/review.py](api/schemas/review.py) — `ReviewResponse` — verify `error_message` is already exposed in the response model (likely yes, since the reproduction curl output included `"error_message":null`)
+- [JOURNAL.md](JOURNAL.md) — already updated with reproduction steps in a prior commit; may want a short "resolved" follow-up note once the fix lands
+
+### Plan
+
+1. **Add the guard in `process_review()`** — right after `_run_ingestion_pipeline()` returns, check if `ingestion_results` is empty. If so, set `review.status = "failed"`, `review.error_message = "No documents have been ingested for this profile. Add a GitHub username, portfolio URL, or resume before requesting a review."`, commit, log a warning, and `return` early — skipping agent orchestration, RAG generation, and safety checks entirely.
+2. **Confirm `error_message` is wired through the API layer** — check `ReviewResponse` in `api/schemas/review.py` and the `GET /reviews/{id}` / `GET /reviews/{id}/status` handlers so the failure reason is actually visible to the client, not just stored in the DB.
+3. **Write the regression test that pins down current (broken) behavior first** — a test calling `process_review()` with a mocked profile that has `github_username=None`, `portfolio_url=None`, `resume_text=None`, asserting `status == "failed"` and `error_message` is set. This should fail before the fix and pass after.
+4. **Write a companion happy-path test** — same test shape but with e.g. `github_username` set, asserting the review still reaches `status == "complete"` with sections populated, to guard against the new check being overly aggressive and blocking valid reviews.
+5. **Run the full unit suite (`make test-unit`) and manually re-run the curl reproduction from `JOURNAL.md`** against the local server to confirm the same profile (`349cc633-fc7a-4178-9207-7283dab27943`) now returns `status: "failed"` with a descriptive message instead of fabricated `status: "complete"` content.
+
+### Inputs & outputs
+
+**Input:** A `profile_id` passed to `process_review()`, resolving to a `Profile` row whose `github_username`, `portfolio_url`, and `resume_text` are all unset (and consequently zero `IngestedSource` rows created for it).
+
+**Output:** The corresponding `Review` row updated to `status="failed"` with a non-null, descriptive `error_message`, and `sections`/`overall_score` left as `null` — instead of the current fabricated `status="complete"` result. No change to the synchronous `POST /reviews` response shape (still `202`/`pending` immediately); the change is entirely in what the background task produces.
+
+### Risks & unknowns
+
+- **Source of truth for "no documents":** the guard as planned checks the return value of `_run_ingestion_pipeline()` (the profile's own fields), not the `ingested_sources` table directly. These should currently be equivalent since that function is the only writer of `IngestedSource` rows, but if a profile could have stale/orphaned `IngestedSource` rows from a previous partial run while its current fields are empty, checking the function's return value vs. querying the table could disagree. Need to confirm which is the intended source of truth before finalizing.
+- **Overly broad failure condition:** need to make sure the check doesn't also reject profiles that have *some* content that legitimately produces zero ingestable sources (e.g. a malformed but non-empty resume) — that's a different failure mode (ingestion error) than "nothing was submitted at all," and conflating them could produce a misleading error message.
+- **Existing consumers of `status="complete"`:** unclear if the frontend or any other code currently assumes every triggered review eventually reaches `"complete"` and doesn't yet handle `"failed"` gracefully in the UI — worth a quick check of `frontend/` before considering this done end-to-end, though that's outside the scope of the backend fix itself.
+- **No existing test scaffolding for `process_review()`:** since this function isn't tested at all today, mocking its two sequential `db.execute()` calls (for `Review` then `Profile`) correctly will take some care to avoid a brittle test that breaks on unrelated refactors.
+
+### Edge cases
+
+- Profile with all three fields (`github_username`, `portfolio_url`, `resume_text`) unset — the primary case from issue #88; should fail cleanly.
+- Profile with fields set but pointing to unreachable/invalid sources (e.g. a GitHub username that doesn't exist) — currently `_run_ingestion_pipeline()` catches exceptions per-source and continues, meaning `ingestion_results` could still end up empty here too; confirm this should also route to the new "no documents" failure path.
+- Profile that has at least one valid source — must still reach `status="complete"` as before (guarded against via the happy-path test).
+- Review for a profile that gets deleted between creation and background processing — already handled by the existing `if not profile` branch; not in scope for this fix but worth confirming it isn't accidentally broken by the new guard's placement.

--- a/api/routes/reviews.py
+++ b/api/routes/reviews.py
@@ -164,6 +164,7 @@ async def get_review_status(
             "review_id": str(review.id),
             "status": review.status,
             "progress_pct": getattr(review, "progress_pct", 0),
+            "error_message": review.error_message,
         }
 
     except HTTPException:

--- a/core/services/review_service.py
+++ b/core/services/review_service.py
@@ -132,6 +132,22 @@ async def process_review(
             sources_count=len(ingestion_results),
         )
 
+        if not ingestion_results:
+            log.warning(
+                "no_ingested_documents",
+                review_id=str(review_id),
+                profile_id=str(profile_id),
+            )
+            review.status = "failed"
+            review.error_message = (
+                "No documents have been ingested for this profile. Add a GitHub "
+                "username, portfolio URL, or resume before requesting a review."
+            )
+            review.updated_at = datetime.utcnow()
+            db.add(review)
+            await db.commit()
+            return
+
         # Step 3: Run agent orchestration
         agent_output = await _run_agent_orchestration(profile, ingestion_results)
         log.info(

--- a/tests/unit/test_review_service.py
+++ b/tests/unit/test_review_service.py
@@ -9,6 +9,7 @@ from core.services.review_service import (
     create_review,
     get_review,
     list_reviews,
+    process_review,
 )
 
 
@@ -338,3 +339,71 @@ class TestReviewService:
 
         # Should order by created_at descending
         mock_db_session.execute.assert_called_once()
+
+
+@pytest.mark.unit
+class TestProcessReviewNoIngestedDocuments:
+    """Regression coverage for issue #88: process_review() with a documentless profile."""
+
+    def _make_db_session(self, review, profile):
+        """Build a mock db session whose execute() resolves Review then Profile lookups in order."""
+        db = AsyncMock()
+        db.add = Mock()
+        db.commit = AsyncMock()
+
+        review_result = Mock()
+        review_result.scalars.return_value.first.return_value = review
+
+        profile_result = Mock()
+        profile_result.scalars.return_value.first.return_value = profile
+
+        db.execute = AsyncMock(side_effect=[review_result, profile_result])
+        return db
+
+    def _make_review(self):
+        review = Mock()
+        review.id = uuid4()
+        review.status = "pending"
+        review.sections = None
+        review.overall_score = None
+        review.error_message = None
+        return review
+
+    def _make_profile(self, github_username=None, portfolio_url=None, resume_text=None):
+        profile = Mock()
+        profile.id = uuid4()
+        profile.user_id = uuid4()
+        profile.github_username = github_username
+        profile.portfolio_url = portfolio_url
+        profile.resume_text = resume_text
+        profile.resume_filename = None
+        return profile
+
+    @pytest.mark.asyncio
+    async def test_process_review_fails_when_profile_has_no_documents(self):
+        """A profile with no github_username, portfolio_url, or resume_text should fail
+        with a descriptive error_message instead of fabricating a completed review."""
+        review = self._make_review()
+        profile = self._make_profile()
+        db = self._make_db_session(review, profile)
+
+        await process_review(db, review.id, profile.id)
+
+        assert review.status == "failed"
+        assert review.error_message
+        assert review.sections is None
+        assert review.overall_score is None
+
+    @pytest.mark.asyncio
+    async def test_process_review_completes_when_profile_has_a_document(self):
+        """A profile with at least one ingestible source should still reach status='complete',
+        guarding against the no-documents check being overly aggressive."""
+        review = self._make_review()
+        profile = self._make_profile(github_username="octocat")
+        db = self._make_db_session(review, profile)
+
+        await process_review(db, review.id, profile.id)
+
+        assert review.status == "complete"
+        assert review.sections is not None
+        assert review.overall_score is not None


### PR DESCRIPTION
## Summary
`POST /reviews` never checked whether a profile actually had any ingested documents before generating feedback. Because the agent orchestration and RAG generation steps in `process_review()` are currently hardcoded placeholders that ignore their input, a profile with no `github_username`, `portfolio_url`, or `resume_text` would silently reach `status="complete"` with fabricated, generic feedback instead of failing. This PR adds a guard that fails the review cleanly with a descriptive `error_message` when ingestion produces nothing, and adds regression tests for both the failure and happy paths.

## Issue
Closes #88

## Changes
- `core/services/review_service.py`: in `process_review()`, check whether `_run_ingestion_pipeline()` returned any results; if not, set `status="failed"` with a descriptive `error_message` and return before running the agent orchestration/RAG/safety-check steps.
- `api/routes/reviews.py`: expose `error_message` on the `GET /reviews/{id}/status` response, so polling clients can see the failure reason without a second request.
- `tests/unit/test_review_service.py`: add `TestProcessReviewNoIngestedDocuments` with two tests — a documentless profile ends in `status="failed"` with a non-null `error_message`, and a profile with at least one source (e.g. `github_username` set) still reaches `status="complete"`.

## Testing
- [x] Unit tests pass (`make test-unit`)
- [x] Integration tests pass (`make test-integration`)
- [ ] Linter passes (`make lint`)
- [ ] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes

Note: `make lint` (182 errors) and `make typecheck` (103 errors) fail on pre-existing issues unrelated to this change, confirmed identical in count and content before and after this fix. `make test-unit` has 53 pre-existing failures in unrelated files; the 2 new tests added here pass. `make test-integration` collects 0 tests (no integration tests exist in the repo yet).

## Screenshots / Demo
N/A — backend-only change. Verified manually via curl against a local server (Postgres via `docker compose up -d`): a documentless profile now returns `status: "failed"` with the descriptive `error_message` on both `GET /reviews/{id}` and `GET /reviews/{id}/status`; a profile with `github_username` set is unaffected and still completes normally.

## Notes for Reviewers
The core fix is the single `if not ingestion_results:` block added to `process_review()` — everything else is the one-line `error_message` addition to the status endpoint, plus new tests. Pre-existing lint/type/test failures in the repo are unrelated to this change (see Testing notes above).