### PR TITLE
fix(agent): match vendored/build dirs by path segment, not slash-anchored substring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ frontend/dist/
 
 # Docker
 *.log
+docker-compose.override.yml
 
 # OS
 .DS_Store

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,4 @@ repos:
       - id: mypy
         additional_dependencies: [types-redis]
         args: [--ignore-missing-imports]
+        files: ^(api|core|ingestion|rag|agent|safety)/

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,28 @@
+# Module 3 Journal
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/150
+
+**Issue title:** Tech detector counts vendored and build-output files, skewing language detection
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The `TechDetector` agent tool analyzes a repo's file list to guess its primary
+programming language, but it doesn't actually filter out vendored or
+build-output paths before counting file extensions. A repo with only 2 Python
+source files and several bundled JavaScript files under `node_modules/` or
+`build/` gets reported as primarily JavaScript instead of Python, which
+defeats the point of the detector — it should reflect what the author wrote,
+not what got bundled or vendored into the repo. The affected code lives in
+`agent/tools/tech_detector.py`, specifically the `_should_skip_file` method
+that's supposed to exclude these paths. A successful fix makes the detector
+correctly ignore vendored/build files so the reported primary language
+matches the repo's actual source composition.
+
+**Branch name:** fix/150-tech-detector-vendored-files
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -60,3 +60,36 @@ problems)
 course portal (a per-section spreadsheet), not in this repo, so it isn't
 reachable from here. Still needs to be filled in by hand: name, GitHub
 username, issue #150, on the correct section tab.
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/ATgzh/pathreview/commit/ff23b0fc64d98ec3271e397dc32adbdeccee407c
+
+**Reproduction summary:**
+Wrote `scripts/repro_issue_150.py`, a runnable script using the exact file
+list from the issue body (2 Python files, 6 vendored/build JS files). Running
+it against current `main` confirms the bug directly: `primary_language`
+comes back `"JavaScript"` instead of the expected `"Python"`, because
+`_should_skip_file`'s leading-slash-anchored patterns never match top-level
+paths like `node_modules/lib/index.js`. This matches the two pre-existing
+failing tests named in the issue (`test_node_modules_excluded`,
+`test_build_directory_excluded`), which I also reran and confirmed still
+fail against `main`.
+
+**PLAN.md link:** https://github.com/ATgzh/pathreview/blob/fix/150-tech-detector-vendored-files/PLAN.md
+
+**Walkthrough video (recommended):** Not recorded — I don't have a screen
+recording tool available in this environment. Skipping it since it's
+explicitly not graded; happy to record one later if it'd help for office
+hours.
+
+**Blockers or open questions:**
+None blocking. Two things I'm carrying into Week 9: (1) I haven't seen the
+"strong vs. weak solution plans" example doc referenced in the Week 8
+resources — no URL was available to me — so I can't confirm PLAN.md matches
+the expected level of detail beyond following the template structure
+carefully; would appreciate a gut-check. (2) My planned fix (splitting paths
+into segments and matching directory components) is a slightly different
+approach than a minimal patch to the existing regex-like patterns — I think
+segment-matching is more correct (see Risks & unknowns in PLAN.md for why),
+but I'll keep it small and reversible if reviewers prefer the narrower diff.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -9,20 +9,54 @@
 **Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
 
 **Problem summary:**
-The `TechDetector` agent tool analyzes a repo's file list to guess its primary
-programming language, but it doesn't actually filter out vendored or
-build-output paths before counting file extensions. A repo with only 2 Python
-source files and several bundled JavaScript files under `node_modules/` or
-`build/` gets reported as primarily JavaScript instead of Python, which
-defeats the point of the detector — it should reflect what the author wrote,
-not what got bundled or vendored into the repo. The affected code lives in
-`agent/tools/tech_detector.py`, specifically the `_should_skip_file` method
-that's supposed to exclude these paths. A successful fix makes the detector
-correctly ignore vendored/build files so the reported primary language
-matches the repo's actual source composition.
+The `TechDetector` agent tool guesses a repo's primary language from its file
+list, and it already has skip logic in `_should_skip_file`
+(`agent/tools/tech_detector.py`) meant to exclude vendored/build directories
+like `node_modules/` and `build/`. The bug is that the skip patterns are
+anchored with a leading slash (e.g. `"/node_modules/"`, `"/build/"`), so a
+path only gets filtered when that directory is nested under something else —
+a top-level path like `node_modules/lib/index.js` or `build/bundle.js` has no
+leading `/` before the directory name, so it slips past the filter uncounted.
+I confirmed this by reading the code and running the existing suite: the two
+tests the issue points to, `test_node_modules_excluded` and
+`test_build_directory_excluded` in `tests/unit/test_tech_detector.py`, both
+fail against current `main`. A repo with 2 Python files and several
+top-level `node_modules`/`build` JS files gets reported as primarily
+JavaScript instead of Python. A successful fix matches these directory names
+regardless of position in the path (e.g. by checking path segments instead of
+a substring that assumes a leading slash), so both currently-failing tests
+pass without breaking the ones that already pass (e.g. nested vendor paths
+like `src/vendor/lib.js`).
 
 **Branch name:** fix/150-tech-detector-vendored-files
 
-**Setup confirmation:** [x] App runs locally at localhost:5173
+**Setup confirmation:** [x] App runs locally at localhost:5173 (verified:
+`make setup` + `make run`, frontend loads at localhost:5173, backend
+`/auth/login` issues a working JWT for the seeded `user1@example.com`
+account, and `pytest tests/unit` runs — 375 passed / 53 failed, with the
+failures matching known-open issues elsewhere in the codebase, not setup
+problems)
 
-**Cohort ledger:** [ ] Issue added to cohort ledger
+**Selection notes (scope check):**
+- *Understand the code before committing?* Yes — read `tech_detector.py`
+  end-to-end (165 lines, one class, no external dependencies) and the
+  matching test file. The bug is a one-line class of fix in a single
+  `@staticmethod`, not a design change.
+- *Is the repro reliable?* Yes — reran the two tests named in the issue
+  myself and both fail exactly as described, so the issue is accurately
+  scoped and not stale.
+- *Blast radius?* Small and contained — `_should_skip_file` is only called
+  from `_detect_tech` in the same file; no other module imports it directly
+  (checked with a repo-wide search), so a fix here shouldn't ripple outward.
+- *Right tier for a first contribution?* Yes — Tier 1 / "good first issue",
+  isolated to one file, existing tests define done, no new dependencies or
+  migrations needed.
+- *Is it still available?* The issue has many "I'll work on this" comments
+  from other students (this is a shared tracker across the cohort), but
+  that's expected for a popular Tier 1 issue — I commented my own claim on
+  2026-07-17 and am tracking it in the cohort ledger per the process below.
+
+**Cohort ledger:** [ ] Issue added to cohort ledger — the ledger lives in the
+course portal (a per-section spreadsheet), not in this repo, so it isn't
+reachable from here. Still needs to be filled in by hand: name, GitHub
+username, issue #150, on the correct section tab.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -145,16 +145,43 @@ loop step I can't complete on my own.
 
 ### Check-in 2 (end of week)
 
-**PR link:** _pending — added once opened_
+**PR link:** https://github.com/ascherj/pathreview/pull/753 — **currently a
+draft**, opened to request peer/mentor feedback in Slack before finalizing.
+Still needs to be marked "Ready for review" before the deadline; this is not
+yet the final submission state.
 
 **Branch:** `fix/150-tech-detector-vendored-files`
 
 **What you built:**
-_pending_
+Fixed `TechDetector._should_skip_file` in `agent/tools/tech_detector.py` so
+it matches vendored/build directories (`node_modules`, `vendor`, `dist`,
+`build`, `.git`, `__pycache__`, `.venv`, `venv`) by exact path segment
+instead of a slash-anchored substring — this catches root-level paths like
+`node_modules/lib/index.js` that the old substring check missed, while
+keeping already-working nested paths (`src/vendor/lib.js`) working and
+avoiding a false positive for a file whose name merely matches a skip-dir
+name.
 
 **Tests added or updated:**
-_pending_
+`tests/unit/test_tech_detector.py` — added a real assertion to
+`test_vendor_files_excluded` (previously asserted nothing), and added 4 new
+tests exercising `_should_skip_file` directly (root-level dirs, nested dirs,
+filename/directory-name collision, substring-vs-exact matching). Also
+cleaned up 7 pre-existing unused-variable lint errors elsewhere in the same
+file that were blocking any commit touching it (documented as a separate
+concern in the commit message and PR description, not part of the #150
+fix itself).
 
-**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+— in the "introduces no new failures" sense defined by this week's
+instructions: baseline captured before any change (53 failed/375 passed on
+test-unit, 182 ruff errors, 52 files needing black, 99 mypy errors) vs. after
+(51 failed/381 passed, 173 ruff errors, 51 files needing black, 99 mypy
+errors unchanged) — every number improved or stayed flat, none regressed.
+Full table is in the PR description. Neither command exits zero overall,
+because of pre-existing repo-wide issues outside files this PR touches.
+
+**Draft PR feedback received from:** none yet — PR was just opened as a
+draft; posting it in Slack for review is my next step.
 
 **Draft PR feedback received from:** _pending_

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -93,3 +93,68 @@ into segments and matching directory components) is a slightly different
 approach than a minimal patch to the existing regex-like patterns — I think
 segment-matching is more correct (see Risks & unknowns in PLAN.md for why),
 but I'll keep it small and reversible if reviewers prefer the narrower diff.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+All 5 sub-tasks from PLAN.md are implemented. `_should_skip_file` in
+`agent/tools/tech_detector.py` now splits each path on `/` and checks the
+directory segments (every part except the filename) against a skip-dir set,
+instead of substring-matching slash-anchored patterns — this is the fix
+described in PLAN.md's Plan section, step 1. `test_node_modules_excluded`
+and `test_build_directory_excluded` pass now. I added a real assertion to
+`test_vendor_files_excluded` (step 3) and 4 new tests exercising
+`_should_skip_file` directly for the edge cases from PLAN.md: root-level
+dirs, nested dirs, a file whose name collides with a skip-dir name, and
+substring-vs-exact matching (`rebuild/` must not match `build`). Reran
+`scripts/repro_issue_150.py` (step 4) — it now prints "Not reproduced." Ran
+`make test-unit` and `make check` (step 5) and confirmed no new failures
+against the baseline I captured before touching anything: test-unit went
+from 53 failed/375 passed to 51 failed/381 passed (the 2 fewer failures are
+the two tests this issue's fix resolves; the 4 more passing are my new
+tests); ruff went from 182 to 173 pre-existing errors repo-wide (fixed 9 in
+files I was already touching, introduced 0 new); black and mypy counts are
+otherwise unchanged. Full breakdown is in the PR description.
+
+Along the way I hit a real blocker: the local pre-commit `mypy` hook has no
+path filter, so it checks every staged Python file — including `tests/`,
+which the project's own `Makefile`/CI explicitly exclude from typechecking.
+That mismatch blocked any commit touching a test file (repo-wide, not just
+mine — the whole test suite fails this hook). I fixed the hook's scope in
+`.pre-commit-config.yaml` to match the Makefile/CI paths, and separately
+cleaned up 7 pre-existing unused-variable lint errors in
+`test_tech_detector.py` that were blocking the ruff hook the same way. Both
+are documented in the same commit as clearly-labeled, separate concerns from
+the actual fix.
+
+**Next steps:**
+Open a PR against the upstream repo, fill in the PR template completely
+(including the pre-existing-failures note above), and get it in front of a
+classmate or mentor in Slack for draft feedback before marking it ready for
+review.
+
+**Blockers:**
+None on the implementation. Opening the actual PR and getting peer/mentor
+review both require steps outside what I can do unassisted — pending
+confirmation to open the PR, and the Slack review itself is a human-in-the-
+loop step I can't complete on my own.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** _pending — added once opened_
+
+**Branch:** `fix/150-tech-detector-vendored-files`
+
+**What you built:**
+_pending_
+
+**Tests added or updated:**
+_pending_
+
+**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+
+**Draft PR feedback received from:** _pending_

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -184,4 +184,54 @@ because of pre-existing repo-wide issues outside files this PR touches.
 **Draft PR feedback received from:** none yet — PR was just opened as a
 draft; posting it in Slack for review is my next step.
 
-**Draft PR feedback received from:** _pending_
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No feedback has come in. Per this term's course note, reviewer feedback
+isn't an active feature for Summer 2026 cohorts, so PR #753 remains open as
+a draft with zero comments and zero reviews as of this week.
+
+**How you responded:**
+N/A — no feedback to respond to.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Finding and working with the bug was harder than expected. The issue title
+made it sound simple, but actually pinning down the root cause, and
+confirming it was specifically the missing leading slash on root-level
+paths in `_should_skip_file`, took real digging into the code rather than
+just trusting the issue description.
+
+**What did you learn about working in a large codebase?**
+Reading and understanding the whole codebase isn't necessary, you just need
+to find the part you actually need. Pathreview has a lot of modules (agent,
+api, core, ingestion, rag, safety, frontend), but my fix only ever touched
+one file and its test file. I learned that the hard way, at first I felt
+like I had to understand everything before touching anything, but that's
+not actually how it works. I'm glad I learned that.
+
+**How did AI tools help — and where did they fall short?**
+AI tools were really helpful for generating ideas, tracking down the bug,
+and thinking through edge cases I wouldn't have considered on my own.
+Honestly, I'm glad I got to experience working this way before doing it in
+a real job. Where it fell short was in occasionally missing mistakes or
+bugs, or not quite doing exactly what I asked for, sometimes skipping over
+part of what I wanted done. Overall it wasn't a huge issue, but it's a
+reminder that I still need to review what AI produces rather than trust it
+blindly.
+
+**What would you do differently if you started over?**
+I would start incorporating AI from the beginning instead of struggling
+through it on my own first. It would've made the whole process a lot
+easier.
+
+**What are you most proud of from this module?**
+I'm proud to be part of CodePath, it's been a genuinely helpful learning
+platform for this kind of hands-on, real-world contribution work.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,99 @@
+## Solution plan
+
+**Issue:** [#150 — Tech detector counts vendored and build-output files, skewing language detection](https://github.com/ascherj/pathreview/issues/150)
+
+### Understand
+`_should_skip_file` in `agent/tools/tech_detector.py` is supposed to exclude
+vendored/build paths before `_detect_tech` counts file extensions. It does
+this by checking whether a slash-anchored pattern like `"/node_modules/"` or
+`"/build/"` appears as a substring of the filepath. That only matches when
+the directory is *nested* under something else — a path rooted at the repo
+root, like `node_modules/lib/index.js` or `build/bundle.js`, has no leading
+`/` before the directory name, so the substring never matches and the file
+is not filtered.
+
+- **Expected:** any file living inside `node_modules/`, `vendor/`, `dist/`,
+  `build/`, `.git/`, `__pycache__/`, `.venv/`, or `venv/` — anywhere in its
+  path, including at the root — is excluded from language detection.
+- **Actual:** only nested occurrences are excluded. Root-level vendored/build
+  files leak into the extension and config-file counts and can flip
+  `primary_language` to the wrong value (confirmed: reports `"JavaScript"`
+  for a repo that's really 2 Python files + 6 vendored JS files — see
+  `scripts/repro_issue_150.py` and the Week 8 JOURNAL entry).
+
+### Map
+- `agent/tools/tech_detector.py` — the fix itself, in the `_should_skip_file`
+  static method (currently lines 143–164). No other method needs to change;
+  `_detect_tech` already calls `_should_skip_file` correctly and just needs
+  it to return the right answer.
+- `tests/unit/test_tech_detector.py` — `test_node_modules_excluded` and
+  `test_build_directory_excluded` already assert the right thing and are
+  currently failing; they should pass once the fix lands. `test_vendor_files_excluded`
+  currently calls the detector but asserts nothing — I'll add a real
+  assertion since it covers the same bug class.
+- `scripts/repro_issue_150.py` — my Week 8 reproduction script. I'll leave it
+  in the repo as a runnable sanity check; it should print "Not reproduced"
+  once the fix is in.
+- Confirmed via `grep -rn "_should_skip_file"` that it has exactly one call
+  site (`_detect_tech`, same file), so the fix is self-contained.
+
+### Plan
+1. Rewrite `_should_skip_file` to split each path on `/` and check the
+   *directory* segments (all path components except the final filename)
+   against a `skip_dirs` set of exact names, instead of substring-matching
+   slash-anchored patterns. This fixes root-level paths without changing
+   behavior for already-working nested paths.
+2. Run `pytest tests/unit/test_tech_detector.py -v` and confirm
+   `test_node_modules_excluded` and `test_build_directory_excluded` now pass,
+   with no other test in the file newly failing.
+3. Add a real assertion to `test_vendor_files_excluded` (it currently exercises
+   the code but checks nothing) so the vendor/build/node_modules cases are
+   consistently covered.
+4. Re-run `python -m scripts.repro_issue_150` and confirm the output flips
+   from "BUG REPRODUCED" to "Not reproduced".
+5. Run `make test-unit` (full unit suite) and `make check` (lint + format +
+   typecheck) to confirm no unrelated regressions before opening the PR.
+
+### Inputs & outputs
+- **Input:** `input_data["files"]` — a flat list of relative file-path
+  strings. `TechDetector` never touches the filesystem itself; whatever
+  assembles the file listing (elsewhere in the agent pipeline) is the actual
+  caller.
+- **Output:** unchanged shape — `execute()` still returns a `ToolResult`
+  with `primary_language: str`, `all_languages: list[str]`,
+  `frameworks: list[str]`. Only the *values* change for inputs that contain
+  root-level vendored/build paths — no schema/API change, so nothing
+  downstream of `TechDetector` should need to change.
+
+### Risks & unknowns
+- **Filename collisions:** segment-based matching must only check directory
+  components, not the final filename — otherwise a real source file
+  literally named `build` or `vendor` (no extension) at the repo root would
+  be wrongly skipped. I'm checking `parts[:-1]`, not all parts, specifically
+  to avoid this; adding a test case for it (see Edge cases).
+- **Scope of the skip-dir list:** I'm not expanding the existing list
+  (`node_modules`, `vendor`, `dist`, `build`, `.git`, `__pycache__`, `.venv`,
+  `venv`) to cover other ecosystems (e.g. `target/` for Rust/Java, `bin/`,
+  `obj/` for .NET) — that's a reasonable follow-up but not what #150 asks
+  for, and adding it unasked would widen the diff beyond the issue.
+  Flagging this as a conscious boundary, not an oversight.
+- **Other tools with similar logic:** haven't audited whether other agent
+  tools duplicate a similar path-skip pattern that has the same bug — out of
+  scope for this issue, but worth a one-line mention in the PR description
+  in case a maintainer wants a follow-up issue filed.
+
+### Edge cases
+- Root-level vendored dir (the actual bug): `node_modules/lib/index.js` →
+  should be skipped.
+- Nested vendored dir (already correct today): `src/vendor/lib.js` → should
+  remain skipped.
+- A file literally named after a skip directory, no extension, at the repo
+  root: `build` → should **not** be skipped (it's a file, not a directory).
+- Skip-directory name as a substring of an unrelated name:
+  `rebuild/notes.py`, `vendor-scripts/setup.py` → should **not** be skipped
+  (a path segment must equal the skip name exactly, not merely contain it).
+- Empty file list → already short-circuited by the early-return branch in
+  `execute()`; unaffected by this fix.
+- Backslash-delimited (Windows-style) paths → out of scope. The rest of
+  `tech_detector.py` already assumes forward slashes (e.g. `filepath.endswith(ext)`
+  string checks), so I won't special-case backslashes unless a test demands it.

--- a/agent/tools/tech_detector.py
+++ b/agent/tools/tech_detector.py
@@ -1,6 +1,7 @@
 """Technology stack detector tool."""
 
 import structlog
+
 from .base import BaseTool, ToolResult
 
 logger = structlog.get_logger()
@@ -75,7 +76,7 @@ class TechDetector(BaseTool):
                     "primary_language": "Unknown",
                     "all_languages": [],
                     "frameworks": [],
-                }
+                },
             )
 
         try:
@@ -84,11 +85,7 @@ class TechDetector(BaseTool):
 
         except Exception as e:
             logger.error("tech_detector_error", error=str(e))
-            return ToolResult(
-                success=False,
-                data={},
-                error=str(e)
-            )
+            return ToolResult(success=False, data={}, error=str(e))
 
     def _detect_tech(self, files: list[str]) -> dict:
         """Detect technologies from file list.
@@ -100,10 +97,7 @@ class TechDetector(BaseTool):
             Dict with detected languages and frameworks
         """
         # Filter out vendor/build directories
-        filtered_files = [
-            f for f in files
-            if not self._should_skip_file(f)
-        ]
+        filtered_files = [f for f in files if not self._should_skip_file(f)]
 
         languages = set()
         frameworks = set()
@@ -131,8 +125,12 @@ class TechDetector(BaseTool):
         all_languages = sorted(languages)
         all_frameworks = sorted(frameworks)
 
-        logger.info("tech_detected", primary_lang=primary,
-                   languages_count=len(all_languages), frameworks_count=len(all_frameworks))
+        logger.info(
+            "tech_detected",
+            primary_lang=primary,
+            languages_count=len(all_languages),
+            frameworks_count=len(all_frameworks),
+        )
 
         return {
             "primary_language": primary,
@@ -144,21 +142,29 @@ class TechDetector(BaseTool):
     def _should_skip_file(filepath: str) -> bool:
         """Check if file should be skipped.
 
+        Checks whether any directory component of the path -- every segment
+        except the filename itself -- is a vendored or build-output
+        directory. Matching on path segments, rather than a slash-anchored
+        substring, catches paths rooted at the repo root (e.g.
+        "node_modules/x.js"), not just paths nested under something else
+        (e.g. "src/node_modules/x.js").
+
         Args:
             filepath: File path
 
         Returns:
             True if file should be skipped
         """
-        skip_patterns = [
-            "/node_modules/",
-            "/vendor/",
-            "/dist/",
-            "/build/",
-            "/.git/",
-            "/__pycache__/",
-            "/.venv/",
-            "/venv/",
-        ]
+        skip_dirs = {
+            "node_modules",
+            "vendor",
+            "dist",
+            "build",
+            ".git",
+            "__pycache__",
+            ".venv",
+            "venv",
+        }
 
-        return any(pattern in filepath for pattern in skip_patterns)
+        directory_parts = filepath.split("/")[:-1]
+        return any(part in skip_dirs for part in directory_parts)

--- a/scripts/repro_issue_150.py
+++ b/scripts/repro_issue_150.py
@@ -1,0 +1,47 @@
+"""Reproduce issue #150: tech detector counts vendored/build files as source.
+
+TechDetector's skip logic in `_should_skip_file` (agent/tools/tech_detector.py)
+matches directory names with a leading slash (e.g. "/node_modules/"), so it
+only filters paths where node_modules/build/vendor appear *nested* under
+something else. A path rooted at the repo root -- "node_modules/..." or
+"build/..." -- has no leading slash before the directory name, so it is never
+skipped and still counts toward language detection.
+
+Usage:
+    python -m scripts.repro_issue_150
+
+See: https://github.com/ascherj/pathreview/issues/150
+"""
+
+from agent.tools.tech_detector import TechDetector
+
+# Exact reproduction from the issue body.
+FILES = [
+    "main.py",
+    "core/app.py",
+    "node_modules/lib/index.js",
+    "node_modules/lib/util.js",
+    "node_modules/x/a.js",
+    "node_modules/y/b.js",
+    "build/bundle.js",
+    "build/vendor.js",
+]
+
+
+def main() -> None:
+    detector = TechDetector()
+    result = detector.execute({"files": FILES})
+    primary = result.data["primary_language"]
+
+    print(f"Files given: {len(FILES)} (2 authored Python files, 6 vendored/build JS files)")
+    print("Expected primary_language: Python")
+    print(f"Observed primary_language: {primary}")
+
+    if primary != "Python":
+        print("\nBUG REPRODUCED: vendored/build files outvoted the real source files.")
+    else:
+        print("\nNot reproduced -- primary_language matched the expected value.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_tech_detector.py
+++ b/tests/unit/test_tech_detector.py
@@ -60,7 +60,6 @@ class TestTechDetector:
         data = result.data
         assert "Python" in data["all_languages"]
         # Should not include JSON or data-only language
-        detected_lower = [lang.lower() for lang in data["all_languages"]]
         # .ipynb should be treated as Python, not JSON
 
     def test_node_modules_excluded(self, detector):
@@ -89,7 +88,8 @@ class TestTechDetector:
 
         result = detector.execute({"files": files})
 
-        # Python should be primary despite vendor files
+        data = result.data
+        assert data["primary_language"] == "Python"
 
     def test_build_directory_excluded(self, detector):
         """Test build directory is excluded."""
@@ -103,6 +103,28 @@ class TestTechDetector:
 
         data = result.data
         assert data["primary_language"] == "Python"
+
+    def test_should_skip_file_root_level_vendored_dirs(self, detector):
+        """Regression test for #150: skip dirs at the repo root (no leading '/')."""
+        assert TechDetector._should_skip_file("node_modules/lib/index.js") is True
+        assert TechDetector._should_skip_file("build/bundle.js") is True
+        assert TechDetector._should_skip_file("vendor/lib.js") is True
+        assert TechDetector._should_skip_file("dist/app.js") is True
+
+    def test_should_skip_file_nested_vendored_dirs(self, detector):
+        """Nested skip dirs (already correct before #150's fix) still work."""
+        assert TechDetector._should_skip_file("src/node_modules/lib/index.js") is True
+        assert TechDetector._should_skip_file("src/vendor/lib.js") is True
+
+    def test_should_skip_file_name_collision_not_treated_as_directory(self, detector):
+        """A file whose *name* matches a skip dir is not itself a directory."""
+        assert TechDetector._should_skip_file("src/vendor") is False
+        assert TechDetector._should_skip_file("build") is False
+
+    def test_should_skip_file_substring_not_exact_match(self, detector):
+        """A dir name that merely contains "build"/"vendor" isn't a skip dir."""
+        assert TechDetector._should_skip_file("rebuild/notes.py") is False
+        assert TechDetector._should_skip_file("vendor-scripts/setup.py") is False
 
     def test_config_file_detection(self, detector):
         """Test detection from config files."""
@@ -125,7 +147,7 @@ class TestTechDetector:
             "main.py",
         ]
 
-        result = detector.execute({"files": files})
+        detector.execute({"files": files})
 
         # Should detect Python as primary language
 
@@ -136,9 +158,8 @@ class TestTechDetector:
             "main.py",
         ]
 
-        result = detector.execute({"files": files})
+        detector.execute({"files": files})
 
-        data = result.data
         # Should detect both Python and CI/CD
 
     def test_makefile_detection(self, detector):
@@ -148,7 +169,7 @@ class TestTechDetector:
             "src/main.py",
         ]
 
-        result = detector.execute({"files": files})
+        detector.execute({"files": files})
 
         # Should detect Makefile as build tool
 
@@ -253,7 +274,7 @@ class TestTechDetector:
             "main.py",
         ]
 
-        result = detector.execute({"files": files})
+        detector.execute({"files": files})
 
         # Should detect frameworks
 
@@ -280,9 +301,8 @@ class TestTechDetector:
             "Index.JS",
         ]
 
-        result = detector.execute({"files": files})
+        detector.execute({"files": files})
 
-        data = result.data
         # Should still detect languages despite case
 
     def test_multiple_extensions_same_file(self, detector):
@@ -359,7 +379,6 @@ class TestTechDetector:
             "header.h",
         ]
 
-        result = detector.execute({"files": files})
+        detector.execute({"files": files})
 
-        data = result.data
         # Should detect C++ (from .cpp files)


### PR DESCRIPTION
## Summary
`TechDetector` guesses a repo's primary language from its file list, but `_should_skip_file` was matching vendored/build directories as a slash-anchored substring (e.g. `"/node_modules/"`), which only catches paths *nested* under something else. A path rooted at the repo root — `node_modules/lib/index.js`, `build/bundle.js` — has no leading slash before the directory name, so it slipped through uncounted and could flip `primary_language` to the wrong value (a repo with 2 Python files and 6 vendored JS files reported as `"JavaScript"`).

## Issue
Closes #150

## Changes
- Rewrote `_should_skip_file` in `agent/tools/tech_detector.py` to split each path into segments and check the directory components (every segment except the filename) against a skip-dir set, instead of substring-matching slash-anchored patterns. Fixes root-level paths, keeps already-working nested paths working, and avoids a false positive for a file whose *name* happens to match a skip dir (e.g. a file literally named `build`).
- Added a real assertion to `test_vendor_files_excluded` (previously exercised the code but asserted nothing).
- Added 4 new tests exercising `_should_skip_file` directly: root-level skip dirs, nested skip dirs (regression guard for behavior that already worked), a filename/directory-name collision, and substring-vs-exact matching (`rebuild/` must not match `build`).
- Fixed 7 pre-existing ruff F841 (unused-variable) issues elsewhere in `tests/unit/test_tech_detector.py`, unrelated to #150, that were blocking any commit touching this file.
- Scoped the local pre-commit `mypy` hook to the same paths already defined in the Makefile/CI (`api/ core/ ingestion/ rag/ agent/ safety/`) — the hook had no path filter and was stricter than the project's own documented/CI-enforced scope, failing on pre-existing test-file type-annotation gaps unrelated to any specific change.
- Added `scripts/repro_issue_150.py`, a runnable reproduction of the original bug (kept as a standing sanity check — prints "Not reproduced" on this branch).
- `PLAN.md` and `JOURNAL.md` document the issue-selection → reproduction → planning → implementation process for this contribution.

## Testing
- [x] Unit tests pass (`make test-unit`) — see pre-existing-failures note below
- [ ] Integration tests pass (`make test-integration`) — not applicable; this is a pure function with no I/O
- [x] Linter passes (`make lint`) — see pre-existing-failures note below
- [x] Type checker passes (`make typecheck`) — `agent/tools/tech_detector.py` has 0 mypy errors, unchanged before/after
- [x] New/updated tests cover the changes

**Pre-existing failures (documented per CONTRIBUTING.md guidance):** this codebase has repo-wide issues unrelated to #150. I captured a baseline before touching anything and compared after:

| Check | Before | After |
|---|---|---|
| `make test-unit` | 53 failed / 375 passed | 51 failed / 381 passed |
| `ruff check .` | 182 errors | 173 errors |
| `black --check .` | 52 files need reformatting | 51 files need reformatting |
| `mypy` (Makefile scope) | 99 errors / 25 files | 99 errors / 25 files (unchanged) |

My changes only ever reduce these numbers or leave them unchanged. The reduction is: the 2 tests this fix resolves, 1 import-order + 1 black-format fix in `agent/tools/tech_detector.py` (the file being rewritten anyway), and the 7 F841 fixes + 1 pre-commit scope fix described above (pre-existing debt in files this PR necessarily touches, not unrelated cleanup). No file I didn't touch changed. `make check`/`make test-unit` still exit non-zero overall due to remaining pre-existing issues in files outside this PR's scope (e.g. `api/routes/profiles.py`, `tests/unit/test_skill_extractor.py`).

## Screenshots / Demo
N/A — backend-only fix, no UI surface. `python -m scripts.repro_issue_150` demonstrates the fix directly: prints "BUG REPRODUCED" against `main`, "Not reproduced" against this branch.

## Notes for Reviewers
- The fix is a slightly different shape than the smallest possible patch: instead of adding a second, non-anchored pattern per skip directory, I switched to segment-based matching (`filepath.split("/")[:-1]` checked against a set). I think it's more correct and readable, and it also closes a latent false-positive gap a minimal patch wouldn't (a file literally named `build`, no extension) — happy to narrow it if a smaller diff is preferred. Full reasoning is in `PLAN.md` under Risks & unknowns.
- This is a CodePath AI201 Module 3 contribution — `JOURNAL.md` has my week-by-week notes if useful context, and this is currently a draft while I get peer/mentor feedback before marking it ready for review.
