### PR TITLE
Fix/156 readme scorer fixture

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -110,3 +110,36 @@ exceed 500 words by adding sections. This fixes the problem by expanding the REA
 **Self-review confirmation:** [x] make check passes  [x] make test-unit passes
 
 **Draft PR feedback received from:** none
+
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [X] No — still awaiting review
+
+**Summary of feedback:**
+No review.
+
+**How you responded:**
+N/A
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Hardest part was likely just selecting a problem and then trying to navigate to the appropriate files within the codebase. Knowing where to look and understanding how the files
+related to each other took more time than the actual fix.
+
+**What did you learn about working in a large codebase?**
+Learned that there is a lot to think about when trying to make a branch or push a fix. More tedious and more to consider rather than your own individual work. In a personal codebase the design can change often but it is not polite to go around changing the intended design of someone else's codebase.
+
+**How did AI tools help — and where did they fall short?**
+The selection of the problem was greatly influenced by Claude. Claude asked questions to gauge my skill level and suggested problems accordingly. Going beyond Claude was to consider which type of fix would be best for the specific problem. If expanding the fixture or changing the assertion.
+
+**What would you do differently if you started over?**
+If starting over, I likely would have picked a more challenging issue to do for the project. This issue was very straightforward and had a simple fix. It is not a true example of what working on code in real life could be like.
+
+**What are you most proud of from this module?**
+Probably that I got more acquainted with Git and GitHub. I didn't have much experience coming in and this forced me to do different things with branches and commits that I had never done before. I now have a better intuition when navigating through those tools.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -46,7 +46,7 @@ The test\_readme\_with\_all\_quality\_signals in the tests for the readme\_score
 
 
 
-\*\*Reproduction commit link:\*\* \[link to commit documenting the reproduced issue]
+\*\*Reproduction commit link:\*\* https://github.com/Cristina-Adame/pathreview/commit/af2b33ae77174ed0458f0b4933df1de57c2088bd 
 
 
 
@@ -66,15 +66,14 @@ Confirms that the README has 51 words but the assertion expects more than 100, c
 
 
 
-\*\*PLAN.md link:\*\* \[link to PLAN.md in your fork]
+\*\*PLAN.md link:\*\* https://github.com/Cristina-Adame/pathreview/blob/fix/156-readme-scorer-fixture/PLAN.md
 
 
 
-\*\*Walkthrough video (recommended):\*\* \[link to your Loom video, ≤2 min — recommended, not graded]
+\*\*Walkthrough video (recommended):\*\* N/A
 
 
 
 \*\*Blockers or open questions:\*\*
 
-\[Anything you're still uncertain about going into Week 9, or leave blank]
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,32 @@
+\## Week 7 — Issue selection
+
+
+
+\*\*Issue link:\*\* https://github.com/ascherj/pathreview/issues/156
+
+
+
+\*\*Issue title:\*\* README scorer test fixture is too short for its own word-count assertion
+
+
+
+\*\*Tier:\*\* \[X] Tier 1  \[ ] Tier 2  \[ ] Tier 3
+
+
+
+\*\*Problem summary:\*\*
+
+The test\_readme\_with\_all\_quality\_signals in the tests for the readme\_scorer.py has it set that the word count of the README would be over 100 words in length \[line: assert data\["word\_count"] > 100], but the current fixture README only has 52 and the test is failing even though its behavior being tested beside that works. Basically the README test is failing the README because it has smaller word count than assumed and not because the README is incorrect in any other fashion. A successful fix would allow for the README scorer to work properly as long as the README is not empty.
+
+
+
+\*\*Branch name:\*\* \[paste branch name here]
+
+
+
+\*\*Setup confirmation:\*\* \[X] App runs locally at localhost:5173
+
+
+
+\*\*Cohort ledger:\*\* \[X] Issue added to cohort ledger
+

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -36,3 +36,45 @@ The test\_readme\_with\_all\_quality\_signals in the tests for the readme\_score
 
 \*\*Cohort ledger:\*\* \[X] Issue added to cohort ledger
 
+
+
+
+
+
+
+\## Week 8 — Reproduction \& solution planning
+
+
+
+\*\*Reproduction commit link:\*\* \[link to commit documenting the reproduced issue]
+
+
+
+\*\*Reproduction summary:\*\*
+
+Ran the command "pytest tests/unit/test\_readme\_scorer.py -q" on my branch and saw the failure:
+
+```
+
+FAILED tests/unit/test\_readme\_scorer.py::TestReadmeScorer::test\_readme\_with\_all\_quality\_signals - assert 51 > 100
+
+
+
+```
+
+Confirms that the README has 51 words but the assertion expects more than 100, causing it to fail. This is failing even though the other README requirements/assertions are met.
+
+
+
+\*\*PLAN.md link:\*\* \[link to PLAN.md in your fork]
+
+
+
+\*\*Walkthrough video (recommended):\*\* \[link to your Loom video, ≤2 min — recommended, not graded]
+
+
+
+\*\*Blockers or open questions:\*\*
+
+\[Anything you're still uncertain about going into Week 9, or leave blank]
+

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -14,13 +14,19 @@
 
 
 
+\*\*Selection reasoning:\*\*
+
+Picked a Tier 1 problem since it is the skill level that seems adequate for me. It deals with seemingly one component, the readme\_scorer.py and the given logic. A higher tier would likely be more involvement of files that rely on one another, which appears far more difficult than I might be able to manage at the moment. This is also a very realistic example where one would have to search for the cause of a "perfect" test file failing and the cause not being the actual behavior but another asserted aspect.
+
+
+
 \*\*Problem summary:\*\*
 
 The test\_readme\_with\_all\_quality\_signals in the tests for the readme\_scorer.py has it set that the word count of the README would be over 100 words in length \[line: assert data\["word\_count"] > 100], but the current fixture README only has 52 and the test is failing even though its behavior being tested beside that works. Basically the README test is failing the README because it has smaller word count than assumed and not because the README is incorrect in any other fashion. A successful fix would allow for the README scorer to work properly as long as the README is not empty.
 
 
 
-\*\*Branch name:\*\* \[paste branch name here]
+\*\*Branch name:\*\* fix/156-readme-scorer-fixture
 
 
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -77,3 +77,36 @@ Confirms that the README has 51 words but the assertion expects more than 100, c
 \*\*Blockers or open questions:\*\*
 
 
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the expanded string README fixture to >500 words. All 23 unit test pass now.
+
+**Next steps:**
+Opening the draft PR, getting feedback, and marking as ready for review.
+
+**Blockers:** none
+
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/739
+
+**Branch:** fix/156-readme-scorer-fixture
+
+**What you built:**
+Expanded the README string fixture in 'test_readme_with_all_quality_signals' to
+exceed 500 words by adding sections. This fixes the problem by expanding the README string fixture to >500 words to match the comprehensive assertion of >500 and the word count assertion of >100.
+
+**Tests added or updated:**
+[Which test files did you touch? What do they cover?]
+'tests/unit/test_readme_scorer.py' by expanding the README string fixture in 'test_readme_with_all_quality_signals'. Fixes 2 assertions: "word\_count"] > 100 and word_count_category == "comprehensive".
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+**Draft PR feedback received from:** none

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,81 @@
+\## Solution plan
+
+
+
+\*\*Issue:\*\* README scorer test fixture is too short for its own word-count assertion
+
+&#x20;#156 
+
+https://github.com/ascherj/pathreview/issues/156 
+
+
+
+\### Understand
+
+The test\_readme\_with\_all\_quality\_signals in the tests for the readme\_scorer.py has it set that the word count of the README would be over 100 words in length \[line: assert data\["word\_count"] > 100], but the current fixture README only has 52 and the test is failing even though its behavior being tested beside that works. Basically the README test is failing the README because it has smaller word count than assumed and not because the README is incorrect in any other fashion. The expected behavior would be that the README be actually long enough to pass the assertion of a 100 < word count and specifically that word\_count\_category == "comprehensive" (which in the file thats labeled as 500+ words).
+
+```
+
+def test\_word\_count\_category\_comprehensive(self, scorer):
+
+&#x20;       """Test word\_count\_category: > 500 = comprehensive."""
+
+&#x20;       readme = " ".join(\["word"] \* 700)  # 700 words
+
+```
+
+
+
+\### Map
+
+Files:
+
+tests/unit/test\_readme\_scorer.py
+
+
+
+Function:
+
+test\_readme\_with\_all\_quality\_signals(self, scorer)
+
+
+
+\### Plan
+
+What are the steps to fix this issue?
+
+Break it into 3–5 concrete sub-tasks.
+
+1. Open tests/unit/test\_readme\_scorer.py and head to test\_readme\_with\_all\_quality\_signals(self, scorer)
+2. Expand the fixture by making the word count greater than 500 to meet the assertion of word count > 100 and that the word\_count\_category == "comprehensive", which has a threshold of greater than 500.
+3. Run the command "pytest tests/unit/test\_readme\_scorer.py -q" to confirm the tests pass now.
+
+
+
+\### Inputs \& outputs
+
+What does your fix take as input? What should it produce or change?
+
+Fix takes in the README string. Should produce and output that the wordcount was greater than 100 and that the word count category is comprehensive (aka 500+ words).
+
+
+
+\### Risks \& unknowns
+
+What could go wrong? What are you still unsure about?
+
+Only adding enough words to reach the 100 assertion of the word count instead of 500. Need to ensure that the expanded string still gets processed correctly as the original README string did for the tests.
+
+
+
+\### Edge cases
+
+What inputs or states should your fix handle gracefully?
+
+* All other assertions should pass.
+* The expanded fixture should make sense as a sample README and not be gibberish to expand the word count.
+
+
+
+
+

--- a/tests/unit/test_readme_scorer.py
+++ b/tests/unit/test_readme_scorer.py
@@ -18,28 +18,88 @@ class TestReadmeScorer:
         """Test README with all quality signals returns high score."""
         readme = """
         # Project Name
-        A comprehensive project description.
+        A comprehensive project description that covers
+        all the important aspects of the project.
 
         ## Installation
-        ```bash
         pip install package
-        ```
+
+        To install the package, run the command above.
+        Make sure you have Python 3.9 or higher installed.
+        You can verify your Python version by running
+        python --version in your terminal. If you need to
+        upgrade, visit the official Python website.
+        It is recommended to use a virtual environment
+        to avoid dependency conflicts with other projects.
 
         ## Usage
-        ```python
         import package
         package.run()
-        ```
+
+        The package can be imported and used as shown above.
+        There are several configuration options available
+        that allow you to customize the behavior.
+        You can pass a configuration dictionary to the run
+        function to override the default settings.
+        For example, you can set the output format,
+        the logging level, and the maximum number of retries.
 
         ## Features
-        - Feature 1
-        - Feature 2
-        - Feature 3
+        - Feature 1: Automatic detection of README quality signals
+        - Feature 2: Scores READMEs based on installation sections
+        - Feature 3: Detects badges and demo links automatically
+        - Feature 4: Returns a normalized score between 0.0 and 1.0
+        - Feature 5: Supports case-insensitive section detection
 
         ## Tech Stack
-        - Python 3.9
-        - FastAPI
-        - PostgreSQL
+        - Python 3.9: Core language for all backend logic
+        - FastAPI: Web framework for the REST API endpoint
+        - PostgreSQL: Database for project metadata and scores
+        - Redis: Used for caching scorer results
+        - Docker: Containerization for local development
+
+        ## Contributing
+        Contributions are welcome! Please read the contributing
+        guide before submitting a pull request.
+        Make sure your code passes all linting requirements.
+        All new features should include unit tests.
+        Follow the existing code style and naming conventions.
+        When writing commit messages, follow conventional commits.
+        Each commit should be focused on a single change.
+        If you are fixing a bug, reference the issue number.
+        For large changes, open a discussion first.
+        Code reviews are required before merging.
+        All pull requests must pass the automated checks.
+
+        ## License
+        This project is licensed under the MIT License.
+        See the LICENSE file for full details.
+        You are free to use, modify, and distribute this software
+        in accordance with the license terms.
+        Attribution is appreciated but not required.
+        If you redistribute a modified version, include a note
+        describing what was changed.
+        The authors are not liable for any damages from its use.
+
+        ## FAQ
+        Q: Does this work with any README format?
+        A: Yes, the scorer supports any markdown README file.
+        Q: What is the minimum score for a good README?
+        A: A score above 0.7 is considered high quality.
+        Q: Can I use this with private repositories?
+        A: Yes, as long as you provide the README content.
+        Q: How is the overall score calculated?
+        A: It combines word count, sections, badges, and links.
+        Q: What happens if my README has no sections?
+        A: It will still score based on word count and badges.
+
+        ## Changelog
+        Version 1.0.0: Initial release with basic scoring.
+        Version 1.1.0: Added badge detection support.
+        Version 1.2.0: Added tech stack section detection.
+        Version 1.3.0: Improved word count categorization.
+        Version 1.4.0: Added demo link detection support.
+        Version 1.5.0: Added case-insensitive section matching.
 
         ![Build Status](https://example.com/badge.svg)
         ![Coverage](https://example.com/coverage.svg)
@@ -157,9 +217,10 @@ class TestReadmeScorer:
 
         result = scorer.execute({"readme_content": readme})
         # "Getting Started" matches the pattern
-        assert result.data["has_installation_section"] is True or result.data[
-            "has_usage_section"
-        ] is True
+        assert (
+            result.data["has_installation_section"] is True
+            or result.data["has_usage_section"] is True
+        )
 
     def test_quickstart_counts_as_usage(self, scorer):
         """Test that 'quickstart' counts as usage."""
@@ -218,7 +279,8 @@ class TestReadmeScorer:
 
     def test_overall_score_calculation(self, scorer):
         """Test that overall score aggregates components."""
-        readme = """
+        readme = (
+            """
         # Good README
 
         ## Installation
@@ -233,7 +295,9 @@ class TestReadmeScorer:
         ![Build](https://example.com/build.svg)
 
         This readme has lots of content here.
-        """ * 3  # Make it comprehensive
+        """
+            * 3
+        )  # Make it comprehensive
 
         result = scorer.execute({"readme_content": readme})
 


### PR DESCRIPTION
## Summary
ORIGINAL ISSUE: "test_readme_with_all_quality_signals asserts data["word_count"] > 100 and word_count_category == "comprehensive", but its fixture README contains only ~51 words, so the test fails against correct scorer behavior. Extend the fixture (or correct the assertion) so the test validates what it intends to."
This fixes the problem by expanding the README string fixture to >500 words to match the comprehensive assertion of >500 and the word count assertion of >100.

## Issue
Closes #156 

## Changes
<!-- Bullet list of the specific changes made -->
- Expanded the README string fixture in 'test_readme_with_all_quality_signals' to 
  exceed 500 words by adding sections.

## Testing
<!-- How did you verify your changes? -->
- [x] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`)
- [ ] Linter passes (`make lint`)
- [ ] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes

## Screenshots / Demo
N/A

## Notes for Reviewers
Any mypy errors present in 'make check' are preexisting, not 
introduced by this change. Ran 'make check' before and after fix, didn't introduce any new failures.
