### PR TITLE
Fix/156 readme scorer fixture length

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -10,3 +10,14 @@ This issue affects the unit tests for the README scoring module in `tests/unit/t
 **Branch name:** fix/156-readme-scorer-fixture-length
 **Setup confirmation:** [x] App runs locally at localhost:5173
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [Paste your commit link here after pushing]
+**Reproduction summary:**
+Ran `pytest tests/unit/test_readme_scorer.py -q` on branch `fix/156-readme-scorer-fixture-length`. Confirmed `test_readme_with_all_quality_signals` fails with `AssertionError: assert 51 > 100` because the string fixture in `test_readme_scorer.py` has only 51 words.
+
+**PLAN.md link:** [Paste link to PLAN.md in your GitHub fork]
+**Walkthrough video (recommended):** 
+**Blockers or open questions:**
+None.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,12 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/156
+**Issue title:** README scorer test fixture is too short for its own word-count assertion
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+This issue affects the unit tests for the README scoring module in `tests/unit/test_readme_scorer.py`. The `test_readme_with_all_quality_signals` test asserts that a README fixture has a word count greater than 100, but the current test fixture string only contains ~51 words, causing `pytest` to fail. A successful fix will expand the mock README text in the fixture to over 100 words so that the word-count assertion passes as intended.
+
+**Branch name:** fix/156-readme-scorer-fixture-length
+**Setup confirmation:** [x] App runs locally at localhost:5173
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -51,3 +51,54 @@ Expanded the mock README fixture string inside `test_readme_with_all_quality_sig
 
 **Self-review confirmation:** [x] make check passes  [x] make test-unit passes
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [X] No — still awaiting review
+
+**Summary of feedback:**
+N/A haven't requested a review
+**How you responded:**
+
+
+---
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [X] Check-in 2 complete — awaiting review
+
+**Summary of feedback:**
+N/A — Review has not been requested yet.
+
+**How you responded:**
+N/A
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Navigating a codebase with hundreds of files and identifying the exact scope of my issue was more challenging than I anticipated. Additionally, figuring out how to fix the fixture so that all related test cases passed required careful trace-backs.
+
+**What did you learn about working in a large codebase?**
+- **Read the documentation first:** Thoroughly reading the project's documentation and contribution guidelines provides critical context for understanding what the project expects.
+- **Plan before coding:** Mapping out a solution beforehand prevents wasted effort and keeps the scope manageable.
+- **Test thoroughly:** Writing, running, and documenting test cases is essential to ensure changes work as intended without breaking existing behavior.
+
+**How did AI tools help — and where did they fall short?**
+Claude was particularly useful during the implementation phase. It helped construct the expanded text fixture accurately, handling precise whitespace and line-count requirements that initially caused test failures.
+
+However, AI tools fell short in several areas:
+- **Planning & Edge Cases:** Gemini helped during the initial planning phase, but its suggested solutions failed to pass all test cases. Iterating with it didn't resolve the issues, requiring manual adjustments alongside Claude.
+- **Git Safety:** Claude attempted to create Git commits automatically without explicit authorization when instructed only to edit files, forcing me to run `git revert`.
+- **Bypassing Checks:** When tests failed in the CI environment, Claude suggested committing with `--no-verify` to bypass pre-commit hooks, which I had to explicitly reject to maintain project standards.
+
+**What would you do differently if you started over?**
+I would dedicate more time to the initial planning phase to thoroughly understand the root cause before writing any code. While AI is a helpful assistant, I would avoid relying on it blindly, ensuring that I manually validate every change rather than accepting temporary fixes.
+
+**What are you most proud of from this module?**
+I am proud of successfully navigating a large, unfamiliar codebase to fix a real bug and submit a Pull Request. I am also proud of learning how to use AI tools responsibly—recognizing their limitations, managing their output, and taking ownership of the final codebase quality.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -21,3 +21,34 @@ Ran `pytest tests/unit/test_readme_scorer.py -q` on branch `fix/156-readme-score
 **Walkthrough video (recommended):** 
 **Blockers or open questions:**
 None.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+**Current progress:**
+- Located `test_readme_with_all_quality_signals` in `tests/unit/test_readme_scorer.py`.
+- Identified that the test fixture string had only ~51 words, causing `assert data["word_count"] > 100` and `assert data["word_count_category"] == "comprehensive"` to fail.
+- Expanded the inline `readme` string fixture to exceed 500 words while maintaining all quality signals (badges, code blocks, links, lists, tech stack section).
+
+**Next steps:**
+- Run local linting and testing checks via `make check` and `make test-unit`.
+- Open a Pull Request on GitHub and request peer review.
+- Fill out Check-in 2 and submit the working branch URL to the course portal.
+
+**Blockers:**
+None.
+
+---
+
+### Check-in 2 (end of week)
+**PR link:** https://github.com/ascherj/pathreview/pull/YOUR_PR_NUMBER_HERE
+>Note: This is draft for now
+**Branch:** fix/156-readme-scorer-fixture-length
+**What you built:**
+Expanded the mock README fixture string inside `test_readme_with_all_quality_signals` in `tests/unit/test_readme_scorer.py` to >500 words. This resolves the failing `word_count` and `word_count_category` assertions without changing any underlying scoring algorithm logic in `agent/tools/readme_scorer.py`.
+
+**Tests added or updated:**
+- `tests/unit/test_readme_scorer.py`: Expanded the `readme` text string fixture inside `test_readme_with_all_quality_signals`. The updated test covers the scenario where a README containing all quality signals (badges, installation, usage, demo links, tech stack) also meets the word count threshold required to qualify for the `"comprehensive"` word count category.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -41,8 +41,7 @@ None.
 ---
 
 ### Check-in 2 (end of week)
-**PR link:** https://github.com/ascherj/pathreview/pull/YOUR_PR_NUMBER_HERE
->Note: This is draft for now
+**PR link:** https://github.com/ascherj/pathreview/pull/817
 **Branch:** fix/156-readme-scorer-fixture-length
 **What you built:**
 Expanded the mock README fixture string inside `test_readme_with_all_quality_signals` in `tests/unit/test_readme_scorer.py` to >500 words. This resolves the failing `word_count` and `word_count_category` assertions without changing any underlying scoring algorithm logic in `agent/tools/readme_scorer.py`.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,26 @@
+## Solution plan
+
+**Issue:** ascherj#156 - README scorer test fixture is too short for its own word-count assertion
+
+### Understand
+The unit test `TestReadmeScorer.test_readme_with_all_quality_signals` in `tests/unit/test_readme_scorer.py` validates that a high-quality README produces a word count greater than 100 (`assert data["word_count"] > 100`). However, the string fixture defined inside the test only contains 51 words. The scorer algorithm accurately counts the 51 words, causing `pytest` to fail with `AssertionError: assert 51 > 100`. The scorer logic itself functions correctly; the issue is entirely that the test fixture string is too short.
+
+### Map
+* `tests/unit/test_readme_scorer.py` (specifically the `test_readme_with_all_quality_signals` test method)
+
+### Plan
+1. Open `tests/unit/test_readme_scorer.py` and locate `test_readme_with_all_quality_signals`.
+2. Expand the inline `readme` multi-line string fixture by adding realistic project documentation details (e.g., prerequisites, detailed configuration options, API usage, and contributing guidelines).
+3. Ensure the updated fixture text comfortably exceeds 100 words while retaining all existing quality markers (headings, badges, code blocks, links, list items).
+4. Run `pytest tests/unit/test_readme_scorer.py -q` to verify the assertion passes and all 23 unit tests pass.
+
+### Inputs & outputs
+* **Input:** An expanded Markdown string fixture for `test_readme_with_all_quality_signals` containing > 100 words.
+* **Output:** `pytest` execution where `result.data["word_count"] > 100` evaluates to `True` without breaking surrounding assertions.
+
+### Risks & unknowns
+* Accidentally altering existing quality signals (like removing badges, links, or code blocks) while expanding the text, which could cause lower-level feature checks in `ReadmeScorer` to fail.
+* Adding text inside code blocks that might be parsed or excluded from word counts differently depending on how `ReadmeScorer` calculates length.
+
+### Edge cases
+* Ensuring prose word count is well over 100 (e.g., 120+ words) so minor variations in how the scorer splits tokens or strips Markdown syntax don't drop the word count back below 100.

--- a/tests/unit/test_readme_scorer.py
+++ b/tests/unit/test_readme_scorer.py
@@ -10,43 +10,110 @@ class TestReadmeScorer:
     """Test suite for ReadmeScorer."""
 
     @pytest.fixture
-    def scorer(self):
+    def scorer(self) -> ReadmeScorer:
         """Create a ReadmeScorer instance."""
         return ReadmeScorer()
 
-    def test_readme_with_all_quality_signals(self, scorer):
+    def test_readme_with_all_quality_signals(self, scorer: ReadmeScorer) -> None:
         """Test README with all quality signals returns high score."""
-        readme = """
-        # Project Name
-        A comprehensive project description.
-
-        ## Installation
-        ```bash
-        pip install package
-        ```
-
-        ## Usage
-        ```python
-        import package
-        package.run()
-        ```
-
-        ## Features
-        - Feature 1
-        - Feature 2
-        - Feature 3
-
-        ## Tech Stack
-        - Python 3.9
-        - FastAPI
-        - PostgreSQL
-
-        ![Build Status](https://example.com/badge.svg)
-        ![Coverage](https://example.com/coverage.svg)
-
-        ## Live Demo
-        [Try it here](https://demo.example.com)
-        """
+        readme = (
+            "# Project Name\n\n"
+            "![Build Status](https://example.com/badge.svg)\n"
+            "![Coverage](https://example.com/coverage.svg)\n\n"
+            "A comprehensive project description that outlines the primary "
+            "objectives, core capabilities, and high-level architecture of this "
+            "application. This platform provides developers with robust tools for "
+            "data ingestion, processing, and intelligent analysis in production "
+            "environments.\n\n"
+            "## Installation\n"
+            "To set up the project locally, ensure you have Python 3.9 or higher "
+            "installed on your system. Run the following command to install the "
+            "required package dependencies directly from the repository:\n\n"
+            "```bash\n"
+            "pip install package\n"
+            "```\n\n"
+            "## Usage\n"
+            "Import the main application module and initialize the standard "
+            "workflow execution engine as shown in the example snippet below:\n\n"
+            "```python\n"
+            "import package\n"
+            "package.run()\n"
+            "```\n\n"
+            "## Features\n"
+            "- Automated data parsing and background document ingestion pipeline\n"
+            "- Real-time performance monitoring and analytical report generation\n"
+            "- Flexible configuration options for seamlessly integrating custom "
+            "storage adapters\n"
+            "- Comprehensive logging and structured diagnostic telemetry for "
+            "enterprise deployments\n"
+            "- Advanced error handling with automatic retry mechanics for "
+            "asynchronous background workers\n\n"
+            "## Tech Stack\n"
+            "- Python 3.9\n"
+            "- FastAPI\n"
+            "- PostgreSQL\n\n"
+            "## Architecture\n"
+            "The application is structured into decoupled components that "
+            "communicate through well-defined interfaces. The core pipeline "
+            "ingests raw documents, converts them into unified data models, and "
+            "indexes them in a persistent store. Worker nodes consume tasks from "
+            "a central queue to process high-throughput document payloads "
+            "efficiently without blocking the primary HTTP server thread.\n\n"
+            "## Detailed Configuration\n"
+            "You can customize runtime behavior by supplying environment "
+            "variables or an external configuration file. Key settings include "
+            "database connection strings, maximum concurrent worker threads, "
+            "memory cache TTL limits, and external service timeout thresholds. "
+            "Refer to the sample configuration file in the project repository "
+            "for default parameter values and recommended production "
+            "overrides.\n\n"
+            "## API Reference\n"
+            "The service exposes a RESTful API with automated OpenAPI "
+            "documentation accessible via the standard Swagger UI endpoint. "
+            "Client applications can issue authenticated HTTP requests to "
+            "register new data streams, query processing statuses, trigger "
+            "on-demand pipeline executions, and retrieve formatted analytical "
+            "summaries. All API responses use standard JSON formatting with "
+            "standardized error payloads.\n\n"
+            "## Contributing Guidelines\n"
+            "We welcome community contributions to improve this repository. "
+            "Before submitting a pull request, please ensure your code conforms "
+            "to the project's formatting and linting guidelines. Run all local "
+            "test suites to verify that new changes do not introduce regressions. "
+            "Include clear documentation and detailed commit messages explaining "
+            "the purpose and design decisions behind your pull request.\n\n"
+            "## Performance Considerations\n"
+            "The system is optimized for handling high-throughput document "
+            "processing with minimal latency. Benchmarks demonstrate consistent "
+            "sub-second response times for typical queries across datasets with "
+            "millions of indexed documents. The architecture scales horizontally "
+            "through containerized worker deployments, allowing elastic resource "
+            "allocation based on current workload demands. Memory usage is "
+            "optimized through efficient data structure implementations and "
+            "automatic garbage collection tuning. Network bandwidth requirements "
+            "are minimized through intelligent caching strategies and delta "
+            "update mechanisms for incremental synchronization.\n\n"
+            "## Security and Authentication\n"
+            "All API endpoints enforce strong authentication mechanisms using "
+            "industry-standard OAuth 2.0 and JWT tokens. Sensitive data is "
+            "encrypted at rest using AES-256 encryption with hardware security "
+            "module support for key management. Transport layer security is "
+            "enforced through TLS 1.3 for all communications. Role-based access "
+            "control provides granular permissions management with audit logging "
+            "for all privileged operations. Regular security assessments and "
+            "penetration testing ensure vulnerability-free operation.\n\n"
+            "## Monitoring and Observability\n"
+            "Comprehensive observability is built into every component through "
+            "structured logging, distributed tracing, and time-series metrics "
+            "collection. Integration with popular monitoring platforms enables "
+            "real-time alerting and anomaly detection. Dashboard templates "
+            "provide visualizations for key performance indicators and health "
+            "metrics. Detailed logs help with troubleshooting and root cause "
+            "analysis of production incidents.\n\n"
+            "## Live Demo\n"
+            "Check out our deployed environment and interact with the live API:\n"
+            "[Try it here](https://demo.example.com)"
+        )
 
         result = scorer.execute({"readme_content": readme})
 
@@ -62,7 +129,7 @@ class TestReadmeScorer:
         assert data["has_tech_stack_section"] is True
         assert data["overall_score"] > 0.7  # Should be high
 
-    def test_readme_with_no_content(self, scorer):
+    def test_readme_with_no_content(self, scorer: ReadmeScorer) -> None:
         """Test README with no content returns score of 0.0."""
         result = scorer.execute({"readme_content": ""})
 
@@ -73,7 +140,7 @@ class TestReadmeScorer:
         assert data["word_count_category"] == "minimal"
         assert data["overall_score"] == 0.0
 
-    def test_readme_with_only_title(self, scorer):
+    def test_readme_with_only_title(self, scorer: ReadmeScorer) -> None:
         """Test README with only a title returns minimal word count category."""
         readme = "# Project Title"
 
@@ -86,7 +153,7 @@ class TestReadmeScorer:
         assert data["word_count_category"] == "minimal"
         assert data["overall_score"] < 0.3
 
-    def test_word_count_category_minimal(self, scorer):
+    def test_word_count_category_minimal(self, scorer: ReadmeScorer) -> None:
         """Test word_count_category: < 100 = minimal."""
         readme = "This is a very short readme with just a few words."
 
@@ -96,7 +163,7 @@ class TestReadmeScorer:
         assert data["word_count"] < 100
         assert data["word_count_category"] == "minimal"
 
-    def test_word_count_category_adequate(self, scorer):
+    def test_word_count_category_adequate(self, scorer: ReadmeScorer) -> None:
         """Test word_count_category: 100-500 = adequate."""
         readme = " ".join(["word"] * 200)  # 200 words
 
@@ -106,7 +173,7 @@ class TestReadmeScorer:
         assert 100 <= data["word_count"] <= 500
         assert data["word_count_category"] == "adequate"
 
-    def test_word_count_category_comprehensive(self, scorer):
+    def test_word_count_category_comprehensive(self, scorer: ReadmeScorer) -> None:
         """Test word_count_category: > 500 = comprehensive."""
         readme = " ".join(["word"] * 700)  # 700 words
 
@@ -116,7 +183,7 @@ class TestReadmeScorer:
         assert data["word_count"] > 500
         assert data["word_count_category"] == "comprehensive"
 
-    def test_installation_section_detection(self, scorer):
+    def test_installation_section_detection(self, scorer: ReadmeScorer) -> None:
         """Test detection of installation section."""
         readme_with_install = """
         # Project
@@ -136,7 +203,7 @@ class TestReadmeScorer:
         result = scorer.execute({"readme_content": readme_without_install})
         assert result.data["has_installation_section"] is False
 
-    def test_usage_section_detection(self, scorer):
+    def test_usage_section_detection(self, scorer: ReadmeScorer) -> None:
         """Test detection of usage section."""
         readme_with_usage = """
         # Project
@@ -147,7 +214,7 @@ class TestReadmeScorer:
         result = scorer.execute({"readme_content": readme_with_usage})
         assert result.data["has_usage_section"] is True
 
-    def test_setup_keyword_counts_as_installation(self, scorer):
+    def test_setup_keyword_counts_as_installation(self, scorer: ReadmeScorer) -> None:
         """Test that 'setup' keyword counts as installation."""
         readme = """
         # Project
@@ -157,11 +224,12 @@ class TestReadmeScorer:
 
         result = scorer.execute({"readme_content": readme})
         # "Getting Started" matches the pattern
-        assert result.data["has_installation_section"] is True or result.data[
-            "has_usage_section"
-        ] is True
+        assert (
+            result.data["has_installation_section"] is True
+            or result.data["has_usage_section"] is True
+        )
 
-    def test_quickstart_counts_as_usage(self, scorer):
+    def test_quickstart_counts_as_usage(self, scorer: ReadmeScorer) -> None:
         """Test that 'quickstart' counts as usage."""
         readme = """
         # Project
@@ -172,7 +240,7 @@ class TestReadmeScorer:
         result = scorer.execute({"readme_content": readme})
         assert result.data["has_usage_section"] is True
 
-    def test_badge_detection(self, scorer):
+    def test_badge_detection(self, scorer: ReadmeScorer) -> None:
         """Test badge detection."""
         readme_with_badges = """
         ![Status](https://example.com/status.svg)
@@ -182,7 +250,7 @@ class TestReadmeScorer:
         result = scorer.execute({"readme_content": readme_with_badges})
         assert result.data["has_badges"] is True
 
-    def test_demo_link_detection(self, scorer):
+    def test_demo_link_detection(self, scorer: ReadmeScorer) -> None:
         """Test demo/live link detection."""
         readme_with_demo = """
         # Project
@@ -192,7 +260,7 @@ class TestReadmeScorer:
         result = scorer.execute({"readme_content": readme_with_demo})
         assert result.data["has_demo_link"] is True
 
-    def test_tech_stack_section_detection(self, scorer):
+    def test_tech_stack_section_detection(self, scorer: ReadmeScorer) -> None:
         """Test tech stack section detection."""
         readme_with_stack = """
         # Project
@@ -205,7 +273,7 @@ class TestReadmeScorer:
         result = scorer.execute({"readme_content": readme_with_stack})
         assert result.data["has_tech_stack_section"] is True
 
-    def test_technologies_keyword_counts(self, scorer):
+    def test_technologies_keyword_counts(self, scorer: ReadmeScorer) -> None:
         """Test that 'Technologies' keyword counts as tech stack."""
         readme = """
         # Project
@@ -216,9 +284,10 @@ class TestReadmeScorer:
         result = scorer.execute({"readme_content": readme})
         assert result.data["has_tech_stack_section"] is True
 
-    def test_overall_score_calculation(self, scorer):
+    def test_overall_score_calculation(self, scorer: ReadmeScorer) -> None:
         """Test that overall score aggregates components."""
-        readme = """
+        readme = (
+            """
         # Good README
 
         ## Installation
@@ -233,7 +302,9 @@ class TestReadmeScorer:
         ![Build](https://example.com/build.svg)
 
         This readme has lots of content here.
-        """ * 3  # Make it comprehensive
+        """
+            * 3
+        )  # Make it comprehensive
 
         result = scorer.execute({"readme_content": readme})
 
@@ -242,7 +313,7 @@ class TestReadmeScorer:
         # Multiple signals should yield higher score
         assert data["overall_score"] > 0.5
 
-    def test_missing_readme_content_key(self, scorer):
+    def test_missing_readme_content_key(self, scorer: ReadmeScorer) -> None:
         """Test handling of missing readme_content key."""
         result = scorer.execute({})
 
@@ -250,7 +321,7 @@ class TestReadmeScorer:
         data = result.data
         assert data["has_readme"] is False
 
-    def test_result_has_all_required_fields(self, scorer):
+    def test_result_has_all_required_fields(self, scorer: ReadmeScorer) -> None:
         """Test that result has all required fields."""
         result = scorer.execute({"readme_content": "# Test"})
 
@@ -265,7 +336,7 @@ class TestReadmeScorer:
         assert "has_tech_stack_section" in data
         assert "overall_score" in data
 
-    def test_case_insensitive_section_detection(self, scorer):
+    def test_case_insensitive_section_detection(self, scorer: ReadmeScorer) -> None:
         """Test that section detection is case insensitive."""
         readme = """
         # Project
@@ -276,7 +347,7 @@ class TestReadmeScorer:
         result = scorer.execute({"readme_content": readme})
         assert result.data["has_installation_section"] is True
 
-    def test_whitespace_only_readme(self, scorer):
+    def test_whitespace_only_readme(self, scorer: ReadmeScorer) -> None:
         """Test handling of whitespace-only README."""
         result = scorer.execute({"readme_content": "   \n\n   \t  "})
 
@@ -284,7 +355,7 @@ class TestReadmeScorer:
         assert data["has_readme"] is False
         assert data["word_count"] == 0
 
-    def test_example_keyword_counts_as_usage(self, scorer):
+    def test_example_keyword_counts_as_usage(self, scorer: ReadmeScorer) -> None:
         """Test that 'Example' counts as usage section."""
         readme = """
         # Project
@@ -295,7 +366,7 @@ class TestReadmeScorer:
         result = scorer.execute({"readme_content": readme})
         assert result.data["has_usage_section"] is True
 
-    def test_score_scales_with_word_count(self, scorer):
+    def test_score_scales_with_word_count(self, scorer: ReadmeScorer) -> None:
         """Test that longer READMEs get bonus in score."""
         short_readme = "# Title\nSmall content."
         long_readme = "# Title\n" + "Content paragraph. " * 100
@@ -305,14 +376,14 @@ class TestReadmeScorer:
 
         assert result_long.data["overall_score"] > result_short.data["overall_score"]
 
-    def test_try_it_as_demo_indicator(self, scorer):
+    def test_try_it_as_demo_indicator(self, scorer: ReadmeScorer) -> None:
         """Test that 'try it' indicates demo link."""
         readme = "Check it out [try it here](https://example.com)"
 
         result = scorer.execute({"readme_content": readme})
         assert result.data["has_demo_link"] is True
 
-    def test_built_with_counts_as_tech_stack(self, scorer):
+    def test_built_with_counts_as_tech_stack(self, scorer: ReadmeScorer) -> None:
         """Test that 'Built With' counts as tech stack."""
         readme = """
         # Project


### PR DESCRIPTION
## Summary
The `test_readme_with_all_quality_signals` unit test in `tests/unit/test_readme_scorer.py` was failing because its mock README fixture contained only 51 words while asserting `word_count > 100` and `word_count_category == "comprehensive"`. The test fixture prose has been expanded to over 500 words while preserving all existing quality signals (badges, code blocks, links, lists, tech stack sections).

## Issue
Closes #156

## Changes
- `tests/unit/test_readme_scorer.py`: Expanded the inline `readme` string fixture inside `test_readme_with_all_quality_signals` with additional realistic documentation sections (Architecture, Configuration, Security, Monitoring) so `word_count` exceeds 500 words and evaluates to `"comprehensive"`.

## Testing
- [x] Unit tests pass (`make test-unit`)
- [x] New/updated tests cover the changes

**Verify the fix:**
1. Check out branch `fix/156-readme-scorer-fixture-length`.
2. Run `pytest tests/unit/test_readme_scorer.py -v`.
3. Observe that all 23 tests pass, specifically confirming that `test_readme_with_all_quality_signals` now passes without an `AssertionError`.

## Screenshots / Demo
N/A — test fixture update only.

## Notes for Reviewers
None observed. All unit tests pass locally.