### PR TITLE
test: restore basic_profile sample portfolio fixture and add consumer tests (#106)

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,32 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/106
+
+**Issue title:** Shared test fixture for a sample user profile is missing from `tests/fixtures/`
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+Several integration tests are currently being skipped because they depend on
+`tests/fixtures/sample_profiles/basic_profile.json`, a shared fixture file
+that was deleted from the repo. The `tests/fixtures/` directory doesn't exist
+at all right now, and `tests/conftest.py` only provides text fixtures
+(`sample_resume_text`, `sample_readme_text`) — there's no shared user-profile
+fixture. A successful fix restores the JSON file with a realistic sample
+portfolio (a GitHub username, resume content, and two repos) matching the
+app's profile schema, so the skipped tests run again and future tests have
+consistent sample data to rely on.
+
+**Branch name:** test/106-restore-basic-profile-fixture
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger
+
+**Issue checklist reasoning:**
+Tier 1, scoped to a single file with no production code changes. The issue
+description names the exact file to restore, existing conftest.py fixtures
+show the pattern to follow, and success is verifiable by running the
+previously-skipped tests. Maintainer estimate is 1–2 hours, which fits my
+availability. Main risk is getting the JSON schema right, which I can check
+against the profile model in the codebase.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -33,7 +33,8 @@ against the profile model in the codebase.
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [paste after you commit]
+**Reproduction commit link:**
+https://github.com/TessyMugisha/pathreview/commit/bff40cb8d271a916dffe146fb679aff7572782f6
 
 **Reproduction summary:**
 I ran `make test-unit` and confirmed the suite runs but no test references the
@@ -44,7 +45,8 @@ tests/` both return no matches, `tests/fixtures/` does not exist, and
 user-profile fixture. The 53 failures in the suite are pre-existing seeded bugs in
 unrelated modules, not caused by this gap.
 
-**PLAN.md: https://github.com/TessyMugisha/pathreview/blob/test/106-restore-basic-profile-fixture/PLAN.md
+**PLAN.md:**
+https://github.com/TessyMugisha/pathreview/blob/test/106-restore-basic-profile-fixture/PLAN.md
 
 **Blockers or open questions:**
 The issue describes skipped integration tests that don't exist in the current
@@ -52,3 +54,64 @@ codebase, so there's nothing to un-skip — I plan to add a consumer test alongs
 the fixture so it isn't an orphaned file. I also need to confirm how the two repos
 should be represented, since `Profile` has no repos field and repo data appears to
 live in `IngestedSource` / `agent/tools/github_tool.py`.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+All three sub-tasks from PLAN.md's "Map" section are implemented on
+`test/106-restore-basic-profile-fixture`:
+
+1. `tests/fixtures/sample_profiles/basic_profile.json` — the fixture itself, a
+   `profile` object mirroring the `Profile` model's columns plus a `repos` list of
+   two entries (`name`, `description`, `language`, `url`, `readme_text`).
+2. `tests/conftest.py` — new `sample_user_profile` fixture that loads the JSON via a
+   `FIXTURES_DIR` path anchored on `__file__`, so it resolves no matter where pytest
+   is invoked from.
+3. `tests/unit/test_sample_profile_fixture.py` — the consumer test, which resolves
+   the orphaned-file risk I flagged in Week 8.
+
+I settled the Week 8 open question about repo shape: repos are not a `Profile`
+column, so the fixture keeps them in a sibling `repos` list shaped to what
+`agent/tools/github_tool.py` consumes (`name` usable as `repo_name`) and to what
+`IngestedSource.raw_data` can hold as free-form JSON. No production code is touched.
+
+**Next steps:**
+- Re-run `make check` and `make test-unit` and confirm my three files add no new
+  failures against the pre-existing baseline.
+- Open the PR as a draft, fill in the template, and document the pre-existing
+  failures explicitly.
+- Ask for peer review in Slack, address feedback, then mark ready for review.
+
+**Blockers:**
+The suite has pre-existing failures from seeded bugs in unrelated modules (bias
+detector, resume parser, review service, PII scrubber). None are in scope for #106,
+so I'm recording the baseline count before and after my change and showing it
+unchanged rather than trying to fix them.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [paste after opening the PR against ascherj/pathreview]
+
+**Branch:** `test/106-restore-basic-profile-fixture`
+
+**What you built:**
+Restored the missing shared test fixture `basic_profile.json` with a realistic
+sample portfolio, added a `sample_user_profile` pytest fixture in `tests/conftest.py`
+that loads it, and added a unit test that asserts the fixture's shape against the
+`Profile` model so the two can't drift apart.
+
+**Tests added or updated:**
+`tests/unit/test_sample_profile_fixture.py` (new) — nine tests covering that the
+fixture loads, that its `profile` keys exactly match `Profile.__table__.columns`,
+that ids parse as UUIDs, that string fields fit the model's column lengths, that
+timestamps are timezone-aware, and that both repo entries carry the fields
+downstream tooling reads. `tests/conftest.py` (updated) — added the
+`sample_user_profile` fixture.
+
+**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+
+**Draft PR feedback received from:** [name or Slack handle, or "none"]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -44,6 +44,7 @@ tests/` both return no matches, `tests/fixtures/` does not exist, and
 user-profile fixture. The 53 failures in the suite are pre-existing seeded bugs in
 unrelated modules, not caused by this gap.
 
+**PLAN.md: https://github.com/TessyMugisha/pathreview/blob/test/106-restore-basic-profile-fixture/PLAN.md
 
 **Blockers or open questions:**
 The issue describes skipped integration tests that don't exist in the current

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -127,3 +127,51 @@ because its `format` target is `black .` rather than `black --check .` and would
 rewritten 52 unrelated files into my diff.
 
 **Draft PR feedback received from:** [name or Slack handle, or "none"]
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+[What did reviewers comment on? Or note that no review came in.]
+- No Response
+**How you responded:**
+[What changes did you make, or what did you reply? If no feedback,
+leave blank.]
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+[Be specific — what part of the process, codebase, or workflow
+surprised you?]
+The issue itself.#106 said integration tests were being skipped because the fixture was missing, so I expected to restore a file and watch some skipped tests turn green. When I actually looked, grep -rn "basic_profile" tests/ returned nothing and tests/integration/ was just an __init__.py — there were no skipped tests, and never had been. I'd assumed the issue description was ground truth. Realizing I had to verify the premise before planning the fix, and then decide what "done" meant on my own (restore the fixture and write a consumer, or ship an orphaned file), was the part that took the most thinking.
+
+**What did you learn about working in a large codebase?**
+[What's different about contributing to someone else's production code
+vs. building your own project?]
+
+You have to discover the constraints in the project rather than in your own project where you know the codebase. To decide the shape of a single JSON fixture I had to read core/models/profile.py for the actual columns, api/schemas/profile.py to find that resume_text exists on the model but in no schema, core/services/review_service.py to learn repos aren't a Profile column at all, and agent/tools/github_tool.py to see what a repo entry needs to expose. In my own project all of that is in my head.
+
+The other thing: you don't get to fix what's broken around you. There are 53 failing tests and 182 lint errors in this repo and none of them were mine to touch. Learning to work cleanly inside a mess and to prove I left it exactly as messy as I found it was a skill.
+
+**How did AI tools help — and where did they fall short?**
+[Where was AI assistance most useful this module? Where did you need
+to go beyond what AI could give you?]
+
+Most useful in tracing where repo data actually lives across four modules, and matching the existing test conventions in tests/unit/ so my file didn't look foreign.
+
+Where it fell short was it couldn't tell me the issue was wrong.#106 described skipped integration tests that don't exist. An AI given that issue will confidently implement the fix as described. Running grep -rn "basic_profile" tests/ myself and finding nothing was the thing that changed the whole shape of the work. Same with my environment: make isn't on Windows PowerShell, and the repo showed 143 files as modified from line endings. Nothing external could see that but me.
+
+**What would you do differently if you started over?**
+[Issue selection, planning, implementation, or process — anything
+you'd change?]
+
+I'd have commented on issue#106 asking the maintainer how repos should be represented, instead of inferring it from github_tool.py and flagging the guess in my PR
+
+**What are you most proud of from this module?**
+[One thing — it doesn't have to be the PR itself.]
+- The test that asserts the fixture's keys equal Profile.__table__.columns. My first instinct was to hardcode the expected field names, which would have just restated the JSON in Python. Comparing against the model instead means the test fails if someone adds a column and forgets the fixture. It's a small thing, but it's the difference between a test that exists and a test that does work.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -112,6 +112,18 @@ timestamps are timezone-aware, and that both repo entries carry the fields
 downstream tooling reads. `tests/conftest.py` (updated) — added the
 `sample_user_profile` fixture.
 
-**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+Recorded against the documented pre-existing baseline, per the module guidance that
+"passes" means my changes introduce no new failures. Unit tests: 53 failed / 375
+passed before, 53 failed / 384 passed after — same 53 failures, plus my 9 new passing
+tests. `ruff check .`: 182 errors before and after. `black --check .`: 52 files before
+and after. My three files are clean under both `ruff check` and `black --check`.
+
+Note on tooling: `make` isn't available in PowerShell on my machine, so I ran the
+underlying commands directly (`.venv\Scripts\pytest tests/unit -v -m unit`,
+`.venv\Scripts\ruff check .`). I deliberately did not run `make check` as a whole,
+because its `format` target is `black .` rather than `black --check .` and would have
+rewritten 52 unrelated files into my diff.
 
 **Draft PR feedback received from:** [name or Slack handle, or "none"]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -30,3 +30,24 @@ show the pattern to follow, and success is verifiable by running the
 previously-skipped tests. Maintainer estimate is 1–2 hours, which fits my
 availability. Main risk is getting the JSON schema right, which I can check
 against the profile model in the codebase.
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [paste after you commit]
+
+**Reproduction summary:**
+I ran `make test-unit` and confirmed the suite runs but no test references the
+missing fixture — `grep -rn "basic_profile" tests/` and `grep -rn "sample_profiles"
+tests/` both return no matches, `tests/fixtures/` does not exist, and
+`tests/integration/` contains only `__init__.py`. `tests/conftest.py` provides only
+`sample_resume_text` and `sample_readme_text`, confirming there is no shared
+user-profile fixture. The 53 failures in the suite are pre-existing seeded bugs in
+unrelated modules, not caused by this gap.
+
+
+**Blockers or open questions:**
+The issue describes skipped integration tests that don't exist in the current
+codebase, so there's nothing to un-skip — I plan to add a consumer test alongside
+the fixture so it isn't an orphaned file. I also need to confirm how the two repos
+should be represented, since `Profile` has no repos field and repo data appears to
+live in `IngestedSource` / `agent/tools/github_tool.py`.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -94,7 +94,7 @@ unchanged rather than trying to fix them.
 
 ### Check-in 2 (end of week)
 
-**PR link:** [paste after opening the PR against ascherj/pathreview]
+**PR link:** https://github.com/ascherj/pathreview/pull/756
 
 **Branch:** `test/106-restore-basic-profile-fixture`
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,78 @@
+## Solution plan
+
+**Issue:** Shared test fixture for a sample user profile is missing from `tests/fixtures/`
+— https://github.com/ascherj/pathreview/issues/106
+
+### Understand
+The repo has no `tests/fixtures/` directory and no shared sample-profile fixture.
+`tests/conftest.py` provides only two text fixtures (`sample_resume_text`,
+`sample_readme_text`), so any test needing a full portfolio profile — GitHub
+username, resume, and repos together — has to build one inline.
+
+Expected: a reusable `tests/fixtures/sample_profiles/basic_profile.json` holding a
+realistic sample portfolio, loadable by tests through a shared pytest fixture.
+Actual: the file and directory do not exist.
+
+Reproduction note: the issue says integration tests were "skipped" because of the
+missing fixture, but `grep -rn "basic_profile" tests/` and
+`grep -rn "sample_profiles" tests/` both return nothing, and `tests/integration/`
+contains only `__init__.py`. So there are no skipped tests to un-skip — this is a
+missing-asset gap, not a failing test. My fix therefore has to supply both the
+fixture and a consumer for it, or it would add a file nothing references.
+
+### Map
+Files I expect to touch:
+- `tests/fixtures/sample_profiles/basic_profile.json` (new — the fixture data)
+- `tests/conftest.py` (new `sample_user_profile` fixture that loads the JSON)
+- `tests/unit/test_sample_profile_fixture.py` (new — verifies it loads and matches
+  the model's field names)
+
+Files I read to determine the fixture's shape:
+- `core/models/profile.py` — authoritative fields: `id`, `user_id`,
+  `github_username`, `resume_filename`, `resume_text`, `portfolio_url`,
+  `created_at`, `updated_at`. All four content fields are `nullable=True`.
+- `api/schemas/profile.py` — `ProfileCreate`/`ProfileUpdate` accept only
+  `github_username` (≤255) and `portfolio_url` (≤500). `ProfileResponse` returns
+  `resume_filename` but never `resume_text`.
+- `core/services/review_service.py::_run_ingestion_pipeline` — repos are not a
+  Profile column. GitHub data is written to `IngestedSource.raw_data` as a JSON
+  string with `source_type: "github"`, keyed off `profile.github_username`.
+- `agent/tools/github_tool.py` — consumes `github_username` + `repo_name`, so each
+  repo entry needs a `name` field usable as `repo_name`.
+
+Fixture shape this implies: a `profile` object mirroring the model's columns, plus a
+sibling `repos` list of two entries (`name`, `description`, `language`,
+`readme_text`, `url`), so the repos can be fed to `github_tool` or serialized into
+an `IngestedSource.raw_data` payload without restructuring.
+
+### Risks & unknowns
+- **Schema vs. model mismatch.** `resume_text` exists on `Profile` but appears in no
+  Pydantic schema. I'm including it in the fixture because parser tests need real
+  resume content, but I'll note in the PR that it's model-only, in case a reviewer
+  expects the fixture to mirror `ProfileResponse` instead.
+- **Repo shape is inferred, not specified.** `IngestedSource.raw_data` is a free-form
+  JSON string, so no schema constrains a repo entry. I'm choosing a shape that
+  matches what `github_tool.py` consumes; a reviewer may prefer a different one.
+- **Pre-existing failures.** The suite reports 53 failures across bias detector,
+  resume parser, review service, PII scrubber and others. These are seeded bugs for
+  unrelated issues. I must not touch them, and I need to show my change leaves the
+  count unchanged.
+- **Orphaned-file risk.** Nothing currently references the fixture, so shipping only
+  the JSON would add a file nothing uses. Adding a conftest loader plus one test is
+  what makes the contribution reviewable.
+- **Path resolution.** Loading via a relative path breaks when pytest runs from
+  outside the repo root; I'll resolve from `Path(__file__).parent`.
+
+### Edge cases
+- All four content fields are nullable, so tests must not assume they're populated.
+  The basic fixture fills them all; I'll note that a `minimal_profile.json` covering
+  the all-null case is a natural follow-up rather than scope for this PR.
+- Field length limits: `github_username` ≤255 and `portfolio_url` ≤500 — the sample
+  values must stay well inside both so the fixture can be used to construct a real
+  `ProfileCreate` without validation errors.
+- `id` and `user_id` are UUID columns, so the fixture must use valid UUID strings,
+  not placeholders like `"user-1"`.
+- Timestamps must be ISO-8601 strings that survive a JSON round-trip into
+  `datetime`.
+- Malformed or missing JSON should fail once, in the loader, with a clear message.
+- Unicode and multi-line resume text must survive the round-trip.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,26 @@
 """Shared test fixtures for PathReview."""
 
+import json
+from pathlib import Path
+from typing import Any
+
 import pytest
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+@pytest.fixture
+def sample_user_profile() -> dict[str, Any]:
+    """Return the shared sample portfolio fixture as a dict.
+
+    Loads ``tests/fixtures/sample_profiles/basic_profile.json``, which holds a
+    ``profile`` object mirroring the columns of :class:`core.models.profile.Profile`
+    and a ``repos`` list of two repositories. Use this instead of building profile
+    data inline so tests share one consistent sample portfolio.
+    """
+    fixture_path = FIXTURES_DIR / "sample_profiles" / "basic_profile.json"
+    with fixture_path.open(encoding="utf-8") as fixture_file:
+        return json.load(fixture_file)
 
 
 @pytest.fixture

--- a/tests/fixtures/sample_profiles/basic_profile.json
+++ b/tests/fixtures/sample_profiles/basic_profile.json
@@ -1,0 +1,28 @@
+{
+  "profile": {
+    "id": "7f3d2a1e-9c4b-4f8a-b6d5-2e1c8a7f4b93",
+    "user_id": "3b8e5c02-1d7a-4e69-9f14-6c2a0d5b8e37",
+    "github_username": "alexrivera",
+    "resume_filename": "alex_rivera_resume.pdf",
+    "resume_text": "Alex Rivera\nSoftware Engineer\nalex.rivera@example.com | github.com/alexrivera\n\nExperience:\n- Backend Engineer at Northwind Labs (2023-2025)\n  Built and maintained REST APIs in Python and FastAPI serving 40k daily requests.\n  Migrated a monolithic service to PostgreSQL with Alembic migrations.\n- Software Engineering Intern at Bluebird Systems (2022)\n  Added React components and unit tests to an internal analytics dashboard.\n\nEducation:\n- B.S. Computer Science, State University (2023)\n\nSkills: Python, FastAPI, TypeScript, React, PostgreSQL, Docker, pytest\n",
+    "portfolio_url": "https://alexrivera.dev",
+    "created_at": "2026-01-15T10:30:00+00:00",
+    "updated_at": "2026-02-02T14:05:00+00:00"
+  },
+  "repos": [
+    {
+      "name": "weather-dashboard",
+      "description": "A React and TypeScript dashboard showing current conditions and a 5-day forecast.",
+      "language": "TypeScript",
+      "url": "https://github.com/alexrivera/weather-dashboard",
+      "readme_text": "# Weather Dashboard\n\nA weather forecasting dashboard built with React and the OpenWeatherMap API.\n\n## Features\n- Current conditions by city\n- 5-day forecast\n- Saved locations\n\n## Tech Stack\n- React 18\n- TypeScript\n- Tailwind CSS\n- Vite\n\n## Getting Started\n```bash\nnpm install\nnpm run dev\n```\n"
+    },
+    {
+      "name": "recipe-api",
+      "description": "A FastAPI service for storing and searching recipes, backed by PostgreSQL.",
+      "language": "Python",
+      "url": "https://github.com/alexrivera/recipe-api",
+      "readme_text": "# Recipe API\n\nA REST API for storing, tagging, and searching recipes.\n\n## Features\n- CRUD endpoints for recipes and tags\n- Full-text search across ingredients\n- JWT authentication\n\n## Tech Stack\n- Python 3.11\n- FastAPI\n- PostgreSQL\n- SQLAlchemy + Alembic\n- pytest\n\n## Running Locally\n```bash\ndocker compose up -d\nuvicorn app.main:app --reload\n```\n"
+    }
+  ]
+}

--- a/tests/unit/test_sample_profile_fixture.py
+++ b/tests/unit/test_sample_profile_fixture.py
@@ -1,0 +1,77 @@
+"""Tests for the shared basic_profile sample portfolio fixture."""
+
+from datetime import datetime
+from uuid import UUID
+
+import pytest
+
+from core.models.profile import Profile
+
+# Fields each repo entry must expose so it can be fed to
+# agent/tools/github_tool.py or serialized into IngestedSource.raw_data.
+EXPECTED_REPO_FIELDS = {"name", "description", "language", "url", "readme_text"}
+
+
+@pytest.mark.unit
+class TestSampleUserProfileFixture:
+    """Test suite for the sample_user_profile fixture."""
+
+    def test_fixture_loads_with_profile_and_repos(self, sample_user_profile):
+        """Test the fixture loads and exposes both top-level sections."""
+        assert isinstance(sample_user_profile, dict)
+        assert set(sample_user_profile) == {"profile", "repos"}
+        assert isinstance(sample_user_profile["profile"], dict)
+        assert isinstance(sample_user_profile["repos"], list)
+
+    def test_profile_keys_match_profile_model_columns(self, sample_user_profile):
+        """Test the profile section stays in sync with the Profile model columns."""
+        model_columns = {column.name for column in Profile.__table__.columns}
+
+        assert set(sample_user_profile["profile"]) == model_columns
+
+    def test_profile_values_are_populated(self, sample_user_profile):
+        """Test every profile field carries real sample content, not None."""
+        profile = sample_user_profile["profile"]
+
+        for field, value in profile.items():
+            assert value, f"profile field {field!r} is empty"
+
+    def test_profile_ids_are_valid_uuids(self, sample_user_profile):
+        """Test id and user_id parse as UUIDs, matching the model's UUID columns."""
+        profile = sample_user_profile["profile"]
+
+        assert UUID(profile["id"])
+        assert UUID(profile["user_id"])
+
+    def test_profile_strings_respect_model_length_limits(self, sample_user_profile):
+        """Test string fields fit the column lengths declared on the model."""
+        profile = sample_user_profile["profile"]
+
+        assert len(profile["github_username"]) <= 255
+        assert len(profile["resume_filename"]) <= 255
+        assert len(profile["portfolio_url"]) <= 500
+
+    def test_profile_timestamps_are_timezone_aware(self, sample_user_profile):
+        """Test timestamps parse as ISO 8601 with a timezone, per DateTime(timezone=True)."""
+        profile = sample_user_profile["profile"]
+
+        for field in ("created_at", "updated_at"):
+            parsed = datetime.fromisoformat(profile[field])
+            assert parsed.tzinfo is not None, f"{field} is not timezone-aware"
+
+    def test_fixture_has_two_repos(self, sample_user_profile):
+        """Test the fixture supplies the two repos the issue calls for."""
+        assert len(sample_user_profile["repos"]) == 2
+
+    def test_repos_expose_fields_github_tool_consumes(self, sample_user_profile):
+        """Test each repo carries the fields downstream tooling reads."""
+        for repo in sample_user_profile["repos"]:
+            assert set(repo) == EXPECTED_REPO_FIELDS
+            for field, value in repo.items():
+                assert value, f"repo field {field!r} is empty"
+
+    def test_repo_names_are_unique(self, sample_user_profile):
+        """Test repo names are distinct so they can be used as lookup keys."""
+        names = [repo["name"] for repo in sample_user_profile["repos"]]
+
+        assert len(set(names)) == len(names)


### PR DESCRIPTION
## Summary

`tests/fixtures/sample_profiles/basic_profile.json` — the shared sample-portfolio
fixture referenced in #106 — was missing from the repo, along with the entire
`tests/fixtures/` directory. This PR restores it with a realistic sample portfolio,
adds a `sample_user_profile` pytest fixture that loads it, and adds a unit test that
pins the fixture's shape to the `Profile` model. Tests that need a full portfolio
(GitHub username, resume text, and repos together) no longer have to build one
inline, and the fixture can't silently drift out of sync with the model.

## Issue

Closes #106

## Changes

- **Added `tests/fixtures/sample_profiles/basic_profile.json`** — a sample portfolio
  with a `profile` object mirroring the `Profile` model's columns and a sibling
  `repos` list of two repositories (`name`, `description`, `language`, `url`,
  `readme_text`).
- **Added the `sample_user_profile` fixture to `tests/conftest.py`** — loads the JSON
  and returns it as a dict. The path is anchored on `__file__` via a `FIXTURES_DIR`
  constant, so it resolves regardless of the directory pytest is invoked from.
- **Added `tests/unit/test_sample_profile_fixture.py`** — nine tests covering the
  fixture's structure and its agreement with the model.

## Testing

- [x] Unit tests pass (`make test-unit`) — no new failures; see the baseline table below
- [ ] Integration tests pass (`make test-integration`) — `tests/integration/` contains only `__init__.py`, so there is nothing to run
- [x] Linter passes (`make lint`) — my files are clean; the 182 repo-wide findings are pre-existing
- [x] Type checker passes (`make typecheck`) — unaffected; mypy does not cover `tests/`
- [x] New/updated tests cover the changes

**What the new tests verify:**

| Test | What it pins down |
| --- | --- |
| `test_fixture_loads_with_profile_and_repos` | The JSON parses and exposes exactly `profile` and `repos` |
| `test_profile_keys_match_profile_model_columns` | The `profile` keys equal `Profile.__table__.columns` — this is the drift guard |
| `test_profile_values_are_populated` | No field is null or empty, so the fixture is usable as realistic sample data |
| `test_profile_ids_are_valid_uuids` | `id` and `user_id` parse as UUIDs, matching the model's `UUID` columns |
| `test_profile_strings_respect_model_length_limits` | `github_username` and `resume_filename` fit `String(255)`, `portfolio_url` fits `String(500)` |
| `test_profile_timestamps_are_timezone_aware` | Timestamps are ISO 8601 with a timezone, matching `DateTime(timezone=True)` |
| `test_fixture_has_two_repos` / `test_repos_expose_fields_github_tool_consumes` / `test_repo_names_are_unique` | Both repos carry the fields downstream tooling reads, with distinct names usable as lookup keys |

**Pre-existing failures in this codebase.** I recorded the baseline before making any
changes and re-ran afterward:

| Check | Before my changes | After my changes |
| --- | --- | --- |
| `pytest tests/unit -m unit` | 53 failed, 375 passed | **53 failed** (unchanged), 384 passed (+9 from this PR) |
| `ruff check .` | 182 errors | 182 errors (unchanged) |
| `black --check .` | 52 files would reformat | 52 files would reformat (unchanged) |

The same 53 tests fail before and after. They are seeded bugs in unrelated modules:

- `test_review_service.py` (13) — `'coroutine' object has no attribute 'first'/'all'`
- `test_bias_detector.py` (10) — detection assertions returning `False`
- `test_resume_parser.py` (5) — section detection and markdown stripping
- `test_skill_extractor.py` (5), `test_pii_scrubber.py` (5),
  `test_faithfulness_checker.py` (4), and single failures across
  `test_batch_processor.py`, `test_keyword_search.py`, `test_output_parser.py`,
  `test_prompt_defense.py`, `test_readme_parser.py` (2), `test_readme_scorer.py`,
  `test_relevance_scorer.py`, `test_security.py`, `test_structural_chunker.py`,
  `test_tech_detector.py` (2)

The ruff and black findings are likewise spread across pre-existing files.
**None of these are touched by this PR** — my three files pass `ruff check` and
`black --check` cleanly, and the failure count is identical before and after. Per the
contribution guidance, the goal here is that this change introduces no new failures,
not that it fixes the entire codebase.

`make typecheck` runs mypy against `api/ core/ ingestion/ rag/ agent/ safety/`, so it
does not cover `tests/`; this PR changes no production code and therefore does not
affect its result.

## Screenshots / Demo

N/A — test-only change, no user-facing behavior.

## Notes for Reviewers

Three judgment calls I'd like a second opinion on:

1. **Repo shape is inferred, not specified.** `Profile` has no repos column — GitHub
   data is written to `IngestedSource.raw_data` as free-form JSON, and
   `agent/tools/github_tool.py` consumes `github_username` + `repo_name`. I shaped
   each repo entry so `name` can be passed straight through as `repo_name` and the
   whole list can be serialized into `raw_data` without restructuring. Since no schema
   constrains this, you may prefer a different shape.

2. **`resume_text` is included, though it's model-only.** It's a column on `Profile`
   but appears in no Pydantic schema — `ProfileResponse` deliberately never returns
   it. I included it because resume-parser tests need real resume content. If you'd
   rather the fixture mirror `ProfileResponse` instead of the model, say so and I'll
   drop it.

3. **The unit test imports `core.models.profile`.** No other test under `tests/unit/`
   imports from `core.models` or `core.database`, so this is a new pattern. Importing
   `Profile` pulls in `core.database`, which builds an async engine at import time —
   it does not connect, and `asyncpg` is already a declared dependency, so this is
   safe in any environment set up via `make setup`. I chose it deliberately: asserting
   against `Profile.__table__.columns` is what makes the test a real drift guard
   rather than a restatement of the JSON. If you'd prefer `tests/unit/` stay free of
   model imports, the alternative is hardcoding the expected field names, which is
   weaker.

One note on the issue text itself: #106 says integration tests were being skipped
because of the missing fixture, but `grep -rn "basic_profile" tests/` and
`grep -rn "sample_profiles" tests/` both return nothing, and `tests/integration/`
contains only `__init__.py`. There were no skipped tests to un-skip — this is a
missing-asset gap. That's why this PR supplies a consumer alongside the fixture
rather than restoring the JSON on its own, which would have left an orphaned file.
