### PR TITLE
Docs/36 update architecture

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -59,6 +59,28 @@ A plan-execute orchestrator that coordinates multiple analysis tools. Each tool 
 ### RAG System (`rag/`)
 Hybrid retrieval (vector similarity + BM25 keyword) fetches relevant context from the user's ingested documents. The generator uses prompt templates to produce structured, evidence-based feedback. The evaluator scores retrieval relevance and generation faithfulness.
 
+#### Hybrid Retrieval Scoring Logic
+The retrieval system utilizes a hybrid scoring method for chunks by summing both normalized (0-1) vector and keyword scores multiplied by their respective weights, with vector being 0.7 and keyword being 0.3. Scores will range from 0 - 1, with 0 corresponding to a chunk having no relevance and 1 having the most relevance. 
+
+##### Normalization
+Each chunk's keyword and vector is normalized as the proportion of the raw score to the max raw score of each result set. 
+
+Ex: If a keyword raw score is 3, and the max keyword score is 5, then the normalized raw score for that individual keyword is 3/5 = 0.6
+
+##### What if a chunk is missing from result sets?
+The chunk does not need to appear in both vector and keyword sets. If it is missing from either one, that side will have a score of 0, and the score will reflect that absence. 
+
+Example:
+| Chunk | Vector Score | Keyword Score | Normalized Vector | Normalized Keyword | Blended (0.7v + 0.3k) |
+|---------|---------|---------|---------|---------|---------|
+A | 0.3 | 0.0 | 0.500| 0.000 | 0.350 
+B | 0.0 | 4.0 | 0.000 | 1.000 | 0.300| 
+C | 0.6 | 1.0 | 1.000 | 0.250 | 0.775| 
+A | 0.2 | 2.0 | 0.333 | 0.500 | 0.381| 
+
+
+
+
 ### Safety Layer (`safety/`)
 Middleware wrapping the generation pipeline. Components run in sequence: prompt injection defense → content filter → bias detector → PII scrubber. All safety events are logged with structured metadata for monitoring.
 

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -1,0 +1,16 @@
+## Week 7 — Issue selection
+
+**Issue link:** [https://github.com/ascherj/pathreview/issues/36]
+
+**Issue title:** [Architecture doc doesn't explain the hybrid retrieval scoring formula #36]
+
+**Tier:** [X] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The issue of ARCHITECTURE.md is that its description of the hybrid retrieval is too vague. It doesn't provide additional details regarding how the hybrid retrieval scores the retrieval relevance and generation faithfulness of its chunks. Updating this file provides more clarity and context of rag/retriever/hybrid.py for contributors in the repository who are working on the RAG, especially the hybridg retrieval system.
+
+**Branch name:** docs/36-update-architecture
+
+**Setup confirmation:** [X] App runs locally at localhost:5173
+
+**Cohort ledger:** [X] Issue added to cohort ledger

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -14,3 +14,17 @@ The issue of ARCHITECTURE.md is that its description of the hybrid retrieval is 
 **Setup confirmation:** [X] App runs locally at localhost:5173
 
 **Cohort ledger:** [X] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** The issue regarding missing details of the hybrid retrieval score in ARCHITECTURE.md exists in my local environment. Because it is documentation, I don't need to reproduce the issue by code. 
+
+**Reproduction summary:**
+[1–2 sentences: How did you reproduce the issue? What did you observe?]
+
+**PLAN.md link:** [link to PLAN.md in your fork]
+
+**Walkthrough video (recommended):** [link to your Loom video, ≤2 min — recommended, not graded]
+
+**Blockers or open questions:**
+[Anything you're still uncertain about going into Week 9, or leave blank]

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -7,7 +7,7 @@
 **Tier:** [X] Tier 1  [ ] Tier 2  [ ] Tier 3
 
 **Problem summary:**
-The issue of ARCHITECTURE.md is that its description of the hybrid retrieval is too vague. It doesn't provide additional details regarding how the hybrid retrieval scores the retrieval relevance and generation faithfulness of its chunks. Updating this file provides more clarity and context of rag/retriever/hybrid.py for contributors in the repository who are working on the RAG, especially the hybridg retrieval system.
+The issue of ARCHITECTURE.md is that its description of the hybrid retrieval is too vague. It doesn't provide additional details regarding how the hybrid retrieval scores its chunks. Updating this file provides more clarity and context of rag/retriever/hybrid.py for contributors in the repository who are working on the RAG, especially the hybridg retrieval system.
 
 **Branch name:** docs/36-update-architecture
 
@@ -44,14 +44,14 @@ I will complete the last two steps I've outlined in PLAN.md
 
 **PR link:** [link to your submitted pull request]
 
-**Branch:** [the branch name you worked on, e.g. `fix/123-short-description`]
+**Branch:** docs/36-update-architecture
 
 **What you built:**
-[1–3 sentences summarizing what your fix does and how it works]
+I added a section under "subsystem details" (Hybrid Retrieval Scoring Logic) which details the scoring logic for the retrieval system. There were two subsections under that section detailing the normalization process as well as what would happen if a chunk is missing from a vector or keyword evaluation set. 
 
 **Tests added or updated:**
-[Which test files did you touch? What do they cover?]
+No tests were added as this was a documentation revision. 
 
-**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+**Self-review confirmation:** [X] make check passes  [X] make test-unit passes
 
-**Draft PR feedback received from:** [name or Slack handle, or "none"]
+**Draft PR feedback received from:** None

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -22,9 +22,36 @@ The issue of ARCHITECTURE.md is that its description of the hybrid retrieval is 
 **Reproduction summary:**
 [1–2 sentences: How did you reproduce the issue? What did you observe?]
 
-**PLAN.md link:** [link to PLAN.md in your fork]
+**PLAN.md link:** https://raw.githubusercontent.com/unsunnysideup/pathreview/refs/heads/docs/36-update-architecture/docs/PLAN.md
 
-**Walkthrough video (recommended):** [link to your Loom video, ≤2 min — recommended, not graded]
+## Week 9 — Solution building & PR submission
 
-**Blockers or open questions:**
-[Anything you're still uncertain about going into Week 9, or leave blank]
+### Check-in 1 (mid-week)
+
+**Current progress:**
+The following subtasks are complete. No coding commits is needed; just comprehension of the root issue and files needed for the revision:
+1. Understanding where in the ARCHITECTURE.md I need to revise and add resolution to the issue
+2. Read and understand the hybrid retrieval scoring formula in rag/retriever/hybrid.py
+
+**Next steps:**
+I will complete the last two steps I've outlined in PLAN.md
+3. Write a cohesive and concise statement about the hybrid retrieval scoring formula in ARCHITECTURE.md
+4. Proofread and submit
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [link to your submitted pull request]
+
+**Branch:** [the branch name you worked on, e.g. `fix/123-short-description`]
+
+**What you built:**
+[1–3 sentences summarizing what your fix does and how it works]
+
+**Tests added or updated:**
+[Which test files did you touch? What do they cover?]
+
+**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+
+**Draft PR feedback received from:** [name or Slack handle, or "none"]

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -55,3 +55,34 @@ No tests were added as this was a documentation revision.
 **Self-review confirmation:** [X] make check passes  [X] make test-unit passes
 
 **Draft PR feedback received from:** None
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [X] No — still awaiting review
+
+**Summary of feedback:**
+N/A
+
+**How you responded:**
+N/A
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Understanding the codebase was harder than I expected because there were many folders and lengthy code in each file. I had to read the ARCHITECTURE.md and README.md to figure out how to navigate, understand the issue I claimed and revise it. 
+
+**What did you learn about working in a large codebase?**
+I learned that working in a large codebase require clear and intentional contributions. This will allow other developers to understand your contribution, and pick it up from there. Additionally, there are varying conventions one must follow while contributing to a large codebase. This experience was different from when I would do my own project because I am the only contributor, so I would know where I left off and what to continue
+
+**How did AI tools help — and where did they fall short?**
+AI assistance was most helpful in helping me understand certain code lines. For instance, there were certain lines in rag/retriever/hybrid.py where I was a bit confused on what code snippets. 
+
+**What would you do differently if you started over?**
+If I started differently, I would take notes while I work so that the next day, I wouldn't need to have to walk back a bit to figure out where to continue. If I took notes, I can trace back in my notes and continue from there, saving the time to resolve issue. 
+
+**What are you most proud of from this module?**
+I am most proud of having the skills to properly contribute to open source projects, such as knowing when to merge and when to debase, as I intend to work on open source projects. 

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -42,12 +42,12 @@ I will complete the last two steps I've outlined in PLAN.md
 
 ### Check-in 2 (end of week)
 
-**PR link:** [link to your submitted pull request]
+**PR link:** [link to the submitted pull request](https://github.com/ascherj/pathreview/pull/788)
 
 **Branch:** docs/36-update-architecture
 
 **What you built:**
-I added a section under "subsystem details" (Hybrid Retrieval Scoring Logic) which details the scoring logic for the retrieval system. There were two subsections under that section detailing the normalization process as well as what would happen if a chunk is missing from a vector or keyword evaluation set. 
+I added a subsection under "subsystem details" -> "Rag System" (Hybrid Retrieval Scoring Logic) which details the scoring logic for the retrieval system. There were two subsections under that section detailing the normalization process as well as what would happen if a chunk is missing from a vector or keyword evaluation set. 
 
 **Tests added or updated:**
 No tests were added as this was a documentation revision. 

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -1,0 +1,25 @@
+## Solution plan
+
+**Issue:** [Architecture doc doesn't explain the hybrid retrieval scoring formula #36](https://github.com/ascherj/pathreview/issues/36#issuecomment-4998114258)
+
+### Understand
+The root cause of this issue is due to missing description entailing the formula used to score chunks. Because this is just documentation issue, the expectation is to include all necessary details that can help a dev understand the fundamental backbone components and logic concepts underlying them. In actuality, while the RAG description talks about the general process of chunk retrieval and assessment, it fails to describe how the process gets scored in the assessment. 
+
+### Map
+I will definitely be revising ARCHITECTURE.md, as that is the source of the issue. I will also be referring to rag/retriever/hybrid.py for understanding what the hybrid retrieval scoring formula is.
+
+### Plan
+1. Understanding where in the ARCHITECTURE.md I need to revise and add resolution to the issue
+2. Read and understand the hybrid retrieval scoring formula in rag/retriever/hybrid.py
+3. Write a cohesive and concise statement about the hybrid retrieval scoring formula in ARCHITECTURE.md
+4. Proofread and submit
+
+### Inputs & outputs
+As this isn't an issue requiring coding, there's no technical inputs and outputs. Rather, my fix takes in 
+a proper understanding of the hybrid retrieval scoring formula to add a clear description of it for the ARCHITECTURE.md. Ultimately, the final output should be a revised RAG description in that documentation markdown file. 
+
+### Risks & unknowns
+There are no unknowns as this is a documentation issue. Only possible risks are misinterpretation and vague/misleading technical writeup of the scoring formula.
+
+### Edge cases
+There are no edge cases as this is a documentation issue. 


### PR DESCRIPTION
## Summary
This PR adds further details to the Rag System in ARCHITECTURE.md by providing a comprehensive summary of how the hybrid retrieval scoring system works, how it handles certain edge cases, and an example illustrating its scoring logic. 

## Issue
Closes #36

## Changes
- Updated ARCHITECTURE.md as detailed below:
  - Added a subsection under "Subsystem Details" -> "Rag System": Hybrid Retrieval Scoring Logic summarizing the hybrid scoring process. 
  - Added a subsection below the above section detailing the normalization procedure
  - Added a subsection below the above section detailing what would happen if a chunk fails to appear in one of the two result sets. 

## Testing
- [X] Unit tests pass (`make test-unit`)
- [X] Integration tests pass (`make test-integration`)
- [X] Linter passes (`make lint`)
- [X] Type checker passes (`make typecheck`)
- [ ] New/updated tests cover the changes

## Screenshots / Demo
Not applicable for a documentation issue. 

## Notes for Reviewers
The "known limitation" warning that keyword_searcher.index() is never called on the _get_all_chunks output is informational only.  Additionally, there is no construction of the BM25 index. It is called only without reference to an actual construct in the codebase.  The latter detail should be further reviewed. 
