### PR TITLE
fix: use text() wrapper method to prevent raw SQL strings passed to db.execute() for API health endpoint

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,40 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/154
+
+**Issue title:** Health check DB probe passes a raw SQL string, which fails under SQLAlchemy 2.x
+
+
+**Tier:** [ x ] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+[In 3–5 sentences, in your own words: what the issue is (not a copy-paste of
+the title), what is currently broken or missing, and what a successful fix
+would accomplish. Naming the part of the codebase it affects is helpful context.]
+
+The issue is that when the GET /health endpoint is hit, the logic in the `health_check` function (located in api/routes/health.py) incorrectly uses a raw SQL string of "SELECT 1" to check if the DB service is up. Since raw SQL strings are not accepted in SQLAlchemy 2.x, an error occurs, resulting in the endpoint falsely determining that the PostgreSQL service is down. This impacts the reliability of the GET /health endpoint.
+
+A successful fix would prevent the use of raw SQL queries, and ensure that the GET /health endpoint accurately reports whether PostgreSQL is up or down, rather than reporting false negatives.
+
+**Branch name:** fix/154-db-probe-raw-sql-error
+
+**Setup confirmation:** [ x ] App runs locally at localhost:5173
+
+**Cohort ledger:** [ x ] Issue added to cohort ledger
+
+**Is This Issue Right for Me? Checklist:**
+Part 1:
+- I am able to understand the issue, locate the file where the issue stems from (api/routes/health.py), and can describe what a fixed app state should look  (a reliable GET /health endpoint).
+
+Part 2:
+- I chose a Tier 1 issue, since this is my first open-source contribution.
+
+Part 3:
+- I read through the `health_check` function in api/routes/health.py, and am able to see where the raw SQL string is used (line 31 - `await db.execute("SELECT 1")`).
+- I have a general understanding of the surrounding code (checks status of PostgreSQL, Redis, and Vector DB via try/except blocks, updating the fields of a dictionary that eventually becomes the endpoint response).
+- I have looked at a test file and saw how existing tests are structured.
+
+Part 4:
+- I have seem the issue comments and the ledger, and I am okay with the number of people working on it.
+- I am confident I can implement, test, and submit a PR before the Week 9 deadline.
+- There are no open blockers.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -41,10 +41,9 @@ Part 4:
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [link to commit documenting the reproduced issue]
+**Reproduction commit link:** https://github.com/hariumapathy/pathreview/commit/42450e1bef452bb7ec0bbe9164a36aa168fcd022
 
 **Reproduction summary:**
-[1–2 sentences: How did you reproduce the issue? What did you observe?]
 
 I reproduced the issue by running the application and then making a API request to the GET /health endpoint, observing both the API response and the terminal output.
 
@@ -88,7 +87,7 @@ To further verify that the Postgres DB is up, we can see the healthy container b
 Therefore, it is confirmed that the response from the GET /health endpoint is incorrectly reporting the uptime status of the Postgres DB service.
 
 
-**PLAN.md link:** [link to PLAN.md in your fork]
+**PLAN.md link:** https://github.com/hariumapathy/pathreview/blob/fix/154-db-probe-raw-sql-error/PLAN.md
 
 
 **Blockers or open questions:**

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -114,7 +114,7 @@ Understanding how to use Mock and when to use it for unit tests is a new concept
 
 ### Check-in 2 (end of week)
 
-**PR link:** [link to your submitted pull request]
+**PR link:** https://github.com/ascherj/pathreview/pull/808
 
 **Branch:** fix/154-db-probe-raw-sql-error
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -128,3 +128,43 @@ I created a new unit test file named `test_health.py`, with 7 tests that are rel
 - Note: There were existing issues in make check and make test-unit that my changes did not worsen
 
 **Draft PR feedback received from:** "none"
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [ x ] No — still awaiting review
+
+**Summary of feedback:**
+No review came in.
+
+**How you responded:**
+N/A
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Starting off in a new codebase and understanding the flow of API routes or where certain DB settings where, and how they interacted, took some time to read and understand. Even though my fix was local to the `api/routes/health.py` file, I still needed a grasp on the codebase, especially the API routes, to understand how to test the GET health endpoint. Reading unit tests also required some familiarity with the style used (such as when and what to mock). Therefore, getting situated in a new codebase, before even writing a fix, is something that I was not used to and took more time than I expected. However, the use of AI tools helped served as a partner of sorts for understanding the important modules and design choices.
+
+**What did you learn about working in a large codebase?**
+[What's different about contributing to someone else's production code
+vs. building your own project?]
+
+When I am building my own project, I often make my own design choices and conventions, whether that is where the logic lives, file structure, documentation, or method naming. As a result, I tend to approach personal projects in a slightly less structured manner. However, contributing to someone else's production code requires an understanding of existing conventions and the ability to follow those. Whether that is docstrings, how unit tests are written, or adhering to the existing linter and formatter, following existing conventions is one of the key takeaways for me as I worked towards this PR.
+
+**How did AI tools help — and where did they fall short?**
+[Where was AI assistance most useful this module? Where did you need
+to go beyond what AI could give you?]
+AI tools and assistance was very useful at getting up to speed on the codebase and summarizing/explaining existing files and methods. Instead of digging through documentation and reading a lot of adjacent files line by line, AI tools helped me to construct a mental mapping of the codebase. This would have been a much more manual process if done without the help of AI.
+
+AI tools fell short when following existing standards; an initial attempt to produce code would produce well-written code. However, such code might not adhere to the codebase specifications. This required further prompting and/or rewriting from my end.
+
+**What would you do differently if you started over?**
+[Issue selection, planning, implementation, or process — anything
+you'd change?]
+If I started over, I would likely try and understand unit testing before diving into a fix. Being able to write unit test(s) before implementing a fix would ensure that the fix is robust. Adding unit tests after implementation can cause rushed testing in the real world, and is a habit that I would like to avoid moving forward.
+
+**What are you most proud of from this module?**
+I am proud of making a codebase contribution for the first time, since up until this point most of my Git and Github usage was for personal, small group, or school projects.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -92,3 +92,39 @@ Therefore, it is confirmed that the response from the GET /health endpoint is in
 
 **Blockers or open questions:**
 Apart from the questions raised in PLAN.md, I have no further blockers.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+[What have you implemented so far? Which sub-tasks from PLAN.md are done?]
+
+So I far I have implemented the fixes in `api/routes/health.py`, importing the `text()` wrapper method and nested it within the `db.execute()` method call. To commit my changes, I also had to add type hints to the `health_check` method, and add a comment `# noqa: B008` to the end of the method signature. This is done to bypass the ruff issue of calling a method within a default. However, the use of the `Depends()` method is a FastAPI convention, and not an improper coding practice.
+
+Therefore, sub-tasks 1 and 2 are done from PLAN.md.
+
+**Next steps:**
+The next steps will be to write unit tests and ensure that no further issues or warnings are introduced into the codebase because of my changes.
+
+**Blockers:**
+Understanding how to use Mock and when to use it for unit tests is a new concept for me. With the use of online resources, Claude, and reading through existing unit tests, I am getting a better idea of how to write tests myself.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [link to your submitted pull request]
+
+**Branch:** fix/154-db-probe-raw-sql-error
+
+**What you built:**
+My fix addresses issue 154, adding the `text()` wrapper method in `api/routes/health.py` wherever a raw SQL string was passed to the `db.execute()` method. This fix prevents false negatives, which is when the health endpoint reports the Postgres service as down even though it actually is up.
+
+**Tests added or updated:**
+I created a new unit test file named `test_health.py`, with 7 tests that are relevant to the API health endpoint. They check various paths, such as when the Postgres service is down or up and whether the endpoint correctly reports that.
+
+**Self-review confirmation:** [ x ] make check passes  [ x ] make test-unit passes
+- Note: There were existing issues in make check and make test-unit that my changes did not worsen
+
+**Draft PR feedback received from:** "none"

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -38,3 +38,58 @@ Part 4:
 - I have seem the issue comments and the ledger, and I am okay with the number of people working on it.
 - I am confident I can implement, test, and submit a PR before the Week 9 deadline.
 - There are no open blockers.
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [link to commit documenting the reproduced issue]
+
+**Reproduction summary:**
+[1–2 sentences: How did you reproduce the issue? What did you observe?]
+
+I reproduced the issue by running the application and then making a API request to the GET /health endpoint, observing both the API response and the terminal output.
+
+See below for the full, detailed reproduction steps.
+
+**Detailed Reproduction Steps:**
+1. Get environment setup
+	1. `docker compose -d`
+	2. `make setup`
+	3. `make run`
+2. Looked at API docs: http://localhost:8000/docs
+3. Used Postman to make a GET request to http://localhost:8000/health
+	1. Got the following response back:
+```
+{
+    "detail": {
+        "status": "unhealthy",
+        "dependencies": {
+            "postgres": "unhealthy",
+            "redis": "unhealthy",
+            "vector_db": "healthy"
+        },
+        "safety_events_last_hour": 0,
+        "timestamp": "2026-07-24T01:14:11.860279"
+    }
+}
+```
+
+- Note that `"postgres": "unhealthy"` appears in the response, indicating that the service is down.
+4. In my VS Code terminal (Git Bash), I saw the following appear:
+```
+2026-07-23 21:14:11 [error    ] postgres_health_check_failed   error="Textual SQL expression 'SELECT 1' should be explicitly declared as text('SELECT 1')" request_id=09306c44-3308-41e8-9039-d977de26b95b
+2026-07-23 21:14:12 [error    ] redis_health_check_failed      error="'Settings' object has no attribute 'redis_host'" request_id=09306c44-3308-41e8-9039-d977de26b95b
+2026-07-23 21:14:12 [debug    ] vector_db_health_check_passed  request_id=09306c44-3308-41e8-9039-d977de26b95b
+INFO:     127.0.0.1:62321 - "GET /health HTTP/1.1" 503 Service Unavailable
+```
+- Note that the error `Textual SQL expression 'SELECT 1' should be explicitly declared as text('SELECT 1')` is the encountered failure message that is reported in the original GitHub issue. This indicates that the bug/issue has been reproduced.
+
+To further verify that the Postgres DB is up, we can see the healthy container by running `docker compose ps`. We can also run `docker exec -it pathreview-db-1 pg_isready`, which results in the output: `/var/run/postgresql:5432 - accepting connections`.
+
+Therefore, it is confirmed that the response from the GET /health endpoint is incorrectly reporting the uptime status of the Postgres DB service.
+
+
+**PLAN.md link:** [link to PLAN.md in your fork]
+
+
+**Blockers or open questions:**
+Apart from the questions raised in PLAN.md, I have no further blockers.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,59 @@
+## Solution plan
+
+**Issue:**
+- Issue Title: "Health check DB probe passes a raw SQL string, which fails under SQLAlchemy 2.x"
+- Issue Link: https://github.com/ascherj/pathreview/issues/154
+
+### Understand
+What is the root cause of this issue? What behavior is expected vs. actual?
+
+The root cause of this issue is in `api/routes/health.py` on line 31. The current line is `await db.execute("SELECT 1")`, which causes an error since the `execute` method does not accept a raw string as a query. As mentioned in the issue description, SQLAlchemy 2.x requires a text SQL query to be wrapped with the `sqlalchemy.text()` method. 
+
+Actual behavior: Since the current code does not use the wrapper method, an error is raised, which is caught in the try/except block. In the except branch, the health status of Postgres is then updated to "unhealthy", which happens in line 36 (`health_status["dependencies"]["postgres"] = "unhealthy"`). This results in the response from the /health endpoint falsely reporting that the Postgres service is down.
+
+The expected behavior is for the /health endpoint to correctly report the status of the Postgres service. For that to occur, false exceptions should not occur, so the `sqlalchemy.text()` wrapper method should be implemented.
+
+
+### Map
+Which files, functions, or modules are involved?
+List the specific files you expect to touch.
+
+The files and functions involved are:
+- `api/routes/health.py`: the function `health_check` needs to be modified to implement the `sqlalchemy.text()` wrapper method.
+- `tests/unit` directory: a new file will have to be added to include unit tests for the GET health endpoint, since no existing unit tests are related to this API endpoint
+
+### Plan
+What are the steps to fix this issue?
+Break it into 3–5 concrete sub-tasks.
+
+1. Read documentation on `sqlalchemy.text()` and `sqlalchemy.execute()` to ensure that the usage matches up with the SQLAlchemy version currently used in the codebase.
+2. Implement the fix in `api/routes/health.py`, wrapping the SQL query text with the `sqlalchemy.text()` method on line 31.
+3. Write unit test(s) to check that the status of Postgres is correctly reported, using `Mock()` and `AsyncMock()` objects to imitate a failed and successful DB query. If such tests pass, then the fix works for both the happy path (DB is up, endpoint reports service as healthy) and the failure path (DB is actually down, endpoint reports service as unhealthy). The resulting status/error codes can be checked within these unit tests.
+4. Run the application and use `curl` commands and/or the Postman client to make a real request to the GET health endpoint, and ensure that the reported service status for Postgres is correct.
+
+### Inputs & outputs
+What does your fix take as input? What should it produce or change?
+
+**Function to Change:** `async def health_check(db=Depends(get_db))`
+- Takes no no inputs
+- Returns a dictionary containing the status of services (where the key is ["dependencies][< service name >])  along with other metadata
+
+**Changed/Correct Behavior:**
+- Correctly report the up status of the Postgres DB service, and to avoid the error `ArgumentError: Textual SQL expression 'SELECT 1' should be explicitly declared as text('SELECT 1')` from appearing in the terminal output.
+
+### Risks & unknowns
+What could go wrong? What are you still unsure about?
+
+I am still unsure whether the fix requires just the implementation of the `sqlalchemy.text()` method, or whether other changes need to be made that might occur as side effects. Through reading documentation and understanding the current flow of paths in the function will help mitigate unwanted cascading issues.
+
+### Edge cases
+What inputs or states should your fix handle gracefully?
+
+The fix should handle:
+- A true positive: The Postgres service is up, so the GET health endpoint should correctly report the Postgres status as "healthy"
+- A true negative: The Postgres service is down, so the GET health endpoint should correctly report the Postgres status
+
+Currently, without the fix, false negatives are the problem (the service is truly up, but the endpoint falsely reports the Postgres status as "unhealthy").
+
+After the proposed fix, no false positives or false negatives should occur. This will be verified with a mix of AP requests and unit testing.
+

--- a/api/routes/health.py
+++ b/api/routes/health.py
@@ -1,6 +1,7 @@
-from fastapi import APIRouter, HTTPException, status, Depends
+from datetime import datetime
+
 import structlog
-from datetime import datetime, timedelta
+from fastapi import APIRouter, Depends, HTTPException, status
 
 from core.database import get_db
 
@@ -28,7 +29,7 @@ async def health_check(db=Depends(get_db)):
 
     try:
         # Check PostgreSQL
-        await db.execute("SELECT 1")
+        await db.execute("SELECT 1")  # see Week 8 entry of JOURNAL.md for issue reproduction
         health_status["dependencies"]["postgres"] = "healthy"
         log.debug("postgres_health_check_passed")
     except Exception as exc:
@@ -39,6 +40,7 @@ async def health_check(db=Depends(get_db)):
     try:
         # Check Redis (if available)
         import redis
+
         from core.config import settings
 
         r = redis.Redis(

--- a/api/routes/health.py
+++ b/api/routes/health.py
@@ -1,7 +1,9 @@
 from datetime import datetime
+from typing import Any
 
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import text
 
 from core.database import get_db
 
@@ -11,12 +13,12 @@ router = APIRouter(prefix="/health", tags=["health"])
 
 
 @router.get("")
-async def health_check(db=Depends(get_db)):
+async def health_check(db: Any = Depends(get_db)) -> dict:  # noqa: B008
     """
     Check health of PostgreSQL, Redis, and Vector DB.
     Returns 200 if all healthy, 503 if any dependency is down.
     """
-    health_status = {
+    health_status: dict[str, Any] = {
         "status": "healthy",
         "dependencies": {
             "postgres": "unknown",
@@ -29,7 +31,7 @@ async def health_check(db=Depends(get_db)):
 
     try:
         # Check PostgreSQL
-        await db.execute("SELECT 1")  # see Week 8 entry of JOURNAL.md for issue reproduction
+        await db.execute(text("SELECT 1"))
         health_status["dependencies"]["postgres"] = "healthy"
         log.debug("postgres_health_check_passed")
     except Exception as exc:

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -1,0 +1,172 @@
+"""Tests for health.py endpoint."""
+
+from typing import cast
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from api.routes.health import health_check
+
+
+@pytest.mark.unit
+class TestHealthCheck:
+    """Test suite for health check endpoint."""
+
+    @pytest.fixture
+    def mock_db(self) -> AsyncMock:
+        """Create a mock database session."""
+        return AsyncMock()
+
+    @pytest.fixture
+    def mock_settings_config(self) -> Mock:
+        """Create mock settings configuration."""
+        settings = Mock()
+        settings.redis_host = "localhost"
+        settings.redis_port = 6379
+        settings.vector_db_url = "http://localhost:6333"
+        return settings
+
+    @pytest.mark.asyncio
+    async def test_health_check_all_services_healthy_returns_200(
+        self, mock_db: AsyncMock, mock_settings_config: Mock
+    ) -> None:
+        """Test health check returns 200 when all services are healthy."""
+        mock_db.execute = AsyncMock()
+
+        with (
+            patch("redis.Redis") as mock_redis,
+            patch("core.config.settings", mock_settings_config),
+        ):
+
+            mock_redis.return_value.ping = Mock()
+
+            result = await health_check(db=mock_db)
+
+            assert result["status"] == "healthy"
+            assert result["dependencies"]["postgres"] == "healthy"
+            assert result["dependencies"]["redis"] == "healthy"
+            assert result["dependencies"]["vector_db"] == "healthy"
+            mock_db.execute.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_health_check_postgres_down_returns_503(
+        self, mock_db: AsyncMock, mock_settings_config: Mock
+    ) -> None:
+        """Test health check returns 503 when PostgreSQL is down."""
+        mock_db.execute = AsyncMock(side_effect=Exception("Connection refused"))
+
+        with (
+            patch("redis.Redis") as mock_redis,
+            patch("core.config.settings", mock_settings_config),
+        ):
+
+            mock_redis.return_value.ping = Mock()
+
+            with pytest.raises(HTTPException) as exc_info:
+                await health_check(db=mock_db)
+
+            assert exc_info.value.status_code == 503
+            detail = cast("dict", exc_info.value.detail)
+            assert detail["status"] == "unhealthy"
+            assert detail["dependencies"]["postgres"] == "unhealthy"
+
+    @pytest.mark.asyncio
+    async def test_health_check_redis_down_returns_503(
+        self, mock_db: AsyncMock, mock_settings_config: Mock
+    ) -> None:
+        """Test health check returns 503 when Redis is down."""
+        mock_db.execute = AsyncMock()
+
+        with (
+            patch("redis.Redis") as mock_redis,
+            patch("core.config.settings", mock_settings_config),
+        ):
+
+            mock_redis.side_effect = Exception("Redis connection failed")
+
+            with pytest.raises(HTTPException) as exc_info:
+                await health_check(db=mock_db)
+
+            assert exc_info.value.status_code == 503
+            detail = cast("dict", exc_info.value.detail)
+            assert detail["status"] == "unhealthy"
+            assert detail["dependencies"]["redis"] == "unhealthy"
+
+    @pytest.mark.asyncio
+    async def test_health_check_vector_db_unavailable_still_healthy(
+        self, mock_db: AsyncMock, mock_settings_config: Mock
+    ) -> None:
+        """Test health check returns 200 when vector_db URL is not set."""
+        mock_db.execute = AsyncMock()
+        mock_settings_config.vector_db_url = None
+
+        with (
+            patch("redis.Redis") as mock_redis,
+            patch("core.config.settings", mock_settings_config),
+        ):
+
+            mock_redis.return_value.ping = Mock()
+
+            result = await health_check(db=mock_db)
+
+            assert result["status"] == "healthy"
+            assert result["dependencies"]["vector_db"] == "unavailable"
+
+    @pytest.mark.asyncio
+    async def test_health_check_response_includes_timestamp(
+        self, mock_db: AsyncMock, mock_settings_config: Mock
+    ) -> None:
+        """Test health check response includes ISO format timestamp."""
+        mock_db.execute = AsyncMock()
+
+        with (
+            patch("redis.Redis") as mock_redis,
+            patch("core.config.settings", mock_settings_config),
+        ):
+
+            mock_redis.return_value.ping = Mock()
+
+            result = await health_check(db=mock_db)
+
+            assert "timestamp" in result
+            assert "T" in result["timestamp"]  # ISO format check
+
+    @pytest.mark.asyncio
+    async def test_health_check_response_includes_safety_events(
+        self, mock_db: AsyncMock, mock_settings_config: Mock
+    ) -> None:
+        """Test health check response includes safety events count."""
+        mock_db.execute = AsyncMock()
+
+        with (
+            patch("redis.Redis") as mock_redis,
+            patch("core.config.settings", mock_settings_config),
+        ):
+
+            mock_redis.return_value.ping = Mock()
+
+            result = await health_check(db=mock_db)
+
+            assert "safety_events_last_hour" in result
+            assert isinstance(result["safety_events_last_hour"], int)
+
+    @pytest.mark.asyncio
+    async def test_health_check_postgres_uses_text_wrapper(
+        self, mock_db: AsyncMock, mock_settings_config: Mock
+    ) -> None:
+        """Test that PostgreSQL check uses sqlalchemy.text() wrapper."""
+        mock_db.execute = AsyncMock()
+
+        with (
+            patch("redis.Redis") as mock_redis,
+            patch("core.config.settings", mock_settings_config),
+            patch("api.routes.health.text") as mock_text,
+        ):
+
+            mock_redis.return_value.ping = Mock()
+
+            await health_check(db=mock_db)
+
+            mock_text.assert_called_once_with("SELECT 1")
+            mock_db.execute.assert_called_once()


### PR DESCRIPTION
## Summary
Fixed the PostgreSQL health check endpoint to properly wrap raw SQL strings using SQLAlchemy's `text()` function. This ensures proper SQL compilation and prevents the API health endpoint reporting false negatives on the Postgres service status.

## Issue
Closes #154

## Changes
The root cause of the issue is the use of a raw SQL string being passed to the `db.execute()` method in `api/routes/health.py`, which would raise an error. This was then caught as an exception, resulting in the Postgres service status to falsely be reported as "unhealthy".
- `api/routes/health.py` - added import `from sqlalchemy import text` for the `text()` wrapper method, and nested the `text()` wrapper around the `"SELECT 1"` string query being used in the `execute()` method within the try/except block.
- `api/routes/health.py` - added type annotations to the `health_check` method and `health_status` dictionary being used wihtin the method, to conform to the project's formatting expectations
- `api/routes/health.py` - added the comment `# noqa: B008` to bypass the ruff issue of having method calls within defaults. However, the `health_check` method's use of the `Depends` call as a default is a common FastAPI practice.
- `tests/unit/test_health.py` - created new unit test file and added seven new unit tests to test the happy and failure paths for when Postgres is up or down, and whether the correct status codes are used in such cases.

## Testing
<!-- How did you verify your changes? -->
- [  x ] Unit tests pass (`make test-unit`) - the new unit tests pass, existing issues noted in Notes for Reviewers section
- [ x ] Integration tests pass (`make test-integration`) - no integration tests present
- [ x  ] Linter passes (`make lint`) - existing issues are a part of `make check`, noted in section below
- [ ] Type checker passes (`make typecheck`) - none of the existing issues are the result of `health.py` or the related changes listed above 
- [ x ] New/updated tests cover the changes - the new tests pass and cover both happy and failure paths

## Screenshots / Demo
This is a change to the API endpoint logic. To test the health endpoint, use curl commands or a client such as Postman to make a GET request to the /health endpoint. You should observe that the Postgres status is reported as "healthy", if Postgres is up.

## Notes for Reviewers
There were existing issues found for `make check` and `make test-unit` before any of the changes listed above were made.

Before the changes, there were 179 errors for `make check`. The only error related to `api/routes/health.py` is:

```
B008 Do not perform function call `Depends` in argument defaults; instead, perform the call within the function, or read the default from a module-level singleton variable
  --> api\routes\health.py:14:27
   |
13 | @router.get("")
14 | async def health_check(db=Depends(get_db)):
   |                           ^^^^^^^^^^^^^^^
15 |     """
16 |     Check health of PostgreSQL, Redis, and Vector DB.
   |
```
After the changes, `make check` had 178 errors, since the existing error with `api/routes/health.py` was addressed with a bypass comment, since it was a non-issue. Therefore, the changes above ignored a non-issue, and did not introduce new errors for `make check`.

Before the changes, for `make test-unit`, the output showed ` 53 failed, 375 passed`.

After the changes, the output for `make test-unit` showed `53 failed, 382 passed`. Since 7 new unit tests were added from before, that means the changes introduced tests that passed, and did not increase the number of failed tests.