### PR TITLE
test(rag): fix partial-overlap fixture in relevance scorer test

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -40,3 +40,35 @@ query words show up in the chunk, so the overlap is complete. The main thing
 I'll have to watch out for is picking new test data that actually gives a
 partial score in the 0.3–0.9 range, and making sure I don't break any of the
 other tests in the file.
+
+## Week 8 - Issue Reproduction & Solution Planning
+
+**Reproduction:**
+I set up the Python side of the project locally (a `.venv` with the dev dependencies from
+`pyproject.toml` — no Docker needed since this test only imports the scorer) and reproduced the
+bug by running:
+
+```
+pytest tests/unit/test_relevance_scorer.py -q
+```
+
+It came back `1 failed, 18 passed`. The failing test is `test_query_with_partial_overlap`, and it
+fails with:
+
+```
+assert 0.3 < score < 0.9
+E   assert 1.0 < 0.9
+[info] relevance_scored  avg_score=1.0 chunks_count=1 query_len=4
+```
+
+So I confirmed exactly what the issue said: the query has 4 words and the sample chunk contains all
+4 of them, so the scorer returns 1.0, which is outside the 0.3–0.9 range the test expects. The
+scorer is doing the right thing — the test's data is what's wrong.
+
+**Solution plan:**
+I wrote up the full plan in [PLAN.md](PLAN.md). The short version: the fix is to change the sample
+chunk in that one test so it only contains *some* of the query words (drop "Django"), which makes
+it a real partial-overlap case and gives a score of 0.75 (inside 0.3–0.9). The only file that
+changes is `tests/unit/test_relevance_scorer.py` — the scorer itself stays the same because it's
+already correct. The main risk I noted is not touching the tokenizer, since a few other tests in
+the file depend on how it currently works.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,42 @@
+# PathReview — Module 3 Journal
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/157
+
+**Issue title:** Relevance scorer "partial overlap" test fixture actually has full query overlap
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+So this issue is basically a broken unit test in
+tests/unit/test_relevance_scorer.py. The test (test_query_with_partial_overlap)
+is supposed to check that a query that only partly matches a chunk gets a score
+somewhere in the middle, but the test data was set up wrong. The query is
+"Python Django web framework" and the chunk it gets tested against actually has
+all four of those words in it, so it's really a full match, not a partial one.
+The scorer does the right thing and gives it a 1.0, but the test expects
+something under 0.9, so it fails even though nothing is actually wrong with the
+code. To fix it I just need to change the sample chunk so it only has some of
+the query words instead of all of them — then it's actually testing partial
+overlap like it's meant to, and the test passes.
+
+**Branch name:** fix/157-relevance-scorer-fixture
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger
+
+---
+
+### "Is this issue right for me?" — checklist reasoning
+I think this one's a good fit for me since it's pretty small and doesn't feel
+overwhelming for a first issue. The change is only in one test file, and I
+don't even have to touch the actual scorer code because the scorer already
+works correctly. I was able to reproduce the failure by running
+`pytest tests/unit/test_relevance_scorer.py -q` and watching it fail with
+"assert 1.0 < 0.9". Once I looked at it, it made sense why — all four of the
+query words show up in the chunk, so the overlap is complete. The main thing
+I'll have to watch out for is picking new test data that actually gives a
+partial score in the 0.3–0.9 range, and making sure I don't break any of the
+other tests in the file.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -25,7 +25,7 @@ overlap like it's meant to, and the test passes.
 
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
-**Cohort ledger:** [ ] Issue added to cohort ledger
+**Cohort ledger:** [x] Issue added to cohort ledger
 
 ---
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -72,3 +72,49 @@ it a real partial-overlap case and gives a score of 0.75 (inside 0.3–0.9). The
 changes is `tests/unit/test_relevance_scorer.py` — the scorer itself stays the same because it's
 already correct. The main risk I noted is not touching the tokenizer, since a few other tests in
 the file depend on how it currently works.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+I implemented the fix from my PLAN.md. Before changing anything I ran the whole unit suite to note
+the pre-existing failures — `pytest tests/unit` gave `53 failed, 375 passed` (the codebase has a
+lot of unrelated failing tests, one per open issue). Then I made the one-line change to the sample
+chunk in `test_query_with_partial_overlap` so it only has 3 of the 4 query words. After the change,
+the target test passes, the whole `test_relevance_scorer.py` file is `19 passed`, and the full
+suite is now `52 failed, 376 passed` — so my change fixed exactly one test and didn't break
+anything else. I committed it as `test(rag): fix partial-overlap fixture in relevance scorer test`.
+
+**Next steps:**
+Open a draft PR against the upstream repo, ask for peer/mentor feedback in Slack, then fill in
+Check-in 2 with the PR link and mark the PR ready for review.
+
+**Blockers:**
+None. Note: `make check` and `make test-unit` have many pre-existing failures unrelated to my
+issue (ruff/black/mypy errors and 52 other failing tests). I confirmed my change introduces no new
+failures — the count of failing tests went down by exactly one.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** _(to add once the PR is opened)_
+
+**Branch:** `fix/157-relevance-scorer-fixture`
+
+**What you built:**
+A one-line fix to a broken unit test. The `test_query_with_partial_overlap` fixture was scoring a
+query against a chunk that contained all four query words (full overlap), so the scorer correctly
+returned 1.0 and the test's `0.3 < score < 0.9` assertion failed. I changed the chunk to contain
+only three of the four words, so it now exercises genuine partial overlap and scores 0.75.
+
+**Tests added or updated:**
+`tests/unit/test_relevance_scorer.py` — updated the fixture in `test_query_with_partial_overlap`.
+No production code changed; the scorer in `rag/evaluator/relevance_scorer.py` was already correct.
+
+**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+<!-- Per the pre-existing-failures guidance: "passes" here means my change introduces no NEW
+failures. Baseline 53 failed -> 52 failed after my change; ruff passes on the changed file. -->
+
+**Draft PR feedback received from:** _(add Slack handle once you get feedback, or "none")_

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -120,3 +120,36 @@ after my change it is 52 failed / 376 passed — exactly one fewer failure and n
 passes on the file I changed.)
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+I checked PR #790 and no reviewer or maintainer comments had come in (the course noted that
+reviewer feedback isn't an active feature this term). The PR is still open with no requested
+changes.
+
+**How you responded:**
+N/A — no feedback to respond to.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+honestly navigating through the issues to pick which ones were right for me
+
+**What did you learn about working in a large codebase?**
+What I learned was that the matter wasn't writing lots of code but tracing the scorer to fine the one file/line that mattered and reproducing the bug before moving onto the next issue
+
+**How did AI tools help — and where did they fall short?**
+Helped: diagnosing the virtualization mess, explaining the scorer logic, scaffolding the journal/plan/PR structure. AI couldn't approve the UAC prompts, reboot, or click through the pr form.
+
+**What would you do differently if you started over?**
+I switched issues twice (#159 → #163 → #157) before settling  using the "is this right for me?" checklist more decisively up front would've saved time.
+
+**What are you most proud of from this module?**
+shipping a clean PR that carefully documented its impact vs. pre-existing failures.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -99,7 +99,7 @@ failures — the count of failing tests went down by exactly one.
 
 ### Check-in 2 (end of week)
 
-**PR link:** _(to add once the PR is opened)_
+**PR link:** https://github.com/ascherj/pathreview/pull/790
 
 **Branch:** `fix/157-relevance-scorer-fixture`
 
@@ -113,8 +113,10 @@ only three of the four words, so it now exercises genuine partial overlap and sc
 `tests/unit/test_relevance_scorer.py` — updated the fixture in `test_query_with_partial_overlap`.
 No production code changed; the scorer in `rag/evaluator/relevance_scorer.py` was already correct.
 
-**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
-<!-- Per the pre-existing-failures guidance: "passes" here means my change introduces no NEW
-failures. Baseline 53 failed -> 52 failed after my change; ruff passes on the changed file. -->
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+(Note: this codebase has many pre-existing failures unrelated to my issue, so "passes" here means
+my change introduces no NEW failures. Baseline `pytest tests/unit` was 53 failed / 375 passed;
+after my change it is 52 failed / 376 passed — exactly one fewer failure and none added. `ruff`
+passes on the file I changed.)
 
-**Draft PR feedback received from:** _(add Slack handle once you get feedback, or "none")_
+**Draft PR feedback received from:** none

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,95 @@
+# Solution Plan — Issue #157
+
+**Issue:** [Relevance scorer "partial overlap" test fixture actually has full query overlap](https://github.com/ascherj/pathreview/issues/157)
+**Branch:** `fix/157-relevance-scorer-fixture`
+**Tier:** 1 (bug / tests)
+
+## Context / Problem
+There is a broken unit test in `tests/unit/test_relevance_scorer.py`. The test
+`test_query_with_partial_overlap` is meant to check that a query which only *partly* matches a
+chunk gets a middle-range relevance score. But the test data is wrong: the query
+`"Python Django web framework"` is scored against a chunk that actually contains **all four** of
+those words, so it's really a full match, not a partial one. The scorer correctly returns `1.0`,
+while the test expects a score below `0.9`, so the test fails even though the scoring code is
+working correctly. The fault is in the test fixture, not the scorer.
+
+## Reproduction
+Environment: Python 3.11+ virtual env with dev dependencies installed (`pip install -e ".[dev]"`).
+No Docker or database is required — this test only imports the scorer.
+
+Command:
+```
+pytest tests/unit/test_relevance_scorer.py::TestRelevanceScorer::test_query_with_partial_overlap -q
+```
+
+- **Expected:** test passes (score in the partial range `0.3 < score < 0.9`).
+- **Actual:** test fails:
+  ```
+  >   assert 0.3 < score < 0.9
+  E   assert 1.0 < 0.9
+  ...
+  [info] relevance_scored  avg_score=1.0 chunks_count=1 query_len=4
+  ```
+Running the whole file gives `1 failed, 18 passed` — this is the only failing test.
+
+## Root cause (traced through the code)
+- `RelevanceScorer.score()` in `rag/evaluator/relevance_scorer.py` computes, per chunk,
+  `overlap = len(query_tokens & chunk_tokens)` then `relevance = overlap / len(query_tokens)`
+  (lines 40–41), and returns the average across chunks capped at `1.0` (line 50).
+- `_tokenize()` (lines 52–62) is simply `text.lower().split()` — lowercase + whitespace split,
+  with no punctuation stripping and no stopword removal.
+- For this test: query tokens = `{python, django, web, framework}` (4 tokens). The chunk
+  `"Django is a Python web framework for rapid development"` contains all four → `overlap = 4`,
+  `score = 4/4 = 1.0`. The assertion `0.3 < 1.0 < 0.9` is therefore False.
+
+So the scorer behaves correctly; the fixture was mislabeled "partial overlap" while actually
+providing full overlap.
+
+## Proposed fix
+Edit **only** the fixture chunk in `test_query_with_partial_overlap` so it contains *some but not
+all* of the query words. Dropping "Django" is the smallest clear change:
+
+```python
+# query stays: "Python Django web framework"  -> {python, django, web, framework}
+"text": "This Python web framework is great for rapid development"
+# contains python, web, framework (3) but NOT django -> 3/4 = 0.75, inside 0.3–0.9
+```
+
+## Files to change
+- `tests/unit/test_relevance_scorer.py` — one line (the chunk `text` inside
+  `test_query_with_partial_overlap`, ~line 52). No other files.
+- The scorer (`rag/evaluator/relevance_scorer.py`) is **not** changed — it is already correct.
+
+## Sub-tasks (in order)
+1. Edit the chunk string in `test_query_with_partial_overlap`.
+2. Run just that test → confirm it passes.
+3. Run the whole file (`pytest tests/unit/test_relevance_scorer.py -q`) → confirm 19 passed.
+4. Run `make test-unit` → confirm no regressions elsewhere.
+5. Run `make check` (ruff / black / mypy).
+6. Commit with a Conventional Commit message, e.g. `test(rag): fix partial-overlap fixture in relevance scorer test` with footer `Fixes #157`.
+7. Open a PR using `.github/PULL_REQUEST_TEMPLATE.md`.
+
+## Risks & edge cases
+- **Do not modify `_tokenize()` or the scorer.** Changing tokenization would break
+  `test_tokenization`, `test_common_words_not_preventing_scoring`, and
+  `test_special_characters_ignored`, and would be the wrong fix (the scorer is correct).
+- **Keep the new score strictly inside `0.3 < score < 0.9`.** With 4 query tokens, matching 2 or 3
+  words gives `0.5` or `0.75` — both safe. Matching all 4 → `1.0` (fails); matching only 1 →
+  `0.25` (fails the lower bound).
+- **No trailing punctuation on kept words** — the tokenizer doesn't strip punctuation, so
+  `"framework."` would not match `"framework"`.
+- **Verify the other 18 tests still pass** — the change is isolated (the chunk is inline and not
+  shared), so no other test should be affected.
+
+## Verification
+- Before the fix: `test_query_with_partial_overlap` fails with `assert 1.0 < 0.9`.
+- After the fix (Week 9): that test passes, the full file is `19 passed`, and
+  `make check && make test-unit` both succeed.
+
+## Alternatives considered
+- **Change the query instead of the chunk** (add a query word absent from the chunk) — also valid;
+  chose the chunk edit as the smaller, clearer change.
+- **Loosen the assertion to allow `1.0`** — rejected; that would defeat the purpose of a
+  "partial overlap" test.
+- **Change `_tokenize` / the scorer** — rejected; the scorer is correct and this would break other
+  tests.

--- a/tests/unit/test_relevance_scorer.py
+++ b/tests/unit/test_relevance_scorer.py
@@ -49,7 +49,7 @@ class TestRelevanceScorer:
         query = "Python Django web framework"
         chunks = [
             {
-                "text": "Django is a Python web framework for rapid development"
+                "text": "This Python web framework is great for rapid development"
             },
         ]
 


### PR DESCRIPTION
## Summary

Fixes the `test_query_with_partial_overlap` unit test in the relevance scorer suite. The test's fixture scored a query against a chunk that actually contained **all four** query keywords (full overlap), so `RelevanceScorer` correctly returned `1.0` while the test asserted a partial-overlap range of `0.3 < score < 0.9` — failing with `assert 1.0 < 0.9`. The scorer was correct; the test data was mislabeled. This changes the fixture to genuinely exercise partial overlap.

## Issue

Closes #157

## Changes

- Updated the sample chunk in `test_query_with_partial_overlap` (`tests/unit/test_relevance_scorer.py`) so it contains three of the four query keywords instead of all four. The query `"Python Django web framework"` is now scored against `"This Python web framework is great for rapid development"` (no "Django"), giving `3/4 = 0.75`, which is inside the asserted range.
- No changes to `rag/evaluator/relevance_scorer.py`; the scorer already behaved correctly.

## Testing

- [x] Unit tests pass (`make test-unit`) — see pre-existing-failures note below
- [ ] Integration tests pass (`make test-integration`) — not run (require Docker; unrelated to this change)
- [x] Linter passes (`make lint`) — `ruff check tests/unit/test_relevance_scorer.py` → "All checks passed!"
- [ ] Type checker passes (`make typecheck`) — mypy targets do not include `tests/`; repo-wide mypy errors are pre-existing and unrelated
- [x] New/updated tests cover the changes — this is a test-fixture fix

**Pre-existing failures (documented per contribution guidance):**
This repo has many failing tests and lint/type errors unrelated to this issue. Baseline before my change: `pytest tests/unit` = **53 failed, 375 passed**. After my change: **52 failed, 376 passed** — my change fixes exactly one test (`test_query_with_partial_overlap`) and introduces **no new failures**. The remaining 52 test failures and the repo-wide `ruff` (182)/`black` (52 files)/`mypy` (5) issues predate this change and are out of scope. `ruff` passes on the file I changed.

## Screenshots / Demo

N/A — test-only change.

## Notes for Reviewers

Single-line change to fixture data. `RelevanceScorer.score` computes `overlap / len(query_tokens)` and `_tokenize` is `text.lower().split()`. The old chunk matched all 4 query tokens → `1.0`; the new chunk matches 3 of 4 → `0.75`. I deliberately did **not** modify the tokenizer or scorer — doing so would break `test_tokenization`, `test_common_words_not_preventing_scoring`, and `test_special_characters_ignored`, and the scorer is already correct.
