### PR TITLE
Test/37 add snapshot tests for prompt templates

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -46,7 +46,7 @@ None.
 
 ### Check-in 2 (end of week)
 
-**PR link:** https://github.com/ascherj/pathreview/pull/YOUR_PR_NUMBER_HERE
+**PR link:** https://github.com/ascherj/pathreview/pull/765
 
 **Branch:** `test/37-add-snapshot-tests-for-prompt-templates`
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -60,3 +60,34 @@ Modified [test_prompt_templates.py](file:///Users/leminhhieu/github/pathreview/t
 *(Note: Pre-existing failures exist in the codebase in other modules/tests, but our changes introduced no new failures).*
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [X] No — still awaiting review
+
+**Summary of feedback:**
+Still awaiting review from the maintainers.
+
+**How you responded:**
+N/A
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Configuring the `mypy` strict type checking rules in `pyproject.toml` to ignore test directories without disabling general strict type checking on main source code. The pre-commit hooks strict checking ran on test files but our test setup wasn't fully typed. Standardizing the mypy overrides solved this cleanly.
+
+**What did you learn about working in a large codebase?**
+You have to accept and document pre-existing test/lint failures without trying to refactor files outside your scope. Keeping your changes tightly scoped and verifying that your specific features don't introduce any new regressions is key to clean, reviewable PR contributions.
+
+**How did AI tools help — and where did they fall short?**
+AI was great at outlining templates and scaffolding files, but fell short in understanding local workspace nuances (such as pre-commit configs vs global check scripts). I had to manually debug the linting environment and design the exact file-based snapshot lookup logic to make the process completely reliable.
+
+**What would you do differently if you started over?**
+Set up the pre-commit linting checks early in the first week rather than at the PR stage. This would prevent surprises with tool configs (like mypy and black) later on and allow resolving configuration discrepancies during the initial setup phase.
+
+**What are you most proud of from this module?**
+The implementation of filesystem-based snapshots (`.txt` files under `tests/snapshots/`). Having readable text files instead of a single massive JSON dictionary makes visual reviews using `git diff` incredibly clear for reviewers to see prompt text modifications.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,16 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/37
+
+**Issue title:** Add snapshot tests for prompt templates to catch accidental changes
+
+**Tier:** Tier 1
+
+**Problem summary:**
+Prompt templates directly affect review quality. Add snapshot tests that fail if a template's content changes without a version bump, so developers must consciously version templates rather than silently editing them. the part of the codebase it affects is the tests path.
+
+**Branch name:** test/37-add-snapshot-tests-for-prompt-templates
+
+**Setup confirmation:** [X] App runs locally at localhost:5173
+
+**Cohort ledger:** [X] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -28,3 +28,35 @@ Altering any prompt template inside `rag/generator/prompt_templates.py` results 
 
 **Blockers or open questions:**
 None.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented a robust filesystem-based snapshot system where each prompt template version's expected content is saved as a separate text file under `tests/snapshots/prompt_templates/`.
+
+**Next steps:**
+Verify that modifying templates fails the test and reverting passes. Add the option to update snapshots using `UPDATE_SNAPSHOTS=1` environment variable. Prepare the PR for review.
+
+**Blockers:**
+None.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/YOUR_PR_NUMBER_HERE
+
+**Branch:** `test/37-add-snapshot-tests-for-prompt-templates`
+
+**What you built:**
+Added snapshot testing for prompt templates. The new `test_template_snapshots` checks active templates in `rag/generator/prompt_templates.py` against reference snapshot files stored under `tests/snapshots/prompt_templates/`. If a template's content is modified without a version bump (and `UPDATE_SNAPSHOTS=1` is not set), the test fails, preventing silent prompt regressions.
+
+**Tests added or updated:**
+Modified [test_prompt_templates.py](file:///Users/leminhhieu/github/pathreview/tests/unit/test_prompt_templates.py) to assert the global MD5 content hash matches the reference hash, and added `test_template_snapshots` to check and manage file-based template snapshots.
+
+**Self-review confirmation:** [X] make check passes  [X] make test-unit passes
+*(Note: Pre-existing failures exist in the codebase in other modules/tests, but our changes introduced no new failures).*
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -14,3 +14,17 @@ Prompt templates directly affect review quality. Add snapshot tests that fail if
 **Setup confirmation:** [X] App runs locally at localhost:5173
 
 **Cohort ledger:** [X] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/hieumile/pathreview/commit/c5f0f10e45b4027b0481eecb513c6d8ffd2e0fa4
+
+**Reproduction summary:**
+Altering any prompt template inside `rag/generator/prompt_templates.py` results in a changed MD5 hash, yet `test_template_snapshot_content_hash` continues to pass. This happens because the test only asserts the output is a 32-character string rather than validating it against a reference hash.
+
+**PLAN.md link:** https://github.com/hieumile/pathreview/blob/test/37-add-snapshot-tests-for-prompt-templates/PLAN.md
+
+**Walkthrough video (recommended):** 
+
+**Blockers or open questions:**
+None.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,35 @@
+# Solution plan
+
+**Issue:** [Add snapshot tests for prompt templates to catch accidental changes (Issue #37)](https://github.com/ascherj/pathreview/issues/37)
+
+### Understand
+* **Root cause:** The unit test `test_template_snapshot_content_hash` in [test_prompt_templates.py](file:///Users/leminhhieu/github/pathreview/tests/unit/test_prompt_templates.py) is a placeholder. It calculates the MD5 hash of the prompt templates but only asserts that the hash is a 32-character string, instead of asserting it against an expected reference value.
+* **Expected behavior:** Any change to the content of an existing prompt template version (e.g. modifying `v1` of `skills_feedback`) should cause the test suite to fail. Developers must consciously bump versions (e.g., introduce `v2`) or explicitly update snapshots when prompt changes are intended.
+* **Actual behavior:** Developers can silently modify the contents of any prompt template version without any test failures.
+
+### Map
+* **Files involved:**
+  * [rag/generator/prompt_templates.py](file:///Users/leminhhieu/github/pathreview/rag/generator/prompt_templates.py): Defines the versioned templates in `PROMPT_TEMPLATES`.
+  * [tests/unit/test_prompt_templates.py](file:///Users/leminhhieu/github/pathreview/tests/unit/test_prompt_templates.py): Location of the test suite where the snapshot verification needs to be implemented.
+  * Optionally, new file(s) under `tests/snapshots/` if we choose filesystem-based snapshot files for greater transparency.
+
+### Plan
+1. **Design Snapshot Strategy:** Decide between using a hardcoded dictionary of MD5 hashes per template version in the test file versus filesystem-based snapshot files (e.g. `tests/snapshots/{template_name}_{version}.txt`).
+   * *Choice:* Filesystem-based snapshot files are preferred because a `git diff` shows the exact text changes in prompt templates.
+2. **Implement Snapshot Generation/Assertion Logic:** Write logic to read snapshots from `tests/snapshots/` and assert they match the current `PROMPT_TEMPLATES`. Include an easy way to write/update snapshots (e.g. a custom `--update-snapshots` CLI flag or auto-generation of new template versions).
+3. **Verify Snapshot Failure:** Test the implementation by editing a template to verify the test fails, and reverting the change to ensure it passes.
+4. **Verify Version Bump flow:** Add a new test template/version and verify the test handles it correctly.
+
+### Inputs & outputs
+* **Inputs:** The active versioned prompt templates loaded from [prompt_templates.py](file:///Users/leminhhieu/github/pathreview/rag/generator/prompt_templates.py).
+* **Outputs:** 
+  * A set of snapshot files stored on disk.
+  * Test execution results (Pass when templates match snapshots, Fail when there is any mismatch).
+
+### Risks & unknowns
+* **Risk:** Different operating systems might check out files with different line endings (LF vs CRLF), which would alter the MD5 hash or file comparison and cause tests to fail on Windows.
+  * *Mitigation:* Normalize all line endings (e.g., `.replace("\r\n", "\n")`) before calculating hashes or doing string comparisons.
+
+### Edge cases
+* **Whitespace / formatting sensitive changes:** Extra trailing newlines or spacing. (Snapshot tests must catch these as LLM outputs can be sensitive to formatting).
+* **Adding new versions:** Introducing a new version should not modify or invalidate the snapshots of older versions.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -99,7 +99,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -449,7 +448,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -473,7 +471,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1561,7 +1558,6 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1579,7 +1575,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1972,7 +1967,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3507,7 +3501,6 @@
       "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^2.0.1",
         "cssstyle": "^4.0.1",
@@ -4094,7 +4087,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4107,7 +4099,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4771,7 +4762,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,11 @@ disallow_untyped_defs = true
 check_untyped_defs = true
 exclude = ["alembic/versions/"]
 
+[[tool.mypy.overrides]]
+module = "tests.*"
+disallow_untyped_defs = false
+
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 markers = [

--- a/tests/snapshots/prompt_templates/first_impression_v1.txt
+++ b/tests/snapshots/prompt_templates/first_impression_v1.txt
@@ -1,0 +1,14 @@
+Provide a 2-3 sentence overall first impression of this portfolio.
+
+Portfolio Context:
+{context}
+
+GitHub Username: {github_username}
+Project Count: {project_count}
+
+Write a concise, professional summary capturing:
+- Overall skill level and trajectory
+- Most impressive aspects
+- Immediate opportunities for growth
+
+Provide only the summary text, no JSON formatting needed.

--- a/tests/snapshots/prompt_templates/gaps_feedback_v1.txt
+++ b/tests/snapshots/prompt_templates/gaps_feedback_v1.txt
@@ -1,0 +1,19 @@
+Identify skill gaps relative to job market demands.
+
+Portfolio Context:
+{context}
+
+GitHub Username: {github_username}
+Project Count: {project_count}
+
+Analyze:
+1. High-demand skills not demonstrated
+2. Underrepresented areas
+3. Market alignment
+4. Growth opportunities
+
+Format as JSON:
+- missing_high_demand_skills: list with market demand info
+- underrepresented_areas: areas with low portfolio coverage
+- market_alignment_score: 0-1
+- recommended_learning_areas: prioritized list

--- a/tests/snapshots/prompt_templates/presentation_feedback_v1.txt
+++ b/tests/snapshots/prompt_templates/presentation_feedback_v1.txt
@@ -1,0 +1,19 @@
+Evaluate the overall presentation quality of the portfolio.
+
+Portfolio Context:
+{context}
+
+GitHub Username: {github_username}
+Project Count: {project_count}
+
+Review:
+1. README quality and completeness
+2. Profile information accessibility
+3. Project organization
+4. Visual presentation
+
+Format as JSON:
+- readme_quality: 0-1 score
+- profile_completeness: percentage
+- organization_score: 0-1
+- presentation_suggestions: list of improvements

--- a/tests/snapshots/prompt_templates/projects_feedback_v1.txt
+++ b/tests/snapshots/prompt_templates/projects_feedback_v1.txt
@@ -1,0 +1,19 @@
+Evaluate the quality and presentation of projects in the portfolio.
+
+Portfolio Context:
+{context}
+
+GitHub Username: {github_username}
+Project Count: {project_count}
+
+Assess:
+1. Project scope and complexity
+2. Code quality indicators
+3. Documentation and README quality
+4. Completeness and polish
+
+Format as JSON:
+- standout_projects: list of exemplary projects
+- project_quality_score: overall 0-1 score
+- complexity_level: beginner/intermediate/advanced
+- presentation_notes: suggestions for improvement

--- a/tests/snapshots/prompt_templates/skills_feedback_v1.txt
+++ b/tests/snapshots/prompt_templates/skills_feedback_v1.txt
@@ -1,0 +1,19 @@
+Analyze the skills demonstrated in the provided portfolio context.
+
+Portfolio Context:
+{context}
+
+GitHub Username: {github_username}
+Project Count: {project_count}
+
+Based on the portfolio evidence above, provide structured feedback on:
+1. Demonstrated technical skills (with specific examples from projects)
+2. Depth of expertise in key areas
+3. Programming language proficiency
+4. Framework and tool mastery
+
+Format your response as JSON with these fields:
+- key_skills: list of demonstrated skills with evidence
+- language_proficiency: dict mapping languages to proficiency level
+- framework_expertise: list of mastered frameworks
+- tool_proficiency: list of tools used effectively

--- a/tests/unit/test_prompt_templates.py
+++ b/tests/unit/test_prompt_templates.py
@@ -1,6 +1,8 @@
 """Tests for prompt_templates.py - Snapshot tests"""
 
 import hashlib
+import os
+from pathlib import Path
 
 import pytest
 
@@ -189,13 +191,7 @@ class TestPromptTemplates:
         assert template_default == template_v1
 
     def test_template_snapshot_content_hash(self):
-        """Snapshot test: verify template content hash.
-
-        GAP / REPRODUCTION NOTE:
-        This test currently does not compare the generated MD5 hash against a stored expected value.
-        It only asserts that `content_hash` is a 32-character string. If any template content is
-        modified without a version bump, the hash changes, but this test still passes.
-        """
+        """Snapshot test: verify template content hash."""
         # Create hash of all template content
         template_content = ""
         for name in sorted(PROMPT_TEMPLATES.keys()):
@@ -206,8 +202,36 @@ class TestPromptTemplates:
 
         # Expected hash - update if templates intentionally change
         # This helps detect unintended changes to templates
-        assert isinstance(content_hash, str)
-        assert len(content_hash) == 32  # MD5 hash length
+        expected_hash = "3e79f974f8c1b6d8d1481dfc42e949ca"
+        assert content_hash == expected_hash, (
+            f"Global template content hash changed! Expected {expected_hash}, got {content_hash}.\n"
+            f"If this change was intentional, update the expected_hash in this test."
+        )
+
+    def test_template_snapshots(self):
+        """Verify that prompt templates match their saved snapshots on disk."""
+        snapshot_dir = Path(__file__).parent.parent / "snapshots" / "prompt_templates"
+        snapshot_dir.mkdir(parents=True, exist_ok=True)
+
+        update_snapshots = os.environ.get("UPDATE_SNAPSHOTS") == "1"
+
+        for name, versions in PROMPT_TEMPLATES.items():
+            for version, template_text in versions.items():
+                snapshot_file = snapshot_dir / f"{name}_{version}.txt"
+
+                # Normalize line endings to avoid OS-specific differences (LF vs CRLF)
+                normalized_text = template_text.replace("\r\n", "\n")
+
+                if update_snapshots or not snapshot_file.exists():
+                    snapshot_file.write_text(normalized_text, encoding="utf-8")
+
+                snapshot_content = snapshot_file.read_text(encoding="utf-8").replace("\r\n", "\n")
+
+                assert normalized_text == snapshot_content, (
+                    f"Snapshot mismatch for template '{name}' version '{version}'!\n"
+                    f"If intentional, run with UPDATE_SNAPSHOTS=1 to update the snapshots.\n"
+                    f"Otherwise, please revert your changes or bump the template version."
+                )
 
     def test_skills_feedback_requests_json_format(self):
         """Test skills_feedback requests JSON output."""

--- a/tests/unit/test_prompt_templates.py
+++ b/tests/unit/test_prompt_templates.py
@@ -1,7 +1,8 @@
 """Tests for prompt_templates.py - Snapshot tests"""
 
-import pytest
 import hashlib
+
+import pytest
 
 from rag.generator.prompt_templates import PROMPT_TEMPLATES, get_template
 
@@ -52,7 +53,9 @@ class TestPromptTemplates:
         """Test each template contains {context} placeholder."""
         for template_name, versions in PROMPT_TEMPLATES.items():
             for version, template_text in versions.items():
-                assert "{context}" in template_text, f"{template_name} v{version} missing {{context}}"
+                assert (
+                    "{context}" in template_text
+                ), f"{template_name} v{version} missing {{context}}"
 
     def test_each_template_contains_github_username_placeholder(self):
         """Test each template contains {github_username} placeholder."""
@@ -151,19 +154,32 @@ class TestPromptTemplates:
         """Test gaps_feedback template mentions missing/gap concepts."""
         template = PROMPT_TEMPLATES["gaps_feedback"]["v1"]
 
-        assert "gap" in template.lower() or "missing" in template.lower() or "demand" in template.lower()
+        assert (
+            "gap" in template.lower()
+            or "missing" in template.lower()
+            or "demand" in template.lower()
+        )
 
     def test_presentation_feedback_mentions_readme(self):
         """Test presentation_feedback template mentions README or presentation."""
         template = PROMPT_TEMPLATES["presentation_feedback"]["v1"]
 
-        assert "readme" in template.lower() or "presentation" in template.lower() or "organization" in template.lower()
+        assert (
+            "readme" in template.lower()
+            or "presentation" in template.lower()
+            or "organization" in template.lower()
+        )
 
     def test_first_impression_is_concise(self):
         """Test first_impression template instructs concise output."""
         template = PROMPT_TEMPLATES["first_impression"]["v1"]
 
-        assert "2" in template or "3" in template or "sentence" in template.lower() or "summary" in template.lower()
+        assert (
+            "2" in template
+            or "3" in template
+            or "sentence" in template.lower()
+            or "summary" in template.lower()
+        )
 
     def test_get_template_default_version(self):
         """Test get_template() defaults to v1 when version not specified."""
@@ -173,7 +189,13 @@ class TestPromptTemplates:
         assert template_default == template_v1
 
     def test_template_snapshot_content_hash(self):
-        """Snapshot test: verify template content hash."""
+        """Snapshot test: verify template content hash.
+
+        GAP / REPRODUCTION NOTE:
+        This test currently does not compare the generated MD5 hash against a stored expected value.
+        It only asserts that `content_hash` is a 32-character string. If any template content is
+        modified without a version bump, the hash changes, but this test still passes.
+        """
         # Create hash of all template content
         template_content = ""
         for name in sorted(PROMPT_TEMPLATES.keys()):
@@ -216,7 +238,11 @@ class TestPromptTemplates:
         template = PROMPT_TEMPLATES["first_impression"]["v1"]
 
         # Should specify format (JSON or plain text)
-        assert "json" in template.lower() or "text" in template.lower() or "summary" in template.lower()
+        assert (
+            "json" in template.lower()
+            or "text" in template.lower()
+            or "summary" in template.lower()
+        )
 
     def test_templates_have_portfolio_context(self):
         """Test templates mention portfolio or context."""
@@ -230,7 +256,8 @@ class TestPromptTemplates:
         # Import logger to verify it's used
         with pytest.MonkeyPatch.context() as mp:
             from unittest.mock import patch
-            with patch('rag.generator.prompt_templates.logger') as mock_logger:
+
+            with patch("rag.generator.prompt_templates.logger") as mock_logger:
                 get_template("skills_feedback")
                 # Should log template retrieval
 
@@ -267,7 +294,8 @@ class TestPromptTemplates:
             for version, template_text in versions.items():
                 # All placeholders should use {name} syntax
                 import re
-                placeholders = re.findall(r'\{(\w+)\}', template_text)
+
+                placeholders = re.findall(r"\{(\w+)\}", template_text)
                 assert "context" in placeholders
                 assert "github_username" in placeholders
                 assert "project_count" in placeholders


### PR DESCRIPTION
## Summary
This PR implements automated snapshot testing for the PathReview prompt templates to prevent accidental/silent changes to prompt texts in production.

## Issue
Closes #37

## Changes
- Updated `test_template_snapshot_content_hash` in `tests/unit/test_prompt_templates.py` to compare global template content hash against the reference hash `3e79f974f8c1b6d8d1481dfc42e949ca`.
- Added `test_template_snapshots` unit test which compares each prompt template/version individually against stored reference snapshot text files under `tests/snapshots/prompt_templates/`.
- Generated baseline snapshot text files for all v1 templates under `tests/snapshots/prompt_templates/`.
- Added a `UPDATE_SNAPSHOTS=1` environment variable flag option to rewrite the local snapshots when intentional template updates or version bumps are made.
- Added mypy override config in `pyproject.toml` for `tests.*` module to allow untyped definitions (normal in test files), resolving pre-commit hook failures on test files.

## Testing
- [x] Unit tests pass (`make test-unit` - the prompt template test suite passes cleanly, other pre-existing codebase failures are unaffected)
- [x] New/updated tests cover the changes

## Notes for Reviewers
Pre-existing test suite failures (53 failed tests out of 428 total) were present on the repository before starting. The prompt templates test suite has 38 tests that all pass cleanly.