### PR TITLE
test: add Hypothesis property coverage for PII scrubber

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -38,7 +38,7 @@ Issue #111 concerns the test coverage of PathReview's PII scrubber in the safety
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** The reproduction record is committed in this Week 8 change; the final commit URL is added in the follow-up documentation commit after its hash is known.
+**Reproduction commit link:** https://github.com/Thankyou-Cheems/pathreview/commit/d9aeb8a9bb514613c1bb9e5e6a2f50f3c046cdf8
 
 **Reproduction summary:** From the Week 7 branch, `pytest --collect-only -q tests/unit/test_pii_scrubber.py` collected 25 tests, all named fixed-example tests in `tests/unit/test_pii_scrubber.py`; searching that file for `hypothesis`, `@given`, `strateg`, or `property` returned no matches. This reproduces the Issue #111 gap: the scrubber has deterministic examples but no property-based coverage for randomized supported PII formats.
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,37 @@
+## Week 7 — Issue selection
+
+**Student:** Ruikang Wang
+**GitHub username:** Thankyou-Cheems
+**Section:** 2a
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/111
+
+**Issue title:** No property-based tests for the PII scrubber
+
+**Tier:** [ ] Tier 1  [x] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+
+Issue #111 concerns the test coverage of PathReview's PII scrubber in the safety layer. The existing unit suite checks a fixed set of email, phone-number, SSN, and street-address examples, but it does not exercise randomized inputs. Format variations could therefore pass the fixed examples while escaping coverage from the test suite. The planned follow-up is to add Hypothesis-based property tests that generate supported PII patterns and verify that the scrubbed output does not retain the generated values; that implementation work is intentionally left for the later module weeks.
+
+**Branch name:** `test/111-pii-scrubber-hypothesis`
+
+**Setup confirmation:** [ ] App runs locally at `localhost:5173` (not yet; Docker Desktop's Linux engine did not start)
+
+**Setup attempt:** The initial `make setup` steps completed the virtual environment, project/development dependency installation (including Hypothesis), and pre-commit hook installation. The command then stopped at `alembic upgrade head` because PostgreSQL at `localhost:5433` refused the connection while Docker Desktop's engine was unavailable. I am not claiming an app URL or a running environment without that verification.
+
+**Cohort ledger:** [x] Issue added to cohort ledger — Section 2a, Issue #111
+
+### Selection notes
+
+- **Scope:** This is a focused tests/enhancement task. The Week 7 scope is issue selection, environment setup, and a journal entry; it does not change the scrubber implementation or add the property tests yet.
+- **Current behavior:** `PIIScrubber.scrub()` applies the regexes in `PIIScrubber.PII_PATTERNS`, and the current unit tests use hand-written examples. The missing coverage is randomized/property-based testing across supported PII formats.
+- **Relevant code:** `safety/pii_scrubber.py` contains the scrubber and pattern definitions; `tests/unit/test_pii_scrubber.py` contains the existing unit coverage; `pyproject.toml` already declares the Hypothesis development dependency.
+- **Tier reasoning:** The issue is labeled Tier 2, `enhancement`, and `tests`. It requires understanding the safety implementation and designing safe Hypothesis strategies, but the expected change is localized to the test layer.
+- **Success criteria:** In the later implementation weeks, add deterministic/reproducible Hypothesis properties for the supported PII types, assert that generated values are removed or masked, and keep the existing PII scrubber unit tests passing.
+
+### Week 7 status
+
+- GitHub claim comment: https://github.com/ascherj/pathreview/issues/111#issuecomment-4998092019
+- The issue had earlier public interest comments; the formal course-ledger entry for Section 2a is the basis for this assignment claim.
+- No implementation or pull request has been completed in Week 7; those are intentionally deferred to the later module weeks.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -35,3 +35,17 @@ Issue #111 concerns the test coverage of PathReview's PII scrubber in the safety
 - GitHub claim comment: https://github.com/ascherj/pathreview/issues/111#issuecomment-4998092019
 - The issue had earlier public interest comments; the formal course-ledger entry for Section 2a is the basis for this assignment claim.
 - No implementation or pull request has been completed in Week 7; those are intentionally deferred to the later module weeks.
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** The reproduction record is committed in this Week 8 change; the final commit URL is added in the follow-up documentation commit after its hash is known.
+
+**Reproduction summary:** From the Week 7 branch, `pytest --collect-only -q tests/unit/test_pii_scrubber.py` collected 25 tests, all named fixed-example tests in `tests/unit/test_pii_scrubber.py`; searching that file for `hypothesis`, `@given`, `strateg`, or `property` returned no matches. This reproduces the Issue #111 gap: the scrubber has deterministic examples but no property-based coverage for randomized supported PII formats.
+
+**Baseline test result:** Running `pytest -q tests/unit/test_pii_scrubber.py` produced `20 passed, 5 failed`; the failures are existing phone/address matching expectations and are recorded as a separate baseline blocker rather than changed in Week 8.
+
+**PLAN.md link:** https://github.com/Thankyou-Cheems/pathreview/blob/test/111-pii-scrubber-hypothesis/PLAN.md
+
+**Walkthrough video (recommended):** Not recorded; this is optional and not graded.
+
+**Blockers or open questions:** Docker Desktop/PostgreSQL remains unavailable for the full application environment. The later property-test implementation must decide how to handle regex overlap, especially street-address matches in ordinary prose and the overlap between US and international phone patterns. No production implementation or pull request is included in Week 8.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -75,3 +75,37 @@ Issue #111 concerns the test coverage of PathReview's PII scrubber in the safety
 **Self-review confirmation:** [ ] `make check` passes (blocked by pre-existing full-repository Ruff/type errors) [ ] `make test-unit` passes (blocked by 48 pre-existing failures outside `safety/pii_scrubber.py`)
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — reviewer feedback is not provided for Summer 2026.
+
+**Summary of feedback:** PR #750 is open and currently has no reviewer comments or review submissions. The Week 10 course page also notes that reviewer feedback is not a Summer 2026 feature.
+
+**How you responded:** No reviewer response or follow-up code change was needed. I kept the PR open and documented the current state instead of implying that the PR had been reviewed or merged.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+
+At first, Issue #111 looked like a small testing task: add property-based tests for the PII scrubber. The harder part was discovering that some existing phone and street-address examples already exposed matching problems. I had to decide which small implementation fixes were necessary for the issue and where to stop so that I did not turn a Tier 2 test task into a broad rewrite. It was also harder than expected to separate failures caused by the existing repository from failures caused by my changes.
+
+**What did you learn about working in a large codebase?**
+
+I learned that the issue description is only the starting point. I needed to read the existing tests, the implementation, the project configuration, the contribution guide, and the course requirements before choosing a change. In someone else's codebase, a small diff with focused evidence is usually safer than fixing every problem that appears during a full-repository run. The existing failures, unavailable Docker/PostgreSQL environment, and strict pre-commit checks all made that boundary visible.
+
+**How did AI tools help — and where did they fall short?**
+
+I mainly used AI tools to look up the relevant project materials and milestone requirements, locate the right files and test seams, and help explore possible Hypothesis strategies. They also helped me organize the testing and submission checklist. They could not decide whether the scrubber's regex behavior matched the project's actual contract, whether an unrelated full-suite failure was in scope, or whether a timed-out browser action had succeeded. I had to inspect the failing examples, review the diff, run the tests, and verify the final GitHub and course-portal state myself.
+
+**What would you do differently if you started over?**
+
+I would run the baseline focused tests, the full unit command, and the repository checks earlier, before writing the property tests. I would also write down the supported phone and address formats and their boundary cases before changing the regexes. Finally, I would open the PR earlier and keep a shorter running record of decisions, so the final journal entry would require less reconstruction.
+
+**What are you most proud of from this module?**
+
+I am most proud that the property tests did more than increase a coverage number: they exposed real phone and address matching issues and helped turn the scrubber behavior into clearer, repeatable checks. I kept the change focused, documented the unrelated repository failures honestly, created a ready-for-review PR, and completed the branch submission without claiming that the PR had been merged or reviewed.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -49,3 +49,29 @@ Issue #111 concerns the test coverage of PathReview's PII scrubber in the safety
 **Walkthrough video (recommended):** Not recorded; this is optional and not graded.
 
 **Blockers or open questions:** Docker Desktop/PostgreSQL remains unavailable for the full application environment. The later property-test implementation must decide how to handle regex overlap, especially street-address matches in ordinary prose and the overlap between US and international phone patterns. No production implementation or pull request is included in Week 8.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:** Implemented the first vertical slice for Issue #111. Added bounded Hypothesis strategies and properties for email, US/international phone, SSN, and street-address values; strengthened fixed address and non-PII assertions; and corrected existing phone/address regex boundary issues exposed by the examples. The focused PII suite now passes all 28 tests.
+
+**Next steps:** Run the repository quality checks, self-review the diff, open a ready-for-review PR, and record the final submission state.
+
+**Blockers:** The repository has pre-existing failures outside the PII scrubber: full unit tests report 48 unrelated failures, while full-repository Ruff and mypy checks also report unrelated baseline errors. The focused PII tests, touched-file checks, and commit hooks pass.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/750
+
+**Branch:** `test/111-pii-scrubber-hypothesis`
+
+**What you built:** Added bounded Hypothesis properties that verify generated supported PII is redacted, detected with accurate source spans, and idempotent on repeated scrubbing. Also fixed phone-format boundaries and street-address suffix boundaries so the existing fixed tests and generated examples agree with the privacy contract.
+
+**Tests added or updated:** `tests/unit/test_pii_scrubber.py` — three Hypothesis properties plus stronger address and non-PII assertions; focused result: `28 passed`. The touched-file Ruff, Black, and mypy checks and the commit hooks all pass.
+
+**Self-review confirmation:** [ ] `make check` passes (blocked by pre-existing full-repository Ruff/type errors) [ ] `make test-unit` passes (blocked by 48 pre-existing failures outside `safety/pii_scrubber.py`)
+
+**Draft PR feedback received from:** none

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,47 @@
+# Week 8 Solution Plan
+
+## Solution plan
+
+**Issue:** [No property-based tests for the PII scrubber](https://github.com/ascherj/pathreview/issues/111)
+
+### Understand
+
+The safety-layer scrubber is implemented in `safety/pii_scrubber.py`, while its current unit coverage is in `tests/unit/test_pii_scrubber.py`. The current suite uses hand-written examples for email, phone, SSN, and address formats, so it does not explore randomized variations that could expose regex gaps. The expected solution is a reproducible Hypothesis-based test layer that checks the scrubber's invariants across supported PII formats; production scrubber behavior is not changed as part of this Week 8 planning work.
+
+### Map
+
+- `safety/pii_scrubber.py`: `PIIScrubber.PII_PATTERNS`, `scrub()`, and `detect()` define the behavior under test.
+- `tests/unit/test_pii_scrubber.py`: existing fixed-example tests and the future home for property-based tests.
+- `pyproject.toml`: declares `hypothesis>=6.92.0` in the development dependencies.
+- `JOURNAL.md`: Week 8 reproduction evidence and the link to this plan.
+
+### Plan
+
+1. Define deterministic Hypothesis strategies for valid emails, US and international phone formats, SSNs, and supported street addresses.
+2. Add properties that verify generated PII is removed or masked by `scrub()` and that `detect()` reports the generated value with a valid span.
+3. Add mixed-input and invariant properties for preserving unrelated text, handling multiple PII values, and keeping scrubbing idempotent.
+4. Run the existing unit suite together with the new property tests, record any baseline failures separately, and use bounded Hypothesis examples so failures are reproducible.
+5. Review generated cases for regex overlap and false positives before proposing the implementation for the later module week.
+
+### Inputs & outputs
+
+- **Inputs:** generated PII values, fixed non-PII text, and mixed messages containing both.
+- **Outputs:** scrubbed text with generated PII absent or replaced by `[REDACTED]`; detection records whose values and start/end spans match the original input.
+- **Test artifacts:** focused property tests in `tests/unit/test_pii_scrubber.py`, reproducible Hypothesis failure examples when a property fails, and a passing focused test command after the later implementation.
+
+### Risks & unknowns
+
+- The broad street-address regex can overlap with ordinary prose, so address strategies must avoid accidentally testing unrelated matches until the intended behavior is agreed.
+- Phone formats may overlap between `phone_us` and `phone_intl`; properties should assert the privacy invariant rather than require one exact detector label unless the implementation contract says otherwise.
+- The current baseline run has five failures in the existing fixed-example suite, including phone and address behavior. Those failures need separate triage and are not silently attributed to Issue #111.
+- Docker/PostgreSQL is not required for this unit-test scope, but the full application environment remains unavailable until Docker Desktop starts successfully.
+
+### Edge cases
+
+- PII at the beginning or end of a string and multiple generated values in one message.
+- Case variations, punctuation, separators, and optional country-code prefixes for supported formats.
+- Near-miss values that should remain unchanged when they do not match a supported pattern.
+- Empty, whitespace-only, and non-PII text should remain unchanged.
+- Re-running `scrub()` on already scrubbed text should not introduce additional changes.
+
+This is a Week 8 planning artifact. The Hypothesis strategies and implementation are intentionally deferred to the later implementation week.

--- a/safety/pii_scrubber.py
+++ b/safety/pii_scrubber.py
@@ -1,6 +1,7 @@
 """PII detection and scrubbing."""
 
 import re
+
 import structlog
 
 logger = structlog.get_logger()
@@ -12,10 +13,18 @@ class PIIScrubber:
     # Regex patterns for common PII
     PII_PATTERNS = {
         "email": r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b",
-        "phone_us": r"\b(?:\+?1[-.]?)?\(?([0-9]{3})\)?[-.]?([0-9]{3})[-.]?([0-9]{4})\b",
-        "phone_intl": r"\+[0-9]{1,3}[-.]?[0-9]{1,14}",
+        "phone_us": (
+            r"(?<!\w)(?:\+?1[\s.-]?)?(?:\([0-9]{3}\)|[0-9]{3})"
+            r"[\s.-]?[0-9]{3}[\s.-]?[0-9]{4}(?!\w)"
+        ),
+        "phone_intl": r"(?<!\w)\+[0-9]{1,3}(?:[\s.-]?[0-9]){6,14}(?!\w)",
         "ssn": r"\b(?!000|666)[0-9]{3}-(?!00)[0-9]{2}-(?!0000)[0-9]{4}\b",
-        "street_address": r"\b\d+\s+[A-Za-z\s]+(?:Street|St|Avenue|Ave|Road|Rd|Boulevard|Blvd|Drive|Dr|Lane|Ln|Court|Ct|Circle|Cir|Park|Pl|Plaza|Place|Drive|Dr|Way|Parkway|Pkwy|Point|Pt|Pike|Run|Summit|Summit|Terrace|Ter|Trail|Trl|Tunnel|Turnpike|View|Vista|Vlg|Village|Vly|Valley)",
+        "street_address": (
+            r"\b\d+\s+[A-Za-z\s]+(?:Street|St|Avenue|Ave|Road|Rd|Boulevard|Blvd|"
+            r"Drive|Dr|Lane|Ln|Court|Ct|Circle|Cir|Park|Pl|Plaza|Place|Drive|Dr|"
+            r"Way|Parkway|Pkwy|Point|Pt|Pike|Run|Summit|Summit|Terrace|Ter|Trail|"
+            r"Trl|Tunnel|Turnpike|View|Vista|Vlg|Village|Vly|Valley)\b"
+        ),
     }
 
     def scrub(self, text: str) -> str:
@@ -29,7 +38,7 @@ class PIIScrubber:
         """
         scrubbed = text
 
-        for pii_type, pattern in self.PII_PATTERNS.items():
+        for _pii_type, pattern in self.PII_PATTERNS.items():
             scrubbed = re.sub(pattern, "[REDACTED]", scrubbed, flags=re.IGNORECASE)
 
         return scrubbed
@@ -47,13 +56,17 @@ class PIIScrubber:
 
         for pii_type, pattern in self.PII_PATTERNS.items():
             for match in re.finditer(pattern, text, flags=re.IGNORECASE):
-                detected.append({
-                    "type": pii_type,
-                    "value": match.group(),
-                    "start": match.start(),
-                    "end": match.end()
-                })
+                detected.append(
+                    {
+                        "type": pii_type,
+                        "value": match.group(),
+                        "start": match.start(),
+                        "end": match.end(),
+                    }
+                )
 
-        logger.info("pii_detected", count=len(detected), types=len(set(d["type"] for d in detected)))
+        logger.info(
+            "pii_detected", count=len(detected), types=len(set(d["type"] for d in detected))
+        )
 
         return detected

--- a/tests/unit/test_pii_scrubber.py
+++ b/tests/unit/test_pii_scrubber.py
@@ -1,8 +1,84 @@
 """Tests for pii_scrubber.py"""
 
+# Existing pytest fixtures and test methods in this module intentionally use
+# pytest's untyped function style; keep strict mypy focused on production code.
+# mypy: disable-error-code="no-untyped-def"
+
+from string import ascii_letters, digits
+
 import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
 
 from safety.pii_scrubber import PIIScrubber
+
+
+@st.composite
+def email_values(draw):
+    """Generate email values covered by the scrubber's email pattern."""
+    first = draw(st.sampled_from(ascii_letters + digits))
+    rest = draw(st.text(alphabet=ascii_letters + digits + "._%+-", min_size=0, max_size=12))
+    domain = draw(st.text(alphabet=ascii_letters + digits, min_size=1, max_size=10))
+    tld = draw(st.text(alphabet=ascii_letters, min_size=2, max_size=6))
+    return f"{first}{rest}@{domain}.{tld}"
+
+
+@st.composite
+def us_phone_values(draw):
+    """Generate supported US phone number formats."""
+    area = draw(st.integers(min_value=200, max_value=999))
+    exchange = draw(st.integers(min_value=200, max_value=999))
+    subscriber = draw(st.integers(min_value=0, max_value=9999))
+    style = draw(st.sampled_from(("hyphen", "parenthesized", "dot", "country", "compact")))
+    area_text = f"{area:03d}"
+    exchange_text = f"{exchange:03d}"
+    subscriber_text = f"{subscriber:04d}"
+
+    if style == "parenthesized":
+        return f"({area_text}) {exchange_text}-{subscriber_text}"
+    if style == "dot":
+        return f"{area_text}.{exchange_text}.{subscriber_text}"
+    if style == "country":
+        return f"+1 {area_text} {exchange_text} {subscriber_text}"
+    if style == "compact":
+        return f"{area_text}{exchange_text}{subscriber_text}"
+    return f"{area_text}-{exchange_text}-{subscriber_text}"
+
+
+@st.composite
+def international_phone_values(draw):
+    """Generate international phone values with supported separators."""
+    country = draw(st.integers(min_value=1, max_value=999))
+    groups = [draw(st.text(alphabet=digits, min_size=2, max_size=4)) for _ in range(3)]
+    separator = draw(st.sampled_from((" ", "-", ".")))
+    return f"+{country}{separator}{separator.join(groups)}"
+
+
+@st.composite
+def ssn_values(draw):
+    """Generate valid SSN-shaped values accepted by the scrubber."""
+    area = draw(st.integers(min_value=1, max_value=665))
+    group = draw(st.integers(min_value=1, max_value=99))
+    serial = draw(st.integers(min_value=1, max_value=9999))
+    return f"{area:03d}-{group:02d}-{serial:04d}"
+
+
+@st.composite
+def street_address_values(draw):
+    """Generate simple street addresses covered by the address pattern."""
+    number = draw(st.integers(min_value=1, max_value=9999))
+    street = draw(st.sampled_from(("Main", "Oak", "Elm", "Maple", "Pine")))
+    suffix = draw(st.sampled_from(("Street", "Avenue", "Road", "Drive", "Lane")))
+    return f"{number} {street} {suffix}"
+
+
+pii_values = st.one_of(
+    email_values(),
+    us_phone_values(),
+    international_phone_values(),
+    ssn_values(),
+    street_address_values(),
+)
 
 
 @pytest.mark.unit
@@ -201,7 +277,8 @@ class TestPIIScrubber:
         for addr in addresses:
             text = f"Address: {addr}"
             scrubbed = scrubber.scrub(text)
-            # Should attempt to redact addresses
+            assert addr not in scrubbed
+            assert "[REDACTED]" in scrubbed
 
     def test_empty_text(self, scrubber):
         """Test with empty text."""
@@ -252,3 +329,38 @@ class TestPIIScrubber:
 
         # Should be minimal or no detections
         # (version number shouldn't be flagged as SSN)
+        assert detected == []
+
+    @given(pii=pii_values)
+    @settings(max_examples=50, deadline=None)
+    def test_scrub_redacts_generated_pii(self, pii):
+        """Test that generated supported PII is absent after scrubbing."""
+        text = f"Profile record: {pii}"
+
+        scrubbed = PIIScrubber().scrub(text)
+
+        assert pii not in scrubbed
+        assert "[REDACTED]" in scrubbed
+
+    @given(pii=pii_values)
+    @settings(max_examples=50, deadline=None)
+    def test_detect_reports_generated_pii_span(self, pii):
+        """Test that generated PII is detected with an accurate source span."""
+        text = f"Profile record: {pii}"
+
+        detections = PIIScrubber().detect(text)
+        matching_detections = [detection for detection in detections if detection["value"] == pii]
+
+        assert matching_detections
+        for detection in matching_detections:
+            assert text[detection["start"] : detection["end"]] == detection["value"]
+
+    @given(pii=pii_values)
+    @settings(max_examples=50, deadline=None)
+    def test_scrub_generated_pii_is_idempotent(self, pii):
+        """Test that generated PII remains stable after a second scrub."""
+        text = f"Profile record: {pii}"
+        scrubber = PIIScrubber()
+        scrubbed_once = scrubber.scrub(text)
+
+        assert scrubber.scrub(scrubbed_once) == scrubbed_once


### PR DESCRIPTION
## Summary

Adds bounded Hypothesis property coverage for the PII scrubber in support of Issue #111.

## Issue

Closes #111

## Changes

- Add Hypothesis strategies for supported email, US/international phone, SSN, and street-address formats.
- Add properties covering redaction, detection spans, and scrub idempotence.
- Strengthen fixed address and non-PII assertions.
- Tighten phone and street-address regex boundaries exposed by the generated and existing examples.

## Testing

- Focused: `pytest -q tests/unit/test_pii_scrubber.py` — 28 passed.
- Touched-file Ruff, Black, and mypy checks pass.
- The commit hooks (Ruff, Black, mypy) pass.
- Full `make test-unit` currently reports 48 failures in unrelated pre-existing modules; no failures are in the PII scrubber tests.
- Full-repository Ruff and mypy also have pre-existing baseline failures outside this change, so `make check` cannot be reported as fully green.

## Screenshots / Demo

Not applicable; this is a test and regex-boundary change.

## Notes for Reviewers

The property strategies are deliberately bounded to formats supported by the current scrubber contract. The implementation changes are limited to correcting existing phone/address matching behavior needed by the new properties and existing fixed tests.
