### PR TITLE
Test/157 partial overlap fixture

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -65,7 +65,7 @@ None.
 
 ### Check-in 2 (end of week)
 
-**PR link:** [paste the GitHub PR link]
+**PR link:** https://github.com/ascherj/pathreview/pull/802
 
 **Branch:** `test/157-partial-overlap-fixture`
 
@@ -76,8 +76,14 @@ I corrected the fixture in `test_query_with_partial_overlap` so it now represent
 Updated `tests/unit/test_relevance_scorer.py`, specifically
 `TestRelevanceScorer.test_query_with_partial_overlap`. The test now covers the case where only some query tokens appear in the retrieved chunk and verifies that the scorer returns a middle-range value rather than full relevance.
 
-**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
-Note: Both make check and make test-unit have pre-existing failures unrelated to relevance_scorer.py. I confirmed that the changes implemented remove the test failures related to relevance_scorer.py.
+**Self-review confirmation:** [x] make check passes (no new failures introduced)  [x] make test-unit passes (no new failures introduced)
+Note: The repository contains pre-existing failures that are unrelated to this issue. Both make check and make test-unit have pre-existing failures unrelated to relevance_scorer.py. I confirmed that the changes implemented remove the test failures related to relevance_scorer.py. 
 
-**Draft PR feedback received from:**
-None.
+I compared the results against `upstream/main` before submitting my PR.
+
+- `upstream/main`: 375 passed, 53 failed
+- This branch: 376 passed, 52 failed
+
+This confirms that my change fixed the targeted relevance scorer test and did not introduce any new failures.
+
+**Draft PR feedback received from:** none (requested peer feedback in Slack but did not receive a response before submission)

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,33 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/157
+
+**Issue title:** Relevance scorer “partial overlap” test fixture actually has full query overlap
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The relevance scorer unit test named `test_query_with_partial_overlap` is intended
+to verify scoring behavior when only some query terms appear in a document chunk.
+However, its current fixture contains all four terms from the query, so the scorer
+correctly calculates full keyword coverage and returns a score of 1.0. The test then
+incorrectly expects the score to be below 0.9, causing it to fail even though the
+scorer is behaving correctly. A successful fix will update the test fixture so that
+it contains only some of the query terms and genuinely represents partial overlap.
+
+**Branch name:** test/157-partial-overlap-fixture
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger
+
+### Selection notes — “Is this right for me?”
+
+This issue appears to have a small and clearly defined scope. It affects an existing
+unit-test fixture rather than requiring a change to the relevance-scoring algorithm
+or application architecture. The reproduction command identifies the exact test
+file and failing assertion, and the expected outcome is clear: revise the fixture so
+that only part of the query overlaps with the chunk. This makes the issue appropriate
+for my current experience level while still allowing me to practice reading tests,
+understanding expected behavior, running targeted checks, and submitting an
+open-source pull request.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -87,3 +87,40 @@ I compared the results against `upstream/main` before submitting my PR.
 This confirms that my change fixed the targeted relevance scorer test and did not introduce any new failures.
 
 **Draft PR feedback received from:** none (requested peer feedback in Slack but did not receive a response before submission)
+
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — feedback not required
+
+**Summary of feedback:**
+
+No reviewer feedback had been received by the submission deadline. My pull request remains open and ready for review.
+
+**How you responded:**
+
+N/A
+
+### Reflection
+
+**What was harder than you expected?**
+
+The hardest part was not fixing the issue itself—it was learning how to work within an unfamiliar open-source project. Setting up the development environment took much longer than I expected because I had to install Docker, configure the `.env` file, troubleshoot database connectivity, and understand the project's workflow before I could even reproduce the issue. I also learned that understanding the existing tests was just as important as understanding the production code.
+
+**What did you learn about working in a large codebase?**
+
+I learned that making a small change often requires understanding much more of the surrounding code than I initially expected. For Issue #157, I investigated both `tests/unit/test_relevance_scorer.py` and `rag/evaluator/relevance_scorer.py` before deciding whether production code actually needed to change. That investigation showed the scoring logic was already correct and the real problem was the test fixture itself. Working in an established codebase requires confirming the root cause before making changes.
+
+**How did AI tools help — and where did they fall short?**
+
+AI was extremely helpful for navigating an unfamiliar codebase, understanding the repository structure, explaining how the relevance scorer worked, and helping me troubleshoot environment setup problems. It also helped me understand Git, pull requests, and the contribution workflow. However, AI could not determine whether failing tests or mypy errors were pre-existing project issues or introduced by my changes. I still needed to investigate the repository, compare results against `upstream/main`, and verify everything myself.
+
+**What would you do differently if you started over?**
+
+If I started over, I would spend more time reading the repository documentation before beginning implementation. I would also run the project's full test suite immediately after setting up the environment to establish a baseline of existing failures before making any changes. That would have made it much easier to recognize which issues were unrelated to my contribution.
+
+**What are you most proud of from this module?**
+
+I'm most proud that I resisted changing production code until I fully understood the problem. After investigating the relevance scorer, I realized the implementation was already correct and that the failing test was caused by an incorrect fixture. Fixing the root cause instead of introducing unnecessary code changes helped me better understand how professional open-source contributions should be approached.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -31,3 +31,21 @@ that only part of the query overlaps with the chunk. This makes the issue approp
 for my current experience level while still allowing me to practice reading tests,
 understanding expected behavior, running targeted checks, and submitting an
 open-source pull request.
+
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:**
+
+
+**PLAN.md link:**
+
+
+**Reproduction summary:**
+I reproduced the issue by running:
+
+```bash
+.venv/bin/pytest tests/unit/test_relevance_scorer.py -q
+```
+
+The test test_query_with_partial_overlap failed because it expected a score below 0.9, but the scorer returned 1.0. After reviewing the issue description, I confirmed that the test fixture actually contains all of the query terms, so it represents full overlap rather than partial overlap.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -36,10 +36,10 @@ open-source pull request.
 ## Week 8 — Reproduction & solution planning
 
 **Reproduction commit link:**
-
+https://github.com/douglasem/pathreview/commit/1cab1ac765ea3c1809bbb277cbd196c877017b84
 
 **PLAN.md link:**
-
+https://github.com/douglasem/pathreview/blob/test/157-partial-overlap-fixture/PLAN.md
 
 **Reproduction summary:**
 I reproduced the issue by running:

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -107,7 +107,7 @@ N/A
 
 **What was harder than you expected?**
 
-The hardest part was not fixing the issue itself—it was learning how to work within an unfamiliar open-source project. Setting up the development environment took much longer than I expected because I had to install Docker, configure the `.env` file, troubleshoot database connectivity, and understand the project's workflow before I could even reproduce the issue. I also learned that understanding the existing tests was just as important as understanding the production code.
+The hardest part was not fixing the issue itself. The hardest part for me was learning how to work within an unfamiliar open-source project. Setting up the development environment took much longer than I expected because I had to install Docker, configure the `.env` file, troubleshoot database connectivity, and understand the project's workflow before I could even reproduce the issue. I also learned that understanding the existing tests was just as important as understanding the production code.
 
 **What did you learn about working in a large codebase?**
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -62,3 +62,22 @@ Run `make check` and `make test-unit`, review the final diff, commit and push th
 
 **Blockers:**
 None.
+
+### Check-in 2 (end of week)
+
+**PR link:** [paste the GitHub PR link]
+
+**Branch:** `test/157-partial-overlap-fixture`
+
+**What you built:**
+I corrected the fixture in `test_query_with_partial_overlap` so it now represents genuine partial keyword overlap. The original chunk matched all four query terms and correctly received a score of `1.0`; the updated chunk matches two of four terms and produces the intended score of `0.5` without changing production code.
+
+**Tests added or updated:**
+Updated `tests/unit/test_relevance_scorer.py`, specifically
+`TestRelevanceScorer.test_query_with_partial_overlap`. The test now covers the case where only some query tokens appear in the retrieved chunk and verifies that the scorer returns a middle-range value rather than full relevance.
+
+**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+Note: Both make check and make test-unit have pre-existing failures unrelated to relevance_scorer.py. I confirmed that the changes implemented remove the test failures related to relevance_scorer.py.
+
+**Draft PR feedback received from:**
+None.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -49,3 +49,16 @@ I reproduced the issue by running:
 ```
 
 The test test_query_with_partial_overlap failed because it expected a score below 0.9, but the scorer returned 1.0. After reviewing the issue description, I confirmed that the test fixture actually contains all of the query terms, so it represents full overlap rather than partial overlap.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+I reproduced Issue #157 and confirmed that `test_query_with_partial_overlap` failed because its fixture contained all four query terms. I inspected `rag/evaluator/relevance_scorer.py` and verified that the scorer calculates keyword overlap as matched query tokens divided by total query tokens. I updated the fixture in `tests/unit/test_relevance_scorer.py` so only two of the four query terms overlap, producing a true partial-overlap score of 0.5. The targeted relevance scorer test file now passes all 19 tests.
+
+**Next steps:**
+Run `make check` and `make test-unit`, review the final diff, commit and push the fix, open a draft pull request, request peer or mentor feedback, and complete Check-in 2 before marking the PR ready for review.
+
+**Blockers:**
+None.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,52 @@
+# Solution plan
+
+**Issue:** Relevance scorer "partial overlap" test fixture actually has full query overlap
+
+https://github.com/ascherj/pathreview/issues/157
+
+## Understand
+
+The unit test `test_query_with_partial_overlap` is intended to verify behavior when only some query terms appear in a document chunk. However, the current fixture contains all of the query terms, so the relevance scorer correctly returns a score of 1.0. The failing assertion is caused by incorrect test data rather than a bug in the scoring algorithm.
+
+## Map
+
+Expected files to examine:
+
+- tests/unit/test_relevance_scorer.py
+- relevance scorer implementation (only if needed to confirm expected behavior)
+
+Primary file expected to change:
+
+- tests/unit/test_relevance_scorer.py
+
+## Plan
+
+1. Run the failing unit test to reproduce the issue.
+2. Locate `test_query_with_partial_overlap` and inspect the query and fixture text.
+3. Modify the fixture so that it contains only a subset of the query terms.
+4. Re-run the unit test to verify the assertion passes.
+5. Run any related relevance scorer tests to ensure no other tests are affected.
+
+## Inputs & outputs
+
+### Input
+
+- Query text
+- Test fixture text
+- Existing relevance scoring function
+
+### Output
+
+- Updated unit test fixture representing true partial overlap
+- Passing unit test without changing the scoring algorithm
+
+## Risks & unknowns
+
+- The scorer may intentionally normalize scores differently than expected, so I want to verify that only the fixture—not the production code—needs modification.
+- Other tests in `tests/unit/test_relevance_scorer.py` may rely on similar fixture wording, so I will check for consistency after making the change.
+
+## Edge cases
+
+- Query terms all present (full overlap) should continue producing a score of 1.0.
+- Only some query terms present should produce a lower relevance score.
+- No query terms present should continue producing a very low score.

--- a/tests/unit/test_relevance_scorer.py
+++ b/tests/unit/test_relevance_scorer.py
@@ -49,7 +49,7 @@ class TestRelevanceScorer:
         query = "Python Django web framework"
         chunks = [
             {
-                "text": "Django is a Python web framework for rapid development"
+                "text": "Django supports rapid web development"
             },
         ]
 


### PR DESCRIPTION
## Summary

This PR fixes the test fixture for `test_query_with_partial_overlap` in the relevance scorer tests. The original fixture unintentionally contained all four query terms ("Python", "Django", "web", and "framework"), causing the scorer to correctly return a relevance score of `1.0` even though the test expected a partial-overlap score. The fixture has been updated so only two of the four query terms appear in the retrieved chunk, allowing the test to accurately verify partial keyword overlap without changing any production code.

## Issue

Closes #157

## Changes

- Updated the fixture in `tests/unit/test_relevance_scorer.py`
- Changed the chunk text from:
  - `"Django is a Python web framework for rapid development"`
  - to `"Django supports rapid web development"`
- Reduced keyword overlap from four matching query terms to two
- Left the implementation in `rag/evaluator/relevance_scorer.py` unchanged because the production logic was already correct

## Testing

- [x] Unit tests pass (`make test-unit`) — interpreted per the course guidance for repositories with documented pre-existing failures
- [ ] Integration tests pass (`make test-integration`) — not run; this is a unit-test fixture-only change
- [ ] Linter passes (`make lint`) — Does not pass. Errors unrelated to relevance_scorer.py
- [ ] Type checker passes (`make typecheck`) — pre-existing missing-annotation errors remain in `tests/unit/test_relevance_scorer.py`
- [x] New/updated tests cover the changes

### Targeted verification

1. Run:

```bash
.venv/bin/pytest tests/unit/test_relevance_scorer.py -q
```

2. Verify all 19 tests pass.

3. Confirm `test_query_with_partial_overlap` now uses a chunk that contains only the query terms **Django** and **web**, producing a relevance score of **0.5** (2 of 4 query terms) rather than **1.0**.

## Screenshots / Demo

Not applicable. This is a test fixture change only.

## Notes for Reviewers

This PR intentionally changes only the test fixture. During investigation I confirmed that `rag/evaluator/relevance_scorer.py` correctly computes relevance as the number of matching query tokens divided by the total number of query tokens. The failing test was caused by an incorrect fixture rather than a bug in the scoring implementation, so no production code changes were necessary.

This is intentionally a test-fixture-only correction. I inspected rag/evaluator/relevance_scorer.py and verified that the scorer calculates:

number of matching query tokens / total number of query tokens

The scorer was already behaving correctly. Changing production code would have
hidden the inaccurate fixture rather than addressing the root cause.
