### PR TITLE
fix(tests): expand README scorer test fixture for word count assertion (#156)

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -17,3 +17,16 @@ The test `test_readme_with_all_quality_signals` in `tests/unit/test_readme_score
 
 ### Selection & Scope Reasoning
 I picked Issue #156 because it is a straightforward Tier 1 bug in the unit testing suite. It has clear steps to reproduce in `tests/unit/test_readme_scorer.py` and doesn't require changing complex core backend logic. This makes it a great fit for practicing codebase navigation, running tests, and getting used to the open-source workflow without getting bogged down in scope creep.
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [updated on GitHub]
+
+**Reproduction summary:**
+Reproduced the issue locally by running `.venv/Scripts/pytest tests/unit/test_readme_scorer.py -q`. Observed `AssertionError: assert 51 > 100` in `test_readme_with_all_quality_signals` because the mock `readme` fixture string only contains 51 words.
+
+**PLAN.md link:** [https://github.com/Nanzib/pathreview/blob/fix/156-readme-scorer-fixture/PLAN.md](https://github.com/Nanzib/pathreview/blob/fix/156-readme-scorer-fixture/PLAN.md)
+
+**Walkthrough video (recommended):** N/A
+
+**Blockers or open questions:** None.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,19 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/156
+
+**Issue title:** README scorer test fixture is too short for its own word-count assertion #156
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The test `test_readme_with_all_quality_signals` in `tests/unit/test_readme_scorer.py` checks if a README is categorized as "comprehensive" when it has more than 100 words. However, the sample README text provided in the test only has about 51 words, causing `pytest` to fail with `assert 51 > 100`. A successful fix will expand the sample README fixture so it actually has over 100 words, allowing the test to pass correctly against the scorer's logic.
+
+**Branch name:** fix/156-readme-scorer-fixture
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger
+
+### Selection & Scope Reasoning
+I picked Issue #156 because it is a straightforward Tier 1 bug in the unit testing suite. It has clear steps to reproduce in `tests/unit/test_readme_scorer.py` and doesn't require changing complex core backend logic. This makes it a great fit for practicing codebase navigation, running tests, and getting used to the open-source workflow without getting bogged down in scope creep.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -30,3 +30,34 @@ Reproduced the issue locally by running `.venv/Scripts/pytest tests/unit/test_re
 **Walkthrough video (recommended):** N/A
 
 **Blockers or open questions:** None.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Completed all sub-tasks from `PLAN.md`. Expanded the mock `readme` string fixture in `tests/unit/test_readme_scorer.py` from 51 words to ~530 words. Added realistic project description, architecture overview, installation steps, configuration flags, and contributing guidelines while maintaining all required Markdown quality signals (`#` headers, badge images, code snippets, demo links).
+
+**Next steps:**
+Verify test suite execution with `pytest`, commit changes, push working branch to remote fork, open Pull Request against upstream repository, and submit final branch link.
+
+**Blockers:**
+None.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [Replace with live PR link after opening PR]
+
+**Branch:** fix/156-readme-scorer-fixture
+
+**What you built:**
+Expanded the inline mock `readme` fixture string in `tests/unit/test_readme_scorer.py` from 51 words to ~530 words. This ensures `TestReadmeScorer.test_readme_with_all_quality_signals` satisfies both `data["word_count"] > 100` and `data["word_count_category"] == "comprehensive"` as expected by the scorer logic.
+
+**Tests updated:**
+Updated `tests/unit/test_readme_scorer.py` (`TestReadmeScorer.test_readme_with_all_quality_signals`). Covered word count thresholds (>500 words for comprehensive tier), category classification ("comprehensive"), and verified that installation, usage, tech stack, badge, and demo link detection signals remain functional.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -61,3 +61,34 @@ Updated `tests/unit/test_readme_scorer.py` (`TestReadmeScorer.test_readme_with_a
 **Self-review confirmation:** [x] make check passes  [x] make test-unit passes
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No review came in.
+
+**How you responded:**
+N/A
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Navigating the pre-commit tooling rules and strict static analysis during git commits was significantly trickier than expected. What initially seemed like a simple task of adding text to a string fixture in `tests/unit/test_readme_scorer.py` triggered strict `ruff` line-length limits (100 character maximum) and `mypy` type annotation requirements (`[no-untyped-def]`). Managing pre-commit hook stashes while reformatting string lines and adding explicit function return type annotations across the entire test class required far more precision than just writing test text.
+
+**What did you learn about working in a large codebase?**
+I learned that contributing to an existing codebase requires strictly respecting hidden contracts and category thresholds defined elsewhere in the system. When modifying the test fixture for `TestReadmeScorer.test_readme_with_all_quality_signals`, I couldn't just insert arbitrary words; I had to ensure the text satisfied the `comprehensive` threshold (>500 words) defined in `agent/tools/readme_scorer.py` while preserving specific regex quality signals like `#` headers, code snippets (`pip install`), badge URLs (`![Status]`), and demo links. Working in production code means changing test inputs without breaking downstream system assumptions.
+
+**How did AI tools help — and where did they fall short?**
+AI tools were incredibly effective for rapidly generating realistic Markdown project content (architecture overviews, tech stacks, setup instructions) and quickly adding missing `mypy` type annotations. However, AI fell short when calibrating text length against domain logic assertions. The initial AI-generated fixture contained ~140 words—which passed the basic `word_count > 100` assertion but failed `assert word_count_category == "comprehensive"`. I had to manually trace the failure through `readme_scorer.py` logic to determine that the `comprehensive` tier required >500 words, and then prompt the AI with those specific domain boundaries.
+
+**What would you do differently if you started over?**
+If I started over, I would inspect the underlying tool implementation (`agent/tools/readme_scorer.py`) much more thoroughly during the Week 8 planning phase before writing my `PLAN.md` sub-tasks. Rather than assuming 120 words would satisfy all quality checks, identifying the exact word count category cutoffs (`minimal` <100, `adequate` 100–500, `comprehensive` >500) upfront would have saved an extra testing iteration. Additionally, I would add separate, dedicated test cases to verify boundary conditions at exactly 101 and 501 words.
+
+**What are you most proud of from this module?**
+I am most proud of successfully navigating the complete open-source lifecycle—from diagnosing issue #156 in an unfamiliar repository to opening a clean, fully-typed Pull Request (#780) that passes all unit tests and linting checks. Seeing all 23 unit tests in `test_readme_scorer.py` pass cleanly alongside passing `ruff`, `black`, and `mypy` hooks gave me genuine confidence in my ability to contribute production-quality code to real-world software projects.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -48,7 +48,7 @@ None.
 
 ### Check-in 2 (end of week)
 
-**PR link:** [Replace with live PR link after opening PR]
+**PR link:** https://github.com/ascherj/pathreview/pull/780
 
 **Branch:** fix/156-readme-scorer-fixture
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,29 @@
+# Solution Plan — Issue #156
+
+**Issue:** [README scorer test fixture is too short for its own word-count assertion #156](https://github.com/ascherj/pathreview/issues/156)
+
+### Understand
+The unit test `test_readme_with_all_quality_signals` inside `tests/unit/test_readme_scorer.py` checks whether a high-quality README file gets categorized as "comprehensive". The scorer in `agent/tools/readme_scorer.py` requires a word count exceeding 100 words (`word_count > 100`) to award that tier. However, the mock README string fixture provided in the test currently contains only 51 words. Running `pytest` outputs `category=minimal word_count=51` and triggers an `AssertionError: assert 51 > 100`. The root cause is a deficient test fixture, not a bug in the scorer's core evaluation logic.
+
+### Map
+* **Files involved:**
+  * `tests/unit/test_readme_scorer.py` — Contains `TestReadmeScorer.test_readme_with_all_quality_signals` and the inline mock `readme` string fixture.
+  * `agent/tools/readme_scorer.py` — The core `ReadmeScorer` class defining quality signal thresholds and word count calculations.
+
+### Plan
+1. **Locate fixture in test suite:** Open `tests/unit/test_readme_scorer.py` and inspect the multi-line string variable `readme` in `test_readme_with_all_quality_signals`.
+2. **Expand README text fixture:** Add ~60–70 additional realistic words (adding detailed sections for configuration, contributing guidelines, or API endpoints) to bring the total word count to ~115–120 words.
+3. **Preserve quality signals:** Ensure the added text maintains required Markdown structure (such as `#` headers, links, and code blocks) so other quality signal assertions do not break.
+4. **Run test suite verification:** Execute `.venv/Scripts/pytest tests/unit/test_readme_scorer.py -q` in Git Bash to verify `assert data["word_count"] > 100` passes and the test turns green.
+
+### Inputs & outputs
+* **Input:** Expanded multi-line `readme` string passed to `scorer.execute({"readme_content": readme})` in `tests/unit/test_readme_scorer.py`.
+* **Output:** A dictionary returned in `result.data` where `data["word_count"]` is an integer greater than 100 (e.g., 115) and `word_count_category` evaluates to `"comprehensive"`.
+
+### Risks & unknowns
+* **Risk 1 (`tests/unit/test_readme_scorer.py`):** Adding new text could accidentally dilute keyword density or section ratios expected by other quality checks in `agent/tools/readme_scorer.py`.
+* **Risk 2 (`agent/tools/readme_scorer.py`):** The internal word count parser might split tokens differently on code snippets vs plain text, so raw word count must be verified against `data["word_count"]` rather than a basic python `.split()`.
+
+### Edge cases
+1. **Boundary condition (101 words):** Ensuring the fixture clearly exceeds 100 words (e.g., 115 words) rather than sitting right at 100, which would fail strict inequality `> 100`.
+2. **Markdown syntax noise:** Ensuring code blocks (` ```bash `) and markdown links in the fixture are handled gracefully by the scorer without affecting header detection.

--- a/tests/unit/test_readme_scorer.py
+++ b/tests/unit/test_readme_scorer.py
@@ -10,41 +10,98 @@ class TestReadmeScorer:
     """Test suite for ReadmeScorer."""
 
     @pytest.fixture
-    def scorer(self):
+    def scorer(self) -> ReadmeScorer:
         """Create a ReadmeScorer instance."""
         return ReadmeScorer()
 
-    def test_readme_with_all_quality_signals(self, scorer):
+    def test_readme_with_all_quality_signals(self, scorer: ReadmeScorer) -> None:
         """Test README with all quality signals returns high score."""
         readme = """
         # Project Name
-        A comprehensive project description.
+        A comprehensive and robust open-source project description designed
+        to manage, evaluate, and review path-based workflows effectively across
+        multiple development environments and complex setups.
 
-        ## Installation
+        ## Overview
+        PathReview provides automated quality scoring and evaluation tools for
+        software repositories. It processes codebase structures, analyzes
+        README files for key quality signals, and generates clear actionable
+        metrics for maintainers, contributors, and engineering leaders. By
+        leveraging modern evaluation frameworks, development teams can ensure
+        their repository documentation remains thorough, clear, up to date, and
+        easy to navigate for incoming engineers joining the team.
+
+        Documentation is often the first impression a project makes on
+        potential users and contributors. High quality documentation improves
+        onboarding speed, reduces duplicate support inquiries, and establishes
+        best practices across software projects. PathReview automates the
+        process of checking whether essential sections, badges, installation
+        steps, and code examples are present in a project repository.
+
+        ## Architecture & System Design
+        The application relies on a modular microservice architecture composed
+        of background worker queues, relational data stores, and specialized
+        evaluation tools. Each tool analyzes specific software artifacts—such
+        as README documentation, directory structures, commit history, and
+        test coverage statistics—to compute holistic repository health scores.
+
+        The system is divided into three distinct layers:
+        1. Ingestion Layer: Fetches repository metadata and documentation.
+        2. Analysis Layer: Runs modular scorers including README completeness.
+        3. Reporting Layer: Aggregates signal scores into summary cards.
+
+        ## Installation & Quickstart Setup
+        Install the package directly from PyPI using pip in your virtual
+        environment:
         ```bash
         pip install package
         ```
+        Ensure you have Python 3.9 or higher installed along with pip and
+        virtualenv tools. Clone the repository locally, create a fresh virtual
+        environment, and execute installation dependencies prior to running
+        scoring suites.
 
         ## Usage
+        Import the core engine and execute the primary scoring suite as shown
+        in this example workflow:
         ```python
         import package
         package.run()
         ```
+        You can pass custom configuration settings to the execution call to
+        tailor scoring thresholds and filter specific signal components based on
+        your team's specific requirements.
 
-        ## Features
-        - Feature 1
-        - Feature 2
-        - Feature 3
+        ## Core Features
+        - Feature 1: Automated README quality signal detection and analysis.
+        - Feature 2: Flexible database persistence with PostgreSQL and Redis.
+        - Feature 3: Vector database integrations using ChromaDB for search.
+        - Feature 4: Comprehensive automated scoring suites covering docs.
+        - Feature 5: Real-time status reporting and visualizations.
 
-        ## Tech Stack
-        - Python 3.9
-        - FastAPI
-        - PostgreSQL
+        ## Tech Stack & Dependencies
+        - Python 3.9+ runtime environment
+        - FastAPI web framework for asynchronous REST API endpoints
+        - PostgreSQL database for relational persistent storage
+        - Redis for session management and background job queues
+        - Docker containerization for simple local deployment
 
         ![Build Status](https://example.com/badge.svg)
         ![Coverage](https://example.com/coverage.svg)
 
-        ## Live Demo
+        ## Configuration Options
+        Configure runtime flags and environment variables using a standard
+        .env configuration file located in your project root directory. You can
+        specify custom database connection strings, API key credentials, logger
+        output formats, and execution timeout parameters to suit local setups.
+
+        ## Contributing Guidelines
+        Contributions are warmly welcomed! Please submit a pull request or open
+        an issue on GitHub to discuss proposed changes before implementation.
+        Ensure all new features include thorough unit tests and pass linting
+        checks before requesting final review from maintainers.
+
+        ## Live Demo & Documentation Link
         [Try it here](https://demo.example.com)
         """
 
@@ -62,7 +119,7 @@ class TestReadmeScorer:
         assert data["has_tech_stack_section"] is True
         assert data["overall_score"] > 0.7  # Should be high
 
-    def test_readme_with_no_content(self, scorer):
+    def test_readme_with_no_content(self, scorer: ReadmeScorer) -> None:
         """Test README with no content returns score of 0.0."""
         result = scorer.execute({"readme_content": ""})
 
@@ -73,7 +130,7 @@ class TestReadmeScorer:
         assert data["word_count_category"] == "minimal"
         assert data["overall_score"] == 0.0
 
-    def test_readme_with_only_title(self, scorer):
+    def test_readme_with_only_title(self, scorer: ReadmeScorer) -> None:
         """Test README with only a title returns minimal word count category."""
         readme = "# Project Title"
 
@@ -86,7 +143,7 @@ class TestReadmeScorer:
         assert data["word_count_category"] == "minimal"
         assert data["overall_score"] < 0.3
 
-    def test_word_count_category_minimal(self, scorer):
+    def test_word_count_category_minimal(self, scorer: ReadmeScorer) -> None:
         """Test word_count_category: < 100 = minimal."""
         readme = "This is a very short readme with just a few words."
 
@@ -96,7 +153,7 @@ class TestReadmeScorer:
         assert data["word_count"] < 100
         assert data["word_count_category"] == "minimal"
 
-    def test_word_count_category_adequate(self, scorer):
+    def test_word_count_category_adequate(self, scorer: ReadmeScorer) -> None:
         """Test word_count_category: 100-500 = adequate."""
         readme = " ".join(["word"] * 200)  # 200 words
 
@@ -106,7 +163,7 @@ class TestReadmeScorer:
         assert 100 <= data["word_count"] <= 500
         assert data["word_count_category"] == "adequate"
 
-    def test_word_count_category_comprehensive(self, scorer):
+    def test_word_count_category_comprehensive(self, scorer: ReadmeScorer) -> None:
         """Test word_count_category: > 500 = comprehensive."""
         readme = " ".join(["word"] * 700)  # 700 words
 
@@ -116,7 +173,7 @@ class TestReadmeScorer:
         assert data["word_count"] > 500
         assert data["word_count_category"] == "comprehensive"
 
-    def test_installation_section_detection(self, scorer):
+    def test_installation_section_detection(self, scorer: ReadmeScorer) -> None:
         """Test detection of installation section."""
         readme_with_install = """
         # Project
@@ -136,7 +193,7 @@ class TestReadmeScorer:
         result = scorer.execute({"readme_content": readme_without_install})
         assert result.data["has_installation_section"] is False
 
-    def test_usage_section_detection(self, scorer):
+    def test_usage_section_detection(self, scorer: ReadmeScorer) -> None:
         """Test detection of usage section."""
         readme_with_usage = """
         # Project
@@ -147,7 +204,7 @@ class TestReadmeScorer:
         result = scorer.execute({"readme_content": readme_with_usage})
         assert result.data["has_usage_section"] is True
 
-    def test_setup_keyword_counts_as_installation(self, scorer):
+    def test_setup_keyword_counts_as_installation(self, scorer: ReadmeScorer) -> None:
         """Test that 'setup' keyword counts as installation."""
         readme = """
         # Project
@@ -157,11 +214,12 @@ class TestReadmeScorer:
 
         result = scorer.execute({"readme_content": readme})
         # "Getting Started" matches the pattern
-        assert result.data["has_installation_section"] is True or result.data[
-            "has_usage_section"
-        ] is True
+        assert (
+            result.data["has_installation_section"] is True
+            or result.data["has_usage_section"] is True
+        )
 
-    def test_quickstart_counts_as_usage(self, scorer):
+    def test_quickstart_counts_as_usage(self, scorer: ReadmeScorer) -> None:
         """Test that 'quickstart' counts as usage."""
         readme = """
         # Project
@@ -172,7 +230,7 @@ class TestReadmeScorer:
         result = scorer.execute({"readme_content": readme})
         assert result.data["has_usage_section"] is True
 
-    def test_badge_detection(self, scorer):
+    def test_badge_detection(self, scorer: ReadmeScorer) -> None:
         """Test badge detection."""
         readme_with_badges = """
         ![Status](https://example.com/status.svg)
@@ -182,7 +240,7 @@ class TestReadmeScorer:
         result = scorer.execute({"readme_content": readme_with_badges})
         assert result.data["has_badges"] is True
 
-    def test_demo_link_detection(self, scorer):
+    def test_demo_link_detection(self, scorer: ReadmeScorer) -> None:
         """Test demo/live link detection."""
         readme_with_demo = """
         # Project
@@ -192,7 +250,7 @@ class TestReadmeScorer:
         result = scorer.execute({"readme_content": readme_with_demo})
         assert result.data["has_demo_link"] is True
 
-    def test_tech_stack_section_detection(self, scorer):
+    def test_tech_stack_section_detection(self, scorer: ReadmeScorer) -> None:
         """Test tech stack section detection."""
         readme_with_stack = """
         # Project
@@ -205,7 +263,7 @@ class TestReadmeScorer:
         result = scorer.execute({"readme_content": readme_with_stack})
         assert result.data["has_tech_stack_section"] is True
 
-    def test_technologies_keyword_counts(self, scorer):
+    def test_technologies_keyword_counts(self, scorer: ReadmeScorer) -> None:
         """Test that 'Technologies' keyword counts as tech stack."""
         readme = """
         # Project
@@ -216,9 +274,10 @@ class TestReadmeScorer:
         result = scorer.execute({"readme_content": readme})
         assert result.data["has_tech_stack_section"] is True
 
-    def test_overall_score_calculation(self, scorer):
+    def test_overall_score_calculation(self, scorer: ReadmeScorer) -> None:
         """Test that overall score aggregates components."""
-        readme = """
+        readme = (
+            """
         # Good README
 
         ## Installation
@@ -233,7 +292,9 @@ class TestReadmeScorer:
         ![Build](https://example.com/build.svg)
 
         This readme has lots of content here.
-        """ * 3  # Make it comprehensive
+        """
+            * 3
+        )  # Make it comprehensive
 
         result = scorer.execute({"readme_content": readme})
 
@@ -242,7 +303,7 @@ class TestReadmeScorer:
         # Multiple signals should yield higher score
         assert data["overall_score"] > 0.5
 
-    def test_missing_readme_content_key(self, scorer):
+    def test_missing_readme_content_key(self, scorer: ReadmeScorer) -> None:
         """Test handling of missing readme_content key."""
         result = scorer.execute({})
 
@@ -250,7 +311,7 @@ class TestReadmeScorer:
         data = result.data
         assert data["has_readme"] is False
 
-    def test_result_has_all_required_fields(self, scorer):
+    def test_result_has_all_required_fields(self, scorer: ReadmeScorer) -> None:
         """Test that result has all required fields."""
         result = scorer.execute({"readme_content": "# Test"})
 
@@ -265,7 +326,7 @@ class TestReadmeScorer:
         assert "has_tech_stack_section" in data
         assert "overall_score" in data
 
-    def test_case_insensitive_section_detection(self, scorer):
+    def test_case_insensitive_section_detection(self, scorer: ReadmeScorer) -> None:
         """Test that section detection is case insensitive."""
         readme = """
         # Project
@@ -276,7 +337,7 @@ class TestReadmeScorer:
         result = scorer.execute({"readme_content": readme})
         assert result.data["has_installation_section"] is True
 
-    def test_whitespace_only_readme(self, scorer):
+    def test_whitespace_only_readme(self, scorer: ReadmeScorer) -> None:
         """Test handling of whitespace-only README."""
         result = scorer.execute({"readme_content": "   \n\n   \t  "})
 
@@ -284,7 +345,7 @@ class TestReadmeScorer:
         assert data["has_readme"] is False
         assert data["word_count"] == 0
 
-    def test_example_keyword_counts_as_usage(self, scorer):
+    def test_example_keyword_counts_as_usage(self, scorer: ReadmeScorer) -> None:
         """Test that 'Example' counts as usage section."""
         readme = """
         # Project
@@ -295,7 +356,7 @@ class TestReadmeScorer:
         result = scorer.execute({"readme_content": readme})
         assert result.data["has_usage_section"] is True
 
-    def test_score_scales_with_word_count(self, scorer):
+    def test_score_scales_with_word_count(self, scorer: ReadmeScorer) -> None:
         """Test that longer READMEs get bonus in score."""
         short_readme = "# Title\nSmall content."
         long_readme = "# Title\n" + "Content paragraph. " * 100
@@ -305,14 +366,14 @@ class TestReadmeScorer:
 
         assert result_long.data["overall_score"] > result_short.data["overall_score"]
 
-    def test_try_it_as_demo_indicator(self, scorer):
+    def test_try_it_as_demo_indicator(self, scorer: ReadmeScorer) -> None:
         """Test that 'try it' indicates demo link."""
         readme = "Check it out [try it here](https://example.com)"
 
         result = scorer.execute({"readme_content": readme})
         assert result.data["has_demo_link"] is True
 
-    def test_built_with_counts_as_tech_stack(self, scorer):
+    def test_built_with_counts_as_tech_stack(self, scorer: ReadmeScorer) -> None:
         """Test that 'Built With' counts as tech stack."""
         readme = """
         # Project


### PR DESCRIPTION
## Summary
Expands the mock `readme` string fixture in `tests/unit/test_readme_scorer.py` from 51 words to ~530 words. This ensures that `test_readme_with_all_quality_signals` satisfies the scorer's requirement for the "comprehensive" category (>500 words) and resolves the failing `assert 51 > 100` assertion.

## Issue
Closes #156

## Changes
- Expanded inline mock README text fixture in `tests/unit/test_readme_scorer.py` to ~530 words by adding realistic architecture, setup, configuration, and contributing sections.
- Preserved all required Markdown quality signals including `#` and `##` headers, badge image syntax, code blocks, tech stack lists, and live demo links.
- Added explicit return and parameter type annotations across `tests/unit/test_readme_scorer.py` to satisfy `mypy` type-checking rules.

## Testing
- [x] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`)
- [x] Linter passes (`make lint`)
- [x] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes

Verified manually by running `.venv/Scripts/pytest tests/unit/test_readme_scorer.py -q` to confirm all 23 unit tests pass cleanly.

## Screenshots / Demo
N/A — Test fixture update only.

## Notes for Reviewers
This PR modifies test fixture data and type annotations in `tests/unit/test_readme_scorer.py` without altering core scoring logic in `agent/tools/readme_scorer.py`. The scorer correctly requires >500 words for the "comprehensive" category, which this expanded fixture now satisfies.