### PR TITLE
test: fixes the test_query_with_partial_overlap testcase to stop returning  a full match 

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -27,13 +27,13 @@ least one query keyword (e.g. drop "Python"), yielding a partial score that land
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [link to commit documenting the reproduced issue]
+**Reproduction commit link:** https://github.com/ascherj/pathreview/commit/050fc046b66dad487f3a68336c3d5cd6d6ebc6c5
 
 **Reproduction summary:**
 [1–2 sentences: How did you reproduce the issue? What did you observe?]
 The issue is reproduced by running the test suite, specifically the `tests/unit/test_relevance_scorer.py` file. I accomplished this by running .venv\Scripts\pytest tests\unit\test_relevance_scorer.py and got a failure of the TestRelevanceScorer.test_query_with_partial_overlap with the following assertation failing "assert 1.0 < 0.9"
 
-**PLAN.md link:** [link to PLAN.md in your fork]
+**PLAN.md link:** https://github.com/AlbertMundadan/pathreview/blob/test/157-relevance-scorer-partial-overlap-test/PLAN.md
 
 **Blockers or open questions:**
 No Blockers

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,26 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/157
+
+**Issue title:** Relevance scorer “partial overlap” test fixture actually has full query overlap
+
+**Tier:** [X] Tier 1 [ ] Tier 2 [ ] Tier 3
+
+**Issue Fit** This issue seemed to be a good fit because it matches my comfort with the codebase according to the provided checklist. I can examplin the problem and expected behavior and understand the location of which code would be changed in this branch. Since it is my first open source contribution, I chose tier 1 and can find the relevant code sections. The expectations for this issue are also reasonable to complete in this timeframe with the required changes being self-contained in a section.
+
+**Problem summary:**
+The `RelevanceScorer` in `rag/evaluator/relevance_scorer.py` scores a chunk by
+the fraction of query keywords it contains, so a
+chunk holding every query term correctly scores 1.0. The unit test
+`test_query_with_partial_overlap` in `tests/unit/test_relevance_scorer.py` claims
+to check "partial" overlap but feeds the query "Python Django web framework" into
+a chunk that actually contains all four terms, then asserts the score is below 0.9.
+The scorer correctly returns 1.0, so `assert 1.0 < 0.9` fails — the test is
+wrong, not the code. A successful fix edits only the fixture so the chunk omits at
+least one query keyword (e.g. drop "Python"), yielding a partial score that lands in the asserted 0.3–0.9 range.
+
+**Branch name:** test/157-relevance-scorer-partial-overlap-test
+
+**Setup confirmation:** [X] App runs locally at localhost:5173
+
+**Cohort ledger:** [X] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -24,3 +24,16 @@ least one query keyword (e.g. drop "Python"), yielding a partial score that land
 **Setup confirmation:** [X] App runs locally at localhost:5173
 
 **Cohort ledger:** [X] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [link to commit documenting the reproduced issue]
+
+**Reproduction summary:**
+[1–2 sentences: How did you reproduce the issue? What did you observe?]
+The issue is reproduced by running the test suite, specifically the `tests/unit/test_relevance_scorer.py` file. I accomplished this by running .venv\Scripts\pytest tests\unit\test_relevance_scorer.py and got a failure of the TestRelevanceScorer.test_query_with_partial_overlap with the following assertation failing "assert 1.0 < 0.9"
+
+**PLAN.md link:** [link to PLAN.md in your fork]
+
+**Blockers or open questions:**
+No Blockers

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -37,3 +37,42 @@ The issue is reproduced by running the test suite, specifically the `tests/unit/
 
 **Blockers or open questions:**
 No Blockers
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+[What have you implemented so far? Which sub-tasks from PLAN.md are done?]
+I have implemented the fix to the test file by adjusting the text chunk and have run tests to ensure that all 19 tests in that file now pass. 
+
+**Next steps:**
+[What are you working on for the rest of the week?]
+I need to commit these changes and draft/create the PR. I need to also review the PR conventions and requirements for contributions. 
+
+**Blockers:**
+[Anything slowing you down? Or leave blank.]
+N/A
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [link to your submitted pull request] https://github.com/ascherj/pathreview/pull/742
+
+**Branch:** [the branch name you worked on, e.g. `fix/123-short-description`]
+test/157-relevance-scorer-partial-overlap-test 
+
+**What you built:**
+[1–3 sentences summarizing what your fix does and how it works]
+In `test_query_with_partial_overlap`, the chunk `text` now omits "Python" so there is not a complete match. This now matches the expected behavior of a partial match which the test checks. 
+
+**Tests added or updated:**
+[Which test files did you touch? What do they cover?]
+I modified the "test_relevance_scorer.py" test file because this issue involved a incorrect pre-existing test. The modifciation made was to change the input text chunk so that there was actually a partial match instead of a full match. 
+
+**Self-review confirmation:** [X] make check passes  [X] make test-unit passes
+There are pre-existing issue that are outside the scope of this PR. 
+
+**Draft PR feedback received from:** [name or Slack handle, or "none"]
+"none"

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -76,3 +76,51 @@ There are pre-existing issue that are outside the scope of this PR.
 
 **Draft PR feedback received from:** [name or Slack handle, or "none"]
 "none"
+
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [X] No — still awaiting review
+
+**Summary of feedback:**
+[What did reviewers comment on? Or note that no review came in.]
+No review 
+
+
+**How you responded:**
+[What changes did you make, or what did you reply? If no feedback,
+leave blank.]
+
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+[Be specific — what part of the process, codebase, or workflow
+surprised you?]
+It was harder then expected to trace the through different files to find where the relevant code to each test was. It took more time than expected and requried a lot of jumping back and forth between files to see how functions connect. 
+
+**What did you learn about working in a large codebase?**
+[What's different about contributing to someone else's production code
+vs. building your own project?]
+I learned about how important it is to have good commit descriptions and documentation to make it easier for someone else to trace through your code/changes. This differs from your own project where you know all the code quite well.  
+
+
+**How did AI tools help — and where did they fall short?**
+[Where was AI assistance most useful this module? Where did you need
+to go beyond what AI could give you?]
+AI tools helped me to identify how functions worked in terms of input/output and the specifics of their implementation. It acted as a veifying source to ensure I understood the code properly. This wasn't always sufficient but worked as a baseline to get a better understanding of the code. 
+
+
+**What would you do differently if you started over?**
+[Issue selection, planning, implementation, or process — anything
+you'd change?]
+If I started over, I would spend more time on issue selection to choose a task that was slightly larger in scope because the issue was simpler than I anticipated. This is not necessarily an issue, just a comment. 
+
+
+**What are you most proud of from this module?**
+[One thing — it doesn't have to be the PR itself.]
+I am most proud of working with tests because I do not have much experience working with testing suites so fixing bugs in the testing suite and understanding how it works was a valuable experience. 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,59 @@
+## Solution plan
+
+**Issue:** Relevance scorer "partial overlap" test fixture actually has full query overlap — https://github.com/ascherj/pathreview/issues/157
+
+### Understand
+
+`RelevanceScorer.score` (`rag/evaluator/relevance_scorer.py:40-41`) scores a chunk
+by the fraction of _query_ keywords it contains: `relevance = overlap / len(query_tokens)`.
+A chunk that contains every query term therefore correctly scores `1.0`.
+
+The unit test `test_query_with_partial_overlap` is named for partial overlap but its
+fixture supplies **full** overlap: query `"Python Django web framework"` (tokens
+`python, django, web, framework`) against chunk `"Django is a Python web framework for
+rapid development"`, which contains all four tokens. The scorer returns `1.0`, but the
+test asserts `0.3 < score < 0.9`, so `assert 1.0 < 0.9` fails.
+
+- **Expected:** a partial-overlap fixture produces a mid-range score inside `0.3–0.9`.
+- **Actual:** the fixture is total overlap, scorer returns `1.0`, assertion fails.
+
+Root cause is the **test fixture**, not the scorer. The scorer behaves correctly.
+
+### Map
+
+- `tests/unit/test_relevance_scorer.py` (lines 47–60) — the failing test; **the only file to change.**
+- `rag/evaluator/relevance_scorer.py` — scorer under test; **read-only, no changes.**
+  Confirms the scoring formula and that `1.0` is correct for full coverage.
+
+### Plan
+
+1. In `test_query_with_partial_overlap`, edit the chunk `text` so it omits at least
+   one query keyword — drop `"Python"`: `"Django is a web framework for rapid development"`.
+2. Leave the query and all three assertions unchanged (they already express the
+   intended partial-overlap contract).
+3. Run `.venv\Scripts\pytest tests\unit\test_relevance_scorer.py -q` and confirm the
+   file goes from `1 failed, 18 passed` to `19 passed`.
+4. Update `JOURNAL.md` problem summary (done) and confirm no production code was touched.
+
+### Inputs & outputs
+
+- **Input:** query `"Python Django web framework"` and the edited chunk missing one term.
+- **Output / change:** scorer now returns `3/4 = 0.75`, which satisfies `0.3 < score < 0.9`.
+  Net effect: the previously failing assertion passes; no behavior change in shipped code.
+
+### Risks & unknowns
+
+- **Low risk** — a test-only, single-string edit. No production logic changes.
+- Must keep the score strictly inside `(0.3, 0.9)`: dropping exactly one of four terms
+  gives `0.75` (safe). Dropping two would give `0.5` (also valid) but the minimal change
+  is preferred.
+- No unknowns in the scorer's behavior; formula is confirmed by reading the source and
+  by the captured log line `avg_score=1.0 query_len=4`.
+
+### Edge cases
+
+- The other tests in the file already cover empty query/chunks, whitespace-only chunks,
+  missing `text` key, case-insensitivity, and very long inputs — all 18 pass and must
+  continue to pass after the edit.
+- Ensure the retained chunk still tokenizes to a non-empty set so it doesn't fall into
+  the `relevances.append(0.0)` empty-chunk branch (`relevance_scorer.py:35-37`).

--- a/tests/unit/test_relevance_scorer.py
+++ b/tests/unit/test_relevance_scorer.py
@@ -49,7 +49,7 @@ class TestRelevanceScorer:
         query = "Python Django web framework"
         chunks = [
             {
-                "text": "Django is a Python web framework for rapid development"
+                "text": "Django is a web framework for rapid development"
             },
         ]
 


### PR DESCRIPTION
## Summary
<!-- One paragraph describing what this PR does and why -->
The `RelevanceScorer` in `rag/evaluator/relevance_scorer.py` scores a chunk by
the fraction of query keywords it contains, so a
chunk holding every query term correctly scores 1.0. The unit test
`test_query_with_partial_overlap` in `tests/unit/test_relevance_scorer.py` claims
to check "partial" overlap but feeds the query "Python Django web framework" into
a chunk that actually contains all four terms, then asserts the score is below 0.9.
The scorer correctly returns 1.0, so `assert 1.0 < 0.9` fails. 

This PR fixes this by omitting one query keyword ("Python"), yielding a partial score that lands in the asserted 0.3–0.9 range.
Thus, the test now passes and matches expected behavior. 

## Issue
Closes #157 

## Changes
<!-- Bullet list of the specific changes made -->
- Removes a query keyword ("Python") from the chunk text in the `test_query_with_partial_overlap` test

Can reproduce and test the fix for this issue by removing/adding "Python" as part of the chunk text. 

## Testing
<!-- How did you verify your changes? -->
- [X ] Unit tests pass (`make test-unit`)
- [X ] New/updated tests cover the changes
All 19 tests in the file now pass instead of only 18. 

## Notes for Reviewers
<!-- Anything the reviewer should pay particular attention to -->
running `make check` returned 182 errors, which exist prior to this fix. No new issues were created. 