### PR TITLE
feat/87-webhook-that-notifies-users-when-review-is-ready

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ venv/
 node_modules/
 frontend/node_modules/
 frontend/dist/
+frontend/vite.config.ts
 
 # Docker
 *.log

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ build/
 .venv/
 venv/
 *.egg
+.python-version
 
 # Environment
 .env

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,5 +14,11 @@ repos:
     rev: v1.8.0
     hooks:
       - id: mypy
-        additional_dependencies: [types-redis]
+        additional_dependencies:
+          - types-redis
+          - fastapi>=0.109.0
+          - sqlalchemy>=2.0.0
+          - pydantic[email]>=2.5.0
+          - pydantic-settings>=2.1.0
+          - structlog>=24.1.0
         args: [--ignore-missing-imports]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -9,6 +9,27 @@ Implement a webhook system that notifies users when their review is ready.
 
 **Tier:** [ ] Tier 1  [ ] Tier 2  [x] Tier 3
 
+**Selection reasoning**
+
+Using the ***Is this right for me?*** checklist, I chose this issue:
+
+Part 1 — Understanding the Issue
+
+Details are in problem summary below.
+
+Part 2 — Tier Fit
+
+1. Prior experience with open source contributions, hence seeked a Tier 3 issue to work on.
+2. Webhook systems are examples of asynchronous workflows, which are usually harder to implement reliably and test, making it a good exercise with my experience as a software engineer.
+
+Part 3 — Codebase Readiness
+
+The Problem Summary below describes the files that needs the changes. Since this is a new service, a new test file should be setup.
+
+Part 4 — Scope and Time
+
+Issue states that it will take 8-12 hours. Allowing buffer time for issues coming up, it will take around 12-15 hours to setup a new webhook, write new unit and integration tests and update the frontend if needed. A week is enough for me to complete these, especially since I will be using Claude Code to help me write the code and tests based on the implementation plan that I will draft.
+
 **Problem summary:**
 
 In the current implementation, a user has a Reviews tab that lets them see the progress of their reviews. However, there isn't a way to notify users when reviews are completed and it is upto the user to check it themselves.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -64,3 +64,37 @@ This issue is a new feature rather than a bug so skipping this section.
 **Blockers or open questions:**
 <NA>
 
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+All implementation is completed, including testing and documentation.
+
+**Next steps:**
+Setting up the PR, its documentation before submission. 
+Also submit the PR for review once done.
+
+**Blockers:**
+None.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/405
+
+**Branch:** `Enhancement/87 webhook that notifies users when review is ready`
+
+**What you built:**
+A webhook notification system for completed reviews: clients register a callback URL per profile via `POST /webhooks/callbacks`, and once a review finishes processing, PathReview POSTs a `review.completed` notification (with a deterministic `notification_id` and up to 3 retries) to that URL.
+
+**Tests added or updated:**
+Added`tests/unit/test_webhook_service.py` and `tests/unit/test_callback.py` (20 tests total).
+Updated `tests/unit/test_review_service.py`(2 tests total).
+Covers callback registration/deletion (success, already-registered `409`, profile-not-owned `404`), notification creation and dedup by `notification_id`, and `send_notification`'s success/retry/max-attempts/timeout paths — asserting the exact POST payload and retry counts, not just end state, notification delivery when callback exists, no delivery when callback doesn't exist.
+
+**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+
+**Draft PR feedback received from:** [name or Slack handle, or "none"]
+

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -84,7 +84,7 @@ None.
 
 **PR link:** https://github.com/ascherj/pathreview/pull/405
 
-**Branch:** `Enhancement/87 webhook that notifies users when review is ready`
+**Branch:** `enhancement/87 webhook that notifies users when review is ready`
 
 **What you built:**
 A webhook notification system for completed reviews: clients register a callback URL per profile via `POST /webhooks/callbacks`, and once a review finishes processing, PathReview POSTs a `review.completed` notification (with a deterministic `notification_id` and up to 3 retries) to that URL.
@@ -94,7 +94,7 @@ Added`tests/unit/test_webhook_service.py` and `tests/unit/test_callback.py` (20 
 Updated `tests/unit/test_review_service.py`(2 tests total).
 Covers callback registration/deletion (success, already-registered `409`, profile-not-owned `404`), notification creation and dedup by `notification_id`, and `send_notification`'s success/retry/max-attempts/timeout paths — asserting the exact POST payload and retry counts, not just end state, notification delivery when callback exists, no delivery when callback doesn't exist.
 
-**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
 
-**Draft PR feedback received from:** [name or Slack handle, or "none"]
+**Draft PR feedback received from:** None yet, raised PR.
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,27 @@
+## Week 7 — Issue selection
+
+**Issue link:** 
+https://github.com/ascherj/pathreview/issues/87
+
+**Issue title:** 
+Implement a webhook system that notifies users when their review is ready.
+
+
+**Tier:** [ ] Tier 1  [ ] Tier 2  [x] Tier 3
+
+**Problem summary:**
+
+In the current implementation, a user has a Reviews tab that lets them see the progress of their reviews. However, there isn't a way to notify users when reviews are completed and it is upto the user to check it themselves.
+
+Adding a webhook as a new route helps to setup notifications and notify when each review is processed.
+
+The following are parts of the codebase that requires changes.
+
+    api/routes/ (new webhooks.py)
+    core/services/ (new webhook_service.py)
+
+**Branch name:** enhancement/87-webhook-that-notifies-users-when-review-is-ready
+
+**Setup confirmation:** App runs locally at localhost:5173 (with minor changes to point to `127.0.0.1:5173` as `node` resolves localhost to `::1` IPv6 address on macOS)
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -46,3 +46,21 @@ The following are parts of the codebase that requires changes.
 **Setup confirmation:** App runs locally at localhost:5173 (with minor changes to point to `127.0.0.1:5173` as `node` resolves localhost to `::1` IPv6 address on macOS)
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:**
+This issue is a new feature rather than a bug so skipping this section.
+
+**Reproduction summary:**
+This issue is a new feature rather than a bug so skipping this section.
+
+**PLAN.md link:** 
+[PLAN.md](./PLAN.md)
+
+**Walkthrough video (recommended):**
+<NA>
+
+**Blockers or open questions:**
+<NA>
+

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -190,18 +190,20 @@ N/A - No feedback received so no changes
 ### Reflection
 
 **What was harder than you expected?**
-Steering AI correctly and validating the code it generated.
+Steering AI correctly and validating the code it generated for `core/services/webhook_service` and `tests/unit/test_webhook_service.py`.
 
 **What did you learn about working in a large codebase?**
 As I have prior experience as a software engineer navigating the codebase wasn't new but it helped refresh my skills and learn how much time AI can save when coding while emphasizing system design and architectural skills.
 
 **How did AI tools help — and where did they fall short?**
-To generate tests, code and validate everything works. The time it took to code it from scratch took less than a day and I spent valuable time on validating and designing the system which sharpened my design skills.
+To generate tests, code and validate everything works. The time it took to code the webhook service, router and tests from scratch took less than a day and I spent valuable time on validating and designing the system which sharpened my design skills.
 
-It fell short when it generated code that worked but failed on specific edge cases and sometimes used the longer path to give me answers.
+It fell short when it generated code that worked but failed on specific edge cases and sometimes used the longer path to give me answers. For example to generate client setup in `docs/API.md` and `tests/unit/test_callback.py`, it took longer than 1 hour.
 
 **What would you do differently if you started over?**
 I wouldn't change anything; the course structure helped me to dip my toes slowly and confidently into using AI along with my current software engineering skills.
 
 **What are you most proud of from this module?**
-Sharpening my comprehension and critical skills on AI generated content to validate, test and question what it does. It is very easy to trust AI as it is, but I did not want to lose my critical thinking skills so I deliberately took my time each week even though the actual work wasn't very hard.
+Setting up and validating the client setup for the webhook from registering, getting notifications etc. It allowed me to demonstrate my software engineering experience from when I would build APIs, SDKs for external clients and it felt satisfying to see the end to end work.
+
+I also got to sharpen my comprehension and critical skills when using AI assisted development to validate, test and question what it does. I deliberately took my time each week for this even though the actual work wasn't very hard.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -82,9 +82,9 @@ None.
 
 ### Check-in 2 (end of week)
 
-**PR link:** https://github.com/ascherj/pathreview/pull/405
+**PR link:** https://github.com/ascherj/pathreview/pull/708
 
-**Branch:** `enhancement/87 webhook that notifies users when review is ready`
+**Branch:** `feat/87-webhook-that-notifies-users-when review-is-ready`
 
 **What you built:**
 A webhook notification system for completed reviews: clients register a callback URL per profile via `POST /webhooks/callbacks`, and once a review finishes processing, PathReview POSTs a `review.completed` notification (with a deterministic `notification_id` and up to 3 retries) to that URL.
@@ -96,5 +96,80 @@ Covers callback registration/deletion (success, already-registered `409`, profil
 
 **Self-review confirmation:** [x] make check passes  [x] make test-unit passes
 
-**Draft PR feedback received from:** None yet, raised PR.
+**Draft PR feedback received from:** None, raised PR.
+
+### PR Description
+
+## Summary
+
+In the current implementation, a user has a Reviews tab that lets them see the progress of their reviews. However, there isn't a way to notify users when reviews are completed, and it is up to the user to check it themselves. Adding a webhook as a new route helps to set up notifications and notify when each review is processed.
+
+## Issue
+
+Closes #87
+
+## Changes
+
+- Added `Callback` and `Notification` models and the corresponding migration.
+- Added `webhook_service.py` with registration/removal + delivery (3 retries, 5s timeout per attempt).
+- Added `POST /webhooks/callbacks` and `DELETE /webhooks/callbacks/{profile_id}` routes and schemas.
+- Updated `process_review` in `review_service.py` to call `notify_callback_on_review_completed` as a separate task, so notifications are sent without blocking `process_review`.
+- Added a runnable example client with dedup, plus a setup walkthrough, and updated [docs/API.md](docs/API.md) with a new `### Webhooks` section and example link.
+- Added missing type packages to the pre-commit `mypy` hook so it checks against real types (see [Notes for Reviewers](#notes-for-reviewers)).
+- Fixed a `B008` lint issue during the pre-commit hook (see [[Notes for Reviewers](https://claude.ai/chat/66897adc-74e8-455a-b24d-2aeeb1908aaf#notes-for-reviewers)](#notes-for-reviewers)).
+
+## Testing
+
+- **Unit tests** (`tests/unit/test_webhook_service.py`, `tests/unit/test_callback.py`, 20 total) cover:
+  - Registering/deleting a callback (success, already-exists `409`, profile-not-owned `404`).
+  - Notification create/dedup by `notification_id`.
+  - `send_notification`'s success/retry/max-attempts/timeout paths.
+
+These mock `httpx.AsyncClient` to assert the exact POST payload and retry/attempt counts, rather than just the end state.
+
+- **Manual end-to-end run** (more details in [docs/examples/client_callback_setup.md](docs/examples/client_callback_setup.md)) against a live server (Postgres/Redis via `docker compose`, API on `:8000`, example client on `:9000`):
+  1. Logged in.
+  2. Registered a callback for a seeded profile.
+  3. Requested a review.
+  4. Confirmed the client's `/callback` received the notification and logged it.
+  5. Confirmed `delivery_status` flipped to `success` in the DB.
+  6. Unregistered the callback and confirmed the row was deleted.
+
+**Checklist**
+
+- [x] Unit tests pass (`make test-unit`)
+- [ ] Integration tests pass (`make test-integration`)
+- [x] Linter passes (`make lint`)
+- [x] Type checker passes (`make typecheck`)
+- [x] New/updated tests cover the changes
+
+## Screenshots / Demo
+
+N/A — changes are only on the backend, so no screenshots/demo needed. Step-by-step instructions to test the client callback are mentioned in [##Testing](Testing)
+
+## Notes for Reviewers
+
+- Integration tests are not set up in the project as of now, hence skipping integration test checks.
+- Added missing type packages to the `mypy` hook in `pre-commit-config.yaml`; otherwise the pre-commit hook fails for successful tests.
+- **Lint errors:** ~202 errors repo-wide before the change, mostly:
+  - `B904` — `raise` inside `except` without `from err` / `from None`
+  - `B008` — do not perform function call `Depends` in argument defaults; instead, perform the call within the function, or read the default from a module-level singleton variable, due to FastAPI's `Depends()`
+
+  Fix made for `B008`(scoped for my changes) to pass the pre-commit hook — in `api/routes/webhooks.py`, added the following to `pyproject.toml`:
+
+  ```toml
+  [tool.ruff.lint.flake8-bugbear]
+  extend-immutable-calls = ["fastapi.Depends"]
+  ```
+
+  This prevents ruff checks from flagging the issue related to [using calls for default arguments](https://docs.astral.sh/ruff/settings/#lint_flake8-boolean-trap_extend-allowed-calls). This change is project-wide, so I've tested it to confirm it doesn't break anything else.
+
+- **Typing errors:** 114 errors repo-wide before the change. Made the following fixes (scoped to my changes) to pass the pre-commit hook:
+  - `core/services/webhook_service.py`, `tests/unit/test_review_service.py` — added `db: AsyncSession` typing to 4 functions; annotated `notification: Notification | None` to fix `Returning Any`.
+  - `tests/unit/test_callback.py` — fully annotated every fixture/test.
+  - `docs/examples/client_callback_server.py` — annotated `data: dict[str, Any] = response.json()` to fix `Returning Any`.
+  - `tests/unit/test_webhook_service.py` — fully annotated every fixture/test.
+  - `api/routes/webhooks.py` — added `db: AsyncSession`, `-> CallbackResponse` / `-> None` return types; fixed `current_user.id` (`str`) → `UUID(current_user.id)` at both call sites.
+  - `core/services/review_service.py` — added `db: AsyncSession` typing to 4 functions; annotated `notification: Notification | None` to fix `Returning Any`.
+  - `tests/unit/test_review_service.py` — fully annotated every fixture/test.
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -173,3 +173,35 @@ N/A — changes are only on the backend, so no screenshots/demo needed. Step-by-
   - `core/services/review_service.py` — added `db: AsyncSession` typing to 4 functions; annotated `notification: Notification | None` to fix `Returning Any`.
   - `tests/unit/test_review_service.py` — fully annotated every fixture/test.
 
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No review came in.
+
+**How you responded:**
+N/A - No feedback received so no changes
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Steering AI correctly and validating the code it generated.
+
+**What did you learn about working in a large codebase?**
+As I have prior experience as a software engineer navigating the codebase wasn't new but it helped refresh my skills and learn how much time AI can save when coding while emphasizing system design and architectural skills.
+
+**How did AI tools help — and where did they fall short?**
+To generate tests, code and validate everything works. The time it took to code it from scratch took less than a day and I spent valuable time on validating and designing the system which sharpened my design skills.
+
+It fell short when it generated code that worked but failed on specific edge cases and sometimes used the longer path to give me answers.
+
+**What would you do differently if you started over?**
+I wouldn't change anything; the course structure helped me to dip my toes slowly and confidently into using AI along with my current software engineering skills.
+
+**What are you most proud of from this module?**
+Sharpening my comprehension and critical skills on AI generated content to validate, test and question what it does. It is very easy to trust AI as it is, but I did not want to lose my critical thinking skills so I deliberately took my time each week even though the actual work wasn't very hard.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,200 @@
+## Solution plan
+
+**Issue:** 
+
+Implement a webhook system that notifies users when their review is ready.
+https://github.com/ascherj/pathreview/issues/87
+
+### Understand
+
+#### Background
+
+For long running reviews, clients currently need to poll against `GET "/{review_id}/status"` in order to get the status of a review. Instead of constant polling, setting up a webhook allows for a hands off approach where the webhook is responsible for notifying the callback URL once a review is completed and all the client needs to do is provide a callback URL to which the webhook sends the notifications to.
+
+#### Investigation into webhooks
+
+FastAPI does not have a standard way of defining a webhook and leaves it to the developer. Looking into`review_service.py`, it already uses `async await` for processing reviews in the background and since these webhooks are meant to be asynchronous anyway, these patterns can be used here as well since callbacks are standard I/O operations done by the webhook where notifications sent may not be reliably received or received at all by the client. The following are the basic components needed for a functioning webhook: 
+
+***Registration***
+
+    FastAPI provides a way to document the schema of a webhook for clients to use, using the decorator @app.webhooks
+
+        ``` python
+        @app.webhooks.post("new-subscription")
+        def new_subscription(body: Subscription):
+        """
+        When a new user subscribes to your service we'll send you a POST request with this
+        data to the URL that you register for the event `new-subscription` in the dashboard.
+        """
+        ```
+    Note that this is not a template for setting up the webhooks.
+
+    The basic requirements to register a URL requires accepting a callback URL and storing it into a database along with a cache for faster processing.
+    Depending on who the notifications needs to be sent to and what needs to be sent, these URLs can be created and monitored at that level.
+
+***Event Source***
+
+    The webhook requires a schema that defines what events the webhook listens for i.e CRUD operations on a database, operation statuses etc.
+
+***Retries and error handling***
+
+    Since there are two delivery endpoints i.e webhook and callback URL, errors are possible when sending and receiving notifications. We should assume that neither are reliable and handle accordingly. The goal is to allow the system to retry failed attempts, but not indefintely to the point that the system cannot recover i.e Retries with backoff and jitter with a timeout.
+
+***Idempotency handling***
+
+    In order to allow the callback URL to handle duplicated requests resulting from system or network failures, the webhook should provide an idempotency key for the callback URL to provide idempotency on their end. This key should include stable identifiers that would not change for each call.
+
+### Map
+
+api/routes/ (new webhooks.py defining routes for registering callback URLs)
+api/schemas/ (new Callback and Notification Schemas)
+core/services/ (new webhook_service.py for monitoring review status and sending notifications to the callback URL)
+core/models/ (new Callback and Notification models for storing callback URL details)
+tests/unit/ (new tests for webhooks, callbacks in test_review_service.py and test_callback.py)
+
+### Plan
+
+This section will discuss the scope and the step by step plan. The aim is to setup a basic webhook that can register and store callback URLs, send notifications as payloads to the callback URL for the user and handle errors with a simple retry with limited attempts, with a timeout for each attempt. 
+
+#### Scope
+
+Webhook:
+- Simple retry with limit and timeout.
+- Database for storing callback details. Updates are not allowed, but deletes are.
+- Error handling for timeout, retries.
+- Idempotency handling to allow clients to manage duplicated or missing payloads.
+- Documentation.
+
+Callback:
+- URLs are preset
+- Testing end to end from registration to notification.
+- Documentation.
+
+Advanced features like caching URLs, payload verification at callback, advanced retry methods can be scoped out into future work as these are more complex to implement (i.e cache refresh, cache eviction methods, setting up secret keys for signing, testing retries with backoff depending on latencies etc) and require extensive testing, which is beyond the scope and time mentioned in the issue.
+
+#### Step by Step
+
+1. Read `api/routes/review.py` and `core/services/review_service.py` to understand how to setup a route and a service asynchronously, and how to setup error handling.
+2. Read  `tests/unit/test_review_service` to understand how the tests are setup for mocking and relevant test cases.
+3. Read  `api/schemas` to understand how the Pydantic models are setup for API responses.
+4. Run `make test-unit` before making any changes. 
+4. In `core/models`, create Callback and Notification as `Callback.py` and `Notification.py`.
+5. In `api/routes`, create a `webhook.py` route.
+6. In `core/services`, create a `webhook_service.py` service.
+7. In `tests/test_review_service`, setup tests for webhooks. Create a new `test_callback.py` file to do the callback testing only(not implementation).
+8. Run `make test-unit` to make sure the new changes work.
+9. Run `make check` to verify lint, formatting, and types are clean.
+10. Document new webhook changes and an example for setting up a webhook in `API.md`, followed by a simple client setup to get notifications.
+
+### Inputs & outputs
+
+#### Callback and Notification Data model
+
+Callback:
+
+callback_id: <uuid generated>
+user_id: <get from client>
+profile_id: <get from client>
+url: <string given by the client through the API>
+created: <date>
+
+Notification:
+
+notification_id: <user_id + profile_id + review_id>
+callback_id: <from Callback Model>
+review_id: <get directly from process_review>
+created: <date>
+last_sent: <date>
+last_ack: <date>
+delivery_status: <success, fail, retry>
+
+#### Pydantic Models
+
+Callback
+
+Notification
+
+#### Webhook Route
+
+The new route has the following methods:
+
+1. register_callback(user_id, profile_id, url):
+
+This gets the url from the client along with the user_id and profile id, calls set_callback_url to update the Callback record and returns a response based on success or failure. 
+2. set_callback_url(user_id, profile_id, url):
+
+This creates a Callback record with the user_id, profile_id, url provided, commits to the database and return a response.
+3. delete_callback_url(user_id, profile_id):
+
+This deletes the callback record associated with the above parameters.
+
+#### Webhook Service
+
+##### Functions
+
+1. notify_callback_on_review_completed(user_id, profile_id, review_id):
+
+This webhook service gets invoked from `process_reviews` in `review_service.py`, where the service is awaited without blocking process_reviews. 
+This fetches the user_id based on the review_id and profile_id and looks up the Callback record for the URL.
+It then calls `create_notification` to create the Notification Record. 
+It then calls `send_notification` to send notifications to the callback URL.
+
+2. create_notification(callback_id, review_id, notification_id):
+
+This creates the Notification record with the above parameters and sets all the fields except `last_ack`.
+
+3. send_notification(Notification, callback_url):
+
+This sends the Notification record as a payload as a POST request to the callback_url. It also handles retries with timeouts.
+
+##### Error classes
+
+A separate error class is implemented with the following:
+TimeoutError - When the timeout value has reached. 
+RetriesExceededError - When the number of retries has exceeded.
+
+#### Unit tests for callback and webhook
+
+Webhook
+
+1. register_callback on success
+2. register_callback on error
+3. set_callback_url on success
+4. set_callback_url on error
+5. notify_callback_on_review_completed on success
+6. notify_callback_on_review_completed on error
+7. send_notification retry
+8. send_notification timeout
+
+Callback
+
+1. notify_client_on_review_completed duplicated
+2. notify_client_on_review_completed success
+
+#### Documentation for callback and webhook
+
+Document the new webhook changes, with an example of how client can do a callback in `API.md`.
+
+### Risks & unknowns
+
+Asynchronous implementations are more unpredictable to test and debug issues for. In addition there are other issues:
+
+1. Recreate a long running review test case reliably.
+2. No payload signing - not in scope.
+3. No caching layer yet - not in scope.
+4. Retry storms under partial outages - not in scope.
+5. Testing async fire-and-forget reliably — awaited without blocking `process_review`.
+6. No manual-send path for when Retries exceed - current implementation has it try again later.
+
+### Edge cases
+
+1. When the webhook doesn't get any acknowledgment from the client and sends a duplicate - same `notification_id` reused on resend.
+2. When the webhook fails to create a callback URL — failure response, no Callback row persisted.
+3. When the client gets a duplicated notification - deduplication mechanism provided by webhook but handled by client. An example will be provided. 
+4. When send_notification exhausts retries (RetriesExceededError) - Ask to try again later.
+5. When a client re-registers a new callback URL for the same user_id/profile_id - not allowed. They can delete a callback if needed.
+6. When the same review triggers multiple completion events - Handled by design (no re-invocation path today).
+7. When a user has multiple profiles with reviews completing concurrently. Handled — key includes profile_id, not just user_id.
+
+
+

--- a/alembic/versions/003_add_callbacks_and_notifications.py
+++ b/alembic/versions/003_add_callbacks_and_notifications.py
@@ -1,0 +1,73 @@
+"""Add callbacks and notifications tables for the review-completed webhook.
+
+Revision ID: 003
+Revises: 002
+Create Date: 2026-07-28 00:00:00.000000
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op  # type: ignore[attr-defined]
+
+revision = "003"
+down_revision = "002"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Create callbacks table
+    op.create_table(
+        "callbacks",
+        sa.Column("id", postgresql.UUID(as_uuid=False), nullable=False),
+        sa.Column("user_id", postgresql.UUID(as_uuid=False), nullable=False),
+        sa.Column("profile_id", postgresql.UUID(as_uuid=False), nullable=False),
+        sa.Column("url", sa.String(2048), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["user_id"], ["users.id"], name=op.f("fk_callbacks_user_id_users"), ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(
+            ["profile_id"],
+            ["profiles.id"],
+            name=op.f("fk_callbacks_profile_id_profiles"),
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_callbacks")),
+        sa.UniqueConstraint("profile_id", name=op.f("uq_callbacks_profile_id")),
+    )
+    op.create_index(op.f("ix_callbacks_user_id"), "callbacks", ["user_id"])
+    op.create_index(op.f("ix_callbacks_profile_id"), "callbacks", ["profile_id"], unique=True)
+
+    # Create notifications table
+    op.create_table(
+        "notifications",
+        sa.Column("id", postgresql.UUID(as_uuid=False), nullable=False),
+        sa.Column("callback_id", postgresql.UUID(as_uuid=False), nullable=False),
+        sa.Column("review_id", postgresql.UUID(as_uuid=False), nullable=False),
+        sa.Column("delivery_status", sa.String(20), nullable=False, server_default="retry"),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("last_sent_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_ack_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["callback_id"],
+            ["callbacks.id"],
+            name=op.f("fk_notifications_callback_id_callbacks"),
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["review_id"],
+            ["reviews.id"],
+            name=op.f("fk_notifications_review_id_reviews"),
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_notifications")),
+    )
+    op.create_index(op.f("ix_notifications_callback_id"), "notifications", ["callback_id"])
+    op.create_index(op.f("ix_notifications_review_id"), "notifications", ["review_id"])
+
+
+def downgrade() -> None:
+    op.drop_table("notifications")
+    op.drop_table("callbacks")

--- a/api/routes/webhooks.py
+++ b/api/routes/webhooks.py
@@ -1,0 +1,107 @@
+from uuid import UUID
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.middleware.auth import get_current_user
+from api.schemas.webhook import CallbackCreate, CallbackResponse
+from core.database import get_db
+from core.models.user import User
+from core.services.webhook_service import (
+    CallbackAlreadyExistsError,
+    ProfileNotFoundError,
+    delete_callback_url,
+    set_callback_url,
+)
+
+log = structlog.get_logger()
+
+router = APIRouter(prefix="/webhooks", tags=["webhooks"])
+
+
+@router.post("/callbacks", response_model=CallbackResponse)
+async def register_callback_endpoint(
+    data: CallbackCreate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> CallbackResponse:
+    """
+    Register a callback URL for a profile. Only one callback is allowed per profile;
+    delete the existing one first to change it.
+    """
+    try:
+        callback = await set_callback_url(
+            db=db,
+            user_id=UUID(current_user.id),
+            profile_id=data.profile_id,
+            url=str(data.url),
+        )
+
+        log.info(
+            "callback_registered",
+            callback_id=str(callback.id),
+            profile_id=str(data.profile_id),
+            user_id=str(current_user.id),
+        )
+
+        return CallbackResponse.model_validate(callback)
+
+    except ProfileNotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Profile not found",
+        ) from exc
+    except CallbackAlreadyExistsError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="A callback is already registered for this profile. Delete it first.",
+        ) from exc
+    except Exception as exc:
+        log.error("callback_registration_error", error=str(exc))
+        await db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to register callback",
+        ) from exc
+
+
+@router.delete("/callbacks/{profile_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_callback_endpoint(
+    profile_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> None:
+    """
+    Delete the callback registered for a profile by the current user.
+    """
+    try:
+        deleted = await delete_callback_url(
+            db=db,
+            user_id=UUID(current_user.id),
+            profile_id=profile_id,
+        )
+
+        if not deleted:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Callback not found",
+            )
+
+        log.info(
+            "callback_deleted",
+            profile_id=str(profile_id),
+            user_id=str(current_user.id),
+        )
+        return None
+
+    except HTTPException as exc:
+        log.warning("callback_deletion_http_error", status_code=exc.status_code, detail=exc.detail)
+        raise
+    except Exception as exc:
+        log.error("callback_deletion_error", error=str(exc))
+        await db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to delete callback",
+        ) from exc

--- a/api/schemas/webhook.py
+++ b/api/schemas/webhook.py
@@ -1,0 +1,31 @@
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, HttpUrl
+
+
+class CallbackCreate(BaseModel):
+    profile_id: UUID
+    url: HttpUrl
+
+
+class CallbackResponse(BaseModel):
+    id: UUID
+    user_id: UUID
+    profile_id: UUID
+    url: str
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class NotificationResponse(BaseModel):
+    id: UUID
+    callback_id: UUID
+    review_id: UUID
+    delivery_status: str
+    created_at: datetime
+    last_sent_at: datetime | None
+    last_ack_at: datetime | None
+
+    model_config = {"from_attributes": True}

--- a/core/models/callback.py
+++ b/core/models/callback.py
@@ -1,0 +1,46 @@
+"""Callback model for storing a client's registered webhook callback URL."""
+
+from datetime import datetime
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+from sqlalchemy import DateTime, ForeignKey, String
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from core.database import Base
+
+if TYPE_CHECKING:
+    from core.models.notification import Notification
+
+
+class Callback(Base):
+    """Model for storing a client's registered webhook callback URL for a profile."""
+
+    __tablename__ = "callbacks"
+
+    id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False), primary_key=True, default=lambda: str(uuid4())
+    )
+    user_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False), ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    profile_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        ForeignKey("profiles.id", ondelete="CASCADE"),
+        nullable=False,
+        unique=True,
+        index=True,
+    )
+    url: Mapped[str] = mapped_column(String(2048), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=datetime.utcnow
+    )
+
+    # Relationships
+    notifications: Mapped[list["Notification"]] = relationship(
+        "Notification", back_populates="callback", cascade="all, delete-orphan"
+    )
+
+    def __repr__(self) -> str:
+        return f"<Callback(id={self.id}, profile_id={self.profile_id}, url={self.url})>"

--- a/core/models/notification.py
+++ b/core/models/notification.py
@@ -1,0 +1,54 @@
+"""Notification model for tracking webhook delivery attempts for completed reviews."""
+
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import DateTime, ForeignKey, String
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from core.database import Base
+
+if TYPE_CHECKING:
+    from core.models.callback import Callback
+
+
+class Notification(Base):
+    """Model for tracking a single webhook notification's delivery status.
+
+    The id is a deterministic value derived from (user_id, profile_id, review_id) rather than a
+    random uuid4, so retries and resends for the same completion event reuse the same row.
+    """
+
+    __tablename__ = "notifications"
+
+    id: Mapped[str] = mapped_column(UUID(as_uuid=False), primary_key=True)
+    callback_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        ForeignKey("callbacks.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    review_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        ForeignKey("reviews.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    delivery_status: Mapped[str] = mapped_column(
+        String(20), nullable=False, default="retry"
+    )  # "success", "fail", "retry"
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=datetime.utcnow
+    )
+    last_sent_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    last_ack_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    # Relationships
+    callback: Mapped["Callback"] = relationship("Callback", back_populates="notifications")
+
+    def __repr__(self) -> str:
+        return (
+            f"<Notification(id={self.id}, review_id={self.review_id}, "
+            f"delivery_status={self.delivery_status})>"
+        )

--- a/core/models/review.py
+++ b/core/models/review.py
@@ -31,7 +31,9 @@ class Review(Base):
     status: Mapped[str] = mapped_column(
         String(50), nullable=False, default="pending"
     )  # "pending", "processing", "complete", "failed"
-    sections: Mapped[dict | None] = mapped_column(JSON, nullable=True)  # Structured review output
+    sections: Mapped[list[dict] | None] = mapped_column(
+        JSON, nullable=True
+    )  # Structured review output
     overall_score: Mapped[float | None] = mapped_column(Float, nullable=True)
     error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(

--- a/core/services/review_service.py
+++ b/core/services/review_service.py
@@ -1,19 +1,24 @@
-from uuid import UUID
-import structlog
+import asyncio
 import json
 from datetime import datetime
-from sqlalchemy import select, and_
+from uuid import UUID
 
-from core.models.review import Review
-from core.models.profile import Profile
-from core.models.ingested_source import IngestedSource
+import structlog
+from sqlalchemy import and_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from api.schemas.review import FeedbackSection
+from core.models.callback import Callback
+from core.models.ingested_source import IngestedSource
+from core.models.profile import Profile
+from core.models.review import Review
+from core.services.webhook_service import notify_callback_on_review_completed
 
 log = structlog.get_logger()
 
 
 async def create_review(
-    db,
+    db: AsyncSession,
     profile_id: UUID,
     user_id: UUID,
 ) -> Review:
@@ -33,22 +38,23 @@ async def create_review(
 
 
 async def get_review(
-    db,
+    db: AsyncSession,
     review_id: UUID,
     user_id: UUID,
 ) -> Review | None:
     """
     Get a review by ID, checking that it belongs to the user's profile.
     """
-    stmt = select(Review).join(Profile).where(
-        and_(Review.id == review_id, Profile.user_id == user_id)
+    stmt = (
+        select(Review).join(Profile).where(and_(Review.id == review_id, Profile.user_id == user_id))
     )
     result = await db.execute(stmt)
-    return result.scalars().first()
+    review: Review | None = result.scalars().first()
+    return review
 
 
 async def list_reviews(
-    db,
+    db: AsyncSession,
     user_id: UUID,
     page: int = 1,
     page_size: int = 20,
@@ -74,13 +80,13 @@ async def list_reviews(
         .limit(page_size)
     )
     result = await db.execute(stmt)
-    reviews = result.scalars().all()
+    reviews = list(result.scalars().all())
 
     return reviews, total
 
 
 async def process_review(
-    db,
+    db: AsyncSession,
     review_id: UUID,
     profile_id: UUID,
 ) -> None:
@@ -179,6 +185,28 @@ async def process_review(
             overall_score=review.overall_score,
         )
 
+        # Notify a registered callback, if any, that this review is ready.
+        callback_stmt = select(Callback).where(Callback.profile_id == str(profile_id))
+        callback_result = await db.execute(callback_stmt)
+        callback = callback_result.scalars().first()
+
+        if callback is None:
+            log.info(
+                "no_callback_registered_for_profile",
+                review_id=str(review_id),
+                profile_id=str(profile_id),
+            )
+        else:
+            asyncio.create_task(
+                notify_callback_on_review_completed(
+                    user_id=profile.user_id,
+                    profile_id=str(profile_id),
+                    review_id=str(review_id),
+                    callback_id=callback.id,
+                    callback_url=callback.url,
+                )
+            )
+
     except Exception as exc:
         log.error("review_processing_failed", review_id=str(review_id), error=str(exc))
         try:
@@ -194,12 +222,12 @@ async def process_review(
             log.error("review_status_update_failed", review_id=str(review_id), error=str(e))
 
 
-async def _run_ingestion_pipeline(db, profile: Profile) -> list[dict]:
+async def _run_ingestion_pipeline(db: AsyncSession, profile: Profile) -> list[dict]:
     """
     Run ingestion pipeline to extract data from profile sources.
     Returns list of ingested source data.
     """
-    sources = []
+    sources: list[dict] = []
 
     # Ingest from GitHub if available
     if profile.github_username:

--- a/core/services/webhook_service.py
+++ b/core/services/webhook_service.py
@@ -1,0 +1,218 @@
+"""Webhook service: manages callback registration and delivers review-completion notifications."""
+
+import uuid
+from datetime import datetime
+from uuid import UUID
+
+import httpx
+import structlog
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from core.database import AsyncSessionLocal
+from core.models.callback import Callback
+from core.models.notification import Notification
+from core.models.profile import Profile
+
+log = structlog.get_logger()
+
+# Fixed namespace so notification ids are deterministic across the app's lifetime.
+NOTIFICATION_NAMESPACE = uuid.UUID("d3f8a1c4-6b2e-4c1a-9c8f-2b8f8a1e2d3f")
+MAX_SEND_ATTEMPTS = 3
+SEND_TIMEOUT_SECONDS = 5.0
+
+
+class ProfileNotFoundError(Exception):
+    """Raised when the profile doesn't exist or isn't owned by the requesting user."""
+
+
+class CallbackAlreadyExistsError(Exception):
+    """Raised when a callback is already registered for a profile."""
+
+
+class WebhookTimeoutError(Exception):
+    """Raised when a single delivery attempt to the callback URL times out."""
+
+
+class RetriesExceededError(Exception):
+    """Raised when send_notification exhausts MAX_SEND_ATTEMPTS without a successful delivery."""
+
+
+async def set_callback_url(db: AsyncSession, user_id: UUID, profile_id: UUID, url: str) -> Callback:
+    """
+    Create a Callback record for the given user/profile, commit it, and return it.
+    Raises ProfileNotFoundError if the profile doesn't exist or isn't owned by user_id.
+    Raises CallbackAlreadyExistsError if one is already registered for this profile —
+    callers must delete it first before registering a new one.
+    """
+    profile_stmt = select(Profile).where(
+        Profile.id == str(profile_id), Profile.user_id == str(user_id)
+    )
+    profile_result = await db.execute(profile_stmt)
+    if profile_result.scalars().first() is None:
+        raise ProfileNotFoundError(f"Profile {profile_id} not found for user {user_id}")
+
+    stmt = select(Callback).where(Callback.profile_id == str(profile_id))
+    result = await db.execute(stmt)
+    existing = result.scalars().first()
+
+    if existing is not None:
+        raise CallbackAlreadyExistsError(f"Callback already registered for profile {profile_id}")
+
+    callback = Callback(
+        user_id=str(user_id),
+        profile_id=str(profile_id),
+        url=url,
+    )
+    db.add(callback)
+    await db.commit()
+    await db.refresh(callback)
+    return callback
+
+
+async def delete_callback_url(db: AsyncSession, user_id: UUID, profile_id: UUID) -> bool:
+    """
+    Delete the Callback registered for this user/profile. Returns True if a row was deleted,
+    False if no matching callback exists.
+    """
+    stmt = select(Callback).where(
+        Callback.profile_id == str(profile_id), Callback.user_id == str(user_id)
+    )
+    result = await db.execute(stmt)
+    callback = result.scalars().first()
+
+    if callback is None:
+        return False
+
+    await db.delete(callback)
+    await db.commit()
+    return True
+
+
+def generate_notification_id(user_id: str, profile_id: str, review_id: str) -> str:
+    """Derive a stable notification id from the triple so retries and resends reuse the same id."""
+    return str(uuid.uuid5(NOTIFICATION_NAMESPACE, f"{user_id}:{profile_id}:{review_id}"))
+
+
+async def notify_callback_on_review_completed(
+    user_id: str, profile_id: str, review_id: str, callback_id: str, callback_url: str
+) -> None:
+    """
+    Entry point invoked (via asyncio.create_task) from process_review once a review completes,
+    with the callback already looked up by process_review (using its own session) so this
+    function doesn't need to re-query it. Opens its own database session since it runs detached
+    from the caller's request-scoped session and may still be running after process_review
+    returns.
+    """
+    async with AsyncSessionLocal() as db:
+        try:
+            notification_id = generate_notification_id(
+                str(user_id), str(profile_id), str(review_id)
+            )
+            notification = await create_notification(
+                db=db,
+                callback_id=callback_id,
+                review_id=str(review_id),
+                notification_id=notification_id,
+            )
+
+            await send_notification(db=db, notification=notification, callback_url=callback_url)
+
+        except RetriesExceededError as exc:
+            log.error(
+                "notify_callback_on_review_completed_retries_exceeded",
+                review_id=str(review_id),
+                profile_id=str(profile_id),
+                error=str(exc),
+            )
+        except Exception as exc:
+            log.error(
+                "notify_callback_on_review_completed_failed",
+                review_id=str(review_id),
+                profile_id=str(profile_id),
+                error=str(exc),
+            )
+
+
+async def create_notification(
+    db: AsyncSession, callback_id: str, review_id: str, notification_id: str
+) -> Notification:
+    """
+    Create the Notification record for this event, or reuse the existing one if this is a resend
+    (same notification_id) so retries don't create duplicate rows.
+    """
+    stmt = select(Notification).where(Notification.id == notification_id)
+    result = await db.execute(stmt)
+    notification: Notification | None = result.scalars().first()
+
+    if notification is None:
+        notification = Notification(
+            id=notification_id,
+            callback_id=callback_id,
+            review_id=review_id,
+            delivery_status="pending",
+        )
+        db.add(notification)
+        await db.commit()
+        await db.refresh(notification)
+
+    return notification
+
+
+async def send_notification(
+    db: AsyncSession, notification: Notification, callback_url: str
+) -> None:
+    """
+    POST the notification payload to callback_url, retrying up to MAX_SEND_ATTEMPTS times with a
+    SEND_TIMEOUT_SECONDS timeout per attempt. Updates delivery_status and raises
+    RetriesExceededError if every attempt fails.
+    """
+    payload = {
+        "notification_id": notification.id,
+        "review_id": notification.review_id,
+        "callback_id": notification.callback_id,
+        "event": "review.completed",
+    }
+
+    last_error: Exception | None = None
+
+    async with httpx.AsyncClient(timeout=SEND_TIMEOUT_SECONDS) as client:
+        for attempt in range(1, MAX_SEND_ATTEMPTS + 1):
+            notification.last_sent_at = datetime.utcnow()
+            try:
+                response = await client.post(callback_url, json=payload)
+                response.raise_for_status()
+
+                notification.delivery_status = "success"
+                notification.last_ack_at = datetime.utcnow()
+                db.add(notification)
+                await db.commit()
+                log.info("notification_delivered", notification_id=notification.id, attempt=attempt)
+                return
+
+            except httpx.TimeoutException as exc:
+                last_error = WebhookTimeoutError(str(exc))
+                log.warning(
+                    "notification_send_timeout", notification_id=notification.id, attempt=attempt
+                )
+            except Exception as exc:
+                last_error = exc
+                log.warning(
+                    "notification_send_failed",
+                    notification_id=notification.id,
+                    attempt=attempt,
+                    error=str(exc),
+                )
+
+    notification.delivery_status = "fail"
+    db.add(notification)
+    await db.commit()
+
+    log.error(
+        "notification_retries_exceeded",
+        notification_id=notification.id,
+        attempts=MAX_SEND_ATTEMPTS,
+    )
+    raise RetriesExceededError(
+        f"Exceeded {MAX_SEND_ATTEMPTS} attempts delivering notification {notification.id}"
+    ) from last_error

--- a/docs/API.md
+++ b/docs/API.md
@@ -25,6 +25,15 @@ Base URL: `http://localhost:8000`
 `GET /reviews/{review_id}` — Retrieve a completed review.
 `GET /reviews` — List reviews for the authenticated user (paginated).
 
+### Webhooks
+
+`POST /webhooks/callbacks` — Register a callback URL to be notified when a profile's review
+completes. Only one callback is allowed per profile; returns `409` if one is already registered,
+or `404` if the profile doesn't exist or isn't owned by the authenticated user.
+`DELETE /webhooks/callbacks/{profile_id}` — Delete the callback registered for a profile.
+
+See [Client Callback Setup](examples/CLIENT_CALLBACK_SETUP.md) for a runnable end-to-end walkthrough.
+
 ## Interactive Docs
 
 When the API is running, visit:

--- a/docs/examples/CLIENT_CALLBACK_SETUP.md
+++ b/docs/examples/CLIENT_CALLBACK_SETUP.md
@@ -1,0 +1,121 @@
+# Client Callback Setup
+
+This guide walks through running an example webhook client and using it to receive notifications of completed reviews from PathReview.
+
+The client here can be any external service that you run to receive PathReview's webhook notifications, by listening on a URL you register via the [Webhooks API](API.md#webhooks). 
+
+In [`docs/examples/client_callback_server.py`](examples/client_callback_server.py), we have provided a runnable, self-contained example implementation built with FastAPI.
+
+> **Note:** This file is a barebones example for local testing/demonstration only. PathReview does not provide a real client implementation; you are responsible for building and testing your own.
+
+## Prerequisites
+
+Complete [SETUP.md](SETUP.md) first and have the server running locally. This should set you up with a user, profile and some reviews.
+
+## Getting a token
+
+`POST /auth/login` takes form-encoded credentials (not JSON) and returns a JWT:
+
+```bash
+curl -X POST http://localhost:8000/auth/login \
+    -d "username=user1@example.com&password=password1"
+```
+
+Response: `{"access_token": "...", "token_type": "bearer"}`.
+
+All authenticated routes below (`/webhooks/callbacks`, `/reviews`) read this token through the `Authorization: Bearer <token>` header. Use the `access_token` as `<token>` in the examples below.
+
+## What can the client do (general)
+
+- `POST /register-callback` / `DELETE /delete-callback` — register a callback URL that receives the notifications and delete them anytime. Note that one cannot update the existing entry; you must delete it the existing entry first.
+- Any API/endpoint that can receive the notification payload and acknowledge it.
+- Dedup by `notification_id` — PathReview provides a way to handle idempotency on the client side using `notification_id`
+  in the example it uses an in-memory db to save the id; a real client should persist this, e.g. a unique index in its own DB.
+
+
+The notification payload shape (sent by `send_notification` in
+`core/services/webhook_service.py`):
+
+```json
+{
+    "notification_id": "...",
+    "review_id": "...",
+    "callback_id": "...",
+    "event": "review.completed"
+}
+```
+
+## Step by step client setup
+
+1. Start the example client:
+
+   ```bash
+   python docs/examples/client_callback_server.py
+   ```
+
+   This runs on `http://localhost:9000`.
+
+2. Get a `profile_id`. `make setup` seeds one or more profiles per user
+   (`user1@example.com` / `user2@example.com` / `user3@example.com`) — pick one belonging to whichever user you logged in as in the previous step. Use the email of that user to get the `profile_id`:
+
+   ```bash
+   docker compose exec db psql -U pathreview -d pathreview_dev -c \
+       "SELECT p.id, u.email FROM profiles p JOIN users u ON u.id = p.user_id WHERE u.email = 'user1@example.com';"
+   ```
+
+   You can also create a new profile with `POST /profiles` (only `github_username`/`portfolio_url`/`resume_file` are accepted, and all are optional):
+
+   ```bash
+   curl -X POST http://localhost:8000/profiles \
+       -H "Authorization: Bearer <token>" \
+       -F "github_username=someuser"
+   ```
+
+3. Register its `/callback` URL for that profile. Only one callback is allowed per profile — if you've already registered one for this profile (e.g. from a previous run of this guide), this returns `409 Conflict`; delete it first (Step 5) before re-registering. 
+
+You can directly do this against PathReview's API:
+
+   ```bash
+   curl -X POST http://localhost:8000/webhooks/callbacks \
+       -H "Authorization: Bearer <token>" \
+       -H "Content-Type: application/json" \
+       -d '{"profile_id": "...", "url": "http://localhost:9000/callback"}'
+   ```
+
+   ...or via the example client's own convenience route:
+
+   ```bash
+   curl -X POST http://localhost:9000/register-callback \
+       -H "Content-Type: application/json" \
+       -d '{"pathreview_base_url": "http://localhost:8000", "token": "<token>", "profile_id": "..."}'
+   ```
+
+4. Request a review for that profile:
+
+   ```bash
+   curl -X POST http://localhost:8000/reviews \
+       -H "Authorization: Bearer <token>" \
+       -H "Content-Type: application/json" \
+       -d '{"profile_id": "..."}'
+   ```
+
+   Once processing completes, the example client logs the received notification:
+
+   ```
+   [received] notification_id=... review_id=... callback_id=... event=review.completed
+   ```
+
+5. You can delete the callback entry when done, either directly:
+
+   ```bash
+   curl -X DELETE http://localhost:8000/webhooks/callbacks/<profile_id> \
+       -H "Authorization: Bearer <token>"
+   ```
+
+   ...or via the example client:
+
+   ```bash
+   curl -X DELETE http://localhost:9000/delete-callback \
+       -H "Content-Type: application/json" \
+       -d '{"pathreview_base_url": "http://localhost:8000", "token": "<token>", "profile_id": "..."}'
+   ```

--- a/docs/examples/client_callback_server.py
+++ b/docs/examples/client_callback_server.py
@@ -1,0 +1,92 @@
+"""Example client callback server: receives PathReview review-completed webhook notifications,
+dedupes by notification_id, and can register/delete its own callback URL.
+
+See docs/CLIENT_SETUP.md for setup and usage instructions.
+"""
+
+from typing import Any
+
+import httpx
+import uvicorn
+from fastapi import FastAPI, HTTPException, Request
+from pydantic import BaseModel
+
+app = FastAPI(title="Example PathReview Callback Client")
+
+# In-memory dedup set. A real client would persist this (e.g. a unique index on
+# notification_id in its own DB) so dedup survives a restart.
+_seen_notification_ids: set[str] = set()
+
+
+@app.post("/callback")
+async def receive_notification(request: Request) -> dict:
+    """Receive a review-completed notification and acknowledge it."""
+    payload = await request.json()
+    notification_id = payload["notification_id"]
+
+    if notification_id in _seen_notification_ids:
+        print(f"[dedup] already processed notification_id={notification_id}, skipping")
+        return {"ok": True}
+
+    # Do the real work here (e.g. notify a user, update a record). This is a
+    # placeholder standing in for that processing.
+    print(
+        f"[received] notification_id={notification_id} "
+        f"review_id={payload['review_id']} callback_id={payload['callback_id']} "
+        f"event={payload['event']}"
+    )
+    _seen_notification_ids.add(notification_id)
+
+    return {"ok": True}
+
+
+class CallbackRegistrationRequest(BaseModel):
+    pathreview_base_url: str
+    token: str
+    profile_id: str
+    # This server's own publicly reachable /callback URL, e.g. "http://localhost:9000/callback".
+    callback_url: str = "http://localhost:9000/callback"
+
+
+@app.post("/register-callback")
+async def register_callback(body: CallbackRegistrationRequest) -> dict:
+    """Register this server's /callback URL with PathReview for a profile. Proxies to
+    POST /webhooks/callbacks (see api/routes/webhooks.py)."""
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            f"{body.pathreview_base_url}/webhooks/callbacks",
+            headers={"Authorization": f"Bearer {body.token}"},
+            json={"profile_id": body.profile_id, "url": body.callback_url},
+        )
+
+    if response.status_code >= 400:
+        raise HTTPException(status_code=response.status_code, detail=response.json())
+
+    data: dict[str, Any] = response.json()
+    return data
+
+
+class CallbackDeletionRequest(BaseModel):
+    pathreview_base_url: str
+    token: str
+    profile_id: str
+
+
+@app.delete("/delete-callback")
+async def delete_callback(body: CallbackDeletionRequest) -> dict:
+    """Delete this profile's registered callback from PathReview. Proxies to
+    DELETE /webhooks/callbacks/{profile_id} (see api/routes/webhooks.py)."""
+    async with httpx.AsyncClient() as client:
+        response = await client.delete(
+            f"{body.pathreview_base_url}/webhooks/callbacks/{body.profile_id}",
+            headers={"Authorization": f"Bearer {body.token}"},
+        )
+
+    if response.status_code >= 400:
+        raise HTTPException(status_code=response.status_code, detail=response.json())
+
+    return {"ok": True}
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=9000)

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     port: 5173,
     proxy: {
       '/api': {
-        target: 'http://localhost:8000',
+        target: 'http://127.0.0.1:8000',
         changeOrigin: true,
         rewrite: (path) => path.replace(/^\/api/, '')
       }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     port: 5173,
     proxy: {
       '/api': {
-        target: 'http://127.0.0.1:8000',
+        target: 'http://localhost:8000',
         changeOrigin: true,
         rewrite: (path) => path.replace(/^\/api/, '')
       }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ select = ["E", "F", "I", "N", "W", "UP", "B", "SIM", "TCH"]
 "core/models/*.py" = ["E501"]
 "scripts/*.py" = ["E501"]
 "alembic/versions/*.py" = ["E501"]
+"api/routes/webhooks.py" = ["B008"]  # FastAPI's Depends() in argument defaults is the intended pattern.
 
 [tool.black]
 target-version = ["py311"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,11 +63,13 @@ line-length = 100
 [tool.ruff.lint]
 select = ["E", "F", "I", "N", "W", "UP", "B", "SIM", "TCH"]
 
+[tool.ruff.lint.flake8-bugbear]
+extend-immutable-calls = ["fastapi.Depends"]
+
 [tool.ruff.lint.per-file-ignores]
 "core/models/*.py" = ["E501"]
 "scripts/*.py" = ["E501"]
 "alembic/versions/*.py" = ["E501"]
-"api/routes/webhooks.py" = ["B008"]  # FastAPI's Depends() in argument defaults is the intended pattern.
 
 [tool.black]
 target-version = ["py311"]

--- a/tests/unit/test_callback.py
+++ b/tests/unit/test_callback.py
@@ -1,0 +1,120 @@
+"""Callback registration tests: registering and deleting a callback URL. This does not test or
+provide a client implementation of the callback handling itself, but client_callback_server.py
+under docs/examples shows a barebones example of how the callback URL can await for notifications
+and handle deduplication.
+"""
+
+from unittest.mock import AsyncMock, Mock
+from uuid import UUID, uuid4
+
+import pytest
+
+from core.services.webhook_service import (
+    CallbackAlreadyExistsError,
+    delete_callback_url,
+    set_callback_url,
+)
+
+
+@pytest.mark.unit
+class TestCallback:
+    """Test suite for registering/deleting a callback."""
+
+    @pytest.fixture
+    def user_id(self) -> UUID:
+        return uuid4()
+
+    @pytest.fixture
+    def profile_id(self) -> UUID:
+        return uuid4()
+
+    @pytest.fixture
+    def mock_db_session(self) -> AsyncMock:
+        """Create a mock async database session."""
+        session = AsyncMock()
+        session.add = Mock()
+        session.delete = AsyncMock()
+        session.commit = AsyncMock()
+        session.refresh = AsyncMock()
+        session.execute = AsyncMock()
+        return session
+
+    @pytest.fixture
+    def mock_callback(self, user_id: UUID, profile_id: UUID) -> Mock:
+        """Create a mock Callback object registered for user_id/profile_id."""
+        callback = Mock()
+        callback.id = str(uuid4())
+        callback.user_id = str(user_id)
+        callback.profile_id = str(profile_id)
+        callback.url = "https://client.example.com/callback"
+        return callback
+
+    @pytest.mark.asyncio
+    async def test_register_callback(
+        self, mock_db_session: AsyncMock, user_id: UUID, profile_id: UUID
+    ) -> None:
+        """Test registering a callback URL for a profile that doesn't already have one."""
+        url = "https://client.example.com/callback"
+
+        profile_result = Mock()
+        profile_result.scalars.return_value.first.return_value = Mock()
+        callback_result = Mock()
+        callback_result.scalars.return_value.first.return_value = None
+        mock_db_session.execute = AsyncMock(side_effect=[profile_result, callback_result])
+
+        result = await set_callback_url(mock_db_session, user_id, profile_id, url)
+
+        added_callback = mock_db_session.add.call_args[0][0]
+        assert added_callback.user_id == str(user_id)
+        assert added_callback.profile_id == str(profile_id)
+        assert added_callback.url == url
+        mock_db_session.commit.assert_called_once()
+        mock_db_session.refresh.assert_called_once()
+        assert result is added_callback
+
+    @pytest.mark.asyncio
+    async def test_register_callback_already_exists_raises(
+        self, mock_db_session: AsyncMock, mock_callback: Mock, user_id: UUID, profile_id: UUID
+    ) -> None:
+        """Test registering a second callback for a profile that already has one is rejected."""
+        profile_result = Mock()
+        profile_result.scalars.return_value.first.return_value = Mock()
+        callback_result = Mock()
+        callback_result.scalars.return_value.first.return_value = mock_callback
+        mock_db_session.execute = AsyncMock(side_effect=[profile_result, callback_result])
+
+        with pytest.raises(CallbackAlreadyExistsError):
+            await set_callback_url(mock_db_session, user_id, profile_id, mock_callback.url)
+
+        mock_db_session.add.assert_not_called()
+        mock_db_session.commit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_delete_callback(
+        self, mock_db_session: AsyncMock, mock_callback: Mock, user_id: UUID, profile_id: UUID
+    ) -> None:
+        """Test deleting a registered callback removes it and commits."""
+        mock_result = Mock()
+        mock_result.scalars.return_value.first.return_value = mock_callback
+        mock_db_session.execute = AsyncMock(return_value=mock_result)
+
+        result = await delete_callback_url(mock_db_session, user_id, profile_id)
+
+        assert result is True
+        mock_db_session.delete.assert_called_once_with(mock_callback)
+        mock_db_session.commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_delete_callback_returns_false_when_not_found(
+        self, mock_db_session: AsyncMock, user_id: UUID, profile_id: UUID
+    ) -> None:
+        """Test deleting a callback that isn't registered is a no-op returning False."""
+        mock_result = Mock()
+        mock_result.scalars.return_value.first.return_value = None
+        mock_db_session.execute = AsyncMock(return_value=mock_result)
+
+        result = await delete_callback_url(mock_db_session, user_id, profile_id)
+
+        assert result is False
+        mock_db_session.delete.assert_not_called()
+        mock_db_session.commit.assert_not_called()

--- a/tests/unit/test_review_service.py
+++ b/tests/unit/test_review_service.py
@@ -1,14 +1,15 @@
 """Tests for review_service.py"""
 
-import pytest
-from uuid import uuid4
 from unittest.mock import AsyncMock, Mock, patch
-import asyncio
+from uuid import UUID, uuid4
+
+import pytest
 
 from core.services.review_service import (
     create_review,
     get_review,
     list_reviews,
+    process_review,
 )
 
 
@@ -17,7 +18,7 @@ class TestReviewService:
     """Test suite for review_service module."""
 
     @pytest.fixture
-    def mock_db_session(self):
+    def mock_db_session(self) -> AsyncMock:
         """Create a mock async database session."""
         session = AsyncMock()
         session.add = Mock()
@@ -27,7 +28,7 @@ class TestReviewService:
         return session
 
     @pytest.fixture
-    def mock_review(self):
+    def mock_review(self) -> Mock:
         """Create a mock Review object."""
         review = Mock()
         review.id = uuid4()
@@ -37,7 +38,7 @@ class TestReviewService:
         return review
 
     @pytest.fixture
-    def mock_profile(self):
+    def mock_profile(self) -> Mock:
         """Create a mock Profile object."""
         profile = Mock()
         profile.id = uuid4()
@@ -45,7 +46,9 @@ class TestReviewService:
         return profile
 
     @pytest.mark.asyncio
-    async def test_create_review_returns_review_with_pending_status(self, mock_db_session, mock_review):
+    async def test_create_review_returns_review_with_pending_status(
+        self, mock_db_session: AsyncMock, mock_review: Mock
+    ) -> None:
         """Test create_review returns Review with status='pending'."""
         profile_id = uuid4()
         user_id = uuid4()
@@ -55,21 +58,23 @@ class TestReviewService:
         mock_db_session.commit = AsyncMock()
         mock_db_session.refresh = AsyncMock()
 
-        with patch('core.services.review_service.Review') as MockReview:
-            mock_instance = MockReview.return_value
+        with patch("core.services.review_service.Review") as mock_review_class:
+            mock_instance = mock_review_class.return_value
             mock_instance.status = "pending"
             mock_instance.sections = None
             mock_instance.overall_score = None
 
-            result = await create_review(mock_db_session, profile_id, user_id)
+            await create_review(mock_db_session, profile_id, user_id)
 
             # Check that Review was instantiated
-            MockReview.assert_called()
-            call_kwargs = MockReview.call_args[1]
-            assert call_kwargs['status'] == "pending"
+            mock_review_class.assert_called()
+            call_kwargs = mock_review_class.call_args[1]
+            assert call_kwargs["status"] == "pending"
 
     @pytest.mark.asyncio
-    async def test_get_review_returns_review_for_correct_owner(self, mock_db_session):
+    async def test_get_review_returns_review_for_correct_owner(
+        self, mock_db_session: AsyncMock
+    ) -> None:
         """Test get_review returns review when user_id matches."""
         review_id = uuid4()
         user_id = uuid4()
@@ -88,10 +93,9 @@ class TestReviewService:
         mock_db_session.execute.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_get_review_returns_none_for_wrong_user(self, mock_db_session):
+    async def test_get_review_returns_none_for_wrong_user(self, mock_db_session: AsyncMock) -> None:
         """Test get_review returns None when user_id doesn't match."""
         review_id = uuid4()
-        user_id = uuid4()
         wrong_user_id = uuid4()
 
         # Setup mock to return None
@@ -104,7 +108,7 @@ class TestReviewService:
         assert result is None
 
     @pytest.mark.asyncio
-    async def test_list_reviews_returns_paginated_results(self, mock_db_session):
+    async def test_list_reviews_returns_paginated_results(self, mock_db_session: AsyncMock) -> None:
         """Test list_reviews returns paginated results."""
         user_id = uuid4()
 
@@ -123,7 +127,9 @@ class TestReviewService:
         assert total >= 0
 
     @pytest.mark.asyncio
-    async def test_list_reviews_page_2_returns_correct_offset(self, mock_db_session):
+    async def test_list_reviews_page_2_returns_correct_offset(
+        self, mock_db_session: AsyncMock
+    ) -> None:
         """Test list_reviews page 2 returns correct offset."""
         user_id = uuid4()
         page_size = 20
@@ -133,9 +139,7 @@ class TestReviewService:
         mock_result.scalars.return_value.all.return_value = []
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
-        reviews, total = await list_reviews(
-            mock_db_session, user_id, page=2, page_size=page_size
-        )
+        await list_reviews(mock_db_session, user_id, page=2, page_size=page_size)
 
         # Second call should pass offset for page 2
         calls = mock_db_session.execute.call_args_list
@@ -143,7 +147,7 @@ class TestReviewService:
         assert len(calls) > 0
 
     @pytest.mark.asyncio
-    async def test_list_reviews_returns_tuple(self, mock_db_session):
+    async def test_list_reviews_returns_tuple(self, mock_db_session: AsyncMock) -> None:
         """Test list_reviews returns (reviews, total) tuple."""
         user_id = uuid4()
 
@@ -160,40 +164,40 @@ class TestReviewService:
         assert isinstance(total, int)
 
     @pytest.mark.asyncio
-    async def test_create_review_calls_db_add(self, mock_db_session):
+    async def test_create_review_calls_db_add(self, mock_db_session: AsyncMock) -> None:
         """Test create_review calls db.add()."""
         profile_id = uuid4()
         user_id = uuid4()
 
-        with patch('core.services.review_service.Review'):
+        with patch("core.services.review_service.Review"):
             await create_review(mock_db_session, profile_id, user_id)
 
             mock_db_session.add.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_create_review_calls_db_commit(self, mock_db_session):
+    async def test_create_review_calls_db_commit(self, mock_db_session: AsyncMock) -> None:
         """Test create_review calls db.commit()."""
         profile_id = uuid4()
         user_id = uuid4()
 
-        with patch('core.services.review_service.Review'):
+        with patch("core.services.review_service.Review"):
             await create_review(mock_db_session, profile_id, user_id)
 
             mock_db_session.commit.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_create_review_calls_db_refresh(self, mock_db_session):
+    async def test_create_review_calls_db_refresh(self, mock_db_session: AsyncMock) -> None:
         """Test create_review calls db.refresh()."""
         profile_id = uuid4()
         user_id = uuid4()
 
-        with patch('core.services.review_service.Review'):
+        with patch("core.services.review_service.Review"):
             await create_review(mock_db_session, profile_id, user_id)
 
             mock_db_session.refresh.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_get_review_uses_select_and_join(self, mock_db_session):
+    async def test_get_review_uses_select_and_join(self, mock_db_session: AsyncMock) -> None:
         """Test get_review constructs proper SQL with join."""
         review_id = uuid4()
         user_id = uuid4()
@@ -208,7 +212,7 @@ class TestReviewService:
         mock_db_session.execute.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_list_reviews_default_pagination(self, mock_db_session):
+    async def test_list_reviews_default_pagination(self, mock_db_session: AsyncMock) -> None:
         """Test list_reviews uses default pagination."""
         user_id = uuid4()
 
@@ -223,7 +227,7 @@ class TestReviewService:
         assert isinstance(total, int)
 
     @pytest.mark.asyncio
-    async def test_list_reviews_custom_page_size(self, mock_db_session):
+    async def test_list_reviews_custom_page_size(self, mock_db_session: AsyncMock) -> None:
         """Test list_reviews with custom page size."""
         user_id = uuid4()
         custom_page_size = 50
@@ -239,21 +243,21 @@ class TestReviewService:
         assert isinstance(reviews, list)
 
     @pytest.mark.asyncio
-    async def test_create_review_with_uuid_ids(self, mock_db_session):
+    async def test_create_review_with_uuid_ids(self, mock_db_session: AsyncMock) -> None:
         """Test create_review handles UUID objects correctly."""
         profile_id = uuid4()
         user_id = uuid4()
 
-        with patch('core.services.review_service.Review') as MockReview:
-            MockReview.return_value = Mock()
+        with patch("core.services.review_service.Review") as mock_review_class:
+            mock_review_class.return_value = Mock()
             await create_review(mock_db_session, profile_id, user_id)
 
-            call_kwargs = MockReview.call_args[1]
-            assert 'profile_id' in call_kwargs
-            assert 'status' in call_kwargs
+            call_kwargs = mock_review_class.call_args[1]
+            assert "profile_id" in call_kwargs
+            assert "status" in call_kwargs
 
     @pytest.mark.asyncio
-    async def test_get_review_verifies_ownership(self, mock_db_session):
+    async def test_get_review_verifies_ownership(self, mock_db_session: AsyncMock) -> None:
         """Test get_review checks Profile.user_id matches."""
         review_id = uuid4()
         user_id = uuid4()
@@ -268,7 +272,7 @@ class TestReviewService:
         mock_db_session.execute.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_list_reviews_counts_total(self, mock_db_session):
+    async def test_list_reviews_counts_total(self, mock_db_session: AsyncMock) -> None:
         """Test list_reviews calculates total count."""
         user_id = uuid4()
 
@@ -283,11 +287,11 @@ class TestReviewService:
         assert isinstance(total, int)
 
     @pytest.mark.asyncio
-    async def test_list_reviews_returns_reviews_list(self, mock_db_session):
+    async def test_list_reviews_returns_reviews_list(self, mock_db_session: AsyncMock) -> None:
         """Test list_reviews returns list of Review objects."""
         user_id = uuid4()
 
-        mock_reviews = [Mock(spec=['id', 'status']) for _ in range(3)]
+        mock_reviews = [Mock(spec=["id", "status"]) for _ in range(3)]
         mock_result = AsyncMock()
         mock_result.scalars.return_value.all.return_value = mock_reviews
         mock_db_session.execute = AsyncMock(return_value=mock_result)
@@ -297,21 +301,23 @@ class TestReviewService:
         assert isinstance(reviews, list)
 
     @pytest.mark.asyncio
-    async def test_review_sections_and_score_initially_none(self, mock_db_session):
+    async def test_review_sections_and_score_initially_none(
+        self, mock_db_session: AsyncMock
+    ) -> None:
         """Test review has None for sections and overall_score initially."""
         profile_id = uuid4()
         user_id = uuid4()
 
-        with patch('core.services.review_service.Review') as MockReview:
-            MockReview.return_value = Mock()
+        with patch("core.services.review_service.Review") as mock_review_class:
+            mock_review_class.return_value = Mock()
             await create_review(mock_db_session, profile_id, user_id)
 
-            call_kwargs = MockReview.call_args[1]
-            assert call_kwargs['sections'] is None
-            assert call_kwargs['overall_score'] is None
+            call_kwargs = mock_review_class.call_args[1]
+            assert call_kwargs["sections"] is None
+            assert call_kwargs["overall_score"] is None
 
     @pytest.mark.asyncio
-    async def test_get_review_with_valid_uuid(self, mock_db_session):
+    async def test_get_review_with_valid_uuid(self, mock_db_session: AsyncMock) -> None:
         """Test get_review handles valid UUID parameters."""
         review_id = uuid4()
         user_id = uuid4()
@@ -326,7 +332,110 @@ class TestReviewService:
         assert result is None or result is not None  # Just verify no exception
 
     @pytest.mark.asyncio
-    async def test_list_reviews_ordered_by_created_at(self, mock_db_session):
+    async def test_process_review_schedules_notification_when_callback_registered(
+        self, mock_db_session: AsyncMock, mock_review: Mock, mock_profile: Mock
+    ) -> None:
+        """Test process_review schedules notify_callback_on_review_completed via
+        asyncio.create_task when a Callback is registered for the profile."""
+        review_id = uuid4()
+        profile_id: UUID = mock_profile.id
+
+        mock_callback = Mock()
+        mock_callback.id = str(uuid4())
+        mock_callback.url = "https://client.example.com/callback"
+
+        review_result = Mock()
+        review_result.scalars.return_value.first.return_value = mock_review
+        profile_result = Mock()
+        profile_result.scalars.return_value.first.return_value = mock_profile
+        callback_result = Mock()
+        callback_result.scalars.return_value.first.return_value = mock_callback
+        mock_db_session.execute = AsyncMock(
+            side_effect=[review_result, profile_result, callback_result]
+        )
+
+        with (
+            patch(
+                "core.services.review_service._run_ingestion_pipeline",
+                new=AsyncMock(return_value=[]),
+            ),
+            patch(
+                "core.services.review_service._run_agent_orchestration",
+                new=AsyncMock(return_value={"sections": []}),
+            ),
+            patch(
+                "core.services.review_service._run_rag_retrieval_generation",
+                new=AsyncMock(return_value={"sections": [], "overall_score": 0.9}),
+            ),
+            patch(
+                "core.services.review_service._run_safety_checks",
+                new=AsyncMock(return_value=True),
+            ),
+            patch(
+                "core.services.review_service.notify_callback_on_review_completed",
+                new=AsyncMock(),
+            ) as mock_notify,
+            patch("core.services.review_service.asyncio.create_task") as mock_create_task,
+        ):
+            await process_review(mock_db_session, review_id, profile_id)
+
+            mock_create_task.assert_called_once()
+            # The scheduled coroutine is never awaited by create_task (it's mocked out),
+            # so await it directly to drive the underlying AsyncMock and avoid a warning.
+            await mock_create_task.call_args[0][0]
+
+        mock_notify.assert_called_once_with(
+            user_id=mock_profile.user_id,
+            profile_id=str(profile_id),
+            review_id=str(review_id),
+            callback_id=mock_callback.id,
+            callback_url=mock_callback.url,
+        )
+
+    @pytest.mark.asyncio
+    async def test_process_review_skips_notification_when_no_callback_registered(
+        self, mock_db_session: AsyncMock, mock_review: Mock, mock_profile: Mock
+    ) -> None:
+        """Test process_review doesn't schedule a notification when no Callback is
+        registered for the profile."""
+        review_id = uuid4()
+        profile_id: UUID = mock_profile.id
+
+        review_result = Mock()
+        review_result.scalars.return_value.first.return_value = mock_review
+        profile_result = Mock()
+        profile_result.scalars.return_value.first.return_value = mock_profile
+        callback_result = Mock()
+        callback_result.scalars.return_value.first.return_value = None
+        mock_db_session.execute = AsyncMock(
+            side_effect=[review_result, profile_result, callback_result]
+        )
+
+        with (
+            patch(
+                "core.services.review_service._run_ingestion_pipeline",
+                new=AsyncMock(return_value=[]),
+            ),
+            patch(
+                "core.services.review_service._run_agent_orchestration",
+                new=AsyncMock(return_value={"sections": []}),
+            ),
+            patch(
+                "core.services.review_service._run_rag_retrieval_generation",
+                new=AsyncMock(return_value={"sections": [], "overall_score": 0.9}),
+            ),
+            patch(
+                "core.services.review_service._run_safety_checks",
+                new=AsyncMock(return_value=True),
+            ),
+            patch("core.services.review_service.asyncio.create_task") as mock_create_task,
+        ):
+            await process_review(mock_db_session, review_id, profile_id)
+
+            mock_create_task.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_list_reviews_ordered_by_created_at(self, mock_db_session: AsyncMock) -> None:
         """Test list_reviews returns results ordered by created_at desc."""
         user_id = uuid4()
 
@@ -334,7 +443,7 @@ class TestReviewService:
         mock_result.scalars.return_value.all.return_value = []
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
-        reviews, total = await list_reviews(mock_db_session, user_id)
+        await list_reviews(mock_db_session, user_id)
 
         # Should order by created_at descending
         mock_db_session.execute.assert_called_once()

--- a/tests/unit/test_webhook_service.py
+++ b/tests/unit/test_webhook_service.py
@@ -1,0 +1,398 @@
+"""Tests for webhook_service.py"""
+
+from collections.abc import Sequence
+from unittest.mock import AsyncMock, Mock, patch
+from uuid import uuid4
+
+import httpx
+import pytest
+
+from core.services.webhook_service import (
+    CallbackAlreadyExistsError,
+    ProfileNotFoundError,
+    RetriesExceededError,
+    WebhookTimeoutError,
+    create_notification,
+    delete_callback_url,
+    generate_notification_id,
+    notify_callback_on_review_completed,
+    send_notification,
+    set_callback_url,
+)
+
+
+def _async_client(post_side_effect: BaseException | Sequence[object] | object) -> AsyncMock:
+    """Build a mock for `async with httpx.AsyncClient() as client` where client.post has the
+    given side_effect (a value, an exception, or a list for successive calls)."""
+    client = AsyncMock()
+    client.post = AsyncMock(side_effect=post_side_effect)
+    context_manager = AsyncMock()
+    context_manager.__aenter__ = AsyncMock(return_value=client)
+    context_manager.__aexit__ = AsyncMock(return_value=False)
+    return context_manager
+
+
+def _response(status_code: int = 200) -> Mock:
+    response = Mock()
+    response.raise_for_status = Mock()
+    response.status_code = status_code
+    return response
+
+
+@pytest.mark.unit
+class TestWebhookService:
+    """Test suite for webhook_service module."""
+
+    @pytest.fixture
+    def mock_db_session(self) -> AsyncMock:
+        """Create a mock async database session."""
+        session = AsyncMock()
+        session.add = Mock()
+        session.delete = AsyncMock()
+        session.commit = AsyncMock()
+        session.refresh = AsyncMock()
+        session.execute = AsyncMock()
+        return session
+
+    @pytest.fixture
+    def mock_callback(self) -> Mock:
+        """Create a mock Callback object."""
+        callback = Mock()
+        callback.id = str(uuid4())
+        callback.user_id = str(uuid4())
+        callback.profile_id = str(uuid4())
+        callback.url = "https://client.example.com/callback"
+        return callback
+
+    @pytest.fixture
+    def mock_notification(self) -> Mock:
+        """Create a mock Notification object."""
+        notification = Mock()
+        notification.id = str(uuid4())
+        notification.callback_id = str(uuid4())
+        notification.review_id = str(uuid4())
+        notification.delivery_status = "retry"
+        notification.last_sent_at = None
+        notification.last_ack_at = None
+        return notification
+
+    @pytest.mark.asyncio
+    async def test_set_callback_url_success(self, mock_db_session: AsyncMock) -> None:
+        """Test set_callback_url creates a Callback when none exists for the profile."""
+        user_id = uuid4()
+        profile_id = uuid4()
+        url = "https://client.example.com/callback"
+
+        profile_result = Mock()
+        profile_result.scalars.return_value.first.return_value = Mock()
+        callback_result = Mock()
+        callback_result.scalars.return_value.first.return_value = None
+        mock_db_session.execute = AsyncMock(side_effect=[profile_result, callback_result])
+
+        result = await set_callback_url(mock_db_session, user_id, profile_id, url)
+
+        added_callback = mock_db_session.add.call_args[0][0]
+        assert added_callback.user_id == str(user_id)
+        assert added_callback.profile_id == str(profile_id)
+        assert added_callback.url == url
+        mock_db_session.add.assert_called_once()
+        mock_db_session.commit.assert_called_once()
+        mock_db_session.refresh.assert_called_once()
+        assert result is added_callback
+
+    @pytest.mark.asyncio
+    async def test_set_callback_url_profile_not_owned_raises(
+        self, mock_db_session: AsyncMock
+    ) -> None:
+        """Test set_callback_url raises when the profile doesn't belong to user_id."""
+        user_id = uuid4()
+        profile_id = uuid4()
+
+        profile_result = Mock()
+        profile_result.scalars.return_value.first.return_value = None
+        mock_db_session.execute = AsyncMock(return_value=profile_result)
+
+        with pytest.raises(ProfileNotFoundError):
+            await set_callback_url(mock_db_session, user_id, profile_id, "https://example.com/cb")
+
+        mock_db_session.add.assert_not_called()
+        mock_db_session.commit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_set_callback_url_already_exists_raises(
+        self, mock_db_session: AsyncMock, mock_callback: Mock
+    ) -> None:
+        """Test set_callback_url raises when a callback already exists for the profile."""
+        user_id = uuid4()
+        profile_id = uuid4()
+
+        profile_result = Mock()
+        profile_result.scalars.return_value.first.return_value = Mock()
+        callback_result = Mock()
+        callback_result.scalars.return_value.first.return_value = mock_callback
+        mock_db_session.execute = AsyncMock(side_effect=[profile_result, callback_result])
+
+        with pytest.raises(CallbackAlreadyExistsError):
+            await set_callback_url(mock_db_session, user_id, profile_id, "https://example.com/cb")
+
+        mock_db_session.add.assert_not_called()
+        mock_db_session.commit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_delete_callback_url_success(
+        self, mock_db_session: AsyncMock, mock_callback: Mock
+    ) -> None:
+        """Test delete_callback_url deletes and commits when a matching callback is found."""
+        user_id = uuid4()
+        profile_id = uuid4()
+
+        mock_result = Mock()
+        mock_result.scalars.return_value.first.return_value = mock_callback
+        mock_db_session.execute = AsyncMock(return_value=mock_result)
+
+        result = await delete_callback_url(mock_db_session, user_id, profile_id)
+
+        assert result is True
+        mock_db_session.delete.assert_called_once_with(mock_callback)
+        mock_db_session.commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_delete_callback_url_returns_false_when_not_found(
+        self, mock_db_session: AsyncMock
+    ) -> None:
+        """Test delete_callback_url returns False when no matching callback exists."""
+        user_id = uuid4()
+        profile_id = uuid4()
+
+        mock_result = Mock()
+        mock_result.scalars.return_value.first.return_value = None
+        mock_db_session.execute = AsyncMock(return_value=mock_result)
+
+        result = await delete_callback_url(mock_db_session, user_id, profile_id)
+
+        assert result is False
+        mock_db_session.delete.assert_not_called()
+        mock_db_session.commit.assert_not_called()
+
+    def test_generate_notification_id_is_deterministic(self) -> None:
+        """Test generate_notification_id returns the same id for the same triple."""
+        user_id, profile_id, review_id = str(uuid4()), str(uuid4()), str(uuid4())
+
+        first = generate_notification_id(user_id, profile_id, review_id)
+        second = generate_notification_id(user_id, profile_id, review_id)
+
+        assert first == second
+
+    def test_generate_notification_id_differs_across_reviews(self) -> None:
+        """Test generate_notification_id returns a different id for a different review_id."""
+        user_id, profile_id = str(uuid4()), str(uuid4())
+
+        first = generate_notification_id(user_id, profile_id, str(uuid4()))
+        second = generate_notification_id(user_id, profile_id, str(uuid4()))
+
+        assert first != second
+
+    @pytest.mark.asyncio
+    async def test_create_notification_creates_new_when_none_exists(
+        self, mock_db_session: AsyncMock
+    ) -> None:
+        """Test create_notification inserts a new row when none exists for this id."""
+        mock_result = Mock()
+        mock_result.scalars.return_value.first.return_value = None
+        mock_db_session.execute = AsyncMock(return_value=mock_result)
+
+        result = await create_notification(
+            mock_db_session,
+            callback_id="callback-1",
+            review_id="review-1",
+            notification_id="notif-1",
+        )
+
+        added_notification = mock_db_session.add.call_args[0][0]
+        assert added_notification.id == "notif-1"
+        assert added_notification.callback_id == "callback-1"
+        assert added_notification.review_id == "review-1"
+        assert added_notification.delivery_status == "pending"
+        mock_db_session.add.assert_called_once()
+        mock_db_session.commit.assert_called_once()
+        assert result is added_notification
+
+    @pytest.mark.asyncio
+    async def test_create_notification_reuses_existing_for_resend(
+        self, mock_db_session: AsyncMock, mock_notification: Mock
+    ) -> None:
+        """Test create_notification reuses the existing row instead of inserting a duplicate."""
+        mock_result = Mock()
+        mock_result.scalars.return_value.first.return_value = mock_notification
+        mock_db_session.execute = AsyncMock(return_value=mock_result)
+
+        result = await create_notification(
+            mock_db_session,
+            callback_id="callback-1",
+            review_id="review-1",
+            notification_id=mock_notification.id,
+        )
+
+        mock_db_session.add.assert_not_called()
+        mock_db_session.commit.assert_not_called()
+        assert result == mock_notification
+
+    @pytest.mark.asyncio
+    async def test_send_notification_success_first_attempt(
+        self, mock_db_session: AsyncMock, mock_notification: Mock
+    ) -> None:
+        """Test send_notification marks the notification 'success' on the first attempt, posting
+        a payload built from the notification's own id/review_id/callback_id."""
+        context_manager = _async_client(post_side_effect=[_response(200)])
+
+        with patch("core.services.webhook_service.httpx.AsyncClient", return_value=context_manager):
+            await send_notification(mock_db_session, mock_notification, "https://example.com/cb")
+
+        assert mock_notification.delivery_status == "success"
+        assert mock_notification.last_ack_at is not None
+        mock_db_session.commit.assert_called_once()
+
+        client = context_manager.__aenter__.return_value
+        client.post.assert_awaited_once_with(
+            "https://example.com/cb",
+            json={
+                "notification_id": mock_notification.id,
+                "review_id": mock_notification.review_id,
+                "callback_id": mock_notification.callback_id,
+                "event": "review.completed",
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_send_notification_retries_then_succeeds(
+        self, mock_db_session: AsyncMock, mock_notification: Mock
+    ) -> None:
+        """Test send_notification retries after a failed attempt and succeeds, reusing a single
+        AsyncClient (opened once) across attempts rather than opening one per attempt."""
+        context_manager = _async_client(
+            post_side_effect=[httpx.ConnectError("boom"), _response(200)]
+        )
+
+        with patch("core.services.webhook_service.httpx.AsyncClient", return_value=context_manager):
+            await send_notification(mock_db_session, mock_notification, "https://example.com/cb")
+
+        assert mock_notification.delivery_status == "success"
+        # One client is opened for the whole call, reused across both post attempts.
+        assert context_manager.__aenter__.await_count == 1
+        client = context_manager.__aenter__.return_value
+        assert client.post.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_send_notification_raises_after_max_attempts(
+        self, mock_db_session: AsyncMock, mock_notification: Mock
+    ) -> None:
+        """Test send_notification raises RetriesExceededError once every attempt fails, still
+        reusing a single AsyncClient across all MAX_SEND_ATTEMPTS attempts."""
+        context_manager = _async_client(post_side_effect=httpx.ConnectError("boom"))
+
+        with (
+            patch("core.services.webhook_service.httpx.AsyncClient", return_value=context_manager),
+            pytest.raises(RetriesExceededError),
+        ):
+            await send_notification(mock_db_session, mock_notification, "https://example.com/cb")
+
+        assert mock_notification.delivery_status == "fail"
+        assert context_manager.__aenter__.await_count == 1
+        client = context_manager.__aenter__.return_value
+        assert client.post.await_count == 3
+
+    @pytest.mark.asyncio
+    async def test_send_notification_timeout_raises_retries_exceeded(
+        self, mock_db_session: AsyncMock, mock_notification: Mock
+    ) -> None:
+        """Test send_notification wraps a timeout on every attempt as RetriesExceededError."""
+        context_manager = _async_client(post_side_effect=httpx.TimeoutException("timed out"))
+
+        with (
+            patch("core.services.webhook_service.httpx.AsyncClient", return_value=context_manager),
+            pytest.raises(RetriesExceededError) as exc_info,
+        ):
+            await send_notification(mock_db_session, mock_notification, "https://example.com/cb")
+
+        assert isinstance(exc_info.value.__cause__, WebhookTimeoutError)
+        assert mock_notification.delivery_status == "fail"
+
+    @pytest.mark.asyncio
+    async def test_notify_callback_on_review_completed_success(
+        self, mock_db_session: AsyncMock, mock_callback: Mock
+    ) -> None:
+        """Test notify_callback_on_review_completed creates and sends a notification using the
+        callback_id/callback_url passed in by the caller, without re-querying Callback."""
+        session_cm = AsyncMock()
+        session_cm.__aenter__ = AsyncMock(return_value=mock_db_session)
+        session_cm.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch("core.services.webhook_service.AsyncSessionLocal", return_value=session_cm),
+            patch(
+                "core.services.webhook_service.create_notification", new=AsyncMock()
+            ) as mock_create,
+            patch("core.services.webhook_service.send_notification", new=AsyncMock()) as mock_send,
+        ):
+            await notify_callback_on_review_completed(
+                user_id=str(uuid4()),
+                profile_id=mock_callback.profile_id,
+                review_id=str(uuid4()),
+                callback_id=mock_callback.id,
+                callback_url=mock_callback.url,
+            )
+
+            mock_create.assert_called_once()
+            assert mock_create.call_args[1]["callback_id"] == mock_callback.id
+            mock_send.assert_called_once()
+            assert mock_send.call_args[1]["callback_url"] == mock_callback.url
+            mock_db_session.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_notify_callback_on_review_completed_swallows_retries_exceeded(
+        self, mock_db_session: AsyncMock, mock_callback: Mock
+    ) -> None:
+        """Test notify_callback_on_review_completed catches RetriesExceededError and doesn't
+        raise."""
+        session_cm = AsyncMock()
+        session_cm.__aenter__ = AsyncMock(return_value=mock_db_session)
+        session_cm.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch("core.services.webhook_service.AsyncSessionLocal", return_value=session_cm),
+            patch("core.services.webhook_service.create_notification", new=AsyncMock()),
+            patch(
+                "core.services.webhook_service.send_notification",
+                new=AsyncMock(side_effect=RetriesExceededError("exceeded")),
+            ),
+        ):
+            # Should not raise.
+            await notify_callback_on_review_completed(
+                user_id=str(uuid4()),
+                profile_id=mock_callback.profile_id,
+                review_id=str(uuid4()),
+                callback_id=mock_callback.id,
+                callback_url=mock_callback.url,
+            )
+
+    @pytest.mark.asyncio
+    async def test_notify_callback_on_review_completed_swallows_lookup_error(
+        self, mock_db_session: AsyncMock, mock_callback: Mock
+    ) -> None:
+        """Test notify_callback_on_review_completed catches an error from create_notification's
+        own DB lookup and doesn't raise."""
+        mock_db_session.execute = AsyncMock(side_effect=RuntimeError("db unavailable"))
+
+        session_cm = AsyncMock()
+        session_cm.__aenter__ = AsyncMock(return_value=mock_db_session)
+        session_cm.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("core.services.webhook_service.AsyncSessionLocal", return_value=session_cm):
+            # Should not raise.
+            await notify_callback_on_review_completed(
+                user_id=str(uuid4()),
+                profile_id=str(uuid4()),
+                review_id=str(uuid4()),
+                callback_id=mock_callback.id,
+                callback_url=mock_callback.url,
+            )


### PR DESCRIPTION
## Summary

In the current implementation, a user has a Reviews tab that lets them see the progress of their reviews. However, there isn't a way to notify users when reviews are completed, and it is up to the user to check it themselves. Adding a webhook as a new route helps to set up notifications and notify when each review is processed.

## Issue

Closes #87

## Changes

- Added `Callback` and `Notification` models and the corresponding migration.
- Added `webhook_service.py` with registration/removal + delivery (3 retries, 5s timeout per attempt).
- Added `POST /webhooks/callbacks` and `DELETE /webhooks/callbacks/{profile_id}` routes and schemas.
- Updated `process_review` in `review_service.py` to call `notify_callback_on_review_completed` as a separate task, so notifications are sent without blocking `process_review`.
- Added a runnable example client with dedup, plus a setup walkthrough, and updated [docs/API.md](docs/API.md) with a new `### Webhooks` section and example link.
- Added missing type packages to the pre-commit `mypy` hook so it checks against real types (see [Notes for Reviewers](#notes-for-reviewers)).
- Fixed a `B008` lint issue during the pre-commit hook (see [Notes for Reviewers](#notes-for-reviewers)).

## Testing

- **Unit tests** (`tests/unit/test_webhook_service.py`, `tests/unit/test_callback.py`, 20 total) cover:
  - Registering/deleting a callback (success, already-exists `409`, profile-not-owned `404`).
  - Notification create/dedup by `notification_id`.
  - `send_notification`'s success/retry/max-attempts/timeout paths.

These mock `httpx.AsyncClient` to assert the exact POST payload and retry/attempt counts, rather than just the end state.

- **Manual end-to-end run** (more details in [docs/examples/client_callback_setup.md](docs/examples/client_callback_setup.md)) against a live server (Postgres/Redis via `docker compose`, API on `:8000`, example client on `:9000`):
  1. Logged in.
  2. Registered a callback for a seeded profile.
  3. Requested a review.
  4. Confirmed the client's `/callback` received the notification and logged it.
  5. Confirmed `delivery_status` flipped to `success` in the DB.
  6. Unregistered the callback and confirmed the row was deleted.

**Checklist**

- [x] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`)
- [x] Linter passes (`make lint`)
- [x] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes

## Screenshots / Demo

N/A — changes are only on the backend, so no screenshots/demo needed. Step-by-step instructions to test the client callback are mentioned in [##Testing](Testing)

## Notes for Reviewers

- Integration tests are not set up in the project as of now, hence skipping integration test checks.
- Added missing type packages to the `mypy` hook in `pre-commit-config.yaml`; otherwise the pre-commit hook fails for successful tests.
- **Lint errors:** ~202 errors repo-wide before the change, mostly:
  - `B904` — `raise` inside `except` without `from err` / `from None`
  - `B008` — do not perform function call `Depends` in argument defaults; instead, perform the call within the function, or read the default from a module-level singleton variable, due to FastAPI's `Depends()`

  Fix made for `B008`(scoped for my changes) to pass the pre-commit hook — in `api/routes/webhooks.py`, added the following to `pyproject.toml`:

  ```toml
  [tool.ruff.lint.flake8-bugbear]
  extend-immutable-calls = ["fastapi.Depends"]
  ```

  This prevents ruff checks from flagging the issue related to [using calls for default arguments](https://docs.astral.sh/ruff/settings/#lint_flake8-boolean-trap_extend-allowed-calls). This change is project-wide, so I've tested it to confirm it doesn't break anything else.

- **Typing errors:** 114 errors repo-wide before the change. Made the following fixes (scoped to my changes) to pass the pre-commit hook:
  - `core/services/webhook_service.py`, `tests/unit/test_review_service.py` — added `db: AsyncSession` typing to 4 functions; annotated `notification: Notification | None` to fix `Returning Any`.
  - `tests/unit/test_callback.py` — fully annotated every fixture/test.
  - `docs/examples/client_callback_server.py` — annotated `data: dict[str, Any] = response.json()` to fix `Returning Any`.
  - `tests/unit/test_webhook_service.py` — fully annotated every fixture/test.
  - `api/routes/webhooks.py` — added `db: AsyncSession`, `-> CallbackResponse` / `-> None` return types; fixed `current_user.id` (`str`) → `UUID(current_user.id)` at both call sites.
  - `core/services/review_service.py` — added `db: AsyncSession` typing to 4 functions; annotated `notification: Notification | None` to fix `Returning Any`.
  - `tests/unit/test_review_service.py` — fully annotated every fixture/test.

