### PR TITLE
Fix test coverage for review_service.py (#109)

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -70,3 +70,44 @@ Fixed 13 broken test mocks in `test_review_service.py` (root cause: `AsyncMock` 
 (Note: `make check` and `make lint`/`make typecheck` show pre-existing failures unrelated to this change — 6 pre-existing mypy missing-annotation errors and 173 pre-existing ruff lint errors, all in files/lines untouched by this PR, confirmed via `git stash` and scoped `ruff check` on just the two changed files. Documented in full in the PR's Notes for Reviewers.)
 
 **Draft PR feedback received from:** none — ran out of time this week to get a peer review before the deadline
+
+
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [X ] No — still awaiting review
+
+**Summary of feedback:**
+[What did reviewers comment on? Or note that no review came in.]
+No review came in.
+
+**How you responded:**
+[What changes did you make, or what did you reply? If no feedback,
+leave blank.]
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+There was an issue that I had to fix that was bigger than what I originally thought would be included with the problem I had picked.
+I needed to increase the coverage of my tests above 40% so I assumed writing more tests but I also had to fix a bug within the actual code as well.
+The bug wasn't that large it just had to do more so with a small syntax and logic error that prevented some tests from passing but it affected the code
+coverage of the review_service file.
+This meant that I had to figure out what the failing part of the code was and then write the tests to increase the coverage. It was just more work
+than I had anticpated when I originally chose the issue.
+
+**What did you learn about working in a large codebase?**
+You have to spend a lot more time familariziing yourself with the code. I used AI a lot to explain certain files to me and how componenets worked together.
+When you write your own project from scratch the planning is already kind of done in your head or preplanned. You're more familiar with which files and classes work together. When you are contributing to someone elses code there's a lot that is thrown at you and it is sort of overwhelming. You also have to be more careful in terms of what you are pushing and that's why we have PR. The code is more carefully reviewed and merged when its a large codebase vs your own personal project.
+
+**How did AI tools help — and where did they fall short?**
+AI was most useful to explain concepts I didn't understand or when it came to explaining code to me. For example I had a hard time realizing what was wrong with the code coverage until Claude had pointed out why the tests were failing. I used it a lot to summarize methods or tell me what was going on in regards to files and the structure of the code. Honeslty AI didn't really let me down too much for this course. It was able to implement code when I needed and also have it explained to me really well.
+
+**What would you do differently if you started over?**
+I chose a tier 2 issue because I thought it would be a good balance. But I chose it in a topic I feel more strongly about which are tests. I don't like writing them but I think that test coverage is an easier topic which I know more about. Im curious to see how I would feel about doing a tier 1 issue for an issue category I'm less confident in. Like for example fixing a bug in the code myself or writing code logic. I think it would have given me more room to grow versus sitcking something I am more comfortable with. 
+
+**What are you most proud of from this module?**
+I am most proud of contributing to an open source large database. It was my first taste of what I'll probably mostly be doing in the real world so it was really cool to see what software engineers actually do on a large scale rather than just coding for a class project or a personal project.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -31,7 +31,7 @@ Result: core/services/review_service.py     135    105    22%   68-79, 98-194, 2
 
 This shows a 22% coverage.
 
-**PLAN.md link:** [link to PLAN.md in your fork]
+**PLAN.md link:** https://github.com/anuvanuzhat/pathreview/blob/test/109-review-service-coverage/PLAN.md
 
 **Walkthrough video (recommended):** [link to your Loom video, ≤2 min — recommended, not graded]
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -37,3 +37,36 @@ This shows a 22% coverage.
 
 **Blockers or open questions:**
 [Anything you're still uncertain about going into Week 9, or leave blank]
+
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+The progress I had when completiting for Week 8. A completed Plan.md to figure out what I need to fix.
+
+**Next steps:**
+Adding tests for `process_review`'s early-return and failure branches (review not found, profile not found, safety check failure, unhandled exception mid-pipeline), then direct tests for `_run_ingestion_pipeline` and `_run_safety_checks` including the confidence-boundary and multi-source-failure edge cases from the plan, then re-running coverage to confirm it's comfortably above 40%.
+
+**Blockers:**
+None.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/815
+
+**Branch:** test/109-review-service-coverage
+
+**What you built:**
+Fixed 13 broken test mocks in `test_review_service.py` (root cause: `AsyncMock` used for synchronous result-object methods) and added new tests covering `process_review`'s success, partial-failure, and full-failure paths plus its helper functions directly. While writing tests for the ingestion pipeline, found and fixed a real bug in `review_service.py`: `IngestedSource` was being constructed with a `raw_data` kwarg that doesn't exist on the model, so every ingestion attempt was silently failing.
+
+**Tests added or updated:**
+`tests/unit/test_review_service.py` — fixed the mocking pattern in all 19 original tests; added tests for `process_review`'s happy path (status=complete, sections/overall_score populated), review-not-found and profile-not-found early returns, safety-check failure, and unhandled-exception handling; added direct tests for `_run_ingestion_pipeline` (all sources present, no sources present, one source failing while others succeed, multiple sources failing while one succeeds) and `_run_safety_checks` (missing/empty sections, missing required fields, confidence out of range, and confidence exactly at the 0 and 1 boundaries). Coverage on `core/services/review_service.py` went from 22% to 94%.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+(Note: `make check` and `make lint`/`make typecheck` show pre-existing failures unrelated to this change — 6 pre-existing mypy missing-annotation errors and 173 pre-existing ruff lint errors, all in files/lines untouched by this PR, confirmed via `git stash` and scoped `ruff check` on just the two changed files. Documented in full in the PR's Notes for Reviewers.)
+
+**Draft PR feedback received from:** none — ran out of time this week to get a peer review before the deadline

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -18,3 +18,24 @@ This is a Tier 2 issue, which fits since I wanted a bit more challenge than a Ti
 **Setup confirmation:** [Yes ] App runs locally at localhost:5173
 
 **Cohort ledger:** [Yes ] Issue added to cohort ledger
+
+**REPRODUCTION NOTE**
+I ran this line: pytest --cov=core.services.review_service --cov-report=term-missing tests/unit/test_review_service.py
+
+Result: core/services/review_service.py     135    105    22%   68-79, 98-194, 202-279, 288, 323, 369-390
+
+This shows a 22% coverage.
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [link to commit documenting the reproduced issue]
+
+**Reproduction summary:**
+[1–2 sentences: How did you reproduce the issue? What did you observe?]
+
+**PLAN.md link:** [link to PLAN.md in your fork]
+
+**Walkthrough video (recommended):** [link to your Loom video, ≤2 min — recommended, not graded]
+
+**Blockers or open questions:**
+[Anything you're still uncertain about going into Week 9, or leave blank]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -19,19 +19,17 @@ This is a Tier 2 issue, which fits since I wanted a bit more challenge than a Ti
 
 **Cohort ledger:** [Yes ] Issue added to cohort ledger
 
-**REPRODUCTION NOTE**
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** (https://github.com/anuvanuzhat/pathreview/commit/2cc0dc314b7d38680dc0d44744d8c56f77d66db3)
+
+**Reproduction summary:**
 I ran this line: pytest --cov=core.services.review_service --cov-report=term-missing tests/unit/test_review_service.py
 
 Result: core/services/review_service.py     135    105    22%   68-79, 98-194, 202-279, 288, 323, 369-390
 
 This shows a 22% coverage.
-
-## Week 8 — Reproduction & solution planning
-
-**Reproduction commit link:** [link to commit documenting the reproduced issue]
-
-**Reproduction summary:**
-[1–2 sentences: How did you reproduce the issue? What did you observe?]
 
 **PLAN.md link:** [link to PLAN.md in your fork]
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,20 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/109
+
+**Issue title:** Test coverage for core/services/review_service.py is below 40%
+ #109
+
+**Tier:** [ ] Tier 1  [X] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The review service handles the app's core review process, but most of it isn't tested — coverage is under 40%. To fix this, I'll write unit tests in tests/unit/test_review_service.py that cover the main scenarios: when things work correctly, when part of the process fails, and when it all fails. This will make the service more reliable and easier to maintain.
+
+**Reasoning:**
+This is a Tier 2 issue, which fits since I wanted a bit more challenge than a Tier 1 fix. I found review_service.py and tests/unit/test_review_service.py, read through the existing service logic and test structure, and feel confident I understand the main execution paths (success, partial failure, full failure) well enough to write tests without getting stuck. Several other students have also claimed this issue, but since claims are non-exclusive and grading is based on my own work, I'm comfortable with that, and I don't see any blockers. I'm estimating 5-7 hours which fits within the Week 8-9 window.
+
+**Branch name:** test/109-review-service-coverage
+
+**Setup confirmation:** [Yes ] App runs locally at localhost:5173
+
+**Cohort ledger:** [Yes ] Issue added to cohort ledger

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,39 @@
+## Solution plan
+
+**Issue:** Test coverage for core/services/review_service.py is below 40%
+(https://github.com/ascherj/pathreview/issues/109)
+
+### Understand
+Root cause of failures: existing tests mock the SQLAlchemy result object
+(`mock_result`) as an `AsyncMock`, but `.scalars()` and `.first()/.all()` are
+synchronous methods called on the *result* of an already-awaited `db.execute()`.
+This makes every call to `.scalars()` return an un-awaited coroutine instead of
+a mock value, causing `AttributeError: 'coroutine' object has no attribute 'first'`.
+Expected behavior: every early-return path (review missing, profile missing, safety check failing) and every exception path should reliably set status="failed" and never crash the caller; actual behavior: 22% coverage due to failing tests.
+
+### Map
+core/services/review_service.py — no production changes expected; this is a test-only issue (the file itself works, the tests calling it are broken/missing)
+tests/unit/test_review_service.py — main file to fix (mock setup) and extend (new test cases for process_review and its helpers)
+core/models/review.py, core/models/profile.py, core/models/ingested_source.py — reference these to build accurate Profile/Review fixtures
+api/schemas/review.py (FeedbackSection) — needed since process_review builds these objects from RAG output
+Possibly tests/unit/conftest.py — if I add a shared, correctly-typed mock_db_session fixture so the AsyncMock/MagicMock fix only has to happen in one place
+
+### Plan
+1. Fix the broken mock pattern. Change every mock_result = AsyncMock() to mock_result = MagicMock() across the 13 failing tests, since only db.execute() itself is async — .scalars(), .first(), and .all() are synchronous calls on the returned result object. Re-run the suite to confirm all 19 existing tests pass before adding anything new.
+2. Add tests for process_review's happy path. Mock the four private helpers (_run_ingestion_pipeline, _run_agent_orchestration, _run_rag_retrieval_generation, _run_safety_checks) to succee
+3. Add tests for process_review's early-return and failure branches.
+4. Add tests for the private helper functions directly: _run_ingestion_pipeline (all sources present, none present, one source raising while others succeed) and _run_safety_checks (empty sections, missing fields, out-of-range confidence, valid input).
+5. Re-run coverage and close remaining gaps. 
+
+### Inputs & outputs
+Input: the real review_service.py source (already reviewed), a corrected mocking pattern (MagicMock for result objects, AsyncMock only for db.execute), and Profile/Review fixtures matching the actual model fields.
+Output: a tests/unit/test_review_service.py where all existing tests pass and new tests cover process_review's success/partial-failure/full-failure paths plus its helper functions, verified by a coverage report showing the file comfortably above 40%. No changes to review_service.py itself unless a genuine bug turns up while testing (would be called out separately, not folded silently into this fix).
+
+### Risks & unknowns
+Since the same broken mock pattern appears in ~13 places, there's a real risk of missing one instance when fixing them
+
+The four private helper functions currently contain placeholder logic rather than real integrations
+
+### Edge cases
+confidence values exactly at the boundaries (0 and 1).
+Multiple ingestion sources failing simultaneously while at least one succeeds.

--- a/core/services/review_service.py
+++ b/core/services/review_service.py
@@ -1,13 +1,13 @@
-from uuid import UUID
-import structlog
-import json
 from datetime import datetime
-from sqlalchemy import select, and_
+from uuid import UUID
 
-from core.models.review import Review
-from core.models.profile import Profile
-from core.models.ingested_source import IngestedSource
+import structlog
+from sqlalchemy import and_, select
+
 from api.schemas.review import FeedbackSection
+from core.models.ingested_source import IngestedSource
+from core.models.profile import Profile
+from core.models.review import Review
 
 log = structlog.get_logger()
 
@@ -40,8 +40,8 @@ async def get_review(
     """
     Get a review by ID, checking that it belongs to the user's profile.
     """
-    stmt = select(Review).join(Profile).where(
-        and_(Review.id == review_id, Profile.user_id == user_id)
+    stmt = (
+        select(Review).join(Profile).where(and_(Review.id == review_id, Profile.user_id == user_id))
     )
     result = await db.execute(stmt)
     return result.scalars().first()
@@ -216,7 +216,7 @@ async def _run_ingestion_pipeline(db, profile: Profile) -> list[dict]:
             ingested = IngestedSource(
                 profile_id=profile.id,
                 source_type="github",
-                raw_data=json.dumps(github_data),
+                source_url=f"https://github.com/{profile.github_username}",
             )
             db.add(ingested)
         except Exception as exc:
@@ -241,7 +241,7 @@ async def _run_ingestion_pipeline(db, profile: Profile) -> list[dict]:
             ingested = IngestedSource(
                 profile_id=profile.id,
                 source_type="portfolio",
-                raw_data=json.dumps(portfolio_data),
+                source_url=profile.portfolio_url,
             )
             db.add(ingested)
         except Exception as exc:
@@ -265,7 +265,7 @@ async def _run_ingestion_pipeline(db, profile: Profile) -> list[dict]:
             ingested = IngestedSource(
                 profile_id=profile.id,
                 source_type="resume",
-                raw_data=json.dumps(resume_data),
+                filename=profile.resume_filename,
             )
             db.add(ingested)
         except Exception as exc:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -99,7 +99,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -449,7 +448,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -473,7 +471,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1561,7 +1558,6 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1579,7 +1575,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1972,7 +1967,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3507,7 +3501,6 @@
       "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^2.0.1",
         "cssstyle": "^4.0.1",
@@ -4094,7 +4087,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4107,7 +4099,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4771,7 +4762,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/tests/unit/test_review_service.py
+++ b/tests/unit/test_review_service.py
@@ -1,20 +1,97 @@
 """Tests for review_service.py"""
 
-import pytest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 from uuid import uuid4
-from unittest.mock import AsyncMock, Mock, patch
-import asyncio
+
+import pytest
 
 from core.services.review_service import (
+    _run_agent_orchestration,
+    _run_ingestion_pipeline,
+    _run_rag_retrieval_generation,
+    _run_safety_checks,
     create_review,
     get_review,
     list_reviews,
+    process_review,
 )
+
+# ---------------------------------------------------------------------------
+# Shared fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def make_profile(**overrides):
+    """Build a lightweight profile-like object with sane defaults.
+
+    Using SimpleNamespace (rather than a bare Mock) means unset attributes
+    are explicitly None instead of auto-vivified truthy Mock objects, which
+    matters because _run_ingestion_pipeline branches on `if profile.x:`.
+    """
+    defaults = dict(
+        id=uuid4(),
+        user_id=uuid4(),
+        github_username=None,
+        portfolio_url=None,
+        resume_text=None,
+        resume_filename=None,
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def make_review(**overrides):
+    defaults = dict(
+        id=uuid4(),
+        profile_id=uuid4(),
+        status="pending",
+        sections=None,
+        overall_score=None,
+        updated_at=None,
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+class RaisesOnFormat:
+    """Stand-in value that blows up when interpolated into an f-string.
+
+    Used to simulate one ingestion source failing while others succeed,
+    without needing to patch internals of the (placeholder) ingestion logic.
+    """
+
+    def __format__(self, spec):
+        raise ValueError("boom")
+
+    def __str__(self):
+        raise ValueError("boom")
+
+
+def make_db_result(first=None, all_=None):
+    """Build a MagicMock standing in for the SQLAlchemy Result object.
+
+    IMPORTANT: this must be a MagicMock, not AsyncMock. `db.execute()` is the
+    only awaited call; `.scalars()` / `.first()` / `.all()` are synchronous
+    calls made on the *already-awaited* result. If this were an AsyncMock,
+    `.scalars` would itself be an AsyncMock, so `.scalars()` would return an
+    unawaited coroutine instead of a value, and `.first()`/`.all()` would
+    raise AttributeError on that coroutine.
+    """
+    result = MagicMock()
+    result.scalars.return_value.first.return_value = first
+    result.scalars.return_value.all.return_value = all_ if all_ is not None else []
+    return result
+
+
+# ---------------------------------------------------------------------------
+# create_review / get_review / list_reviews
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.unit
 class TestReviewService:
-    """Test suite for review_service module."""
+    """Test suite for create_review, get_review, and list_reviews."""
 
     @pytest.fixture
     def mock_db_session(self):
@@ -28,58 +105,38 @@ class TestReviewService:
 
     @pytest.fixture
     def mock_review(self):
-        """Create a mock Review object."""
-        review = Mock()
-        review.id = uuid4()
-        review.status = "pending"
-        review.sections = None
-        review.overall_score = None
-        return review
+        return make_review()
 
     @pytest.fixture
     def mock_profile(self):
-        """Create a mock Profile object."""
-        profile = Mock()
-        profile.id = uuid4()
-        profile.user_id = uuid4()
-        return profile
+        return make_profile()
 
     @pytest.mark.asyncio
-    async def test_create_review_returns_review_with_pending_status(self, mock_db_session, mock_review):
+    async def test_create_review_returns_review_with_pending_status(self, mock_db_session):
         """Test create_review returns Review with status='pending'."""
         profile_id = uuid4()
         user_id = uuid4()
 
-        # Setup mock
-        mock_db_session.add = Mock()
-        mock_db_session.commit = AsyncMock()
-        mock_db_session.refresh = AsyncMock()
-
-        with patch('core.services.review_service.Review') as MockReview:
-            mock_instance = MockReview.return_value
+        with patch('core.services.review_service.Review') as mock_review_cls:
+            mock_instance = mock_review_cls.return_value
             mock_instance.status = "pending"
             mock_instance.sections = None
             mock_instance.overall_score = None
 
-            result = await create_review(mock_db_session, profile_id, user_id)
+            await create_review(mock_db_session, profile_id, user_id)
 
-            # Check that Review was instantiated
-            MockReview.assert_called()
-            call_kwargs = MockReview.call_args[1]
-            assert call_kwargs['status'] == "pending"
+            mock_review_cls.assert_called()
+            call_kwargs = mock_review_cls.call_args[1]
+            assert call_kwargs["status"] == "pending"
 
     @pytest.mark.asyncio
     async def test_get_review_returns_review_for_correct_owner(self, mock_db_session):
         """Test get_review returns review when user_id matches."""
         review_id = uuid4()
         user_id = uuid4()
+        mock_review = make_review(id=review_id)
 
-        mock_review = Mock()
-        mock_review.id = review_id
-
-        # Setup mock execute to return review
-        mock_result = AsyncMock()
-        mock_result.scalars.return_value.first.return_value = mock_review
+        mock_result = make_db_result(first=mock_review)
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
         result = await get_review(mock_db_session, review_id, user_id)
@@ -91,12 +148,9 @@ class TestReviewService:
     async def test_get_review_returns_none_for_wrong_user(self, mock_db_session):
         """Test get_review returns None when user_id doesn't match."""
         review_id = uuid4()
-        user_id = uuid4()
         wrong_user_id = uuid4()
 
-        # Setup mock to return None
-        mock_result = AsyncMock()
-        mock_result.scalars.return_value.first.return_value = None
+        mock_result = make_db_result(first=None)
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
         result = await get_review(mock_db_session, review_id, wrong_user_id)
@@ -107,39 +161,28 @@ class TestReviewService:
     async def test_list_reviews_returns_paginated_results(self, mock_db_session):
         """Test list_reviews returns paginated results."""
         user_id = uuid4()
+        mock_reviews = [make_review() for _ in range(5)]
 
-        # Create mock reviews
-        mock_reviews = [Mock() for _ in range(5)]
-
-        # Setup execute mock to return reviews
-        mock_result = AsyncMock()
-        mock_result.scalars.return_value.all.return_value = mock_reviews
+        mock_result = make_db_result(all_=mock_reviews)
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
         reviews, total = await list_reviews(mock_db_session, user_id, page=1, page_size=20)
 
-        assert len(reviews) > 0 or len(reviews) == 0  # May be empty
         assert isinstance(total, int)
         assert total >= 0
+        assert isinstance(reviews, list)
 
     @pytest.mark.asyncio
     async def test_list_reviews_page_2_returns_correct_offset(self, mock_db_session):
-        """Test list_reviews page 2 returns correct offset."""
+        """Test list_reviews page 2 issues queries (offset applied internally)."""
         user_id = uuid4()
-        page_size = 20
 
-        # Setup mock
-        mock_result = AsyncMock()
-        mock_result.scalars.return_value.all.return_value = []
+        mock_result = make_db_result(all_=[])
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
-        reviews, total = await list_reviews(
-            mock_db_session, user_id, page=2, page_size=page_size
-        )
+        await list_reviews(mock_db_session, user_id, page=2, page_size=20)
 
-        # Second call should pass offset for page 2
         calls = mock_db_session.execute.call_args_list
-        # Should have at least one call
         assert len(calls) > 0
 
     @pytest.mark.asyncio
@@ -147,8 +190,7 @@ class TestReviewService:
         """Test list_reviews returns (reviews, total) tuple."""
         user_id = uuid4()
 
-        mock_result = AsyncMock()
-        mock_result.scalars.return_value.all.return_value = []
+        mock_result = make_db_result(all_=[])
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
         result = await list_reviews(mock_db_session, user_id)
@@ -162,179 +204,505 @@ class TestReviewService:
     @pytest.mark.asyncio
     async def test_create_review_calls_db_add(self, mock_db_session):
         """Test create_review calls db.add()."""
-        profile_id = uuid4()
-        user_id = uuid4()
-
-        with patch('core.services.review_service.Review'):
-            await create_review(mock_db_session, profile_id, user_id)
-
+        with patch("core.services.review_service.Review"):
+            await create_review(mock_db_session, uuid4(), uuid4())
             mock_db_session.add.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_create_review_calls_db_commit(self, mock_db_session):
         """Test create_review calls db.commit()."""
-        profile_id = uuid4()
-        user_id = uuid4()
-
-        with patch('core.services.review_service.Review'):
-            await create_review(mock_db_session, profile_id, user_id)
-
+        with patch("core.services.review_service.Review"):
+            await create_review(mock_db_session, uuid4(), uuid4())
             mock_db_session.commit.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_create_review_calls_db_refresh(self, mock_db_session):
         """Test create_review calls db.refresh()."""
-        profile_id = uuid4()
-        user_id = uuid4()
-
-        with patch('core.services.review_service.Review'):
-            await create_review(mock_db_session, profile_id, user_id)
-
+        with patch("core.services.review_service.Review"):
+            await create_review(mock_db_session, uuid4(), uuid4())
             mock_db_session.refresh.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_get_review_uses_select_and_join(self, mock_db_session):
-        """Test get_review constructs proper SQL with join."""
-        review_id = uuid4()
-        user_id = uuid4()
-
-        mock_result = AsyncMock()
-        mock_result.scalars.return_value.first.return_value = None
+        """Test get_review constructs a query and calls execute."""
+        mock_result = make_db_result(first=None)
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
-        await get_review(mock_db_session, review_id, user_id)
+        await get_review(mock_db_session, uuid4(), uuid4())
 
-        # Should call execute with a statement
         mock_db_session.execute.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_list_reviews_default_pagination(self, mock_db_session):
-        """Test list_reviews uses default pagination."""
-        user_id = uuid4()
-
-        mock_result = AsyncMock()
-        mock_result.scalars.return_value.all.return_value = []
+        """Test list_reviews uses default page=1, page_size=20."""
+        mock_result = make_db_result(all_=[])
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
-        reviews, total = await list_reviews(mock_db_session, user_id)
+        reviews, total = await list_reviews(mock_db_session, uuid4())
 
-        # Should use default page=1, page_size=20
         assert isinstance(reviews, list)
         assert isinstance(total, int)
 
     @pytest.mark.asyncio
     async def test_list_reviews_custom_page_size(self, mock_db_session):
-        """Test list_reviews with custom page size."""
-        user_id = uuid4()
-        custom_page_size = 50
-
-        mock_result = AsyncMock()
-        mock_result.scalars.return_value.all.return_value = []
+        """Test list_reviews with a custom page size."""
+        mock_result = make_db_result(all_=[])
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
-        reviews, total = await list_reviews(
-            mock_db_session, user_id, page=1, page_size=custom_page_size
-        )
+        reviews, total = await list_reviews(mock_db_session, uuid4(), page=1, page_size=50)
 
         assert isinstance(reviews, list)
 
     @pytest.mark.asyncio
     async def test_create_review_with_uuid_ids(self, mock_db_session):
-        """Test create_review handles UUID objects correctly."""
-        profile_id = uuid4()
-        user_id = uuid4()
+        """Test create_review passes profile_id and status through to Review()."""
+        with patch('core.services.review_service.Review') as mock_review_cls:
+            await create_review(mock_db_session, uuid4(), uuid4())
 
-        with patch('core.services.review_service.Review') as MockReview:
-            MockReview.return_value = Mock()
-            await create_review(mock_db_session, profile_id, user_id)
-
-            call_kwargs = MockReview.call_args[1]
-            assert 'profile_id' in call_kwargs
-            assert 'status' in call_kwargs
+            call_kwargs = mock_review_cls.call_args[1]
+            assert "profile_id" in call_kwargs
+            assert "status" in call_kwargs
 
     @pytest.mark.asyncio
     async def test_get_review_verifies_ownership(self, mock_db_session):
-        """Test get_review checks Profile.user_id matches."""
-        review_id = uuid4()
-        user_id = uuid4()
-
-        mock_result = AsyncMock()
-        mock_result.scalars.return_value.first.return_value = None
+        """Test get_review issues a single query joining on Profile.user_id."""
+        mock_result = make_db_result(first=None)
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
-        await get_review(mock_db_session, review_id, user_id)
+        await get_review(mock_db_session, uuid4(), uuid4())
 
-        # Should construct query with user_id filter
         mock_db_session.execute.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_list_reviews_counts_total(self, mock_db_session):
-        """Test list_reviews calculates total count."""
-        user_id = uuid4()
-
-        mock_reviews = [Mock() for _ in range(5)]
-        mock_result = AsyncMock()
-        mock_result.scalars.return_value.all.return_value = mock_reviews
+        """Test list_reviews calculates total count from the count query."""
+        mock_reviews = [make_review() for _ in range(5)]
+        mock_result = make_db_result(all_=mock_reviews)
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
-        reviews, total = await list_reviews(mock_db_session, user_id)
+        reviews, total = await list_reviews(mock_db_session, uuid4())
 
-        # Total should be counted
         assert isinstance(total, int)
 
     @pytest.mark.asyncio
     async def test_list_reviews_returns_reviews_list(self, mock_db_session):
-        """Test list_reviews returns list of Review objects."""
-        user_id = uuid4()
-
-        mock_reviews = [Mock(spec=['id', 'status']) for _ in range(3)]
-        mock_result = AsyncMock()
-        mock_result.scalars.return_value.all.return_value = mock_reviews
+        """Test list_reviews returns a list of Review-like objects."""
+        mock_reviews = [make_review() for _ in range(3)]
+        mock_result = make_db_result(all_=mock_reviews)
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
-        reviews, total = await list_reviews(mock_db_session, user_id)
+        reviews, total = await list_reviews(mock_db_session, uuid4())
 
         assert isinstance(reviews, list)
 
     @pytest.mark.asyncio
     async def test_review_sections_and_score_initially_none(self, mock_db_session):
-        """Test review has None for sections and overall_score initially."""
-        profile_id = uuid4()
-        user_id = uuid4()
+        """Test a newly created review has sections and overall_score as None."""
+        with patch('core.services.review_service.Review') as mock_review_cls:
+            await create_review(mock_db_session, uuid4(), uuid4())
 
-        with patch('core.services.review_service.Review') as MockReview:
-            MockReview.return_value = Mock()
-            await create_review(mock_db_session, profile_id, user_id)
-
-            call_kwargs = MockReview.call_args[1]
-            assert call_kwargs['sections'] is None
-            assert call_kwargs['overall_score'] is None
+            call_kwargs = mock_review_cls.call_args[1]
+            assert call_kwargs["sections"] is None
+            assert call_kwargs["overall_score"] is None
 
     @pytest.mark.asyncio
     async def test_get_review_with_valid_uuid(self, mock_db_session):
-        """Test get_review handles valid UUID parameters."""
-        review_id = uuid4()
-        user_id = uuid4()
-
-        mock_result = AsyncMock()
-        mock_result.scalars.return_value.first.return_value = None
+        """Test get_review handles valid UUID parameters without raising."""
+        mock_result = make_db_result(first=None)
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
-        # Should not raise
-        result = await get_review(mock_db_session, review_id, user_id)
+        result = await get_review(mock_db_session, uuid4(), uuid4())
 
-        assert result is None or result is not None  # Just verify no exception
+        assert result is None
 
     @pytest.mark.asyncio
     async def test_list_reviews_ordered_by_created_at(self, mock_db_session):
-        """Test list_reviews returns results ordered by created_at desc."""
-        user_id = uuid4()
-
-        mock_result = AsyncMock()
-        mock_result.scalars.return_value.all.return_value = []
+        """Test list_reviews issues its queries (ordering is applied in the
+        paginated statement). list_reviews makes two execute() calls: one for
+        the total count, one for the paginated/ordered results."""
+        mock_result = make_db_result(all_=[])
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
-        reviews, total = await list_reviews(mock_db_session, user_id)
+        await list_reviews(mock_db_session, uuid4())
 
-        # Should order by created_at descending
-        mock_db_session.execute.assert_called_once()
+        assert mock_db_session.execute.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# process_review — happy path, early returns, and failure branches
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestProcessReview:
+    """Test suite for process_review's success, partial-failure, and
+    full-failure paths."""
+
+    @pytest.fixture
+    def mock_db_session(self):
+        session = AsyncMock()
+        session.add = Mock()
+        session.commit = AsyncMock()
+        return session
+
+    @pytest.fixture
+    def agent_output(self):
+        return {
+            "sections": [
+                {
+                    "section_name": "Technical Skills",
+                    "content": "Analysis of technical skills",
+                    "confidence": 0.8,
+                    "suggestions": ["Add more detail"],
+                },
+            ],
+            "overall_score": 0.75,
+        }
+
+    @pytest.fixture
+    def rag_output(self):
+        return {
+            "sections": [
+                {
+                    "section_name": "Technical Skills",
+                    "content": "Detailed feedback on technical skills",
+                    "confidence": 0.85,
+                    "suggestions": ["Include specific technologies"],
+                },
+            ],
+            "overall_score": 0.81,
+        }
+
+    @pytest.mark.asyncio
+    async def test_process_review_happy_path_sets_complete_and_stores_sections(
+        self, mock_db_session, agent_output, rag_output
+    ):
+        """Full success path should set status='complete' and populate
+        sections + overall_score from the RAG output."""
+        review = make_review(status="pending")
+        profile = make_profile(github_username="alice")
+
+        mock_db_session.execute = AsyncMock(
+            side_effect=[
+                make_db_result(first=review),
+                make_db_result(first=profile),
+            ]
+        )
+
+        with (
+            patch(
+                "core.services.review_service._run_ingestion_pipeline",
+                new=AsyncMock(return_value=[{"source_type": "github"}]),
+            ),
+            patch(
+                "core.services.review_service._run_agent_orchestration",
+                new=AsyncMock(return_value=agent_output),
+            ),
+            patch(
+                "core.services.review_service._run_rag_retrieval_generation",
+                new=AsyncMock(return_value=rag_output),
+            ),
+            patch(
+                "core.services.review_service._run_safety_checks",
+                new=AsyncMock(return_value=True),
+            ),
+        ):
+            await process_review(mock_db_session, review.id, profile.id)
+
+        assert review.status == "complete"
+        assert review.overall_score == 0.81
+        assert review.sections[0]["section_name"] == "Technical Skills"
+        assert review.sections[0]["confidence"] == 0.85
+
+    @pytest.mark.asyncio
+    async def test_process_review_review_not_found_returns_without_commit(self, mock_db_session):
+        """If the review can't be found, log and return — no writes at all."""
+        mock_db_session.execute = AsyncMock(return_value=make_db_result(first=None))
+
+        await process_review(mock_db_session, uuid4(), uuid4())
+
+        mock_db_session.commit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_process_review_profile_not_found_marks_failed(self, mock_db_session):
+        """If the profile can't be found, the review should be marked failed."""
+        review = make_review(status="pending")
+
+        mock_db_session.execute = AsyncMock(
+            side_effect=[
+                make_db_result(first=review),
+                make_db_result(first=None),
+            ]
+        )
+
+        await process_review(mock_db_session, review.id, uuid4())
+
+        assert review.status == "failed"
+        mock_db_session.commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_process_review_safety_check_failure_marks_failed_without_sections(
+        self, mock_db_session, agent_output, rag_output
+    ):
+        """If safety checks fail, status should be 'failed' and sections/score
+        must NOT be populated from the (rejected) RAG output."""
+        review = make_review(status="pending")
+        profile = make_profile(github_username="alice")
+
+        mock_db_session.execute = AsyncMock(
+            side_effect=[
+                make_db_result(first=review),
+                make_db_result(first=profile),
+            ]
+        )
+
+        with (
+            patch(
+                "core.services.review_service._run_ingestion_pipeline",
+                new=AsyncMock(return_value=[]),
+            ),
+            patch(
+                "core.services.review_service._run_agent_orchestration",
+                new=AsyncMock(return_value=agent_output),
+            ),
+            patch(
+                "core.services.review_service._run_rag_retrieval_generation",
+                new=AsyncMock(return_value=rag_output),
+            ),
+            patch(
+                "core.services.review_service._run_safety_checks",
+                new=AsyncMock(return_value=False),
+            ),
+        ):
+            await process_review(mock_db_session, review.id, profile.id)
+
+        assert review.status == "failed"
+        assert review.sections is None
+        assert review.overall_score is None
+
+    @pytest.mark.asyncio
+    async def test_process_review_exception_during_pipeline_marks_failed(self, mock_db_session):
+        """An unexpected exception anywhere in the pipeline should be caught,
+        and the review re-fetched and marked failed rather than crashing the
+        caller."""
+        review = make_review(status="pending")
+        profile = make_profile(github_username="alice")
+
+        # 1st execute: fetch review: 2nd: fetch profile; 3rd: re-fetch review
+        # inside the except block to mark it failed.
+        mock_db_session.execute = AsyncMock(
+            side_effect=[
+                make_db_result(first=review),
+                make_db_result(first=profile),
+                make_db_result(first=review),
+            ]
+        )
+
+        with patch(
+            "core.services.review_service._run_ingestion_pipeline",
+            new=AsyncMock(side_effect=RuntimeError("ingestion exploded")),
+        ):
+            # Should not raise -- process_review is a background task and
+            # must swallow its own errors.
+            await process_review(mock_db_session, review.id, profile.id)
+
+        assert review.status == "failed"
+        assert review.updated_at is not None
+
+
+# ---------------------------------------------------------------------------
+# _run_ingestion_pipeline
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRunIngestionPipeline:
+    """Test suite for _run_ingestion_pipeline."""
+
+    @pytest.fixture
+    def mock_db_session(self):
+        session = AsyncMock()
+        session.add = Mock()
+        session.commit = AsyncMock()
+        return session
+
+    @pytest.mark.asyncio
+    async def test_all_sources_present_returns_three_entries(self, mock_db_session):
+        """When github, portfolio, and resume are all set, all three should
+        be ingested and stored."""
+        profile = make_profile(
+            github_username="alice",
+            portfolio_url="https://alice.dev",
+            resume_text="Experienced engineer...",
+            resume_filename="resume.pdf",
+        )
+
+        sources = await _run_ingestion_pipeline(mock_db_session, profile)
+
+        assert len(sources) == 3
+        source_types = {s["source_type"] for s in sources}
+        assert source_types == {"github", "portfolio", "resume"}
+        assert mock_db_session.add.call_count == 3
+        mock_db_session.commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_no_sources_present_returns_empty_list(self, mock_db_session):
+        """When none of the source fields are set, nothing should be
+        ingested, but commit is still called once at the end."""
+        profile = make_profile()
+
+        sources = await _run_ingestion_pipeline(mock_db_session, profile)
+
+        assert sources == []
+        mock_db_session.add.assert_not_called()
+        mock_db_session.commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_one_source_raising_does_not_block_the_others(self, mock_db_session):
+        """If one source's ingestion fails, the others should still succeed
+        and be returned/stored."""
+        profile = make_profile(
+            github_username="alice",
+            portfolio_url=RaisesOnFormat(),
+            resume_text="Experienced engineer...",
+            resume_filename="resume.pdf",
+        )
+
+        sources = await _run_ingestion_pipeline(mock_db_session, profile)
+
+        source_types = {s["source_type"] for s in sources}
+        assert source_types == {"github", "resume"}
+        assert len(sources) == 2
+        assert mock_db_session.add.call_count == 2
+        mock_db_session.commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_multiple_sources_raising_while_one_succeeds(self, mock_db_session):
+        """Even if two of the three sources fail, the pipeline should still
+        return the one that succeeded rather than failing the whole run."""
+        profile = make_profile(
+            github_username=RaisesOnFormat(),
+            portfolio_url=RaisesOnFormat(),
+            resume_text="Experienced engineer...",
+            resume_filename="resume.pdf",
+        )
+
+        sources = await _run_ingestion_pipeline(mock_db_session, profile)
+
+        assert len(sources) == 1
+        assert sources[0]["source_type"] == "resume"
+        assert mock_db_session.add.call_count == 1
+        mock_db_session.commit.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# _run_agent_orchestration / _run_rag_retrieval_generation (placeholder
+# integrations -- smoke tests confirming their output shape)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestPlaceholderIntegrations:
+
+    @pytest.mark.asyncio
+    async def test_run_agent_orchestration_returns_sections_and_score(self):
+        profile = make_profile(github_username="alice")
+
+        output = await _run_agent_orchestration(profile, [{"source_type": "github"}])
+
+        assert "sections" in output
+        assert isinstance(output["sections"], list)
+        assert "overall_score" in output
+
+    @pytest.mark.asyncio
+    async def test_run_rag_retrieval_generation_returns_sections_and_score(self):
+        profile = make_profile(github_username="alice")
+        agent_output = {"sections": [], "overall_score": 0.5}
+
+        output = await _run_rag_retrieval_generation(profile, [], agent_output)
+
+        assert "sections" in output
+        assert isinstance(output["sections"], list)
+        assert "overall_score" in output
+
+
+# ---------------------------------------------------------------------------
+# _run_safety_checks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRunSafetyChecks:
+    """Test suite for _run_safety_checks, including confidence boundaries."""
+
+    @pytest.mark.asyncio
+    async def test_empty_sections_fails(self):
+        assert await _run_safety_checks({"sections": []}) is False
+
+    @pytest.mark.asyncio
+    async def test_missing_sections_key_fails(self):
+        assert await _run_safety_checks({}) is False
+
+    @pytest.mark.asyncio
+    async def test_section_missing_section_name_fails(self):
+        output = {
+            "sections": [
+                {"content": "some content", "confidence": 0.5},
+            ]
+        }
+        assert await _run_safety_checks(output) is False
+
+    @pytest.mark.asyncio
+    async def test_section_missing_content_fails(self):
+        output = {
+            "sections": [
+                {"section_name": "Skills", "confidence": 0.5},
+            ]
+        }
+        assert await _run_safety_checks(output) is False
+
+    @pytest.mark.asyncio
+    async def test_confidence_below_zero_fails(self):
+        output = {
+            "sections": [
+                {"section_name": "Skills", "content": "x", "confidence": -0.01},
+            ]
+        }
+        assert await _run_safety_checks(output) is False
+
+    @pytest.mark.asyncio
+    async def test_confidence_above_one_fails(self):
+        output = {
+            "sections": [
+                {"section_name": "Skills", "content": "x", "confidence": 1.01},
+            ]
+        }
+        assert await _run_safety_checks(output) is False
+
+    @pytest.mark.asyncio
+    async def test_confidence_exactly_zero_passes(self):
+        output = {
+            "sections": [
+                {"section_name": "Skills", "content": "x", "confidence": 0},
+            ]
+        }
+        assert await _run_safety_checks(output) is True
+
+    @pytest.mark.asyncio
+    async def test_confidence_exactly_one_passes(self):
+        output = {
+            "sections": [
+                {"section_name": "Skills", "content": "x", "confidence": 1},
+            ]
+        }
+        assert await _run_safety_checks(output) is True
+
+    @pytest.mark.asyncio
+    async def test_valid_multi_section_output_passes(self):
+        output = {
+            "sections": [
+                {"section_name": "Skills", "content": "x", "confidence": 0.8},
+                {"section_name": "Projects", "content": "y", "confidence": 0.6},
+            ]
+        }
+        assert await _run_safety_checks(output) is True


### PR DESCRIPTION
## Summary
Fixes broken unit test mocking in `test_review_service.py` and adds new tests covering `process_review` and its helper functions, raising `core/services/review_service.py` coverage from 22% to 94%. Along the way, found and fixed a real bug: `_run_ingestion_pipeline` was constructing `IngestedSource` objects with a `raw_data` keyword argument that doesn't exist on the model, so every ingestion attempt (github/portfolio/resume) was silently failing and nothing was ever actually being persisted to the database.

## Issue
Closes #109

## Changes
- Fixed the root cause of 13 failing tests: existing tests mocked SQLAlchemy result objects as `AsyncMock`, but `.scalars()`/`.first()`/`.all()` are synchronous calls made on the already-awaited result of `db.execute()`. Since child mocks of an `AsyncMock` default to `AsyncMock` too, `.scalars()` returned an unawaited coroutine instead of a value, and calling `.first()` on that coroutine raised `AttributeError`. Fixed by using `MagicMock` for result objects and reserving `AsyncMock` only for `db.execute()` itself.
- Added tests for `process_review`'s happy path (status set to "complete", sections/overall_score populated from RAG output), early-return branches (review not found, profile not found), the safety-check-failure branch (status set to "failed", sections/score left untouched), and the unhandled-exception branch (caught, review re-fetched and marked "failed" rather than crashing the caller).
- Added direct tests for `_run_ingestion_pipeline` (all sources present, no sources present, one source failing while others succeed, multiple sources failing while one succeeds) and for `_run_safety_checks` (empty sections, missing required fields, confidence out of range, and confidence exactly at the 0/1 boundaries).
- Fixed `core/services/review_service.py`: replaced the invalid `raw_data` kwarg in the three `IngestedSource(...)` calls with the model's actual `source_url` (github/portfolio) and `filename` (resume) fields.

## Testing
To manually verify:
1. Check out this branch and run:
pytest --cov=core.services.review_service --cov-report=term-missing tests/unit/test_review_service.py

2. Confirm all 39 tests pass and coverage for `core/services/review_service.py` is ~94% (up from 22%).
3. To see the bug this PR fixes in isolation: on `main`, try `IngestedSource(profile_id=..., source_type="github", raw_data="test")` in a Python shell — it raises `TypeError: 'raw_data' is an invalid keyword argument for IngestedSource`, confirming ingestion was silently broken before this fix.
4. Run `make check` — confirm the only failures are the pre-existing mypy findings documented in Notes for Reviewers below, with no new ones introduced.

- [x] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`) — not applicable, no integration-level changes in this PR
- [x] Linter passes (`make lint`) - 173 pre-existing lint errors exist repo-wide in files unrelated to this PR (rag/, safety/, unrelated test files); not introduced by this change
- [ ] Type checker passes (`make typecheck`) — pre-existing mypy errors unrelated to this change remain (see Notes for Reviewers); no new errors introduced by this PR
- [x] New/updated tests cover the changes

## Screenshots / Demo
<!-- If applicable, add screenshots or a link to a demo video -->

## Notes for Reviewers
- Pre-existing `make check`/mypy findings, confirmed present before this change via `git stash`/`git show HEAD~1`: 6 missing-type-annotation errors on `db` parameters across `review_service.py` (lines 15, 35, 47, 50, 82, 197), and the same missing-annotation pattern across most functions in the (also pre-existing, untyped) test file. Not introduced by this PR — my changes add no new mypy error categories, and one pre-existing `arg-type` error was incidentally resolved as a side effect of the `raw_data` fix.
- Three pre-existing deprecation warnings surface during the test run (1 Pydantic `class Config` deprecation in `core/config.py`, 2 `datetime.utcnow()` deprecations in `review_service.py` lines 171/190) — unrelated to this issue, not introduced by these changes.
- I found the `raw_data` bug while writing tests, not while looking for it — flagging per CONTRIBUTING.md guidance rather than folding it in silently. Happy to split it into a separate PR if preferred, but it was small enough (3 lines) that I included it here since it directly blocked getting real coverage on the ingestion pipeline.
