### PR TITLE
fix: configure structlog for stdlib logging so caplog captures events

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,37 @@
 """Shared test fixtures for PathReview."""
 
+from collections.abc import Iterator
+
 import pytest
+import structlog
+
+
+@pytest.fixture(autouse=True)
+def configure_structlog_for_tests() -> Iterator[None]:
+    """Route structlog events through stdlib logging so ``caplog`` can capture them.
+
+    ``configure_logging()`` is never called during tests, so structlog falls back to
+    its default ``PrintLoggerFactory``, which writes straight to stdout and bypasses
+    the stdlib ``logging`` module that pytest's ``caplog`` fixture hooks into. That is
+    why log assertions saw an empty ``caplog.text`` while the event showed up in
+    captured stdout.
+
+    ``render_to_log_kwargs`` is the final processor so the event string arrives as the
+    record's ``msg`` (a clean ``record.message``) and the bound key/values land in
+    ``extra``; the record's level comes from the stdlib method structlog dispatches to.
+
+    ``cache_logger_on_first_use`` must stay ``False``: modules bind their logger at
+    import time (e.g. ``ingestion/embeddings/batch_processor.py``), so a cached logger
+    would freeze whatever factory was active at first use and ignore this fixture.
+    """
+    structlog.configure(
+        processors=[structlog.stdlib.render_to_log_kwargs],
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        wrapper_class=structlog.stdlib.BoundLogger,
+        cache_logger_on_first_use=False,
+    )
+    yield
+    structlog.reset_defaults()
 
 
 @pytest.fixture

--- a/tests/unit/test_logging_capture.py
+++ b/tests/unit/test_logging_capture.py
@@ -1,0 +1,46 @@
+"""Regression tests for structlog events reaching pytest's caplog (issue #159).
+
+The logger below is bound at module import time on purpose: application modules such
+as ``ingestion/embeddings/batch_processor.py`` bind theirs the same way, and that is
+the path that used to bypass stdlib logging entirely -- structlog's default
+``PrintLoggerFactory`` wrote to stdout, so ``caplog`` stayed empty. The autouse
+``configure_structlog_for_tests`` fixture in ``tests/conftest.py`` is what makes these
+assertions hold.
+"""
+
+import logging
+
+import pytest
+import structlog
+
+logger = structlog.get_logger()
+
+
+@pytest.mark.unit
+class TestStructlogCaplogCapture:
+    """structlog output must be visible to ``caplog``, not just to stdout."""
+
+    def test_warning_is_captured_with_level_and_message(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A warning emitted through structlog reaches caplog verbatim."""
+        message = "Empty chunks list provided to BatchEmbeddingProcessor"
+
+        logger.warning(message)
+
+        records = [record for record in caplog.records if record.message == message]
+        assert len(records) == 1
+        assert records[0].levelname == "WARNING"
+        assert message in caplog.text
+
+    def test_bound_values_do_not_leak_into_the_message(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Structured key/values ride along as record attributes, not in the message."""
+        with caplog.at_level(logging.INFO):
+            logger.info("Batch embedded", batch_size=100)
+
+        records = [record for record in caplog.records if record.message == "Batch embedded"]
+        assert len(records) == 1
+        assert records[0].levelname == "INFO"
+        assert records[0].batch_size == 100


### PR DESCRIPTION
## Summary
Pytest's `caplog` fixture only sees log records that pass through the stdlib `logging` module, but structlog is never configured during tests — so it falls back to its default `PrintLoggerFactory`, writing events straight to stdout and leaving `caplog` empty while assertions fail. This PR adds a test-only autouse fixture that routes structlog events through stdlib logging so `caplog`-based assertions work suite-wide. No production module is modified.

## Issue
Closes #159

## Changes
Root cause: `caplog` captures only records that flow through stdlib `logging`. The repo has a correct config — `core.logging.configure_logging()` routes structlog through `stdlib.LoggerFactory` — but it is only ever called by `scripts/seed_db.py`, never during tests. Unconfigured, structlog uses `PrintLoggerFactory`, which bypasses stdlib logging entirely; that is why the event was visible in captured stdout while `caplog.text` stayed empty.

- `tests/conftest.py` — new autouse fixture `configure_structlog_for_tests`: configures structlog with `stdlib.LoggerFactory` and `render_to_log_kwargs` as the final processor (clean `record.message`, bound key/values in `extra`, correct level via `stdlib.BoundLogger`), with `cache_logger_on_first_use=False` so module-level loggers bound at import time don't freeze a stale factory, and `structlog.reset_defaults()` on teardown.
- `tests/unit/test_logging_capture.py` — two regression tests: a structlog event from a module-level `structlog.get_logger()` reaches `caplog` with the expected level and message, and bound key/values arrive as record attributes rather than leaking into the message. Both fail with the exact issue symptom when the fixture is absent.

## Testing
- [x] Unit tests pass (`make test-unit`) — the previously-failing `test_empty_chunks_list_returns_empty` now passes; suite goes from 53 failed / 375 passed to 52 failed / 378 passed, and the failure-list diff vs. the pre-fix baseline is exactly the one fixed test (the remaining 52 belong to other tracked issues: #158, #148, #149, #150)
- [ ] Integration tests pass (`make test-integration`) — N/A: `tests/integration/` currently contains no tests to run
- [ ] Linter passes (`make lint`) — pre-existing failures on `main` unrelated to this change (see Notes for Reviewers); both touched files pass `ruff check` and `black --check` cleanly
- [ ] Type checker passes (`make typecheck`) — pre-existing failure on `main` (see Notes for Reviewers); this diff is tests-only and outside mypy's CI scope
- [x] New/updated tests cover the changes

**Reproduce the original bug (before the fix):**
1. Check out `main`
2. Run: `.venv/bin/pytest "tests/unit/test_batch_processor.py::TestBatchEmbeddingProcessor::test_empty_chunks_list_returns_empty" -q --tb=short`
3. Observe: the test fails with `assert ('Empty chunks list' in '')` — yet the warning `Empty chunks list provided to BatchEmbeddingProcessor` is right there in the "Captured stdout call" section. The event is emitted but never reaches stdlib logging, so `caplog` is empty.

**Verify the fix (on this branch):**
1. Check out `fix/159-caplog-structlog-config`
2. Run the same command — the test now passes
3. Run the regression tests in isolation: `.venv/bin/pytest tests/unit/test_logging_capture.py -v` — 2 passed
4. Run `make test-unit` — the 52 remaining failures are the pre-existing ones tracked in #158/#148/#149/#150; the failure list is identical to `main`'s baseline minus this issue's test, so nothing new breaks

## Screenshots / Demo
N/A — test-infrastructure fix; the observable change is the before/after pytest output in the Testing steps above.

## Notes for Reviewers
- **Pre-existing `make check` / test failures (not introduced by this PR):** on `main` before this change, `ruff check .` reports 182 findings, `black --check .` would reformat 52 files, and `mypy` aborts on a numpy-stubs/`python_version` mismatch before checking any project file. None of these are in files this PR touches — both touched files pass `ruff` and `black --check` cleanly. `make test-unit` has 52 pre-existing failures tracked in #158, #148, #149, #150; this PR leaves that list byte-identical.
- **Why a new test file:** `tests/unit/` has one file per module, and the module changed here is `tests/conftest.py` itself, which has no test file — so the regression tests live in a new `tests/unit/test_logging_capture.py`. This also keeps the diff free of unrelated formatting churn in `test_batch_processor.py` (repo-wide `black` is currently red).
- **Design choice I'd like your input on:** I configured structlog for tests directly rather than reusing `configure_logging()` — its dev branch ends in `ConsoleRenderer`, which turns `record.message` into a pre-rendered (possibly ANSI-colored) line and makes assertions fragile, and it calls `logging.basicConfig()` as a side effect. Happy to switch to reusing it if you prefer tests to exercise the exact production pipeline.
- `configure_logging()` appears to be called only by `scripts/seed_db.py` — never at API startup. Looks like a separate gap; I can file a follow-up issue rather than widen this PR.
- The autouse fixture will also apply to future `tests/integration` tests; none exist today, so it is currently exercised only by the unit suite.
