### PR TITLE
Docs/36 hybrid retrieval scoring

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -36,3 +36,17 @@ I selected this issue because it is a Tier 1 task with a clearly defined and man
 
 \*\*Cohort ledger:\*\* \[x] Issue added to cohort ledger
 
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [to be added after the reproduction commit is pushed]
+
+**Reproduction summary:**  
+I reproduced issue #36 by comparing `docs/ARCHITECTURE.md` with the hybrid retrieval implementation in `rag/retriever/hybrid.py`. The architecture document only states that hybrid retrieval combines vector similarity and BM25 keyword search, while the implementation normalizes both scores, applies default weights of 0.7 and 0.3, calculates a blended score, filters by a minimum score, and sorts the remaining results.
+
+**PLAN.md link:** [to be added after PLAN.md is created and pushed]
+
+**Walkthrough video (recommended):** Not recorded
+
+**Blockers or open questions:**  
+I need to ensure the documentation explains the scoring behavior accurately without making the architecture section unnecessarily difficult to understand.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,38 @@
+\## Week 7 — Issue Selection
+
+
+
+\*\*Issue link:\*\* https://github.com/ascherj/pathreview/issues/36
+
+
+
+\*\*Issue title:\*\* Architecture doc doesn't explain the hybrid retrieval scoring formula
+
+
+
+\*\*Tier:\*\* \[x] Tier 1  \[ ] Tier 2  \[ ] Tier 3
+
+
+
+\*\*Problem summary:\*\*
+
+The architecture documentation explains that hybrid retrieval combines vector similarity and keyword relevance, but it does not show how those scores are mathematically combined. It also does not identify the default weights used by the system, making the retrieval process harder for contributors to understand or reproduce. This issue affects `docs/ARCHITECTURE.md` and does not require changing the application's runtime behavior. A successful fix will document the scoring formula, state the default weights, and include a clear worked example.
+
+
+
+\*\*Selection reasoning:\*\*
+
+I selected this issue because it is a Tier 1 task with a clearly defined and manageable scope. The work is limited to one documentation file, and I can inspect the existing retrieval code to confirm the formula and weights before writing the explanation. It does not require redesigning the application or modifying several unrelated modules. This makes it appropriate for my current experience while still requiring me to understand how the hybrid retrieval system works.
+
+
+
+\*\*Branch name:\*\* `docs/36-hybrid-retrieval-scoring`
+
+
+
+\*\*Setup confirmation:\*\* \[x] App runs locally at localhost:5173
+
+
+
+\*\*Cohort ledger:\*\* \[x] Issue added to cohort ledger
+

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -39,12 +39,12 @@ I selected this issue because it is a Tier 1 task with a clearly defined and man
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [to be added after the reproduction commit is pushed]
+**Reproduction commit link:** https://github.com/mattmiara04/pathreview/commit/4b8bfce
 
 **Reproduction summary:**  
 I reproduced issue #36 by comparing `docs/ARCHITECTURE.md` with the hybrid retrieval implementation in `rag/retriever/hybrid.py`. The architecture document only states that hybrid retrieval combines vector similarity and BM25 keyword search, while the implementation normalizes both scores, applies default weights of 0.7 and 0.3, calculates a blended score, filters by a minimum score, and sorts the remaining results.
 
-**PLAN.md link:** [to be added after PLAN.md is created and pushed]
+**PLAN.md link:** https://github.com/mattmiara04/pathreview/blob/docs/36-hybrid-retrieval-scoring/PLAN.md
 
 **Walkthrough video (recommended):** Not recorded
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -50,3 +50,36 @@ I reproduced issue #36 by comparing `docs/ARCHITECTURE.md` with the hybrid retri
 
 **Blockers or open questions:**  
 I need to ensure the documentation explains the scoring behavior accurately without making the architecture section unnecessarily difficult to understand.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**  
+I reviewed the hybrid retrieval implementation and completed the documentation update described in `PLAN.md`. I added the scoring formulas, default weights, threshold behavior, ranking process, worked example, and edge-case behavior to `docs/ARCHITECTURE.md`.
+
+**Next steps:**  
+Add and run a focused test for the architecture documentation, complete the repository checks, open the pull request, and document the final results.
+
+**Blockers:**  
+The repository has pre-existing Ruff, Black, Mypy, and unit-test failures unrelated to Issue #36.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [PASTE_PR_URL_HERE](https://github.com/ascherj/pathreview/pull/726)
+
+**Branch:** `docs/36-hybrid-retrieval-scoring`
+
+**What you built:**  
+I updated the architecture documentation to explain how vector similarity and BM25 scores are normalized and combined using the default 0.7/0.3 weighting formula. I also documented threshold filtering, ranking, missing-result behavior, and added a worked scoring example.
+
+**Tests added or updated:**  
+Added `tests/unit/test_architecture_docs.py`. It verifies that `docs/ARCHITECTURE.md` includes the hybrid scoring section, normalized score names, blended formula, default weights, minimum threshold, and missing-result behavior.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+The repository contains documented pre-existing failures, but the same failures remained before and after my contribution. The unit-test result improved from 375 passing tests to 376 passing tests while remaining at 53 failures, confirming that the new test passed and no new failures were introduced.
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -83,3 +83,34 @@ Added `tests/unit/test_architecture_docs.py`. It verifies that `docs/ARCHITECTUR
 The repository contains documented pre-existing failures, but the same failures remained before and after my contribution. The unit-test result improved from 375 passing tests to 376 passing tests while remaining at 53 failures, confirming that the new test passed and no new failures were introduced.
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**  
+No reviewer feedback was received. The Summer 2026 course notes stated that reviewer feedback was not being provided during this term, so I documented that no review came in.
+
+**How you responded:**  
+No changes were required in response to reviewer feedback because none was received.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**  
+The hardest part was navigating a large unfamiliar codebase and figuring out where the actual hybrid retrieval behavior was implemented. At first, searches returned unrelated scoring code and files inside `.venv` and `node_modules`, so I had to narrow the search until I found `rag/retriever/hybrid.py` and compare it directly with `docs/ARCHITECTURE.md`.
+
+**What did you learn about working in a large codebase?**  
+I learned that contributing to an existing project requires understanding how multiple files work together before making even a small change. For Issue #36, I had to trace the behavior across `rag/retriever/hybrid.py`, `rag/retriever/vector_store.py`, `rag/retriever/keyword_search.py`, and `docs/ARCHITECTURE.md` instead of assuming the documentation alone described the full system.
+
+**How did AI tools help — and where did they fall short?**  
+AI tools helped me navigate the repository, narrow down searches, understand the hybrid scoring formula, create a solution plan, and structure the documentation and test. However, I still had to verify the suggestions against the real code, especially when early searches returned unrelated files and when the repository had many pre-existing Ruff, Mypy, formatting, and unit-test failures.
+
+**What would you do differently if you started over?**  
+I would inspect the project structure and exclude folders such as `.venv` and `node_modules` from searches immediately. I would also run the baseline tests and validation checks earlier so I could separate pre-existing failures from anything caused by my contribution before starting the implementation.
+
+**What are you most proud of from this module?**  
+I am most proud that I was able to take Issue #36 from initial investigation through planning, implementation, testing, and a real pull request. I documented the hybrid retrieval scoring process, including the 0.7 vector and 0.3 BM25 weighting, added a focused test for the architecture documentation, and confirmed that my work did not introduce new test failures.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,87 @@
+# Solution plan
+
+**Issue:** [Architecture doc doesn't explain the hybrid retrieval scoring formula](https://github.com/ascherj/pathreview/issues/36)
+
+## Understand
+
+The architecture documentation currently describes hybrid retrieval only as a combination of vector similarity and BM25 keyword search. It does not explain how the two scores are normalized, weighted, blended, filtered, or ranked.
+
+The implementation in `rag/retriever/hybrid.py` normalizes the vector and BM25 scores against the maximum score in each result set. It then calculates a blended score using default weights of 0.7 for vector similarity and 0.3 for keyword relevance. Results below the minimum score threshold are removed, and the remaining results are sorted from highest to lowest blended score.
+
+The expected behavior is for `docs/ARCHITECTURE.md` to clearly explain this process and its default values. The actual behavior is that readers are told which retrieval methods are combined but not how the final ranking is calculated.
+
+## Map
+
+The following files are involved:
+
+- `docs/ARCHITECTURE.md` — the primary file that needs clearer documentation.
+- `rag/retriever/hybrid.py` — the source of truth for score normalization, weighting, filtering, and sorting.
+- `rag/retriever/vector_store.py` — converts ChromaDB distance values into vector similarity scores.
+- `rag/retriever/keyword_search.py` — generates the BM25 keyword scores used by the hybrid retriever.
+- `core/config.py` — contains the configured minimum relevance score and should be checked to ensure the documented threshold is accurate.
+
+The expected implementation is documentation-only unless investigation reveals that the documentation and current configuration disagree.
+
+## Plan
+
+1. Review `rag/retriever/hybrid.py`, `rag/retriever/vector_store.py`, `rag/retriever/keyword_search.py`, and `core/config.py` to confirm the current scoring behavior and default values.
+
+2. Add a hybrid retrieval scoring subsection to `docs/ARCHITECTURE.md` that defines the normalized vector score and normalized BM25 score.
+
+3. Document the blended scoring formula:
+
+   `blended_score = (vector_weight * normalized_vector_score) + (keyword_weight * normalized_keyword_score)`
+
+4. Explain the default vector weight of 0.7, keyword weight of 0.3, and minimum score threshold of 0.3.
+
+5. Explain that a chunk appearing in only one retrieval result set receives a score of zero from the missing retrieval method.
+
+6. Add a small worked example showing how vector and keyword scores produce a final blended score.
+
+7. Verify the completed documentation against the implementation and run the repository’s formatting or pre-commit checks before committing the change.
+
+## Inputs & outputs
+
+The scoring process takes the following inputs:
+
+- A user query.
+- Vector-search results containing chunk IDs and vector similarity scores.
+- BM25 search results containing chunk IDs and BM25 scores.
+- The configured vector and keyword weights.
+- The minimum blended-score threshold.
+- The maximum number of chunks to return.
+
+The process produces:
+
+- A normalized vector score for each chunk.
+- A normalized keyword score for each chunk.
+- A blended relevance score.
+- A filtered and descending-ranked list of chunks.
+
+This issue should change the architecture documentation only. It should not change the retrieval output or runtime behavior.
+
+## Risks & unknowns
+
+- The vector score originates in `rag/retriever/vector_store.py`, where ChromaDB distance is converted to similarity. The documentation must describe this accurately without implying that the raw distance is blended directly.
+
+- The default minimum relevance score also appears in `core/config.py`. I need to verify whether the configured value and the `HybridRetriever.retrieve()` default are always used consistently.
+
+- The normalization behavior depends on the maximum score returned by each retrieval method. The explanation must accurately cover empty result sets and zero maximum scores.
+
+- Default weights could change later, causing the architecture documentation to become outdated. The documentation should identify them as current defaults rather than permanent requirements.
+
+- It is currently unclear whether the issue expects only the formula or also expects a worked scoring example. I will include a concise example to make the explanation easier to verify.
+
+## Edge cases
+
+- A chunk appears in the vector results but not the BM25 results. Its keyword score should be treated as zero.
+
+- A chunk appears in the BM25 results but not the vector results. Its vector score should be treated as zero.
+
+- One or both retrieval methods return no results. Normalization should avoid division by zero and should not produce invalid scores.
+
+- All scores from one retrieval method are zero. The normalized score for that method should remain zero.
+
+- A blended score is exactly equal to the minimum threshold. It should remain in the results because the implementation uses `>=`.
+
+- More qualifying chunks exist than `max_chunks` permits. Only the highest-ranked chunks should be returned.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -58,6 +58,50 @@ A plan-execute orchestrator that coordinates multiple analysis tools. Each tool 
 
 ### RAG System (`rag/`)
 Hybrid retrieval (vector similarity + BM25 keyword) fetches relevant context from the user's ingested documents. The generator uses prompt templates to produce structured, evidence-based feedback. The evaluator scores retrieval relevance and generation faithfulness.
+### Hybrid retrieval scoring
+
+The hybrid retriever combines vector similarity results with BM25 keyword
+results. Because the two retrieval methods produce scores on different scales,
+each set of scores is normalized independently before the scores are combined.
+
+For each chunk, the normalized scores are calculated as:
+
+```text
+normalized_vector_score = vector_score / maximum_vector_score
+normalized_keyword_score = bm25_score / maximum_bm25_score
+```
+
+The final blended score is:
+
+```text
+blended_score =
+    (vector_weight * normalized_vector_score)
+    + (keyword_weight * normalized_keyword_score)
+```
+
+The current default weights are:
+
+- Vector similarity: `0.7`
+- BM25 keyword relevance: `0.3`
+
+For example, suppose a chunk has a normalized vector score of `0.8` and a
+normalized keyword score of `0.6`. Its blended score is:
+
+```text
+(0.7 * 0.8) + (0.3 * 0.6) = 0.74
+```
+
+A chunk that appears in only one result set receives a score of `0` from the
+other retrieval method. Results with a blended score below the minimum
+threshold are removed. The current default minimum score is `0.3`; scores equal
+to the threshold are retained. The remaining chunks are sorted from highest to
+lowest blended score, and only the requested maximum number of chunks is
+returned.
+
+Vector similarity scores originate in `rag/retriever/vector_store.py`, where
+ChromaDB distance is converted using `1 / (1 + distance)`. BM25 scores originate
+in `rag/retriever/keyword_search.py`. The normalization, weighting, filtering,
+and ranking logic is implemented in `rag/retriever/hybrid.py`.
 
 ### Safety Layer (`safety/`)
 Middleware wrapping the generation pipeline. Components run in sequence: prompt injection defense → content filter → bias detector → PII scrubber. All safety events are logged with structured metadata for monitoring.

--- a/tests/unit/test_architecture_docs.py
+++ b/tests/unit/test_architecture_docs.py
@@ -1,0 +1,23 @@
+"""Tests for required architecture documentation."""
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+ARCHITECTURE_DOC = Path(__file__).resolve().parents[2] / "docs" / "ARCHITECTURE.md"
+
+
+def test_hybrid_retrieval_scoring_is_documented() -> None:
+    """Verify that the hybrid retrieval scoring behavior is documented."""
+    content = ARCHITECTURE_DOC.read_text(encoding="utf-8")
+
+    assert "Hybrid retrieval scoring" in content
+    assert "normalized_vector_score" in content
+    assert "normalized_keyword_score" in content
+    assert "blended_score" in content
+    assert "Vector similarity: `0.7`" in content
+    assert "BM25 keyword relevance: `0.3`" in content
+    assert "minimum score is `0.3`" in content
+    assert "receives a score of `0`" in content


### PR DESCRIPTION
## Summary

Updates the architecture documentation to clearly explain how hybrid retrieval scores are calculated. The new section documents score normalization, the weighted formula, default values, threshold filtering, ranking behavior, and relevant edge cases.

## Issue

Closes #36

The architecture document previously said that the system combines vector similarity and BM25 keyword retrieval, but it did not explain how the two scores are normalized or combined into the final ranking score.

## Changes

- Added a “Hybrid retrieval scoring” section to `docs/ARCHITECTURE.md`
- Documented normalization of vector and BM25 scores
- Documented the blended scoring formula
- Documented the default `0.7` vector weight and `0.3` keyword weight
- Added a worked scoring example
- Explained the `0.3` minimum-score threshold
- Explained behavior when a chunk appears in only one result set
- Explained result filtering and descending ranking
- Added `tests/unit/test_architecture_docs.py` to verify the required details remain documented

## Testing

- [ ] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`)
- [ ] Linter passes (`make lint`)
- [ ] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes

New test added:

```text
python -m pytest tests/unit/test_architecture_docs.py -v

Result:
1 passed
```

## Screenshots / Demo

Not applicable. This is a documentation-only change and does not modify the user interface.

## Notes for Reviewers

This contribution only updates architecture documentation and adds a documentation test. It does not change runtime retrieval behavior.

The repository has the following pre-existing validation failures:

- Ruff: 182 existing errors
- Black: 52 existing files would be reformatted
- Mypy: 5 existing errors in 4 files
- Unit tests: 53 existing failures

The same failures were present before and after this contribution. The new architecture documentation test passes, and no new failures were introduced.