### PR TITLE
Fix/151 bias detector too narrow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ htmlcov/
 
 # Build artifacts
 *.pyc
+
+# Agent
+CLAUDE.md

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -14,3 +14,17 @@
 **Setup confirmation:** App runs locally at localhost:5173
 
 **Cohort ledger:** Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [commit link](https://github.com/Harsh-D20/pathreview/commit/a6de94d85f04585a36c050509589de238312f7c4)
+
+**Reproduction summary:**
+Ran `.venv/bin/pytest tests/unit/test_bias_detector.py -v` and confirmed 9 of 32 tests fail exactly as described in the issue — e.g. `test_dismissive_bootcamp_language_detected` ("bootcamp graduates can't write production code") and `test_demographic_assumption_age_detected` ("young developers can't handle complex systems") both return `is_biased=False` because the existing regexes only match singular subjects and a narrow set of verb phrasings. Documented the root cause with an inline comment in `safety/bias_detector.py`.
+
+**PLAN.md link:** [PLAN.md link](https://github.com/Harsh-D20/pathreview/blob/fix/151-bias-detector-too-narrow/PLAN.md)
+
+**Walkthrough video (recommended):** N/A
+
+**Blockers or open questions:**
+None currently — candidate regex patterns for both `DISMISSIVE_PATTERNS` and `DEMOGRAPHIC_PATTERNS` were hand-validated against all 32 test assertions in a scratch script (0 mismatches) before writing PLAN.md, so the approach is de-risked going into implementation in Week 9. Still need to apply the patterns to `safety/bias_detector.py` itself and confirm against the real `pytest` run (scratch validation isn't a substitute for that).

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,16 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/151
+
+**Issue title:** Bias detector patterns are too narrow to match common phrasings
+
+**Tier:** Tier 1
+
+**Problem summary:**
+`BiasDetector.detect_bias()` in `safety/bias_detector.py` relies on a small set of rigid regexes that only match near-exact phrase orderings (e.g. "bootcamp education is insufficient"), so it misses the same bias expressed in more natural phrasing, such as "bootcamp graduates can't write production code" or "young developers can't handle complex systems." As a result, 9 of the tests in `tests/unit/test_bias_detector.py` currently fail, meaning dismissive-education and demographic-assumption bias can slip past the safety layer undetected in generated feedback. A successful fix reworks the `DISMISSIVE_PATTERNS` and `DEMOGRAPHIC_PATTERNS` regex lists (or the matching approach) to catch these common phrasing variations — covering verbs like "can't"/"lack"/"struggle" and subject variants like "developers"/"programmers"/"graduates" — while still passing the existing tests that assert neutral/positive mentions of bootcamps or educational background are not flagged.
+
+**Branch name:** fix/151-bias-detector-too-narrow
+
+**Setup confirmation:** App runs locally at localhost:5173
+
+**Cohort ledger:** Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -28,3 +28,34 @@ Ran `.venv/bin/pytest tests/unit/test_bias_detector.py -v` and confirmed 9 of 32
 
 **Blockers or open questions:**
 None currently — candidate regex patterns for both `DISMISSIVE_PATTERNS` and `DEMOGRAPHIC_PATTERNS` were hand-validated against all 32 test assertions in a scratch script (0 mismatches) before writing PLAN.md, so the approach is de-risked going into implementation in Week 9. Still need to apply the patterns to `safety/bias_detector.py` itself and confirm against the real `pytest` run (scratch validation isn't a substitute for that).
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented PLAN.md steps 1–3: rewrote `DISMISSIVE_PATTERNS` and `DEMOGRAPHIC_PATTERNS` in `safety/bias_detector.py` to accept plural subjects (`developers`/`programmers`/`graduates`), broader verb phrasings (`can't`/`lacks?`/`missing`), and looser subject-verb ordering. Captured a `make check`/`make test-unit` baseline before the change, then re-ran both after and diffed the failing-test lists by exact test ID to confirm the 9 target tests now pass and no other test/lint/type-check result changed. Documented all of this in `PR_description.md`.
+
+**Next steps:**
+Commit the fix, `PLAN.md`, and `PR_description.md`; push; open the PR against `ascherj/pathreview`; do the manual sanity-check pass from PLAN.md step 4 on a few phrasings outside the test file to gauge generalization.
+
+**Blockers:**
+None technical. Nothing is committed/pushed yet — still need to do that before a PR link exists.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [https://github.com/ascherj/pathreview/pull/786](https://github.com/ascherj/pathreview/pull/786)
+
+**Branch:** `fix/151-bias-detector-too-narrow`
+
+**What you built:**
+Broadened the two `BiasDetector` regex pattern lists in `safety/bias_detector.py` to catch common real-world phrasings of dismissive-education and demographic-assumption bias (plural subjects, more verbs, looser word order) instead of only the exact phrase orderings the original regexes were written against — the public `detect_bias(text) -> (bool, str)` interface is unchanged.
+
+**Tests added or updated:**
+None added or modified — `tests/unit/test_bias_detector.py` (32 tests) was already the complete spec from the issue (9 of the 32 were failing); the fix's job was to make all 32 pass without touching the test file.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -59,3 +59,33 @@ None added or modified — `tests/unit/test_bias_detector.py` (32 tests) was alr
 **Self-review confirmation:** [x] make check passes  [x] make test-unit passes
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [X] No — still awaiting review
+
+**Summary of feedback:**
+no review
+
+**How you responded:**
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Getting the regex broad enough to catch the 9 missing phrasings without drifting into false positives on the neutral/positive test cases was a genuine balancing act, not the mechanical find-replace I expected going in. Every time I widened a subject or verb alternation, I had to re-check it against sentences like "your bootcamp background shows strong fundamentals" that share keywords with the biased phrasings but aren't biased.
+
+**What did you learn about working in a large codebase?**
+I learned to map effects before touching shared code. Before editing the pattern lists I confirmed no other module reaches into `DISMISSIVE_PATTERNS`/`DEMOGRAPHIC_PATTERNS` directly, which meant the change was safely contained to one file and its return signature couldn't be assumed correct without checking.
+
+**How did AI tools help — and where did they fall short?**
+AI assistance was most useful for cheap experimentation: instead of editing the real file and re-running pytest over and over, I had Claude write a standalone scratch script with all 32 test assertions hardcoded and iterate on the regex patterns there first, catching mismatches before they ever touched `safety/bias_detector.py`. It also caught the "before/after" testing discipline for me — diffing exact failing-test IDs rather than just comparing counts. Where it fell short was anything requiring a judgment call only I could make: it explicitly stopped and asked rather than guessing when the PLAN.md planning framework wasn't actually in my message, and again before pushing/committing to the branch.
+
+**What would you do differently if you started over?**
+I would investigate semantic checking systems. Due to time and novelty, I didn't go into that rabbit hole, but it is something worth considering since Regex has a known ceiling in its effectiveness. 
+
+**What are you most proud of from this module?**
+The validation discipline, not the fix itself — hand-testing the candidate patterns against all 32 assertions before touching the real file, then diffing the exact failing-test IDs before and after the change to back up "no new failures" with evidence instead of a visual skim of pytest output. I was proud to be able to direct Claude and reproduce its work in order to make sure my work did not actually change anything currently not in my issue's scope.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,53 @@
+## Solution plan
+
+**Issue:** Bias detector patterns are too narrow to match common phrasings — https://github.com/ascherj/pathreview/issues/151
+
+### Understand
+
+Root cause: the patterns were written against the exact wording of a handful of example sentences instead of the underlying subject/verb/object structure of the bias claim, so anything not in that literal word order slips through undetected.
+ 
+**Expected:** biased phrasings that vary the verb ("can't", "lacks", "struggle", "won't") or the subject noun ("developers", "programmers", "graduates", plural vs. singular) around the same underlying claim should all be flagged, while neutral/positive/factual mentions of bootcamps or educational background should not be.
+
+**Actual:** 9 of 32 tests in `tests/unit/test_bias_detector.py` fail because the regexes are too rigid:
+- `DISMISSIVE_PATTERNS[1]` only matches singular `graduate|developer` + `lack|missing` + `rigor|fundamentals|proper training` — misses `can't write ...`, plural `developers`/`programmers`, and `"education lacks fundamentals"` (subject/verb order it wasn't written for).
+- `DISMISSIVE_PATTERNS[3]` requires `self-taught|bootcamp` immediately followed by `is/never`, so `"self-taught developers are not equal to..."` (subject noun inserted before the verb) doesn't match.
+- No pattern covers `"<subject> attendance means inadequate training"` (assumption vs. observation case).
+- `DEMOGRAPHIC_PATTERNS[0]` only matches singular `developer|programmer`, missing plural `"young developers can't..."`.
+- `DEMOGRAPHIC_PATTERNS[1]` only matches `"person from"|"coming from"`, missing `"developers from poor backgrounds"`.
+
+### Map
+
+- `safety/bias_detector.py` — `DISMISSIVE_PATTERNS` and `DEMOGRAPHIC_PATTERNS` class attributes on `BiasDetector`. This is the only file that needs a code change.
+- `tests/unit/test_bias_detector.py` — existing test suite (32 tests, 9 failing); no changes needed here, it's the spec the fix must satisfy. Used as the source of truth for validation.
+- No other module calls into these two pattern lists directly.
+
+### Plan
+
+1. **Rewrite `DISMISSIVE_PATTERNS`** to key off subject/verb pairs rather than fixed phrases:
+   - Broaden the "education/training is X" pattern to make `is` optional and let `lacks` take a trailing object (`bootcamp education lacks fundamentals`).
+   - Add `programmers?` and `coding bootcamp` to the "graduates/developers lack/can't" pattern, and generalize the verb set to `can't|cannot|won't|will not|lacks?|missing` followed by any object.
+   - Loosen the "X is not equal to Y" pattern to allow an optional subject noun between `self-taught|bootcamp` and `is/are` (`self-taught developers are not equal to...`).
+   - Add a new pattern for `"<bootcamp|self-taught> attendance means insufficient/inadequate/..."` to catch the assumption-vs-observation case without flagging plain factual mentions of attendance.
+2. **Rewrite `DEMOGRAPHIC_PATTERNS`** to accept plural subjects and broader subject sets:
+   - `person|developers?|programmers?` (was singular-only) before `can't/cannot/won't/will not`.
+   - `person|people|developers?|programmers?|coming` before `from poor/rich/working-class` (was `person from`/`coming from` only).
+   - Keep the immigrant/international/foreign pattern, optionally extend to `programmers?` for consistency with the other patterns.
+3. **Validate against the full existing test suite** (`.venv/bin/pytest tests/unit/test_bias_detector.py -v`) — all 32 tests, not just the 9 failing ones, must pass so the fix doesn't regress the neutral/positive cases.
+4. **Manually sanity-check a few phrasings not in the test file** (e.g. "bootcamp grads can't handle scale", "developer from a working-class background") to gauge whether the broadened patterns generalize or were tuned to just the test strings.
+5. **Run `make check`** (lint + format + typecheck) and commit as `fix(safety): broaden bias detector regex patterns to match common phrasings`.
+
+### Inputs & outputs
+
+- **Input:** a single string of generated feedback text (`text: str`)
+- **Output:** `tuple[bool, str]` — `(is_biased, reason)` 
+- **Change is confined to:** the regex literals inside `DISMISSIVE_PATTERNS` / `DEMOGRAPHIC_PATTERNS`
+
+### Risks & unknowns
+
+- **Regex is inherently pattern-matching against known phrasings** — broadening to fix these 9 tests doesn't guarantee every real-world phrasing of the same bias gets caught (e.g. "grads" instead of "graduates", contractions written without an apostrophe are already handled via `'?` but new abbreviations won't be). This is a known ceiling of a regex-based approach vs. a classifier/LLM-based check, out of scope for this fix.
+- **False-positive risk when broadening subject/verb gaps** — e.g. allowing `lacks?(?:\s+\w+)?` as a trailing object is intentionally generic; need to confirm it doesn't fire on sentences like "bootcamp education lacks nothing but polish" (double negative) — not in the current test set, worth a manual check.
+
+### Edge cases
+
+- empty and whitespace is already handled by the function.
+- Text containing neutral takes without the assumption itself (e.g. "your bootcamp background shows strong fundamentals", "your resume shows bootcamp attendance") must stay unflagged

--- a/safety/bias_detector.py
+++ b/safety/bias_detector.py
@@ -1,6 +1,7 @@
 """Bias detection in generated feedback."""
 
 import re
+
 import structlog
 
 logger = structlog.get_logger()
@@ -8,6 +9,10 @@ logger = structlog.get_logger()
 
 class BiasDetector:
     """Detect biased language in feedback."""
+
+    # these regex patterns below miss strings where the intent is the same
+    # but the words are different. Tests in `tests/unit/test_bias_detector.py`
+    # catch this already
 
     # Genuinely dismissive phrases about educational background
     DISMISSIVE_PATTERNS = [

--- a/safety/bias_detector.py
+++ b/safety/bias_detector.py
@@ -10,23 +10,20 @@ logger = structlog.get_logger()
 class BiasDetector:
     """Detect biased language in feedback."""
 
-    # these regex patterns below miss strings where the intent is the same
-    # but the words are different. Tests in `tests/unit/test_bias_detector.py`
-    # catch this already
-
     # Genuinely dismissive phrases about educational background
     DISMISSIVE_PATTERNS = [
-        r"(?:bootcamp|self-taught|online\s+course)\s+(?:education|training)\s+is\s+(?:insufficient|inadequate|lacks)",
-        r"(?:bootcamp|self-taught)\s+(?:graduates?|developers?)\s+(?:lack|missing)\s+(?:rigor|fundamentals|proper\s+training)",
+        r"(?:bootcamp|self-taught|online\s+course|coding\s+bootcamp)\s+(?:education|training)\s+(?:is\s+)?(?:insufficient|inadequate|lacks?(?:\s+\w+)?)",
+        r"(?:bootcamp|self-taught|coding\s+bootcamp)\s+(?:graduates?|developers?|programmers?)\s+(?:can'?t|cannot|won'?t|will\s+not|lacks?|missing)\s+\w+",
         r"(?:bootcamp|coding\s+bootcamp)\s+(?:doesn't|does\s+not)\s+prepare\s+(?:you|developers?)",
-        r"(?:self-taught|bootcamp)\s+is\s+(?:not|never)\s+(?:equal|comparable)\s+to\s+(?:university|traditional|formal)",
+        r"(?:self-taught|bootcamp)(?:\s+(?:developers?|graduates?|programmers?))?\s+(?:is|are)\s+(?:not|never)\s+(?:equal|comparable)\s+to\s+(?:university|traditional|formal)",
+        r"(?:bootcamp|self-taught)\s+attendance\s+means\s+(?:insufficient|inadequate|poor|lack\s+of)",
     ]
 
     # Demographic assumptions (about age, background, identity)
     DEMOGRAPHIC_PATTERNS = [
-        r"(?:young|old|aged)\s+(?:person|developer|programmer)\s+(?:can't|cannot|won't|will\s+not)",
-        r"(?:person\s+from|coming\s+from)\s+(?:poor|rich|working[\s-]?class)",
-        r"(?:immigrant|international|foreign)\s+developers?.*(?:can't|cannot|won't|struggle)",
+        r"(?:young|old|aged)\s+(?:person|developers?|programmers?)\s+(?:can't|cannot|won't|will\s+not)",
+        r"(?:person|people|developers?|programmers?|coming)\s+from\s+(?:poor|rich|working[\s-]?class)",
+        r"(?:immigrant|international|foreign)\s+(?:developers?|programmers?).*(?:can't|cannot|won't|struggle)",
     ]
 
     @staticmethod


### PR DESCRIPTION
## Summary
This PR broadens `DISMISSIVE_PATTERNS` and `DEMOGRAPHIC_PATTERNS` to accept plural subjects (`developers`/`programmers`/`graduates`), additional verb phrasings (`can't`/`lacks?`/`missing`), and looser subject-verb ordering, without changing the public `detect_bias(text) -> (bool, str)` interface. This was needed since `BiasDetector.detect_bias()` in `safety/bias_detector.py` relied on a small set of rigid regexes that only matched near-exact phrase orderings (e.g. "bootcamp education is insufficient"), so common natural phrasings of the same bias (e.g. "bootcamp graduates can't write production code") slipped past the safety layer undetected. 

## Issue
Closes #151 

## Changes
- Broadened `DISMISSIVE_PATTERNS` in `safety/bias_detector.py`: 
  - made `is` optional before `insufficient/inadequate/lacks`
  - added `programmers?` and `coding bootcamp` to the graduates/developers pattern
  - generalized the verb set (`can't`/`cannot`/`won't`/`will not`/`lacks?`/`missing`)
  - loosened the "not equal/comparable to" pattern to allow an inserted subject noun
  - added a new pattern for the "attendance means inadequate ..." assumption phrasing.
- Broadened `DEMOGRAPHIC_PATTERNS` in `safety/bias_detector.py`: 
  - accept plural `developers?`/`programmers?` (previously singular-only) in both the age-assumption and background-assumption patterns
  - broadened the background pattern's subject set beyond `person from`/`coming from`.

## Testing
- [x] Unit tests pass (`make test-unit`)
- [x] Integration tests pass (`make test-integration`)
- [x] Linter passes (`make lint`)
- [x] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes

## Screenshots / Demo
No screenshots or demo necessary

## Notes for Reviewers
Regex-based detection has a known ceiling. Broadening these patterns to catch the additional phrasings in this issue doesn't guarantee every real-world phrasing of the same bias is caught. That fix would require some sort of semantic checker, which is out of the scope of the issue.