### PR TITLE
feat(safety): add offline bias audit report

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -24,7 +24,7 @@ I reproduced issue #72 as a missing-feature gap. The expected offline audit scri
 
 **PLAN.md link:** https://github.com/antunishdPursuit/pathreview/blob/feat/72-bias-audit-report/PLAN.md
 
-**Walkthrough video (recommended):** Not recorded yet.
+**Walkthrough video (recommended):** https://www.loom.com/share/a48973d934254ea8b9481bd80d1d820e
 
 **Blockers or open questions:**
 I still need to confirm which stored review source should be sampled and how the report should label false positives and false negatives when there is no existing ground-truth dataset.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -17,14 +17,15 @@ PathReview has a bias detector, but there is not yet an offline audit report tha
 
 ## Week 8 - Reproduction & solution planning
 
-**Reproduction commit link:** To be added after this reproduction note is committed.
+**Reproduction commit link:** https://github.com/antunishdPursuit/pathreview/commit/fc3d948dca0a39e1a8e9d5c88395f226fa9165bc
 
 **Reproduction summary:**
 I reproduced issue #72 as a missing-feature gap. The expected offline audit script, `scripts/audit_bias.py`, does not exist, while the reusable bias detection logic exists in `safety/bias_detector.py` through `BiasDetector.detect_bias(text)`.
 
-**PLAN.md link:** To be added after `PLAN.md` is created.
+**PLAN.md link:** https://github.com/antunishdPursuit/pathreview/blob/feat/72-bias-audit-report/PLAN.md
 
 **Walkthrough video (recommended):** Not recorded yet.
 
 **Blockers or open questions:**
 I still need to confirm which stored review source should be sampled and how the report should label false positives and false negatives when there is no existing ground-truth dataset.
+

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,16 @@
+## Week 7 - Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/72
+
+**Issue title:** Add a bias audit report that runs over a sample of stored reviews
+
+**Tier:** [ ] Tier 1  [ ] Tier 2  [x] Tier 3
+
+**Problem summary:**
+PathReview has a bias detector, but there is not yet an offline audit report that checks how that detector performs across a sample of stored reviews. This means the project has limited visibility into where the detector may create false positives or false negatives, especially when review text includes demographic signals. A successful fix would add a script that samples stored reviews, runs them through the bias detector with clear logging, and produces a report summarizing the results. The work should mainly affect `scripts/audit_bias.py` and `safety/bias_detector.py`.
+
+**Branch name:** feat/72-bias-audit-report
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -14,3 +14,17 @@ PathReview has a bias detector, but there is not yet an offline audit report tha
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 - Reproduction & solution planning
+
+**Reproduction commit link:** To be added after this reproduction note is committed.
+
+**Reproduction summary:**
+I reproduced issue #72 as a missing-feature gap. The expected offline audit script, `scripts/audit_bias.py`, does not exist, while the reusable bias detection logic exists in `safety/bias_detector.py` through `BiasDetector.detect_bias(text)`.
+
+**PLAN.md link:** To be added after `PLAN.md` is created.
+
+**Walkthrough video (recommended):** Not recorded yet.
+
+**Blockers or open questions:**
+I still need to confirm which stored review source should be sampled and how the report should label false positives and false negatives when there is no existing ground-truth dataset.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -57,29 +57,37 @@ I still need to confirm which stored review source should be sampled and how the
 
 **Draft PR feedback received from:** none
 
-## Week 10 - Reflection
+## Week 10 — Iteration & reflection
 
-**Did you receive reviewer feedback?**
+### Reviewer feedback
 
-No. Reviewer feedback was not provided during Summer 2026, so there was no feedback to address for this assignment.
+**Feedback received:** [ ] Yes [x] No
 
-### 1. What was harder than you expected?
+**Summary of feedback:** No reviewer feedback was provided during Summer 2026.
+
+**How you responded:**
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
 
 The hardest part was making sure the AI stayed focused on Issue #72. Sometimes it tried to fix unrelated problems or expand the solution by adding more tests and changes than the issue required, so I had to keep bringing it back to the approved scope. It was also difficult to decide how to test the bias audit when the database contained only five eligible reviews instead of the requested sample of 100, and I ultimately decided to use the available reviews rather than invent data.
 
-### 2. What did you learn about working in a large codebase?
+**What did you learn about working in a large codebase?**
 
 Working in a large codebase taught me how important it is to understand where files and functions belong before changing anything. For Issue #72, I had to determine that the new audit belonged in `scripts/audit_bias.py`, understand how it would load reviews, and reuse the existing `BiasDetector` without modifying it because our task was to evaluate the detector. I also learned to keep track of the files I touched and how they interacted so that a narrow change would not affect unrelated behavior.
 
-### 3. How did AI tools help, and where did they fall short?
+**How did AI tools help — and where did they fall short?**
 
 AI tools helped me research the codebase, understand existing functions, write parts of the audit script, and develop tests. They fell short when the requirements were unclear, and they sometimes tried to fix unrelated problems, add more tests, or expand the solution beyond the issue. I still had to decide whether to use only the five stored reviews, whether creating additional data was appropriate, and how human labels should be added before calculating false-positive and false-negative rates.
 
-### 4. What would you do differently if you started over?
+**What would you do differently if you started over?**
 
 If I started over, I would read the issue and nearby code more deeply before implementing anything, and I would ask the maintainers more specific questions when the requirements were unclear. This could have clarified whether the sample of 100 was a strict requirement, how ground-truth labels should be established, and what report format they expected. I might also choose a more challenging issue that would expand my abilities while still keeping the implementation narrowly focused.
 
-### 5. What are you most proud of from this module?
+**What are you most proud of from this module?**
 
 I am most proud that I completed the assignments and applied lessons from earlier AI 201 projects to the final pull request. For Issue #72, I built a flow that loads stored reviews, generates an editable JSON report for human labels, and processes the updated report to calculate the final metrics without modifying `BiasDetector` or inventing data. I am also proud that the course helped me make better architecture decisions, explain the code more clearly in interviews, and apply what I learned during a hackathon.
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -41,3 +41,19 @@ I still need to confirm which stored review source should be sampled and how the
 
 ---
 
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/763
+
+**Branch:** `feat/72-bias-audit-report`
+
+**What you built:** I built an offline bias audit that samples completed stored reviews, runs their combined content and suggestions through the existing bias detector, and generates an editable JSON report. After human labels are added, the same script can calculate false-positive and false-negative rates by demographic signal and generate an evaluated report.
+
+**Tests added or updated:** I added `tests/unit/test_audit_bias.py` with three tests covering review-text extraction, labeled report evaluation and temporary-file cleanup, and invalid demographic signal rejection. All three audit tests pass. The full unit suite reported 378 passed and 53 failures in unrelated test files.
+
+**Self-review confirmation:**
+[x] `make check` introduces no new failures in the changed files. Focused Ruff, Black, and mypy checks pass. The repository-wide lint step stops on 182 unrelated existing errors.
+[x] `make test-unit` introduces no new audit failures. All three audit tests pass, while the repository-wide suite has 53 failures in unrelated test files.
+
+**Draft PR feedback received from:** none
+

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -29,3 +29,15 @@ I reproduced issue #72 as a missing-feature gap. The expected offline audit scri
 **Blockers or open questions:**
 I still need to confirm which stored review source should be sampled and how the report should label false positives and false negatives when there is no existing ground-truth dataset.
 
+## Week 9 - Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:** I implemented the offline bias audit for Issue #72. The script samples up to 100 completed stored reviews, combines each review's content and suggestions, runs the existing bias detector, logs each result, and generates an editable JSON report. The same script can be edited by a human to add human labels and then calculate false-positive and false-negative rates by demographic signal. I also added three unit tests that passed.
+
+**Next steps:** Run the remaining repository checks, document unrelated existing failures, push the branch, open a draft pull request against the upstream repo, and complete Check-in 2 with the final PR information.
+
+**Blockers:** The local database contains only five eligible completed reviews, so the audit cannot demonstrate a full 100-review sample. The full unit suite currently reports 53 failures in unrelated test files, while all three tests for the audit workflow pass.
+
+---
+

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -57,3 +57,29 @@ I still need to confirm which stored review source should be sampled and how the
 
 **Draft PR feedback received from:** none
 
+## Week 10 - Reflection
+
+**Did you receive reviewer feedback?**
+
+No. Reviewer feedback was not provided during Summer 2026, so there was no feedback to address for this assignment.
+
+### 1. What was harder than you expected?
+
+The hardest part was making sure the AI stayed focused on Issue #72. Sometimes it tried to fix unrelated problems or expand the solution by adding more tests and changes than the issue required, so I had to keep bringing it back to the approved scope. It was also difficult to decide how to test the bias audit when the database contained only five eligible reviews instead of the requested sample of 100, and I ultimately decided to use the available reviews rather than invent data.
+
+### 2. What did you learn about working in a large codebase?
+
+Working in a large codebase taught me how important it is to understand where files and functions belong before changing anything. For Issue #72, I had to determine that the new audit belonged in `scripts/audit_bias.py`, understand how it would load reviews, and reuse the existing `BiasDetector` without modifying it because our task was to evaluate the detector. I also learned to keep track of the files I touched and how they interacted so that a narrow change would not affect unrelated behavior.
+
+### 3. How did AI tools help, and where did they fall short?
+
+AI tools helped me research the codebase, understand existing functions, write parts of the audit script, and develop tests. They fell short when the requirements were unclear, and they sometimes tried to fix unrelated problems, add more tests, or expand the solution beyond the issue. I still had to decide whether to use only the five stored reviews, whether creating additional data was appropriate, and how human labels should be added before calculating false-positive and false-negative rates.
+
+### 4. What would you do differently if you started over?
+
+If I started over, I would read the issue and nearby code more deeply before implementing anything, and I would ask the maintainers more specific questions when the requirements were unclear. This could have clarified whether the sample of 100 was a strict requirement, how ground-truth labels should be established, and what report format they expected. I might also choose a more challenging issue that would expand my abilities while still keeping the implementation narrowly focused.
+
+### 5. What are you most proud of from this module?
+
+I am most proud that I completed the assignments and applied lessons from earlier AI 201 projects to the final pull request. For Issue #72, I built a flow that loads stored reviews, generates an editable JSON report for human labels, and processes the updated report to calculate the final metrics without modifying `BiasDetector` or inventing data. I am also proud that the course helped me make better architecture decisions, explain the code more clearly in interviews, and apply what I learned during a hackathon.
+

--- a/PLAN.md
+++ b/PLAN.md
@@ -5,17 +5,17 @@
 
 ### Understand
 
-The project already has bias detection logic in `safety/bias_detector.py`, but there is no offline audit script at `scripts/audit_bias.py`. The expected behavior is that a contributor can run a script that samples stored reviews, passes each review through `BiasDetector.detect_bias(text)`, and produces a clear report about possible bias results. The actual behavior is that the detector can analyze one text string at a time, but there is no script that runs it over stored review data or summarizes false positive and false negative patterns.
+The project already has bias detection logic in `safety/bias_detector.py`, but there is no offline audit script at `scripts/audit_bias.py`. What we want is that a contributor can run a script that samples stored reviews, passes each review through `BiasDetector.detect_bias(text)`, and produces a clear report about possible bias results. What is actually happening is that the detector can analyze one text string at a time, but there is no script that runs it over stored review data or summarizes false positive and false negative patterns.
 
 ### Map
 
 Files I expect to inspect or touch:
 
-- `scripts/audit_bias.py`: add the new offline audit script.
-- `safety/bias_detector.py`: reuse `BiasDetector.detect_bias(text)` and only adjust detector behavior if needed.
+- `scripts/audit_bias.py`: add the script.
+- `safety/bias_detector.py`: reuse `BiasDetector.detect_bias(text)` method
 - `scripts/run_evals.py`: use as a nearby example for script structure.
 - `scripts/seed_db.py`: inspect sample review data shape if the script needs seeded reviews.
-- `tests/`: add or update tests if there is an existing pattern for script or safety tests.
+- `tests/`: add or update tests if need be
 
 Important functions or modules:
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,60 @@
+## Solution plan
+
+**Issue:** Add a bias audit report that runs over a sample of stored reviews  
+**Link:** https://github.com/ascherj/pathreview/issues/72
+
+### Understand
+
+The project already has bias detection logic in `safety/bias_detector.py`, but there is no offline audit script at `scripts/audit_bias.py`. The expected behavior is that a contributor can run a script that samples stored reviews, passes each review through `BiasDetector.detect_bias(text)`, and produces a clear report about possible bias results. The actual behavior is that the detector can analyze one text string at a time, but there is no script that runs it over stored review data or summarizes false positive and false negative patterns.
+
+### Map
+
+Files I expect to inspect or touch:
+
+- `scripts/audit_bias.py`: add the new offline audit script.
+- `safety/bias_detector.py`: reuse `BiasDetector.detect_bias(text)` and only adjust detector behavior if needed.
+- `scripts/run_evals.py`: use as a nearby example for script structure.
+- `scripts/seed_db.py`: inspect sample review data shape if the script needs seeded reviews.
+- `tests/`: add or update tests if there is an existing pattern for script or safety tests.
+
+Important functions or modules:
+
+- `BiasDetector.detect_bias(text)`: returns `(is_biased, reason)`.
+- `structlog.get_logger()`: existing safety files use structured logging for detected safety events.
+
+### Plan
+
+1. Inspect the stored review model and seed data to find a reliable source of review text.
+2. Create `scripts/audit_bias.py` with a `main()` function that loads up to 100 review records.
+3. For each review, call `BiasDetector.detect_bias(text)` and store the result, reason, and review identifier.
+4. Produce a report that summarizes total reviews checked, detected bias count, reasons, and any known false positive or false negative labels when available.
+5. Add focused tests or sample-run verification so the script behavior can be checked before opening a pull request.
+
+### Inputs & outputs
+
+Input:
+
+- Stored review text from the local database, seeded data, or another project-approved sample source.
+- Optional expected labels if a review sample includes ground-truth bias labels.
+
+Output:
+
+- A readable audit report from `scripts/audit_bias.py`.
+- Summary counts for reviews checked and bias detections.
+- Reason-level breakdowns from `BiasDetector.detect_bias(text)`.
+- False positive and false negative counts if ground-truth labels are available.
+
+### Risks & unknowns
+
+- I still need to confirm the best source for stored review text.
+- The issue asks for false positive and false negative rates, but the current repo may not include ground-truth labels for stored reviews.
+- If there is no labeled dataset, the script may need to report detected bias patterns first and leave false positive/negative rates as unavailable.
+- The script should not duplicate bias detection logic that already exists in `BiasDetector`.
+
+### Edge cases
+
+- No reviews exist in the local database.
+- A review has empty or missing text.
+- More than 100 reviews exist, so the script should sample or limit results consistently.
+- `BiasDetector.detect_bias(text)` returns `False` with an empty reason.
+- The report should still run if every sampled review is non-biased or every sampled review is flagged.

--- a/scripts/audit_bias.py
+++ b/scripts/audit_bias.py
@@ -1,10 +1,11 @@
 """Run an offline bias audit over stored portfolio reviews."""
 
+import argparse
 import asyncio
 import json
 from collections.abc import Sequence
 from pathlib import Path
-from typing import TypedDict
+from typing import TypedDict, cast
 
 from sqlalchemy import func, select
 
@@ -15,6 +16,7 @@ from safety.bias_detector import BiasDetector
 
 SAMPLE_SIZE = 100
 REPORT_PATH = Path(__file__).resolve().parents[1] / "bias_audit_report.json"
+EVALUATED_REPORT_PATH = Path(__file__).resolve().parents[1] / "bias_audit_evaluated.json"
 logger = get_logger(__name__)
 
 
@@ -34,8 +36,8 @@ class AuditMetrics(TypedDict):
 
     status: str
     reason: str
-    false_positive_rate_by_demographic_signal: dict[str, float]
-    false_negative_rate_by_demographic_signal: dict[str, float]
+    false_positive_rate_by_demographic_signal: dict[str, float | None]
+    false_negative_rate_by_demographic_signal: dict[str, float | None]
 
 
 class AuditReport(TypedDict):
@@ -135,6 +137,113 @@ def write_report(
     return output_path
 
 
+def load_report(input_path: Path) -> AuditReport:
+    """Load and validate an editable audit report."""
+    data = json.loads(input_path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict) or not isinstance(data.get("results"), list):
+        raise ValueError("Audit report must contain a results list.")
+
+    for entry in data["results"]:
+        if not isinstance(entry, dict):
+            raise ValueError("Each audit result must be a JSON object.")
+
+        review_id = entry.get("review_id")
+        if not isinstance(review_id, str):
+            raise ValueError("Each audit result must contain a review_id.")
+        if not isinstance(entry.get("predicted_biased"), bool):
+            raise ValueError(f"Review {review_id} must contain a Boolean predicted_biased value.")
+
+        expected_biased = entry.get("expected_biased")
+        demographic_signal = entry.get("demographic_signal")
+        if expected_biased is not None and not isinstance(expected_biased, bool):
+            raise ValueError(f"Review {review_id} expected_biased must be true, false, or null.")
+        if demographic_signal is not None and not isinstance(demographic_signal, str):
+            raise ValueError(f"Review {review_id} demographic_signal must be text or null.")
+        if (expected_biased is None) != (demographic_signal is None):
+            raise ValueError(
+                f"Review {review_id} must set both expected_biased and "
+                "demographic_signal, or leave both null."
+            )
+        if isinstance(demographic_signal, str) and not demographic_signal.strip():
+            raise ValueError(f"Review {review_id} demographic_signal cannot be blank.")
+
+    return cast("AuditReport", data)
+
+
+def calculate_metrics(results: Sequence[AuditResult]) -> AuditMetrics:
+    """Calculate error rates for each human-labeled demographic signal."""
+    labeled_by_signal: dict[str, list[AuditResult]] = {}
+    for result in results:
+        expected_biased = result["expected_biased"]
+        demographic_signal = result["demographic_signal"]
+        if expected_biased is None or demographic_signal is None:
+            continue
+
+        signal = demographic_signal.strip()
+        labeled_by_signal.setdefault(signal, []).append(result)
+
+    if not labeled_by_signal:
+        return {
+            "status": "unavailable",
+            "reason": (
+                "No complete human labels were found. Set expected_biased and "
+                "demographic_signal in the audit report."
+            ),
+            "false_positive_rate_by_demographic_signal": {},
+            "false_negative_rate_by_demographic_signal": {},
+        }
+
+    false_positive_rates: dict[str, float | None] = {}
+    false_negative_rates: dict[str, float | None] = {}
+    for signal, signal_results in labeled_by_signal.items():
+        actual_negative_count = sum(not result["expected_biased"] for result in signal_results)
+        actual_positive_count = sum(bool(result["expected_biased"]) for result in signal_results)
+        false_positive_count = sum(
+            result["predicted_biased"] and not result["expected_biased"]
+            for result in signal_results
+        )
+        false_negative_count = sum(
+            not result["predicted_biased"] and bool(result["expected_biased"])
+            for result in signal_results
+        )
+
+        false_positive_rates[signal] = (
+            false_positive_count / actual_negative_count if actual_negative_count else None
+        )
+        false_negative_rates[signal] = (
+            false_negative_count / actual_positive_count if actual_positive_count else None
+        )
+
+    return {
+        "status": "available",
+        "reason": (
+            "A rate is null when its demographic signal has no examples for "
+            "the required denominator."
+        ),
+        "false_positive_rate_by_demographic_signal": false_positive_rates,
+        "false_negative_rate_by_demographic_signal": false_negative_rates,
+    }
+
+
+def evaluate_report(
+    input_path: Path,
+    output_path: Path = EVALUATED_REPORT_PATH,
+) -> Path:
+    """Calculate metrics from an edited report and write the evaluated report."""
+    report = load_report(input_path)
+    report["metrics"] = calculate_metrics(report["results"])
+    output_path.write_text(
+        json.dumps(report, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    logger.info(
+        "bias_audit_evaluation_written",
+        input_path=str(input_path),
+        output_path=str(output_path),
+    )
+    return output_path
+
+
 async def load_reviews() -> list[Review]:
     """Load a random sample of completed reviews with stored sections.
 
@@ -170,9 +279,26 @@ async def run_audit() -> list[AuditResult]:
     return results
 
 
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse audit generation or evaluation arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--evaluate",
+        type=Path,
+        metavar="REPORT_PATH",
+        help="Evaluate human labels in an existing bias audit report.",
+    )
+    return parser.parse_args(argv)
+
+
 def main() -> None:
-    """Configure logging and run the offline audit."""
+    """Run a new audit or evaluate an edited audit report."""
     configure_logging()
+    args = parse_args()
+    if args.evaluate:
+        evaluate_report(args.evaluate)
+        return
+
     asyncio.run(run_audit())
 
 

--- a/scripts/audit_bias.py
+++ b/scripts/audit_bias.py
@@ -1,11 +1,24 @@
 """Run an offline bias audit over stored portfolio reviews."""
 
+from collections.abc import Sequence
+from typing import TypedDict
+
 from sqlalchemy import func, select
 
 from core.database import AsyncSessionLocal
 from core.models.review import Review
+from safety.bias_detector import BiasDetector
 
 SAMPLE_SIZE = 100
+
+
+class AuditResult(TypedDict):
+    """One review's bias detection result."""
+
+    review_id: str
+    review_text: str
+    predicted_biased: bool
+    reason: str
 
 
 def extract_review_text(review: Review) -> str:
@@ -31,6 +44,28 @@ def extract_review_text(review: Review) -> str:
             )
 
     return "\n".join(text_parts)
+
+
+def audit_reviews(reviews: Sequence[Review]) -> list[AuditResult]:
+    """Run the existing bias detector once for each nonempty review."""
+    results: list[AuditResult] = []
+
+    for review in reviews:
+        review_text = extract_review_text(review)
+        if not review_text:
+            continue
+
+        predicted_biased, reason = BiasDetector.detect_bias(review_text)
+        results.append(
+            {
+                "review_id": str(review.id),
+                "review_text": review_text,
+                "predicted_biased": predicted_biased,
+                "reason": reason,
+            }
+        )
+
+    return results
 
 
 async def load_reviews() -> list[Review]:

--- a/scripts/audit_bias.py
+++ b/scripts/audit_bias.py
@@ -15,6 +15,15 @@ from core.models.review import Review
 from safety.bias_detector import BiasDetector
 
 SAMPLE_SIZE = 100
+VALID_DEMOGRAPHIC_SIGNALS = frozenset(
+    {
+        "age",
+        "education_background",
+        "socioeconomic_background",
+        "immigration_status",
+        "none",
+    }
+)
 REPORT_PATH = Path(__file__).resolve().parents[1] / "bias_audit_report.json"
 EVALUATED_REPORT_PATH = Path(__file__).resolve().parents[1] / "bias_audit_evaluated.json"
 logger = get_logger(__name__)
@@ -166,6 +175,14 @@ def load_report(input_path: Path) -> AuditReport:
             )
         if isinstance(demographic_signal, str) and not demographic_signal.strip():
             raise ValueError(f"Review {review_id} demographic_signal cannot be blank.")
+        if isinstance(demographic_signal, str):
+            signal = demographic_signal.strip()
+            if signal not in VALID_DEMOGRAPHIC_SIGNALS:
+                valid_signals = ", ".join(sorted(VALID_DEMOGRAPHIC_SIGNALS))
+                raise ValueError(
+                    f"Review {review_id} demographic_signal must be one of: {valid_signals}."
+                )
+            entry["demographic_signal"] = signal
 
     return cast("AuditReport", data)
 

--- a/scripts/audit_bias.py
+++ b/scripts/audit_bias.py
@@ -1,7 +1,9 @@
 """Run an offline bias audit over stored portfolio reviews."""
 
 import asyncio
+import json
 from collections.abc import Sequence
+from pathlib import Path
 from typing import TypedDict
 
 from sqlalchemy import func, select
@@ -12,6 +14,7 @@ from core.models.review import Review
 from safety.bias_detector import BiasDetector
 
 SAMPLE_SIZE = 100
+REPORT_PATH = Path(__file__).resolve().parents[1] / "bias_audit_report.json"
 logger = get_logger(__name__)
 
 
@@ -22,6 +25,26 @@ class AuditResult(TypedDict):
     review_text: str
     predicted_biased: bool
     reason: str
+
+
+class AuditMetrics(TypedDict):
+    """Metric fields that require human-reviewed ground-truth labels."""
+
+    status: str
+    reason: str
+    false_positive_rate_by_demographic_signal: dict[str, float]
+    false_negative_rate_by_demographic_signal: dict[str, float]
+
+
+class AuditReport(TypedDict):
+    """Serialized output from one audit run."""
+
+    sampled_count: int
+    checked_count: int
+    skipped_count: int
+    detected_bias_count: int
+    metrics: AuditMetrics
+    results: list[AuditResult]
 
 
 def extract_review_text(review: Review) -> str:
@@ -78,6 +101,36 @@ def audit_reviews(reviews: Sequence[Review]) -> list[AuditResult]:
     return results
 
 
+def write_report(
+    sampled_count: int,
+    results: list[AuditResult],
+    output_path: Path = REPORT_PATH,
+) -> Path:
+    """Write the audit results and current metric availability to JSON."""
+    report: AuditReport = {
+        "sampled_count": sampled_count,
+        "checked_count": len(results),
+        "skipped_count": sampled_count - len(results),
+        "detected_bias_count": sum(result["predicted_biased"] for result in results),
+        "metrics": {
+            "status": "unavailable",
+            "reason": (
+                "Ground-truth annotations are required to calculate false "
+                "positive and false negative rates by demographic signal."
+            ),
+            "false_positive_rate_by_demographic_signal": {},
+            "false_negative_rate_by_demographic_signal": {},
+        },
+        "results": results,
+    }
+    output_path.write_text(
+        json.dumps(report, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    logger.info("bias_audit_report_written", path=str(output_path))
+    return output_path
+
+
 async def load_reviews() -> list[Review]:
     """Load a random sample of completed reviews with stored sections.
 
@@ -101,6 +154,7 @@ async def run_audit() -> list[AuditResult]:
     logger.info("bias_audit_started", sample_limit=SAMPLE_SIZE)
     reviews = await load_reviews()
     results = audit_reviews(reviews)
+    write_report(len(reviews), results)
 
     logger.info(
         "bias_audit_completed",

--- a/scripts/audit_bias.py
+++ b/scripts/audit_bias.py
@@ -1,15 +1,18 @@
 """Run an offline bias audit over stored portfolio reviews."""
 
+import asyncio
 from collections.abc import Sequence
 from typing import TypedDict
 
 from sqlalchemy import func, select
 
 from core.database import AsyncSessionLocal
+from core.logging import configure_logging, get_logger
 from core.models.review import Review
 from safety.bias_detector import BiasDetector
 
 SAMPLE_SIZE = 100
+logger = get_logger(__name__)
 
 
 class AuditResult(TypedDict):
@@ -53,9 +56,16 @@ def audit_reviews(reviews: Sequence[Review]) -> list[AuditResult]:
     for review in reviews:
         review_text = extract_review_text(review)
         if not review_text:
+            logger.info("bias_audit_review_skipped", review_id=str(review.id))
             continue
 
         predicted_biased, reason = BiasDetector.detect_bias(review_text)
+        logger.info(
+            "bias_audit_review_checked",
+            review_id=str(review.id),
+            predicted_biased=predicted_biased,
+            reason=reason or None,
+        )
         results.append(
             {
                 "review_id": str(review.id),
@@ -84,3 +94,29 @@ async def load_reviews() -> list[Review]:
     async with AsyncSessionLocal() as session:
         result = await session.execute(statement)
         return list(result.scalars().all())
+
+
+async def run_audit() -> list[AuditResult]:
+    """Load eligible reviews, audit them, and log a summary."""
+    logger.info("bias_audit_started", sample_limit=SAMPLE_SIZE)
+    reviews = await load_reviews()
+    results = audit_reviews(reviews)
+
+    logger.info(
+        "bias_audit_completed",
+        sampled_count=len(reviews),
+        checked_count=len(results),
+        skipped_count=len(reviews) - len(results),
+        detected_bias_count=sum(result["predicted_biased"] for result in results),
+    )
+    return results
+
+
+def main() -> None:
+    """Configure logging and run the offline audit."""
+    configure_logging()
+    asyncio.run(run_audit())
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/audit_bias.py
+++ b/scripts/audit_bias.py
@@ -25,6 +25,8 @@ class AuditResult(TypedDict):
     review_text: str
     predicted_biased: bool
     reason: str
+    expected_biased: bool | None
+    demographic_signal: str | None
 
 
 class AuditMetrics(TypedDict):
@@ -95,6 +97,8 @@ def audit_reviews(reviews: Sequence[Review]) -> list[AuditResult]:
                 "review_text": review_text,
                 "predicted_biased": predicted_biased,
                 "reason": reason,
+                "expected_biased": None,
+                "demographic_signal": None,
             }
         )
 

--- a/scripts/audit_bias.py
+++ b/scripts/audit_bias.py
@@ -1,0 +1,26 @@
+"""Run an offline bias audit over stored portfolio reviews."""
+
+from sqlalchemy import func, select
+
+from core.database import AsyncSessionLocal
+from core.models.review import Review
+
+SAMPLE_SIZE = 100
+
+
+async def load_reviews() -> list[Review]:
+    """Load a random sample of completed reviews with stored sections.
+
+    Returns:
+        Up to 100 eligible reviews.
+    """
+    statement = (
+        select(Review)
+        .where(Review.status == "complete", Review.sections.is_not(None))
+        .order_by(func.random())
+        .limit(SAMPLE_SIZE)
+    )
+
+    async with AsyncSessionLocal() as session:
+        result = await session.execute(statement)
+        return list(result.scalars().all())

--- a/scripts/audit_bias.py
+++ b/scripts/audit_bias.py
@@ -8,6 +8,31 @@ from core.models.review import Review
 SAMPLE_SIZE = 100
 
 
+def extract_review_text(review: Review) -> str:
+    """Combine the review's written feedback into one auditable text value."""
+    if not isinstance(review.sections, list):
+        return ""
+
+    text_parts: list[str] = []
+    for section in review.sections:
+        if not isinstance(section, dict):
+            continue
+
+        content = section.get("content")
+        if isinstance(content, str) and content.strip():
+            text_parts.append(content.strip())
+
+        suggestions = section.get("suggestions")
+        if isinstance(suggestions, list):
+            text_parts.extend(
+                suggestion.strip()
+                for suggestion in suggestions
+                if isinstance(suggestion, str) and suggestion.strip()
+            )
+
+    return "\n".join(text_parts)
+
+
 async def load_reviews() -> list[Review]:
     """Load a random sample of completed reviews with stored sections.
 

--- a/tests/unit/test_audit_bias.py
+++ b/tests/unit/test_audit_bias.py
@@ -1,0 +1,98 @@
+"""Tests for the offline bias audit workflow."""
+
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pytest
+
+from core.models.review import Review
+from scripts.audit_bias import (
+    AuditResult,
+    evaluate_report,
+    extract_review_text,
+    load_report,
+    write_report,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _result(review_id: str, predicted_biased: bool) -> AuditResult:
+    return {
+        "review_id": review_id,
+        "review_text": "Review feedback",
+        "predicted_biased": predicted_biased,
+        "reason": "",
+        "expected_biased": None,
+        "demographic_signal": None,
+    }
+
+
+def test_extract_review_text_combines_content_and_suggestions() -> None:
+    review = Review(
+        id="review-1",
+        profile_id="profile-1",
+        status="complete",
+        sections=[
+            {
+                "section_name": "Technical Skills",
+                "content": "Clear feedback",
+                "suggestions": ["Add tests", "Document behavior"],
+            }
+        ],
+    )
+
+    assert extract_review_text(review) == "Clear feedback\nAdd tests\nDocument behavior"
+
+
+def test_labeled_report_produces_evaluated_metrics() -> None:
+    with TemporaryDirectory() as temp_dir:
+        report_path = Path(temp_dir) / "bias_audit_report.json"
+        evaluated_path = Path(temp_dir) / "bias_audit_evaluated.json"
+        write_report(
+            3,
+            [_result("review-1", True), _result("review-2", False), _result("review-3", False)],
+            report_path,
+        )
+
+        report = json.loads(report_path.read_text(encoding="utf-8"))
+        labels = [
+            (False, "education_background"),
+            (True, "age"),
+            (False, "none"),
+        ]
+        for result, (expected_biased, signal) in zip(report["results"], labels, strict=True):
+            result["expected_biased"] = expected_biased
+            result["demographic_signal"] = signal
+        report_path.write_text(json.dumps(report), encoding="utf-8")
+
+        evaluate_report(report_path, evaluated_path)
+        metrics = json.loads(evaluated_path.read_text(encoding="utf-8"))["metrics"]
+
+        assert metrics["false_positive_rate_by_demographic_signal"] == {
+            "education_background": 1.0,
+            "age": None,
+            "none": 0.0,
+        }
+        assert metrics["false_negative_rate_by_demographic_signal"] == {
+            "education_background": None,
+            "age": 1.0,
+            "none": None,
+        }
+
+    assert not report_path.exists()
+    assert not evaluated_path.exists()
+
+
+def test_load_report_rejects_unknown_demographic_signal() -> None:
+    with TemporaryDirectory() as temp_dir:
+        report_path = Path(temp_dir) / "bias_audit_report.json"
+        write_report(1, [_result("review-1", False)], report_path)
+        report = json.loads(report_path.read_text(encoding="utf-8"))
+        report["results"][0]["expected_biased"] = False
+        report["results"][0]["demographic_signal"] = "Age"
+        report_path.write_text(json.dumps(report), encoding="utf-8")
+
+        with pytest.raises(ValueError, match="must be one of"):
+            load_report(report_path)


### PR DESCRIPTION
## Summary
Adds an offline bias audit workflow for stored PathReview reviews. The script samples completed reviews, reuses the existing bias detector, writes an editable JSON report, and evaluates human labels to report false-positive and false-negative rates by demographic signal.

## Issue
Closes #72

## Changes
- Sample up to 100 completed stored reviews and combine section content with suggestions.
- Run `BiasDetector.detect_bias()` once per nonempty review with structured progress logging.
- Generate `bias_audit_report.json` with editable human-label fields.
- Evaluate an edited report with the same script and write `bias_audit_evaluated.json`.
- Validate the approved demographic signals: age, education background, socioeconomic background, immigration status, and none.
- Add three focused unit tests for text extraction, labeled report evaluation, temporary-file cleanup, and invalid signal rejection.

## Testing
- [ ] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`)
- [ ] Linter passes (`make lint`)
- [ ] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes

Focused verification:
- `tests/unit/test_audit_bias.py`: 3 passed.
- Ruff passes for `scripts/audit_bias.py` and `tests/unit/test_audit_bias.py`.
- Black check passes for both changed Python files.
- Mypy passes for `scripts/audit_bias.py` with imported modules skipped because the repository has unrelated imported-module typing errors.

Repository-wide results:
- `make test-unit`: 378 passed, 53 failed in unrelated test files; none of the audit tests failed.
- `make check`: stopped during repository-wide Ruff lint with 182 errors in unrelated existing files; neither audit file was reported.
- Integration tests were not run because this change is covered by focused unit tests and a local database audit run.

### Manual verification

1. Start the local database services.
2. Run `python -m scripts.audit_bias`.
3. Confirm `bias_audit_report.json` is created with sampled review results.
4. Add `expected_biased` and `demographic_signal` labels to its results.
5. Run `python -m scripts.audit_bias --evaluate bias_audit_report.json`.
6. Confirm `bias_audit_evaluated.json` contains false-positive and false-negative rates by demographic signal.

## Screenshots / Demo
Not applicable. This is an offline command-line audit workflow.

## Notes for Reviewers
- The local seeded database contains five eligible completed reviews, so the local audit processes all five while retaining a sample limit of 100.
- False-positive and false-negative rates require human labels. The first run creates editable fields; `--evaluate` reads the edited report and writes the evaluated report without resampling the database.
- Generated JSON reports remain local and are not included in this PR.
- The existing detector test suite has known failures outside this issue; this PR reuses the detector without changing its patterns.