### PR TITLE
fix(ingestion): detect JavaScript, TypeScript, and Dockerfiles in skill extractor

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -151,7 +151,7 @@ so in the commit message rather than widening scope to fix unrelated tests.
 
 ### Check-in 2 (end of week)
 
-**PR link:** [pending - to be added when the PR is opened]
+**PR link:** https://github.com/ascherj/pathreview/pull/799
 
 **Branch:** `fix/148-detect-javascript-typescript`
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -185,3 +185,138 @@ Newly failing tests: none. Newly passing: the four named in the issue. The ruff 
 because the repo's own pre-commit `ruff --fix` hook reformatted the files I touched.
 
 **Draft PR feedback received from:** none yet
+
+## Week 10 - Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No - still awaiting review
+
+**Summary of feedback:**
+No review came in. As of the Week 10 deadline, PR #799 has zero reviews and zero comments.
+This appears to be the norm for the cohort rather than a signal about the PR: of the 13 open
+PRs against issue #148, 11 have no feedback of any kind, one has a Copilot bot comment, and
+exactly one has a human review. Repo-wide, 636 PRs are open and 1 has ever been merged.
+
+**How you responded:**
+No changes were required. I re-checked the PR for comments before writing this entry and left
+it open and ready for review.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+
+I expected the regex work to be the hard part. It wasn't. The hard part was telling my own
+breakage apart from breakage that was already there. This repo fails its own quality gates on
+a clean checkout: `ruff check .` reports 182 errors on `main`, `mypy` reports 91, and
+`make test-unit` fails 53 tests. The first time I ran `make check` I assumed I had caused it.
+There is no way to answer "did I break this?" without capturing a baseline first, and I didn't
+capture mine until after I had already started editing, which cost me time re-deriving it.
+
+The second surprise was that the test file defining "done" was itself broken.
+`test_database_technology_detection` fails with `UnboundLocalError` because line 138 reads
+`skill_names = [s.name for s in skill_names]`, referencing the variable it is assigning. I had
+assumed the failing tests named in the issue were a trustworthy specification. Four of them
+were. A fifth in the same file was simply wrong, and deciding it was not my problem took
+longer than fixing it would have.
+
+Setup was also harder than it should have been. On a fresh clone `make setup` died at
+`alembic upgrade head` because it assumed `.env` existed and that the Postgres and Redis
+containers were already running.
+
+**What did you learn about working in a large codebase?**
+
+That reading is most of the work, and the reading is defensive. Before changing
+`_detect_languages` I grepped for `extract_skills` and `SkillExtractor` to find the blast
+radius, and learned two things I would not have guessed. The ingestion parser has no
+production callers at all, since only its test file imports it. And there is a second,
+unrelated class with the same name in `agent/tools/skill_extractor.py` that *is* wired into
+`agent/orchestrator.py`. On my own project I would have known both facts already. Here I had
+to establish them before I could safely touch anything.
+
+I also learned that dead code isn't yours to delete. `JS_TS_KEYWORDS` and `PYTHON_KEYWORDS`
+are both defined and never referenced anywhere in the repo. The obvious move is to remove or
+wire up the unused constant. The correct move was to leave it and explain why in the PR,
+because I don't know what the maintainer intends, and a drive-by deletion is how a small
+reviewable fix turns into an argument.
+
+The broader lesson is that scope is a real engineering decision rather than a formality. I
+made the same call three separate times, on the broken database test, the unused keyword sets,
+and `_detect_react` firing on `.tsx`, and each time chose to document rather than fix. That
+restraint is what kept the diff at 138 added lines in the module instead of a rewrite.
+
+**How did AI tools help - and where did they fall short?**
+
+Most useful for orientation and for mechanical work: mapping an unfamiliar codebase quickly,
+matching existing test conventions, and drafting regression tests once I had specified what
+each one needed to assert.
+
+Three places it fell short, all of which cost me something real.
+
+1. **The plan it helped me write was wrong on the central step.** `PLAN.md` step 1 said to
+   build JavaScript detection from the existing `JS_TS_KEYWORDS` set. That set contains
+   `import`, `class`, `async`, and `await`, all of which Python uses, so implementing the plan
+   as written tags every Python file as JavaScript and breaks `test_text_with_python_imports`.
+   I had to throw that step out and design separate strong and weak pattern sets instead. A
+   plausible-sounding plan is not a correct plan, and I only found out by running it.
+
+2. **Passing tests convinced me I was done when I wasn't.** After implementing the plan, the
+   four target tests passed, but the issue's own example, "Wrote index.js using const arrow
+   functions", still returned nothing, because the filename appears in the body text rather
+   than being passed as an argument. I caught it by running the snippet from the issue instead
+   of trusting the suite. The unit tests were not a complete specification of the bug.
+
+3. **It asserted tool results it had not actually run.** When drafting the PR description, the
+   `make lint` and `make typecheck` boxes were ticked based on my journal's summary rather
+   than on executed commands. I asked for both to be verified before submitting, and neither
+   passes: `ruff` exits non-zero with 179 findings and `mypy` with 91. My *change* introduces
+   no new failures, which is what the Week 9 guidance actually asks for, so the claim was
+   defensible once reworded. But "no new failures" and "passes" are different statements, and
+   only running the tools tells you which one is true. I ended up rewording both checkboxes to
+   state the before and after counts explicitly.
+
+The pattern across all three is the same. AI was reliable for things I could immediately
+verify, and unreliable for exactly the things I was tempted to take on faith.
+
+**What would you do differently if you started over?**
+
+Capture the baseline first. Before writing a line of code I would record the `make check` and
+`make test-unit` counts and commit them to the journal, so that every later "is this mine?"
+question becomes a lookup instead of an investigation.
+
+Get the toolchain working locally before starting rather than during. Because I could not run
+`ruff` and `mypy` cleanly, I committed with `--no-verify` and carried an unverified claim
+about lint and typecheck all the way into the PR description, where it had to be corrected.
+That was avoidable with thirty minutes of setup up front.
+
+Open the draft PR at the start of the week instead of the end. The instructions said to, and I
+didn't. Because I opened it late there was no window for peer feedback, and the
+"Draft PR feedback received from" field says none for a reason that was entirely within my
+control.
+
+**What are you most proud of from this module?**
+
+Two things, and they turned out to be connected.
+
+The first is the regression tests nobody asked for. The issue named four failing tests, and
+making those four pass would have satisfied the acceptance criteria. But broadening keyword
+matching is exactly the kind of change that fixes the stated case and quietly breaks the
+unstated one, so I wrote seven more aimed at the false positives: that English prose
+containing "constant" and "classic" does not register as JavaScript, that Python imports don't
+either, that TypeScript is no longer misreported as Python, and that Docker isn't
+double-counted when both named and structural evidence appear. Those tests are why I could
+tighten the Python annotation regex with confidence instead of hoping.
+
+The second is realizing how much of the work was finding problems the issue never mentioned. I
+went in assuming an issue describes one defect and you go fix that defect. In practice #148
+named the JavaScript and TypeScript gap, but getting it right meant first discovering that the
+Python annotation regex matched `: string` as `str`, that Docker detection missed Dockerfiles
+and compose files entirely because it searched for the literal word "docker", that a test in
+the same file was broken with an `UnboundLocalError`, that `_detect_react` fires on `.tsx`
+with no React present, and that `make setup` did not work on a clean clone. Some of those I
+fixed, because the issue could not be closed without them. Others I deliberately worked around
+and documented instead, and filed or flagged separately. Learning to tell those two categories
+apart, and to route around a defect rather than absorb it into my diff, did more for the
+quality of this PR than the fix itself did.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -49,7 +49,7 @@ this branch).
 
 ## Week 8 - Reproduction & solution planning
 
-**Reproduction commit link:** [pending - filled in below]
+**Reproduction commit link:** https://github.com/Aristide021/pathreview/commit/dd1b0ba565f41ba882d47f8baddd19f0391f3b8e
 
 **Reproduction summary:**
 I reproduced the bug two ways in my local venv. Running the snippet from the issue against
@@ -113,7 +113,7 @@ the test itself: line 138 reads `skill_names = [s.name for s in skill_names]`, w
 `UnboundLocalError`. It is unrelated to #148 and I plan to report it as its own issue rather
 than widen this PR.
 
-**PLAN.md link:** [pending]
+**PLAN.md link:** https://github.com/Aristide021/pathreview/blob/fix/148-detect-javascript-typescript/PLAN.md
 
 **Walkthrough video (recommended):** not recorded
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -122,3 +122,66 @@ Two judgment calls I want feedback on. First, whether TypeScript input should al
 JavaScript, since TS is a superset. The test only asserts TypeScript is present, so either
 reading passes. Second, whether to fix the unrelated broken test at line 138 in this PR or
 file it separately. I lean toward filing it separately to keep the diff scoped to #148.
+
+## Week 9 - Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+All six sub-tasks from `PLAN.md` are implemented and committed in
+`fix(ingestion): detect JavaScript, TypeScript, and Dockerfiles in skill extractor`.
+JavaScript now detects from strong signals (`require()`, `module.exports`, arrow functions,
+ES6 import-from, `.js` references) or any two weak ones (`const`, `let`, `var`, `function`,
+`export`). TypeScript detects from body text with no filename. The Python annotation regex
+gained a `\b` so `: string` no longer registers as Python. Docker detects Dockerfile
+directives and compose keys structurally. All four tests named in the issue pass, and I added
+7 regression tests.
+
+**Next steps:**
+Request peer review on a draft PR, then open the PR against upstream with the pre-existing
+failure counts documented.
+
+**Blockers:**
+None blocking. One thing to flag in review: the pre-commit `mypy` hook cannot pass on
+`tests/unit/test_skill_extractor.py` because of 21 pre-existing errors, one of which comes
+from the broken `test_database_technology_detection`. I committed with `--no-verify` and said
+so in the commit message rather than widening scope to fix unrelated tests.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [pending - to be added when the PR is opened]
+
+**Branch:** `fix/148-detect-javascript-typescript`
+
+**What you built:**
+A rewrite of JavaScript and TypeScript detection in
+`ingestion/parsers/skill_extractor.py`, replacing a filename-only check and a regex that
+required trailing whitespace with pattern sets matched against the text body. TypeScript is
+now detectable without a filename and no longer misreported as Python. Docker detection
+recognizes Dockerfile directives and compose file structure, neither of which contains the
+literal word "docker".
+
+**Tests added or updated:**
+`tests/unit/test_skill_extractor.py`. Added 7 regression tests covering the false positives
+the existing tests do not exercise: TypeScript detected without a filename, TypeScript not
+reported as Python, `require('fs')` with no trailing space, English prose containing
+"constant"/"classic" not registering as JavaScript, Python imports not registering as
+JavaScript, Dockerfile directives detected without the word "docker", and Docker not
+duplicated when both named and structural evidence appear.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+Both commands fail on this repo before any of my changes, so "passes" means no new failures,
+per the Week 9 guidance on pre-existing failures:
+
+| Command | Before | After |
+|---|---|---|
+| `make check` (ruff) | 182 errors | 179 errors |
+| `make test-unit` | 53 failed, 375 passed | 49 failed, 386 passed |
+
+Newly failing tests: none. Newly passing: the four named in the issue. The ruff count drops
+because the repo's own pre-commit `ruff --fix` hook reformatted the files I touched.
+
+**Draft PR feedback received from:** none yet

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,48 @@
+# JOURNAL
+
+## Week 7 - Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/148
+
+**Issue title:** Skill extractor fails to detect JavaScript and TypeScript
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Selection reasoning:**
+This is my first time contributing to a codebase this size, so I deliberately started at
+Tier 1 rather than reaching for something bigger. Against the "is this right for me?"
+checklist: the issue is reproducible in two lines (the report gives exact input/output
+pairs), the blast radius is contained to a single function (`_detect_languages` in
+`ingestion/parsers/skill_extractor.py`) with no cross-module or DB/API side effects, and the
+four failing unit tests named in the issue already define what "done" looks like, so I don't
+have to guess at acceptance criteria. It's also labeled "good first issue," which lines up
+with wanting a bounded, well-specified first PR rather than something open-ended.
+
+**Problem summary:**
+`SkillExtractor.extract_skills()` in `ingestion/parsers/skill_extractor.py` is supposed to
+detect programming languages from resume/repo text, but its JavaScript/TypeScript detection
+only fires when a filename with a `.js`/`.ts` extension is explicitly passed in, or when the
+text literally contains the word "import" or "require". It ignores the `JS_TS_KEYWORDS` set
+already defined on the class (`const`, `let`, `function`, `async`, `await`, etc.) and never
+scans the text body for TypeScript signals such as `.ts`/`.tsx` mentions or the word
+"TypeScript" the way Python detection checks multiple signals (imports, `def`, type
+annotations). As a result, text describing JS/TS work with arrow functions, async/await, or
+in-body `.tsx`/`.ts` file mentions returns no language detection at all, or in the TypeScript
+case gets misclassified as only "React" (via the unrelated `REACT_INDICATORS` substring
+match). A successful fix broadens `_detect_languages` to use the existing keyword set and
+add TypeScript-specific signals, making the four currently-failing tests in
+`tests/unit/test_skill_extractor.py` (`test_javascript_detection`,
+`test_text_with_typescript_files`, `test_devops_tool_detection`,
+`test_docker_compose_detection`) pass.
+
+**Branch name:** fix/148-detect-javascript-typescript
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Setup note:** On a fresh clone, `make setup` failed at `alembic upgrade head` because it
+assumed `.env` already existed and that the Postgres/Redis Docker containers were already
+running. Fixed by having the `setup` target copy `.env.example` to `.env` if missing and run
+`docker compose up -d --wait db redis` before the migration step (see the first commit on
+this branch).
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -46,3 +46,79 @@ running. Fixed by having the `setup` target copy `.env.example` to `.env` if mis
 this branch).
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 - Reproduction & solution planning
+
+**Reproduction commit link:** [pending - filled in below]
+
+**Reproduction summary:**
+I reproduced the bug two ways in my local venv. Running the snippet from the issue against
+`SkillExtractor.extract_skills()` returned `[]` for JavaScript text and `['React']` for
+TypeScript text, matching the reported behavior exactly. Running
+`pytest tests/unit/test_skill_extractor.py` gave 5 failures out of 18, including all four
+tests named in the issue.
+
+### How to reproduce
+
+```bash
+.venv/bin/python -c "
+from ingestion.parsers.skill_extractor import SkillExtractor
+e = SkillExtractor()
+print('JS  :', [d.name for d in e.extract_skills('Wrote index.js using const arrow functions and async/await callbacks')])
+print('TS  :', [d.name for d in e.extract_skills('Built app.tsx and types.ts with strict TypeScript interfaces')])
+"
+```
+
+Observed output:
+
+```
+JS  : []
+TS  : ['React']
+```
+
+Expected: `['JavaScript']` and a list containing `TypeScript`.
+
+```bash
+.venv/bin/python -m pytest tests/unit/test_skill_extractor.py -v
+```
+
+Observed: `5 failed, 13 passed`.
+
+```
+FAILED tests/unit/test_skill_extractor.py::TestSkillExtractor::test_text_with_typescript_files
+FAILED tests/unit/test_skill_extractor.py::TestSkillExtractor::test_database_technology_detection
+FAILED tests/unit/test_skill_extractor.py::TestSkillExtractor::test_devops_tool_detection
+FAILED tests/unit/test_skill_extractor.py::TestSkillExtractor::test_javascript_detection
+FAILED tests/unit/test_skill_extractor.py::TestSkillExtractor::test_docker_compose_detection
+```
+
+### What I found while tracing it
+
+All four in-scope failures come from `_detect_languages` and `_detect_tools` in
+`ingestion/parsers/skill_extractor.py`:
+
+- The `JS_TS_KEYWORDS` set on line 30 is defined but never referenced anywhere in the repo.
+  JS detection never looks at `const`, `let`, `function`, or `=>`.
+- `re.search(r"\b(import|require)\s+", text)` on line 179 requires whitespace after the
+  keyword, so `require('fs')` does not match.
+- TypeScript is only ever selected by filename (line 186). Text-only TS input can never
+  produce a TypeScript detection, and line 186 makes JS and TS mutually exclusive.
+- The TS test text gets labeled Python, because the annotation regex on line 160,
+  `:\s*(int|str|float|bool|list|dict)`, matches `: string` (`str` is a prefix of `string`).
+- `_detect_tools` substring-matches the literal word "docker". Dockerfile content
+  (`FROM`, `RUN`, `EXPOSE`) and compose YAML (`services:`, `ports:`) never contain it.
+
+The fifth failure, `test_database_technology_detection`, is a separate pre-existing bug in
+the test itself: line 138 reads `skill_names = [s.name for s in skill_names]`, which raises
+`UnboundLocalError`. It is unrelated to #148 and I plan to report it as its own issue rather
+than widen this PR.
+
+**PLAN.md link:** [pending]
+
+**Walkthrough video (recommended):** not recorded
+
+**Blockers or open questions:**
+Two judgment calls I want feedback on. First, whether TypeScript input should also report
+JavaScript, since TS is a superset. The test only asserts TypeScript is present, so either
+reading passes. Second, whether to fix the unrelated broken test at line 138 in this PR or
+file it separately. I lean toward filing it separately to keep the diff scoped to #148.

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,8 @@ setup: ## First-time setup: venv, deps, migrations, seed data
 	$(PYTHON) -m pip install --upgrade pip setuptools wheel
 	$(PIP) install -e ".[dev]"
 	$(VENV_BIN)/pre-commit install
+	@if [ ! -f .env ]; then cp .env.example .env; fi
+	docker compose up -d --wait db redis
 	$(VENV_BIN)/alembic upgrade head
 	$(PYTHON) scripts/seed_db.py
 	cd frontend && npm install

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,161 @@
+# Solution plan
+
+**Issue:** [#148 Skill extractor fails to detect JavaScript and TypeScript](https://github.com/ascherj/pathreview/issues/148)
+
+## Understand
+
+`SkillExtractor.extract_skills()` is supposed to read resume or repo text and report which
+languages and tools it sees. It handles Python, databases, and most frameworks, but the
+JavaScript and TypeScript path barely works, and Docker detection misses Dockerfiles.
+
+Expected: text describing JavaScript work returns a `JavaScript` detection, TypeScript text
+returns a `TypeScript` detection, and Dockerfile or compose content returns `Docker`.
+
+Actual: JavaScript text returns `[]`. TypeScript text returns `['React']` or gets mislabeled
+`Python`. Dockerfile and compose content return neither.
+
+Five specific causes, all in `ingestion/parsers/skill_extractor.py`:
+
+1. `JS_TS_KEYWORDS` (line 30) is defined but never referenced anywhere in the repo. The JS
+   branch never checks for `const`, `let`, `function`, `var`, or `export`.
+2. `re.search(r"\b(import|require)\s+", text)` (line 179) requires whitespace after the
+   keyword, so `require('fs')` and `import{x}` do not match.
+3. TypeScript is selected only by filename (line 186). Text-only TypeScript can never be
+   detected, and the ternary makes JavaScript and TypeScript mutually exclusive.
+4. The Python annotation regex `:\s*(int|str|float|bool|list|dict)` (line 160) has no closing
+   word boundary, so TypeScript's `: string` matches `str` and TypeScript code gets reported
+   as Python.
+5. `_detect_tools` (line 263) substring-matches the literal word `docker`. Dockerfile
+   directives (`FROM`, `RUN`, `EXPOSE`) and compose keys (`services:`, `ports:`) never
+   contain that word.
+
+## Map
+
+Files I expect to touch:
+
+| File | Change |
+|---|---|
+| `ingestion/parsers/skill_extractor.py` | All production changes. `_detect_languages` (lines 143-214) and `_detect_tools` (lines 263-276). May add a `DOCKER_INDICATORS` constant near the existing `TOOLS` dict. |
+| `tests/unit/test_skill_extractor.py` | Add regression tests for the false positives the four target tests do not cover. |
+
+Files I expect to read but not change:
+
+- `agent/tools/skill_extractor.py` has a same-named `SkillExtractor` class with its own
+  `SKILL_PATTERNS` regexes. It is a separate `BaseTool` subclass wired into
+  `agent/orchestrator.py:119`. I will borrow naming conventions from its patterns but not
+  edit it, since the issue names the ingestion parser.
+- `ingestion/parsers/__init__.py` is empty, so there is no export list to update.
+
+Blast radius check: grepping for `extract_skills` and `SkillExtractor` shows the ingestion
+parser has no production callers. Only `tests/unit/test_skill_extractor.py` imports it. So
+this change cannot break the API or the agent pipeline.
+
+## Plan
+
+1. **Wire up JavaScript keyword detection.** In `_detect_languages`, add text-content signals
+   built from the existing `JS_TS_KEYWORDS` set using word-boundary regexes, plus `=>`,
+   `console.log`, and `module.exports`. Fix the import/require regex to
+   `\b(import|require)\s*[\s('"]` so `require('fs')` matches. Require at least two distinct
+   keyword hits before reporting JavaScript, so ordinary prose containing "class" or "with"
+   does not trigger it.
+
+2. **Add filename-independent TypeScript detection.** Detect `interface X {`, `type X =`,
+   `Promise<`, `enum`, TS-style annotations (`: string`, `: number`, `: boolean`), the literal
+   word "typescript", and `.ts` or `.tsx` appearing in the body text rather than only the
+   filename. Emit `TypeScript` as its own `SkillDetection` instead of routing through the
+   line 186 ternary.
+
+3. **Stop TypeScript from being reported as Python.** Add a closing `\b` to the annotation
+   regex on line 160 so `: string` no longer matches `str`. I confirmed with a scratch script
+   that the tightened regex still matches Python's `url: str)` and now rejects `: string`.
+
+4. **Detect Docker structurally.** In `_detect_tools`, add a Dockerfile check for
+   line-anchored directives (`FROM`, `RUN`, `EXPOSE`, `COPY`, `WORKDIR`) using
+   `re.MULTILINE`, and a compose check requiring `services:` together with at least one of
+   `ports:`, `build:`, or `image:`. Merge these into the single existing `Docker` entry rather
+   than creating a second one.
+
+5. **Verify and guard.** Run `pytest tests/unit/test_skill_extractor.py` and confirm the four
+   target tests pass and the 13 already-passing tests stay green. Then run
+   `make lint && make typecheck` for the pre-commit hooks, and add the regression tests from
+   step 6 below.
+
+6. **Add regression tests** for the false positives that the four target tests do not cover:
+   prose containing "constant" and "variety" must not yield JavaScript, and TypeScript-only
+   text must not yield Python.
+
+## Inputs & outputs
+
+**Input:** unchanged. `extract_skills(text: str, filename: Optional[str] = None) ->
+list[SkillDetection]`. No signature change, so no caller has to be updated.
+
+**Output:** the same sorted `list[SkillDetection]`, still ordered by descending confidence,
+with each item carrying `name`, `category`, `confidence` (float, 0.0 to 1.0), and `evidence`
+(list of human-readable strings).
+
+What changes in the returned data:
+
+- New `JavaScript` detections for text with JS syntax and no filename.
+- New `TypeScript` detections for text with TS syntax and no filename.
+- New `Docker` detections for Dockerfile and compose content.
+- `Python` no longer appears for TypeScript-only text. This is a deliberate removal, not a
+  regression.
+- Evidence strings for JS and TS will name the specific signal found, matching the style of
+  the existing Python strings like `"Python type annotations"`.
+
+Confidence stays on the existing `min(0.95, 0.6 + len(evidence) * 0.1)` formula so new
+detections rank alongside old ones instead of dominating the sort.
+
+## Risks & unknowns
+
+**Broadening JS keywords could produce false positives.** `JS_TS_KEYWORDS` contains `class`,
+`async`, `await`, and `import`, which Python also uses. Naive matching would tag every Python
+file as JavaScript and break `test_text_with_python_imports`. Mitigation is the two-hit
+threshold in step 1 plus preferring JS-only tokens (`const`, `let`, `=>`, `require`). I need
+to check this against `test_mixed_language_text`, which deliberately mixes all three.
+
+**Tightening the line 160 regex could regress Python detection.** I already ran the check:
+`test_text_with_python_type_annotations` passes on the `\bdef\s+\w+\s*\(` signal, and the
+tightened annotation regex still matches `url: str)`. Low risk, but worth re-running the full
+file rather than only the four target tests.
+
+**`_detect_react` can fire on `.tsx` with no React present.** Lines 231-246 substring-match
+`.tsx` against lowered text, which is why the issue's TypeScript sample returns `React`. Once
+TypeScript is detected properly, that stray `React` will still be there. I have not decided
+whether tightening it belongs in this PR or a follow-up, since `test_react_detection` passes
+today and I do not want to destabilize it.
+
+**Unknown: should TypeScript text also report JavaScript?** TypeScript is a superset, so both
+are defensible. `test_text_with_typescript_files` only asserts TypeScript is present, so both
+pass. I will report only TypeScript when TS-specific evidence exists, and note the choice in
+the PR description so a reviewer can push back.
+
+**Unknown: are the dead keyword sets meant to be wired in or deleted?** `PYTHON_KEYWORDS` is
+also unused. The issue implies JS_TS_KEYWORDS should be used, so I will wire that one in and
+leave `PYTHON_KEYWORDS` alone rather than expanding scope.
+
+**Out of scope, needs its own issue.** `tests/unit/test_skill_extractor.py:138` reads
+`skill_names = [s.name for s in skill_names]` and raises `UnboundLocalError`. It is a fifth
+failing test unrelated to #148. I plan to file it separately.
+
+## Edge cases
+
+- **Empty and whitespace-only text.** Must return `[]` without raising.
+  `test_empty_text` covers this.
+- **Plain English prose.** "This is just plain English text with no code." must not detect
+  anything. Substrings matter here: "constant" contains `const`, "variety" contains `var`,
+  and "classic" contains `class`. Every new keyword check needs `\b` anchors.
+- **Mixed-language documents.** A file with JavaScript, Python, and TypeScript together
+  should return all three rather than one winner. `test_mixed_language_text` asserts more
+  than one name comes back.
+- **TypeScript with `filename=None`.** The whole point of the issue. TS must be detectable
+  from body text alone.
+- **Filename and content disagree.** A `.ts` filename holding plain JavaScript. Current code
+  lets the filename win; I will keep that precedence and add both detections when both kinds
+  of evidence exist.
+- **Docker mentioned in prose vs. a real Dockerfile.** "I used Docker at my last job" must
+  still work through the existing literal match, and must not produce a duplicate `Docker`
+  entry when structural directives are also present.
+- **A Dockerfile that is also Python.** The `test_devops_tool_detection` fixture contains
+  `requirements.txt`, so it detects Python too. The test only asserts Docker, so both
+  appearing is fine and should stay that way.

--- a/PLAN.md
+++ b/PLAN.md
@@ -159,3 +159,38 @@ failing test unrelated to #148. I plan to file it separately.
 - **A Dockerfile that is also Python.** The `test_devops_tool_detection` fixture contains
   `requirements.txt`, so it detects Python too. The test only asserts Docker, so both
   appearing is fine and should stay that way.
+
+## Implementation notes (added Week 9)
+
+Where the finished work diverged from the plan above.
+
+**I did not wire in `JS_TS_KEYWORDS` as written.** Step 1 said to build the JavaScript check
+from that set. In practice the set is too blunt: it contains `import`, `class`, `async`, and
+`await`, all of which Python uses, so matching on it directly tags every Python file as
+JavaScript. I replaced it with two purpose-built dicts, `JS_STRONG_PATTERNS` and
+`JS_WEAK_PATTERNS`, mapping a regex to a human-readable evidence string. One strong signal
+identifies JavaScript on its own; weak signals need two. `JS_TS_KEYWORDS` remains unused, as
+it was before this change. Removing it felt like scope creep, so I left it for the maintainer
+to decide.
+
+**I added a `.js`/`.jsx` body reference as a strong signal, which the plan missed.** The
+issue's own example, "Wrote index.js using const arrow functions", names a `.js` file in the
+text rather than passing a filename. I had planned that mirror for TypeScript (`.ts`/`.tsx`)
+but not for JavaScript, so the example still failed after step 1. Caught it by running the
+issue's snippet rather than trusting the unit tests.
+
+**The Python false-positive fix worked as predicted.** Adding `\b` to
+`:\s*(int|str|float|bool|list|dict)` stops `: string` from matching `str` and does not
+regress `url: str)`.
+
+**Pre-existing tooling failures I did not fix.** The pre-commit `mypy` hook fails on 21
+errors in `tests/unit/test_skill_extractor.py`, all pre-existing, including one caused by the
+broken `test_database_technology_detection`. That test cannot be made to pass without the
+separate driver-alias work, so the file cannot be made mypy-clean inside this issue's scope.
+My changes add zero new mypy, ruff, or black findings. The commit used `--no-verify` for that
+reason and says so in its message.
+
+**The repo's own pre-commit `ruff --fix` hook modified the files I touched.** It sorted an
+import in the test file and converted `Optional[str]` to `str | None` in
+`skill_extractor.py`, dropping the now-unused `typing.Optional` import. Those hunks are tool
+output, not deliberate edits, and they lower the repo-wide ruff count from 182 to 179.

--- a/ingestion/parsers/skill_extractor.py
+++ b/ingestion/parsers/skill_extractor.py
@@ -1,11 +1,11 @@
 import re
 from dataclasses import dataclass
-from typing import Optional
 
 
 @dataclass
 class SkillDetection:
     """Result of detecting a skill."""
+
     name: str
     category: str
     confidence: float
@@ -39,6 +39,57 @@ class SkillExtractor:
         "await",
         "class",
     }
+
+    # Signals distinctive enough to identify JavaScript on their own. Python never
+    # writes require(), module.exports, arrow functions, or `import x from "y"`.
+    JS_STRONG_PATTERNS = {
+        r"\brequire\s*\(": "CommonJS require() call",
+        r"\bmodule\.exports\b": "module.exports assignment",
+        r"\bconsole\.log\s*\(": "console.log call",
+        r"=>": "arrow functions",
+        r"\bimport\s+.*\bfrom\s+['\"]": "ES6 import ... from",
+        r"\bexport\s+default\b": "export default",
+        r"\.jsx?\b": "JavaScript file reference (.js/.jsx)",
+    }
+
+    # Weaker signals. Any two together identify JavaScript; one alone does not,
+    # because prose ("a constant variety of work") can trip a single pattern.
+    JS_WEAK_PATTERNS = {
+        r"\bconst\s+\w+": "const declarations",
+        r"\blet\s+\w+\s*=": "let declarations",
+        r"\bvar\s+\w+\s*=": "var declarations",
+        r"\bfunction\s*\w*\s*\(": "function keyword",
+        r"\bexport\s+\w+": "export statements",
+    }
+
+    # TypeScript-specific syntax. These are checked against the text body, so
+    # TypeScript is detectable without a .ts filename.
+    TS_PATTERNS = {
+        r"\binterface\s+\w+\s*\{": "TypeScript interface declaration",
+        r"\btype\s+\w+\s*=": "TypeScript type alias",
+        r"\benum\s+\w+\s*\{": "TypeScript enum declaration",
+        r":\s*(string|number|boolean|any|unknown|void)\b": "TypeScript type annotations",
+        r"\bPromise\s*<": "TypeScript generic Promise",
+        r"\btypescript\b": "TypeScript mentioned by name",
+        r"\.tsx?\b": "TypeScript file reference (.ts/.tsx)",
+    }
+
+    # Dockerfile directives. Matched case-sensitively so Python's lowercase
+    # `from x import y` cannot be mistaken for a Dockerfile FROM.
+    DOCKERFILE_DIRECTIVES = (
+        "FROM",
+        "RUN",
+        "EXPOSE",
+        "COPY",
+        "WORKDIR",
+        "CMD",
+        "ENTRYPOINT",
+        "ENV",
+        "ADD",
+    )
+
+    # A compose file needs `services:` plus at least one of these keys.
+    COMPOSE_SUPPORTING_KEYS = ("ports", "build", "image", "volumes", "environment")
 
     REACT_INDICATORS = {
         "import React",
@@ -105,7 +156,7 @@ class SkillExtractor:
         "ansible": 0.85,
     }
 
-    def extract_skills(self, text: str, filename: Optional[str] = None) -> list[SkillDetection]:
+    def extract_skills(self, text: str, filename: str | None = None) -> list[SkillDetection]:
         """
         Extract skills from source code or documentation text.
 
@@ -143,7 +194,7 @@ class SkillExtractor:
     def _detect_languages(
         self,
         text: str,
-        filename: Optional[str],
+        filename: str | None,
         skills_dict: dict,
     ) -> None:
         """Detect programming languages."""
@@ -157,7 +208,7 @@ class SkillExtractor:
             python_evidence.append("Python import statements")
         if re.search(r"\bdef\s+\w+\s*\(", text):
             python_evidence.append("Python function definitions")
-        if re.search(r":\s*(int|str|float|bool|list|dict)", text):
+        if re.search(r":\s*(int|str|float|bool|list|dict)\b", text):
             python_evidence.append("Python type annotations")
         if "requirements.txt" in text_lower:
             python_evidence.append("requirements.txt found")
@@ -171,23 +222,48 @@ class SkillExtractor:
             )
 
         # JavaScript/TypeScript detection
-        js_evidence = []
-        if ".js" in str(filename or "").lower():
-            js_evidence.append("JavaScript file extension (.js)")
-        if ".ts" in str(filename or "").lower():
-            js_evidence.append("TypeScript file extension (.ts)")
-        if re.search(r"\b(import|require)\s+", text):
-            js_evidence.append("CommonJS or ES6 imports")
+        js_filename = ".js" in str(filename or "").lower()
+        ts_filename = ".ts" in str(filename or "").lower()
+
+        js_strong = [
+            desc for pattern, desc in self.JS_STRONG_PATTERNS.items() if re.search(pattern, text)
+        ]
+        js_weak = [
+            desc for pattern, desc in self.JS_WEAK_PATTERNS.items() if re.search(pattern, text)
+        ]
+        ts_evidence = [
+            desc
+            for pattern, desc in self.TS_PATTERNS.items()
+            if re.search(pattern, text, re.IGNORECASE)
+        ]
+
+        js_evidence = js_strong + js_weak
+        if js_filename:
+            js_evidence.insert(0, "JavaScript file extension (.js)")
+        if ts_filename:
+            ts_evidence.insert(0, "TypeScript file extension (.ts)")
         if "package.json" in text_lower:
             js_evidence.append("package.json found")
 
-        if js_evidence:
-            confidence = min(0.95, 0.6 + len(js_evidence) * 0.1)
-            lang = "TypeScript" if ".ts" in str(filename or "").lower() else "JavaScript"
-            skills_dict[lang] = SkillDetection(
-                name=lang,
+        # One strong signal is enough; weak signals need corroboration so that
+        # ordinary prose does not register as code.
+        has_javascript = bool(js_filename or js_strong or len(js_weak) >= 2)
+        has_javascript = has_javascript or "package.json" in text_lower
+
+        # TypeScript is a superset of JavaScript, so TypeScript evidence wins and
+        # a single language is reported rather than both.
+        if ts_evidence:
+            skills_dict["TypeScript"] = SkillDetection(
+                name="TypeScript",
                 category="Language",
-                confidence=confidence,
+                confidence=min(0.95, 0.6 + len(ts_evidence) * 0.1),
+                evidence=ts_evidence,
+            )
+        elif has_javascript:
+            skills_dict["JavaScript"] = SkillDetection(
+                name="JavaScript",
+                category="Language",
+                confidence=min(0.95, 0.6 + len(js_evidence) * 0.1),
                 evidence=js_evidence,
             )
 
@@ -274,3 +350,48 @@ class SkillExtractor:
                         confidence=confidence,
                         evidence=[f"Found '{tool}' reference in content"],
                     )
+
+        # Dockerfiles and compose files describe Docker usage without ever
+        # containing the word "docker", so the loop above misses them.
+        docker_evidence = self._detect_docker_structure(text)
+        if docker_evidence:
+            if "Docker" in skills_dict:
+                skills_dict["Docker"].evidence.extend(docker_evidence)
+            else:
+                skills_dict["Docker"] = SkillDetection(
+                    name="Docker",
+                    category="Tool",
+                    confidence=self.TOOLS["docker"],
+                    evidence=docker_evidence,
+                )
+
+    def _detect_docker_structure(self, text: str) -> list[str]:
+        """Detect Docker from Dockerfile directives or compose file structure.
+
+        Args:
+            text: The source text to analyze
+
+        Returns:
+            List of evidence strings, empty if no Docker structure is found
+        """
+        evidence = []
+
+        directives = [
+            directive
+            for directive in self.DOCKERFILE_DIRECTIVES
+            if re.search(rf"^\s*{directive}\s+", text, re.MULTILINE)
+        ]
+        # Two directives are required because a single RUN or ADD can appear in prose.
+        if len(directives) >= 2:
+            evidence.append(f"Dockerfile directives ({', '.join(directives)})")
+
+        if re.search(r"^\s*services:", text, re.MULTILINE):
+            supporting = [
+                key
+                for key in self.COMPOSE_SUPPORTING_KEYS
+                if re.search(rf"^\s*{key}:", text, re.MULTILINE)
+            ]
+            if supporting:
+                evidence.append(f"docker-compose keys (services, {', '.join(supporting)})")
+
+        return evidence

--- a/tests/unit/test_skill_extractor.py
+++ b/tests/unit/test_skill_extractor.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from ingestion.parsers.skill_extractor import SkillExtractor, SkillDetection
+from ingestion.parsers.skill_extractor import SkillDetection, SkillExtractor
 
 
 @pytest.mark.unit
@@ -229,13 +229,85 @@ class TestSkillExtractor:
             assert isinstance(skill.confidence, float)
             assert 0.0 <= skill.confidence <= 1.0
 
+    def test_typescript_detected_without_filename(self, extractor: SkillExtractor) -> None:
+        """Test that TypeScript is detected from body text alone, with no filename."""
+        text = "Built app.tsx and types.ts with strict TypeScript interfaces"
+        result = extractor.extract_skills(text)
+
+        skill_names = [s.name for s in result]
+        assert any("typescript" in s.lower() for s in skill_names), f"Got: {skill_names}"
+
+    def test_typescript_not_reported_as_python(self, extractor: SkillExtractor) -> None:
+        """Test that TypeScript's `: string` annotations do not register as Python."""
+        text = """
+        export interface User {
+            id: string;
+            name: string;
+        }
+        """
+        result = extractor.extract_skills(text)
+
+        skill_names = [s.name for s in result]
+        assert not any("python" in s.lower() for s in skill_names), f"Got: {skill_names}"
+
+    def test_require_without_trailing_space(self, extractor: SkillExtractor) -> None:
+        """Test that require('fs') is detected even with no space after the keyword."""
+        text = "const fs = require('fs');"
+        result = extractor.extract_skills(text)
+
+        skill_names = [s.name for s in result]
+        assert any("javascript" in s.lower() for s in skill_names), f"Got: {skill_names}"
+
+    def test_prose_does_not_trigger_javascript(self, extractor: SkillExtractor) -> None:
+        """Test that English words containing JS keywords do not register as code."""
+        text = "I maintain a constant variety of classic work, letting the team vary its output."
+        result = extractor.extract_skills(text)
+
+        skill_names = [s.name for s in result]
+        assert not any("javascript" in s.lower() for s in skill_names), f"Got: {skill_names}"
+
+    def test_python_imports_do_not_trigger_javascript(self, extractor: SkillExtractor) -> None:
+        """Test that Python import statements are not misread as JavaScript."""
+        text = """
+        import os
+        from typing import List
+        """
+        result = extractor.extract_skills(text)
+
+        skill_names = [s.name for s in result]
+        assert not any("javascript" in s.lower() for s in skill_names), f"Got: {skill_names}"
+
+    def test_dockerfile_directives_detected(self, extractor: SkillExtractor) -> None:
+        """Test Docker detection from Dockerfile directives without the word 'docker'."""
+        text = """
+        FROM python:3.11
+        WORKDIR /app
+        COPY . .
+        CMD ["python", "main.py"]
+        """
+        result = extractor.extract_skills(text)
+
+        skill_names = [s.name for s in result]
+        assert any("docker" in s.lower() for s in skill_names), f"Got: {skill_names}"
+
+    def test_docker_not_duplicated_when_named_and_structural(
+        self, extractor: SkillExtractor
+    ) -> None:
+        """Test that a Dockerfile mentioning Docker yields one entry, not two."""
+        text = """
+        # Docker build file
+        FROM python:3.11
+        RUN pip install -r requirements.txt
+        """
+        result = extractor.extract_skills(text)
+
+        docker_entries = [s for s in result if s.name.lower() == "docker"]
+        assert len(docker_entries) == 1, f"Got: {docker_entries}"
+
     def test_skill_detection_dataclass(self):
         """Test SkillDetection dataclass structure."""
         skill = SkillDetection(
-            name="Python",
-            category="Language",
-            confidence=0.95,
-            evidence=["import statement"]
+            name="Python", category="Language", confidence=0.95, evidence=["import statement"]
         )
 
         assert skill.name == "Python"


### PR DESCRIPTION
## Summary

`SkillExtractor.extract_skills()` in `ingestion/parsers/skill_extractor.py` could not detect JavaScript or TypeScript from text content. JavaScript was only recognized when a `.js` filename was passed in or when the text contained `import ` / `require ` with a trailing space, and TypeScript was selected purely by filename — so TypeScript in body text was reported as `Python` or `React` instead. This PR replaces the filename-only check with pattern sets matched against the text body, so both languages are detected from source content alone, and adds structural Docker detection for Dockerfiles and compose files.

## Issue

Closes #148

## Changes

**Root cause:** `_detect_languages` had three independent defects. (1) The `JS_TS_KEYWORDS` set defined on the class was never referenced anywhere in the repo, so JavaScript detection never looked at `const`, `let`, `function`, or `=>`. (2) The regex `\b(import|require)\s+` required whitespace after the keyword, so `require('fs')` — the overwhelmingly common form — did not match. (3) TypeScript was chosen by a filename ternary (`"TypeScript" if ".ts" in filename else "JavaScript"`), which made the two languages mutually exclusive and made text-only TypeScript undetectable. A fourth defect in `_detect_tools` meant Docker was found only by substring-matching the literal word `docker`, which never appears in Dockerfile directives (`FROM`, `RUN`, `EXPOSE`) or compose keys (`services:`, `ports:`).

Separately, the Python annotation regex `:\s*(int|str|float|bool|list|dict)` had no closing word boundary, so TypeScript's `: string` matched `str` and TypeScript samples were reported as Python.

- `ingestion/parsers/skill_extractor.py` — `_detect_languages` now matches `JS_STRONG_PATTERNS` (`require()`, `module.exports`, arrow functions, ES6 `import ... from`, `.js`/`.jsx` references) and `JS_WEAK_PATTERNS` (`const`, `let`, `var`, `function`, `export`) against the text body. One strong signal identifies JavaScript on its own; weak signals require two, so prose like "a constant variety of work" does not register as code.
- `ingestion/parsers/skill_extractor.py` — added `TS_PATTERNS` for filename-independent TypeScript detection (interface/type/enum declarations, `Promise<`, TS annotations, `.ts`/`.tsx` body references). TypeScript evidence now takes precedence over JavaScript rather than routing through the filename ternary.
- `ingestion/parsers/skill_extractor.py` — added a closing `\b` to the Python annotation regex so `: string` no longer matches `str`. Verified the tightened regex still matches Python's `url: str)`.
- `ingestion/parsers/skill_extractor.py` — new `_detect_docker_structure()` helper detects line-anchored Dockerfile directives (two or more required, since a lone `RUN` or `ADD` appears in prose) and compose files (`services:` plus at least one supporting key). Evidence merges into the existing `Docker` entry rather than creating a duplicate.
- `tests/unit/test_skill_extractor.py` — added 7 regression tests.

**A note on scope, for reviewer input:** TypeScript is a superset of JavaScript, so text with TS evidence could arguably report both languages. This PR reports only `TypeScript` in that case. `test_text_with_typescript_files` only asserts TypeScript is present, so either reading passes — happy to change it if you prefer both.

## Testing

- [x] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`) — not run; requires Postgres/Redis services
- [x] Linter passes (`make lint`) — no new findings; repo-wide ruff goes 182 → 179
- [x] Type checker passes (`make typecheck`) — no new errors; 91 on both `main` and this branch
- [x] New/updated tests cover the changes

`tests/unit/test_skill_extractor.py` goes from **5 failed / 13 passed** to **1 failed / 24 passed**. The four tests named in the issue (`test_javascript_detection`, `test_text_with_typescript_files`, `test_devops_tool_detection`, `test_docker_compose_detection`) now pass. The one remaining failure is pre-existing and unrelated — see Notes for Reviewers.

**Reproduce the original bug (on `main`):**

```bash
git checkout main
python -c "
from ingestion.parsers.skill_extractor import SkillExtractor
e = SkillExtractor()
print('JS  :', [d.name for d in e.extract_skills('Wrote index.js using const arrow functions and async/await callbacks')])
print('TS  :', [d.name for d in e.extract_skills('Built app.tsx and types.ts with strict TypeScript interfaces')])
"
```

Observed on `main`:

```
JS  : []
TS  : ['React']
```

**Verify the fix (on this branch):**

```bash
git checkout fix/148-detect-javascript-typescript
# same snippet as above
```

Expected on this branch:

```
JS  : ['JavaScript']
TS  : ['TypeScript', 'React']
```

Then run the test file directly:

```bash
pytest tests/unit/test_skill_extractor.py -v
```

Expected: `1 failed, 24 passed` — the failure being `test_database_technology_detection`, which fails identically on `main`.

## Screenshots / Demo

N/A — backend-only change with no UI surface. The observable change is the return value of `SkillExtractor.extract_skills()`, shown in the reproduction steps above.

## Notes for Reviewers

**Pre-existing failure, not introduced here.** `tests/unit/test_skill_extractor.py::test_database_technology_detection` fails on `main` and on this branch with the same `UnboundLocalError`. Line 138 reads `skill_names = [s.name for s in skill_names]`, referencing the variable it is assigning — the function under test is fine, the test itself is broken. It is unrelated to #148 and I left it alone rather than widening this PR; happy to file it as its own issue.

**Pre-existing tooling failures.** `make check` reports failures on `main` before any of my changes (182 ruff findings; the pre-commit `mypy` hook reports 21 errors in `tests/unit/test_skill_extractor.py`, one of them caused by the broken test above). My changes introduce no new ruff, black, or mypy findings — the repo-wide ruff count drops from 182 to 179 because the repo's own pre-commit `ruff --fix` hook reformatted the files I touched (sorted an import, converted `Optional[str]` to `str | None`). Those hunks are tool output rather than deliberate edits.

**`JS_TS_KEYWORDS` is still unused.** The issue implies it should be wired in, but in practice the set is too blunt: it contains `import`, `class`, `async`, and `await`, all of which Python uses, so matching on it directly tags every Python file as JavaScript and breaks `test_text_with_python_imports`. I built purpose-built strong/weak pattern dicts instead and left the constant untouched for you to decide on — removing it felt like scope creep.

**One commit outside the issue's scope.** `521a26e` ("chore: auto-copy .env and start db/redis containers in make setup") adds 2 lines to the `Makefile`. On a fresh clone `make setup` failed at `alembic upgrade head` because it assumed `.env` existed and that the Postgres/Redis containers were already running. I hit this during setup and fixed it in place. Glad to split it into its own PR if you would rather keep this one strictly on #148.

**`_detect_react` still fires on `.tsx`.** Lines 231-246 substring-match `.tsx`, which is why the TypeScript sample also returns `React`. That behavior predates this PR and `test_react_detection` depends on it, so I did not touch it — but it is arguably a separate bug worth its own issue.
