### PR TITLE
fix(api): use redis_url for health check instead of nonexistent redis_host

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,21 @@
+# PathReview — Module 3 Journal
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/155
+
+**Issue title:** Health check references `settings.redis_host`, which does not exist on Settings
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The `/health` endpoint in `api/routes/health.py` is supposed to report whether the app's Redis connection is healthy, but it tries to read `settings.redis_host` and `settings.redis_port` off the `Settings` model in `core/config.py`, and neither field actually exists there — only `redis_url` is defined. Because of this mismatch, calling `GET /health` throws an `AttributeError` before the Redis probe can even run, so the endpoint fails outright instead of just reporting Redis as unavailable. This turns a check meant to give visibility into service status into something that crashes the request, which defeats the purpose for any monitoring or uptime tooling relying on it. A successful fix would update the Redis probe in `api/routes/health.py` to use configuration that actually exists on `Settings` — either by deriving host/port from the existing `redis_url`, or by adding proper `redis_host`/`redis_port` fields to `core/config.py` — so the endpoint returns accurate Redis status instead of erroring out. Since `/health` currently has no test coverage, a solid fix should also add a basic test confirming the endpoint behaves correctly when Redis is reachable and when it isn't.
+
+**Issue checklist reasoning:**
+This is a small, well-scoped Tier 1 bug: the root cause is a one-line attribute mismatch between two files (`api/routes/health.py` and `core/config.py`), it's easy to reproduce (`GET /health`), and the fix doesn't require touching the frontend, database schema, or other modules. It's a good fit for a first contribution because the blast radius is contained to the health-check path and there's a clear, testable definition of "done" (endpoint returns 200 with real Redis status instead of erroring). One risk I noted: this issue is popular — several classmates have already claimed it and there are multiple linked PRs (#160, #177, #188, #208) attempting to close it — so there's a real chance it gets resolved by someone else before I finish. I'm proceeding anyway since I already claimed it and understand the fix, but I'm keeping my changes small and self-contained so I can pivot quickly if it closes out from under me.
+
+**Branch name:** fix/155-health-check-redis-host
+
+**Setup confirmation:** [ ] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -16,6 +16,34 @@ This is a small, well-scoped Tier 1 bug: the root cause is a one-line attribute 
 
 **Branch name:** fix/155-health-check-redis-host
 
-**Setup confirmation:** [ ] App runs locally at localhost:5173
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+*Note: on my machine, port 5173 was already occupied by an unrelated local project, so Vite
+auto-selected 5174 instead (`http://localhost:5174`) — confirmed it's genuinely the PathReview
+frontend (page `<title>PathReview - AI Portfolio Review Assistant</title>`), not a stale
+process. Backend confirmed running at `http://localhost:8000` per SETUP.md (also shifted to
+8010 locally for the same reason). This is a local port-conflict artifact, not a project bug.*
 
 **Cohort ledger:** [ ] Issue added to cohort ledger
+
+---
+
+## Week 8 — Reproduction and planning
+
+**Reproduced locally:** Yes. Ran `docker compose up -d`, `alembic upgrade head`, and
+`uvicorn api.main:app`, then called `GET /health`. Confirmed the exact `AttributeError` from
+the issue:
+
+```
+2026-07-29 00:45:07 [error] redis_health_check_failed error="'Settings' object has no attribute 'redis_host'"
+```
+
+**Important nuance found during reproduction:** the `AttributeError` is caught by an existing
+`except Exception` block in `api/routes/health.py`, so the endpoint doesn't crash outright —
+it silently reports `"redis": "unhealthy"` no matter what Redis's real status is. Full details
+and my fix approach are in [PLAN.md](PLAN.md).
+
+**Plan:** See [PLAN.md](PLAN.md) — root cause, files to change, step-by-step plan, test
+specification, and risks/edge cases.
+
+**Loom walkthrough:** [ ] Recorded (not yet — recommended but not graded)

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -47,3 +47,38 @@ and my fix approach are in [PLAN.md](PLAN.md).
 specification, and risks/edge cases.
 
 **Loom walkthrough:** [ ] Recorded (not yet — recommended but not graded)
+
+---
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the fix in `api/routes/health.py`: swapped the broken `redis.Redis(host=settings.redis_host, port=settings.redis_port, ...)` call for `redis.Redis.from_url(settings.redis_url, decode_responses=True)`, matching the "use the existing `redis_url` field" direction from `PLAN.md`. Wrote the first test coverage for `/health` in `tests/unit/test_health.py` — 4 tests covering the healthy, unreachable, and malformed-URL cases, plus a regression guard that `redis_host`/`redis_port` don't reappear. All sub-tasks from `PLAN.md`'s Plan section are done.
+
+**Next steps:**
+Run `make check`/`make test-unit`, self-review against `CONTRIBUTING.md`, and open the PR.
+
+**Blockers:**
+`make check`'s `mypy` step follows imports transitively — since `api/main.py` imports the health router, getting `health.py` to typecheck meant the whole reachable graph (`api/routes/reviews.py`, `api/routes/profiles.py`, `core/services/review_service.py`, `core/services/profile_service.py`, `api/main.py`, `api/middleware/request_id.py`) needed missing type annotations added too — none of that was in scope for #155 itself, but was unavoidable to get a clean typecheck. Documented this in the PR description rather than treating it as scope creep I chose unprompted. Separately, `mypy` on the full `api/ core/ ingestion/ rag/ agent/` target still fails on a pre-existing `numpy`/mypy version incompatibility inside `rag/`/`agent/` that I confirmed is unrelated to this change (reproduces identically with nothing touched in those directories) — noted as a pre-existing failure rather than something I attempted to fix.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/754
+
+**Branch:** `fix/155-health-check-redis-host`
+
+**What you built:**
+Fixed `/health`'s Redis probe to use `settings.redis_url` (which exists) instead of `settings.redis_host`/`settings.redis_port` (which don't), via `redis.Redis.from_url()`. The real bug wasn't a crash — the `AttributeError` was already caught by an existing `except` block — it was that `/health` silently reported Redis as unhealthy regardless of Redis's actual status; the fix makes it report real status.
+
+**Tests added or updated:**
+`tests/unit/test_health.py` (new) — 4 tests: Redis healthy → 200, Redis unreachable → clean 503 (not a crash), malformed `REDIS_URL` → clean 503, and a regression guard on `Settings` no longer having `redis_host`/`redis_port`. Mounts a minimal `FastAPI()` app with just the health router (not the full `api.main` app) to avoid pulling in unrelated `auth`/`profiles`/`reviews` dependencies.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+*(Both pass in the sense the assignment defines for a codebase with documented pre-existing failures: `make test-unit` shows the identical 53 pre-existing failures before and after my change — zero new failures, 4 new passing tests. `make check`'s `ruff`/`black`/`mypy` all pass on every file this PR touches, confirmed via the actual pre-commit hook; the full-repo `mypy` target still fails on an unrelated, pre-existing `numpy` version incompatibility in `rag/`/`agent/` that I verified predates and is unaffected by this PR. Both are documented in the PR description.)*
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -82,3 +82,36 @@ Fixed `/health`'s Redis probe to use `settings.redis_url` (which exists) instead
 *(Both pass in the sense the assignment defines for a codebase with documented pre-existing failures: `make test-unit` shows the identical 53 pre-existing failures before and after my change — zero new failures, 4 new passing tests. `make check`'s `ruff`/`black`/`mypy` all pass on every file this PR touches, confirmed via the actual pre-commit hook; the full-repo `mypy` target still fails on an unrelated, pre-existing `numpy` version incompatibility in `rag/`/`agent/` that I verified predates and is unaffected by this PR. Both are documented in the PR description.)*
 
 **Draft PR feedback received from:** none
+
+---
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+I checked [PR #754](https://github.com/ascherj/pathreview/pull/754) at the start of Week 10 (`gh pr view 754 --repo ascherj/pathreview --json comments,reviews`) — zero comments, zero reviews. Per the Su26 note, reviewer feedback isn't a feature this term, so this is expected rather than a sign the PR is being ignored. It's still open, not merged, not closed.
+
+**How you responded:**
+N/A — nothing to respond to. I didn't make any further code changes this week since there was no feedback to act on.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The bug itself was genuinely a one-line fix (`redis_host`/`redis_port` → `redis_url`). What I didn't expect was how much of the actual work was *environment* work, not code work: Docker services already occupying ports another local project had claimed, a numpy release that shipped Python 3.12-only type stubs breaking `mypy` on `rag/`/`agent/` for reasons that had nothing to do with my change, and — most surprising — discovering that `mypy` follows imports transitively, so "fix one file" turned into "the whole reachable import graph now needs type annotations" once I actually tried to get a clean typecheck. I also didn't expect the issue's own description to be slightly wrong: it said the endpoint "raises an AttributeError" as if that crashes the request, but when I actually reproduced it, the error was already being swallowed by an existing `except Exception` block. The real bug was subtler — a silent false negative, not a crash — and I only caught that by actually running the app and reading the response body, not by reading the code.
+
+**What did you learn about working in a large codebase?**
+That "fix the bug" and "land a fix cleanly" are different jobs. The bug fix was three lines. Getting it to pass the project's own gates (`ruff`, `black`, `mypy`, the pre-commit hook) meant touching six other files I had no intention of touching, because someone else's untyped function three imports away becomes my problem the moment `mypy` walks the graph. I also learned that a big codebase always has pre-existing rot — 53 already-failing unit tests, a `mypy` target that's been broken on `rag/`/`agent/` independent of anything I did — and the professional move isn't to fix all of it, it's to measure the baseline, prove your change doesn't add to it, and say so plainly in the PR. I made a deliberate call not to fix the sibling Postgres `text()` bug sitting in the same function I was editing, even though it would've been easy to "just fix while I'm in there" — staying scoped to the one issue I claimed felt more important than it would have on a personal project.
+
+**How did AI tools help — and where did they fall short?**
+AI was strongest at the mechanical, high-volume parts: orienting in an unfamiliar codebase fast (finding `get_db`, understanding the FastAPI dependency-injection pattern, matching existing test conventions in `tests/unit/test_resume_parser.py`), and systematically working through a list of ~50 `mypy` errors across multiple files without losing track of which were mine to fix. It fell short on anything that required actually *running* the system rather than reasoning about it — the Gatekeeper scan delays, the port conflicts with an unrelated project, the numpy stub crash — those needed real trial-and-error with logs and process inspection, not pattern-matching against training data. It also couldn't make scope-judgment calls unilaterally and shouldn't have: whether to fix the pre-existing `mypy` debt at all, whether to skip a broken pre-commit hook, whether to pin a dependency version — those got surfaced as explicit questions rather than decided silently, which is the right way to use AI assistance on someone else's production codebase.
+
+**What would you do differently if you started over?**
+I'd build the test file against a minimal app (just the one router I'm testing) from the start, instead of importing the full `api.main` app first and only narrowing it down after `mypy` surfaced ~50 unrelated errors. I'd also check `docker ps`/port availability before following the setup guide literally, since this machine already had an unrelated project's dev servers sitting on the exact ports SETUP.md assumes are free. Neither changes the actual fix, but both would've saved real time.
+
+**What are you most proud of from this module?**
+Catching that the issue's description didn't quite match reality. It would've been easy to read "raises an AttributeError," write a fix, and move on. Actually reproducing it — standing up Docker, running migrations, hitting the endpoint, reading the real log line and response body — showed the bug was a masked false negative, not a crash. That distinction changed how I explained the fix in `PLAN.md` and the PR description, and it's the part of this module that felt the most like real engineering rather than following a checklist.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,144 @@
+## Solution plan
+
+**Issue:** #155 — Health check references `settings.redis_host`, which does not exist on Settings
+
+### Understand
+
+`api/routes/health.py` has a `redis` try/except block (lines 39–56) that builds a client with
+`redis.Redis(host=settings.redis_host, port=settings.redis_port, ...)`. `Settings` in
+`core/config.py` never defines `redis_host` or `redis_port` — the only Redis-related field is
+`redis_url: str = Field(default="redis://localhost:6379/0")` (line 12). Accessing
+`settings.redis_host` raises `AttributeError: 'Settings' object has no attribute 'redis_host'`.
+
+**What I confirmed by actually reproducing it** (not just reading the code): I ran the app
+locally (`docker compose up -d`, `alembic upgrade head`, `uvicorn api.main:app`) and hit
+`GET /health`. The `AttributeError` really does fire, exactly as the issue says — but it does
+**not** crash the endpoint the way the issue description implies. It's caught by the existing
+`except Exception as exc:` block at line 53, logged, and turned into
+`"redis": "unhealthy"` in the response body:
+
+```
+2026-07-29 00:45:07 [error] redis_health_check_failed error="'Settings' object has no attribute 'redis_host'"
+```
+
+```json
+{"detail":{"status":"unhealthy","dependencies":{"postgres":"unhealthy","redis":"unhealthy","vector_db":"healthy"},...}}
+```
+`HTTP 503`
+
+So the real bug isn't an unhandled crash — it's a **false negative that can never be fixed by
+Redis itself being healthy**. Even with Redis fully up (confirmed via `docker compose ps` →
+`healthy`), `/health` will always report `redis: unhealthy`, because the code never gets far
+enough to actually ping Redis. That's arguably worse for an on-call engineer than a loud crash:
+the endpoint looks like it's doing a real check but the result is meaningless.
+
+(Side note: I also observed `postgres: unhealthy` in the same response, caused by a different,
+already-tracked bug — raw `"SELECT 1"` needs `text()` for SQLAlchemy 2.x. That's a separate
+issue from #155 and I'm leaving it alone — see Risks below.)
+
+**Root cause:** `api/routes/health.py`'s Redis probe reads config fields that were never added
+to `Settings`.
+
+**Fix direction:** Use `redis.Redis.from_url(settings.redis_url)` instead of constructing the
+client from `host=`/`port=`. This uses the field that already exists, needs no changes to
+`core/config.py`, and is the standard `redis-py` entry point for a connection string — so it's
+a smaller diff than adding two new `Settings` fields that would just duplicate what `redis_url`
+already encodes.
+
+### Map
+
+Files I expect to touch:
+- `api/routes/health.py` (lines 39–56) — replace the `redis.Redis(host=..., port=...)` call
+  with `redis.Redis.from_url(settings.redis_url, decode_responses=True)`.
+- `tests/unit/test_health.py` (new file) — first test coverage for this endpoint. Following the
+  convention in `tests/unit/test_resume_parser.py`: `@pytest.mark.unit` on a test class,
+  `unittest.mock.patch` for external dependencies (no existing `tests/api/` directory or
+  `TestClient` usage anywhere in the repo yet, so this also establishes the pattern for future
+  route tests).
+- `core/config.py` — not touching. Confirmed `redis_url` already covers what's needed once the
+  fix uses `from_url`.
+
+### Plan
+
+1. Confirm `redis.Redis.from_url()` accepts a full `redis://host:port/db` string and exposes
+   `.ping()` the same way the current `host=`/`port=` constructor does (checked: it does — same
+   class, just a different entry point).
+2. Edit `api/routes/health.py`: replace lines 44–49 with
+   `r = redis.Redis.from_url(settings.redis_url, decode_responses=True)`.
+3. Manually re-run `GET /health` locally and confirm `redis` now reports `"healthy"` (Redis
+   container is already up and healthy in `docker compose ps`).
+4. Add `tests/unit/test_health.py`:
+   - override the `get_db` dependency with a fake session whose `execute()` doesn't raise, so
+     the Postgres branch doesn't interfere with the Redis-specific test
+   - patch `redis.Redis.from_url` to return a mock whose `.ping()` succeeds → assert
+     `dependencies.redis == "healthy"`
+   - patch it to raise (e.g. `redis.exceptions.ConnectionError`) → assert
+     `dependencies.redis == "unhealthy"` and no unhandled exception escapes the route
+   - a regression test that directly asserts `settings.redis_host` is never referenced (i.e.
+     the fixed code no longer touches a nonexistent attribute) — really just covered by the
+     two cases above passing without `AttributeError`
+5. Run `make test-unit` to confirm the new tests pass and nothing else broke.
+6. Run `make check` (ruff + black + mypy) before opening the PR.
+
+### Inputs & outputs
+
+**Function I'm changing:** the Redis block inside `health_check()` in `api/routes/health.py`.
+
+**Existing (broken) behavior:**
+- Input: any request to `GET /health`, Redis reachable or not
+- Output: `dependencies.redis` is always `"unhealthy"` (masked by the `AttributeError`)
+
+**New behavior:**
+- Input: `GET /health`, Redis reachable → Output: `dependencies.redis == "healthy"`
+- Input: `GET /health`, Redis unreachable (e.g. connection refused) →
+  Output: `dependencies.redis == "unhealthy"`, still a clean 503, no unhandled exception
+
+**Tests I'll write** (`tests/unit/test_health.py`):
+
+```python
+@pytest.mark.unit
+class TestHealthCheck:
+    async def test_health_check_redis_healthy(self, ...):
+        # patch redis.Redis.from_url(...).ping() to succeed
+        # assert response body dependencies["redis"] == "healthy"
+
+    async def test_health_check_redis_unreachable(self, ...):
+        # patch redis.Redis.from_url(...).ping() to raise ConnectionError
+        # assert dependencies["redis"] == "unhealthy", no 500, no AttributeError
+```
+
+I'll check how `get_db` is imported in `api/routes/health.py` to decide the cleanest way to
+override it in tests (`app.dependency_overrides[get_db] = ...` vs. patching the import site).
+
+### Risks & unknowns
+
+1. **Postgres bug is out of scope, on purpose.** I confirmed `postgres: unhealthy` is caused by
+   a different bug (`"SELECT 1"` not wrapped in `text()`), already the subject of other PRs
+   (#177, #188, #208 — see issue #155 discussion). I'm intentionally not fixing it here to keep
+   this PR scoped to #155; mentioning it explicitly so it isn't mistaken for something I missed.
+2. **`from_url` vs. `host=`/`port=` argument differences.** `redis.Redis.from_url()` parses
+   `db` from the URL path (`/0`) automatically; the old code passed `db=0` explicitly. Need to
+   confirm the parsed URL's db index matches what the old hardcoded `db=0` assumed — it does for
+   the default `redis://localhost:6379/0`, but I should not assume every possible `REDIS_URL`
+   value in `.env.example`/prod configs is `/0`. I'll trust the URL rather than hardcoding.
+3. **Mocking `redis.Redis.from_url` where it's imported locally.** `import redis` happens
+   inside the function body in `health.py`, not at module level. `unittest.mock.patch` needs to
+   target `"redis.Redis.from_url"` (patching the class method on the `redis` module itself)
+   rather than `"api.routes.health.redis.Redis"`, since there's no module-level `redis` name to
+   patch. I'll verify this works before assuming the mock takes effect.
+4. **Whether the multiple already-open PRs (#160, #177, #188, #208) beat me to this.** Real risk
+   noted in my Week 7 journal — if one of them merges first, I'll rebase my scoped, single-issue
+   version on whatever lands, or pivot to a different open issue.
+
+### Edge cases
+
+- Redis reachable and healthy → `"healthy"`, overall `status` unaffected by this check.
+- Redis process down / connection refused → `"unhealthy"`, 503, no unhandled exception (this is
+  the case the current code silently gets "right" by accident, since it's masked either way —
+  need my test to prove it's right for the *correct* reason now).
+- Malformed `REDIS_URL` (e.g. missing scheme) → `redis.Redis.from_url()` raises `ValueError`
+  before `.ping()` is ever called; this is still caught by the existing outer
+  `except Exception as exc:`, so behavior degrades gracefully to `"unhealthy"` rather than a
+  500. I'll add a short comment noting this is intentional, not accidental.
+- Vector DB and other dependencies are untouched by this change — confirmed by the fact that
+  `vector_db: "healthy"` already appears correctly in my reproduction output above.

--- a/api/main.py
+++ b/api/main.py
@@ -1,11 +1,13 @@
+from typing import Any
+
+import structlog
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import JSONResponse
 from fastapi.openapi.utils import get_openapi
-import structlog
+from fastapi.responses import JSONResponse
 
 from api.middleware.request_id import RequestIDMiddleware
-from api.routes import auth, profiles, reviews, health
+from api.routes import auth, health, profiles, reviews
 from core.database import init_db
 
 log = structlog.get_logger()
@@ -19,23 +21,22 @@ app = FastAPI(
 
 
 # Configure OpenAPI
-def custom_openapi():
-    if app.openapi_schema:
-        return app.openapi_schema
+def custom_openapi() -> dict[str, Any]:
+    existing_schema: dict[str, Any] | None = app.openapi_schema
+    if existing_schema:
+        return existing_schema
 
-    openapi_schema = get_openapi(
+    openapi_schema: dict[str, Any] = get_openapi(
         title="PathReview API",
         version="1.0.0",
         description="AI-powered portfolio review assistant",
         routes=app.routes,
     )
 
-    openapi_schema["info"]["x-logo"] = {
-        "url": "https://pathreview.example.com/logo.png"
-    }
+    openapi_schema["info"]["x-logo"] = {"url": "https://pathreview.example.com/logo.png"}
 
     app.openapi_schema = openapi_schema
-    return app.openapi_schema
+    return openapi_schema
 
 
 app.openapi = custom_openapi
@@ -56,7 +57,7 @@ app.add_middleware(RequestIDMiddleware)
 
 # Exception handler for unhandled exceptions
 @app.exception_handler(Exception)
-async def generic_exception_handler(request: Request, exc: Exception):
+async def generic_exception_handler(request: Request, exc: Exception) -> JSONResponse:
     request_id = getattr(request.state, "request_id", "unknown")
     log.error(
         "unhandled_exception",
@@ -84,7 +85,7 @@ app.include_router(health.router)
 
 # Startup event
 @app.on_event("startup")
-async def startup_event():
+async def startup_event() -> None:
     """Initialize database on startup."""
     try:
         await init_db()
@@ -96,7 +97,7 @@ async def startup_event():
 
 # Root endpoint
 @app.get("/")
-async def root():
+async def root() -> dict[str, str]:
     """Health check endpoint."""
     return {
         "message": "PathReview API is running",

--- a/api/middleware/request_id.py
+++ b/api/middleware/request_id.py
@@ -1,8 +1,9 @@
-from fastapi import Request
-from starlette.middleware.base import BaseHTTPMiddleware
-from starlette.responses import Response
 import uuid
+
 import structlog
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.responses import Response
 
 log = structlog.get_logger()
 
@@ -14,7 +15,7 @@ class RequestIDMiddleware(BaseHTTPMiddleware):
     Also binds the request_id to structlog context for the duration of the request.
     """
 
-    async def dispatch(self, request: Request, call_next) -> Response:
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
         # Generate unique request ID
         request_id = str(uuid.uuid4())
 

--- a/api/routes/health.py
+++ b/api/routes/health.py
@@ -1,6 +1,9 @@
-from fastapi import APIRouter, HTTPException, status, Depends
+from datetime import datetime
+from typing import Any
+
 import structlog
-from datetime import datetime, timedelta
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from core.database import get_db
 
@@ -10,12 +13,12 @@ router = APIRouter(prefix="/health", tags=["health"])
 
 
 @router.get("")
-async def health_check(db=Depends(get_db)):
+async def health_check(db: AsyncSession = Depends(get_db)) -> dict[str, Any]:
     """
     Check health of PostgreSQL, Redis, and Vector DB.
     Returns 200 if all healthy, 503 if any dependency is down.
     """
-    health_status = {
+    health_status: dict[str, Any] = {
         "status": "healthy",
         "dependencies": {
             "postgres": "unknown",
@@ -39,14 +42,10 @@ async def health_check(db=Depends(get_db)):
     try:
         # Check Redis (if available)
         import redis
+
         from core.config import settings
 
-        r = redis.Redis(
-            host=settings.redis_host,
-            port=settings.redis_port,
-            db=0,
-            decode_responses=True,
-        )
+        r = redis.Redis.from_url(settings.redis_url, decode_responses=True)
         r.ping()
         health_status["dependencies"]["redis"] = "healthy"
         log.debug("redis_health_check_passed")

--- a/api/routes/profiles.py
+++ b/api/routes/profiles.py
@@ -1,18 +1,19 @@
-from fastapi import APIRouter, Depends, HTTPException, status, UploadFile, File, Form
-from uuid import UUID
-import structlog
 import mimetypes
+from uuid import UUID
 
-from api.schemas.profile import ProfileCreate, ProfileResponse, ProfileUpdate
+import structlog
+from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from api.middleware.auth import get_current_user
-from core.models.user import User
-from core.models.profile import Profile
+from api.schemas.profile import ProfileCreate, ProfileResponse, ProfileUpdate
 from core.database import get_db
+from core.models.user import User
 from core.services.profile_service import (
     create_profile,
+    delete_profile,
     get_profile,
     update_profile,
-    delete_profile,
 )
 
 log = structlog.get_logger()
@@ -22,12 +23,12 @@ router = APIRouter(prefix="/profiles", tags=["profiles"])
 
 @router.post("", response_model=ProfileResponse)
 async def create_profile_endpoint(
-    github_username: str = Form(default=None),
-    portfolio_url: str = Form(default=None),
-    resume_file: UploadFile = File(default=None),
+    github_username: str | None = Form(default=None),
+    portfolio_url: str | None = Form(default=None),
+    resume_file: UploadFile | None = File(default=None),
     current_user: User = Depends(get_current_user),
-    db=Depends(get_db),
-):
+    db: AsyncSession = Depends(get_db),
+) -> ProfileResponse:
     """
     Create a new profile with optional resume upload.
     Resume must be PDF or Markdown.
@@ -59,16 +60,15 @@ async def create_profile_endpoint(
             if file_mime == "application/pdf":
                 try:
                     import PyPDF2
+
                     pdf_reader = PyPDF2.PdfReader(content)
-                    resume_text = "\n".join(
-                        page.extract_text() for page in pdf_reader.pages
-                    )
+                    resume_text = "\n".join(page.extract_text() for page in pdf_reader.pages)
                 except Exception as exc:
                     log.error("pdf_parsing_failed", error=str(exc))
                     raise HTTPException(
                         status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
                         detail="Failed to parse PDF resume",
-                    )
+                    ) from exc
             else:
                 # Markdown or plain text
                 resume_text = content.decode("utf-8")
@@ -95,7 +95,8 @@ async def create_profile_endpoint(
             user_id=str(current_user.id),
         )
 
-        return ProfileResponse.model_validate(new_profile)
+        profile_response: ProfileResponse = ProfileResponse.model_validate(new_profile)
+        return profile_response
 
     except HTTPException:
         raise
@@ -105,15 +106,15 @@ async def create_profile_endpoint(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to create profile",
-        )
+        ) from exc
 
 
 @router.get("/{profile_id}", response_model=ProfileResponse)
 async def get_profile_endpoint(
     profile_id: UUID,
     current_user: User = Depends(get_current_user),
-    db=Depends(get_db),
-):
+    db: AsyncSession = Depends(get_db),
+) -> ProfileResponse:
     """
     Get a profile by ID.
     Returns 404 if not found or not owned by current user.
@@ -132,7 +133,8 @@ async def get_profile_endpoint(
                 detail="Profile not found",
             )
 
-        return ProfileResponse.model_validate(profile)
+        profile_response: ProfileResponse = ProfileResponse.model_validate(profile)
+        return profile_response
 
     except HTTPException:
         raise
@@ -141,7 +143,7 @@ async def get_profile_endpoint(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to retrieve profile",
-        )
+        ) from exc
 
 
 @router.put("/{profile_id}", response_model=ProfileResponse)
@@ -149,8 +151,8 @@ async def update_profile_endpoint(
     profile_id: UUID,
     data: ProfileUpdate,
     current_user: User = Depends(get_current_user),
-    db=Depends(get_db),
-):
+    db: AsyncSession = Depends(get_db),
+) -> ProfileResponse:
     """
     Update a profile.
     Returns 404 if not found or not owned by current user.
@@ -180,7 +182,8 @@ async def update_profile_endpoint(
             user_id=str(current_user.id),
         )
 
-        return ProfileResponse.model_validate(updated_profile)
+        profile_response: ProfileResponse = ProfileResponse.model_validate(updated_profile)
+        return profile_response
 
     except HTTPException:
         raise
@@ -190,15 +193,15 @@ async def update_profile_endpoint(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to update profile",
-        )
+        ) from exc
 
 
 @router.delete("/{profile_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_profile_endpoint(
     profile_id: UUID,
     current_user: User = Depends(get_current_user),
-    db=Depends(get_db),
-):
+    db: AsyncSession = Depends(get_db),
+) -> None:
     """
     Delete a profile and cascade delete reviews and ingested sources.
     Returns 404 if not found or not owned by current user.
@@ -235,4 +238,4 @@ async def delete_profile_endpoint(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to delete profile",
-        )
+        ) from exc

--- a/api/routes/reviews.py
+++ b/api/routes/reviews.py
@@ -1,12 +1,14 @@
-from fastapi import APIRouter, Depends, HTTPException, status, BackgroundTasks
+from typing import Any
 from uuid import UUID
-import structlog
 
-from api.schemas.review import ReviewCreate, ReviewResponse, ReviewListResponse
+import structlog
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from api.middleware.auth import get_current_user
-from core.models.user import User
-from core.models.review import Review
+from api.schemas.review import ReviewCreate, ReviewListResponse, ReviewResponse
 from core.database import get_db
+from core.models.user import User
 from core.services.review_service import (
     create_review,
     get_review,
@@ -24,8 +26,8 @@ async def create_review_endpoint(
     data: ReviewCreate,
     background_tasks: BackgroundTasks,
     current_user: User = Depends(get_current_user),
-    db=Depends(get_db),
-):
+    db: AsyncSession = Depends(get_db),
+) -> ReviewResponse:
     """
     Create a new review for a profile.
     Triggers ingestion pipeline and agent orchestration asynchronously.
@@ -49,7 +51,8 @@ async def create_review_endpoint(
             user_id=str(current_user.id),
         )
 
-        return ReviewResponse.model_validate(review)
+        review_response: ReviewResponse = ReviewResponse.model_validate(review)
+        return review_response
 
     except HTTPException:
         raise
@@ -59,15 +62,15 @@ async def create_review_endpoint(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to create review",
-        )
+        ) from exc
 
 
 @router.get("/{review_id}", response_model=ReviewResponse)
 async def get_review_endpoint(
     review_id: UUID,
     current_user: User = Depends(get_current_user),
-    db=Depends(get_db),
-):
+    db: AsyncSession = Depends(get_db),
+) -> ReviewResponse:
     """
     Get a review by ID.
     Returns 404 if not found or not owned by current user.
@@ -86,7 +89,8 @@ async def get_review_endpoint(
                 detail="Review not found",
             )
 
-        return ReviewResponse.model_validate(review)
+        review_response: ReviewResponse = ReviewResponse.model_validate(review)
+        return review_response
 
     except HTTPException:
         raise
@@ -95,7 +99,7 @@ async def get_review_endpoint(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to retrieve review",
-        )
+        ) from exc
 
 
 @router.get("", response_model=ReviewListResponse)
@@ -103,8 +107,8 @@ async def list_reviews_endpoint(
     page: int = 1,
     page_size: int = 20,
     current_user: User = Depends(get_current_user),
-    db=Depends(get_db),
-):
+    db: AsyncSession = Depends(get_db),
+) -> ReviewListResponse:
     """
     List reviews for current user with pagination.
     """
@@ -133,15 +137,15 @@ async def list_reviews_endpoint(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to list reviews",
-        )
+        ) from exc
 
 
 @router.get("/{review_id}/status")
 async def get_review_status(
     review_id: UUID,
     current_user: User = Depends(get_current_user),
-    db=Depends(get_db),
-):
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
     """
     Get review status and progress.
     Returns {review_id, status, progress_pct}
@@ -173,4 +177,4 @@ async def get_review_status(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to retrieve review status",
-        )
+        ) from exc

--- a/core/services/profile_service.py
+++ b/core/services/profile_service.py
@@ -1,21 +1,23 @@
 from uuid import UUID
+
 import structlog
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
+from api.schemas.profile import ProfileCreate, ProfileUpdate
+from core.models.ingested_source import IngestedSource
 from core.models.profile import Profile
 from core.models.review import Review
-from core.models.ingested_source import IngestedSource
-from api.schemas.profile import ProfileCreate, ProfileUpdate
 
 log = structlog.get_logger()
 
 
 async def create_profile(
-    db,
+    db: AsyncSession,
     user_id: UUID,
     data: ProfileCreate,
-    resume_filename: str = None,
-    resume_text: str = None,
+    resume_filename: str | None = None,
+    resume_text: str | None = None,
 ) -> Profile:
     """
     Create a new profile for a user.
@@ -34,22 +36,21 @@ async def create_profile(
 
 
 async def get_profile(
-    db,
+    db: AsyncSession,
     profile_id: UUID,
     user_id: UUID,
 ) -> Profile | None:
     """
     Get a profile by ID, checking ownership.
     """
-    stmt = select(Profile).where(
-        (Profile.id == profile_id) & (Profile.user_id == user_id)
-    )
+    stmt = select(Profile).where((Profile.id == profile_id) & (Profile.user_id == user_id))
     result = await db.execute(stmt)
-    return result.scalars().first()
+    profile: Profile | None = result.scalars().first()
+    return profile
 
 
 async def update_profile(
-    db,
+    db: AsyncSession,
     profile_id: UUID,
     user_id: UUID,
     data: ProfileUpdate,
@@ -73,7 +74,7 @@ async def update_profile(
 
 
 async def delete_profile(
-    db,
+    db: AsyncSession,
     profile_id: UUID,
     user_id: UUID,
 ) -> bool:

--- a/core/services/review_service.py
+++ b/core/services/review_service.py
@@ -1,19 +1,22 @@
-from uuid import UUID
-import structlog
 import json
 from datetime import datetime
-from sqlalchemy import select, and_
+from typing import Any
+from uuid import UUID
 
-from core.models.review import Review
-from core.models.profile import Profile
-from core.models.ingested_source import IngestedSource
+import structlog
+from sqlalchemy import and_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from api.schemas.review import FeedbackSection
+from core.models.ingested_source import IngestedSource
+from core.models.profile import Profile
+from core.models.review import Review
 
 log = structlog.get_logger()
 
 
 async def create_review(
-    db,
+    db: AsyncSession,
     profile_id: UUID,
     user_id: UUID,
 ) -> Review:
@@ -33,22 +36,23 @@ async def create_review(
 
 
 async def get_review(
-    db,
+    db: AsyncSession,
     review_id: UUID,
     user_id: UUID,
 ) -> Review | None:
     """
     Get a review by ID, checking that it belongs to the user's profile.
     """
-    stmt = select(Review).join(Profile).where(
-        and_(Review.id == review_id, Profile.user_id == user_id)
+    stmt = (
+        select(Review).join(Profile).where(and_(Review.id == review_id, Profile.user_id == user_id))
     )
     result = await db.execute(stmt)
-    return result.scalars().first()
+    review: Review | None = result.scalars().first()
+    return review
 
 
 async def list_reviews(
-    db,
+    db: AsyncSession,
     user_id: UUID,
     page: int = 1,
     page_size: int = 20,
@@ -80,7 +84,7 @@ async def list_reviews(
 
 
 async def process_review(
-    db,
+    db: AsyncSession,
     review_id: UUID,
     profile_id: UUID,
 ) -> None:
@@ -194,12 +198,12 @@ async def process_review(
             log.error("review_status_update_failed", review_id=str(review_id), error=str(e))
 
 
-async def _run_ingestion_pipeline(db, profile: Profile) -> list[dict]:
+async def _run_ingestion_pipeline(db: AsyncSession, profile: Profile) -> list[dict[str, Any]]:
     """
     Run ingestion pipeline to extract data from profile sources.
     Returns list of ingested source data.
     """
-    sources = []
+    sources: list[dict[str, Any]] = []
 
     # Ingest from GitHub if available
     if profile.github_username:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,20 @@ select = ["E", "F", "I", "N", "W", "UP", "B", "SIM", "TCH"]
 "scripts/*.py" = ["E501"]
 "alembic/versions/*.py" = ["E501"]
 
+[tool.ruff.lint.flake8-bugbear]
+# FastAPI's dependency-injection pattern requires calling Depends()/Query()/etc.
+# in argument defaults; these are not the mutable-default footgun B008 warns about.
+extend-immutable-calls = [
+    "fastapi.Depends",
+    "fastapi.Query",
+    "fastapi.Path",
+    "fastapi.Body",
+    "fastapi.Header",
+    "fastapi.Cookie",
+    "fastapi.Form",
+    "fastapi.File",
+]
+
 [tool.black]
 target-version = ["py311"]
 line-length = 100

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -1,0 +1,81 @@
+"""Tests for api/routes/health.py"""
+
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.routes.health import router as health_router
+from core.database import get_db
+
+
+@pytest.fixture
+def client() -> TestClient:
+    """TestClient for a minimal app with only the health router mounted.
+
+    Avoids importing api.main (and therefore auth/profiles/reviews and their
+    service-layer dependencies), which aren't relevant to this endpoint.
+    """
+
+    async def override_get_db() -> AsyncIterator[Any]:
+        yield AsyncMock()
+
+    app = FastAPI()
+    app.include_router(health_router)
+    app.dependency_overrides[get_db] = override_get_db
+    return TestClient(app)
+
+
+@pytest.mark.unit
+class TestHealthCheck:
+    """Test suite for the /health endpoint's Redis probe."""
+
+    def test_redis_healthy_reports_healthy(self, client: TestClient) -> None:
+        """When Redis responds to ping(), the endpoint should report it as healthy."""
+        mock_redis = MagicMock()
+        mock_redis.ping.return_value = True
+
+        with patch("redis.Redis.from_url", return_value=mock_redis) as mock_from_url:
+            response = client.get("/health")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["dependencies"]["redis"] == "healthy"
+        # Confirms the fix: connects via the existing redis_url setting, not
+        # nonexistent redis_host/redis_port attributes.
+        mock_from_url.assert_called_once()
+        called_url = mock_from_url.call_args.args[0]
+        assert called_url.startswith("redis://")
+
+    def test_redis_unreachable_reports_unhealthy_without_crashing(self, client: TestClient) -> None:
+        """A connection failure should be caught and reported, not raised as a 500."""
+        with patch(
+            "redis.Redis.from_url",
+            side_effect=ConnectionError("Connection refused"),
+        ):
+            response = client.get("/health")
+
+        assert response.status_code == 503
+        body = response.json()["detail"]
+        assert body["dependencies"]["redis"] == "unhealthy"
+        # Postgres check (mocked healthy) shouldn't be affected by the Redis failure.
+        assert body["dependencies"]["postgres"] == "healthy"
+
+    def test_malformed_redis_url_handled_gracefully(self, client: TestClient) -> None:
+        """A malformed REDIS_URL should degrade to 'unhealthy', not an unhandled 500."""
+        with patch("redis.Redis.from_url", side_effect=ValueError("Invalid Redis URL")):
+            response = client.get("/health")
+
+        assert response.status_code == 503
+        assert response.json()["detail"]["dependencies"]["redis"] == "unhealthy"
+
+    def test_settings_has_no_removed_redis_host_attribute(self) -> None:
+        """Regression guard: the fix must not depend on fields that don't exist on Settings."""
+        from core.config import settings
+
+        assert not hasattr(settings, "redis_host")
+        assert not hasattr(settings, "redis_port")
+        assert hasattr(settings, "redis_url")


### PR DESCRIPTION
## Summary
The `/health` endpoint's Redis probe read `settings.redis_host` and `settings.redis_port`, neither of which is defined on `Settings` (only `redis_url` is). This raised an `AttributeError` on every call — but because it was caught by an existing `except Exception` block, the endpoint never actually crashed. Instead it silently reported `redis: "unhealthy"` no matter what Redis's real status was, which is arguably worse for on-call visibility than a loud failure. This PR switches the probe to `redis.Redis.from_url(settings.redis_url)`, using the config field that already exists, and adds the first test coverage for this endpoint.

## Issue
Closes #155

## Changes
- `api/routes/health.py`: replace `redis.Redis(host=settings.redis_host, port=settings.redis_port, ...)` with `redis.Redis.from_url(settings.redis_url, decode_responses=True)`
- `tests/unit/test_health.py` (new): 4 tests covering Redis healthy, Redis unreachable, malformed `REDIS_URL`, and a regression guard that `redis_host`/`redis_port` stay gone
- Added type annotations across `api/main.py`, `api/middleware/request_id.py`, `api/routes/reviews.py`, `api/routes/profiles.py`, `core/services/review_service.py`, `core/services/profile_service.py` — mypy follows imports transitively (`api/main.py` imports the health router), so getting `health.py` to typecheck cleanly required the whole reachable graph to be clean. No behavior changes in these files, purely annotations, narrowing a couple of `Any`-returning calls, and fixing implicit-`Optional` defaults in `profile_service.create_profile`.
- `pyproject.toml`: added `extend-immutable-calls` for FastAPI's `Depends`/`Query`/`Form`/etc. to ruff's `flake8-bugbear` config. Calling these in argument defaults is the required FastAPI DI pattern, not the mutable-default footgun `B008` warns about — it was firing on every route function in the app.

## Testing
- [x] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`) — not applicable, no integration test suite covers this endpoint
- [x] Linter passes (`make lint`)
- [x] Type checker passes (`make typecheck`) — see note below on pre-existing failures
- [x] New/updated tests cover the changes

**Pre-existing failures observed (unrelated to this change):**
- `make test-unit` on `main` (before my changes) reports **53 failed, 379 passed**. After my changes: **the same 53 failed, 379 passed** (plus my 4 new tests, all passing) — identical failure set, zero regressions. These 53 are pre-existing bugs in unrelated modules (`resume_parser`, `pii_scrubber`, `review_service` test doubles, etc.) seeded elsewhere in this course repo.
- `make check`'s `mypy` step, when run across the full `api/ core/ ingestion/ rag/ agent/` target, fails on `rag/`/`agent/` with a `numpy`/mypy version incompatibility: `numpy>=1.26.0` (unpinned) resolves to a version whose type stubs use Python 3.12+ syntax, which the project's `mypy` config (`python_version = "3.11"`) can't parse. I confirmed this reproduces identically with zero changes to `rag/`/`agent/` — it's not caused by this PR. The pre-commit `mypy` hook itself (which runs in its own isolated environment without the project's `numpy` installed) does **not** hit this and passes cleanly on every file this PR touches.
- Separately, `postgres: "unhealthy"` will still show up in `/health` responses locally — that's a different, already-tracked bug (raw `"SELECT 1"` needing `text()` for SQLAlchemy 2.x, see #155's linked PRs #177/#188/#208) and out of scope here.

## Screenshots / Demo
Reproduced locally and confirmed the fix end-to-end:

Before (on `main`):
```json
{"detail":{"status":"unhealthy","dependencies":{"postgres":"unhealthy","redis":"unhealthy","vector_db":"healthy"},...}}
```
```
redis_health_check_failed error="'Settings' object has no attribute 'redis_host'"
```

After (this branch, Redis container healthy):
```json
{"dependencies":{"redis":"healthy", ...}}
```

## Notes for Reviewers
- The type-annotation changes outside `health.py` are a direct consequence of mypy's import-following (not scope creep I chose unprompted) — happy to split them into a separate PR if preferred, but they were required for `health.py` itself to typecheck given `api/main.py` imports it.
- I deliberately did **not** fix the sibling `postgres` raw-SQL bug visible in the same function, to keep this PR scoped to #155 — see PLAN.md in my fork for the full reasoning.
- `tests/unit/test_health.py` mounts a minimal `FastAPI()` app with just the health router, rather than importing the full `api.main` app, to avoid pulling in unrelated `auth`/`profiles`/`reviews` dependencies for a test that doesn't touch them.
