### PR TITLE
test(rag): pin per-template snapshot hashes to catch accidental prompt changes

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,16 @@
+## Week 7 — Issue selection
+
+**Issue link:** [Issue](https://github.com/ascherj/pathreview/issues/37)
+
+**Issue title:** Add snapshot tests for prompt templates to catch accidental changes
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+There's already a test that looks like a snapshot test for the prompt templates, but it just computes a hash and never checks it against anything fixed, so it passes no matter what changes. That means someone could quietly reword a template and every test would still go green. The fix is to make that test actually compare against a saved expected hash, so it fails unless the version gets bumped on purpose.
+
+**Branch name:** test/37-snapshot-tests-prompt-templates
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -17,12 +17,12 @@ There's already a test that looks like a snapshot test for the prompt templates,
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [link to commit documenting the reproduced issue]
+**Reproduction commit link:** https://github.com/riyan42069/pathreview/commit/db973ec
 
 **Reproduction summary:**
 Ran the existing `test_template_snapshot_content_hash` test and confirmed it passes at baseline. Then computed the same MD5 hash logic against a version of `PROMPT_TEMPLATES` with a wording edit to `skills_feedback` v1 (no version bump) - the hash changed as expected, but the test's actual assertions (`isinstance(hash, str)`, `len(hash) == 32`) pass regardless, since they never compare against a fixed expected value.
 
-**PLAN.md link:** [link to PLAN.md in your fork]
+**PLAN.md link:** https://github.com/riyan42069/pathreview/blob/test/37-snapshot-tests-prompt-templates/PLAN.md
 
 **Walkthrough video (recommended):** [link to your Loom video, ≤2 min - recommended, not graded]
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -14,3 +14,17 @@ There's already a test that looks like a snapshot test for the prompt templates,
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [link to commit documenting the reproduced issue]
+
+**Reproduction summary:**
+Ran the existing `test_template_snapshot_content_hash` test and confirmed it passes at baseline. Then computed the same MD5 hash logic against a version of `PROMPT_TEMPLATES` with a wording edit to `skills_feedback` v1 (no version bump) - the hash changed as expected, but the test's actual assertions (`isinstance(hash, str)`, `len(hash) == 32`) pass regardless, since they never compare against a fixed expected value.
+
+**PLAN.md link:** [link to PLAN.md in your fork]
+
+**Walkthrough video (recommended):** [link to your Loom video, ≤2 min - recommended, not graded]
+
+**Blockers or open questions:**
+None blocking - the fix is clear: pin an expected hash (or per-template expected hashes) in the test and assert equality, failing when content changes without a matching version key bump.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -60,3 +60,38 @@ Replaced the fake "snapshot" test in `tests/unit/test_prompt_templates.py` with 
 (Both defined as: my changes introduce no new failures. `make check` has 163 pre-existing ruff errors and 5 pre-existing mypy errors unrelated to this change - confirmed present on the commit before my fix, and `test_prompt_templates.py` contributes zero of them. `make test-unit` has 53 pre-existing failures in unrelated modules, also confirmed present before my fix; all 38 tests in `test_prompt_templates.py` pass.)
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No review has come in on PR #716 yet.
+
+**How you responded:**
+N/A - nothing to respond to yet. If feedback comes in after submission, I'll follow up in a comment on the PR itself rather than editing this journal further, since Week 10 is meant to be the final entry.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Figuring out that the existing test was fake took more than a glance. `test_template_snapshot_content_hash` looked complete on first read, it had a docstring calling it a snapshot test, it computed a real hash, it had reasonable-looking assertions. I only caught that it wasn't actually checking anything by reading the two assertions line by line and realizing `isinstance(hash, str)` and `len(hash) == 32` are true for literally any MD5 hash, not just the "right" one. That's a different kind of bug than I expected going in - I was ready to debug broken logic, not to notice logic that was quietly checking nothing at all.
+
+The other surprise was the pre-commit hooks. My actual fix was small, maybe 15 lines of real change, but committing it failed on ruff and mypy errors for unused loop variables and missing return type annotations that had nothing to do with my change and had clearly been sitting in that file for a long time. I had to fix all of them just to get my own commit through, which meant touching almost every method in the file even though my actual logic change was tiny.
+
+**What did you learn about working in a large codebase?**
+The biggest thing was that "does the test suite pass" isn't a yes/no question in a codebase this size. Before I could even claim my change didn't break anything, I had to establish what was already broken - I checked out the commit before my fix and ran `make check` and `make test-unit` against it to get a real baseline (163 ruff errors, 5 mypy errors, 53 failing tests, none of it related to prompt templates). Without that baseline, I couldn't have told the difference between "my change is fine" and "my change happens to run in a codebase with unrelated problems." In a personal project there's no such thing as a pre-existing failure, everything failing is yours. Here, most of what's red has nothing to do with you, and part of the job is proving that.
+
+**How did AI tools help - and where did they fall short?**
+AI was most useful for the mechanical, repeatable parts: writing the throwaway reproduction script that mirrored the real test's logic without touching tracked files, generating the actual baseline MD5 hashes instead of guessing at them, and running the same before/after comparison (checking out the prior commit in a worktree, rerunning checks) reliably each time. It was also useful for drafting and iterating on the PR description and journal entries once I told it what actually happened.
+
+Where it fell short: it couldn't open the PR for me since the `gh` CLI wasn't installed in this environment, so I had to do that step manually through the GitHub web UI. It also couldn't tell me on its own whether the pre-existing ruff/mypy/test failures mattered for this PR - that judgment call (are these actually pre-existing, is it safe to claim "no new failures") required me to actually direct it to check out the prior commit and compare, rather than trusting a single run of `make check` at face value.
+
+**What would you do differently if you started over?**
+I'd run `make check` and `make test-unit` in week 8, right after reproducing the bug, instead of waiting until the self-review step in week 9. I found out about the pre-existing lint and mypy issues late, which meant a chunk of week 9 went into cleaning up code I didn't write instead of just my actual fix. Establishing the "here's what's already broken" baseline earlier would have saved time and made the eventual self-review section easier to write with confidence instead of scrambling to verify it right before opening the PR.
+
+**What are you most proud of from this module?**
+Actually proving the fix works instead of just trusting the logic on paper. I temporarily edited a template's wording, reran the test, watched it fail with a message naming the exact template and version, then reverted the edit and confirmed everything went back to green. It would have been easy to write the hash-comparison logic, see it look reasonable, and call it done - the extra step of deliberately breaking something to watch my own test catch it is what actually gave me confidence the fix does what the issue asked for, instead of just resembling a fix.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -28,3 +28,35 @@ Ran the existing `test_template_snapshot_content_hash` test and confirmed it pas
 
 **Blockers or open questions:**
 None blocking - the fix is clear: pin an expected hash (or per-template expected hashes) in the test and assert equality, failing when content changes without a matching version key bump.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the fix from PLAN.md - steps 1 through 5 are done. Confirmed no existing snapshot-testing library/convention is used elsewhere in the repo, so I hand-rolled per-template-per-version expected hashes (`EXPECTED_TEMPLATE_HASHES`) in `tests/unit/test_prompt_templates.py` instead of a single combined hash, since it gives failures that name the exact template/version that drifted. Rewrote `test_template_snapshot_content_hash` to assert against those recorded hashes, and added `test_no_new_templates_or_versions_are_missing_a_snapshot` to catch a new template being added without a recorded hash. Verified the fix works both ways: unmodified templates pass, and a temporary deliberate wording edit (reverted after) made the test fail with a clear message. Committed as `b8a680e`.
+
+**Next steps:**
+Self-review against `docs/CONTRIBUTING.md` (branch name, commit message, docstrings), run `make check` and `make test-unit`, document any pre-existing failures, then push the branch and open the PR.
+
+**Blockers:**
+None. `make check` and `make test-unit` both surface a large number of pre-existing failures/errors unrelated to this change (163 ruff errors, 5 mypy errors, 53 failing unit tests across other modules) - confirmed these exist identically on the commit before my fix, so they're not something I introduced.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [link to your submitted pull request]
+
+**Branch:** `test/37-snapshot-tests-prompt-templates`
+
+**What you built:**
+Replaced the fake "snapshot" test in `tests/unit/test_prompt_templates.py` with a real one. `test_template_snapshot_content_hash` now compares each template/version's live MD5 hash against a recorded expected hash in `EXPECTED_TEMPLATE_HASHES`, so any wording change without a deliberate version bump + hash update now fails the test suite instead of silently passing.
+
+**Tests added or updated:**
+`tests/unit/test_prompt_templates.py` - rewrote `test_template_snapshot_content_hash` to assert real equality instead of generic type/length checks, and added `test_no_new_templates_or_versions_are_missing_a_snapshot` to guard against a new template/version being added with no recorded hash. Also cleaned up pre-existing ruff violations (unused loop variables, `dict.keys()` iteration) and added missing `-> None` return annotations across the file's test methods so it passes the repo's pre-commit hooks.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+(Both defined as: my changes introduce no new failures. `make check` has 163 pre-existing ruff errors and 5 pre-existing mypy errors unrelated to this change - confirmed present on the commit before my fix, and `test_prompt_templates.py` contributes zero of them. `make test-unit` has 53 pre-existing failures in unrelated modules, also confirmed present before my fix; all 38 tests in `test_prompt_templates.py` pass.)
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -46,7 +46,7 @@ None. `make check` and `make test-unit` both surface a large number of pre-exist
 
 ### Check-in 2 (end of week)
 
-**PR link:** [link to your submitted pull request]
+**PR link:** https://github.com/ascherj/pathreview/pull/716
 
 **Branch:** `test/37-snapshot-tests-prompt-templates`
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,62 @@
+# PLAN.md (rough draft)
+
+## Solution plan
+
+**Issue:** [Add snapshot tests for prompt templates to catch accidental changes (#37)](https://github.com/ascherj/pathreview/issues/37)
+
+### Understand
+There's already a test in `tests/unit/test_prompt_templates.py` called
+`test_template_snapshot_content_hash` that looks like it should catch this, but it doesn't. It hashes
+all the template content, and then just checks that the hash is a string of length 32. It never
+compares that hash to anything fixed, so it can't actually tell if the content changed.
+
+What should happen: if someone edits a template's wording without bumping its version, the test
+suite should catch it and fail. What actually happens: you can change the text however you want and
+everything stays green, because there's nothing pinned to compare against. I confirmed this in Week
+8 by copying the templates, tweaking one, and rerunning the same hash logic - the hash changed like
+it should, but the test itself would've kept passing either way.
+
+### Map
+- `rag/generator/prompt_templates.py` - this is where the templates actually live (5 of them, each
+  currently sitting at version "v1"), plus `get_template()`. I don't think this needs to change,
+  other than maybe bumping a version temporarily to make sure my fix actually works.
+- `tests/unit/test_prompt_templates.py` - the main file I'll be editing. This is where the broken
+  snapshot test is.
+- Maybe a new file for storing the expected hashes, if I decide not to keep them inline in the test
+  (something like `tests/unit/__snapshots__/prompt_templates.json`). Still deciding on this.
+
+### Plan
+1. Look around the repo first to see if there's already a snapshot-testing pattern or library in
+   use (syrupy, pytest-snapshot, etc.) before I build something from scratch.
+2. Decide: one combined hash for everything (closer to what's there now, simpler) or a separate
+   expected hash per template/version (more setup, but tells you exactly what changed). Leaning
+   toward the per-template version since a failure that just says "something changed" isn't that
+   useful.
+3. Record the current hashes as the "expected" baseline.
+4. Rewrite the test to actually compare against that baseline and fail with a message that says
+   which template/version drifted.
+5. Actually test that it works - run it once with nothing changed (should pass), then edit a
+   template on purpose, rerun (should fail), then put it back.
+
+### Inputs & outputs
+Input is just whatever's currently in `PROMPT_TEMPLATES` when the test runs. Output is pass or fail
+- pass if every template's content still matches its recorded hash, fail (with a message pointing at
+the specific template/version) if something drifted without the version being bumped.
+
+### Risks & unknowns
+- Don't know yet if there's already a snapshot convention elsewhere in the repo I should be
+  following instead of rolling my own.
+- Per-template hashes mean more to maintain than one combined hash - not 100% sure it's worth it yet.
+- MD5 is already what's being used; no strong reason to swap it for sha256, but flagging it in case
+  someone asks.
+- All templates are currently on "v1" and I haven't seen any of them actually get bumped to "v2" -
+  want to double check the intended workflow makes sense before assuming the test should handle
+  multiple versions gracefully.
+
+### Edge cases
+- Someone adds a brand new template with no recorded hash yet - should fail loudly instead of just
+  silently skipping it, so the hash gets recorded on purpose.
+- A template gets a real new version added (v2 next to v1) - both versions should still get checked
+  against their own hashes.
+- Someone makes a "harmless" whitespace-only edit - should still count as a change and fail, since
+  even small formatting shifts can affect what the model sees.

--- a/PLAN.md
+++ b/PLAN.md
@@ -5,58 +5,59 @@
 **Issue:** [Add snapshot tests for prompt templates to catch accidental changes (#37)](https://github.com/ascherj/pathreview/issues/37)
 
 ### Understand
-There's already a test in `tests/unit/test_prompt_templates.py` called
-`test_template_snapshot_content_hash` that looks like it should catch this, but it doesn't. It hashes
-all the template content, and then just checks that the hash is a string of length 32. It never
-compares that hash to anything fixed, so it can't actually tell if the content changed.
+`tests/unit/test_prompt_templates.py` already contains a test called `test_template_snapshot_content_hash`
+that computes an MD5 hash of all template content in `PROMPT_TEMPLATES`. The root cause is that this
+test never compares that hash against a fixed expected value - it only asserts generic things
+(`isinstance(hash, str)`, `len(hash) == 32`), so it passes regardless of what the hash actually is.
 
-What should happen: if someone edits a template's wording without bumping its version, the test
-suite should catch it and fail. What actually happens: you can change the text however you want and
-everything stays green, because there's nothing pinned to compare against. I confirmed this in Week
-8 by copying the templates, tweaking one, and rerunning the same hash logic - the hash changed like
-it should, but the test itself would've kept passing either way.
+Expected behavior: if any template's text changes without a version bump, the test suite should fail.
+Actual behavior: template text can be edited freely and every test (including the "snapshot" one)
+stays green, since nothing is pinned to a known-good value. Confirmed this in Week 8 by reproducing
+against a monkeypatched copy of `PROMPT_TEMPLATES` - the hash changed as expected, but the test's
+actual assertions still passed.
 
 ### Map
-- `rag/generator/prompt_templates.py` - this is where the templates actually live (5 of them, each
-  currently sitting at version "v1"), plus `get_template()`. I don't think this needs to change,
-  other than maybe bumping a version temporarily to make sure my fix actually works.
-- `tests/unit/test_prompt_templates.py` - the main file I'll be editing. This is where the broken
-  snapshot test is.
-- Maybe a new file for storing the expected hashes, if I decide not to keep them inline in the test
-  (something like `tests/unit/__snapshots__/prompt_templates.json`). Still deciding on this.
+- `rag/generator/prompt_templates.py` - defines `PROMPT_TEMPLATES` (5 templates x versioned dict,
+  currently all at `"v1"`) and `get_template()`. Not expected to change, aside from a test-only
+  version bump while validating the fix.
+- `tests/unit/test_prompt_templates.py` - primary file to change; contains
+  `test_template_snapshot_content_hash` and the rest of the template test suite.
+- Possibly a new snapshot/fixture file if expected hashes end up stored separately rather than
+  inline in the test (e.g. `tests/unit/__snapshots__/prompt_templates.json`) - TBD.
 
 ### Plan
-1. Look around the repo first to see if there's already a snapshot-testing pattern or library in
-   use (syrupy, pytest-snapshot, etc.) before I build something from scratch.
-2. Decide: one combined hash for everything (closer to what's there now, simpler) or a separate
-   expected hash per template/version (more setup, but tells you exactly what changed). Leaning
-   toward the per-template version since a failure that just says "something changed" isn't that
-   useful.
-3. Record the current hashes as the "expected" baseline.
-4. Rewrite the test to actually compare against that baseline and fail with a message that says
-   which template/version drifted.
-5. Actually test that it works - run it once with nothing changed (should pass), then edit a
-   template on purpose, rerun (should fail), then put it back.
+1. Check whether the repo already uses a snapshot-testing convention or library elsewhere
+   (e.g. `syrupy`, `pytest-snapshot`) before hand-rolling anything new.
+2. Decide between a single combined hash (matches current style, simplest) vs. per-template
+   per-version expected hashes (more setup, but pinpoints exactly which template changed on
+   failure). Leaning toward per-template for clearer failure messages.
+3. Generate and record baseline expected hash(es) for the current template content.
+4. Rewrite `test_template_snapshot_content_hash` to assert live hash(es) against the recorded
+   expected hash(es), with a failure message identifying which template/version drifted.
+5. Verify the fix actually works: confirm unmodified templates pass, then temporarily edit a
+   template's wording (revert after) and confirm the test now fails as expected.
 
 ### Inputs & outputs
-Input is just whatever's currently in `PROMPT_TEMPLATES` when the test runs. Output is pass or fail
-- pass if every template's content still matches its recorded hash, fail (with a message pointing at
-the specific template/version) if something drifted without the version being bumped.
+- **Input:** the live `PROMPT_TEMPLATES` dict (name -> version -> template string) at test-run time.
+- **Output:** a pass/fail signal - test passes only when every template/version's content hash
+  matches its recorded expected hash; fails with a clear message naming the template/version whose
+  content drifted, prompting a deliberate version bump + hash update.
 
 ### Risks & unknowns
-- Don't know yet if there's already a snapshot convention elsewhere in the repo I should be
-  following instead of rolling my own.
-- Per-template hashes mean more to maintain than one combined hash - not 100% sure it's worth it yet.
-- MD5 is already what's being used; no strong reason to swap it for sha256, but flagging it in case
-  someone asks.
-- All templates are currently on "v1" and I haven't seen any of them actually get bumped to "v2" -
-  want to double check the intended workflow makes sense before assuming the test should handle
-  multiple versions gracefully.
+- Unclear if there's a preferred snapshot-testing pattern already used elsewhere in this codebase -
+  need to check before committing to a hand-rolled hash approach.
+- Per-template hashing adds more to maintain than a single combined hash; still deciding if the
+  extra clarity is worth it.
+- Not sure whether MD5 should be kept (already in use, just unenforced) or swapped for something
+  like sha256 - probably no strong reason to change it.
+- Unclear how version bumps are meant to work in practice (all templates are currently only at
+  "v1") - want to confirm the intended workflow before assuming the test should compare across
+  version keys automatically vs. per-fixed-version.
 
 ### Edge cases
-- Someone adds a brand new template with no recorded hash yet - should fail loudly instead of just
-  silently skipping it, so the hash gets recorded on purpose.
-- A template gets a real new version added (v2 next to v1) - both versions should still get checked
-  against their own hashes.
-- Someone makes a "harmless" whitespace-only edit - should still count as a change and fail, since
-  even small formatting shifts can affect what the model sees.
+- A brand-new template added to `PROMPT_TEMPLATES` with no recorded expected hash yet - test should
+  fail clearly (not silently skip) so the new template's hash gets deliberately recorded.
+- A template gets a genuinely new version key added (e.g. `"v2"`) alongside `"v1"` - test should
+  still validate both versions' content against their own expected hashes.
+- Whitespace-only or formatting-only edits to a template - these should still be treated as content
+  changes and fail the test, since even minor wording/formatting shifts can affect model output.

--- a/tests/unit/test_prompt_templates.py
+++ b/tests/unit/test_prompt_templates.py
@@ -1,16 +1,28 @@
 """Tests for prompt_templates.py - Snapshot tests"""
 
-import pytest
 import hashlib
 
+import pytest
+
 from rag.generator.prompt_templates import PROMPT_TEMPLATES, get_template
+
+# Recorded content hashes for each template/version. If a template's wording
+# changes, its hash here must be deliberately updated (and its version bumped
+# if the change is meant to be a new prompt variant, not an in-place edit).
+EXPECTED_TEMPLATE_HASHES = {
+    "first_impression": {"v1": "ef6429d3a6d426b3c9913381020dd7e4"},
+    "gaps_feedback": {"v1": "e5bfd6644fd62a0fe01f60c9aa456762"},
+    "presentation_feedback": {"v1": "43549ee59818dfc8eb3627554a563b2e"},
+    "projects_feedback": {"v1": "d346d01b24ee7aad92594014a46557af"},
+    "skills_feedback": {"v1": "f93103d823482a2e65decc6653e4ee5c"},
+}
 
 
 @pytest.mark.unit
 class TestPromptTemplates:
     """Test suite for prompt templates."""
 
-    def test_all_5_templates_exist(self):
+    def test_all_5_templates_exist(self) -> None:
         """Test all 5 templates exist in PROMPT_TEMPLATES."""
         expected_templates = {
             "skills_feedback",
@@ -23,38 +35,40 @@ class TestPromptTemplates:
         actual_templates = set(PROMPT_TEMPLATES.keys())
         assert actual_templates == expected_templates
 
-    def test_skills_feedback_template_exists(self):
+    def test_skills_feedback_template_exists(self) -> None:
         """Test skills_feedback template exists."""
         assert "skills_feedback" in PROMPT_TEMPLATES
         assert "v1" in PROMPT_TEMPLATES["skills_feedback"]
 
-    def test_projects_feedback_template_exists(self):
+    def test_projects_feedback_template_exists(self) -> None:
         """Test projects_feedback template exists."""
         assert "projects_feedback" in PROMPT_TEMPLATES
         assert "v1" in PROMPT_TEMPLATES["projects_feedback"]
 
-    def test_presentation_feedback_template_exists(self):
+    def test_presentation_feedback_template_exists(self) -> None:
         """Test presentation_feedback template exists."""
         assert "presentation_feedback" in PROMPT_TEMPLATES
         assert "v1" in PROMPT_TEMPLATES["presentation_feedback"]
 
-    def test_gaps_feedback_template_exists(self):
+    def test_gaps_feedback_template_exists(self) -> None:
         """Test gaps_feedback template exists."""
         assert "gaps_feedback" in PROMPT_TEMPLATES
         assert "v1" in PROMPT_TEMPLATES["gaps_feedback"]
 
-    def test_first_impression_template_exists(self):
+    def test_first_impression_template_exists(self) -> None:
         """Test first_impression template exists."""
         assert "first_impression" in PROMPT_TEMPLATES
         assert "v1" in PROMPT_TEMPLATES["first_impression"]
 
-    def test_each_template_contains_context_placeholder(self):
+    def test_each_template_contains_context_placeholder(self) -> None:
         """Test each template contains {context} placeholder."""
         for template_name, versions in PROMPT_TEMPLATES.items():
             for version, template_text in versions.items():
-                assert "{context}" in template_text, f"{template_name} v{version} missing {{context}}"
+                assert (
+                    "{context}" in template_text
+                ), f"{template_name} v{version} missing {{context}}"
 
-    def test_each_template_contains_github_username_placeholder(self):
+    def test_each_template_contains_github_username_placeholder(self) -> None:
         """Test each template contains {github_username} placeholder."""
         for template_name, versions in PROMPT_TEMPLATES.items():
             for version, template_text in versions.items():
@@ -62,7 +76,7 @@ class TestPromptTemplates:
                     "{github_username}" in template_text
                 ), f"{template_name} v{version} missing {{github_username}}"
 
-    def test_each_template_contains_project_count_placeholder(self):
+    def test_each_template_contains_project_count_placeholder(self) -> None:
         """Test each template contains {project_count} placeholder."""
         for template_name, versions in PROMPT_TEMPLATES.items():
             for version, template_text in versions.items():
@@ -70,7 +84,7 @@ class TestPromptTemplates:
                     "{project_count}" in template_text
                 ), f"{template_name} v{version} missing {{project_count}}"
 
-    def test_get_template_returns_correct_template(self):
+    def test_get_template_returns_correct_template(self) -> None:
         """Test get_template() returns correct template."""
         template = get_template("skills_feedback", "v1")
 
@@ -78,182 +92,210 @@ class TestPromptTemplates:
         assert "{context}" in template
         assert "skills" in template.lower()
 
-    def test_get_template_projects_feedback(self):
+    def test_get_template_projects_feedback(self) -> None:
         """Test get_template for projects_feedback."""
         template = get_template("projects_feedback", "v1")
 
         assert isinstance(template, str)
         assert "project" in template.lower()
 
-    def test_get_template_presentation_feedback(self):
+    def test_get_template_presentation_feedback(self) -> None:
         """Test get_template for presentation_feedback."""
         template = get_template("presentation_feedback", "v1")
 
         assert isinstance(template, str)
         assert "presentation" in template.lower() or "readme" in template.lower()
 
-    def test_get_template_gaps_feedback(self):
+    def test_get_template_gaps_feedback(self) -> None:
         """Test get_template for gaps_feedback."""
         template = get_template("gaps_feedback", "v1")
 
         assert isinstance(template, str)
         assert "gap" in template.lower() or "skill" in template.lower()
 
-    def test_get_template_first_impression(self):
+    def test_get_template_first_impression(self) -> None:
         """Test get_template for first_impression."""
         template = get_template("first_impression", "v1")
 
         assert isinstance(template, str)
         assert "impression" in template.lower() or "summary" in template.lower()
 
-    def test_get_template_unknown_name_raises_error(self):
+    def test_get_template_unknown_name_raises_error(self) -> None:
         """Test get_template() raises KeyError/ValueError for unknown template."""
         with pytest.raises((KeyError, ValueError)):
             get_template("nonexistent_template")
 
-    def test_get_template_unknown_version_raises_error(self):
+    def test_get_template_unknown_version_raises_error(self) -> None:
         """Test get_template() raises KeyError/ValueError for unknown version."""
         with pytest.raises((KeyError, ValueError)):
             get_template("skills_feedback", "v999")
 
-    def test_all_templates_have_v1(self):
+    def test_all_templates_have_v1(self) -> None:
         """Test all templates have v1 version."""
-        for template_name in PROMPT_TEMPLATES.keys():
+        for template_name in PROMPT_TEMPLATES:
             assert "v1" in PROMPT_TEMPLATES[template_name]
 
-    def test_templates_are_strings(self):
+    def test_templates_are_strings(self) -> None:
         """Test all templates are strings."""
-        for template_name, versions in PROMPT_TEMPLATES.items():
-            for version, template_text in versions.items():
+        for versions in PROMPT_TEMPLATES.values():
+            for template_text in versions.values():
                 assert isinstance(template_text, str)
                 assert len(template_text) > 0
 
-    def test_templates_have_reasonable_length(self):
+    def test_templates_have_reasonable_length(self) -> None:
         """Test templates have reasonable length."""
         for template_name, versions in PROMPT_TEMPLATES.items():
             for version, template_text in versions.items():
                 # Templates should be at least 100 chars
                 assert len(template_text) > 100, f"{template_name} v{version} too short"
 
-    def test_skills_feedback_mentions_technical_skills(self):
+    def test_skills_feedback_mentions_technical_skills(self) -> None:
         """Test skills_feedback template mentions technical skills."""
         template = PROMPT_TEMPLATES["skills_feedback"]["v1"]
 
         assert "skill" in template.lower()
 
-    def test_projects_feedback_mentions_code_quality(self):
+    def test_projects_feedback_mentions_code_quality(self) -> None:
         """Test projects_feedback template mentions code quality."""
         template = PROMPT_TEMPLATES["projects_feedback"]["v1"]
 
         assert "project" in template.lower() or "quality" in template.lower()
 
-    def test_gaps_feedback_mentions_missing_skills(self):
+    def test_gaps_feedback_mentions_missing_skills(self) -> None:
         """Test gaps_feedback template mentions missing/gap concepts."""
         template = PROMPT_TEMPLATES["gaps_feedback"]["v1"]
 
-        assert "gap" in template.lower() or "missing" in template.lower() or "demand" in template.lower()
+        assert (
+            "gap" in template.lower()
+            or "missing" in template.lower()
+            or "demand" in template.lower()
+        )
 
-    def test_presentation_feedback_mentions_readme(self):
+    def test_presentation_feedback_mentions_readme(self) -> None:
         """Test presentation_feedback template mentions README or presentation."""
         template = PROMPT_TEMPLATES["presentation_feedback"]["v1"]
 
-        assert "readme" in template.lower() or "presentation" in template.lower() or "organization" in template.lower()
+        assert (
+            "readme" in template.lower()
+            or "presentation" in template.lower()
+            or "organization" in template.lower()
+        )
 
-    def test_first_impression_is_concise(self):
+    def test_first_impression_is_concise(self) -> None:
         """Test first_impression template instructs concise output."""
         template = PROMPT_TEMPLATES["first_impression"]["v1"]
 
-        assert "2" in template or "3" in template or "sentence" in template.lower() or "summary" in template.lower()
+        assert (
+            "2" in template
+            or "3" in template
+            or "sentence" in template.lower()
+            or "summary" in template.lower()
+        )
 
-    def test_get_template_default_version(self):
+    def test_get_template_default_version(self) -> None:
         """Test get_template() defaults to v1 when version not specified."""
         template_default = get_template("skills_feedback")
         template_v1 = get_template("skills_feedback", "v1")
 
         assert template_default == template_v1
 
-    def test_template_snapshot_content_hash(self):
-        """Snapshot test: verify template content hash."""
-        # Create hash of all template content
-        template_content = ""
+    def test_no_new_templates_or_versions_are_missing_a_snapshot(self) -> None:
+        """Every template/version in PROMPT_TEMPLATES must have a recorded hash."""
+        for name, versions in PROMPT_TEMPLATES.items():
+            assert name in EXPECTED_TEMPLATE_HASHES, (
+                f"'{name}' has no recorded snapshot hash in EXPECTED_TEMPLATE_HASHES. "
+                f"Add its current hash deliberately before this test can pass."
+            )
+            for version in versions:
+                assert version in EXPECTED_TEMPLATE_HASHES[name], (
+                    f"'{name}' {version} has no recorded snapshot hash. "
+                    f"Add its current hash deliberately before this test can pass."
+                )
+
+    def test_template_snapshot_content_hash(self) -> None:
+        """Snapshot test: fail if any template's content drifted from its recorded hash."""
         for name in sorted(PROMPT_TEMPLATES.keys()):
             for version in sorted(PROMPT_TEMPLATES[name].keys()):
-                template_content += PROMPT_TEMPLATES[name][version]
+                actual_hash = hashlib.md5(PROMPT_TEMPLATES[name][version].encode()).hexdigest()
+                expected_hash = EXPECTED_TEMPLATE_HASHES[name][version]
 
-        content_hash = hashlib.md5(template_content.encode()).hexdigest()
+                assert actual_hash == expected_hash, (
+                    f"Content for template '{name}' {version} has changed "
+                    f"(expected hash {expected_hash}, got {actual_hash}). "
+                    f"If this change is intentional, bump the template's version "
+                    f"and record the new hash in EXPECTED_TEMPLATE_HASHES."
+                )
 
-        # Expected hash - update if templates intentionally change
-        # This helps detect unintended changes to templates
-        assert isinstance(content_hash, str)
-        assert len(content_hash) == 32  # MD5 hash length
-
-    def test_skills_feedback_requests_json_format(self):
+    def test_skills_feedback_requests_json_format(self) -> None:
         """Test skills_feedback requests JSON output."""
         template = PROMPT_TEMPLATES["skills_feedback"]["v1"]
 
         assert "json" in template.lower()
 
-    def test_projects_feedback_requests_json_format(self):
+    def test_projects_feedback_requests_json_format(self) -> None:
         """Test projects_feedback requests JSON output."""
         template = PROMPT_TEMPLATES["projects_feedback"]["v1"]
 
         assert "json" in template.lower()
 
-    def test_presentation_feedback_requests_json_format(self):
+    def test_presentation_feedback_requests_json_format(self) -> None:
         """Test presentation_feedback requests JSON output."""
         template = PROMPT_TEMPLATES["presentation_feedback"]["v1"]
 
         assert "json" in template.lower()
 
-    def test_gaps_feedback_requests_json_format(self):
+    def test_gaps_feedback_requests_json_format(self) -> None:
         """Test gaps_feedback requests JSON output."""
         template = PROMPT_TEMPLATES["gaps_feedback"]["v1"]
 
         assert "json" in template.lower()
 
-    def test_first_impression_plain_text(self):
+    def test_first_impression_plain_text(self) -> None:
         """Test first_impression may request plain text."""
         template = PROMPT_TEMPLATES["first_impression"]["v1"]
 
         # Should specify format (JSON or plain text)
-        assert "json" in template.lower() or "text" in template.lower() or "summary" in template.lower()
+        assert (
+            "json" in template.lower()
+            or "text" in template.lower()
+            or "summary" in template.lower()
+        )
 
-    def test_templates_have_portfolio_context(self):
+    def test_templates_have_portfolio_context(self) -> None:
         """Test templates mention portfolio or context."""
-        for name in PROMPT_TEMPLATES.keys():
+        for name in PROMPT_TEMPLATES:
             template = PROMPT_TEMPLATES[name]["v1"]
             # All should have context mention or portfolio mention
             assert "{context}" in template or "portfolio" in template.lower()
 
-    def test_template_get_logs_retrieval(self):
+    def test_template_get_logs_retrieval(self) -> None:
         """Test that get_template logs retrieval."""
-        # Import logger to verify it's used
-        with pytest.MonkeyPatch.context() as mp:
-            from unittest.mock import patch
-            with patch('rag.generator.prompt_templates.logger') as mock_logger:
-                get_template("skills_feedback")
-                # Should log template retrieval
+        from unittest.mock import patch
 
-    def test_each_template_name_is_valid_identifier(self):
+        with patch("rag.generator.prompt_templates.logger") as mock_logger:
+            get_template("skills_feedback")
+            mock_logger.info.assert_called_once()
+
+    def test_each_template_name_is_valid_identifier(self) -> None:
         """Test template names are valid Python identifiers."""
-        for name in PROMPT_TEMPLATES.keys():
+        for name in PROMPT_TEMPLATES:
             assert name.isidentifier()
             assert "_" in name  # Should use snake_case
 
-    def test_template_versions_are_strings(self):
+    def test_template_versions_are_strings(self) -> None:
         """Test template version keys are strings."""
-        for template_name, versions in PROMPT_TEMPLATES.items():
+        for versions in PROMPT_TEMPLATES.values():
             assert isinstance(versions, dict)
-            for version_key in versions.keys():
+            for version_key in versions:
                 assert isinstance(version_key, str)
                 assert version_key.startswith("v")
 
-    def test_no_hardcoded_usernames_in_templates(self):
+    def test_no_hardcoded_usernames_in_templates(self) -> None:
         """Test templates don't contain hardcoded test usernames."""
         forbidden = ["john", "jane", "test", "demo"]
 
-        for name, versions in PROMPT_TEMPLATES.items():
-            for version, template_text in versions.items():
+        for versions in PROMPT_TEMPLATES.values():
+            for template_text in versions.values():
                 for forbidden_word in forbidden:
                     # Should use {github_username} placeholder instead
                     assert not (
@@ -261,13 +303,14 @@ class TestPromptTemplates:
                         and "{github_username}" not in template_text
                     )
 
-    def test_templates_use_consistent_placeholders(self):
+    def test_templates_use_consistent_placeholders(self) -> None:
         """Test all templates use consistent placeholder syntax."""
-        for name, versions in PROMPT_TEMPLATES.items():
-            for version, template_text in versions.items():
+        import re
+
+        for versions in PROMPT_TEMPLATES.values():
+            for template_text in versions.values():
                 # All placeholders should use {name} syntax
-                import re
-                placeholders = re.findall(r'\{(\w+)\}', template_text)
+                placeholders = re.findall(r"\{(\w+)\}", template_text)
                 assert "context" in placeholders
                 assert "github_username" in placeholders
                 assert "project_count" in placeholders


### PR DESCRIPTION
## Summary
There was already a test that looked like a snapshot test for the prompt templates, but it wasn't really checking anything. It hashed all the template content and then just confirmed the hash was a string of the right length, nothing more. That meant you could reword any template and every test would keep passing, since nothing was compared against a known-good value. This PR fixes that by recording the actual expected hash for each template and version, and having the test fail if a template's content drifts from what's recorded without a deliberate version bump.

## Issue
Closes #37

## Changes
I added a small dictionary of expected hashes, one per template and version, and rewrote the old snapshot test to compare against it instead of doing a meaningless type check. I also added a second test that catches the case where someone adds a brand new template without recording a hash for it, so that doesn't slip through silently either. While I was in the file I cleaned up a handful of pre-existing lint issues (some unused loop variables and outdated iteration patterns) since they were blocking the pre-commit hooks from passing.

## Testing
I ran `make test-unit`, `make lint`, and `make typecheck` before and after making this change, using the commit right before my fix as the baseline. The results were the same both times: 53 unrelated test failures in other modules like the bias detector, resume parser, and review service, 163 pre-existing ruff errors elsewhere in the codebase (actually a few fewer than before, since my cleanup incidentally fixed some), and 5 mypy errors that don't even touch the tests folder. None of that is caused by this change, and all 38 tests in `test_prompt_templates.py` pass on their own.

- [x] Unit tests pass (`make test-unit`) - pre-existing unrelated failures noted above
- [ ] Integration tests pass (`make test-integration`)
- [x] Linter passes (`make lint`) - pre-existing unrelated errors noted above
- [x] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes

## Screenshots / Demo
N/A, this is just a test change with no UI to show.

## Notes for Reviewers
I went with recording a hash per template and version rather than one combined hash for everything. That way, if a template does drift, the failure message points at exactly which one changed instead of just saying something, somewhere, is different.
