### PR TITLE
fix: configure structlog for stdlib logging in tests (#159)

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -56,7 +56,7 @@ None — the plan from Week 8 held up as written.
 
 **Branch:** `fix/159-structured-caplog-fix`
 
-**PR link:** [\[add once opened\]](https://github.com/DariaZS/pathreview/pull/784)
+**PR link:** `https://github.com/DariaZS/pathreview/pull/784`
 
 **What was built:**
 Added an `autouse`, session-scoped pytest fixture in `tests/conftest.py` that calls the existing (but previously unused) `configure_logging()` function before the test session starts. This routes structlog through Python's stdlib `logging` module, so pytest's `caplog` fixture can correctly capture structlog events — fixing suite-wide log assertion failures described in issue #159.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -56,7 +56,7 @@ None — the plan from Week 8 held up as written.
 
 **Branch:** `fix/159-structured-caplog-fix`
 
-**PR link:** [add once opened]
+**PR link:** [\[add once opened\]](https://github.com/DariaZS/pathreview/pull/784)
 
 **What was built:**
 Added an `autouse`, session-scoped pytest fixture in `tests/conftest.py` that calls the existing (but previously unused) `configure_logging()` function before the test session starts. This routes structlog through Python's stdlib `logging` module, so pytest's `caplog` fixture can correctly capture structlog events — fixing suite-wide log assertion failures described in issue #159.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -36,3 +36,34 @@ Ran `tests/unit/test_batch_processor.py::test_empty_chunks_list_returns_empty` a
 
 **Blockers or open questions:**
 None yet — root cause is clear. Still deciding exact scope of the fix (test-only fixture vs. also wiring configure_logging() into app startup).
+
+## Week 9 — Implementation & PR submission
+
+### Check-in 1 (mid-week)
+
+**Progress:**
+Completed Plan step 1 (added `configure_logging()` fixture to `tests/conftest.py`) and step 2 (confirmed `tests/unit/test_batch_processor.py::test_empty_chunks_list_returns_empty` now passes, up from 141s cold-run to 0.37s once cached). Verified via `git stash` that the 52 pre-existing failures found in `make test-all` are unrelated to this fix — identical failures occur with or without the fixture in place.
+
+**Next steps:**
+Add a dedicated regression test that directly exercises the fix (not just an existing test that benefits from it), run the repo-wide lint/type checks, and open the PR.
+
+**Blockers:**
+None — the plan from Week 8 held up as written.
+
+---
+
+### Check-in 2 (end of week)
+
+**Branch:** `fix/159-structured-caplog-fix`
+
+**PR link:** [add once opened]
+
+**What was built:**
+Added an `autouse`, session-scoped pytest fixture in `tests/conftest.py` that calls the existing (but previously unused) `configure_logging()` function before the test session starts. This routes structlog through Python's stdlib `logging` module, so pytest's `caplog` fixture can correctly capture structlog events — fixing suite-wide log assertion failures described in issue #159.
+
+**Tests:**
+Added `tests/unit/test_logging_config.py::test_configure_logging_enables_caplog_capture` — a new regression test that directly verifies structlog output reaches `caplog.text` (independent of any other test's behavior). Also confirmed the originally-failing test, `tests/unit/test_batch_processor.py::test_empty_chunks_list_returns_empty`, now passes.
+
+**Self-review:**
+- [x] `make check` passes for this PR's files — repo-wide `make check` fails due to 182 pre-existing lint errors in unrelated test files (unsorted imports, unused variables, long lines — none in files this PR touches). Verified `ruff check tests/conftest.py tests/unit/test_logging_config.py` passes cleanly, and `black`/`mypy` passed via pre-commit hooks on every commit in this PR.
+- [x] `make test-unit` passes for files touched by this PR (verified individually; full-suite run surfaces the 52 pre-existing unrelated failures noted above)

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -23,3 +23,16 @@ The application logs through structlog, but structlog isn't configured to propag
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [will fill in after commit]
+
+**Reproduction summary:**
+Ran `tests/unit/test_batch_processor.py::test_empty_chunks_list_returns_empty` and confirmed the failure: the warning "Empty chunks list provided to BatchEmbeddingProcessor" appears in captured stdout, but `caplog.text` and `caplog.records` are both empty, so the assertion fails. Traced the root cause to `core/logging.py`: `configure_logging()` wires structlog into Python's stdlib `logging` module (which `caplog` listens to), but this function is never actually called anywhere in the codebase — not in tests, not even at app startup in `api/main.py`. As a result, structlog falls back to its default `PrintLoggerFactory`, which writes straight to stdout and bypasses stdlib logging entirely.
+
+**PLAN.md link:** [will fill in after commit]
+
+**Blockers or open questions:**
+None yet — root cause is clear. Still deciding exact scope of the fix (test-only fixture vs. also wiring configure_logging() into app startup).

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,25 @@
+# PathReview Contribution Journal
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/159
+
+**Issue title:** structlog output is not captured by pytest caplog — log assertions fail suite-wide
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The application logs through structlog, but structlog isn't configured to propagate its output into Python's standard library logging system during tests. Because pytest's `caplog` fixture only sees events that go through stdlib logging, every test that asserts on `caplog` fails — even though the code under test is correctly emitting the expected log event (visible directly on stderr). This is a suite-wide problem, not a single-file bug, since any test anywhere that checks "did we log this correctly" depends on the same broken wiring. A successful fix configures structlog in `tests/conftest.py` — likely using `structlog.stdlib` processors or a `capture_logs` helper — so that `caplog`-based assertions correctly detect the log events again.
+
+**Scope reasoning ("Is this right for me?" checklist):**
+- *Actually open?* Confirmed via the issue sidebar — no branches or linked PRs. One other commenter (`amanadhav`) stated intent to work on it but has no commits or branch yet.
+- *Scope clear?* Yes — the issue names the exact root cause (structlog not propagating into stdlib logging), gives concrete reproduction steps, and points to the likely fix location (`tests/conftest.py`).
+- *Right size?* Likely small — this is a test-configuration fix localized to one file, not a multi-service change.
+- *Maintainer active?* N/A — this is a class repository, not an actively maintained open-source project.
+- *Matches where I am?* Yes — I spent this week's setup debugging Docker health checks and container logging output, so I have direct, recent experience with "the underlying behavior is correct, but the check/assertion around it is misconfigured," which is exactly this bug's shape.
+
+**Branch name:** docs/159-structured-caplog-fix
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -67,3 +67,34 @@ Added `tests/unit/test_logging_config.py::test_configure_logging_enables_caplog_
 **Self-review:**
 - [x] `make check` passes for this PR's files — repo-wide `make check` fails due to 182 pre-existing lint errors in unrelated test files (unsorted imports, unused variables, long lines — none in files this PR touches). Verified `ruff check tests/conftest.py tests/unit/test_logging_config.py` passes cleanly, and `black`/`mypy` passed via pre-commit hooks on every commit in this PR.
 - [x] `make test-unit` passes for files touched by this PR (verified individually; full-suite run surfaces the 52 pre-existing unrelated failures noted above)
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No reviewer feedback came in - per the course note, revewer feedback isn't an active feature in Summer 20206
+
+**How you responded:**
+N/A - no feedback to respond to.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Verifying my fix didn't break anything else was harder than the fix itself. Running the full suite surfaces 52 failing tests, and my first reaction was to assume I'd caused them. Instead of guessing, I used `git stash` to remove my change and re-ran the same failing tests - they failed identically without my fix in place, confirming they were pre-existing. That extra step took real time, but it's the difference between an assumption and something I could defend in a PR.
+
+**What did you learn about working in a large codebase?**
+The biggest surprise wasn't a bug - it was dead code. `configure_logging()` was fully written, well-documented, and looked production-ready, but it was never actually called anywhere, not even at app startup. In my own projects, if I write a function, I call it. In a larger codebase, a funcion can exist, look correct, and still not be wired in. That's a different kind of but to look for, not just 'does this work' but 'does anything actually using this.'
+
+**How did AI tools help — and where did they fall short?**
+AI was most useful for keeping me moving in small, verifiable steps when I was exhausted and pulled in a lot of different directions this week - reproducing the bug methodically, writing the regression test, and catching things I'd have skipped under pressure (such as skipping `ruff` to just my changed files, or checkign `CONTRIBUTING.md` for the correct brunch naming convention before opening the PR). Where it fell short: it can't run my terminal, restart Docker, or notice a typo like `make test all` instead of `make test-all`, I still had to debug my environment.
+
+**What would you do differently if you started over?**
+I'd read the brunch naming convention in `CONTRIBUTING.md` before creating my brunch in Week 7, instead of discovering the mismatch (`docs/` vs `fix/`) in Week 9 and having to rename it later.
+
+**What are you most proud of from this module?**
+Catching that 'Tests Adequately Cover The Changes' was still an open gap, even after my fix already worked. It would've been easy to submit once the original failing test passed, but I noticed the difference between a test that *benefits* from my fix and one that *directly verifies* it, and wrote `test_logging_config.py` to close that gap before submitting

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -27,12 +27,12 @@ The application logs through structlog, but structlog isn't configured to propag
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [will fill in after commit]
+**Reproduction commit link:** `https://github.com/DariaZS/pathreview/commit/4f9ffee`
 
 **Reproduction summary:**
 Ran `tests/unit/test_batch_processor.py::test_empty_chunks_list_returns_empty` and confirmed the failure: the warning "Empty chunks list provided to BatchEmbeddingProcessor" appears in captured stdout, but `caplog.text` and `caplog.records` are both empty, so the assertion fails. Traced the root cause to `core/logging.py`: `configure_logging()` wires structlog into Python's stdlib `logging` module (which `caplog` listens to), but this function is never actually called anywhere in the codebase — not in tests, not even at app startup in `api/main.py`. As a result, structlog falls back to its default `PrintLoggerFactory`, which writes straight to stdout and bypasses stdlib logging entirely.
 
-**PLAN.md link:** [will fill in after commit]
+**PLAN.md link:** `https://github.com/DariaZS/pathreview/blob/docs/159-structured-caplog-fix/PLAN.md`
 
 **Blockers or open questions:**
 None yet — root cause is clear. Still deciding exact scope of the fix (test-only fixture vs. also wiring configure_logging() into app startup).

--- a/PLAN.md
+++ b/PLAN.md
@@ -60,4 +60,5 @@ Output: after the fix, structlog log calls made during tests will produce stdlib
 - Multiple tests running in the same session with `cache_logger_on_first_use=True` — confirm a logger configured in one test doesn't carry stale state into the next.
 - Tests that already inspect stdout directly (e.g. via `capsys`) instead of `caplog` — confirm they still pass once output also starts flowing through stdlib logging (could result in duplicate output if both stdout print and logging handler are active).
 
-
+### Outcome
+Implemented steps 1–3 and 5 as planned. Step 4 (wiring `configure_logging()` into `api/main.py`) was deliberately deferred — flagged as a follow-up issue in the PR's "Notes for Reviewers" rather than bundled into this fix, to keep the PR scoped to the test-capture bug in #159.

--- a/PLAN.md
+++ b/PLAN.md
@@ -7,6 +7,29 @@ Expected: log events emitted via structlog (e.g. the "Empty chunks list" warning
 
 Actual: structlog is never configured in the test environment — `configure_logging()` in `core/logging.py`, which wires structlog into stdlib logging via `structlog.stdlib.LoggerFactory()`, is defined but never called anywhere in the codebase (not in tests, not even at app startup in `api/main.py`). Without it, structlog falls back to its default `PrintLoggerFactory`, which writes directly to stdout and never touches stdlib logging — so `caplog` sees nothing, even though the log call happened correctly.
 
+
+### Log flow — before the fix
+
+```mermaid
+flowchart LR
+    A[App code calls log.warning] --> B[structlog default PrintLoggerFactory]
+    B --> C[stdout]
+    D[pytest caplog] -.->|listens to| E[stdlib logging root logger]
+    E -.->|never receives events| F[caplog.records stays empty]
+```
+
+### Log flow — after the fix
+
+```mermaid
+flowchart LR
+    A[App code calls log.warning] --> B[structlog.stdlib.LoggerFactory]
+    B --> C[stdlib logging root logger]
+    C --> D[stdout]
+    C --> E[pytest caplog handler]
+    E --> F[caplog.records populated correctly]
+```
+
+
 ### Map
 - `core/logging.py` — contains `configure_logging()`, the function that sets up structlog's processor chain and routes it through stdlib logging. This is the function that needs to be invoked.
 - `tests/conftest.py` — currently has no logging-related fixtures at all; this is where the fix will likely live (a fixture that calls `configure_logging()` before each test, or once per session).
@@ -36,3 +59,20 @@ Output: after the fix, structlog log calls made during tests will produce stdlib
 - Tests that check for the *absence* of log output (e.g. asserting no warnings were logged) — must still pass once logging is actually wired up, not just tests expecting a positive match.
 - Multiple tests running in the same session with `cache_logger_on_first_use=True` — confirm a logger configured in one test doesn't carry stale state into the next.
 - Tests that already inspect stdout directly (e.g. via `capsys`) instead of `caplog` — confirm they still pass once output also starts flowing through stdlib logging (could result in duplicate output if both stdout print and logging handler are active).
+
+
+## Summary
+Fixes #159 — structlog log output was not visible to pytest's `caplog` fixture, causing log-based test assertions to fail even though logging worked correctly.
+
+## Root cause
+`configure_logging()` in `core/logging.py` wires structlog into Python's stdlib `logging` module (which `caplog` listens to via `structlog.stdlib.LoggerFactory()`). This function was fully implemented but never actually called anywhere — not in tests, and not at app startup. As a result, structlog fell back to its default `PrintLoggerFactory`, writing directly to stdout and bypassing stdlib logging entirely.
+
+## Fix
+Added an `autouse`, session-scoped fixture in `tests/conftest.py` that calls `configure_logging()` before the test session starts, ensuring structlog routes through stdlib logging during tests.
+
+## Testing
+- `tests/unit/test_batch_processor.py::test_empty_chunks_list_returns_empty` — previously failed with empty `caplog.text`, now passes
+- Ran full suite (`make test-all`) to confirm no regressions
+
+## Notes
+`configure_logging()` is also never called in `api/main.py` at app startup — outside the scope of this fix, but worth flagging as a separate follow-up issue.

--- a/PLAN.md
+++ b/PLAN.md
@@ -61,18 +61,3 @@ Output: after the fix, structlog log calls made during tests will produce stdlib
 - Tests that already inspect stdout directly (e.g. via `capsys`) instead of `caplog` — confirm they still pass once output also starts flowing through stdlib logging (could result in duplicate output if both stdout print and logging handler are active).
 
 
-## Summary
-Fixes #159 — structlog log output was not visible to pytest's `caplog` fixture, causing log-based test assertions to fail even though logging worked correctly.
-
-## Root cause
-`configure_logging()` in `core/logging.py` wires structlog into Python's stdlib `logging` module (which `caplog` listens to via `structlog.stdlib.LoggerFactory()`). This function was fully implemented but never actually called anywhere — not in tests, and not at app startup. As a result, structlog fell back to its default `PrintLoggerFactory`, writing directly to stdout and bypassing stdlib logging entirely.
-
-## Fix
-Added an `autouse`, session-scoped fixture in `tests/conftest.py` that calls `configure_logging()` before the test session starts, ensuring structlog routes through stdlib logging during tests.
-
-## Testing
-- `tests/unit/test_batch_processor.py::test_empty_chunks_list_returns_empty` — previously failed with empty `caplog.text`, now passes
-- Ran full suite (`make test-all`) to confirm no regressions
-
-## Notes
-`configure_logging()` is also never called in `api/main.py` at app startup — outside the scope of this fix, but worth flagging as a separate follow-up issue.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,38 @@
+## Solution plan
+
+**Issue:** #159 — structlog output is not captured by pytest caplog (log assertions fail suite-wide)
+
+### Understand
+Expected: log events emitted via structlog (e.g. the "Empty chunks list" warning in `batch_processor.py`) should be visible to pytest's `caplog` fixture, since `caplog` attaches a handler to the stdlib root logger.
+
+Actual: structlog is never configured in the test environment — `configure_logging()` in `core/logging.py`, which wires structlog into stdlib logging via `structlog.stdlib.LoggerFactory()`, is defined but never called anywhere in the codebase (not in tests, not even at app startup in `api/main.py`). Without it, structlog falls back to its default `PrintLoggerFactory`, which writes directly to stdout and never touches stdlib logging — so `caplog` sees nothing, even though the log call happened correctly.
+
+### Map
+- `core/logging.py` — contains `configure_logging()`, the function that sets up structlog's processor chain and routes it through stdlib logging. This is the function that needs to be invoked.
+- `tests/conftest.py` — currently has no logging-related fixtures at all; this is where the fix will likely live (a fixture that calls `configure_logging()` before each test, or once per session).
+- `api/main.py` — the app entry point; confirmed via grep that it never calls `configure_logging()` either, so this file may also need a one-line addition if we decide to fix the app-wide issue, not just the test issue.
+- `tests/unit/test_batch_processor.py` — the test we used to reproduce the bug; will serve as the verification test once the fix is in.
+
+
+### Plan
+1. Add a pytest fixture in `tests/conftest.py` (likely `autouse=True`, session or function scoped) that calls `configure_logging()` before tests run, so structlog routes through `structlog.stdlib.LoggerFactory()`.
+2. Run `test_empty_chunks_list_returns_empty` again to confirm `caplog.text` now contains the expected message, and that the assertion passes.
+3. Run the full test suite (`make test-all`) to check whether other tests relying on log assertions are also fixed, and whether anything regresses (e.g. tests that assumed silent/plain stdout output).
+4. Decide and document whether to also call `configure_logging()` in `api/main.py` at startup, since it's currently dead code there too — even though it's outside the strict scope of #159.
+5. Update `JOURNAL.md` with the fix summary once verified.
+
+### Inputs & outputs
+Input: no new external inputs — the fix changes when/how `configure_logging()` runs, not any function signature. Test files remain unchanged in how they call `caplog`.
+Output: after the fix, structlog log calls made during tests will produce stdlib `LogRecord` objects that populate `caplog.records` and `caplog.text`, matching what tests already expect.
+
+### Risks & unknowns
+- `tests/conftest.py` fixture scope matters: if scoped too broadly (e.g. `session`), `cache_logger_on_first_use=True` in `core/logging.py` could cause stale logger config across tests — need to verify this doesn't cause cross-test leakage.
+- Calling `configure_logging()` also runs `logging.basicConfig(...)`, which sets the stdout stream and log level globally — could affect test output verbosity or interfere with pytest's own log capture setup if run more than once.
+- Unclear whether other tests (outside `test_batch_processor.py`) implicitly depended on the *current* broken behavior (e.g. asserting stdout output directly instead of using `caplog`) — running the full suite in step 3 of the Plan should surface this.
+- If we also fix `api/main.py` (Plan step 4), that changes production log formatting (JSON vs console) for the first time in the running app — worth flagging as a behavior change beyond just fixing tests.
+
+### Edge cases
+- A test that runs with `caplog.set_level(...)` set to a level stricter than `settings.log_level` — need to confirm the fixture doesn't silently swallow records below that threshold.
+- Tests that check for the *absence* of log output (e.g. asserting no warnings were logged) — must still pass once logging is actually wired up, not just tests expecting a positive match.
+- Multiple tests running in the same session with `cache_logger_on_first_use=True` — confirm a logger configured in one test doesn't carry stale state into the next.
+- Tests that already inspect stdout directly (e.g. via `capsys`) instead of `caplog` — confirm they still pass once output also starts flowing through stdlib logging (could result in duplicate output if both stdout print and logging handler are active).

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,15 @@
 
 import pytest
 
+from core.logging import configure_logging
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _configure_test_logging() -> None:
+    """Ensure structlog routes through stdlib logging so pytest's caplog
+    fixture can capture log events (see issue #159)."""
+    configure_logging()
+
 
 @pytest.fixture
 def sample_resume_text() -> str:

--- a/tests/unit/test_logging_config.py
+++ b/tests/unit/test_logging_config.py
@@ -1,0 +1,19 @@
+"""Tests for structlog/caplog integration (issue #159)."""
+
+import pytest
+import structlog
+
+
+def test_configure_logging_enables_caplog_capture(caplog: pytest.LogCaptureFixture) -> None:
+    """Regression test for #159: structlog events should be captured by caplog.
+
+    Prior to the fix, configure_logging() was never called during tests,
+    so structlog fell back to its default PrintLoggerFactory and log
+    events never reached caplog's stdlib logging handler.
+    """
+    log = structlog.get_logger()
+
+    with caplog.at_level("WARNING"):
+        log.warning("test message for caplog capture")
+
+    assert "test message for caplog capture" in caplog.text


### PR DESCRIPTION
## Summary
structlog log events were not visible to pytest's `caplog` fixture, causing log-based test assertions to fail even though the app was logging correctly. This fixes it by ensuring structlog is actually configured to route through Python's stdlib logging module during tests.

## Issue
Closes #159

## Changes
- Added an `autouse`, session-scoped fixture in `tests/conftest.py` that calls `configure_logging()` before the test session starts
- Added `tests/unit/test_logging_config.py` — a regression test that directly verifies structlog events are captured by `caplog`
- Root cause: `configure_logging()` in `core/logging.py` was fully implemented but never called anywhere in the codebase (not in tests, not even at app startup), so structlog fell back to its default `PrintLoggerFactory`, bypassing stdlib logging entirely

## Testing
- [x] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`)
- [x] Linter passes (`make lint`)
- [x] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes

Verified `tests/unit/test_batch_processor.py::test_empty_chunks_list_returns_empty` — previously failed with empty `caplog.text`, now passes. Added a new direct regression test (`test_logging_config.py`) covering the fix itself. Confirmed via `git stash` that 52 pre-existing failures elsewhere in the suite are unrelated to this change (identical failures occur with or without the fix). Note: `make lint`/`make typecheck` pass for this PR's files specifically — repo-wide `make check` surfaces 182 pre-existing lint errors in unrelated test files.

## Screenshots / Demo
N/A — logging/test infrastructure change, no UI impact.

## Notes for Reviewers
`configure_logging()` is also never called in `api/main.py` at app startup — outside the scope of this fix, but flagging as a possible follow-up issue since it means structlog isn't using its intended JSON/console renderers in production either.