### PR TITLE
Fix vendored/build path exclusion in TechDetector (closes #150)

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,38 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/150
+
+**Issue title:** Tech detector counts vendored and build-output files, skewing language detection
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem Summary:**
+
+The TechDetector tool in agent/tools/tech_detector.py is supposed to
+ignore files inside vendor/build folders like node_modules/ and build/
+when detecting a repository's primary programming language. However,
+its skip-list checks for patterns like "/node_modules/" with a leading
+slash, while file paths passed into the tool (e.g. "node_modules/lib/index.js")
+often don't have that leading slash. Because of this mismatch, those
+files are never filtered out and get counted as if they were part of
+the actual codebase. As a result, a repo that is mostly Python can be
+incorrectly reported as "primarily JavaScript" just because it has a
+few bundled JS dependency files. Fixing this means correcting the skip
+logic so it matches these paths regardless of a leading slash, restoring
+accurate language detection.
+
+**Branch name:** fix/150-tech-detector-vendored-files
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger
+
+**Selection notes ("Is this right for me?" checklist):**
+
+I chose Tier 1 issue #150 over #153 (also Tier 1) because it involves a
+single, well-contained bug in one file (agent/tools/tech_detector.py),
+has clear reproduction steps and named failing tests, and touches the
+agent/ area of the codebase, which interests me. I avoided #153 for a
+different reason: it had an unusually high number of claims and several
+already-open pull requests, and I wanted to reduce the temptation to
+reference existing solutions before reasoning through the bug myself.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -58,3 +58,29 @@ paths without one (e.g. `"node_modules/lib/index.js"`).
 None major yet. I still need to confirm whether file paths can ever arrive
 with backslashes instead of forward slashes on Windows, but I don't
 expect this to block the fix in Week 9.
+
+## Week 9 — Mid-week check-in
+
+**Date:** July 30, 2026
+
+**Progress:**
+Implemented the fix in `_should_skip_file()` (`agent/tools/tech_detector.py`,
+commit `499f202`): instead of substring-matching slash-anchored patterns like
+`"/node_modules/"`, the method now splits each filepath into path segments and
+checks whether any directory segment (excluding the filename) exactly matches
+a known vendor/build directory name. This correctly excludes paths with or
+without a leading slash, while avoiding false positives like
+`src/node_modules_helper.py`.
+
+**Verification so far:**
+- Both previously-failing tests now pass: `test_node_modules_excluded` and
+  `test_build_directory_excluded`
+- Full test suite for the file passes: 27/27 tests
+- Manually re-ran the original reproduction steps from the issue — confirmed
+  `primary_language` now returns `"Python"` instead of `"JavaScript"`
+- `ruff check agent/tools/tech_detector.py` passes with no errors
+
+**Remaining for this week:**
+- Write PR description following the project's contribution standards
+- Open the pull request
+- Final Week 9 check-in with PR link

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -39,7 +39,7 @@ reference existing solutions before reasoning through the bug myself.
 
 ## Week 8 — Reproduction & solution planning
 
-
+**Reproduction commit link:** https://github.com/DataMnk/pathreview/commit/939b152
 
 **Reproduction summary:**
 I reproduced the bug locally using the Python REPL with the exact steps
@@ -51,3 +51,10 @@ fails to filter out these vendored/build paths because it checks for
 patterns with a leading slash (e.g. `"/node_modules/"`) that don't match
 paths without one (e.g. `"node_modules/lib/index.js"`).
 
+**PLAN.md link:** https://github.com/DataMnk/pathreview/blob/fix/150-tech-detector-vendored-files/PLAN.md
+
+
+**Blockers or open questions:**
+None major yet. I still need to confirm whether file paths can ever arrive
+with backslashes instead of forward slashes on Windows, but I don't
+expect this to block the fix in Week 9.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -53,13 +53,12 @@ paths without one (e.g. `"node_modules/lib/index.js"`).
 
 **PLAN.md link:** https://github.com/DataMnk/pathreview/blob/fix/150-tech-detector-vendored-files/PLAN.md
 
-
 **Blockers or open questions:**
 None major yet. I still need to confirm whether file paths can ever arrive
 with backslashes instead of forward slashes on Windows, but I don't
 expect this to block the fix in Week 9.
 
-## Week 9 — Mid-week check-in
+## Week 9 — Check-in 1 (mid-week)
 
 **Date:** July 30, 2026
 
@@ -83,4 +82,44 @@ without a leading slash, while avoiding false positives like
 **Remaining for this week:**
 - Write PR description following the project's contribution standards
 - Open the pull request
+- Add regression tests for the edge cases identified in PLAN.md
 - Final Week 9 check-in with PR link
+
+## Week 9 — Check-in 2 (end of week)
+
+**Date:** August 4, 2026
+
+**Branch:** fix/150-tech-detector-vendored-files
+
+**Pull Request:** https://github.com/ascherj/pathreview/pull/804
+
+**Summary:**
+Opened PR #804 against `ascherj/pathreview:main`, closing issue #150.
+
+**Self-review against the seven conditions for "done":**
+- [x] The fix works — confirmed against the bug spec (reproduction steps
+      from the issue now return `"Python"` instead of `"JavaScript"`)
+- [x] Existing tests still pass — full suite is 27/27
+- [x] New tests are written — the two previously-failing named tests pass,
+      but I have not yet added new regression tests for the edge cases
+      identified in PLAN.md (`src/node_modules_helper.py`, backslash paths,
+      `build/vendor.js`). **In progress — adding these now.**
+- [x] The code follows codebase conventions — docstrings and comment style
+      match the rest of `tech_detector.py`
+- [x] The linter passes — `ruff check agent/tools/tech_detector.py` is clean
+- [x] Documentation is updated — inline comment explains the root cause and
+      the fix for future contributors
+- [x] The PR description is written — all template sections filled in with
+      real content, not placeholders
+
+**Tests documented:**
+- `test_node_modules_excluded` and `test_build_directory_excluded` (both
+  pre-existing, previously failing) now pass with the fix
+- Full file suite: 27/27 passing
+- Manual verification in the Python REPL against the original issue
+  reproduction steps
+- Three new regression tests added for edge cases from PLAN.md — all
+  passing. Full suite: 30/30
+
+**Blockers or open questions:**
+None blocking. Finishing edge-case test coverage before final resubmission.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -100,10 +100,12 @@ Opened PR #804 against `ascherj/pathreview:main`, closing issue #150.
 - [x] The fix works — confirmed against the bug spec (reproduction steps
       from the issue now return `"Python"` instead of `"JavaScript"`)
 - [x] Existing tests still pass — full suite is 27/27
-- [x] New tests are written — the two previously-failing named tests pass,
-      but I have not yet added new regression tests for the edge cases
-      identified in PLAN.md (`src/node_modules_helper.py`, backslash paths,
-      `build/vendor.js`). **In progress — adding these now.**
+- [x] New tests are written — the two previously-failing named tests
+      (`test_node_modules_excluded`, `test_build_directory_excluded`) pass,
+      and I added three new regression tests covering the edge cases
+      identified in PLAN.md: a lookalike filename that should NOT be
+      excluded, a `build/vendor.js` path, and Windows backslash paths.
+      Full suite is now 30/30.
 - [x] The code follows codebase conventions — docstrings and comment style
       match the rest of `tech_detector.py`
 - [x] The linter passes — `ruff check agent/tools/tech_detector.py` is clean
@@ -123,3 +125,63 @@ Opened PR #804 against `ascherj/pathreview:main`, closing issue #150.
 
 **Blockers or open questions:**
 None blocking. Finishing edge-case test coverage before final resubmission.
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No reviewer feedback has come in on PR #804. Per the course's Summer 2026
+note, reviewer feedback is not a feature this term, so this is expected.
+
+**How you responded:**
+N/A — no feedback to respond to.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Well, this is the first time that I work in a big collaborative project
+like this one. This semester was particularly challenging: the content,
+the rhythm, the length. From the beginning the technical part needed
+some extra work — I had to download and install Docker and prepare the
+environment, do some reading.
+
+**What did you learn about working in a large codebase?**
+It was a project that needed guidance; the class Q&A was very helpful.
+The fix itself was relatively simple — dividing some strings and doing
+some checkups — which alone would have been simple enough, however
+embedded in such a big project there is a lot of code reading that needs
+to be done before even touching anything. Then the testing part was fun,
+and being able to write new tests was also interesting. A great learning
+opportunity in general.
+
+**How did AI tools help — and where did they fall short?**
+Claude helped understanding the git collaboration process in general. It
+was necessary to stay in the loop and understand the codebase to be able
+to ask the right questions and not letting it deviate from the purpose
+or the goal, which was to actually learn how to participate and
+collaborate in GitHub effectively. For example: when the linter flagged
+181 errors across the whole repo, I couldn't just take Claude's word that
+they weren't mine — I had to actually check the output myself to confirm
+none of those errors were in my file before deciding `--no-verify` was
+the right call, backed by what Margaret had confirmed in class Q&A, not
+just Claude's suggestion.
+
+**What would you do differently if you started over?**
+I think overall it was a good experience — next time I'll know some
+things better. Given the knowledge and time I had, I think it was a good
+journey. I feel tempted to say "if I had more time..." but that doesn't
+happen in real life — time is always short, so it's important to learn
+to do everything consciously every time, or as much as possible.
+
+**What are you most proud of from this module?**
+I feel more proud of actually having pushed through until the end, of
+having persevered, because this semester was particularly difficult on
+so many levels. I'm glad it's over and I hope things get better over
+Fall. I'm proud that I managed to push through till the end. I almost
+missed these final reflection questions, but here I am. I think we
+learned a lot and it's all very relevant.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -36,3 +36,18 @@ agent/ area of the codebase, which interests me. I avoided #153 for a
 different reason: it had an unusually high number of claims and several
 already-open pull requests, and I wanted to reduce the temptation to
 reference existing solutions before reasoning through the bug myself.
+
+## Week 8 — Reproduction & solution planning
+
+
+
+**Reproduction summary:**
+I reproduced the bug locally using the Python REPL with the exact steps
+from the issue: `TechDetector().execute({'files': [...]})` with a file
+list containing `node_modules/lib/index.js` and `build/bundle.js` among
+Python files. The result's `primary_language` came back as `JavaScript`
+instead of the expected `Python`, confirming that `_should_skip_file()`
+fails to filter out these vendored/build paths because it checks for
+patterns with a leading slash (e.g. `"/node_modules/"`) that don't match
+paths without one (e.g. `"node_modules/lib/index.js"`).
+

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,78 @@
+## Solution plan
+
+**Issue:** #150 — Tech detector counts vendored and build-output files, skewing language detection
+https://github.com/ascherj/pathreview/issues/150
+
+### Understand
+`TechDetector._detect_tech()` is supposed to only count files that are part of the
+actual project when detecting the primary language. It filters files using
+`_should_skip_file()`, which checks whether a filepath contains patterns like
+`"/node_modules/"`, `"/build/"`, `"/vendor/"`, etc. — each pattern has a leading
+and trailing slash. However, file paths passed into the tool (as shown in the
+issue's reproduction steps, e.g. `"node_modules/lib/index.js"`) often don't have
+a leading slash, since they're relative paths from the repo root. Because the
+pattern requires a leading `/`, the substring check fails silently, the file is
+never skipped, and it gets counted toward language detection. Expected behavior:
+files under vendored/build directories should be excluded regardless of whether
+the path has a leading slash. Actual behavior: a repo with 2 Python files and 6
+vendored JS files is reported as `primary_language: "JavaScript"` instead of
+`"Python"`.
+
+**Root cause:** `_should_skip_file()` in `agent/tools/tech_detector.py` uses
+slash-anchored substring patterns that don't match relative paths lacking a
+leading slash.
+
+### Map
+Files I expect to touch:
+- `agent/tools/tech_detector.py` — `_should_skip_file()` method (the skip_patterns
+  list and the matching logic itself need to change).
+- `tests/unit/test_tech_detector.py` — contains `test_node_modules_excluded` and
+  `test_build_directory_excluded`, the two named failing tests I need to make pass.
+
+### Plan
+1. Read `tests/unit/test_tech_detector.py` to see exactly what inputs and
+   assertions `test_node_modules_excluded` and `test_build_directory_excluded`
+   expect, so I know the exact contract I need to satisfy.
+2. Rewrite `_should_skip_file()` so it matches vendor/build directory names
+   regardless of a leading slash — e.g. by checking path segments (splitting on
+   `/`) instead of raw substring matching, or by normalizing the path with a
+   leading slash before checking.
+3. Run the two named failing tests locally to confirm they now pass:
+   `pytest tests/unit/test_tech_detector.py -k "node_modules or build_directory"`.
+4. Manually re-run my original reproduction steps in the Python REPL to confirm
+   `primary_language` now returns `"Python"` instead of `"JavaScript"`.
+5. Run the full test suite for this file (`pytest tests/unit/test_tech_detector.py`)
+   to make sure I didn't break any other passing test.
+
+### Inputs & outputs
+**Function I'm changing:** `_should_skip_file(filepath: str) -> bool`
+
+**Existing behavior:** returns `True` only when a pattern like `/node_modules/`
+appears as a substring of `filepath` — meaning paths without a leading slash are
+never skipped.
+
+**New behavior:** returns `True` for any path where one of the target directory
+names (`node_modules`, `vendor`, `dist`, `build`, `.git`, `__pycache__`, `.venv`,
+`venv`) appears as a full path segment, whether or not the path starts with `/`.
+
+### Risks & unknowns
+1. **Over-matching risk:** if I switch to a looser check (e.g. just `"node_modules"
+   in filepath`), I could accidentally skip a legitimate file that merely contains
+   that substring in its name (e.g. `my_node_modules_analyzer.py`). I need to split
+   the path into segments and compare whole segments, not just substrings.
+2. **Windows vs. Unix path separators:** I'm developing on Windows; I need to
+   confirm whether `filepath` ever arrives with backslashes (`\`) instead of `/`,
+   which would break a `/`-based split. I'll check how `files` is populated
+   upstream (likely from GitHub API data, which should always use `/`).
+3. **I haven't yet read the existing test file**, so my understanding of the
+   exact expected fixture inputs is based only on the issue description, not the
+   actual test code — I'll confirm this in Plan step 1 before finalizing the fix.
+
+### Edge cases
+- A path like `node_modules/lib/index.js` (no leading slash) → should be skipped
+- A path like `/node_modules/lib/index.js` (leading slash) → should still be skipped
+- A path like `src/node_modules_helper.py` (directory name is a substring, not a
+  real segment) → should NOT be skipped
+- A path like `build/vendor.js` → should be skipped (matches `build`)
+- A path with no vendor/build segments at all (e.g. `main.py`) → should never be
+  skipped

--- a/agent/tools/tech_detector.py
+++ b/agent/tools/tech_detector.py
@@ -148,21 +148,23 @@ class TechDetector(BaseTool):
         Returns:
             True if file should be skipped
         """
-        # BUG (issue #150): these patterns assume a leading "/", but paths like
-        # "node_modules/lib/index.js" (no leading slash) never match, so vendored
-        # files are counted toward primary_language detection.
-        # Reproduced: TechDetector().execute({'files': [...]}) with a path like
-        # 'node_modules/lib/index.js' returns primary_language='JavaScript'
-        # instead of the expected 'Python'.
-        skip_patterns = [
-            "/node_modules/",
-            "/vendor/",
-            "/dist/",
-            "/build/",
-            "/.git/",
-            "/__pycache__/",
-            "/.venv/",
-            "/venv/",
-        ]
-
-        return any(pattern in filepath for pattern in skip_patterns)
+        # Fix for issue #150: compare whole path segments instead of raw
+        # substrings, so vendored/build directories are excluded whether or
+        # not the path has a leading slash (e.g. both "node_modules/x.js" and
+        # "/node_modules/x.js" are skipped), while avoiding false positives
+        # like "src/node_modules_helper.py" (a filename that merely contains
+        # the substring, not a real directory segment).
+        skip_dirs = {
+            "node_modules",
+            "vendor",
+            "dist",
+            "build",
+            ".git",
+            "__pycache__",
+            ".venv",
+            "venv",
+        }
+        parts = filepath.replace("\\", "/").split("/")
+        # Exclude the last part (the filename itself) — only directory
+        # segments should trigger a skip.
+        return any(part in skip_dirs for part in parts[:-1])

--- a/agent/tools/tech_detector.py
+++ b/agent/tools/tech_detector.py
@@ -1,6 +1,7 @@
 """Technology stack detector tool."""
 
 import structlog
+
 from .base import BaseTool, ToolResult
 
 logger = structlog.get_logger()
@@ -75,7 +76,7 @@ class TechDetector(BaseTool):
                     "primary_language": "Unknown",
                     "all_languages": [],
                     "frameworks": [],
-                }
+                },
             )
 
         try:
@@ -84,11 +85,7 @@ class TechDetector(BaseTool):
 
         except Exception as e:
             logger.error("tech_detector_error", error=str(e))
-            return ToolResult(
-                success=False,
-                data={},
-                error=str(e)
-            )
+            return ToolResult(success=False, data={}, error=str(e))
 
     def _detect_tech(self, files: list[str]) -> dict:
         """Detect technologies from file list.
@@ -100,10 +97,7 @@ class TechDetector(BaseTool):
             Dict with detected languages and frameworks
         """
         # Filter out vendor/build directories
-        filtered_files = [
-            f for f in files
-            if not self._should_skip_file(f)
-        ]
+        filtered_files = [f for f in files if not self._should_skip_file(f)]
 
         languages = set()
         frameworks = set()
@@ -131,8 +125,12 @@ class TechDetector(BaseTool):
         all_languages = sorted(languages)
         all_frameworks = sorted(frameworks)
 
-        logger.info("tech_detected", primary_lang=primary,
-                   languages_count=len(all_languages), frameworks_count=len(all_frameworks))
+        logger.info(
+            "tech_detected",
+            primary_lang=primary,
+            languages_count=len(all_languages),
+            frameworks_count=len(all_frameworks),
+        )
 
         return {
             "primary_language": primary,
@@ -150,6 +148,12 @@ class TechDetector(BaseTool):
         Returns:
             True if file should be skipped
         """
+        # BUG (issue #150): these patterns assume a leading "/", but paths like
+        # "node_modules/lib/index.js" (no leading slash) never match, so vendored
+        # files are counted toward primary_language detection.
+        # Reproduced: TechDetector().execute({'files': [...]}) with a path like
+        # 'node_modules/lib/index.js' returns primary_language='JavaScript'
+        # instead of the expected 'Python'.
         skip_patterns = [
             "/node_modules/",
             "/vendor/",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -99,7 +99,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -449,7 +448,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -473,7 +471,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1561,7 +1558,6 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1579,7 +1575,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1972,7 +1967,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3507,7 +3501,6 @@
       "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^2.0.1",
         "cssstyle": "^4.0.1",
@@ -4094,7 +4087,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4107,7 +4099,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4771,7 +4762,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/tests/unit/test_tech_detector.py
+++ b/tests/unit/test_tech_detector.py
@@ -363,3 +363,44 @@ class TestTechDetector:
 
         data = result.data
         # Should detect C++ (from .cpp files)
+
+    def test_node_modules_lookalike_filename_not_excluded(self, detector:TechDetector) -> None:
+        """Test a filename that merely contains 'node_modules' as a
+        substring (not a real directory segment) is NOT excluded."""
+        files = [
+            "src/node_modules_helper.py",
+            "utils.py",
+        ]
+
+        result = detector.execute({"files": files})
+
+        data = result.data
+        # This file should be COUNTED, not skipped, since "node_modules"
+        # here is part of the filename, not a real directory.
+        assert data["primary_language"] == "Python"
+
+    def test_build_vendor_file_excluded(self, detector:TechDetector) -> None:
+        """Test a file directly inside build/ (e.g. build/vendor.js) is
+        excluded, matching the issue's reproduction example."""
+        files = [
+            "main.py",
+            "build/vendor.js",
+        ]
+
+        result = detector.execute({"files": files})
+
+        data = result.data
+        assert data["primary_language"] == "Python"
+
+    def test_windows_backslash_paths_excluded(self, detector:TechDetector) -> None:
+        """Test that vendored directories are still excluded when the
+        path uses Windows-style backslashes instead of forward slashes."""
+        files = [
+            "src\\main.py",
+            "node_modules\\lib\\index.js",
+        ]
+
+        result = detector.execute({"files": files})
+
+        data = result.data
+        assert data["primary_language"] == "Python"


### PR DESCRIPTION
## Summary
Fixes the TechDetector tool so it correctly excludes vendored/build files
(e.g. `node_modules/`, `build/`) when detecting a repository's primary
language, instead of incorrectly counting them and skewing the result
toward JavaScript.

## Issue
Closes #150

## Changes
- Rewrote `_should_skip_file()` in `agent/tools/tech_detector.py`: instead
  of substring-matching slash-anchored patterns like `"/node_modules/"`
  (which silently failed to match relative paths without a leading slash,
  e.g. `"node_modules/lib/index.js"`), it now splits each filepath into
  path segments and checks whether any directory segment (excluding the
  filename itself) exactly matches a known vendor/build directory name
- This correctly excludes paths with or without a leading slash, while
  avoiding false positives on filenames that merely contain a vendor
  directory name as a substring (e.g. `src/node_modules_helper.py`)

## Testing
- [x] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`)
- [x] Linter passes (`make lint`) — verified on the modified file with
      `ruff check agent/tools/tech_detector.py`
- [ ] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes — the two previously-failing
    tests named in the issue, test_node_modules_excluded and
    test_build_directory_excluded, now pass. I also added three new
    regression tests for edge cases identified in my PLAN.md: a
    lookalike filename that should NOT be excluded
    (test_node_modules_lookalike_filename_not_excluded), a build/vendor.js
    path (test_build_vendor_file_excluded), and Windows backslash paths
    (test_windows_backslash_paths_excluded). Full file suite is now 30/30

To verify by hand:
1. `git checkout fix/150-tech-detector-vendored-files`
2. `pytest tests/unit/test_tech_detector.py -v` — all 30 tests pass
3. In a Python REPL:
```python
   from agent.tools.tech_detector import TechDetector
   files = ['main.py', 'node_modules/lib/index.js', 'build/bundle.js']
   TechDetector().execute({'files': files}).data['primary_language']
   # Returns 'Python' instead of 'JavaScript'
```

## Screenshots / Demo
N/A — backend logic change, no UI impact.

## Notes for Reviewers
When I first chose this bug, it took me some time to understand what it
was really about, so I started exploring the repo structure and files.
That took a while but there was a lot of new stuff to take in, so the
time was worth it. Once you understand it, it's pretty intuitive.

I used Claude to help explain the existing code and propose some fixes,
and this approach (splitting into path segments) was the one that made
the most sense to me — the best option out of what we considered.

There's always a lot to learn along the way, and it was tempting to look
into other bugs I noticed while exploring. That would have led to me not
delivering anything and just exploring endlessly, so I forced myself to
focus and just work on my bug.