### PR TITLE
Fix #155: Redis health check uses settings.redis_url instead of nonexistent redis_host/redis_port

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,11 +1,10 @@
 ## Week 7 — Issue selection
 
-**Issue link:** [(https://github.com/ascherj/pathreview/issues/155)]
+**Issue link:** https://github.com/ascherj/pathreview/issues/155
 
-**Issue title:** [Health check references settings.redis_host, which does not exist on Settings
- #155]
+**Issue title:** Health check references settings.redis_host, which does not exist on Settings
 
-**Tier:**  Tier 1 
+**Tier:** [x] Tier 1
 
 **Problem summary:**
 The `/health` endpoint's Redis check tries to connect using `settings.redis_host`
@@ -17,8 +16,9 @@ running fine. This affects the `api` health check route (and touches
 `core/config` where `Settings` is defined). A correct fix would update the
 Redis connection code to use the actual config field(s) available on
 `Settings`, so the health check accurately reflects Redis's real status.
-**Branch name:**fix/155-health-check-redis-host
 
-**Setup confirmation:** [ ] App runs locally at localhost:5173
+**Branch name:** fix/155-health-check-redis-host
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [ ] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -8,11 +8,16 @@
 **Tier:**  Tier 1 
 
 **Problem summary:**
-[In 3–5 sentences, in your own words: what the issue is (not a copy-paste of
-the title), what is currently broken or missing, and what a successful fix
-would accomplish. Naming the part of the codebase it affects is helpful context.]
-
-**Branch name:** [paste branch name here]
+The `/health` endpoint's Redis check tries to connect using `settings.redis_host`
+and `settings.redis_port`, but the `Settings` class doesn't define those
+attributes — it only stores a combined `redis_url`. This causes an
+`AttributeError` every time the health check runs, which gets silently
+caught and reported as "redis: unhealthy," even when Redis is actually
+running fine. This affects the `api` health check route (and touches
+`core/config` where `Settings` is defined). A correct fix would update the
+Redis connection code to use the actual config field(s) available on
+`Settings`, so the health check accurately reflects Redis's real status.
+**Branch name:**fix/155-health-check-redis-host
 
 **Setup confirmation:** [ ] App runs locally at localhost:5173
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -21,4 +21,4 @@ Redis connection code to use the actual config field(s) available on
 
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
-**Cohort ledger:** [ ] Issue added to cohort ledger
+**Cohort ledger:** [x ] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,19 @@
+## Week 7 — Issue selection
+
+**Issue link:** [(https://github.com/ascherj/pathreview/issues/155)]
+
+**Issue title:** [Health check references settings.redis_host, which does not exist on Settings
+ #155]
+
+**Tier:**  Tier 1 
+
+**Problem summary:**
+[In 3–5 sentences, in your own words: what the issue is (not a copy-paste of
+the title), what is currently broken or missing, and what a successful fix
+would accomplish. Naming the part of the codebase it affects is helpful context.]
+
+**Branch name:** [paste branch name here]
+
+**Setup confirmation:** [ ] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -22,29 +22,26 @@ Redis connection code to use the actual config field(s) available on
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x ] Issue added to cohort ledger
-## Week 8 — Reproduction
+## Week 8 — Reproduction & solution planning
 
-**Reproduction steps:**
-Started the app locally with `make run` (backend on port 8000, frontend on 5173,
-with Postgres/Redis/ChromaDB running via `docker compose up -d`). Hit the health
-check endpoint directly:
+**Reproduction commit link:** https://github.com/AbigailVincent/pathreview/commit/0496aef
 
-curl http://127.0.0.1:8000/health
+**Reproduction summary:**
+Ran the app locally and hit `curl http://127.0.0.1:8000/health`. Server logs
+confirmed the exact predicted error — `'Settings' object has no attribute
+'redis_host'` — causing the endpoint to report Redis as unhealthy even
+though `docker compose ps` showed the Redis container itself running and
+healthy.
 
-**Observed output:**
-{"detail":{"status":"unhealthy","dependencies":{"postgres":"unhealthy","redis":"unhealthy","vector_db":"healthy"},"safety_events_last_hour":0,"timestamp":"2026-07-27T21:30:10.544903"}}
+**PLAN.md link:** https://github.com/AbigailVincent/pathreview/blob/fix/155-health-check-redis-host/PLAN.md
 
-**Server logs confirmed the exact cause:**
-redis_health_check_failed      error="'Settings' object has no attribute 'redis_host'"
+**Walkthrough video (recommended):** N/A — did not record one this week.
 
-This confirms the bug described in issue #155: the Redis health check in
-`api/routes/health.py` references `settings.redis_host` and `settings.redis_port`,
-neither of which exist on the `Settings` class (only `redis_url` is defined in
-`.env`/config). This raises an `AttributeError` every time the health check runs,
-which is silently caught and reported as `"redis": "unhealthy"` — even though
-Docker confirms the Redis container itself is healthy
-(`docker compose ps` shows `pathreview-redis-1 ... (healthy)`).
-
-Note: the same response also showed `"postgres": "unhealthy"`, caused by a
-separate, unrelated bug (raw SQL string needing `text()` wrapping under
+**Blockers or open questions:**
+The same `/health` response also shows `"postgres": "unhealthy"`, caused by
+a separate, unrelated bug (raw SQL string needing `text()` wrapping under
+SQLAlchemy 2.x — this matches issue #154, not mine). Not a blocker, just
+noting it so it's not confused with my actual fix in Week 9. No open
+questions on my own issue at this point — root cause and fix location are
+both clear.
 SQLAlchemy 2.x — this matches issue #154, not my assigned issue).

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -68,7 +68,7 @@ unrelated to this fix) but my change introduces zero new failures.
 
 ## Week 9 — Submission
 
-**PR link:** [will add once opened — see below]
+**PR link:** https://github.com/ascherj/pathreview/pull/787
 
 **Summary:** Fixed issue #155 — the `/health` endpoint's Redis check now
 uses the correct `settings.redis_url` config field instead of nonexistent

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -73,4 +73,70 @@ unrelated to this fix) but my change introduces zero new failures.
 **Summary:** Fixed issue #155 — the `/health` endpoint's Redis check now
 uses the correct `settings.redis_url` config field instead of nonexistent
 `redis_host`/`redis_port` attributes, so it accurately reports Redis's real
-status instead of always failing.
+status instead of always failing. 
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No review has come in yet. Per the course note, reviewer feedback isn't
+a feature this term, so I'm not expecting formal comments on PR #787.
+
+**How you responded:**
+N/A — no feedback to respond to.
+
+
+
+### Reflection
+
+**What was harder than you expected?**
+Environment setup took far longer than I expected — way more than the
+actual bug fix. I hit a chain of unrelated issues: PowerShell vs. Git
+Bash confusion, `make` not existing on Windows, Docker Desktop needing
+restarts multiple times, a corrupted `.bashrc`, and Node/npm not being
+installed at all. Even after setup, I ran into repeated file corruption
+issues when editing code through Notepad copy-paste — small things like
+a dropped character turning `async` into `aasync`, or pasting into the
+wrong window entirely. I ended up committing the actual fix through
+GitHub's web editor instead of my local terminal, which felt strange for
+a "real" contribution but got the job done reliably. The lesson: tooling
+friction on someone else's project, on an unfamiliar OS setup, is a real
+and significant part of the work — not a distraction from it.
+
+**What did you learn about working in a large codebase?**
+The actual bug (a wrong attribute name in a config lookup) was tiny —
+maybe 4 lines changed. But confirming it safely meant understanding the
+`Settings` class, checking `.env.example`, running the app end-to-end,
+and reproducing the failure with real logs before touching anything.
+I also learned that a codebase can have multiple, unrelated bugs
+tangled together in the same code path (my Redis bug and a separate
+Postgres bug were both surfacing in the same `/health` endpoint) — and
+part of the job is telling them apart so you don't accidentally scope-
+creep into fixing something that isn't your issue.
+
+**How did AI tools help — and where did they fall short?**
+AI was most useful for the parts that needed broad troubleshooting
+knowledge fast — diagnosing terminal/OS-specific errors, explaining what
+tools like `make`, Docker, and pre-commit hooks were actually doing, and
+drafting boilerplate like the test file and PR description in the
+project's existing style. Where it fell short was anything requiring
+direct file access — repeated manual copy-pasting through Notepad led to
+real corruption (dropped characters, misplaced content between files)
+that took multiple rounds to catch and fix. Working directly in the
+terminal or through GitHub's web editor ended up being more reliable
+than routing every edit through a GUI text editor.
+
+**What would you do differently if you started over?**
+I'd verify my dev environment (Node, Docker, `make`) *before* picking an
+issue, not after, so Week 7 wasn't half spent on tooling. I'd also make
+edits directly via a proper code editor or the GitHub web UI from the
+start, rather than Notepad, to avoid the repeated corruption issues that
+ate up time in Week 9.
+
+**What are you most proud of from this module?**
+Getting a real, verified fix — not just "it compiles," but actually
+proving it in both directions (Redis healthy vs. genuinely down) with
+matching log evidence and a regression test that guards against the
+exact bug coming back. Given how much environment trouble I hit along
+the way, actually landing a clean, tested PR feels like a real result.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -45,3 +45,32 @@ noting it so it's not confused with my actual fix in Week 9. No open
 questions on my own issue at this point — root cause and fix location are
 both clear.
 SQLAlchemy 2.x — this matches issue #154, not my assigned issue).
+## Week 9 — Implementation (mid-week check-in)
+
+Implemented the fix in `api/routes/health.py`: the Redis health check now
+builds its client from `settings.redis_url` via `redis.Redis.from_url()`,
+replacing the broken references to the nonexistent `settings.redis_host`
+and `settings.redis_port`. Added a socket timeout (2s) so a slow/unreachable
+Redis can't hang the health check indefinitely.
+
+Verified manually in both directions: with Redis running, `/health` now
+correctly reports `"redis": "healthy"`; with Redis stopped
+(`docker compose stop redis`), it correctly reports `"redis": "unhealthy"`
+with a real connection-timeout error in the logs, instead of the old
+`AttributeError`.
+
+Wrote `tests/unit/test_health.py` with 3 tests covering the healthy case,
+the genuinely-unhealthy case, and a regression test asserting the fix uses
+`settings.redis_url` specifically (guards against this exact bug recurring).
+All 3 pass. Ran the full test suite to confirm no regressions — pre-existing
+failures exist in the suite (tracked separately as issues #158/#159,
+unrelated to this fix) but my change introduces zero new failures.
+
+## Week 9 — Submission
+
+**PR link:** [will add once opened — see below]
+
+**Summary:** Fixed issue #155 — the `/health` endpoint's Redis check now
+uses the correct `settings.redis_url` config field instead of nonexistent
+`redis_host`/`redis_port` attributes, so it accurately reports Redis's real
+status instead of always failing.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -22,3 +22,29 @@ Redis connection code to use the actual config field(s) available on
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x ] Issue added to cohort ledger
+## Week 8 — Reproduction
+
+**Reproduction steps:**
+Started the app locally with `make run` (backend on port 8000, frontend on 5173,
+with Postgres/Redis/ChromaDB running via `docker compose up -d`). Hit the health
+check endpoint directly:
+
+curl http://127.0.0.1:8000/health
+
+**Observed output:**
+{"detail":{"status":"unhealthy","dependencies":{"postgres":"unhealthy","redis":"unhealthy","vector_db":"healthy"},"safety_events_last_hour":0,"timestamp":"2026-07-27T21:30:10.544903"}}
+
+**Server logs confirmed the exact cause:**
+redis_health_check_failed      error="'Settings' object has no attribute 'redis_host'"
+
+This confirms the bug described in issue #155: the Redis health check in
+`api/routes/health.py` references `settings.redis_host` and `settings.redis_port`,
+neither of which exist on the `Settings` class (only `redis_url` is defined in
+`.env`/config). This raises an `AttributeError` every time the health check runs,
+which is silently caught and reported as `"redis": "unhealthy"` — even though
+Docker confirms the Redis container itself is healthy
+(`docker compose ps` shows `pathreview-redis-1 ... (healthy)`).
+
+Note: the same response also showed `"postgres": "unhealthy"`, caused by a
+separate, unrelated bug (raw SQL string needing `text()` wrapping under
+SQLAlchemy 2.x — this matches issue #154, not my assigned issue).

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,76 @@
+## Solution plan
+
+**Issue:** Health check references settings.redis_host, which does not exist on Settings — https://github.com/ascherj/pathreview/issues/155
+
+### Understand
+The `/health` endpoint's Redis check calls `settings.redis_host` and
+`settings.redis_port` to build a `redis.Redis(...)` connection. Neither
+attribute exists on the `Settings` class — the config only defines a single
+combined `REDIS_URL` (e.g. `redis://localhost:6379/0`). Every call to this
+code path raises an `AttributeError`, which is caught by a broad
+`except Exception` block and silently reported as `"redis": "unhealthy"`.
+Expected behavior: the health check should connect to Redis using the
+actual `redis_url` config value and report `"healthy"` when Redis is
+genuinely reachable. Actual behavior: it always reports `"unhealthy"`
+regardless of Redis's real status, making the health check useless for its
+intended purpose (and would return a false 503 in production monitoring).
+
+### Map
+- `api/routes/health.py` — contains the buggy Redis check block (references
+  `settings.redis_host` / `settings.redis_port`); this is the primary file
+  to change.
+- `core/config.py` — where the `Settings` class is defined; need to confirm
+  the exact attribute name (`redis_url`) and type available here.
+- `.env` / `.env.example` — confirms only `REDIS_URL` is defined, no split
+  host/port variables.
+- `tests/` (whichever test file covers `api/routes/health.py`, if one
+  exists) — will need a new or updated test for the fixed behavior.
+
+### Plan
+1. Inspect `core/config.py` to confirm the exact `Settings` attribute name
+   and type for the Redis connection string (`redis_url`).
+2. Update `api/routes/health.py` to build the Redis client from
+   `settings.redis_url` instead of the non-existent `redis_host`/`redis_port`
+   fields — likely via `redis.Redis.from_url(settings.redis_url, ...)`
+   rather than manually passing `host=`/`port=`.
+3. Manually re-test locally: run `curl http://127.0.0.1:8000/health` with
+   Redis running (expect `"redis": "healthy"`) and with Redis stopped via
+   `docker compose stop redis` (expect `"redis": "unhealthy"`, proving the
+   check is now accurate in both directions).
+4. Add/update an automated test for the health endpoint's Redis check,
+   covering both the healthy and unhealthy cases.
+5. Clean up: remove the now-unnecessary `import redis` duplication if any,
+   confirm logging messages (`redis_health_check_passed` /
+   `_failed`) still fire correctly.
+
+### Inputs & outputs
+**Input:** the `Settings` object's Redis connection string (`redis_url`),
+and the real-time state of the Redis service it points to.
+**Output:** an accurate `"redis": "healthy"` or `"redis": "unhealthy"` value
+in the `/health` endpoint's JSON response, matching Redis's actual
+reachability rather than always failing due to the config bug.
+
+### Risks & unknowns
+- Unsure whether `redis.Redis.from_url()` behaves identically to the
+  current `redis.Redis(host=..., port=...)` call in terms of timeouts /
+  `decode_responses` — need to check the `redis` library docs for
+  equivalent kwargs.
+- Unclear whether other parts of the codebase (outside `health.py`) also
+  reference `settings.redis_host`/`redis_port` and would need the same fix
+  — a repo-wide search for those attribute names is needed before
+  considering this fully resolved.
+- Risk of masking a *different* real Redis outage during testing if Docker
+  containers are flaky (as I saw firsthand this week) — need to verify
+  Docker state independently (`docker compose ps`) before trusting any
+  single test run.
+
+### Edge cases
+- Redis genuinely down/unreachable (container stopped) → should report
+  `"unhealthy"` with a clear log message, not crash the whole endpoint.
+- Malformed or missing `REDIS_URL` in `.env` → should fail gracefully with
+  a logged error, not an unhandled exception that takes down the health
+  endpoint.
+- Redis reachable but slow to respond → should ideally still resolve within
+  a reasonable timeout rather than hanging the health check indefinitely
+  (worth checking if `redis.Redis.from_url` needs an explicit
+  `socket_timeout` set).

--- a/api/routes/health.py
+++ b/api/routes/health.py
@@ -1,21 +1,22 @@
-from fastapi import APIRouter, HTTPException, status, Depends
+from datetime import datetime
+from typing import Any
+
 import structlog
-from datetime import datetime, timedelta
+from fastapi import APIRouter, Depends, HTTPException, status
 
 from core.database import get_db
 
 log = structlog.get_logger()
-
 router = APIRouter(prefix="/health", tags=["health"])
 
 
 @router.get("")
-async def health_check(db=Depends(get_db)):
+async def health_check(db: Any = Depends(get_db)) -> dict:  # noqa: B008
     """
     Check health of PostgreSQL, Redis, and Vector DB.
     Returns 200 if all healthy, 503 if any dependency is down.
     """
-    health_status = {
+    health_status: dict = {
         "status": "healthy",
         "dependencies": {
             "postgres": "unknown",
@@ -25,9 +26,7 @@ async def health_check(db=Depends(get_db)):
         "safety_events_last_hour": 0,
         "timestamp": datetime.utcnow().isoformat(),
     }
-
     try:
-        # Check PostgreSQL
         await db.execute("SELECT 1")
         health_status["dependencies"]["postgres"] = "healthy"
         log.debug("postgres_health_check_passed")
@@ -37,15 +36,14 @@ async def health_check(db=Depends(get_db)):
         health_status["status"] = "unhealthy"
 
     try:
-        # Check Redis (if available)
         import redis
         from core.config import settings
 
-        r = redis.Redis(
-            host=settings.redis_host,
-            port=settings.redis_port,
-            db=0,
+        r = redis.Redis.from_url(
+            settings.redis_url,
             decode_responses=True,
+            socket_connect_timeout=2,
+            socket_timeout=2,
         )
         r.ping()
         health_status["dependencies"]["redis"] = "healthy"
@@ -56,12 +54,8 @@ async def health_check(db=Depends(get_db)):
         health_status["status"] = "unhealthy"
 
     try:
-        # Check Vector DB (if available)
-        # This is a placeholder - actual implementation depends on vector DB choice
         from core.config import settings
 
-        # Attempt heartbeat to vector DB
-        # For now, assume it's healthy if connection string exists
         if settings.vector_db_url:
             health_status["dependencies"]["vector_db"] = "healthy"
             log.debug("vector_db_health_check_passed")
@@ -72,18 +66,16 @@ async def health_check(db=Depends(get_db)):
         health_status["dependencies"]["vector_db"] = "unhealthy"
         health_status["status"] = "unhealthy"
 
-    # Count safety events in last hour (placeholder)
     try:
-        # This would be populated by actual safety event logging
         health_status["safety_events_last_hour"] = 0
     except Exception as exc:
         log.error("safety_events_check_failed", error=str(exc))
 
-    # Return 503 if any critical dependency is down
     if health_status["status"] == "unhealthy":
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail=health_status,
         )
-
     return health_status
+
+     

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -1,0 +1,60 @@
+"""Tests for api/routes/health.py"""
+from contextlib import suppress
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from api.routes.health import health_check
+
+
+@pytest.mark.unit
+class TestHealthCheckRedis:
+    """Test suite for the /health endpoint's Redis dependency check."""
+
+    @pytest.fixture
+    def mock_db(self) -> MagicMock:
+        db = MagicMock()
+        db.execute = AsyncMock(return_value=None)
+        return db
+
+    @pytest.mark.asyncio
+    async def test_redis_healthy_when_reachable(self, mock_db: MagicMock) -> None:
+        mock_redis_client = MagicMock()
+        mock_redis_client.ping = MagicMock(return_value=True)
+
+        with patch("redis.Redis.from_url", return_value=mock_redis_client):
+            try:
+                result = await health_check(db=mock_db)
+            except HTTPException as exc:
+                result = exc.detail
+
+        assert result["dependencies"]["redis"] == "healthy"
+
+    @pytest.mark.asyncio
+    async def test_redis_unhealthy_when_unreachable(self, mock_db: MagicMock) -> None:
+        with (
+            patch("redis.Redis.from_url", side_effect=Exception("Timeout connecting to server")),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            await health_check(db=mock_db)
+
+        assert exc_info.value.status_code == 503
+        assert exc_info.value.detail["dependencies"]["redis"] == "unhealthy"
+
+    @pytest.mark.asyncio
+    async def test_redis_check_uses_settings_redis_url(self, mock_db: MagicMock) -> None:
+        mock_redis_client = MagicMock()
+        mock_redis_client.ping = MagicMock(return_value=True)
+
+        with (
+            patch("redis.Redis.from_url", return_value=mock_redis_client) as mock_from_url,
+            suppress(HTTPException),
+        ):
+            await health_check(db=mock_db)
+
+        assert mock_from_url.called
+        call_args, _ = mock_from_url.call_args
+        assert len(call_args) >= 1
+        assert isinstance(call_args[0], str)
+        assert call_args[0].startswith("redis://")


### PR DESCRIPTION
Closes #155

## Problem
The `/health` endpoint's Redis check referenced `settings.redis_host` and
`settings.redis_port`, neither of which exist on the `Settings` class (only
`redis_url` is defined). This raised an `AttributeError` on every call,
silently caught and reported as `"redis": "unhealthy"` — even when Redis
was completely healthy.

## Fix
Updated the Redis client construction to use `redis.Redis.from_url(settings.redis_url, ...)`
instead of the nonexistent host/port fields. Also added a 2-second socket
timeout so a slow/unreachable Redis can't hang the health check.

## Testing
- Manually verified both directions: `/health` reports `"redis": "healthy"`
  when Redis is running, and `"redis": "unhealthy"` (with a real connection
  error, not the old AttributeError) when Redis is stopped.
- Added `tests/unit/test_health.py` with 3 tests: healthy case, genuinely
  unhealthy case, and a regression test confirming the fix uses
  `settings.redis_url` specifically.
- Ran the full test suite: no new failures introduced by this change.
  (Pre-existing suite failures are tracked separately in #158/#159 and are
  unrelated to this fix.)