### PR TITLE
Fix/150 ignore vendored build output

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,19 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/150
+
+**Issue title:** Tech detector counts vendored and build-output files, skewing language detection
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The technology detector currently counts files inside directories such as `node_modules/` and `build/` when determining a repository's primary programming language. These directories normally contain third-party dependencies or generated build files rather than code written by the repository owner. As a result, a mainly Python project can incorrectly be classified as JavaScript. A successful fix will exclude these directories from language detection while continuing to count the project's actual source files correctly.
+
+**Selection notes — “Is this issue right for me?” checklist reasoning:**
+This issue has a clearly defined problem, reproduction example, and expected result. The work is limited mainly to `agent/tools/tech_detector.py` and the related tests in `tests/unit/test_tech_detector.py`. It is labeled Tier 1 and good first issue, so its scope is appropriate for a first contribution to this codebase. I can verify the solution using the two identified tests for excluding `node_modules/` and `build/`.
+
+**Branch name:** fix/150-ignore-vendored-build-output
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -16,4 +16,4 @@ This issue has a clearly defined problem, reproduction example, and expected res
 
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
-**Cohort ledger:** [ ] Issue added to cohort ledger
+**Cohort ledger:** [X] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -21,14 +21,15 @@ This issue has a clearly defined problem, reproduction example, and expected res
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [to be added after committing]
+**Reproduction commit link:** https://github.com/hedreez09/pathreview/commit/c2dedbe
 
 **Reproduction summary:**
 I reproduced issue #150 by running the existing tests for excluding `node_modules/` and `build/` files. Both tests failed because the detector counted JavaScript files in those directories and reported JavaScript as the primary language instead of Python.
 
-**PLAN.md link:** [to be added after creating PLAN.md]
+**PLAN.md link:**https://github.com/hedreez09/pathreview/blob/fix/150-ignore-vendored-build-output/PLAN.md
 
 **Walkthrough video (recommended):** Not recorded
 
 **Blockers or open questions:**
 I need to determine whether the fix should normalize both forward-slash and Windows backslash paths while avoiding false matches for similarly named directories.
+

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -6,7 +6,7 @@
 
 **Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
 
-**Problem summary:**
+**Problem summary:**  
 The technology detector currently counts files inside directories such as `node_modules/` and `build/` when determining a repository's primary programming language. These directories normally contain third-party dependencies or generated build files rather than code written by the repository owner. As a result, a mainly Python project can incorrectly be classified as JavaScript. A successful fix will exclude these directories from language detection while continuing to count the project's actual source files correctly.
 
 **Selection notes — “Is this issue right for me?” checklist reasoning:**
@@ -17,3 +17,18 @@ This issue has a clearly defined problem, reproduction example, and expected res
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [X] Issue added to cohort ledger
+
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [to be added after committing]
+
+**Reproduction summary:**
+I reproduced issue #150 by running the existing tests for excluding `node_modules/` and `build/` files. Both tests failed because the detector counted JavaScript files in those directories and reported JavaScript as the primary language instead of Python.
+
+**PLAN.md link:** [to be added after creating PLAN.md]
+
+**Walkthrough video (recommended):** Not recorded
+
+**Blockers or open questions:**
+I need to determine whether the fix should normalize both forward-slash and Windows backslash paths while avoiding false matches for similarly named directories.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -67,3 +67,35 @@ Updated `tests/unit/test_tech_detector.py` with one focused reproduction test an
 * `make test-unit` improved from 53 failed and 375 passed to 51 failed and 383 passed. The two issue #150 failures now pass; the remaining failures are pre-existing.
 
 **Draft PR feedback received from:** none
+
+
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No reviewer or maintainer feedback was received. Reviewer feedback is not enabled for the Summer 2026 PathReview module, so I proceeded with documenting my work and reflecting on the contribution process.
+
+**How you responded:**
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The hardest part was identifying the exact cause of the bug without changing unrelated behavior. At first, the ignored-directory logic appeared straightforward, but I discovered that `_should_skip_file()` depended on slash-prefixed substring patterns. This meant paths such as `node_modules/file.js` and `build/file.js` were not ignored when those directories appeared at the root of a repository. I also had to ensure the fix handled nested, absolute, and Windows-style paths without incorrectly excluding similarly named directories such as `build_tools`.
+
+**What did you learn about working in a large codebase?**
+I learned that contributing to an existing codebase requires understanding the surrounding behavior before making even a small change. Unlike building my own project, I could not simply choose a new implementation without considering existing conventions, tests, supported operating systems, and possible side effects. I also learned the importance of reproducing a reported bug first, making a focused change, and using regression tests to prove both that the bug was fixed and that valid files were still processed.
+
+**How did AI tools help — and where did they fall short?**
+AI tools helped me trace the path-filtering logic, reason about possible edge cases, and organize test cases for root-level, nested, absolute, and Windows-style paths. AI was also useful for explaining unfamiliar parts of the repository and reviewing my implementation plan. However, AI could not independently determine whether a suggestion matched the project’s exact behavior or distinguish failures caused by my work from failures already present in the repository. I still needed to inspect the code, run the tests, compare the results with the baseline, and verify the final behavior myself.
+
+**What would you do differently if you started over?**
+I would record the complete baseline test and lint results immediately after setting up the project. During this contribution, the broader test suite and `make check` contained pre-existing failures, including existing Ruff errors. Having a clearly documented baseline from the beginning would have made it faster to separate repository-wide problems from anything introduced by my change. I would also study the relevant helper function and its existing tests before writing the implementation plan so that I could identify cross-platform path handling earlier.
+
+**What are you most proud of from this module?**
+I am most proud that I followed the complete open-source contribution process instead of stopping after finding the bug. I reproduced Issue #150, identified its root cause, planned a focused solution, updated the path-handling logic, and added regression coverage for several path formats and false-positive cases. The targeted tech-detector test suite passed all 33 tests, and I submitted the work through a pull request with a documented contribution history.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -33,3 +33,37 @@ I reproduced issue #150 by running the existing tests for excluding `node_module
 **Blockers or open questions:**
 I need to determine whether the fix should normalize both forward-slash and Windows backslash paths while avoiding false matches for similarly named directories.
 
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+I reviewed the approved PLAN.md, reproduced the root-level ignored-directory bug, and added a focused failing test for `node_modules/pkg/index.js`. I identified that the existing matching logic required a leading slash, so it failed to recognize ignored directories located at the repository root.
+
+**Next steps:**
+Implement the smallest fix by normalizing path separators and matching exact directory components. Then add boundary tests for root-level, nested, absolute, and Windows-style paths while confirming that similarly named directories are not incorrectly skipped.
+
+**Blockers:**
+The repository has pre-existing Ruff, mypy, and unit-test failures unrelated to issue #150. I documented their baseline results and kept my changes limited to the issue.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/727
+
+**Branch:** `fix/150-ignore-vendored-build-output`
+
+**What you built:**
+I updated the tech detector to exclude files inside ignored directories by matching exact path components. The implementation normalizes Windows and Unix path separators, correctly handles root-level and nested directories, and avoids false positives such as `build_tools` and `node_modules_backup`.
+
+**Tests added or updated:**
+Updated `tests/unit/test_tech_detector.py` with one focused reproduction test and five parameterized boundary cases. The complete tech-detector test suite passes with 33 tests, including coverage for root-level, nested, absolute, and Windows-style paths.
+
+**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+
+* `make check` still reports 182 pre-existing Ruff errors unrelated to this change.
+* `make test-unit` improved from 53 failed and 375 passed to 51 failed and 383 passed. The two issue #150 failures now pass; the remaining failures are pre-existing.
+
+**Draft PR feedback received from:** none

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,113 @@
+# Solution plan
+
+**Issue:** [Tech detector counts vendored and build-output files, skewing language detection — #150](https://github.com/ascherj/pathreview/issues/150)
+
+**Working branch:** `fix/150-ignore-vendored-build-output`
+
+### Understand
+
+The technology detector receives repository file paths and passes them through `TechDetector._should_skip_file()` before detecting languages and frameworks. The current skip patterns in `agent/tools/tech_detector.py` include strings such as `"/node_modules/"` and `"/build/"`. Those patterns work when an ignored directory appears after another path segment, such as `"frontend/node_modules/package/index.js"`, but they do not match root-relative paths such as `"node_modules/package/index.js"` or `"build/bundle.js"` because those paths have no leading slash.
+
+As a result, JavaScript files from third-party dependencies and generated build output remain in `filtered_files`. Their `.js` extensions are then treated as repository source code, which adds JavaScript to the detected languages and causes the two issue-specific tests to report JavaScript instead of the expected Python.
+
+**Expected behavior:** Files inside ignored directories should not influence `primary_language`, `all_languages`, or `frameworks`, whether the ignored directory is at the repository root or nested inside another directory.
+
+**Actual behavior:** Root-level `node_modules/` and `build/` paths are not skipped, so their files influence technology detection.
+
+**Decision and reason:** I will fix directory recognition inside `_should_skip_file()` instead of adding special cases inside the language-detection loops. Filtering is already this method's responsibility, and correcting it once protects both extension-based language detection and configuration-file detection.
+
+**Scope decision and reason:** I will not redesign how `_detect_tech()` selects the primary language. Although that method currently stores languages in a set and selects the first sorted value, issue #150 and its acceptance tests concern ignored paths. Changing primary-language ranking would expand the scope and could alter unrelated behavior.
+
+### Map
+
+I expect to modify these files:
+
+1. **`agent/tools/tech_detector.py`**
+   - Function: `TechDetector._should_skip_file()`
+   - Role: Normalize incoming file paths and determine whether any directory component is in the existing ignored-directory list.
+   - Reason: This is the source of the root-level matching failure and the single filtering point used before both language and framework detection.
+
+2. **`tests/unit/test_tech_detector.py`**
+   - Tests: `test_node_modules_excluded` and `test_build_directory_excluded`
+   - Additional coverage: nested ignored directories, Windows-style separators, and similarly named directories that should not be ignored.
+   - Reason: The existing failing tests prove the reported bug. Additional focused cases will prevent a partial fix that works only for one path format or skips valid directories accidentally.
+
+No frontend, API, database, or configuration files should need changes because the defect is contained within the detector's file-path filtering logic.
+
+### Plan
+
+1. **Preserve the reproduced failure as the baseline.**
+   - Re-run the two issue-specific tests before implementation and confirm that both fail with JavaScript returned instead of Python.
+   - Reason: This provides a clear before-and-after comparison and confirms that the later passing result is caused by the fix.
+
+2. **Replace slash-dependent substring matching with directory-component matching.**
+   - Normalize backslashes to forward slashes so paths from Windows and Unix-like systems have one comparable format.
+   - Split the normalized path into components and compare directory components with the existing ignored directory names, including `node_modules`, `vendor`, `dist`, `build`, `.git`, `__pycache__`, `.venv`, and `venv`.
+   - Reason: Component matching detects ignored directories at both root and nested positions. It also avoids false matches in legitimate names such as `build_tools` or `node_modules_backup`.
+
+3. **Strengthen the focused unit tests.**
+   - Keep the existing root-level `node_modules/` and `build/` reproduction cases.
+   - Assert that ignored JavaScript files do not appear in `all_languages`, not only that `primary_language` is Python.
+   - Add representative nested paths and Windows-style backslash paths.
+   - Add a similarly named directory case to prove that only exact directory components are ignored.
+   - Reason: Testing both the positive and negative boundaries verifies the intended behavior without relying only on the current primary-language selection implementation.
+
+4. **Run targeted and regression tests.**
+   - First run the two issue-specific tests for fast feedback.
+   - Then run the complete `tests/unit/test_tech_detector.py` file.
+   - Finally run the repository's documented broader test command if the focused suite passes.
+   - Reason: The targeted tests verify issue #150 directly, while the wider tests check that existing language and framework detection behavior was not broken.
+
+5. **Review the final diff before committing the implementation.**
+   - Confirm that changes are limited to the detector and its unit tests and that no generated, dependency, or environment files are included.
+   - Reason: Keeping the commit focused makes the fix easier to review and prevents unrelated local setup changes from entering the pull request.
+
+### Inputs & outputs
+
+**Input:** `TechDetector.execute()` continues to accept a dictionary containing `"files": list[str]`. Each string may be a root-relative, nested, absolute, Unix-style, or Windows-style file path.
+
+**Output:** The public `ToolResult` structure remains unchanged:
+
+- `primary_language`: the selected language or `"Unknown"`
+- `all_languages`: sorted detected languages
+- `frameworks`: sorted detected frameworks
+
+The intended change is only which paths are allowed to contribute to those values.
+
+| Example input path | Intended filtering result | Reason |
+|---|---|---|
+| `node_modules/pkg/index.js` | Skip | `node_modules` is an ignored root directory |
+| `frontend/node_modules/pkg/index.js` | Skip | An ignored directory may be nested |
+| `build/bundle.js` | Skip | Generated build output should not count |
+| `frontend\build\bundle.js` | Skip | Windows separators should behave consistently |
+| `src/build_tools/helper.js` | Keep | `build_tools` is not the exact ignored name `build` |
+| `src/main.py` | Keep | It is repository source code outside an ignored directory |
+
+**Decision and reason:** The method signatures and returned data structure will not change because callers should receive the same API; only the accuracy of the filtered input should improve.
+
+### Risks & unknowns
+
+- **Cross-platform separators:** Git file lists often use `/`, but local or external callers may supply `\`. The implementation must normalize both formats before matching.
+- **False-positive directory names:** A broad substring check could incorrectly skip paths such as `src/build_tools/` or `node_modules_backup/`. Exact component comparison is required.
+- **Root, nested, and absolute paths:** The solution must behave consistently for `build/file.js`, `app/build/file.js`, and `/workspace/app/build/file.js`.
+- **Existing ignored directories:** The current list also includes `vendor`, `dist`, `.git`, `__pycache__`, `.venv`, and `venv`. The new matching logic should preserve these exclusions and make their root-level behavior consistent.
+- **Framework detection:** Ignored directories can contain files such as `package.json`. Because `filtered_files` feeds both detector loops, tests should confirm the fix prevents ignored configuration files from adding frameworks as well as languages if this behavior is covered by the existing design.
+- **Primary-language calculation:** `_detect_tech()` currently uses a set of detected languages rather than counting files, even though the issue description discusses skewed counts. This is related code but is not required to make the supplied issue tests pass. I will treat it as a separate concern unless maintainers clarify that issue #150 also requires changing the ranking algorithm.
+- **Input validation:** The declared input is a list of path strings. Handling non-string values is outside the current issue unless testing reveals that such values are part of the supported contract.
+
+### Edge cases
+
+The fix should handle these cases gracefully:
+
+- The ignored directory is the first component of a relative path.
+- The ignored directory appears several levels inside a path.
+- The path uses Windows backslashes, Unix forward slashes, or a mixture of both.
+- The path is absolute rather than repository-relative.
+- A valid directory merely contains an ignored word, such as `build_tools`, `rebuild`, or `node_modules_backup`.
+- Ignored directories contain recognized source extensions or configuration filenames.
+- All supplied files are ignored; the detector should return `"Unknown"` with empty language and framework lists.
+- The file list is empty; existing `"Unknown"` behavior should remain unchanged.
+- Normal source files outside ignored directories continue to be detected.
+- Existing ignored directories such as `vendor`, `dist`, `.git`, `__pycache__`, `.venv`, and `venv` continue to work at root and nested levels.
+
+This plan is a living document and may be updated in Week 9 if implementation or test results reveal an additional repository requirement.

--- a/agent/tools/tech_detector.py
+++ b/agent/tools/tech_detector.py
@@ -75,7 +75,7 @@ class TechDetector(BaseTool):
                     "primary_language": "Unknown",
                     "all_languages": [],
                     "frameworks": [],
-                }
+                },
             )
 
         try:
@@ -84,11 +84,7 @@ class TechDetector(BaseTool):
 
         except Exception as e:
             logger.error("tech_detector_error", error=str(e))
-            return ToolResult(
-                success=False,
-                data={},
-                error=str(e)
-            )
+            return ToolResult(success=False, data={}, error=str(e))
 
     def _detect_tech(self, files: list[str]) -> dict:
         """Detect technologies from file list.
@@ -100,10 +96,7 @@ class TechDetector(BaseTool):
             Dict with detected languages and frameworks
         """
         # Filter out vendor/build directories
-        filtered_files = [
-            f for f in files
-            if not self._should_skip_file(f)
-        ]
+        filtered_files = [f for f in files if not self._should_skip_file(f)]
 
         languages = set()
         frameworks = set()
@@ -131,8 +124,12 @@ class TechDetector(BaseTool):
         all_languages = sorted(languages)
         all_frameworks = sorted(frameworks)
 
-        logger.info("tech_detected", primary_lang=primary,
-                   languages_count=len(all_languages), frameworks_count=len(all_frameworks))
+        logger.info(
+            "tech_detected",
+            primary_lang=primary,
+            languages_count=len(all_languages),
+            frameworks_count=len(all_frameworks),
+        )
 
         return {
             "primary_language": primary,
@@ -142,23 +139,19 @@ class TechDetector(BaseTool):
 
     @staticmethod
     def _should_skip_file(filepath: str) -> bool:
-        """Check if file should be skipped.
+        """Check if file should be skipped."""
+        ignored_directories = {
+            "node_modules",
+            "vendor",
+            "dist",
+            "build",
+            ".git",
+            "__pycache__",
+            ".venv",
+            "venv",
+        }
 
-        Args:
-            filepath: File path
+        normalized_path = filepath.replace("\\", "/")
+        directory_components = normalized_path.split("/")[:-1]
 
-        Returns:
-            True if file should be skipped
-        """
-        skip_patterns = [
-            "/node_modules/",
-            "/vendor/",
-            "/dist/",
-            "/build/",
-            "/.git/",
-            "/__pycache__/",
-            "/.venv/",
-            "/venv/",
-        ]
-
-        return any(pattern in filepath for pattern in skip_patterns)
+        return any(component in ignored_directories for component in directory_components)

--- a/tests/unit/test_tech_detector.py
+++ b/tests/unit/test_tech_detector.py
@@ -14,6 +14,17 @@ class TestTechDetector:
         """Create a TechDetector instance."""
         return TechDetector()
 
+    def test_root_node_modules_path_should_be_skipped(self, detector: TechDetector) -> None:
+        """Reproduce root-level node_modules path filtering bug."""
+        filepath = "node_modules/pkg/index.js"
+
+        actual_result = detector._should_skip_file(filepath)
+
+        assert actual_result is True, (
+            f"Expected _should_skip_file({filepath!r}) to return True, "
+            f"but received {actual_result!r}"
+        )
+
     def test_single_language_repo(self, detector):
         """Test single-language repo correctly identifies primary_language."""
         files = [

--- a/tests/unit/test_tech_detector.py
+++ b/tests/unit/test_tech_detector.py
@@ -25,6 +25,30 @@ class TestTechDetector:
             f"but received {actual_result!r}"
         )
 
+    @pytest.mark.parametrize(
+        ("filepath", "expected_result"),
+        [
+            ("frontend/node_modules/pkg/index.js", True),
+            (r"frontend\build\bundle.js", True),
+            ("/workspace/project/dist/bundle.js", True),
+            ("src/build_tools/helper.js", False),
+            ("src/node_modules_backup/index.js", False),
+        ],
+    )
+    def test_ignored_directory_path_boundaries(
+        self,
+        detector: TechDetector,
+        filepath: str,
+        expected_result: bool,
+    ) -> None:
+        """Test ignored directories across path formats and boundaries."""
+        actual_result = detector._should_skip_file(filepath)
+
+        assert actual_result is expected_result, (
+            f"Expected _should_skip_file({filepath!r}) to return "
+            f"{expected_result!r}, but received {actual_result!r}"
+        )
+
     def test_single_language_repo(self, detector):
         """Test single-language repo correctly identifies primary_language."""
         files = [
@@ -135,23 +159,20 @@ class TestTechDetector:
             "app.py",
             "main.py",
         ]
-
         result = detector.execute({"files": files})
 
-        # Should detect Python as primary language
-
+    # Should detect Python as primary language
     def test_github_actions_detection(self, detector):
         """Test GitHub Actions detection."""
         files = [
             ".github/workflows/test.yml",
             "main.py",
         ]
-
         result = detector.execute({"files": files})
 
         data = result.data
-        # Should detect both Python and CI/CD
 
+    # Should detect both Python and CI/CD
     def test_makefile_detection(self, detector):
         """Test Makefile detection."""
         files = [


### PR DESCRIPTION
## Summary

Fixes the tech detector so that vendored and generated files inside ignored directories are excluded consistently. The previous implementation failed to recognize root-level directories such as `node_modules/` and `build/` because its matching logic expected a preceding slash. The updated implementation normalizes path separators and checks exact directory components, preventing both missed exclusions and false positives.

## Issue

Closes #150

## Changes

* Added a focused reproduction test for root-level `node_modules/` paths.
* Normalized Windows-style backslashes to forward slashes before evaluating paths.
* Replaced substring matching with exact directory-component matching.
* Ensured ignored directories are detected at root, nested, and absolute path levels.
* Added tests for Windows-style paths and similarly named valid directories.
* Confirmed directories such as `build_tools` and `node_modules_backup` are not incorrectly excluded.

## Testing

* [ ] Unit tests pass (`make test-unit`)

  * Tech-detector suite: **33 passed**
  * Repository-wide results before fix: **53 failed, 375 passed**
  * Repository-wide results after fix: **51 failed, 383 passed**
  * The remaining 51 failures are unrelated pre-existing failures.
* [ ] Integration tests pass (`make test-integration`)

  * Not run because this change is isolated to unit-level path-filtering behavior.
* [ ] Linter passes (`make lint`)

  * `make check` reports the same **182 pre-existing Ruff errors** unrelated to this PR.
* [ ] Type checker passes (`make typecheck`)

  * Not completed because `make check` stopped at the existing Ruff failures.
* [x] New/updated tests cover the changes

  * Added one focused reproduction case and five path-boundary cases.

## Screenshots / Demo

Not applicable. This change affects backend path-filtering logic and is verified through automated tests.

## Notes for Reviewers

The reproduction and implementation were intentionally separated:

* `8adbc45` — focused reproduction test for the root-level ignored-path bug.
* `50719ba` — implementation fix and additional boundary coverage.

Please pay particular attention to the exact component matching in `_should_skip_file()`. It excludes directories such as `build` and `node_modules` without incorrectly excluding similarly named directories such as `build_tools` or `node_modules_backup`.

The repository-wide Ruff errors and remaining unit-test failures existed before this change and were not modified to keep the PR limited to issue #150.
