### PR TITLE
Fix leading-whitespace detection in resume section headers (#147)

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -17,3 +17,19 @@ I chose Tier 1 because this is my first time contributing to a large multi-modul
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+---
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/UFmainuddin/pathreview/commit/de11633
+
+**Reproduction summary:**
+Ran `pytest tests/unit/test_resume_parser.py -v` locally and confirmed 5 tests fail. The key failure is `test_detect_sections`, which passes indented text (e.g., `"    Experience:"`) and asserts `len(sections) > 0` — the actual result is `[]` because all four regex patterns in `_detect_sections()` require the section keyword at column 0 (`^section`) or immediately after a newline (`\nsection`), with no allowance for leading whitespace. A related bug in `_strip_markdown()` — its `^#+\s+` pattern also fails to strip `#` headers with leading whitespace — was discovered during reproduction and causes two additional test failures.
+
+**PLAN.md link:** https://github.com/UFmainuddin/pathreview/blob/fix/147-resume-section-whitespace/PLAN.md
+
+**Walkthrough video (recommended):** N/A
+
+**Blockers or open questions:**
+The `_strip_markdown()` bug was not mentioned in issue #147 but was discovered during reproduction (it causes `test_strip_markdown_syntax` and `test_parse_markdown_resume` to fail). The fix is one character in the same file. I plan to include it in the same PR and call it out in the PR description — but want to confirm this is acceptable scope for a Tier 1 issue before Week 9.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -71,3 +71,36 @@ No new test files — the 5 pre-existing failing tests in `tests/unit/test_resum
 **Self-review confirmation:** [x] make check passes (our file: `ruff check ingestion/parsers/resume_parser.py` — all checks passed; 48 pre-existing failures in unrelated files unchanged) [x] make test-unit passes (10/10 resume parser tests pass; no new failures introduced)
 
 **Draft PR feedback received from:** none
+
+---
+
+## Week 10 - Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No - still awaiting review
+
+**Summary of feedback:**
+No reviewer feedback has arrived yet. For Summer 2026, reviewer feedback is not provided, so I am marking that I am still awaiting review.
+
+**How you responded:**
+No response was needed because no reviewer feedback came in. I still checked my PR and made sure my Week 10 journal is updated.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The harder part was understanding how a small regex change could affect the resume parser. At first, the issue looked very simple, but I had to read `ingestion/parsers/resume_parser.py` carefully to understand why leading spaces from PDF text made `_detect_sections()` fail.
+
+**What did you learn about working in a large codebase?**
+I learned that even a small change needs careful testing in a large codebase. I could not only change the regex and stop; I had to run `tests/unit/test_resume_parser.py` and also check the larger unit test result to make sure my fix did not create new problems.
+
+**How did AI tools help - and where did they fall short?**
+AI tools helped me understand the failing tests and explain the regex problem in simpler words. They were also useful for planning the fix for issue `#147`. But AI did not replace checking the real code and test output, because I still had to confirm that `_detect_sections()` and `_strip_markdown()` were the correct places to change.
+
+**What would you do differently if you started over?**
+If I started over, I would inspect the related helper functions earlier instead of only focusing on the exact issue description. The issue talked about section detection, but the markdown stripping problem was also related and caused more failing tests, so I would look for nearby similar patterns sooner.
+
+**What are you most proud of from this module?**
+I am most proud that I made a small but real fix and opened PR `#800` to the upstream PathReview project. The change was not large, but it made the parser handle indented resume sections better and all 10 resume parser tests passed after the fix.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -33,3 +33,41 @@ Ran `pytest tests/unit/test_resume_parser.py -v` locally and confirmed 5 tests f
 
 **Blockers or open questions:**
 The `_strip_markdown()` bug was not mentioned in issue #147 but was discovered during reproduction (it causes `test_strip_markdown_syntax` and `test_parse_markdown_resume` to fail). The fix is one character in the same file. I plan to include it in the same PR and call it out in the PR description — but want to confirm this is acceptable scope for a Tier 1 issue before Week 9.
+
+---
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+All sub-tasks from PLAN.md are complete. Applied both fixes to `ingestion/parsers/resume_parser.py`:
+- Sub-task 1: Updated all 4 regex patterns in `_detect_sections()` — `^` → `^\s*` and `\n` → `\n\s*` — so indented PDF-extracted headers are matched.
+- Sub-task 2: Updated the header-removal pattern in `_strip_markdown()` — `^#+\s+` → `^\s*#+\s+` — so markdown headers with leading whitespace are stripped.
+- Sub-task 3: All 10 tests in `tests/unit/test_resume_parser.py` pass (was 5 failing before the fix).
+- Sub-task 4: Full `make test-unit` run confirms no regressions introduced by our change (48 pre-existing failures across unrelated test files remain unchanged).
+- Sub-task 5: `ruff check ingestion/parsers/resume_parser.py` — all checks passed.
+
+**Next steps:**
+Open PR to upstream `ascherj/pathreview`, fill out PR template completely, update JOURNAL.md Check-in 2 with PR link, submit branch URL via course portal.
+
+**Blockers:**
+None.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [link to be added after PR is opened]
+
+**Branch:** `fix/147-resume-section-whitespace`
+
+**What you built:**
+Fixed `_detect_sections()` in `ingestion/parsers/resume_parser.py` by adding `\s*` after the `^` and `\n` anchors in all four regex patterns, so section headers with leading whitespace (common in pypdf-extracted text) are correctly detected instead of always returning an empty list. Also fixed a related bug in `_strip_markdown()` where markdown `#` headers with leading whitespace were not being stripped — changed `^#+\s+` to `^\s*#+\s+`.
+
+**Tests added or updated:**
+No new test files — the 5 pre-existing failing tests in `tests/unit/test_resume_parser.py` (`test_detect_sections`, `test_parse_single_column_resume_text`, `test_parse_resume_no_work_experience`, `test_parse_markdown_resume`, `test_strip_markdown_syntax`) now all pass. All 10 tests in the file pass. The full unit suite (`make test-unit`) shows the same 48 pre-existing failures in unrelated files; our change introduced zero new failures.
+
+**Self-review confirmation:** [x] make check passes (our file: `ruff check ingestion/parsers/resume_parser.py` — all checks passed; 48 pre-existing failures in unrelated files unchanged) [x] make test-unit passes (10/10 resume parser tests pass; no new failures introduced)
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -58,7 +58,7 @@ None.
 
 ### Check-in 2 (end of week)
 
-**PR link:** [link to be added after PR is opened]
+**PR link:** https://github.com/ascherj/pathreview/pull/800
 
 **Branch:** `fix/147-resume-section-whitespace`
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,19 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/147
+
+**Issue title:** Resume section detection fails on text with leading whitespace
+
+**Tier:** [x] Tier 1 [ ] Tier 2 [ ] Tier 3
+
+**Problem summary:**
+The `_detect_sections()` method in `ingestion/parsers/resume_parser.py` uses regex patterns that require section headers (like "Education" or "Experience") to begin at the very start of a line (`^Experience`) or immediately after a newline (`\nExperience`). Text extracted from PDFs commonly preserves leading indentation — spaces or tabs before content — which means none of those patterns ever match, and `detected_sections` always comes back empty. As a result, the ingestion pipeline has no structural information about the resume even when well-known sections like Education or Skills are clearly present. A successful fix would update the four patterns inside `_detect_sections()` to tolerate optional leading whitespace (e.g., `^\s*Experience`) so that section detection works regardless of indentation level.
+
+**Selection notes ("Is this right for me?" reasoning):**
+I chose Tier 1 because this is my first time contributing to a large multi-module codebase. The fix is tightly scoped: it touches exactly one method (`_detect_sections`) in one file (`ingestion/parsers/resume_parser.py`), and the issue body already identifies the root cause (regex anchoring) and the three failing tests to use for verification. There are no external API calls, no schema changes, and no frontend involvement — I can reproduce the bug in a Python shell in under a minute, confirm my fix with the existing tests, and move on. That tight feedback loop made this a confident Tier 1 pick.
+
+**Branch name:** fix/147-resume-section-whitespace
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,82 @@
+## Solution plan
+
+**Issue:** [Resume section detection fails on text with leading whitespace](https://github.com/ascherj/pathreview/issues/147)
+
+### Understand
+
+**Root cause:** `_detect_sections()` in `ingestion/parsers/resume_parser.py` builds four regex patterns per section header — two anchored with `^` and two anchored with `\n`:
+
+```python
+rf"^{re.escape(section)}\s*$"
+rf"^{re.escape(section)}\s*[:|-]"
+rf"\n{re.escape(section)}\s*$"
+rf"\n{re.escape(section)}\s*[:|-]"
+```
+
+Text extracted from PDFs via `pypdf` commonly preserves indentation, so lines arrive as `"    Experience:"` or `"\t Skills"`. None of the four patterns match because the section name is preceded by whitespace, so `detected_sections` always comes back empty.
+
+A related bug exists in `_strip_markdown()`: the header-stripping regex `^#+\s+` also requires `#` at column 0, so markdown headers with leading whitespace are not stripped.
+
+**Expected:** `_detect_sections()` returns a non-empty list when section headers are indented. `_strip_markdown()` removes `#` headers regardless of leading whitespace.  
+**Actual:** `_detect_sections()` returns `[]` for any indented text; `_strip_markdown()` leaves `#` headers in place when they have leading whitespace.
+
+**Confirmed locally:** 5 tests fail — `test_detect_sections`, `test_parse_single_column_resume_text`, `test_parse_resume_no_work_experience`, `test_parse_markdown_resume`, `test_strip_markdown_syntax`.
+
+### Map
+
+Files to change:
+- `ingestion/parsers/resume_parser.py`
+  - `_detect_sections()` (lines 134–138): update 4 regex patterns — `^` → `^\s*`, `\n` → `\n\s*`
+  - `_strip_markdown()` (line 102): update header pattern `^#+\s+` → `^\s*#+\s+`
+
+Files to read but not change:
+- `tests/unit/test_resume_parser.py` — 5 failing tests already cover the bug; no new tests needed unless a tab-indented edge case is uncovered
+- `tests/conftest.py` — `sample_resume_text` fixture uses 4-space indentation, which is the exact input that triggers the bug
+
+### Plan
+
+1. **Update `_detect_sections()` patterns** — In `ingestion/parsers/resume_parser.py`, replace the four pattern strings inside the `patterns` list:
+   - `rf"^{re.escape(section)}\s*$"` → `rf"^\s*{re.escape(section)}\s*$"`
+   - `rf"^{re.escape(section)}\s*[:|-]"` → `rf"^\s*{re.escape(section)}\s*[:|-]"`
+   - `rf"\n{re.escape(section)}\s*$"` → `rf"\n\s*{re.escape(section)}\s*$"`
+   - `rf"\n{re.escape(section)}\s*[:|-]"` → `rf"\n\s*{re.escape(section)}\s*[:|-]"`
+
+2. **Update `_strip_markdown()` header pattern** — In the same file, change the header-removal regex from `r"^#+\s+"` to `r"^\s*#+\s+"` (`re.MULTILINE` is already applied).
+
+3. **Run the 5 failing tests** — Confirm all pass: `pytest tests/unit/test_resume_parser.py -v`.
+
+4. **Run the full unit suite** — Confirm no regressions in the 5 currently-passing tests.
+
+5. **Run linter and formatter** — `ruff check` and `black` to match codebase style before opening the PR.
+
+### Inputs & outputs
+
+**`_detect_sections(text: str) -> list[str]`**
+- Input: plain-text string — after the fix, any amount of leading whitespace before a section header is tolerated
+- Output: list of title-cased section names (e.g., `["Experience", "Education", "Skills"]`) — previously `[]` for indented input; now correctly populated
+- No signature change; behavior change only
+
+**`_strip_markdown(content: str) -> str`**
+- Input: markdown string, possibly with leading whitespace before `#` headers
+- Output: plain-text string with markdown syntax stripped — after fix, `#`-prefixed headers with leading whitespace are removed
+- No signature change; behavior change only
+
+### Risks & unknowns
+
+- **`\s*` is greedy** — `^\s*` matches any amount of whitespace. If a section keyword somehow appeared mid-line after real content (not just whitespace), it would not match — but that is correct behavior. Verify with the existing test for `test_parse_preserves_text_content` that body lines like `"experience with React"` are not misclassified as section headers.
+  - Investigation path: `ingestion/parsers/resume_parser.py` lines 134–138 after change; run `test_parse_preserves_text_content`.
+
+- **`_strip_markdown()` scope creep** — The issue description names only `_detect_sections()`, but `_strip_markdown()` has the same root cause and its failure (`test_strip_markdown_syntax`) blocks `test_parse_markdown_resume` too. Both fixes are in the same file, one line each. I will mention this in the PR description to flag the expanded scope.
+  - Investigation path: `ingestion/parsers/resume_parser.py` line 102.
+
+- **`re.MULTILINE` interaction** — `^` with `re.MULTILINE` matches at the start of each line. Adding `\s*` after `^` still behaves correctly. Verify with a `\r\n` (Windows-style) line-ending input, since `pypdf` on Windows may produce CRLF text.
+
+### Edge cases
+
+1. **Tabs vs spaces** — `\s*` matches both. A header like `"\t\tEducation:"` must be detected. The existing fixtures use spaces; will verify tabs work after the fix by running `test_detect_sections` and checking the `\s*` pattern matches tab-indented input.
+
+2. **Mixed indentation** — A document where some headers are flush and some are indented should correctly detect all of them. The `^\s*` pattern matches both `"Experience:"` (zero whitespace) and `"    Experience:"` (four spaces).
+
+3. **Section keyword mid-line** — A body line like `"    I have experience with React"` must not be detected as a section. The patterns `^\s*experience\s*$` and `^\s*experience\s*[:|-]` require either nothing after the keyword or an immediate colon/dash, so mid-sentence mentions are safe.
+
+4. **Empty or whitespace-only input** — `_detect_sections("")` and `_detect_sections("   \n  ")` must return `[]` without error. Adding `\s*` does not change this behavior.

--- a/ingestion/parsers/resume_parser.py
+++ b/ingestion/parsers/resume_parser.py
@@ -5,7 +5,6 @@ from pypdf import PdfReader
 
 from .base import BaseParser, ParseResult
 
-
 SECTION_HEADERS = {
     "experience",
     "education",
@@ -75,7 +74,7 @@ class ResumeParser(BaseParser):
                 source_type="resume",
             )
         except Exception as e:
-            raise ValueError(f"Failed to parse PDF: {str(e)}")
+            raise ValueError(f"Failed to parse PDF: {str(e)}") from e
 
     def _parse_markdown(self, content: str) -> ParseResult:
         """Extract text from markdown resume, stripping markdown syntax."""
@@ -130,7 +129,19 @@ class ResumeParser(BaseParser):
         text_lower = text.lower()
 
         for section in SECTION_HEADERS:
-            # Look for section header patterns
+            # BUG (issue #147): patterns below anchor section headers at the exact
+            # start of a line (^) or immediately after a newline (\n).  Text
+            # extracted from PDFs via pypdf commonly preserves leading indentation,
+            # so a line like "    Experience:" never matches any of these patterns
+            # and detected_sections always comes back empty.
+            #
+            # Reproduction (confirmed locally):
+            #   from ingestion.parsers.resume_parser import ResumeParser
+            #   r = ResumeParser()
+            #   res = r.parse('\n    Jane Doe\n\n    Education:\n    - B.S. CS\n')
+            #   assert res.metadata['detected_sections'] == []  # BUG: should contain 'Education'
+            #
+            # Fix: replace ^ with ^\s* and \n with \n\s* in all four patterns.
             patterns = [
                 rf"^{re.escape(section)}\s*$",
                 rf"^{re.escape(section)}\s*[:|-]",

--- a/ingestion/parsers/resume_parser.py
+++ b/ingestion/parsers/resume_parser.py
@@ -97,8 +97,8 @@ class ResumeParser(BaseParser):
 
     def _strip_markdown(self, content: str) -> str:
         """Remove markdown syntax from content."""
-        # Remove markdown headers
-        text = re.sub(r"^#+\s+", "", content, flags=re.MULTILINE)
+        # Remove markdown headers (including those with leading whitespace)
+        text = re.sub(r"^\s*#+\s+", "", content, flags=re.MULTILINE)
 
         # Remove markdown links [text](url)
         text = re.sub(r"\[([^\]]+)\]\(([^\)]+)\)", r"\1", text)
@@ -129,24 +129,14 @@ class ResumeParser(BaseParser):
         text_lower = text.lower()
 
         for section in SECTION_HEADERS:
-            # BUG (issue #147): patterns below anchor section headers at the exact
-            # start of a line (^) or immediately after a newline (\n).  Text
-            # extracted from PDFs via pypdf commonly preserves leading indentation,
-            # so a line like "    Experience:" never matches any of these patterns
-            # and detected_sections always comes back empty.
-            #
-            # Reproduction (confirmed locally):
-            #   from ingestion.parsers.resume_parser import ResumeParser
-            #   r = ResumeParser()
-            #   res = r.parse('\n    Jane Doe\n\n    Education:\n    - B.S. CS\n')
-            #   assert res.metadata['detected_sections'] == []  # BUG: should contain 'Education'
-            #
-            # Fix: replace ^ with ^\s* and \n with \n\s* in all four patterns.
+            # Fix for issue #147: patterns now allow optional leading whitespace
+            # before section headers so that PDF-extracted text with indentation
+            # (e.g., "    Experience:") is correctly detected.
             patterns = [
-                rf"^{re.escape(section)}\s*$",
-                rf"^{re.escape(section)}\s*[:|-]",
-                rf"\n{re.escape(section)}\s*$",
-                rf"\n{re.escape(section)}\s*[:|-]",
+                rf"^\s*{re.escape(section)}\s*$",
+                rf"^\s*{re.escape(section)}\s*[:|-]",
+                rf"\n\s*{re.escape(section)}\s*$",
+                rf"\n\s*{re.escape(section)}\s*[:|-]",
             ]
 
             for pattern in patterns:


### PR DESCRIPTION
## Summary                                                                                                                                                                      
                  
  `_detect_sections()` in `ingestion/parsers/resume_parser.py` anchored section-header patterns at column 0 (`^section` or `\nsection`). Text extracted from PDFs via `pypdf`
  commonly preserves indentation, so a line like `"    Experience:"` never matched any pattern and `detected_sections` always returned `[]`. Fixed by adding `\s*` after each
  anchor in all four patterns.

  A related bug in `_strip_markdown()` had the same root cause — `^#+\s+` also required `#` at column 0, so indented markdown headers were not stripped. Fixed in the same commit
  by changing to `^\s*#+\s+`.

  ## Issue

  Closes #147

  ## Changes

  - `ingestion/parsers/resume_parser.py` — `_detect_sections()`: changed four patterns:
    - `^{section}` → `^\s*{section}` (matches flush and indented headers)
    - `\n{section}` → `\n\s*{section}` (matches headers after any indented newline)
  - `ingestion/parsers/resume_parser.py` — `_strip_markdown()`: changed `^#+\s+` → `^\s*#+\s+`

  No signature changes. Behavior change only.

  ## Testing

  The 5 tests that previously failed due to this bug now pass:

  - `test_detect_sections` — indented `Experience:`, `Education:`, `Skills:` all detected
  - `test_parse_single_column_resume_text` — sections detected in 4-space-indented fixture
  - `test_parse_resume_no_work_experience` — indented `Education:` and `Skills:` detected
  - `test_parse_markdown_resume` — indented `## Experience` stripped and detected
  - `test_strip_markdown_syntax` — indented `# Header` removed correctly

  To verify manually:
  pytest tests/unit/test_resume_parser.py -v

  All 10 tests in `tests/unit/test_resume_parser.py` pass. The broader `make test-unit` run shows 48 pre-existing failures in unrelated files (e.g., `test_bias_detector`,
  `test_skill_extractor`); our change introduces zero new failures.

  `ruff check ingestion/parsers/resume_parser.py` — all checks passed. Pre-commit hooks (ruff, black, mypy) all passed on commit.

  ## Notes for Reviewers

  The `_strip_markdown()` fix is not mentioned in issue #147 but has the same root cause and its failure blocked two additional tests. Both fixes are a single-pattern change each
   in the same file.

  `\s*` is greedy but safe: `^\s*experience\s*$` requires the entire line to be just the keyword, so body lines like `"I have experience with React"` are not misclassified as
  section headers.