### PR TITLE
Fix/24 hybrid retriever

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -14,3 +14,17 @@ The issue is that the keywords are being matched incorrectly and the model will 
 **Setup confirmation:** [X] App runs locally at localhost:5173
 
 **Cohort ledger:** [X] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [link to commit documenting the reproduced issue]
+
+**Reproduction summary:**
+[1–2 sentences: How did you reproduce the issue? What did you observe?]
+
+**PLAN.md link:** [link to PLAN.md in your fork]
+
+**Walkthrough video (recommended):** [link to your Loom video, ≤2 min — recommended, not graded]
+
+**Blockers or open questions:**
+[Anything you're still uncertain about going into Week 9, or leave blank]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -20,9 +20,9 @@ The issue is that the keywords are being matched incorrectly and the model will 
 **Reproduction commit link:** [link to commit documenting the reproduced issue]
 
 **Reproduction summary:**
-[1–2 sentences: How did you reproduce the issue? What did you observe?]
+I reproduced the issue by uploading my own resume. There didn't seem to be much errors however, there were some slight variability for the same resume across different accounts.
 
 **PLAN.md link:** [link to PLAN.md in your fork]
 
 **Blockers or open questions:**
-[Anything you're still uncertain about going into Week 9, or leave blank]
+I am still uncertain about where the error exactly is and what type of logic error it is.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -24,7 +24,5 @@ The issue is that the keywords are being matched incorrectly and the model will 
 
 **PLAN.md link:** [link to PLAN.md in your fork]
 
-**Walkthrough video (recommended):** [link to your Loom video, ≤2 min — recommended, not graded]
-
 **Blockers or open questions:**
 [Anything you're still uncertain about going into Week 9, or leave blank]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -17,12 +17,12 @@ The issue is that the keywords are being matched incorrectly and the model will 
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [link to commit documenting the reproduced issue]
+**Reproduction commit link:** https://github.com/scnoder/pathreview/commit/0c6168bc2fd051bd759f4422745c6aa4924a5a7b
 
 **Reproduction summary:**
 I reproduced the issue by uploading my own resume. There didn't seem to be much errors however, there were some slight variability for the same resume across different accounts.
 
-**PLAN.md link:** [link to PLAN.md in your fork]
+**PLAN.md link:** https://github.com/scnoder/pathreview/blob/fix/24-hybrid-retriever/PLAN.md
 
 **Blockers or open questions:**
 I am still uncertain about where the error exactly is and what type of logic error it is.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,16 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/24
+
+**Issue title:** Hybrid retriever over-weights keyword results when query contains technology names
+
+**Tier:** [ ] Tier 1  [X] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The issue is that the keywords are being matched incorrectly and the model will return irrelevant chunks from the wrong document because of similar wordings. What is currently broken is the RAG retrieval system in `rag/retriever/hybrid.py` and a successful fix would be that the correct chunks are being returned for the model to use.
+
+**Branch name:** [paste branch name here]
+
+**Setup confirmation:** [ ] App runs locally at localhost:5173
+
+**Cohort ledger:** [X] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -26,3 +26,34 @@ I reproduced the issue by uploading my own resume. There didn't seem to be much 
 
 **Blockers or open questions:**
 I am still uncertain about where the error exactly is and what type of logic error it is.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+[What have you implemented so far? Which sub-tasks from PLAN.md are done?]
+
+**Next steps:**
+[What are you working on for the rest of the week?]
+
+**Blockers:**
+[Anything slowing you down? Or leave blank.]
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [link to your submitted pull request]
+
+**Branch:** [the branch name you worked on, e.g. `fix/123-short-description`]
+
+**What you built:**
+[1–3 sentences summarizing what your fix does and how it works]
+
+**Tests added or updated:**
+[Which test files did you touch? What do they cover?]
+
+**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+
+**Draft PR feedback received from:** [name or Slack handle, or "none"]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -9,8 +9,8 @@
 **Problem summary:**
 The issue is that the keywords are being matched incorrectly and the model will return irrelevant chunks from the wrong document because of similar wordings. What is currently broken is the RAG retrieval system in `rag/retriever/hybrid.py` and a successful fix would be that the correct chunks are being returned for the model to use.
 
-**Branch name:** [paste branch name here]
+**Branch name:** fix/24-hybrid-retriver
 
-**Setup confirmation:** [ ] App runs locally at localhost:5173
+**Setup confirmation:** [X] App runs locally at localhost:5173
 
 **Cohort ledger:** [X] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -62,14 +62,13 @@ I touched `hybrid.py` and `keyword_search.py` because the focus on the BM25 scor
 
 ### Reviewer feedback
 
-**Feedback received:** [ ] Yes  [X] No — still awaiting review
+**Feedback received:** [X] Yes  [] No — still awaiting review
 
 **Summary of feedback:**
-[What did reviewers comment on? Or note that no review came in.]
+My reviewer told me to talk more about what files were changed and have better commit messages.
 
 **How you responded:**
-[What changes did you make, or what did you reply? If no feedback,
-leave blank.]
+I responded by updating the PR to have more files and details about those files. I will work on having more detailed commit messages in the future.
 
 ---
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -44,7 +44,7 @@ Since this is a logic error, there are many places where the error could reside.
 
 ### Check-in 2 (end of week)
 
-**PR link:** [link to your submitted pull request]
+**PR link:** https://github.com/ascherj/pathreview/pull/732
 
 **Branch:** `fix/24-hybrid-reviewer`
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -52,7 +52,7 @@ Since this is a logic error, there are many places where the error could reside.
 [1–3 sentences summarizing what your fix does and how it works]
 
 **Tests added or updated:**
-[Which test files did you touch? What do they cover?]
+I touched `hybrid.py` and `keyword_search.py` because the focus on the BM25 scoring which is what the model uses to run.
 
 **Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -32,13 +32,13 @@ I am still uncertain about where the error exactly is and what type of logic err
 ### Check-in 1 (mid-week)
 
 **Current progress:**
-[What have you implemented so far? Which sub-tasks from PLAN.md are done?]
+I have looked through `hybrid.py` and I have deduced what the error might be. I have located possible locations to fix this error as well.
 
 **Next steps:**
-[What are you working on for the rest of the week?]
+I am working on narrowing down the location and fixing the error. I plan to have this done by the end of the week.
 
 **Blockers:**
-[Anything slowing you down? Or leave blank.]
+Since this is a logic error, there are many places where the error could reside.
 
 ---
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -62,7 +62,7 @@ I touched `hybrid.py` and `keyword_search.py` because the focus on the BM25 scor
 
 ### Reviewer feedback
 
-**Feedback received:** [ ] Yes  [ ] No — still awaiting review
+**Feedback received:** [ ] Yes  [X] No — still awaiting review
 
 **Summary of feedback:**
 [What did reviewers comment on? Or note that no review came in.]
@@ -76,20 +76,15 @@ leave blank.]
 ### Reflection
 
 **What was harder than you expected?**
-[Be specific — what part of the process, codebase, or workflow
-surprised you?]
+Something that was harder was learning how to properly run the code and connect it. I was having trouble with Docker and getting the code to run. In the end, I finally got it to work.
 
 **What did you learn about working in a large codebase?**
-[What's different about contributing to someone else's production code
-vs. building your own project?]
+Contributing to someone else's database is more structured. When developing my own personal projects, it is more flexible to update code and push changes. Additionally, there isn't an issue where I need to keep the current branch updated with main.
 
 **How did AI tools help — and where did they fall short?**
-[Where was AI assistance most useful this module? Where did you need
-to go beyond what AI could give you?]
-
+I used AI assistance when brainstorming how to fix the issue. I needed to go beyond when I researched what BM25 was and other information about the modules in the code. It feel short in explaining some of the modules because it was more focused on the solution rather than explaning some of the code.
 **What would you do differently if you started over?**
-[Issue selection, planning, implementation, or process — anything
-you'd change?]
+I would start earlier. I think that if I had started earlier I would have done really good progress and have made a more effective fix.  
 
 **What are you most proud of from this module?**
-[One thing — it doesn't have to be the PR itself.]
+I am proud of picking a issue that wasn't too difficult and not too easy. It was a goldilocks issue that was a good step in my learning.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -57,3 +57,39 @@ I touched `hybrid.py` and `keyword_search.py` because the focus on the BM25 scor
 **Self-review confirmation:** [X] make check passes  [X] make test-unit passes
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [ ] No — still awaiting review
+
+**Summary of feedback:**
+[What did reviewers comment on? Or note that no review came in.]
+
+**How you responded:**
+[What changes did you make, or what did you reply? If no feedback,
+leave blank.]
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+[Be specific — what part of the process, codebase, or workflow
+surprised you?]
+
+**What did you learn about working in a large codebase?**
+[What's different about contributing to someone else's production code
+vs. building your own project?]
+
+**How did AI tools help — and where did they fall short?**
+[Where was AI assistance most useful this module? Where did you need
+to go beyond what AI could give you?]
+
+**What would you do differently if you started over?**
+[Issue selection, planning, implementation, or process — anything
+you'd change?]
+
+**What are you most proud of from this module?**
+[One thing — it doesn't have to be the PR itself.]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -46,14 +46,14 @@ Since this is a logic error, there are many places where the error could reside.
 
 **PR link:** [link to your submitted pull request]
 
-**Branch:** [the branch name you worked on, e.g. `fix/123-short-description`]
+**Branch:** `fix/24-hybrid-reviewer`
 
 **What you built:**
-[1–3 sentences summarizing what your fix does and how it works]
+My fix reevaluates the BM25 retriever only so that when the chunks are scored, there is much better evaluation. This made the keyword signals more meaningful.
 
 **Tests added or updated:**
 I touched `hybrid.py` and `keyword_search.py` because the focus on the BM25 scoring which is what the model uses to run.
 
-**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+**Self-review confirmation:** [X] make check passes  [X] make test-unit passes
 
-**Draft PR feedback received from:** [name or Slack handle, or "none"]
+**Draft PR feedback received from:** none

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,23 @@
+## Solution plan
+
+**Issue:** [issue title and link]
+
+### Understand
+What is the root cause of this issue? What behavior is expected vs. actual?
+
+### Map
+Which files, functions, or modules are involved?
+List the specific files you expect to touch.
+
+### Plan
+What are the steps to fix this issue?
+Break it into 3–5 concrete sub-tasks.
+
+### Inputs & outputs
+What does your fix take as input? What should it produce or change?
+
+### Risks & unknowns
+What could go wrong? What are you still unsure about?
+
+### Edge cases
+What inputs or states should your fix handle gracefully?

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,23 +1,24 @@
 ## Solution plan
 
-**Issue:** [issue title and link]
+**Issue:** [Hybrid retriever over-weights keyword results when query contains technology names #24](https://github.com/ascherj/pathreview/issues/24)
 
 ### Understand
-What is the root cause of this issue? What behavior is expected vs. actual?
+The root cause of this issue is the schematic chunking. The data is getting retrived but the chunks are not being evaluated properly to get relevant results. This causes sometimes unexpected behaviors that seem relevant.
 
 ### Map
-Which files, functions, or modules are involved?
-List the specific files you expect to touch.
+I expect to touch `rag/retriver/hybrid.py` and `app.py`.
 
 ### Plan
-What are the steps to fix this issue?
-Break it into 3–5 concrete sub-tasks.
+1. Retry the prompt to see if that could fix the problem.
+2. Review the code in `hybrid.py` to decide where the root of the problem might be.
+3. Trace through the code and look at other files in `rag/retriver`.
+4. Fix the problem by reframing how chunks are sorted. 
 
 ### Inputs & outputs
-What does your fix take as input? What should it produce or change?
+The fix takes in the query from the user and the profile id to know which user the question is referring to. It returns all of the chunks in a list.
 
 ### Risks & unknowns
-What could go wrong? What are you still unsure about?
+What could go wrong is the evaluation of the individual chunks that are being sent for NLP. What is unknown currently is how the chunks are being retreived.
 
 ### Edge cases
-What inputs or states should your fix handle gracefully?
+The fix should gracefully handle a situation where there are no chunks to be retrieved.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -99,7 +99,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -449,7 +448,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -473,7 +471,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1561,7 +1558,6 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1579,7 +1575,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1972,7 +1967,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3507,7 +3501,6 @@
       "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^2.0.1",
         "cssstyle": "^4.0.1",
@@ -4094,7 +4087,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4107,7 +4099,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4771,7 +4762,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/rag/retriever/hybrid.py
+++ b/rag/retriever/hybrid.py
@@ -1,8 +1,9 @@
 """Hybrid retriever combining vector and keyword search."""
 
 import structlog
-from .vector_store import VectorStore
+
 from .keyword_search import KeywordSearcher
+from .vector_store import VectorStore
 
 logger = structlog.get_logger()
 
@@ -10,8 +11,13 @@ logger = structlog.get_logger()
 class HybridRetriever:
     """Combines vector similarity and BM25 keyword search."""
 
-    def __init__(self, vector_store: VectorStore, keyword_searcher: KeywordSearcher,
-                 vector_weight: float = 0.7, keyword_weight: float = 0.3):
+    def __init__(
+        self,
+        vector_store: VectorStore,
+        keyword_searcher: KeywordSearcher,
+        vector_weight: float = 0.7,
+        keyword_weight: float = 0.3,
+    ) -> None:
         """Initialize hybrid retriever.
 
         Args:
@@ -25,8 +31,14 @@ class HybridRetriever:
         self.vector_weight = vector_weight
         self.keyword_weight = keyword_weight
 
-    def retrieve(self, query: str, profile_id: str, query_embedding: list[float],
-                 max_chunks: int = 10, min_score: float = 0.3) -> list[dict]:
+    def retrieve(
+        self,
+        query: str,
+        profile_id: str,
+        query_embedding: list[float],
+        max_chunks: int = 10,
+        min_score: float = 0.3,
+    ) -> list[dict]:
         """Retrieve chunks using hybrid approach.
 
         Args:
@@ -40,14 +52,13 @@ class HybridRetriever:
             List of dicts with blended scores
         """
         collection_name = f"profile_{profile_id}"
-
         # Vector search
         vector_results = self.vector_store.query(
             query_embedding, collection_name, n_results=max_chunks * 2
         )
 
         # Keyword search - need to fetch all chunks first
-        all_chunks = self._get_all_chunks(collection_name)
+        # all_chunks = self._get_all_chunks(collection_name)
         keyword_results = self.keyword_searcher.search(query, top_k=max_chunks * 2)
 
         # Create id-to-chunk mapping for both approaches
@@ -67,18 +78,27 @@ class HybridRetriever:
             keyword_score = 0.0
 
             if chunk_id in vector_map:
-                vector_score = (vector_map[chunk_id]["score"] / vector_scores_max) if vector_scores_max > 0 else 0
+                vector_score = (
+                    (vector_map[chunk_id]["score"] / vector_scores_max)
+                    if vector_scores_max > 0
+                    else 0
+                )
                 base_chunk = vector_map[chunk_id]
             else:
                 base_chunk = keyword_map[chunk_id]
 
             if chunk_id in keyword_map:
-                keyword_score = (keyword_map[chunk_id].get("bm25_score", 0) / keyword_scores_max) if keyword_scores_max > 0 else 0
+                keyword_score = (
+                    (keyword_map[chunk_id].get("bm25_score", 0) / keyword_scores_max)
+                    if keyword_scores_max > 0
+                    else 0
+                )
 
-            blended_score = (
-                self.vector_weight * vector_score +
-                self.keyword_weight * keyword_score
-            )
+            keyword_weight = self._adjust_keyword_weight(keyword_map.get(chunk_id, {}))
+
+            vector_weight = 1 - keyword_weight
+
+            blended_score = vector_weight * vector_score + keyword_weight * keyword_score
 
             blended[chunk_id] = {
                 "id": chunk_id,
@@ -86,7 +106,7 @@ class HybridRetriever:
                 "metadata": base_chunk.get("metadata", {}),
                 "score": blended_score,
                 "vector_score": vector_score,
-                "keyword_score": keyword_score
+                "keyword_score": keyword_score,
             }
 
         # Filter by min_score and sort
@@ -96,10 +116,15 @@ class HybridRetriever:
         # Return top max_chunks
         final_results = results[:max_chunks]
 
-        logger.info("hybrid_retrieval_complete", query_len=len(query),
-                   vector_results=len(vector_results), keyword_results=len(keyword_results),
-                   blended_count=len(blended), filtered_count=len(results),
-                   final_count=len(final_results))
+        logger.info(
+            "hybrid_retrieval_complete",
+            query_len=len(query),
+            vector_results=len(vector_results),
+            keyword_results=len(keyword_results),
+            blended_count=len(blended),
+            filtered_count=len(results),
+            final_count=len(final_results),
+        )
 
         return final_results
 
@@ -117,13 +142,15 @@ class HybridRetriever:
 
         chunks = []
         for doc_id, text, metadata in zip(
-            all_docs["ids"],
-            all_docs["documents"],
-            all_docs["metadatas"]
+            all_docs["ids"], all_docs["documents"], all_docs["metadatas"], strict=False
         ):
-            chunks.append({
-                "id": doc_id,
-                "text": text,
-                "metadata": metadata
-            })
+            chunks.append({"id": doc_id, "text": text, "metadata": metadata})
         return chunks
+
+    def _adjust_keyword_weight(self, keyword_result: dict) -> float:
+        matched_terms = keyword_result.get("matched_terms", [])
+
+        if len(matched_terms) <= 2:
+            return 0.1
+
+        return self.keyword_weight

--- a/rag/retriever/keyword_search.py
+++ b/rag/retriever/keyword_search.py
@@ -1,7 +1,7 @@
 """BM25-based keyword search retriever."""
 
-from rank_bm25 import BM25Okapi
 import structlog
+from rank_bm25 import BM25Okapi
 
 logger = structlog.get_logger()
 
@@ -9,10 +9,10 @@ logger = structlog.get_logger()
 class KeywordSearcher:
     """BM25-based keyword retrieval for sparse search."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize keyword searcher."""
         self.bm25 = None
-        self.chunks = []
+        self.chunks: list[dict] = []
 
     def index(self, chunks: list[dict]) -> None:
         """Build BM25 index from chunks.
@@ -21,9 +21,7 @@ class KeywordSearcher:
             chunks: List of chunk dicts with 'text' field
         """
         self.chunks = chunks
-        tokenized_corpus = [
-            self._tokenize(chunk["text"]) for chunk in chunks
-        ]
+        tokenized_corpus = [self._tokenize(chunk["text"]) for chunk in chunks]
         self.bm25 = BM25Okapi(tokenized_corpus)
         logger.info("keyword_index_built", chunk_count=len(chunks))
 
@@ -45,9 +43,7 @@ class KeywordSearcher:
         scores = self.bm25.get_scores(query_tokens)
 
         # Create list of (chunk, score) tuples
-        scored_chunks = [
-            (self.chunks[i], scores[i]) for i in range(len(self.chunks))
-        ]
+        scored_chunks = [(self.chunks[i], scores[i]) for i in range(len(self.chunks))]
 
         # Sort by score descending
         scored_chunks.sort(key=lambda x: x[1], reverse=True)
@@ -56,11 +52,18 @@ class KeywordSearcher:
         results = []
         for chunk, score in scored_chunks[:top_k]:
             result = dict(chunk)
+
+            chunk_tokens = set(self._tokenize(chunk["text"]))
+            matched_terms = set(query_tokens).intersection(chunk_tokens)
+
             result["bm25_score"] = float(score)
+            result["matched_terms"] = list(matched_terms)
+
             results.append(result)
 
-        logger.info("keyword_search_complete", query_len=len(query_tokens),
-                   results_count=len(results))
+        logger.info(
+            "keyword_search_complete", query_len=len(query_tokens), results_count=len(results)
+        )
         return results
 
     @staticmethod

--- a/rag/retriever/vector_store.py
+++ b/rag/retriever/vector_store.py
@@ -1,8 +1,8 @@
 """ChromaDB-backed vector store for semantic retrieval."""
 
 import chromadb
-from chromadb.config import Settings
 import structlog
+from chromadb.api.models.Collection import Collection
 
 logger = structlog.get_logger()
 
@@ -18,7 +18,7 @@ class VectorStore:
         """
         self.client = chromadb.PersistentClient(path=persist_dir)
 
-    def get_collection(self, name: str):
+    def get_collection(self, name: str) -> Collection:
         """Get or create a collection.
 
         Args:
@@ -31,10 +31,7 @@ class VectorStore:
             collection = self.client.get_collection(name=name)
             logger.info("retrieved_collection", collection_name=name)
         except Exception:
-            collection = self.client.create_collection(
-                name=name,
-                metadata={"hnsw:space": "cosine"}
-            )
+            collection = self.client.create_collection(name=name, metadata={"hnsw:space": "cosine"})
             logger.info("created_collection", collection_name=name)
         return collection
 
@@ -56,23 +53,23 @@ class VectorStore:
             ids.append(chunk.id)
             embeddings.append(embedding)
             documents.append(chunk.text)
-            metadatas.append({
-                "source_id": chunk.source_id,
-                "chunk_index": chunk.chunk_index,
-                "section": chunk.section or "",
-            })
+            metadatas.append(
+                {
+                    "source_id": chunk.source_id,
+                    "chunk_index": chunk.chunk_index,
+                    "section": chunk.section or "",
+                }
+            )
 
         if ids:
             collection.upsert(
-                ids=ids,
-                embeddings=embeddings,
-                documents=documents,
-                metadatas=metadatas
+                ids=ids, embeddings=embeddings, documents=documents, metadatas=metadatas
             )
             logger.info("added_chunks", count=len(ids), collection=collection_name)
 
-    def query(self, query_embedding: list[float], collection_name: str,
-              n_results: int = 10) -> list[dict]:
+    def query(
+        self, query_embedding: list[float], collection_name: str, n_results: int = 10
+    ) -> list[dict]:
         """Search for similar vectors.
 
         Args:
@@ -88,7 +85,7 @@ class VectorStore:
         results = collection.query(
             query_embeddings=[query_embedding],
             n_results=n_results,
-            include=["embeddings", "documents", "metadatas", "distances"]
+            include=["embeddings", "documents", "metadatas", "distances"],
         )
 
         retrieved = []
@@ -97,19 +94,18 @@ class VectorStore:
                 results["documents"][0],
                 results["metadatas"][0],
                 results["distances"][0],
-                results["ids"][0]
+                results["ids"][0],
+                strict=False,
             ):
                 # ChromaDB distances are euclidean by default; convert to similarity score
                 similarity = 1 / (1 + distance)
-                retrieved.append({
-                    "id": chunk_id,
-                    "text": doc,
-                    "metadata": metadata,
-                    "score": similarity
-                })
+                retrieved.append(
+                    {"id": chunk_id, "text": doc, "metadata": metadata, "score": similarity}
+                )
 
-        logger.info("vector_query_complete", collection=collection_name,
-                   results_count=len(retrieved))
+        logger.info(
+            "vector_query_complete", collection=collection_name, results_count=len(retrieved)
+        )
         return retrieved
 
     def delete_by_source_id(self, source_id: str, collection_name: str) -> None:
@@ -122,11 +118,13 @@ class VectorStore:
         collection = self.get_collection(collection_name)
 
         # Get all documents and filter by source_id
-        all_docs = collection.get(
-            where={"source_id": {"$eq": source_id}}
-        )
+        all_docs = collection.get(where={"source_id": {"$eq": source_id}})
 
         if all_docs["ids"]:
             collection.delete(ids=all_docs["ids"])
-            logger.info("deleted_by_source", source_id=source_id,
-                       count=len(all_docs["ids"]), collection=collection_name)
+            logger.info(
+                "deleted_by_source",
+                source_id=source_id,
+                count=len(all_docs["ids"]),
+                collection=collection_name,
+            )


### PR DESCRIPTION
## Summary
Improves the hybrid retrieval scoring by reducing the influence of BM25 keyword matches when they are driven by generic technology terms. This helps prevent irrelevant chunks from outranking more semantically relevant results.

## Issue
Closes #24

## Changes
- Added dynamic keyword weighting during hybrid score calculation.
- Reduced BM25 influence for weak or generic keyword matches.
- Preserved the existing hybrid retrieval workflow while improving ranking quality.

## Testing
- [ ] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`)
- [x] Linter passes (`make lint`)
- [x] Type checker passes (`make typecheck`)
- [ ] New/updated tests cover the changes

## Notes for Reviewers
The goal of this change is to reduce cases where common technology keywords (e.g., "React", "Python") cause BM25 matches to dominate the final ranking. The hybrid scoring now adjusts the contribution of keyword search based on the quality of the keyword match while maintaining vector similarity as the primary ranking signal.