### PR TITLE
fix(rag): handle None text in faithfulness context chunks

### DIFF
--- a/rag/evaluator/faithfulness_checker.py
+++ b/rag/evaluator/faithfulness_checker.py
@@ -30,9 +30,9 @@ class FaithfulnessChecker:
             logger.info("faithfulness_no_claims_extracted")
             return 0.5  # Default to neutral if no extractable claims
 
-        # Concatenate context text
+        # Concatenate context text (treat a None or absent "text" value as empty)
         context_text = " ".join([
-            chunk.get("text", "") for chunk in context_chunks
+            (chunk.get("text") or "") for chunk in context_chunks
         ])
 
         # Check each claim for support

--- a/tests/unit/test_faithfulness_checker.py
+++ b/tests/unit/test_faithfulness_checker.py
@@ -254,6 +254,35 @@ class TestFaithfulnessChecker:
         assert isinstance(score, float)
         assert 0.0 <= score <= 1.0
 
+    def test_mixed_valid_and_none_chunk_text(self, checker):
+        """Test a None-text chunk mixed with a valid chunk: no crash, valid chunk still counts."""
+        feedback = "Has Python and Django skills"
+        context_chunks = [
+            {"text": "Python and Django expertise"},
+            {"text": None},
+        ]
+
+        score = checker.check(feedback, context_chunks)
+
+        # Should handle gracefully and still credit the valid chunk
+        assert isinstance(score, float)
+        assert 0.0 <= score <= 1.0
+        assert score > 0.0
+
+    def test_all_none_context_chunks(self, checker):
+        """Test that all-None chunk text yields an empty context and a valid zero score."""
+        feedback = "Has Python skills"
+        context_chunks = [
+            {"text": None},
+            {"text": None},
+        ]
+
+        score = checker.check(feedback, context_chunks)
+
+        # Should handle gracefully
+        assert isinstance(score, float)
+        assert 0.0 <= score <= 1.0
+
     def test_score_consistency(self, checker):
         """Test that same input produces same score."""
         feedback = "The developer has strong Python skills."


### PR DESCRIPTION
## Summary

`FaithfulnessChecker.check()` crashed with a `TypeError` whenever a retrieved context chunk
had its `text` key present but set to `None` (e.g. `{"text": None}`). The context string was
assembled with `chunk.get("text", "")`, but `dict.get`'s default only applies to a *missing*
key — a present `None` is returned unchanged, so `" ".join([None])` raised
`TypeError: sequence item 0: expected str instance, NoneType found`. This PR coalesces a
`None`/absent `text` value to an empty string, so a null chunk contributes no context, exactly
as a missing key already does.

## Issue
Closes #153

## Changes
- `rag/evaluator/faithfulness_checker.py`: assemble context with `(chunk.get("text") or "")`
  instead of `chunk.get("text", "")`, so a present-but-`None` `text` is treated as empty.
- `tests/unit/test_faithfulness_checker.py`: add two edge-case tests — a mixed valid + `None`
  chunk list (valid chunk still contributes) and an all-`None` list (empty context, valid zero
  score). The pre-existing `test_none_context_chunk_text` now passes.

## Testing
- [x] Unit tests pass (`make test-unit`) — *no new failures introduced; see Notes*
- [ ] Integration tests pass (`make test-integration`) — *require Docker services; not run in this environment*
- [x] Linter passes (`make lint`) — *no new lint errors on the changed lines; see Notes*
- [x] Type checker passes (`make typecheck`) — *no new type errors; see Notes*
- [x] New/updated tests cover the changes

Verified on the two changed files:
- `test_none_context_chunk_text` flips **FAIL → PASS**; both new edge-case tests pass.
- Full unit suite went **53 failed / 375 passed → 52 failed / 378 passed** — one failure fixed,
  two new passing tests, and **zero new failures**.

## Notes for Reviewers
This change is intentionally minimal and scoped strictly to issue #153.

**Pre-existing failures (unrelated to this PR), observed on `main` before any change:**
`ruff check .` → 182 errors · `black --check .` → 52 files · `mypy` → 5 errors ·
`pytest tests/unit -m unit` → 53 failed / 375 passed.

After this change those counts are unchanged except that unit failures drop by one (the #153
crash) and passing tests rise by three. In particular, the three remaining failures in
`test_faithfulness_checker.py` — `test_partial_support_returns_middle_score`,
`test_multiple_context_chunks`, and `test_multiple_claims_varying_support` — stem from a
**separate** bug (the `_is_supported()` ≥2-token-overlap threshold, tracked as #152) and are
deliberately left untouched here.

