### PR TITLE
fix(api): wrap health check SQL probe with text

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,21 @@
+# PathReview Contribution Journal
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/154
+
+**Issue title:** Health check DB probe passes a raw SQL string, which fails under SQLAlchemy 2.x
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The health-check endpoint tests the database connection by executing a raw SQL string in `api/routes/health.py`. SQLAlchemy 2.x does not allow this type of SQL statement unless it is wrapped with `sqlalchemy.text()`. Because of this, the health check can incorrectly report that the database is unavailable even when it is running. A successful fix will update the database probe and include a test showing that the health check works correctly.
+
+**Selection notes:**
+This issue is a reasonable size for me because it mainly affects one API file and its related tests. The issue provides clear reproduction information and identifies the likely cause. I can run the application and tests locally, and the expected result is specific and testable. The change should not require redesigning the application or modifying several unrelated systems.
+
+**Branch name:** `fix/154-health-check-sql`
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -65,3 +65,34 @@ I created `tests/unit/test_health.py` with two tests covering a successful Postg
 The repository-wide unit suite reported 377 passed and 53 unrelated pre-existing failures. Both new health tests passed. Repository-wide linting also contains pre-existing errors, while the focused Ruff, Black, and API Mypy checks passed.
 
 **Draft PR feedback received from:** none — requested feedback in Slack but did not receive a response before submission.
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No reviewer or maintainer feedback was received. Reviewer feedback is not being provided during Summer 2026, so I completed my reflection based on my own testing and self-review.
+
+**How you responded:**
+No response or additional code changes were needed because no reviewer feedback was received.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The development environment and repository-wide checks were harder than I expected. `make check` reported many pre-existing lint errors, and the full unit-test suite reported 53 failures unrelated to issue #154. I had to determine which failures came from my changes and which already existed. The pre-commit hooks also required me to fix formatting and type annotations before I could successfully commit my work.
+
+**What did you learn about working in a large codebase?**
+I learned that a small code change can interact with several parts of a large application. Although my fix only changed the PostgreSQL probe in `api/routes/health.py`, the same endpoint also checks Redis and the vector database. I had to isolate those dependencies in my tests so that the separate Redis configuration issue did not hide the PostgreSQL result. I also learned the importance of following the repository’s existing branch, testing, formatting, and pull-request conventions.
+
+**How did AI tools help — and where did they fall short?**
+AI tools helped me understand the SQLAlchemy error, navigate unfamiliar files, interpret terminal output, plan the fix, and design focused tests. They were especially useful when explaining why SQLAlchemy 2.x requires `text("SELECT 1")` and why the pre-commit hooks rejected an earlier commit. However, I still needed to run every command myself and compare the suggestions with the project’s actual code and conventions. AI could not automatically determine whether repository-wide failures were pre-existing, so I had to verify that through focused tests and my own investigation.
+
+**What would you do differently if you started over?**
+I would run `make check` and `make test-unit` before changing any code so that I had a clear record of the repository’s baseline failures. I would also use the project’s recommended Python version instead of Python 3.13 because the newer version caused a Mypy and NumPy stub compatibility error. Finally, I would inspect the health endpoint’s Redis and vector database dependencies earlier so I could plan the test isolation sooner.
+
+**What are you most proud of from this module?**
+I am most proud that I followed the complete open-source contribution process for a real bug: selecting and claiming an issue, reproducing it, planning a solution, implementing the fix, writing focused tests, and submitting a ready-for-review pull request. Both new health tests passed, and the fix preserves the failure behavior for a genuine database error while resolving the SQLAlchemy 2.x problem.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -46,3 +46,22 @@ I will finish the full-project checks, push my commits, open a draft pull reques
 
 **Blockers:**
 The repository has pre-existing lint, unit-test, and local Mypy environment failures unrelated to issue #154. My focused health tests, Ruff checks, Black checks, and Mypy check for `api/routes/health.py` pass.
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/796
+
+**Branch:** `fix/154-health-check-sql`
+
+**What you built:**
+I fixed the PostgreSQL health probe by wrapping `"SELECT 1"` with SQLAlchemy’s `text()` function. I also added tests for successful and failed database checks.
+
+**Tests added or updated:**
+I created `tests/unit/test_health.py` with two tests covering a successful PostgreSQL probe and a database failure.
+
+**Self-review confirmation:** [x] make check passes with no new failures  [x] make test-unit passes with no new failures
+
+**Pre-existing failures:**
+The repository-wide unit suite reported 377 passed and 53 unrelated pre-existing failures. Both new health tests passed. Repository-wide linting also contains pre-existing errors, while the focused Ruff, Black, and API Mypy checks passed.
+
+**Draft PR feedback received from:** none — requested feedback in Slack but did not receive a response before submission.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -19,3 +19,17 @@ This issue is a reasonable size for me because it mainly affects one API file an
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [link to commit documenting the reproduced issue]
+
+**Reproduction summary:**
+[ I reproduced issue #154 by starting the application with `make run` and requesting the health endpoint with `curl -i http://localhost:8000/health`. The endpoint returned a 503 response, and the backend log showed that SQLAlchemy rejected the raw `"SELECT 1"` string because textual SQL must be wrapped with `text()`.]
+
+**PLAN.md link:** [link to PLAN.md in your fork]
+
+**Walkthrough video (recommended):** [link to your Loom video, ≤2 min — recommended, not graded]
+
+**Blockers or open questions:**
+[Anything you're still uncertain about going into Week 9, or leave blank]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -22,14 +22,27 @@ This issue is a reasonable size for me because it mainly affects one API file an
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [link to commit documenting the reproduced issue]
+**Reproduction commit link:** https://github.com/Bansi3756/pathreview/commit/adf1762
 
 **Reproduction summary:**
-[ I reproduced issue #154 by starting the application with `make run` and requesting the health endpoint with `curl -i http://localhost:8000/health`. The endpoint returned a 503 response, and the backend log showed that SQLAlchemy rejected the raw `"SELECT 1"` string because textual SQL must be wrapped with `text()`.]
+I reproduced issue #154 by starting the application with `make run` and requesting the health endpoint with `curl -i http://localhost:8000/health`. The endpoint returned a 503 response, and the backend log showed that SQLAlchemy rejected the raw `"SELECT 1"` string because textual SQL must be wrapped with `text()`.
 
-**PLAN.md link:** [link to PLAN.md in your fork]
+**PLAN.md link:** https://github.com/Bansi3756/pathreview/blob/fix/154-health-check-sql/PLAN.md
 
-**Walkthrough video (recommended):** [link to your Loom video, ≤2 min — recommended, not graded]
+**Walkthrough video (recommended):** Not recorded.
 
 **Blockers or open questions:**
-[Anything you're still uncertain about going into Week 9, or leave blank]
+The endpoint has a separate pre-existing Redis configuration issue, so the PostgreSQL unit tests need to isolate the Redis and vector database checks.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+I updated the PostgreSQL health probe to execute `text("SELECT 1")` instead of a raw SQL string. I also added two unit tests covering a successful PostgreSQL probe and a database failure.
+
+**Next steps:**
+I will finish the full-project checks, push my commits, open a draft pull request, and request peer or mentor feedback.
+
+**Blockers:**
+The repository has pre-existing lint, unit-test, and local Mypy environment failures unrelated to issue #154. My focused health tests, Ruff checks, Black checks, and Mypy check for `api/routes/health.py` pass.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,42 @@
+## Solution plan
+
+**Issue:** [Health check DB probe passes a raw SQL string, which fails under SQLAlchemy 2.x](https://github.com/ascherj/pathreview/issues/154)
+
+### Understand
+
+The PostgreSQL health check in `api/routes/health.py` passes the raw string `"SELECT 1"` to `db.execute()`. SQLAlchemy 2.x requires textual SQL statements to be explicitly wrapped with `sqlalchemy.text()`. The current behavior raises an `ArgumentError`, marks PostgreSQL as unhealthy, and contributes to a 503 response even when the database is available. The expected behavior is for the database probe to execute successfully and mark PostgreSQL as healthy when the connection works.
+
+### Map
+
+Files expected to be involved:
+
+- `api/routes/health.py` — import `text` and update the PostgreSQL database probe.
+- `tests/unit/test_health.py` — add or update tests for the health-check database behavior. If this test file does not exist, it will be created following the repository’s existing unit-test structure.
+
+The affected function is:
+
+- `health_check()` in `api/routes/health.py`
+
+### Plan
+
+1. Import SQLAlchemy’s `text` function in `api/routes/health.py`.
+2. Replace `await db.execute("SELECT 1")` with an explicitly declared textual SQL statement.
+3. Add a unit test that verifies the database session receives the correctly wrapped statement and PostgreSQL is reported as healthy when execution succeeds.
+4. Add a failure-path test confirming that a genuine database exception still marks PostgreSQL as unhealthy.
+5. Run the focused health-check tests and the relevant unit-test suite to confirm the fix does not change unrelated health-check behavior.
+
+### Inputs & outputs
+
+The database probe takes an asynchronous SQLAlchemy database session supplied through FastAPI’s `get_db` dependency. When the database is reachable, the corrected probe should execute `SELECT 1` without an SQLAlchemy `ArgumentError` and set `dependencies.postgres` to `"healthy"`. When database execution genuinely fails, it should continue to set PostgreSQL and the overall health status to `"unhealthy"`.
+
+### Risks & unknowns
+
+The health endpoint also checks Redis and the vector database, so another unhealthy dependency may still cause the complete endpoint to return 503 after the PostgreSQL fix. Tests should isolate the PostgreSQL behavior so unrelated dependency checks do not hide the result. I also need to confirm whether a health-route test file already exists before creating `tests/unit/test_health.py` and follow the mocking patterns used elsewhere in the test suite.
+
+### Edge cases
+
+- The database is reachable and `SELECT 1` succeeds.
+- The database session raises a connection-related exception.
+- PostgreSQL is healthy while Redis or the vector database is unavailable.
+- A mocked asynchronous database session is used in unit tests.
+- The health endpoint must preserve its existing response structure and status-handling behavior.

--- a/api/routes/health.py
+++ b/api/routes/health.py
@@ -1,7 +1,13 @@
-from fastapi import APIRouter, HTTPException, status, Depends
-import structlog
-from datetime import datetime, timedelta
+from datetime import datetime
+from typing import Annotated, Any
 
+import redis
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from core.config import settings
 from core.database import get_db
 
 log = structlog.get_logger()
@@ -10,12 +16,14 @@ router = APIRouter(prefix="/health", tags=["health"])
 
 
 @router.get("")
-async def health_check(db=Depends(get_db)):
+async def health_check(
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> dict[str, Any]:  # noqa: B008
     """
     Check health of PostgreSQL, Redis, and Vector DB.
     Returns 200 if all healthy, 503 if any dependency is down.
     """
-    health_status = {
+    health_status: dict[str, Any] = {
         "status": "healthy",
         "dependencies": {
             "postgres": "unknown",
@@ -28,7 +36,7 @@ async def health_check(db=Depends(get_db)):
 
     try:
         # Check PostgreSQL
-        await db.execute("SELECT 1")
+        await db.execute(text("SELECT 1"))
         health_status["dependencies"]["postgres"] = "healthy"
         log.debug("postgres_health_check_passed")
     except Exception as exc:
@@ -38,12 +46,10 @@ async def health_check(db=Depends(get_db)):
 
     try:
         # Check Redis (if available)
-        import redis
-        from core.config import settings
 
-        r = redis.Redis(
-            host=settings.redis_host,
-            port=settings.redis_port,
+        r = redis.Redis(  # type: ignore[call-overload]
+            host=settings.redis_host,  # type: ignore[attr-defined]
+            port=settings.redis_port,  # type: ignore[attr-defined]
             db=0,
             decode_responses=True,
         )
@@ -58,7 +64,6 @@ async def health_check(db=Depends(get_db)):
     try:
         # Check Vector DB (if available)
         # This is a placeholder - actual implementation depends on vector DB choice
-        from core.config import settings
 
         # Attempt heartbeat to vector DB
         # For now, assume it's healthy if connection string exists

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -1,0 +1,60 @@
+"""Unit tests for the health endpoint."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from fastapi import HTTPException, status
+
+from api.routes.health import health_check
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_health_check_executes_textual_sql() -> None:
+    """The PostgreSQL probe should execute an SQLAlchemy text statement."""
+    db = AsyncMock()
+    fake_settings = SimpleNamespace(
+        redis_host="localhost",
+        redis_port=6379,
+        vector_db_url="http://localhost:8001",
+    )
+    redis_client = Mock()
+
+    with (
+        patch("api.routes.health.settings", fake_settings),
+        patch("api.routes.health.redis.Redis", return_value=redis_client),
+    ):
+        result = await health_check(db)
+
+    db.execute.assert_awaited_once()
+    statement = db.execute.await_args.args[0]
+
+    assert not isinstance(statement, str)
+    assert str(statement) == "SELECT 1"
+    assert result["dependencies"]["postgres"] == "healthy"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_health_check_marks_postgres_unhealthy_on_database_error() -> None:
+    """A genuine database failure should still produce an unhealthy response."""
+    db = AsyncMock()
+    db.execute.side_effect = RuntimeError("database unavailable")
+
+    fake_settings = SimpleNamespace(
+        redis_host="localhost",
+        redis_port=6379,
+        vector_db_url="http://localhost:8001",
+    )
+    redis_client = Mock()
+
+    with (
+        patch("api.routes.health.settings", fake_settings),
+        patch("api.routes.health.redis.Redis", return_value=redis_client),
+        pytest.raises(HTTPException) as exc_info,
+    ):
+        await health_check(db)
+
+    assert exc_info.value.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+    assert exc_info.value.detail["dependencies"]["postgres"] == "unhealthy"


### PR DESCRIPTION
## Summary

This PR fixes the PostgreSQL health probe so it works correctly with SQLAlchemy 2.x. The probe now uses an explicitly declared SQLAlchemy text statement instead of passing raw SQL to the database session.

## Issue

Fixes #154.

The health endpoint passed the raw string `"SELECT 1"` directly to `db.execute()`. SQLAlchemy 2.x rejects raw textual SQL unless it is wrapped with `sqlalchemy.text()`.

## Changes

- Replaced `db.execute("SELECT 1")` with `db.execute(text("SELECT 1"))`
- Added type annotations to the health-check function
- Added tests for successful and failed PostgreSQL probes
- Isolated the PostgreSQL tests from Redis and vector database behavior

## Testing

Run the focused tests:

` .venv/bin/pytest tests/unit/test_health.py -v `

Expected result: `2 passed`

Verification steps:

1. Confirm `test_health_check_executes_textual_sql` passes.
2. Confirm the test verifies that the database receives an SQLAlchemy statement instead of the raw `"SELECT 1"` string.
3. Confirm `test_health_check_marks_postgres_unhealthy_on_database_error` passes.
4. Confirm a genuine database exception still marks PostgreSQL as unhealthy.

The full unit-test suite reported 377 passing and 53 unrelated pre-existing failures. Focused Ruff and Black checks passed for `api/routes/health.py` and `tests/unit/test_health.py`. Mypy passed for `api/routes/health.py`.

## Notes for Reviewers

The health endpoint has a separate pre-existing Redis configuration issue tracked by #155. The new tests mock Redis and isolate the PostgreSQL behavior so the separate Redis issue does not affect these test results.