### PR TITLE
Fix/153 faithfulness checker none text crash

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,24 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/153
+
+**Issue title:** Faithfulness checker crashes when a context chunk has `text: None`
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The faithfulness checker verifies that generated claims are actually supported
+by the retrieved context, but it crashes when a context chunk has `None` as
+its text value instead of an empty string. The code uses
+`chunk.get("text", "")` to build the combined context string, which only
+falls back to the default when the "text" key is missing entirely — if the
+key exists but is explicitly `None`, `.get()` returns `None`, and joining a
+list containing `None` with a string raises a TypeError. This affects the
+`rag` module's faithfulness-scoring logic, and the fix would involve safely
+coercing a `None` text value to an empty string before concatenation.
+
+**Branch name:** fix/153-faithfulness-checker-none-text-crash
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -84,3 +84,68 @@ pre-existing baseline of 53 test failures / 182 lint errors, unrelated to
 issue #153 — see PR description for details)
 
 **Draft PR feedback received from:** none
+
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:** No reviewer feedback arrived on PR #801 by the
+end of the module. Per the Su26 note, reviewer feedback isn't a feature
+this term.
+
+**How you responded:** N/A — no feedback to respond to.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Confirming the pre-existing baseline was more involved than I expected.
+Before touching any code, `make test-unit` showed 53 failing tests and
+`make check` showed 182 lint errors across the codebase, almost entirely
+unrelated to my issue. It would have been easy to assume something was
+wrong with my setup, but the real work was carefully separating "failures
+that already existed" from "failures I might have caused" — running the
+full suite before and after my change and diffing the counts, not just
+trusting a single passing test in isolation.
+
+**What did you learn about working in a large codebase?**
+A one-line bug fix touches more than one line of process. The actual code
+change — `chunk.get("text", "")` to `chunk.get("text") or ""` — took
+minutes. Documenting it, tracing it to the exact root cause (`dict.get()`'s
+default only applies to missing keys, not `None` values), confirming it
+against the existing test suite, and writing up the pre-existing-failures
+context for reviewers took much longer. In a codebase you don't own, the
+explanation and the evidence trail matter as much as the fix itself,
+because a reviewer has to trust your change didn't break something they
+can't see from the diff alone.
+
+**How did AI tools help — and where did they fall short?**
+AI was most useful for orientation — quickly understanding what
+`FaithfulnessChecker.check()` and its surrounding test file were doing,
+and for double-checking my PLAN.md's risk section before I finalized it.
+It fell short on judgment calls that needed the actual codebase in front
+of me: deciding whether the three other failing tests in
+`test_faithfulness_checker.py` were related to my change (they weren't,
+but I had to actually read the failure output and the `_is_supported`
+logic to be sure) and deciding exactly how to phrase the pre-existing-failures
+section of the PR description so it was honest without sounding like I
+was making excuses.
+
+**What would you do differently if you started over?**
+I'd run `make check` and `make test-unit` for the baseline in Week 7,
+before writing PLAN.md, rather than waiting until Week 9. Having the exact
+pre-existing failure count early would have let me write a sharper "Risks
+& unknowns" section from the start, instead of discovering the scope of
+pre-existing issues later.
+
+**What are you most proud of from this module?**
+Catching that the three other `test_faithfulness_checker.py` failures were
+pre-existing and unrelated, rather than assuming my fix caused them. It
+would have been easy to either panic and try to fix all four failures, or
+to not notice the distinction at all. Running the full suite before and
+after, and reading each failure's actual assertion rather than just its
+name, is the habit I'm most glad I built this module.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -27,7 +27,7 @@ coercing a `None` text value to an empty string before concatenation.
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [will fill in after next commit]
+**Reproduction commit link:** https://github.com/ReevaSharma/pathreview/commit/3f8f6c0
 
 **Reproduction summary:** Ran `FaithfulnessChecker().check('Knows Python.',
 [{'text': None}])` locally and confirmed it raises `TypeError: sequence
@@ -35,7 +35,7 @@ item 0: expected str instance, NoneType found`, matching the issue. Also
 confirmed `test_none_context_chunk_text` in the existing test suite
 currently fails with the same error.
 
-**PLAN.md link:** [will fill in after push]
+**PLAN.md link:** https://github.com/ReevaSharma/pathreview/blob/fix/153-faithfulness-checker-none-text-crash/PLAN.md
 
 **Blockers or open questions:**
 None currently — the fix is a small, well-scoped one-line change.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -22,3 +22,20 @@ coercing a `None` text value to an empty string before concatenation.
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger 
+
+
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [will fill in after next commit]
+
+**Reproduction summary:** Ran `FaithfulnessChecker().check('Knows Python.',
+[{'text': None}])` locally and confirmed it raises `TypeError: sequence
+item 0: expected str instance, NoneType found`, matching the issue. Also
+confirmed `test_none_context_chunk_text` in the existing test suite
+currently fails with the same error.
+
+**PLAN.md link:** [will fill in after push]
+
+**Blockers or open questions:**
+None currently — the fix is a small, well-scoped one-line change.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -59,3 +59,28 @@ feedback, then finalize the PR description and submit.
 
 **Blockers:** None.
 
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/801
+
+**Branch:** fix/153-faithfulness-checker-none-text-crash
+
+**What you built:** Fixed a crash in `FaithfulnessChecker.check()` where a
+context chunk with `text: None` caused a `TypeError` when building the
+combined context string. Changed `chunk.get("text", "")` to
+`chunk.get("text") or ""` so that both a missing key and an explicit
+`None` value are treated as an empty string.
+
+**Tests added or updated:** No new test file was needed — the existing
+test `test_none_context_chunk_text` in `tests/unit/test_faithfulness_checker.py`
+already covered this exact scenario. It was failing before the fix and
+passes after it.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+(both confirmed to introduce no new failures beyond the documented
+pre-existing baseline of 53 test failures / 182 lint errors, unrelated to
+issue #153 — see PR description for details)
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -39,3 +39,23 @@ currently fails with the same error.
 
 **Blockers or open questions:**
 None currently — the fix is a small, well-scoped one-line change.
+
+
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:** Implemented the fix in `faithfulness_checker.py` —
+changed `chunk.get("text", "")` to `chunk.get("text") or ""` so that a
+`None` value is treated the same as a missing key. Confirmed the
+previously-failing `test_none_context_chunk_text` now passes, and
+`make test-unit` shows 52 failed / 376 passed (down from the 53/375
+baseline), confirming no new regressions were introduced.
+
+**Next steps:** Run `make check` to confirm no new lint issues in the
+touched file, self-review against CONTRIBUTING.md, open a draft PR for
+feedback, then finalize the PR description and submit.
+
+**Blockers:** None.
+

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,56 @@
+## Solution plan
+
+**Issue:** Faithfulness checker crashes when a context chunk has `text: None` — https://github.com/ascherj/pathreview/issues/153
+
+### Understand
+`FaithfulnessChecker.check()` builds `context_text` using
+`chunk.get("text", "")`. Python's `dict.get(key, default)` only returns
+the default when the key is *absent* — if the key exists but its value is
+`None`, `.get()` returns `None` itself. When a chunk like `{"text": None}`
+is passed in, this produces `None` in the list passed to `" ".join(...)`,
+which raises `TypeError: sequence item 0: expected str instance, NoneType
+found`. Expected behavior: chunks with `text: None` should be treated the
+same as chunks with an empty or missing `text` field — contributing an
+empty string to the context, not crashing.
+
+### Map
+- `rag/evaluator/faithfulness_checker.py` — the `check()` method, specifically
+  the `context_text` construction line
+- `tests/unit/test_faithfulness_checker.py` — `test_none_context_chunk_text`
+  (already exists, currently failing) and `test_missing_text_key_in_chunk`
+  (already passing, used to confirm the fix doesn't regress this case)
+
+### Plan
+1. Reproduce the crash locally and confirm `test_none_context_chunk_text` fails
+2. Fix the line in `check()` to treat `None` values the same as missing keys —
+   change `chunk.get("text", "")` to `chunk.get("text") or ""`
+3. Run the full test suite to confirm `test_none_context_chunk_text` passes
+   and no other tests regress
+4. Add a code comment explaining why `or ""` is used instead of a plain
+   default, since the reason (None vs missing key) isn't obvious at a glance
+5. Update JOURNAL.md and push final commits
+
+### Inputs & outputs
+Input: `context_chunks`, a list of dicts that may contain `"text"` as a
+string, `None`, or be missing entirely. Output: `context_text`, a single
+joined string that should never be `None`, regardless of which of the
+three input variants occurs.
+
+### Risks & unknowns
+- Need to confirm no other part of the codebase relies on `chunk.get("text", "")`
+  returning `None` for some other conditional check — a quick repo-wide
+  search for `.get("text"` will confirm this method is only used here
+- Same pattern may exist elsewhere with other optional dict keys in the
+  RAG pipeline — worth a quick grep for `.get(` with default `""` across
+  `rag/` in case a similar bug hides elsewhere, though that's out of scope
+  for this specific issue
+
+### Edge cases
+- `{"text": None}` → should contribute `""`, no crash (the reported bug)
+- `{"content": "..."}` (key missing entirely) → should contribute `""`,
+  no crash (already works, covered by existing passing test)
+- `{"text": ""}` → should contribute `""` (already works)
+- `{"text": "actual context"}` → should contribute the string unchanged
+  (already works)
+- Empty `context_chunks` list → already handled by the early return
+  (`if not feedback or not context_chunks`)

--- a/rag/evaluator/faithfulness_checker.py
+++ b/rag/evaluator/faithfulness_checker.py
@@ -1,6 +1,7 @@
 """Check if generated feedback is supported by retrieved context."""
 
 import re
+
 import structlog
 
 logger = structlog.get_logger()
@@ -20,8 +21,11 @@ class FaithfulnessChecker:
             Faithfulness score 0.0-1.0 (ratio of supported claims)
         """
         if not feedback or not context_chunks:
-            logger.info("faithfulness_empty_input", has_feedback=bool(feedback),
-                       has_chunks=bool(context_chunks))
+            logger.info(
+                "faithfulness_empty_input",
+                has_feedback=bool(feedback),
+                has_chunks=bool(context_chunks),
+            )
             return 0.0
 
         # Extract key claims from feedback (sentences)
@@ -31,9 +35,7 @@ class FaithfulnessChecker:
             return 0.5  # Default to neutral if no extractable claims
 
         # Concatenate context text
-        context_text = " ".join([
-            chunk.get("text", "") for chunk in context_chunks
-        ])
+        context_text = " ".join([chunk.get("text") or "" for chunk in context_chunks])
 
         # Check each claim for support
         supported = 0
@@ -43,8 +45,9 @@ class FaithfulnessChecker:
 
         score = supported / len(claims) if claims else 0.0
 
-        logger.info("faithfulness_checked", claims_count=len(claims),
-                   supported_count=supported, score=score)
+        logger.info(
+            "faithfulness_checked", claims_count=len(claims), supported_count=supported, score=score
+        )
 
         return score
 
@@ -59,7 +62,7 @@ class FaithfulnessChecker:
             List of claims (sentences)
         """
         # Split by sentence (simple regex)
-        sentences = re.split(r'[.!?]+', text)
+        sentences = re.split(r"[.!?]+", text)
         claims = [s.strip() for s in sentences if s.strip() and len(s.strip()) > 10]
         return claims[:10]  # Limit to 10 claims for scoring
 
@@ -81,8 +84,25 @@ class FaithfulnessChecker:
         # Require at least some meaningful overlap
         overlap = claim_tokens & context_tokens
         # Filter out common stop words
-        stop_words = {'a', 'an', 'the', 'is', 'are', 'was', 'were', 'be', 'been',
-                     'and', 'or', 'but', 'in', 'of', 'to', 'for', 'that'}
+        stop_words = {
+            "a",
+            "an",
+            "the",
+            "is",
+            "are",
+            "was",
+            "were",
+            "be",
+            "been",
+            "and",
+            "or",
+            "but",
+            "in",
+            "of",
+            "to",
+            "for",
+            "that",
+        }
         meaningful_overlap = overlap - stop_words
 
         return len(meaningful_overlap) >= 2


### PR DESCRIPTION
## Summary
Fixes a crash in `FaithfulnessChecker.check()` when a context chunk has
`text: None` instead of a string or missing key.

## Issue
Closes #153

## Changes
- Changed `chunk.get("text", "")` to `chunk.get("text") or ""` in
  `rag/evaluator/faithfulness_checker.py`. `dict.get()`'s default only
  applies when a key is missing, not when it's present with value `None`,
  so `{"text": None}` previously caused `" ".join(...)` to raise
  `TypeError: sequence item 0: expected str instance, NoneType found`.

## Testing
- [x] Unit tests pass (`make test-unit`) — with caveats noted below
- [ ] Integration tests pass (`make test-integration`) — not run, not
      relevant to this change
- [x] Linter passes (`make lint`) — no new issues in the touched file
- [x] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes — the existing test
      `test_none_context_chunk_text` in `tests/unit/test_faithfulness_checker.py`
      already covered this exact scenario; it was failing before this fix
      and passes after it

**Pre-existing failures (documented, unrelated to this change):**
This codebase has pre-existing test and lint failures unrelated to issue
#153. Before my change: `make test-unit` showed 53 failed / 375 passed.
After my change: 52 failed / 376 passed — only `test_none_context_chunk_text`
changed status (failing → passing); no new failures were introduced. The
other 3 pre-existing failures in `test_faithfulness_checker.py`
(`test_partial_support_returns_middle_score`, `test_multiple_context_chunks`,
`test_multiple_claims_varying_support`) are unrelated scoring-logic issues
in `_is_supported` and are unchanged by this PR. Similarly, `make check`
shows 182 pre-existing lint errors across the codebase; none are in
`rag/evaluator/faithfulness_checker.py`, and my change passes `ruff`,
`black`, and `mypy` cleanly.

## Screenshots / Demo
N/A — backend logic fix, no UI change.

## Notes for Reviewers
```bash
python3 -c "
from rag.evaluator.faithfulness_checker import FaithfulnessChecker
FaithfulnessChecker().check('Knows Python.', [{'text': None}])
"
# Should return a float score instead of raising TypeError

pytest tests/unit/test_faithfulness_checker.py -v
# test_none_context_chunk_text should PASS
```