### PR TITLE
Feat/11 portfolio url ingestion

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -17,5 +17,11 @@ Right now PathReview can use GitHub and resume data, but it cannot pull informat
 
 ## Week 8 — Reproduction & solution planning
 
+**Reproduction commit link:** https://github.com/ItzRae/pathreview/commit/103ecae18838f6b23b87fa79f2afad92ee71201a
+
 **Reproduction summary:**
 I created a profile and confirmed that the app already lets users enter a portfolio URL. However, after tracing the ingestion code, I found that the URL is only stored on the profile and is never fetched or processed. The pipeline currently supports resumes, READMEs, and repository metadata, but there is no web parser or portfolio ingestion flow to add website content to the vector store.
+
+**PLAN.md link:** https://github.com/ItzRae/pathreview/blob/feat/11-portfolio-url-ingestion/PLAN.md
+
+**Blockers or open questions:** None at the moment. My remaining work is primarily implementation and tracing the existing ingestion flow to determine the correct integration point.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -60,3 +60,36 @@ Implemented support for ingesting portfolio websites into the existing ingestion
 
 **Draft PR feedback received from:**
 None (awaiting feedback)
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [x] Yes  [ ] No — still awaiting review
+
+**Summary of feedback:**
+My reviewer pointed out three smaller issues with the web parser: the page title was also being included in the extracted body text, `source_type` was being stored redundantly in both the metadata and `ParseResult`, and an unclosed `<script>` tag could cause the parser to ignore the rest of the page. The last point was especially useful because it was an edge case I had not considered in my original tests.
+
+**How you responded:**
+I reproduced the unclosed `<script>` issue with a new test before changing the implementation, then updated the parser to handle the malformed HTML case. I also prevented title text from being duplicated in the body and changed the metadata structure to be consistent with the existing parsers. I added/updated tests for these cases, reran the checks, and pushed the fixes to my existing PR.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Understanding the boundaries of the issue was harder than the actual HTML parsing. I initially assumed there would be an existing profile workflow where I could simply plug in portfolio ingestion, but while tracing the code I found that the existing resume and README ingestion methods were not wired into an application-level trigger either. I had to figure out what belonged in my issue versus what would unnecessarily expand its scope. I also underestimated how many edge cases even a relatively small web parser could have, especially with malformed HTML.
+
+
+**What did you learn about working in a large codebase?**
+I learned that contributing to someone else's codebase is less about finding a solution that works in isolation and more about understanding and following the patterns that are already there. I spent a lot more time tracing existing parsers, the ingestion pipeline, tests, typing conventions, and contribution guidelines than I normally would when building my own project. I also learned not to assume that every part of a codebase is complete or perfectly consistent. There were existing type-checking failures and partially connected workflows, so I had to distinguish between problems caused by my changes and problems that were already there.
+
+**How did AI tools help — and where did they fall short?**
+AI was most useful for helping me navigate an unfamiliar codebase, understand existing patterns, think through test cases, and debug tooling issues like my Python environment and pre-commit checks. It also helped me reason about how the new parser should fit into the existing ingestion pipeline. Where it fell short was knowing the intended scope and architecture of the repository. For example, I still needed to inspect the code myself to discover that the existing ingestion methods were not connected to an application-level trigger. I also needed peer review to catch edge cases like the unclosed `<script>` tag that I had not originally tested
+
+
+**What would you do differently if you started over?**
+I would spend more time tracing the complete existing workflow before writing my implementation - I started with the files listed in the issue, but mapping where data entered the system, how the existing ingestion methods were used, and what tests already existed earlier would have made my plan more precise. I would also run the repository-wide linting and type checks before making any changes so I had a clearer baseline of which failures were pre-existing.
+
+**What are you most proud of from this module?**
+I'm most proud that I took on a Tier 2 issue even though this was my first time working through an opensource-style contribution workflow. I was able to go from reproducing a feature gap and navigating an unfamiliar codebase to implementing and testing the feature, opening a structured PR, getting peer feedback, reproducing an edge case from that feedback, and iterating on the implementation instead of treating the first working version as finished.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -14,3 +14,8 @@ Right now PathReview can use GitHub and resume data, but it cannot pull informat
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction summary:**
+I created a profile and confirmed that the app already lets users enter a portfolio URL. However, after tracing the ingestion code, I found that the URL is only stored on the profile and is never fetched or processed. The pipeline currently supports resumes, READMEs, and repository metadata, but there is no web parser or portfolio ingestion flow to add website content to the vector store.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -25,3 +25,38 @@ I created a profile and confirmed that the app already lets users enter a portfo
 **PLAN.md link:** https://github.com/ItzRae/pathreview/blob/feat/11-portfolio-url-ingestion/PLAN.md
 
 **Blockers or open questions:** None at the moment. My remaining work is primarily implementation and tracing the existing ingestion flow to determine the correct integration point.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the core portfolio website ingestion feature. I added a new `WebParser` to extract readable text and metadata from HTML pages, integrated a new `ingest_portfolio()` method into the ingestion pipeline, and added unit tests for both the parser and pipeline. I also verified the implementation by reproducing the issue locally and comparing it with the existing ingestion architecture.
+
+**Next steps:**
+Run final project checks, open a draft PR for feedback, address any review comments, and prepare the PR for final submission.
+
+**Blockers:**
+No major blockers. While tracing the codebase, I found that the existing resume and README ingestion methods are not currently wired into an application-level workflow either, so I began drafting my PR to ask/confirm whether that integration is expected as part of this issue.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/783
+
+**Branch:** `feat/11-portfolio-url-ingestion`
+
+**What you built:**
+Implemented support for ingesting portfolio websites into the existing ingestion pipeline. The new `WebParser` extracts readable content and metadata from HTML pages, and `ingest_portfolio()` fetches portfolio pages, processes them through the existing chunking and embedding workflow, and stores the resulting content with portfolio-specific metadata.
+
+**Tests added or updated:**
+- `tests/unit/test_web_parser.py` — verifies HTML parsing, metadata extraction, ignored elements, and invalid input handling.
+- `tests/unit/test_ingestion_pipeline.py` — verifies successful portfolio ingestion, metadata propagation, invalid URLs, empty pages, duplicate sources, and request failures.
+
+**Self-review confirmation:**
+- [x] make check passes (no new failures introduced beyond documented pre-existing mypy issues)
+- [x] make test-unit passes
+
+**Draft PR feedback received from:**
+None (awaiting feedback)

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,16 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/11
+
+**Issue title:** Add support for ingesting a portfolio website URL
+
+**Tier:** [ ] Tier 1  [x] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+Right now PathReview can use GitHub and resume data, but it cannot pull information from a user’s personal portfolio website. That means project descriptions, bios, and other useful context on a portfolio site are currently left out of the review. This issue would add a web parser that fetches and extracts relevant text from a submitted URL, then passes that content through the existing ingestion pipeline. A successful fix would store that portfolio content in the vector store alongside the user’s other profile data.
+
+**Branch name:** feat/11-portfolio-url-ingestion
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,117 @@
+## Solution plan
+
+**Issue:** [Add support for ingesting a portfolio website URL](https://github.com/ascherj/pathreview/issues/11)
+
+### Understand
+The project currently allows a user to provide a portfolio website URL, but the application does not process the website’s contents as part of the ingestion pipeline.
+
+The profile schema already includes a `portfolio_url` field, so the URL can be accepted and stored. However, the ingestion system only supports resumes, GitHub README files, and repository metadata. There is no parser responsible for fetching and extracting text from a portfolio website and there is no pipeline method that sends portfolio content to the vector store.
+
+#### Expected behavior
+
+When a user provides a valid portfolio URL, PathReview should:
+
+1. Fetch the webpage.
+2. Extract useful, human-readable text from the page.
+3. Convert the extracted content into documents or chunks compatible with the existing ingestion pipeline.
+4. Store the content in the vector store so it can be used during portfolio analysis and review.
+
+#### Actual behavior
+
+The `portfolio_url` value is accepted by the profile schema, but it is not passed through an ingestion workflow. As a result, the portfolio website does not contribute any context to the generated review.
+
+### Map
+The following files and modules are involved:
+
+- `ingestion/parsers/web_parser.py`
+  - New parser for fetching a portfolio URL and extracting readable webpage content
+
+- `ingestion/pipeline.py`
+  - Initialize the new web parser
+  - Add a method such as `ingest_portfolio()` to process and store portfolio website content.
+
+- `api/schemas/profile.py`
+  - Confirm that the existing `portfolio_url` field has the validation needed by the ingestion flow.
+  - Update the schema only if additional URL validation or typing is necessary
+
+- Existing parser modules in `ingestion/parsers/`
+  - Use the resume and README parsers as references for return types, metadata, error handling, and code structure
+
+- Existing ingestion tests
+  - Add tests for webpage parsing and pipeline integration in the test location that matches the repository’s current testing structure.
+
+### Plan
+
+1. **Study the existing parser interface**
+   - Review the resume and README parsers to determine the expected document structure, metadata fields, and error-handling conventions.
+   - Confirm how parsed documents are passed into the vector store.
+
+2. **Implement the web parser**
+   - Create `ingestion/parsers/web_parser.py`.
+   - Fetch the provided URL with a timeout
+   - Parse the returned HTML
+   - Remove non-content elements such as scripts, styles, etc where practical.
+   - Return cleaned page text in the same document format used by the existing ingestion pipeline
+
+3. **Add portfolio ingestion to the pipeline**
+   - Initialize the web parser inside `IngestionPipeline`
+   - Add an `ingest_portfolio()` method
+   - Attach metadata identifying the source as a portfolio website and preserving the original URL
+   - Pass the parsed content into the existing chunking, embedding, and storage workflow
+
+4. **Connect the portfolio URL to the existing profile workflow**
+   - Trace where resume and GitHub ingestion are triggered
+   - Call the new portfolio ingestion method when a profile contains a non-empty `portfolio_url`.
+   - Ensure profiles without a portfolio URL continue to work unchanged
+
+5. **Add tests and verify behavior**
+   - Test successful HTML extraction.
+   - Test invalid URLs, connection failures, timeouts, empty pages, and unsupported responses.
+   - Mock network requests so tests don't depend on live websites
+   - Confirm portfolio content reaches the vector store with the expected metadata.
+
+
+### Inputs & outputs
+#### Input
+
+The feature takes a portfolio website URL, for example:
+
+```text
+https://example.com
+```
+
+#### Output
+
+The feature should produce one or more documents containing cleaned text extracted from the portfolio website.
+
+Each document should include metadata consistent with the existing ingestion system, potentially including:
+
+```text
+{
+    "source": "portfolio",
+    "url": "https://example.com"
+}
+```
+
+If the URL cannot be processed, the system should return or record a clear error without crashing unrelated ingestion tasks.
+
+### Risks & unknowns
+- The repository may already have a shared document format or parser base class that the new parser must follow.
+- It's not yet clear where the complete profile-ingestion workflow is triggered, so an additional API, service, or task file may need to be modified
+- Portfolio websites may depend heavily on JavaScript, while a standard HTTP request will only retrieve the initial HTML.
+- Some sites may block automated requests or return rate-limit responses.
+- Navigation menus, headers, repeated layout text, etc may reduce the quality of the extracted content.
+- The project may expect ingestion failures to raise exceptions, return empty results, or be logged and skipped. This should match existing conventions.
+
+### Edge cases
+My feature should handle gracefully:
+- Missing or empty portfolio URL; invalid URL format
+- Unsupported URL schemes such as file://
+- DNS failures or refused connections / request timeouts
+- Redirects
+- HTTP error responses such as 404, 403, or 500.
+- Non-HTML responses such as PDFs or image files
+- Pages with no meaningful visible text / containing only JavaScript-rendered content
+- Duplicate ingestion of the same portfolio URL
+- HTML containing scripts, styles, tracking text, or malformed markup
+- Portfolio ingestion failing while resume or GitHub ingestion succeeds

--- a/ingestion/parsers/web_parser.py
+++ b/ingestion/parsers/web_parser.py
@@ -1,0 +1,93 @@
+import re
+from html.parser import HTMLParser
+
+from .base import BaseParser, ParseResult
+
+
+class _TextExtractor(HTMLParser):
+    """Extract visible text and page-title content from HTML."""
+
+    _SKIPPED_TAGS = {"script", "style", "noscript", "template"}
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.parts: list[str] = []
+        self.title_parts: list[str] = []
+        self._skip_depth = 0
+        self._in_title = False
+
+    def handle_starttag(
+        self,
+        tag: str,
+        attrs: list[tuple[str, str | None]],
+    ) -> None:
+        """Track skipped elements and title content."""
+        tag = tag.lower()
+
+        if tag in self._SKIPPED_TAGS:
+            self._skip_depth += 1
+        elif tag == "title" and self._skip_depth == 0:
+            self._in_title = True
+
+    def handle_endtag(self, tag: str) -> None:
+        """Stop tracking skipped elements and title content."""
+        tag = tag.lower()
+
+        if tag in self._SKIPPED_TAGS and self._skip_depth > 0:
+            self._skip_depth -= 1
+        elif tag == "title":
+            self._in_title = False
+
+    def handle_data(self, data: str) -> None:
+        """Collect visible text outside skipped elements."""
+        if self._skip_depth > 0:
+            return
+
+        self.parts.append(data)
+
+        if self._in_title:
+            self.title_parts.append(data)
+
+
+class WebParser(BaseParser):
+    """Parse visible text from portfolio website HTML."""
+
+    def parse(self, content: str | bytes) -> ParseResult:
+        """Extract readable text and metadata from HTML content.
+
+        Args:
+            content: Portfolio page HTML as text or UTF-8 bytes.
+
+        Returns:
+            Parsed page text and metadata.
+
+        Raises:
+            ValueError: If the supplied content cannot be parsed as HTML text.
+        """
+        if isinstance(content, bytes):
+            content = content.decode("utf-8", errors="replace")
+
+        if not isinstance(content, str):
+            raise ValueError("Content must be an HTML string or bytes")
+
+        extractor = _TextExtractor()
+        extractor.feed(content)
+        extractor.close()
+
+        text = self._normalize_whitespace(extractor.parts)
+        title = self._normalize_whitespace(extractor.title_parts)
+
+        return ParseResult(
+            text=text,
+            metadata={
+                "source_type": "web",
+                "title": title,
+                "word_count": len(text.split()),
+            },
+            source_type="web",
+        )
+
+    @staticmethod
+    def _normalize_whitespace(parts: list[str]) -> str:
+        """Join text fragments and collapse repeated whitespace."""
+        return re.sub(r"\s+", " ", " ".join(parts)).strip()

--- a/ingestion/parsers/web_parser.py
+++ b/ingestion/parsers/web_parser.py
@@ -43,14 +43,31 @@ class _TextExtractor(HTMLParser):
         if self._skip_depth > 0:
             return
 
-        self.parts.append(data)
-
         if self._in_title:
             self.title_parts.append(data)
+            return
+
+        self.parts.append(data)
 
 
 class WebParser(BaseParser):
     """Parse visible text from portfolio website HTML."""
+
+    @staticmethod
+    def _close_unterminated_skipped_tags(content: str) -> str:
+        """Remove unterminated skipped tags so later text can still be parsed."""
+        skipped_tags = ("script", "style", "noscript", "template")
+
+        for tag in skipped_tags:
+            pattern = rf"<{tag}\b[^>]*>(?!.*</{tag}\s*>)"
+            content = re.sub(
+                pattern,
+                "",
+                content,
+                flags=re.IGNORECASE | re.DOTALL,
+            )
+
+        return content
 
     def parse(self, content: str | bytes) -> ParseResult:
         """Extract readable text and metadata from HTML content.
@@ -70,6 +87,9 @@ class WebParser(BaseParser):
         if not isinstance(content, str):
             raise ValueError("Content must be an HTML string or bytes")
 
+        # sanitize malformed skipped tags before parsing
+        content = self._close_unterminated_skipped_tags(content)
+
         extractor = _TextExtractor()
         extractor.feed(content)
         extractor.close()
@@ -80,7 +100,6 @@ class WebParser(BaseParser):
         return ParseResult(
             text=text,
             metadata={
-                "source_type": "web",
                 "title": title,
                 "word_count": len(text.split()),
             },

--- a/ingestion/pipeline.py
+++ b/ingestion/pipeline.py
@@ -1,6 +1,8 @@
 import hashlib
 from dataclasses import dataclass
-from typing import Optional
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlparse
+from urllib.request import Request, urlopen
 
 import structlog
 
@@ -10,7 +12,7 @@ from .embeddings.provider import EmbeddingProvider
 from .parsers.readme_parser import ReadmeParser
 from .parsers.repo_analyzer import RepoAnalyzer
 from .parsers.resume_parser import ResumeParser
-
+from .parsers.web_parser import WebParser
 
 logger = structlog.get_logger()
 
@@ -18,10 +20,11 @@ logger = structlog.get_logger()
 @dataclass
 class IngestResult:
     """Result of ingesting a source."""
+
     source_id: str
     chunk_count: int
     skipped: bool
-    skip_reason: Optional[str] = None
+    skip_reason: str | None = None
 
 
 class IngestionPipeline:
@@ -50,7 +53,142 @@ class IngestionPipeline:
         # Initialize parsers
         self.resume_parser = ResumeParser()
         self.readme_parser = ReadmeParser()
+        self.web_parser = WebParser()
         self.repo_analyzer = RepoAnalyzer()
+
+    def ingest_portfolio(
+        self,
+        profile_id: str,
+        portfolio_url: str,
+    ) -> IngestResult:
+        """
+        Fetch and ingest a portfolio website.
+
+        Args:
+            profile_id: ID of the profile owner
+            portfolio_url: URL of the portfolio website
+
+        Returns:
+            IngestResult with ingestion status
+
+        """
+
+        parsed_url = urlparse(portfolio_url)
+
+        if parsed_url.scheme not in {"http", "https"} or not parsed_url.netloc:
+            raise ValueError("Portfolio URL must be a valid HTTP or HTTPS URL.")
+
+        logger.info(
+            "Starting portfolio website ingestion",
+            profile_id=profile_id,
+            portfolio_url=portfolio_url,
+        )
+
+        try:
+            request = Request(
+                portfolio_url,
+                headers={
+                    "User-Agent": "PathReview/1.0",
+                    "Accept": "text/html",
+                },
+            )
+
+            with urlopen(request, timeout=10) as response:
+                content_type = response.headers.get_content_type()
+
+                if content_type != "text/html":
+                    raise ValueError(f"Portfolio URL must return HTML, received {content_type}")
+
+                html_content = response.read()
+
+        except HTTPError as exc:
+            logger.error(
+                "Portfolio request returned an HTTP error",
+                profile_id=profile_id,
+                portfolio_url=portfolio_url,
+                status_code=exc.code,
+            )
+            raise RuntimeError(f"Portfolio website returned HTTP status {exc.code}") from exc
+
+        except URLError as exc:
+            logger.error(
+                "Portfolio website could not be reached",
+                profile_id=profile_id,
+                portfolio_url=portfolio_url,
+                error=str(exc.reason),
+            )
+            raise RuntimeError("Portfolio website could not be reached") from exc
+
+        source_id = f"portfolio_{profile_id}_{self._hash_content(html_content)}"
+
+        skip_result = self._check_skip(source_id, "portfolio")
+        if skip_result:
+            return skip_result
+
+        try:
+            parse_result = self.web_parser.parse(html_content)
+
+            if not parse_result.text:
+                raise ValueError("Portfolio website contains no readable text")
+
+            logger.info(
+                "Portfolio website parsed successfully",
+                profile_id=profile_id,
+                portfolio_url=portfolio_url,
+                title=parse_result.metadata.get("title"),
+                word_count=parse_result.metadata.get("word_count"),
+            )
+
+            metadata = parse_result.metadata.copy()
+            metadata.update(
+                {
+                    "source_id": source_id,
+                    "profile_id": profile_id,
+                    "portfolio_url": portfolio_url,
+                    "source_type": "web",
+                }
+            )
+
+            chunks = self.strategy_selector.chunk(
+                parse_result.text,
+                metadata,
+            )
+
+            logger.info(
+                "Portfolio website chunked successfully",
+                profile_id=profile_id,
+                chunk_count=len(chunks),
+            )
+
+            self.batch_processor.process(chunks)
+
+            logger.info(
+                "Portfolio embeddings stored",
+                profile_id=profile_id,
+                chunk_count=len(chunks),
+            )
+
+            self._record_ingested_source(
+                source_id,
+                "portfolio",
+                profile_id,
+                len(chunks),
+            )
+
+            return IngestResult(
+                source_id=source_id,
+                chunk_count=len(chunks),
+                skipped=False,
+            )
+
+        except Exception as exc:
+            logger.error(
+                "Portfolio website ingestion failed",
+                profile_id=profile_id,
+                portfolio_url=portfolio_url,
+                error=str(exc),
+            )
+            raise
 
     def ingest_resume(
         self,
@@ -86,16 +224,21 @@ class IngestionPipeline:
         try:
             # Parse resume
             parse_result = self.resume_parser.parse(content)
-            logger.info("Resume parsed successfully", sections=parse_result.metadata.get("detected_sections"))
+            logger.info(
+                "Resume parsed successfully",
+                sections=parse_result.metadata.get("detected_sections"),
+            )
 
             # Prepare metadata
             metadata = parse_result.metadata.copy()
-            metadata.update({
-                "source_id": source_id,
-                "profile_id": profile_id,
-                "filename": filename,
-                "source_type": "resume",
-            })
+            metadata.update(
+                {
+                    "source_id": source_id,
+                    "profile_id": profile_id,
+                    "filename": filename,
+                    "source_type": "resume",
+                }
+            )
 
             # Chunk the content
             chunks = self.strategy_selector.chunk(parse_result.text, metadata)
@@ -165,12 +308,14 @@ class IngestionPipeline:
 
             # Prepare metadata
             metadata = parse_result.metadata.copy()
-            metadata.update({
-                "source_id": source_id,
-                "profile_id": profile_id,
-                "repo_name": repo_name,
-                "source_type": "readme",
-            })
+            metadata.update(
+                {
+                    "source_id": source_id,
+                    "profile_id": profile_id,
+                    "repo_name": repo_name,
+                    "source_type": "readme",
+                }
+            )
 
             # Chunk the content
             chunks = self.strategy_selector.chunk(parse_result.text, metadata)
@@ -239,11 +384,13 @@ class IngestionPipeline:
 
             # Prepare metadata
             metadata = parse_result.metadata.copy()
-            metadata.update({
-                "source_id": source_id,
-                "profile_id": profile_id,
-                "source_type": "repo",
-            })
+            metadata.update(
+                {
+                    "source_id": source_id,
+                    "profile_id": profile_id,
+                    "source_type": "repo",
+                }
+            )
 
             # Chunk the content
             chunks = self.strategy_selector.chunk(parse_result.text, metadata)
@@ -277,7 +424,7 @@ class IngestionPipeline:
             content = content.encode()
         return hashlib.sha256(content).hexdigest()[:16]
 
-    def _check_skip(self, source_id: str, source_type: str) -> Optional[IngestResult]:
+    def _check_skip(self, source_id: str, source_type: str) -> IngestResult | None:
         """
         Check if source has already been ingested.
 
@@ -286,9 +433,11 @@ class IngestionPipeline:
         try:
             # Query database for existing source
             # This assumes a table/model named IngestedSource
-            existing = self.db_session.query(
-                "IngestedSource"  # Placeholder - actual query depends on ORM
-            ).filter_by(source_id=source_id).first()
+            existing = (
+                self.db_session.query("IngestedSource")  # Placeholder - actual query depends on ORM
+                .filter_by(source_id=source_id)
+                .first()
+            )
 
             if existing:
                 logger.info("Source already ingested, skipping", source_id=source_id)

--- a/tests/unit/test_ingestion_pipeline.py
+++ b/tests/unit/test_ingestion_pipeline.py
@@ -1,0 +1,274 @@
+"""Tests for portfolio website ingestion."""
+
+from email.message import Message
+from typing import Any, cast
+from unittest.mock import MagicMock, Mock, patch
+from urllib.error import HTTPError, URLError
+
+import pytest
+
+from ingestion.parsers.base import ParseResult
+from ingestion.pipeline import IngestionPipeline
+
+
+@pytest.mark.unit
+class TestPortfolioIngestion:
+    """Test suite for portfolio website ingestion."""
+
+    @pytest.fixture
+    def pipeline(self) -> Any:
+        """Create an ingestion pipeline with mocked dependencies."""
+        pipeline = IngestionPipeline(
+            vector_db=Mock(),
+            db_session=Mock(),
+            embedding_provider=Mock(),
+        )
+
+        mock_pipeline = cast(Any, pipeline)
+
+        mock_pipeline.web_parser = Mock()
+        mock_pipeline.strategy_selector = Mock()
+        mock_pipeline.batch_processor = Mock()
+        mock_pipeline._check_skip = Mock(return_value=None)
+        mock_pipeline._record_ingested_source = Mock()
+
+        return mock_pipeline
+
+    @patch("ingestion.pipeline.urlopen")
+    def test_ingest_portfolio_success(
+        self,
+        mock_urlopen: Mock,
+        pipeline: Any,
+    ) -> None:
+        """Test successful portfolio fetching, parsing, and ingestion."""
+        html = b"""
+        <html>
+            <head><title>Jane Doe Portfolio</title></head>
+            <body>
+                <h1>Jane Doe</h1>
+                <p>Software engineer building AI applications.</p>
+            </body>
+        </html>
+        """
+
+        response = MagicMock()
+        response.read.return_value = html
+        response.headers.get_content_type.return_value = "text/html"
+        mock_urlopen.return_value.__enter__.return_value = response
+
+        parse_result = ParseResult(
+            text="Jane Doe Software engineer building AI applications.",
+            metadata={
+                "source_type": "web",
+                "title": "Jane Doe Portfolio",
+                "word_count": 7,
+            },
+            source_type="web",
+        )
+        pipeline.web_parser.parse.return_value = parse_result
+
+        chunks = [Mock(), Mock()]
+        pipeline.strategy_selector.chunk.return_value = chunks
+
+        result = pipeline.ingest_portfolio(
+            profile_id="profile-123",
+            portfolio_url="https://example.com",
+        )
+
+        mock_urlopen.assert_called_once()
+        pipeline.web_parser.parse.assert_called_once_with(html)
+
+        pipeline.strategy_selector.chunk.assert_called_once()
+        chunk_text, metadata = pipeline.strategy_selector.chunk.call_args.args
+
+        assert chunk_text == parse_result.text
+        assert metadata["profile_id"] == "profile-123"
+        assert metadata["portfolio_url"] == "https://example.com"
+        assert metadata["source_type"] == "web"
+        assert metadata["title"] == "Jane Doe Portfolio"
+        assert metadata["source_id"].startswith("portfolio_profile-123_")
+
+        pipeline.batch_processor.process.assert_called_once_with(chunks)
+
+        pipeline._record_ingested_source.assert_called_once_with(
+            result.source_id,
+            "portfolio",
+            "profile-123",
+            2,
+        )
+
+        assert result.chunk_count == 2
+        assert result.skipped is False
+        assert result.source_id.startswith("portfolio_profile-123_")
+
+    def test_ingest_portfolio_rejects_invalid_url(
+        self,
+        pipeline: Any,
+    ) -> None:
+        """Test that non-HTTP portfolio URLs are rejected."""
+        with pytest.raises(
+            ValueError,
+            match="valid HTTP or HTTPS URL",
+        ):
+            pipeline.ingest_portfolio(
+                profile_id="profile-123",
+                portfolio_url="not-a-valid-url",
+            )
+
+        pipeline.web_parser.parse.assert_not_called()
+        pipeline.batch_processor.process.assert_not_called()
+
+    @patch("ingestion.pipeline.urlopen")
+    def test_ingest_portfolio_handles_connection_failure(
+        self,
+        mock_urlopen: Mock,
+        pipeline: Any,
+    ) -> None:
+        """Test that connection failures produce a clear error."""
+        mock_urlopen.side_effect = URLError("Connection refused")
+
+        with pytest.raises(
+            RuntimeError,
+            match="could not be reached",
+        ):
+            pipeline.ingest_portfolio(
+                profile_id="profile-123",
+                portfolio_url="https://example.com",
+            )
+
+        pipeline.web_parser.parse.assert_not_called()
+        pipeline.batch_processor.process.assert_not_called()
+
+    @patch("ingestion.pipeline.urlopen")
+    def test_ingest_portfolio_handles_timeout(
+        self,
+        mock_urlopen: Mock,
+        pipeline: Any,
+    ) -> None:
+        """Test that request timeouts are handled gracefully."""
+        mock_urlopen.side_effect = URLError(TimeoutError("Request timed out"))
+
+        with pytest.raises(
+            RuntimeError,
+            match="could not be reached",
+        ):
+            pipeline.ingest_portfolio(
+                profile_id="profile-123",
+                portfolio_url="https://example.com",
+            )
+
+        pipeline.web_parser.parse.assert_not_called()
+        pipeline.batch_processor.process.assert_not_called()
+
+    @patch("ingestion.pipeline.urlopen")
+    def test_ingest_portfolio_rejects_non_html_response(
+        self,
+        mock_urlopen: Mock,
+        pipeline: Any,
+    ) -> None:
+        """Test that non-HTML portfolio responses are rejected."""
+        response = MagicMock()
+        response.headers.get_content_type.return_value = "application/pdf"
+        mock_urlopen.return_value.__enter__.return_value = response
+
+        with pytest.raises(
+            ValueError,
+            match="must return HTML",
+        ):
+            pipeline.ingest_portfolio(
+                profile_id="profile-123",
+                portfolio_url="https://example.com/portfolio.pdf",
+            )
+
+        pipeline.web_parser.parse.assert_not_called()
+        pipeline.batch_processor.process.assert_not_called()
+
+    @patch("ingestion.pipeline.urlopen")
+    def test_ingest_portfolio_rejects_empty_page(
+        self,
+        mock_urlopen: Mock,
+        pipeline: Any,
+    ) -> None:
+        """Test that pages with no readable content are rejected."""
+        response = MagicMock()
+        response.read.return_value = b"<html><body></body></html>"
+        response.headers.get_content_type.return_value = "text/html"
+        mock_urlopen.return_value.__enter__.return_value = response
+
+        pipeline.web_parser.parse.return_value = ParseResult(
+            text="",
+            metadata={
+                "source_type": "web",
+                "title": "",
+                "word_count": 0,
+            },
+            source_type="web",
+        )
+
+        with pytest.raises(
+            ValueError,
+            match="no readable text",
+        ):
+            pipeline.ingest_portfolio(
+                profile_id="profile-123",
+                portfolio_url="https://example.com",
+            )
+
+        pipeline.batch_processor.process.assert_not_called()
+        pipeline._record_ingested_source.assert_not_called()
+
+    @patch("ingestion.pipeline.urlopen")
+    def test_ingest_portfolio_handles_http_error(
+        self,
+        mock_urlopen: Mock,
+        pipeline: Any,
+    ) -> None:
+        """Test that unsuccessful HTTP responses are handled."""
+        mock_urlopen.side_effect = HTTPError(
+            url="https://example.com",
+            code=404,
+            msg="Not Found",
+            hdrs=Message(),
+            fp=None,
+        )
+
+        with pytest.raises(
+            RuntimeError,
+            match="HTTP status 404",
+        ):
+            pipeline.ingest_portfolio(
+                profile_id="profile-123",
+                portfolio_url="https://example.com",
+            )
+
+        pipeline.web_parser.parse.assert_not_called()
+        pipeline.batch_processor.process.assert_not_called()
+
+    @patch("ingestion.pipeline.urlopen")
+    def test_ingest_portfolio_skips_duplicate_source(
+        self,
+        mock_urlopen: Mock,
+        pipeline: Any,
+    ) -> None:
+        """Test that previously ingested portfolio content is skipped."""
+        response = MagicMock()
+        response.read.return_value = b"<html><body>Portfolio</body></html>"
+        response.headers.get_content_type.return_value = "text/html"
+        mock_urlopen.return_value.__enter__.return_value = response
+
+        skipped_result = Mock(
+            source_id="portfolio_profile-123_existing",
+            chunk_count=0,
+            skipped=True,
+            skip_reason="Source already ingested",
+        )
+        pipeline._check_skip.return_value = skipped_result
+
+        result = pipeline.ingest_portfolio(
+            profile_id="profile-123",
+            portfolio_url="https://example.com",
+        )
+
+        assert result is skipped_result
+        pipeline.web_parser.parse.assert_not_called()
+        pipeline.batch_processor.process.assert_not_called()

--- a/tests/unit/test_web_parser.py
+++ b/tests/unit/test_web_parser.py
@@ -24,8 +24,25 @@ def test_parse_extracts_visible_text(parser: WebParser) -> None:
     assert "Rachel Lin" in result.text
     assert "Software engineer building AI applications." in result.text
     assert result.metadata["title"] == "Rachel's Portfolio"
-    assert result.metadata["source_type"] == "web"
     assert result.source_type == "web"
+
+
+def test_parse_handles_unclosed_script_tag(parser: WebParser) -> None:
+    html = """
+    <html>
+        <body>
+            <p>Visible before script</p>
+            <script>
+                broken script
+            <p>Visible after script</p>
+        </body>
+    </html>
+    """
+
+    result = parser.parse(html)
+
+    assert "Visible before script" in result.text
+    assert "Visible after script" in result.text
 
 
 def test_parse_ignores_script_and_style_content(parser: WebParser) -> None:

--- a/tests/unit/test_web_parser.py
+++ b/tests/unit/test_web_parser.py
@@ -1,0 +1,81 @@
+import pytest
+
+from ingestion.parsers.web_parser import WebParser
+
+
+@pytest.fixture
+def parser() -> WebParser:
+    return WebParser()
+
+
+def test_parse_extracts_visible_text(parser: WebParser) -> None:
+    html = """
+    <html>
+        <head><title>Rachel's Portfolio</title></head>
+        <body>
+            <h1>Rachel Lin</h1>
+            <p>Software engineer building AI applications.</p>
+        </body>
+    </html>
+    """
+
+    result = parser.parse(html)
+
+    assert "Rachel Lin" in result.text
+    assert "Software engineer building AI applications." in result.text
+    assert result.metadata["title"] == "Rachel's Portfolio"
+    assert result.metadata["source_type"] == "web"
+    assert result.source_type == "web"
+
+
+def test_parse_ignores_script_and_style_content(parser: WebParser) -> None:
+    html = """
+    <html>
+        <head>
+            <style>.secret { display: none; }</style>
+            <script>console.log("hidden script text")</script>
+        </head>
+        <body>
+            <p>Visible portfolio content</p>
+        </body>
+    </html>
+    """
+
+    result = parser.parse(html)
+
+    assert "Visible portfolio content" in result.text
+    assert "hidden script text" not in result.text
+    assert "display: none" not in result.text
+
+
+def test_parse_collapses_whitespace(parser: WebParser) -> None:
+    html = "<p>Hello      world</p>\n\n<p>Project description</p>"
+
+    result = parser.parse(html)
+
+    assert result.text == "Hello world Project description"
+
+
+def test_parse_handles_missing_title(parser: WebParser) -> None:
+    result = parser.parse("<html><body><p>Portfolio content</p></body></html>")
+
+    assert result.metadata["title"] == ""
+    assert result.text == "Portfolio content"
+
+
+def test_parse_accepts_bytes(parser: WebParser) -> None:
+    result = parser.parse(b"<p>Byte content</p>")
+
+    assert result.text == "Byte content"
+
+
+def test_parse_empty_html(parser: WebParser) -> None:
+    result = parser.parse("")
+
+    assert result.text == ""
+    assert result.metadata["word_count"] == 0
+
+
+def test_parse_rejects_unsupported_content_type(parser: WebParser) -> None:
+    with pytest.raises(ValueError, match="HTML string or bytes"):
+        parser.parse(123)  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary
This PR adds support for ingesting portfolio websites into the existing ingestion pipeline. It introduces a new HTML parser that extracts readable content from portfolio pages, preserves useful metadata (such as the page title and original URL), and passes the extracted text through the existing chunking, embedding, and vector storage workflow.

## Issue
Closes #11 

## Changes
- Added a new `WebParser` for extracting visible text from HTML portfolio pages
- Added `ingest_portfolio()` to `IngestionPipeline`
- Preserved portfolio metadata, including the original URL and page title
- Reused the existing chunking, embedding, and storage pipeline for portfolio content
- Added unit tests for `WebParser`
- Added unit tests covering successful portfolio ingestion, metadata propagation, invalid URLs, empty pages, duplicate sources, and request failures

## Testing
- [x] Unit tests pass (`pytest tests/unit/test_web_parser.py`)
- [x] Unit tests pass (`pytest tests/unit/test_ingestion_pipeline.py`)
- [ ] Integration tests pass (`make test-integration`) *(not run)*
- [x] Linter passes (`make lint`)
- [ ] Type checker passes (`make typecheck`)

Type checking currently reports pre-existing mypy errors in the repository (for example in the chunking modules and existing portions of `ingestion/pipeline.py`). My changes do not introduce any additional mypy errors beyond those already present.

- [x] New tests cover the added functionality

## Screenshots / Demo
N/A

## Notes for Reviewers
While tracing the ingestion flow, I found that the existing `ingest_resume()` and `ingest_readme()` pipeline methods are also not currently invoked outside `ingestion/pipeline.py`. Because of that, this PR focuses on adding portfolio ingestion support to the pipeline itself rather than introducing a new application-level trigger that would only apply to portfolio URLs.

I would appreciate feedback on whether wiring all ingestion methods into the profile workflow is intended for this issue or should be handled in a separate change.