### PR TITLE
test: restore missing basic_profile sample portfolio fixture

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,28 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/106
+
+**Issue title:** Shared test fixture for a sample user profile is missing from `tests/fixtures/`
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+PathReview's test suite is meant to share a single canned user portfolio —
+stored at `tests/fixtures/sample_profiles/basic_profile.json` — that
+integration tests load to drive the ingestion and review pipeline end to end.
+That fixture (in fact the entire `tests/fixtures/` directory) is currently
+missing from the repo, so any test depending on it cannot run and is skipped,
+leaving that pipeline path unverified. Fixing it means recreating the fixture
+as a realistic sample portfolio: a GitHub username, resume text, and two
+repositories described with the GitHub-API-style fields the ingestion parsers
+already expect (`name`, `language`, `stargazers_count`, `html_url`,
+`readme_content`, etc.). Once the file exists and matches those shapes, the
+dependent integration tests can load real data and exercise the pipeline
+instead of being skipped. The change is confined to test fixtures (and possibly
+a small loader in `tests/conftest.py`) and touches no production code.
+
+**Branch name:** test/106-restore-basic-profile-fixture
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -26,3 +26,11 @@ a small loader in `tests/conftest.py`) and touches no production code.
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduce the issue and plan the fix
+
+**Reproduction commit:** https://github.com/ujval9/pathreview/commit/f06165a1bdd781cd4331f20aaf30103c7e5a8451
+
+**PLAN.md:** https://github.com/ujval9/pathreview/blob/test/106-restore-basic-profile-fixture/PLAN.md
+
+**Walkthrough video:** Not recorded.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -29,6 +29,21 @@ a small loader in `tests/conftest.py`) and touches no production code.
 
 ## Week 8 — Reproduce the issue and plan the fix
 
+**Reproduction summary:**
+Before reproducing, I checked the repo's actual state rather than trusting the
+issue text: `git log --all --full-history -- tests/fixtures/**` returns zero
+commits, meaning the fixture never existed in history, and `origin/main` is
+identical to `upstream/main` (0 commits apart either way), so this isn't a
+stale-fork issue. `tests/integration/` contained only an empty `__init__.py` —
+no existing test depended on the fixture. To make the bug concrete and
+verifiable, I added a `basic_profile` loader fixture to `tests/conftest.py`
+and a new integration test, `tests/integration/test_sample_profile_fixture.py`,
+that loads `tests/fixtures/sample_profiles/basic_profile.json` and feeds it
+through `RepoAnalyzer` and `ResumeParser`. Running
+`pytest tests/integration -m integration -v` fails all three tests with
+`FileNotFoundError` at the fixture-load step, before any parser code runs —
+confirming the root cause is simply that the fixture file is missing.
+
 **Reproduction commit:** https://github.com/ujval9/pathreview/commit/f06165a1bdd781cd4331f20aaf30103c7e5a8451
 
 **PLAN.md:** https://github.com/ujval9/pathreview/blob/test/106-restore-basic-profile-fixture/PLAN.md

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -25,4 +25,4 @@ a small loader in `tests/conftest.py`) and touches no production code.
 
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
-**Cohort ledger:** [ ] Issue added to cohort ledger
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -77,7 +77,7 @@ None.
 
 ### Check-in 2 (end of week)
 
-**PR link:** _pending — filled in once the PR is opened_
+**PR link:** https://github.com/ascherj/pathreview/pull/711
 
 **Branch:** `test/106-restore-basic-profile-fixture`
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -98,3 +98,61 @@ unit/integration tests that exercise it.
 **Self-review confirmation:** [x] make check passes (no new failures vs. documented pre-existing baseline)  [x] make test-unit passes (no new failures vs. documented pre-existing baseline)
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No review has come in yet. I opened PR #711 as ready-for-review and shared it in
+the cohort Slack channel; if feedback arrives before the deadline I will update
+this entry.
+
+**How you responded:**
+_(No feedback yet — nothing to respond to.)_
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The biggest surprise was codebase navigation. Before this module I had never had
+to understand an architecture I didn't write — tracing how the services, routes,
+and ingestion parsers fit together was fascinating but genuinely challenging. It
+forced me to slow down and work in a structured way — reading the code and git
+history before touching anything — instead of jumping straight into "vibe
+coding." That shift, from writing code first to understanding the system first,
+was the hardest and most valuable part.
+
+**What did you learn about working in a large codebase?**
+A codebase you didn't structure yourself is much harder to navigate than a
+personal project, where I always know where things are because I put them there.
+What helped was reading first: following the existing architecture, function
+signatures, and tests to build a mental model before changing anything. In my
+own projects I rarely design a deliberate structure or navigate it that way;
+here I learned to lean on the project's conventions (and on AI to explain data
+flow) to understand the system design before contributing to it.
+
+**How did AI tools help — and where did they fall short?**
+AI was most useful for understanding — explaining the architecture, how data
+flows through an unfamiliar system, and brainstorming different approaches and
+their trade-offs. Where it fell short was scope: it would sometimes propose a
+complex solution to a simple problem, or generate code that wasn't actually
+needed. Keeping the change minimal and confined to exactly what issue #106
+required was something I had to judge myself.
+
+**What would you do differently if you started over?**
+I would spend more time up front planning and understanding the structure before
+writing anything. Now that I know how to approach a codebase systematically and
+how to write a clear PLAN.md, I would also feel confident reaching for a more
+challenging (Tier 2) issue — choosing a Tier 1 for my first contribution was the
+right call, but I'd push myself further next time.
+
+**What are you most proud of from this module?**
+Completing my first open-source contribution end to end on someone else's
+production codebase. I'm proud that I did it in a structured way — reproducing
+the issue, writing a real PLAN.md, and producing a clear, well-documented PR,
+none of which I had done in a disciplined manner before — and that I got
+comfortable navigating a RAG-based system I didn't build.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -49,3 +49,52 @@ confirming the root cause is simply that the fixture file is missing.
 **PLAN.md:** https://github.com/ujval9/pathreview/blob/test/106-restore-basic-profile-fixture/PLAN.md
 
 **Walkthrough video:** Not recorded.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the fix from PLAN.md. First established a baseline on `main`
+(d5f196d): `make test-unit` = 53 failed / 375 passed and `ruff` = 182 errors,
+both pre-existing and unrelated to this issue. Then completed PLAN sub-tasks 1–5:
+read `ResumeParser._detect_sections` and `RepoAnalyzer.parse` to lock the exact
+shapes, authored `tests/fixtures/sample_profiles/basic_profile.json` (GitHub
+username, multi-section resume, portfolio URL, two GitHub-API-shaped repos), and
+added a `tests/unit/test_sample_profiles.py` schema test. The reproduction
+integration test now passes (`make test-integration` → 3 passed) and
+`make test-unit` is 53 failed / 378 passed — the same 53 pre-existing failures
+plus my 3 new passing unit tests, i.e. no new failures.
+
+**Next steps:**
+Run the full self-review checklist (`make check`, read the diff, verify commit
+and branch conventions), fill in the PR template, and open the PR.
+
+**Blockers:**
+None.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** _pending — filled in once the PR is opened_
+
+**Branch:** `test/106-restore-basic-profile-fixture`
+
+**What you built:**
+Restored the missing shared sample-portfolio fixture
+(`tests/fixtures/sample_profiles/basic_profile.json`) as a realistic portfolio —
+a GitHub username, a multi-section resume, and two repositories shaped like the
+GitHub API dicts the ingestion parsers read — plus a `conftest.py` loader and
+unit/integration tests that exercise it.
+
+**Tests added or updated:**
+- `tests/integration/test_sample_profile_fixture.py` — loads the fixture and
+  feeds it through `RepoAnalyzer` and `ResumeParser`.
+- `tests/unit/test_sample_profiles.py` — validates the fixture's schema so
+  `make test-unit` covers the change.
+- `tests/conftest.py` — added the `basic_profile` loader fixture.
+
+**Self-review confirmation:** [x] make check passes (no new failures vs. documented pre-existing baseline)  [x] make test-unit passes (no new failures vs. documented pre-existing baseline)
+
+**Draft PR feedback received from:** none

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,138 @@
+## Solution plan
+
+**Issue:** #106 — Shared test fixture for a sample user profile is missing from `tests/fixtures/`
+
+### Understand
+The project is meant to keep one shared "sample portfolio" fixture at
+`tests/fixtures/sample_profiles/basic_profile.json` that integration tests load
+to drive the ingestion pipeline (resume + repositories) end to end. Reading the
+repo rather than trusting the issue text turned up something important: the
+fixture has **never existed** in git history (`git log --all --full-history --
+'tests/fixtures/**'` returns 0 commits), my fork's `origin/main` is identical to
+`upstream/main` (0 commits apart either way), and the only real code reference to
+the path is a TODO comment in [scripts/run_evals.py:8](scripts/run_evals.py#L8).
+There were also **no** integration tests consuming it — `tests/integration/` held
+only an empty `__init__.py`.
+
+So the issue's literal wording ("multiple integration tests were skipped because
+[the fixture] was deleted") is seeded phrasing from
+`scripts/issues_manifest.json`; the true state is *the fixture and its consuming
+test are both absent*. The expected behavior after the fix: the fixture exists as
+a realistic portfolio (a GitHub username, a resume, and two repositories), and the
+integration test that loads it — already added in reproduction commit `f06165a` —
+passes instead of erroring with `FileNotFoundError`.
+
+**Root cause:** the fixture file
+`tests/fixtures/sample_profiles/basic_profile.json` does not exist, so any code
+that loads it fails at read time before the pipeline runs.
+
+### Map
+Files I expect to touch:
+- `tests/fixtures/sample_profiles/basic_profile.json` — **NEW**, the fix. Must
+  contain `github_username`, `resume_text`, `portfolio_url`, and a `repositories`
+  list of exactly two entries shaped like the GitHub API dicts the analyzer reads.
+- `tests/conftest.py` — **already added** in `f06165a`: `FIXTURES_DIR` helper and
+  the `basic_profile` loader fixture (line ~52). No further change expected unless
+  the loader needs adjusting.
+- `tests/integration/test_sample_profile_fixture.py` — **already added** in
+  `f06165a`: the consuming test. It turns green once the fixture exists; I may add
+  assertions if the fixture reveals gaps.
+
+Reference only (read, not edited):
+- `ingestion/parsers/repo_analyzer.py` — `RepoAnalyzer.parse()` (lines ~50–105)
+  defines exactly which repo fields are read: `name`, `description`, `language`,
+  `stargazers_count`, `forks_count`, `open_issues_count`, `pushed_at`, `html_url`,
+  `readme_content`.
+- `ingestion/parsers/resume_parser.py` — `ResumeParser.parse()` /
+  `_detect_sections()` decides which resume headers are recognized.
+- `core/models/profile.py` — the `Profile` fields (`github_username`,
+  `resume_text`, `portfolio_url`) the fixture mirrors.
+
+### Plan
+1. Re-read `RepoAnalyzer.parse()` and its helpers (`_detect_ci`, `_detect_tests`,
+   `_detect_tech_stack`) in `ingestion/parsers/repo_analyzer.py` to lock the exact
+   keys and confirm which fields make `has_ci` / `has_tests` / `tech_stack` come
+   out realistic.
+2. Re-read `ResumeParser._detect_sections()` to confirm the header strings it
+   recognizes, so `resume_text` reliably yields Experience / Skills / Education.
+3. Author `tests/fixtures/sample_profiles/basic_profile.json`:
+   - `github_username` (e.g. `"janedoe"`), a realistic multi-section `resume_text`,
+     and a `portfolio_url`;
+   - `repositories`: exactly two, one Python-heavy and one JS/TS, each with the
+     GitHub-API fields from step 1, including `readme_content` and an ISO-8601
+     `pushed_at`.
+4. Run `.venv/bin/python -m pytest tests/integration -m integration -v` and confirm
+   the three tests go from error → pass (green).
+5. Run `make test-unit` to confirm the additive `conftest.py` change causes no
+   regressions in the 428 existing unit tests.
+6. Run `make check` (ruff, black, mypy) so the branch is clean for the PR.
+7. Open a PR against `upstream/main` using the PR template, linking issue #106.
+
+### Inputs & outputs
+**Consumer:** the `basic_profile` fixture in `tests/conftest.py`
+(`json.loads(fixture_path.read_text())` → `dict`).
+
+**Contract the fixture must satisfy:**
+```json
+{
+  "github_username": "str",
+  "resume_text": "str (multi-section)",
+  "portfolio_url": "str",
+  "repositories": [ { "...repo..." }, { "...repo..." } ]
+}
+```
+**Each repo (subset `RepoAnalyzer` reads):**
+```json
+{
+  "name": "str", "description": "str", "language": "str",
+  "stargazers_count": 0, "forks_count": 0, "open_issues_count": 0,
+  "pushed_at": "ISO-8601 str", "html_url": "str", "readme_content": "str"
+}
+```
+**Test behavior** (spec already written in `f06165a`):
+- Before fix: all 3 tests **error** (`FileNotFoundError`) at fixture load.
+- After fix:
+  - `test_fixture_has_required_portfolio_fields` → keys present, exactly 2 repos.
+  - `test_repositories_parse_through_repo_analyzer` → `RepoAnalyzer.parse(repo)`
+    returns a `ParseResult`; `metadata["repo_name"] == repo["name"]` and
+    `metadata["primary_language"] == repo["language"]`.
+  - `test_resume_parses_through_resume_parser` → `ResumeParser` detects an
+    Experience or Skills section.
+
+### Risks & unknowns
+1. **`primary_language` assertion is exact.** `RepoAnalyzer.parse()` does
+   `primary_language = repo_data.get("language", "Unknown")`
+   ([repo_analyzer.py:58](ingestion/parsers/repo_analyzer.py#L58)), and my test
+   asserts it equals `repo["language"]`. If I forget `language` on a repo, parse
+   returns `"Unknown"` and the assertion breaks. Mitigation: always set an explicit
+   `language` on both repos.
+2. **Unconfirmed resume-section matching.** I have not yet read
+   `_detect_sections()` closely, so I don't know if it matches `"Experience:"` vs
+   `"Work Experience"` etc. Risk: a plausible-looking `resume_text` parses to zero
+   detected sections and `test_resume_parses...` fails. Mitigation: model
+   `resume_text` on the existing `sample_resume_text` fixture in
+   [tests/conftest.py](tests/conftest.py), which is already known to parse.
+3. **Scope ambiguity around `run_evals.py`.** Its TODO says "load benchmark
+   *portfolios*" (plural), which could imply a directory of profiles rather than a
+   single file. I'm scoping to exactly what issue #106 asks (one profile, two
+   repos) and treating `run_evals.py` (a stub) as out of scope — noted so it can be
+   revisited if a reviewer expects more.
+4. **Pre-commit hooks are stricter than `make check`.** The `mypy` hook runs on
+   changed files (not just `api/ core/ ...`), which already forced type
+   annotations in `f06165a`. JSON isn't type-checked, but any further edit to
+   `conftest.py` must keep the `dict[str, Any]` annotations to stay green.
+
+### Edge cases
+- **Repo with no `readme_content`:** `RepoAnalyzer` sets `has_readme=False` — valid,
+  but at least one repo in the fixture should include `readme_content` so the
+  `has_readme=True` path is exercised.
+- **Repo missing `language`:** would default to `"Unknown"` and desync the
+  assertion — explicitly avoided by always setting it (see Risk 1).
+- **Resume with only an Education section:** the test accepts Experience *or*
+  Skills, so `resume_text` must contain at least one of those two, not only
+  Education.
+- **Exactly two repos:** the test asserts `len(repositories) == 2`; a third entry
+  would fail — the count is fixed per the issue.
+- **Extra GitHub-API keys in a repo dict:** harmless — `RepoAnalyzer` reads via
+  `.get()` and ignores unknown fields, so a fuller, more realistic repo object is
+  safe.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,12 @@
 """Shared test fixtures for PathReview."""
 
+import json
+from pathlib import Path
+from typing import Any
+
 import pytest
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
 
 @pytest.fixture
@@ -40,3 +46,17 @@ def sample_readme_text() -> str:
     - Tailwind CSS
     - OpenWeatherMap API
     """
+
+
+@pytest.fixture
+def basic_profile() -> dict[str, Any]:
+    """Load the shared sample portfolio fixture.
+
+    Returns the parsed contents of
+    ``tests/fixtures/sample_profiles/basic_profile.json`` — a realistic sample
+    portfolio (GitHub username, resume text, and two repositories) used by
+    integration tests to drive the ingestion pipeline.
+    """
+    fixture_path = FIXTURES_DIR / "sample_profiles" / "basic_profile.json"
+    data: dict[str, Any] = json.loads(fixture_path.read_text())
+    return data

--- a/tests/fixtures/sample_profiles/basic_profile.json
+++ b/tests/fixtures/sample_profiles/basic_profile.json
@@ -1,0 +1,46 @@
+{
+  "github_username": "janedoe",
+  "portfolio_url": "https://janedoe.dev",
+  "resume_text": "Jane Doe\nSoftware Engineer\njane.doe@example.com | github.com/janedoe\n\nSummary:\nBackend-leaning full-stack engineer with two years of experience building\nPython APIs and TypeScript front-ends.\n\nExperience:\n- Software Engineer at TechCorp (2022-2024): Built and maintained REST APIs\n  using Python and FastAPI, backed by PostgreSQL. Added CI with GitHub Actions.\n- Software Engineering Intern at DataWorks (2021): Built internal dashboards in\n  React and TypeScript.\n\nEducation:\n- B.S. Computer Science, State University (2022)\n\nSkills:\nPython, FastAPI, JavaScript, TypeScript, React, PostgreSQL, Docker, Git",
+  "repositories": [
+    {
+      "name": "portfolio-analyzer",
+      "description": "A CLI that analyzes a GitHub profile and scores portfolio readiness.",
+      "language": "Python",
+      "stargazers_count": 47,
+      "forks_count": 8,
+      "open_issues_count": 3,
+      "pushed_at": "2026-06-15T14:23:00Z",
+      "html_url": "https://github.com/janedoe/portfolio-analyzer",
+      "readme_content": "# Portfolio Analyzer\n\nAnalyze a GitHub profile and score portfolio readiness.\n\n## Features\n- Fetches public repositories via the GitHub API\n- Scores README quality, test coverage signals, and activity\n- Outputs a JSON report\n\n## Tech Stack\n- Python 3.11\n- FastAPI\n- pytest\n",
+      "file_structure": [
+        ".github/workflows/ci.yml",
+        "src/analyzer/__init__.py",
+        "src/analyzer/scoring.py",
+        "tests/test_scoring.py",
+        "requirements.txt",
+        "README.md"
+      ]
+    },
+    {
+      "name": "weather-dashboard",
+      "description": "A responsive weather dashboard with a 5-day forecast.",
+      "language": "TypeScript",
+      "stargazers_count": 23,
+      "forks_count": 4,
+      "open_issues_count": 1,
+      "pushed_at": "2026-05-02T09:10:00Z",
+      "html_url": "https://github.com/janedoe/weather-dashboard",
+      "readme_content": "# Weather Dashboard\n\nA responsive weather dashboard built with React and TypeScript.\n\n## Features\n- Current conditions and 5-day forecast\n- Location search\n- Light/dark theme\n\n## Tech Stack\n- React 18\n- TypeScript\n- Vite\n- Tailwind CSS\n",
+      "file_structure": [
+        "package.json",
+        "tsconfig.json",
+        "vite.config.ts",
+        "src/App.tsx",
+        "src/components/Forecast.tsx",
+        "__tests__/App.test.tsx",
+        "README.md"
+      ]
+    }
+  ]
+}

--- a/tests/integration/test_sample_profile_fixture.py
+++ b/tests/integration/test_sample_profile_fixture.py
@@ -1,0 +1,51 @@
+"""Integration tests for the shared sample portfolio fixture.
+
+These tests exercise ``tests/fixtures/sample_profiles/basic_profile.json``
+through the ingestion parsers to guarantee the fixture stays realistic and
+pipeline-compatible. They are skipped (in effect, they error) whenever the
+fixture is missing — which is the state issue #106 is about.
+"""
+
+from typing import Any
+
+import pytest
+
+from ingestion.parsers.base import ParseResult
+from ingestion.parsers.repo_analyzer import RepoAnalyzer
+from ingestion.parsers.resume_parser import ResumeParser
+
+
+@pytest.mark.integration
+class TestSampleProfileFixture:
+    """Validate the shared sample portfolio fixture end to end."""
+
+    def test_fixture_has_required_portfolio_fields(self, basic_profile: dict[str, Any]) -> None:
+        """The fixture must describe a GitHub username, resume, and two repos."""
+        assert basic_profile["github_username"]
+        assert basic_profile["resume_text"].strip()
+        assert basic_profile["portfolio_url"]
+
+        repos = basic_profile["repositories"]
+        assert isinstance(repos, list)
+        assert len(repos) == 2
+
+    def test_repositories_parse_through_repo_analyzer(self, basic_profile: dict[str, Any]) -> None:
+        """Each repo entry should be shaped like the GitHub API dict RepoAnalyzer reads."""
+        analyzer = RepoAnalyzer()
+
+        for repo in basic_profile["repositories"]:
+            result = analyzer.parse(repo)
+
+            assert isinstance(result, ParseResult)
+            assert result.source_type == "repo"
+            assert result.metadata["repo_name"] == repo["name"]
+            assert result.metadata["primary_language"] == repo["language"]
+
+    def test_resume_parses_through_resume_parser(self, basic_profile: dict[str, Any]) -> None:
+        """The fixture's resume_text should parse into recognizable sections."""
+        result = ResumeParser().parse(basic_profile["resume_text"])
+
+        assert isinstance(result, ParseResult)
+        assert result.source_type == "resume"
+        detected = [s.lower() for s in result.metadata["detected_sections"]]
+        assert any("experience" in s for s in detected) or any("skills" in s for s in detected)

--- a/tests/unit/test_sample_profiles.py
+++ b/tests/unit/test_sample_profiles.py
@@ -1,0 +1,49 @@
+"""Unit tests for the shared sample portfolio fixture (basic_profile.json).
+
+These validate the *structure* of the fixture so a future edit that breaks its
+schema is caught by ``make test-unit``. The end-to-end behaviour (feeding the
+fixture through the ingestion parsers) is covered separately by
+``tests/integration/test_sample_profile_fixture.py``.
+"""
+
+from typing import Any
+
+import pytest
+
+
+@pytest.mark.unit
+class TestBasicProfileFixture:
+    """Validate the structure of the basic_profile.json fixture."""
+
+    def test_has_required_top_level_fields(self, basic_profile: dict[str, Any]) -> None:
+        """The fixture exposes a GitHub username, resume text, and portfolio URL."""
+        assert isinstance(basic_profile["github_username"], str)
+        assert basic_profile["github_username"]
+        assert isinstance(basic_profile["resume_text"], str)
+        assert basic_profile["resume_text"].strip()
+        assert isinstance(basic_profile["portfolio_url"], str)
+        assert basic_profile["portfolio_url"].startswith("http")
+
+    def test_has_exactly_two_repositories(self, basic_profile: dict[str, Any]) -> None:
+        """The fixture describes exactly two repositories, per issue #106."""
+        repos = basic_profile["repositories"]
+        assert isinstance(repos, list)
+        assert len(repos) == 2
+
+    def test_repositories_expose_github_api_fields(self, basic_profile: dict[str, Any]) -> None:
+        """Each repo carries the GitHub-API fields the ingestion parsers read."""
+        required_fields: dict[str, type] = {
+            "name": str,
+            "description": str,
+            "language": str,
+            "stargazers_count": int,
+            "forks_count": int,
+            "open_issues_count": int,
+            "pushed_at": str,
+            "html_url": str,
+            "readme_content": str,
+        }
+        for repo in basic_profile["repositories"]:
+            for field, field_type in required_fields.items():
+                assert field in repo, f"repo is missing field: {field}"
+                assert isinstance(repo[field], field_type)


### PR DESCRIPTION
## Summary

Issue #106 reported that a shared sample-portfolio fixture, `tests/fixtures/sample_profiles/basic_profile.json`, was missing, so any test or tool that loads it fails. This PR restores the fixture as a realistic sample portfolio (a GitHub username, a multi-section resume, and two repositories) and adds tests that load and exercise it.

## Issue

Closes #106

## Changes

Root cause: the fixture file `tests/fixtures/sample_profiles/basic_profile.json` does not exist in the repository — it was never present in git history, and my fork's `main` is identical to `upstream/main` (0 commits apart). Any code path that loads it fails with `FileNotFoundError` at read time, and there were no tests exercising it (`tests/integration/` held only `__init__.py`).

- Added `tests/fixtures/sample_profiles/basic_profile.json` — a realistic portfolio: `github_username`, a multi-section `resume_text` (section headers flush-left so `ResumeParser._detect_sections` recognizes them), a `portfolio_url`, and two repositories carrying the GitHub-API fields `RepoAnalyzer.parse()` reads (`name`, `description`, `language`, `stargazers_count`, `forks_count`, `open_issues_count`, `pushed_at`, `html_url`, `readme_content`, `file_structure`).
- Added a `basic_profile` loader fixture and a `FIXTURES_DIR` helper to `tests/conftest.py`.
- Added `tests/integration/test_sample_profile_fixture.py` (marked `integration`) — loads the fixture and feeds it through `RepoAnalyzer` and `ResumeParser`. Committed first as a failing reproduction (`FileNotFoundError`), now passing.
- Added `tests/unit/test_sample_profiles.py` (marked `unit`) — validates the fixture's schema so `make test-unit` covers the change directly.

## Testing

- [x] Unit tests pass (`make test-unit`) — no new failures vs. baseline (see Notes)
- [x] Integration tests pass (`make test-integration`) — 3 passed
- [x] Linter passes (`make lint`) — no new errors vs. baseline (see Notes)
- [ ] Type checker passes (`make typecheck`) — pre-existing errors only, none in changed files (see Notes)
- [x] New/updated tests cover the changes

**Reproduce the original state (before the fix):**
1. Check out the commit before `1bf3cb5` (fixture absent).
2. Run `pytest tests/integration -m integration -v`.
3. Observe: 3 errors — `FileNotFoundError: .../sample_profiles/basic_profile.json`.

**Verify the fix (this branch):**
1. `pytest tests/integration -m integration -v` → 3 passed.
2. `pytest tests/unit/test_sample_profiles.py -v` → 3 passed.

## Notes for Reviewers

This repository has pre-existing failures unrelated to this change, confirmed on `main` (`d5f196d`) before I started:

- `make test-unit`: 53 failed / 375 passed on `main`. On this branch: 53 failed / 378 passed — the same 53 failures plus my 3 new passing unit tests. **No new failures.**
- `make lint` (ruff): 182 errors on `main`, unchanged on this branch — my new files are ruff-clean.
- `make typecheck` (mypy): 5 pre-existing errors, in `rag/retriever/keyword_search.py` (missing `rank_bm25` stubs) and a NumPy `.pyi` syntax error under Python 3.14.

My change is confined to `tests/` and introduces no new failures in any of these commands.
