### PR TITLE
fix(ingestion): detect indented resume section headings

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -31,3 +31,34 @@ I reproduced issue 147 with a focused resume parser regression test using indent
 
 **Blockers or open questions:**
 None right now. The main follow-up risk is ensuring the section detection regex stays anchored to heading-like lines so it does not over-detect normal body text.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the issue 147 parser fix and added a focused regression test for indented resume section headings. The planned parser and test sub-tasks from `PLAN.md` are complete.
+
+**Next steps:**
+Open the pull request, request peer or mentor feedback, and confirm the final validation status before marking the PR ready for review.
+
+**Blockers:**
+Repo-wide `make check` and `make test-unit` currently fail in unrelated modules, so the PR description should document those pre-existing failures and note that the focused resume parser tests pass.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** TODO: add submitted PR link
+
+**Branch:** `fix/147-resume-section-leading-whitespace`
+
+**What you built:**
+Updated resume section detection so headings with leading whitespace, such as indented `Education:` and `Skills:` lines from PDF extraction, are detected the same way as non-indented headings. The regex remains anchored to line starts so normal body sentences are not treated as section headers.
+
+**Tests added or updated:**
+Updated `tests/unit/test_resume_parser.py` with `test_detect_sections_with_leading_whitespace`, which covers indented `Education:` and `Skills:` headings.
+
+**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -62,3 +62,33 @@ Updated `tests/unit/test_resume_parser.py` with `test_detect_sections_with_leadi
 **Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No reviewer or maintainer feedback has come in on PR #812 yet. I checked the PR conversation and inline review threads, and there were no comments to respond to.
+
+**How you responded:**
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The hardest part was keeping the fix small while still being confident it handled the real problem. The code change for issue 147 was only a regex adjustment, but it was easy to make the pattern too broad and accidentally detect words like "skills" inside normal resume body text. I had to think carefully about anchoring the match to heading-like lines and only adding optional leading whitespace where PDF extraction would realistically introduce it.
+
+**What did you learn about working in a large codebase?**
+I learned that even a small bug fix needs to fit the codebase's existing behavior and tests. In my own projects, I might rewrite a parser more freely, but here the better contribution was to preserve the existing `ResumeParser._detect_sections()` structure and add a focused regression test. I also learned to separate my change from unrelated repo-wide test failures so reviewers can see what my PR actually validates.
+
+**How did AI tools help — and where did they fall short?**
+AI tools helped most with navigating the repository, identifying the affected parser and test file, and turning the issue description into a concrete reproduction plan. They were also useful for checking whether the test covered the exact leading-whitespace case. Where AI fell short was judgment: I still had to verify the regex behavior myself, decide what not to change, and make sure the PR notes were honest about the broader test suite failures.
+
+**What would you do differently if you started over?**
+I would check the full test suite status earlier, before implementing the fix, so I could document pre-existing failures sooner instead of discovering them near PR submission. I would also write the reproduction test first and keep it as a separate checkpoint, because that made the issue much clearer than only reading the parser code.
+
+**What are you most proud of from this module?**
+I am most proud that the final PR is narrow and reviewable. It fixes a realistic parsing edge case, includes a regression test for the exact bug, and avoids changing unrelated parser behavior just to make the solution look larger.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -17,3 +17,17 @@ This issue is a good fit because it is Tier 1, has a focused scope, and affects 
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [ ] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/PrishaTHE-PRO/pathreview/commit/9b883cef99bd1eae6b8cb9be8eb4fefa67472df9
+
+**Reproduction summary:**
+I reproduced issue 147 with a focused resume parser regression test using indented `Education:` and `Skills:` headings. The affected behavior lives in `ResumeParser._detect_sections()`, where section headings need to be detected even when PDF or Markdown extraction preserves leading whitespace.
+
+**PLAN.md link:** https://github.com/PrishaTHE-PRO/pathreview/blob/fix/147-resume-section-leading-whitespace/PLAN.md
+
+**Walkthrough video (recommended):** Not recorded.
+
+**Blockers or open questions:**
+None right now. The main follow-up risk is ensuring the section detection regex stays anchored to heading-like lines so it does not over-detect normal body text.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,19 @@
+## Week 7 - Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/147
+
+**Issue title:** Resume section detection fails on text with leading whitespace
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The resume parser currently misses section headers when extracted text contains leading spaces before headings like Education or Skills. This matters because PDF text extraction often preserves indentation, so valid resumes can produce an empty `detected_sections` list even though the sections are present. The affected code is in `ingestion/parsers/resume_parser.py`, specifically the `_detect_sections()` logic. A successful fix should allow section headers to be detected whether or not they are indented, while keeping the existing resume parser behavior intact.
+
+**Selection notes:**
+This issue is a good fit because it is Tier 1, has a focused scope, and affects one parser module with existing unit tests. The expected behavior is clear from the issue reproduction: indented section headers should be detected the same way as unindented headers. The fix can be verified with a targeted regression test in `tests/unit/test_resume_parser.py`.
+
+**Branch name:** fix/147-resume-section-leading-whitespace
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -49,7 +49,7 @@ Repo-wide `make check` and `make test-unit` currently fail in unrelated modules,
 
 ### Check-in 2 (end of week)
 
-**PR link:** TODO: add submitted PR link
+**PR link:** https://github.com/ascherj/pathreview/pull/812
 
 **Branch:** `fix/147-resume-section-leading-whitespace`
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,57 @@
+# Solution plan
+
+**Issue:** Resume section detection fails on text with leading whitespace
+
+**Link:** https://github.com/ascherj/pathreview/issues/147
+
+### Understand
+
+The resume parser should detect common section headings such as `Education:` and `Skills:` even when extracted resume text preserves indentation before those headings. The current issue appears when section detection expects the heading text to begin at the start of the line. In real PDF extraction output, headings can be preceded by spaces, so valid sections may be omitted from `metadata["detected_sections"]`.
+
+Expected behavior: indented section headings should be detected the same way as non-indented headings.
+
+Actual behavior before the fix: headings such as `    Education:` and `    Skills:` are missed, producing incomplete section metadata.
+
+### Map
+
+Files involved:
+
+- `ingestion/parsers/resume_parser.py`: contains `ResumeParser._detect_sections()` and markdown cleanup logic.
+- `tests/unit/test_resume_parser.py`: contains unit coverage for resume parsing and section detection.
+- `JOURNAL.md`: records the Week 8 reproduction summary and deliverable links.
+
+Primary function involved:
+
+- `ResumeParser._detect_sections(text: str) -> list[str]`
+
+Related helper:
+
+- `ResumeParser._strip_markdown(content: str) -> str`
+
+### Plan
+
+1. Add a focused regression test in `tests/unit/test_resume_parser.py` using resume text where `Education:` and `Skills:` are indented.
+2. Confirm the test reproduces the issue against the original detection behavior.
+3. Update `_detect_sections()` in `ingestion/parsers/resume_parser.py` so section header regexes allow optional whitespace after the line-start anchor.
+4. Keep the regex anchored to the beginning of each line to avoid detecting section words inside normal body sentences.
+5. Run `python -m pytest tests/unit/test_resume_parser.py` to verify the regression and existing resume parser behavior.
+
+### Inputs & outputs
+
+Input: resume text from Markdown or PDF extraction, including lines that may start with whitespace before a known section heading.
+
+Output: `ParseResult.metadata["detected_sections"]` should include recognized sections such as `Education` and `Skills` when those headings are indented, while preserving the existing parsed text and metadata shape.
+
+### Risks & unknowns
+
+- `ingestion/parsers/resume_parser.py`: loosening the regex too much could classify ordinary body text as a section heading. The fix should only allow leading whitespace while preserving line-start anchoring.
+- `tests/unit/test_resume_parser.py`: section order is not stable because `_detect_sections()` removes duplicates with a set, so tests should assert membership rather than exact order.
+- PDF extraction output can vary by source document. The current plan covers leading spaces before headings, but future parser work may need to handle bullets, all-caps headings, or unusual punctuation.
+
+### Edge cases
+
+- Headings with spaces before the section name, such as `    Education:`.
+- Headings without indentation, such as `Education:`.
+- Headings with trailing punctuation, such as `Skills: Python` or `Experience -`.
+- Body sentences that mention section names should not be detected unless they appear in a heading-like line position.
+- Markdown headings with indentation should still have markdown syntax stripped before section detection.

--- a/docs/planning/issue-147-resume-section-leading-whitespace.md
+++ b/docs/planning/issue-147-resume-section-leading-whitespace.md
@@ -1,0 +1,87 @@
+# Issue 147 Plan: Resume Section Detection With Leading Whitespace
+
+## Issue
+
+- Link: https://github.com/ascherj/pathreview/issues/147
+- Title: Resume section detection fails on text with leading whitespace
+- Branch: `fix/147-resume-section-leading-whitespace`
+- Tier: Tier 1
+
+## Problem Summary
+
+The resume parser misses valid section headers when extracted resume text contains indentation before headings such as `Education:` or `Skills:`. This is a realistic PDF extraction case because text extraction often preserves layout spacing. When those headers are missed, `detected_sections` can be incomplete even though the resume contains recognizable sections.
+
+## Reproduction
+
+Run the focused resume parser test after adding a regression case with indented headers:
+
+```bash
+python -m pytest tests/unit/test_resume_parser.py -k leading_whitespace
+```
+
+Minimal failing input:
+
+```text
+    John Smith
+    john@example.com
+
+    Education:
+    - B.S. Computer Science
+
+    Skills: Python
+```
+
+Expected result:
+
+- `Education` is present in `detected_sections`
+- `Skills` is present in `detected_sections`
+
+Actual result before the fix:
+
+- The parser does not detect these headers because the section regex only matches section names at the beginning of a line or immediately after `\n`, without allowing spaces before the header text.
+
+## Root Cause
+
+The affected code is `ResumeParser._detect_sections()` in `ingestion/parsers/resume_parser.py`. The existing patterns anchor section names with `^` or `\n` but do not permit leading whitespace before the section name. With `re.MULTILINE`, `^education` matches `Education:` only when `Education` starts at column 0.
+
+The markdown stripping logic has a related edge case: indented markdown headings such as `    ## Skills` are not stripped by the previous heading regex.
+
+## Solution Plan
+
+1. Add a focused regression test in `tests/unit/test_resume_parser.py` that passes resume text with indented `Education:` and `Skills:` headings to `_detect_sections()`.
+2. Update `_detect_sections()` so section header patterns allow optional leading whitespace with `^\s*`.
+3. Keep matching constrained to line starts so normal body text that happens to contain words like "skills" is not treated as a section header.
+4. Update markdown heading stripping to allow optional leading whitespace before `#` headings.
+5. Run the targeted parser test file, then run broader unit checks if time allows.
+
+## Test Plan
+
+Primary check:
+
+```bash
+python -m pytest tests/unit/test_resume_parser.py
+```
+
+Regression covered:
+
+- `test_detect_sections_with_leading_whitespace` verifies indented `Education:` and `Skills:` headings are detected.
+
+Existing behavior covered:
+
+- Standard section detection still works for non-indented `Experience:`, `Education:`, and `Skills:`.
+- Markdown resume parsing still strips markdown syntax.
+- Invalid content types and PDF parsing errors still raise clear `ValueError` exceptions.
+
+## Risks
+
+- The regex change could over-detect section names inside regular text if the pattern becomes too broad. To avoid this, the fix should keep the `^` line-start anchor and only add optional whitespace after the anchor.
+- Section order is not guaranteed because `_detect_sections()` returns `list(set(detected))`; tests should assert membership instead of exact order.
+
+## Loom Walkthrough Outline
+
+1. Show the issue link and summarize the bug: indented resume section headers are missed.
+2. Open `ingestion/parsers/resume_parser.py` and point to `_detect_sections()`.
+3. Show the minimal reproduction input with leading spaces before `Education:` and `Skills:`.
+4. Explain the intended fix: allow optional leading whitespace after the line-start anchor.
+5. Show the regression test in `tests/unit/test_resume_parser.py`.
+6. Run `python -m pytest tests/unit/test_resume_parser.py` and show the passing result.

--- a/ingestion/parsers/resume_parser.py
+++ b/ingestion/parsers/resume_parser.py
@@ -5,7 +5,6 @@ from pypdf import PdfReader
 
 from .base import BaseParser, ParseResult
 
-
 SECTION_HEADERS = {
     "experience",
     "education",
@@ -75,7 +74,7 @@ class ResumeParser(BaseParser):
                 source_type="resume",
             )
         except Exception as e:
-            raise ValueError(f"Failed to parse PDF: {str(e)}")
+            raise ValueError(f"Failed to parse PDF: {str(e)}") from e
 
     def _parse_markdown(self, content: str) -> ParseResult:
         """Extract text from markdown resume, stripping markdown syntax."""
@@ -99,7 +98,7 @@ class ResumeParser(BaseParser):
     def _strip_markdown(self, content: str) -> str:
         """Remove markdown syntax from content."""
         # Remove markdown headers
-        text = re.sub(r"^#+\s+", "", content, flags=re.MULTILINE)
+        text = re.sub(r"^\s*#+\s+", "", content, flags=re.MULTILINE)
 
         # Remove markdown links [text](url)
         text = re.sub(r"\[([^\]]+)\]\(([^\)]+)\)", r"\1", text)
@@ -132,10 +131,8 @@ class ResumeParser(BaseParser):
         for section in SECTION_HEADERS:
             # Look for section header patterns
             patterns = [
-                rf"^{re.escape(section)}\s*$",
-                rf"^{re.escape(section)}\s*[:|-]",
-                rf"\n{re.escape(section)}\s*$",
-                rf"\n{re.escape(section)}\s*[:|-]",
+                rf"^\s*{re.escape(section)}\s*$",
+                rf"^\s*{re.escape(section)}\s*[:|-]",
             ]
 
             for pattern in patterns:

--- a/tests/unit/test_resume_parser.py
+++ b/tests/unit/test_resume_parser.py
@@ -1,11 +1,12 @@
 """Tests for resume_parser.py"""
 
-import pytest
-from unittest.mock import Mock, patch, MagicMock
-from io import BytesIO
+from typing import Any
+from unittest.mock import Mock, patch
 
-from ingestion.parsers.resume_parser import ResumeParser
+import pytest
+
 from ingestion.parsers.base import ParseResult
+from ingestion.parsers.resume_parser import ResumeParser
 
 
 @pytest.mark.unit
@@ -13,11 +14,13 @@ class TestResumeParser:
     """Test suite for ResumeParser."""
 
     @pytest.fixture
-    def parser(self):
+    def parser(self) -> ResumeParser:
         """Create a ResumeParser instance."""
         return ResumeParser()
 
-    def test_parse_single_column_resume_text(self, parser, sample_resume_text):
+    def test_parse_single_column_resume_text(
+        self, parser: ResumeParser, sample_resume_text: str
+    ) -> None:
         """Test parsing a standard single-column resume text."""
         result = parser.parse(sample_resume_text)
 
@@ -33,7 +36,7 @@ class TestResumeParser:
             "skills" in s for s in detected_lower
         )
 
-    def test_parse_resume_no_work_experience(self, parser):
+    def test_parse_resume_no_work_experience(self, parser: ResumeParser) -> None:
         """Test parsing a resume with no work experience section - handles gracefully."""
         resume_no_work = """
         John Smith
@@ -54,7 +57,7 @@ class TestResumeParser:
         detected_lower = [s.lower() for s in result.metadata["detected_sections"]]
         assert any("education" in s for s in detected_lower)
 
-    def test_parse_multipage_pdf(self, parser):
+    def test_parse_multipage_pdf(self, parser: ResumeParser) -> None:
         """Test parsing a multi-page PDF resume."""
         # Create a mock PDF with multiple pages
         with patch("ingestion.parsers.resume_parser.PdfReader") as mock_pdf_reader:
@@ -81,7 +84,7 @@ class TestResumeParser:
             assert "Page 2 Content" in result.text
             assert "Page 3 Content" in result.text
 
-    def test_parse_markdown_resume(self, parser):
+    def test_parse_markdown_resume(self, parser: ResumeParser) -> None:
         """Test parsing a Markdown resume."""
         markdown_resume = """
         # Jane Doe
@@ -105,25 +108,27 @@ class TestResumeParser:
         assert "#" not in result.text or result.text.count("#") < markdown_resume.count("#")
         assert "Jane Doe" in result.text
 
-    def test_parse_invalid_content_type(self, parser):
+    def test_parse_invalid_content_type(self, parser: ResumeParser) -> None:
         """Test that invalid content type raises ValueError with clear message."""
+        invalid_content: Any = 12345
         with pytest.raises(ValueError) as exc_info:
-            parser.parse(12345)  # Invalid: integer
+            parser.parse(invalid_content)  # Invalid: integer
 
         assert "Content must be bytes" in str(exc_info.value) or "Content must be" in str(
             exc_info.value
         )
 
-    def test_parse_invalid_list_content(self, parser):
+    def test_parse_invalid_list_content(self, parser: ResumeParser) -> None:
         """Test that list content raises ValueError."""
+        invalid_content: Any = ["not", "valid"]
         with pytest.raises(ValueError) as exc_info:
-            parser.parse(["not", "valid"])
+            parser.parse(invalid_content)
 
         assert "Content must be bytes" in str(exc_info.value) or "Content must be" in str(
             exc_info.value
         )
 
-    def test_detect_sections(self, parser):
+    def test_detect_sections(self, parser: ResumeParser) -> None:
         """Test section detection in resume text."""
         text = """
         Experience:
@@ -143,7 +148,24 @@ class TestResumeParser:
         assert any("education" in s for s in sections_lower)
         assert any("skills" in s for s in sections_lower)
 
-    def test_strip_markdown_syntax(self, parser):
+    def test_detect_sections_with_leading_whitespace(self, parser: ResumeParser) -> None:
+        """Test section detection when extracted text preserves indentation."""
+        text = """
+            John Smith
+            john@example.com
+
+            Education:
+            - B.S. Computer Science
+
+            Skills: Python
+        """
+        sections = parser._detect_sections(text)
+
+        sections_lower = [s.lower() for s in sections]
+        assert any("education" in s for s in sections_lower)
+        assert any("skills" in s for s in sections_lower)
+
+    def test_strip_markdown_syntax(self, parser: ResumeParser) -> None:
         """Test markdown syntax stripping."""
         markdown_text = """
         # Header
@@ -163,7 +185,7 @@ class TestResumeParser:
         # But actual text content should remain
         assert "Header" in stripped or "Bold text" in stripped
 
-    def test_pdf_parsing_error_handling(self, parser):
+    def test_pdf_parsing_error_handling(self, parser: ResumeParser) -> None:
         """Test graceful error handling for invalid PDF."""
         with patch("ingestion.parsers.resume_parser.PdfReader") as mock_pdf_reader:
             mock_pdf_reader.side_effect = Exception("Invalid PDF format")
@@ -173,7 +195,7 @@ class TestResumeParser:
 
             assert "Failed to parse PDF" in str(exc_info.value)
 
-    def test_parse_preserves_text_content(self, parser):
+    def test_parse_preserves_text_content(self, parser: ResumeParser) -> None:
         """Test that parsing preserves actual content text."""
         original_text = "John Doe\nSoftware Engineer\nPython, JavaScript, React"
         result = parser.parse(original_text)


### PR DESCRIPTION
## Summary

Fixes issue #147 by updating resume section detection so headings with leading whitespace are handled the same way as headings at column 0. This covers extracted resume text where PDF or Markdown parsing preserves indentation before section names like `Education:` or `Skills:`.

## Root cause

`ResumeParser._detect_sections()` matched known section names only when the heading text started immediately at the beginning of a line. Indented headings were skipped, which could leave `metadata["detected_sections"]` incomplete.

## Changes

- Allow optional leading whitespace before known section headings while keeping regexes anchored to line starts.
- Preserve heading-style constraints for colon, dash, or standalone section lines.
- Strip indented Markdown heading markers before section detection.
- Add a focused regression test for indented `Education:` and `Skills:` headings.
- Document the issue plan and Week 9 check-ins.

## Validation

- Passes: `.venv/bin/python -m pytest tests/unit/test_resume_parser.py -v` (`11 passed`)
- Repo-wide `make test-unit` currently fails in unrelated modules outside the resume parser area.
- Repo-wide `make check` currently fails on unrelated existing lint/type issues.

## Notes

The branch diff is scoped to the issue 147 parser fix, parser tests, and assignment documentation.