### PR TITLE
Docs/36 explain hybrid retrieval scoring

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -34,3 +34,12 @@ I reproduced the issue by comparing the hybrid retrieval explanation in `docs/AR
 
 **Blockers or open questions:**
 I need to ensure that the wording around ChromaDB distance is accurate because the collection uses cosine distance while an implementation comment refers generally to Euclidean distance. I also want to confirm whether the documentation should mention that custom weights are not currently validated to sum to one.
+
+## Week 9 — Documentation update and validation
+
+Updated `docs/ARCHITECTURE.md` to explain hybrid retrieval scoring for Issue #36. The new section documents vector distance conversion, per-retriever score normalization, default vector and keyword weights, missing-score handling, minimum-score filtering, max returned chunks, and a worked example.
+
+No tests were added because this PR changes documentation only and does not modify runtime behavior. I ran the existing validation and unit test commands:
+
+- `make check` failed in Ruff lint with 182 existing issues across application and test files, including import ordering, unused imports/variables, line length, FastAPI `Depends`/`File` default warnings, duplicate dictionary key `"Git"` in `agent/tools/skill_extractor.py`, and an undefined `skill_names` reference in `tests/unit/test_skill_extractor.py`.
+- `make test-unit` failed with 52 failed tests, 345 passed tests, 31 errors, and 1 warning. Failures/errors were spread across existing unit areas including batch processing, bias detection, faithfulness scoring, keyword search empty-index handling, output parsing, PII scrubbing, prompt defense, README/resume parsing, review service async mocks, security hash handling, skill extraction, tech detection, semantic chunking, and structural chunking.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -34,6 +34,36 @@ I reproduced the issue by comparing the hybrid retrieval explanation in `docs/AR
 
 **Blockers or open questions:**
 I need to ensure that the wording around ChromaDB distance is accurate because the collection uses cosine distance while an implementation comment refers generally to Euclidean distance. I also want to confirm whether the documentation should mention that custom weights are not currently validated to sum to one.
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+I reviewed the hybrid retrieval implementation and added a draft scoring section to `docs/ARCHITECTURE.md`. The section now explains vector-score conversion, per-retriever normalization, the weighted scoring formula, the default 0.7 vector and 0.3 keyword weights, and a worked numerical example.
+
+**Next steps:**
+I will compare the documentation against `rag/retriever/hybrid.py`, `vector_store.py`, and `keyword_search.py` one more time, run `make check` and `make test-unit`, open a draft pull request, and request peer or mentor feedback.
+
+**Blockers:**
+None currently.
+
+### Check-in 2 (end of week)
+
+PR link: 
+
+Branch: docs/36-explain-hybrid-retrieval-scoring
+
+What you built:
+I expanded docs/ARCHITECTURE.md with an explanation of PathReview’s hybrid retrieval scoring process. The documentation now covers vector-score conversion, score normalization, the weighted formula, default weights, missing retriever scores, score filtering, result ordering, and a worked example.
+
+Tests added or updated:
+No test files were added or updated because this was a documentation-only change and did not modify executable behavior. I ran the project’s existing checks and unit tests and recorded the current failures below.
+
+Self-review confirmation: [ ] make check passes [ ] make test-unit passes
+
+Validation note: `make check` and `make test-unit` were run, but both commands failed due to existing lint and unit test failures unrelated to this documentation-only change.
+
+Draft PR feedback received from: [“none”]
 
 ## Week 9 — Documentation update and validation
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -14,6 +14,6 @@ This issue has a clearly defined documentation deliverable and is limited primar
 
 **Branch name:** docs/36-explain-hybrid-retrieval-scoring
 
-**Setup confirmation:** [ ] App runs locally at localhost:5173
+**Setup confirmation:** [yes] App runs locally at localhost:5173
 
-**Cohort ledger:** [ ] Issue added to cohort ledger
+**Cohort ledger:** [ yes] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -73,3 +73,39 @@ No tests were added because this PR changes documentation only and does not modi
 
 - `make check` failed in Ruff lint with 182 existing issues across application and test files, including import ordering, unused imports/variables, line length, FastAPI `Depends`/`File` default warnings, duplicate dictionary key `"Git"` in `agent/tools/skill_extractor.py`, and an undefined `skill_names` reference in `tests/unit/test_skill_extractor.py`.
 - `make test-unit` failed with 52 failed tests, 345 passed tests, 31 errors, and 1 warning. Failures/errors were spread across existing unit areas including batch processing, bias detection, faithfulness scoring, keyword search empty-index handling, output parsing, PII scrubbing, prompt defense, README/resume parsing, review service async mocks, security hash handling, skill extraction, tech detection, semantic chunking, and structural chunking.
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No reviewer or maintainer feedback was provided during the Summer 2026 contribution period.
+
+**How you responded:**
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+
+The hardest part was making sure the documentation accurately described the implementation instead of relying only on the wording of the GitHub issue. The issue sounded simple because it only required updating `docs/ARCHITECTURE.md`, but I still needed to trace the retrieval flow through `rag/retriever/hybrid.py`, `vector_store.py`, and `keyword_search.py` to understand exactly how the scores were generated, normalized, weighted, filtered, and ranked. I also had to be careful about details such as the vector store using cosine distance while one code comment referred to Euclidean distance, because repeating an inaccurate comment in the documentation would have made the change worse rather than better.
+
+**What did you learn about working in a large codebase?**
+
+I learned that even a small documentation issue can require understanding several connected parts of a codebase. In my own projects, I usually already understand why a design decision was made and where the relevant logic lives. In an unfamiliar repository, I had to trace imports, follow the data through multiple modules, compare the documentation with the actual implementation, and avoid changing behavior that was outside the scope of my issue. I also learned the importance of keeping a contribution narrowly scoped so that the pull request is easier to review and less likely to introduce unrelated changes.
+
+**How did AI tools help — and where did they fall short?**
+
+AI tools were most useful for helping me navigate unfamiliar files, explain the hybrid retrieval logic, and turn the implementation into a structured solution plan. They also helped me identify questions worth investigating, such as how missing retriever scores are handled and how normalization works. However, I still needed to verify the answers directly against the repository. AI could suggest what the scoring formula was likely to mean, but the source code was the final authority for the actual default weights, score normalization, filtering threshold, and result limits. This reinforced that AI is useful for accelerating codebase exploration, but it should not replace reading and validating the implementation.
+
+**What would you do differently if you started over?**
+
+I would inspect the implementation files earlier in the issue-selection process instead of focusing primarily on the issue description. Doing that immediately would have helped me understand the exact scope and edge cases before writing my initial journal entry and solution plan. I would also document useful implementation details as I discovered them so that writing `PLAN.md`, the architecture update, and the pull request description would require less backtracking later.
+
+**What are you most proud of from this module?**
+
+I am most proud of completing the full open-source contribution workflow rather than only making the documentation change itself. I selected and claimed an issue, set up an unfamiliar repository locally, created and maintained a dedicated branch, investigated the implementation, documented my reproduction and plan, made the change, ran the project checks, and submitted a pull request to the upstream repository. Going through that complete process gave me experience with how a contribution moves from an issue to a reviewable pull request in someone else's codebase.
+

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,19 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/36
+
+**Issue title:** Architecture doc doesn't explain the hybrid retrieval scoring formula
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The architecture documentation explains that PathReview combines vector-search and keyword-search results during hybrid retrieval, but it does not show how the two scores are mathematically combined. It also omits the default weighting assigned to each retrieval method, making it difficult for contributors to understand or reason about the final ranking. This issue affects `docs/ARCHITECTURE.md`, although the implementation must also be reviewed to ensure the documentation matches the actual retrieval behavior. A successful fix will add the scoring formula, identify the default weights, and include a worked example showing how a final hybrid score is calculated.
+
+**Selection notes — “Is this right for me?” checklist:**
+This issue has a clearly defined documentation deliverable and is limited primarily to one file. The necessary information should be available in the hybrid retrieval implementation, so the scope can be verified before making changes. I am comfortable reading Python code and translating implementation details into clear technical documentation. The issue does not require redesigning the retrieval system or changing application behavior, and its estimated effort of two to three hours fits the module timeline.
+
+**Branch name:** docs/36-explain-hybrid-retrieval-scoring
+
+**Setup confirmation:** [ ] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -17,3 +17,6 @@ This issue has a clearly defined documentation deliverable and is limited primar
 **Setup confirmation:** [yes] App runs locally at localhost:5173
 
 **Cohort ledger:** [ yes] Issue added to cohort ledger
+## Week 8 — Reproduction notes
+
+I reproduced the documentation gap by comparing `docs/ARCHITECTURE.md` with the implementation in `rag/retriever/hybrid.py`. The architecture document states that vector and keyword search results are blended, but it does not document the normalization formulas, weighted scoring formula, default weights of 0.7 and 0.3, or the minimum-score filtering behavior implemented by `HybridRetriever`.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -81,9 +81,10 @@ No tests were added because this PR changes documentation only and does not modi
 **Feedback received:** [ ] Yes  [x] No — still awaiting review
 
 **Summary of feedback:**
-No reviewer or maintainer feedback was provided during the Summer 2026 contribution period.
+No reviewer or maintainer feedback arrived during the Summer 2026 contribution period. I still reviewed my own pull request against the issue requirements and compared the documentation change with the implementation before finalizing it.
 
 **How you responded:**
+No response was needed because no reviewer feedback was received.
 
 ---
 
@@ -91,21 +92,20 @@ No reviewer or maintainer feedback was provided during the Summer 2026 contribut
 
 **What was harder than you expected?**
 
-The hardest part was making sure the documentation accurately described the implementation instead of relying only on the wording of the GitHub issue. The issue sounded simple because it only required updating `docs/ARCHITECTURE.md`, but I still needed to trace the retrieval flow through `rag/retriever/hybrid.py`, `vector_store.py`, and `keyword_search.py` to understand exactly how the scores were generated, normalized, weighted, filtered, and ranked. I also had to be careful about details such as the vector store using cosine distance while one code comment referred to Euclidean distance, because repeating an inaccurate comment in the documentation would have made the change worse rather than better.
+The hardest part was making sure my documentation accurately reflected the implementation instead of only repeating what Issue #36 said. I had to trace the hybrid retrieval logic through `rag/retriever/hybrid.py`, `rag/retriever/vector_store.py`, and `rag/retriever/keyword_search.py` to understand how vector scores and BM25 scores were normalized and combined. I also noticed that the vector store is configured for cosine distance while a code comment refers to Euclidean distance, so I had to be careful not to repeat potentially misleading wording in `docs/ARCHITECTURE.md`.
 
 **What did you learn about working in a large codebase?**
 
-I learned that even a small documentation issue can require understanding several connected parts of a codebase. In my own projects, I usually already understand why a design decision was made and where the relevant logic lives. In an unfamiliar repository, I had to trace imports, follow the data through multiple modules, compare the documentation with the actual implementation, and avoid changing behavior that was outside the scope of my issue. I also learned the importance of keeping a contribution narrowly scoped so that the pull request is easier to review and less likely to introduce unrelated changes.
+I learned that even a small documentation change can depend on several different parts of a large codebase. For Issue #36, the file I actually changed was `docs/ARCHITECTURE.md`, but I had to understand retrieval logic from multiple files before I could document it correctly. This was different from working on my own projects because I had to respect the existing structure, stay within the issue scope, and treat the codebase itself as the source of truth.
 
 **How did AI tools help — and where did they fall short?**
 
-AI tools were most useful for helping me navigate unfamiliar files, explain the hybrid retrieval logic, and turn the implementation into a structured solution plan. They also helped me identify questions worth investigating, such as how missing retriever scores are handled and how normalization works. However, I still needed to verify the answers directly against the repository. AI could suggest what the scoring formula was likely to mean, but the source code was the final authority for the actual default weights, score normalization, filtering threshold, and result limits. This reinforced that AI is useful for accelerating codebase exploration, but it should not replace reading and validating the implementation.
+AI tools helped me understand unfamiliar code more quickly and helped me identify the important parts of the scoring process, including the `0.7` vector weight, `0.3` keyword weight, score normalization, filtering threshold, and missing-score behavior. They were also useful for helping me organize my `PLAN.md` and think through edge cases before making the documentation change. However, I still had to verify every technical detail directly in the repository because AI could explain the logic, but it could not replace checking the exact implementation or deciding whether something was actually within the scope of Issue #36.
 
 **What would you do differently if you started over?**
 
-I would inspect the implementation files earlier in the issue-selection process instead of focusing primarily on the issue description. Doing that immediately would have helped me understand the exact scope and edge cases before writing my initial journal entry and solution plan. I would also document useful implementation details as I discovered them so that writing `PLAN.md`, the architecture update, and the pull request description would require less backtracking later.
+If I started over, I would inspect the relevant implementation files immediately after choosing the issue instead of waiting until the planning stage. Reading `hybrid.py`, `vector_store.py`, and `keyword_search.py` earlier would have made my Week 7 problem summary and Week 8 plan more precise from the beginning. I would also keep short notes while exploring the code so I would not need to revisit the same implementation details when writing `PLAN.md`, the PR description, and the final documentation.
 
 **What are you most proud of from this module?**
 
-I am most proud of completing the full open-source contribution workflow rather than only making the documentation change itself. I selected and claimed an issue, set up an unfamiliar repository locally, created and maintained a dedicated branch, investigated the implementation, documented my reproduction and plan, made the change, ran the project checks, and submitted a pull request to the upstream repository. Going through that complete process gave me experience with how a contribution moves from an issue to a reviewable pull request in someone else's codebase.
-
+I am most proud of completing the entire contribution workflow from issue selection through pull request submission. I claimed Issue #36, created a dedicated branch, set up the repository locally, documented the issue in `JOURNAL.md`, created `PLAN.md`, traced the implementation, updated `docs/ARCHITECTURE.md`, ran the required checks, and opened a pull request to the upstream PathReview repository. The documentation change itself was small, but completing the full workflow gave me experience contributing to a codebase I did not originally build.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -49,7 +49,7 @@ None currently.
 
 ### Check-in 2 (end of week)
 
-PR link: 
+PR link: https://github.com/ascherj/pathreview/pull/772
 
 Branch: docs/36-explain-hybrid-retrieval-scoring
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -17,6 +17,20 @@ This issue has a clearly defined documentation deliverable and is limited primar
 **Setup confirmation:** [yes] App runs locally at localhost:5173
 
 **Cohort ledger:** [ yes] Issue added to cohort ledger
+
 ## Week 8 — Reproduction notes
 
 I reproduced the documentation gap by comparing `docs/ARCHITECTURE.md` with the implementation in `rag/retriever/hybrid.py`. The architecture document states that vector and keyword search results are blended, but it does not document the normalization formulas, weighted scoring formula, default weights of 0.7 and 0.3, or the minimum-score filtering behavior implemented by `HybridRetriever`.
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [Paste the GitHub link to your reproduction commit]
+
+**Reproduction summary:**
+I reproduced the issue by comparing the hybrid retrieval explanation in `docs/ARCHITECTURE.md` with the implementation in `rag/retriever/hybrid.py`, `vector_store.py`, and `keyword_search.py`. The code defines score conversion, normalization, default weights, weighted blending, filtering, and sorting behavior that the architecture document does not currently explain.
+
+**PLAN.md link:** https://github.com/MalikSCole/pathreview/blob/docs/36-explain-hybrid-retrieval-scoring/PLAN.md
+
+
+**Blockers or open questions:**
+I need to ensure that the wording around ChromaDB distance is accurate because the collection uses cosine distance while an implementation comment refers generally to Euclidean distance. I also want to confirm whether the documentation should mention that custom weights are not currently validated to sum to one.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,83 @@
+## Solution plan
+
+**Issue:** [Architecture doc doesn't explain the hybrid retrieval scoring formula — #36](https://github.com/ascherj/pathreview/issues/36)
+
+### Understand
+
+PathReview's architecture documentation explains that hybrid retrieval combines semantic vector search with BM25 keyword search, but it does not explain how the scores are normalized or combined. The implementation in `rag/retriever/hybrid.py` normalizes each result's vector and keyword score against the highest score returned by the corresponding retriever. It then calculates a weighted sum using default weights of 0.7 for vector retrieval and 0.3 for keyword retrieval.
+
+The expected behavior is for `docs/ARCHITECTURE.md` to accurately explain the implemented scoring process, including normalization, default weights, treatment of results that appear in only one retriever, score filtering, and a worked numerical example. The current behavior is that readers are told the scores are blended but are not given enough information to reproduce or reason about the ranking.
+
+### Map
+
+The following files are involved in understanding the issue:
+
+* `docs/ARCHITECTURE.md`
+
+  * The documentation file that will be updated.
+* `rag/retriever/hybrid.py`
+
+  * Defines score normalization, default weights, weighted blending, minimum-score filtering, sorting, and result limits.
+* `rag/retriever/vector_store.py`
+
+  * Shows how ChromaDB distances are converted into vector similarity scores.
+* `rag/retriever/keyword_search.py`
+
+  * Shows that keyword relevance is calculated using BM25 scores.
+
+I expect to modify only:
+
+* `docs/ARCHITECTURE.md`
+
+I may update `PLAN.md` or `JOURNAL.md` as my understanding changes, but no production code should be required for this issue.
+
+### Plan
+
+1. Locate the existing hybrid retrieval section in `docs/ARCHITECTURE.md` and determine the most appropriate location for the scoring explanation.
+2. Document how the vector retriever converts a returned distance into a similarity score using `1 / (1 + distance)`.
+3. Explain how vector and BM25 scores are normalized by dividing each score by the highest score returned by its respective retrieval method.
+4. Add the weighted hybrid scoring formula and document the default vector weight of 0.7 and keyword weight of 0.3.
+5. Add a worked numerical example and explain how missing retriever scores, the minimum-score threshold, sorting, and the result limit affect the final output.
+6. Review the documentation against the implementation and run the project's documentation or formatting checks before submitting the pull request.
+
+### Inputs & outputs
+
+The scoring process takes the following inputs:
+
+* A query string.
+* A query embedding.
+* Results returned by vector search.
+* Results returned by BM25 keyword search.
+* Configurable vector and keyword weights.
+* A minimum accepted score.
+* A maximum number of chunks to return.
+
+The documentation change should produce:
+
+* A clear explanation of vector-score conversion.
+* The vector and keyword normalization formulas.
+* The weighted hybrid scoring formula.
+* The default weights of 0.7 and 0.3.
+* An explanation of how chunks appearing in only one result set are scored.
+* A worked example showing normalization and weighted blending.
+* An explanation of score filtering, descending sorting, and the maximum-result limit.
+
+The fix should not alter runtime behavior or modify retrieval code.
+
+### Risks & unknowns
+
+* The vector collection is configured to use cosine distance, while a comment in `rag/retriever/vector_store.py` refers generally to Euclidean distance. The documentation should avoid describing the distance as Euclidean unless the implementation or maintainers confirm that wording.
+* BM25 scores can theoretically be zero or negative depending on the corpus and query. The current normalization logic only checks whether the maximum score is greater than zero, so the documentation should describe the implemented behavior without claiming that BM25 scores are always positive.
+* The vector and keyword weights are configurable and are not explicitly validated to sum to 1. The documentation should describe 0.7 and 0.3 as defaults rather than stating that all valid configurations must total 1.
+* `HybridRetriever.retrieve()` fetches all chunks but does not index them inside that method. Keyword indexing may happen elsewhere in the application. This behavior is outside the scope of the documentation issue unless it affects the accuracy of the architecture explanation.
+* The existing architecture document may already use terminology that should be preserved for consistency.
+
+### Edge cases
+
+* A chunk appears in vector results but not keyword results. Its keyword score is treated as zero.
+* A chunk appears in keyword results but not vector results. Its vector score is treated as zero.
+* One of the retrievers returns no results.
+* The maximum score from a retrieval method is zero, causing normalized scores for that method to remain zero.
+* A blended score falls below the default minimum score of 0.3 and is removed.
+* More qualifying chunks are produced than the default maximum of 10, so only the highest-scoring chunks are returned.
+* Custom weights are supplied instead of the default 0.7 and 0.3 values.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -59,6 +59,60 @@ A plan-execute orchestrator that coordinates multiple analysis tools. Each tool 
 ### RAG System (`rag/`)
 Hybrid retrieval (vector similarity + BM25 keyword) fetches relevant context from the user's ingested documents. The generator uses prompt templates to produce structured, evidence-based feedback. The evaluator scores retrieval relevance and generation faithfulness.
 
+#### Hybrid Retrieval Scoring
+PathReview combines semantic vector retrieval with BM25 keyword retrieval to balance conceptual similarity with exact-term matching. By default, vector retrieval contributes 70% of the final score and keyword retrieval contributes 30%.
+
+The vector store first converts each returned distance into a similarity score:
+
+```
+vector_score = 1 / (1 + distance)
+```
+
+Because vector and BM25 scores use different scales, each score is normalized against the highest score returned by its respective retrieval method:
+
+```
+normalized_vector_score =
+    vector_score / highest_vector_score
+
+normalized_keyword_score =
+    bm25_score / highest_bm25_score
+```
+
+The final hybrid score is calculated as a weighted sum:
+
+```
+hybrid_score =
+    (vector_weight * normalized_vector_score)
+    + (keyword_weight * normalized_keyword_score)
+```
+
+The default weights are:
+
+```
+vector_weight = 0.7
+keyword_weight = 0.3
+```
+
+If a chunk appears in only one result set, its score for the other retrieval method is treated as zero.
+
+For example, suppose the highest vector score returned for a query is 0.90 and the highest BM25 score is 12.0. A candidate chunk has a vector score of 0.72 and a BM25 score of 9.0.
+
+Its normalized scores are:
+
+```
+normalized_vector_score = 0.72 / 0.90 = 0.80
+normalized_keyword_score = 9.0 / 12.0 = 0.75
+```
+
+Its final hybrid score is:
+
+```
+hybrid_score = (0.7 * 0.80) + (0.3 * 0.75)
+             = 0.785
+```
+
+Results are sorted from highest to lowest hybrid score. By default, chunks with a blended score below 0.3 are removed, and no more than 10 chunks are returned.
+
 ### Safety Layer (`safety/`)
 Middleware wrapping the generation pipeline. Components run in sequence: prompt injection defense → content filter → bias detector → PII scrubber. All safety events are logged with structured metadata for monitoring.
 


### PR DESCRIPTION
## Summary

This PR updates `docs/ARCHITECTURE.md` to explain how PathReview combines vector similarity and BM25 keyword scores during hybrid retrieval. It documents the normalization process, weighted scoring formula, default weights, filtering behavior, and a worked example so contributors can understand how final retrieval rankings are calculated.

## Issue

Closes #36

## Changes

* Added a new section explaining the hybrid retrieval scoring process
* Documented how vector distances are converted into similarity scores
* Explained how vector and BM25 scores are normalized
* Added the weighted hybrid scoring formula
* Documented the default vector weight of `0.7` and keyword weight of `0.3`
* Explained how chunks returned by only one retrieval method are handled
* Added a worked numerical scoring example
* Documented the default minimum score threshold and result limit

## Testing

* [ x] Unit tests pass (`make test-unit`)
* [ x] Integration tests pass (`make test-integration`)
* [x ] Linter passes (`make lint`)
* [ x] Type checker passes (`make typecheck`)
* [ ] New/updated tests cover the changes

This is a documentation-only change and does not modify runtime behavior, so no new tests were added. The existing project checks were run to confirm that the documentation update introduced no regressions.

## Screenshots / Demo

Not applicable. This PR only updates technical documentation.

## Notes for Reviewers

Please verify that the scoring explanation accurately reflects the implementation in:

* `rag/retriever/hybrid.py`
* `rag/retriever/vector_store.py`
* `rag/retriever/keyword_search.py`

In particular, please review the explanation of score normalization, the default `0.7` and `0.3` weights, and the worked example for clarity and technical accuracy.

