### PR TITLE
Feat/50 detect has tests

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,19 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/50
+
+**Issue title:** Add a has_tests boolean to the repo analysis output #50
+
+**Tier:** Tier 1
+
+**Problem summary:**
+When the agent reviews a candidate's GitHub repo, it currently has no way of telling whether the project has any automated tests at all, as repo with thorough test coverage and one with none look exactly the same to the scoring logic. Since having tests is one of the clearer signals of engineering maturity on a portfolio, this is a missing signal the review is currently blind to. The fix adds detection logic in new created `agent/tools/repo_analyzer.py`, using file-tree data already fetched by `agent/tools/github_tool.py`, that checks for a `tests/`/`test/` directory, a `pytest.ini`, or files matching `test_*.py`. A successful fix surfaces this as a new `has_tests` boolean on the analysis output, so later scoring and feedback can factor in whether a candidate's project is actually tested. 
+
+**Problem fit:**
+I've read the the file this issue touches (`agent/tools/github_tool.py`) and located the existing analyzer logic I'd be extending. I have some prior experience contributing to open source, but I'm still new to this specific codebase, so I chose a Tier 1 issue: it's a self-contained, additive check on top of an existing analyzer rather than a change to core matching or scoring logic. I also spent a significant amount of time getting my local environment and Docker working, hitting several failed setup attempts along the way, which made me want a lower-risk issue that wouldn't require touching a more complex or unfamiliar part of the stack in case my environment breaks again.
+
+**Branch name:** feat/50-detect-has-tests
+
+**Setup confirmation:** App runs locally at localhost:5173
+
+**Cohort ledger:** Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -17,3 +17,19 @@ I've read the the file this issue touches (`agent/tools/github_tool.py`) and loc
 **Setup confirmation:** App runs locally at localhost:5173
 
 **Cohort ledger:** Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** 
+
+ 
+**Reproduction summary:**
+- `agent/tools/github_tool.py` already fetches repo metadata via the GitHub API and includes a `_has_readme()` helper — the same shape I'd follow for `_has_tests()`. No test-detection logic exists there yet.
+- `agent/tools/repo_analyzer.py` doesn't exist yet, despite the issue referencing it as if it does. I'll either create it or add the detection logic alongside `tech_detector.py`, which already does similar file-pattern detection — need to check that file before deciding where this belongs.
+- `tests/unit/` has 20 test files, but none for `github_tool` or a repo analyzer, confirming this is a green-field addition with no prior coverage to build on.
+
+**PLAN.md link:** [link to PLAN.md](PLAN.md)
+
+**Walkthrough video (recommended):** 
+
+**Blockers or open questions:**

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -21,7 +21,7 @@ I've read the the file this issue touches (`agent/tools/github_tool.py`) and loc
 ## Week 8 — Reproduction & solution planning
 
 **Reproduction commit link:** 
-
+https://github.com/fyf820/pathreview/commit/1ba8a122077083ccd100333fbb23b00819667ff1
  
 **Reproduction summary:**
 - `agent/tools/github_tool.py` already fetches repo metadata via the GitHub API and includes a `_has_readme()` helper — the same shape I'd follow for `_has_tests()`. No test-detection logic exists there yet.
@@ -31,5 +31,6 @@ I've read the the file this issue touches (`agent/tools/github_tool.py`) and loc
 **PLAN.md link:** [link to PLAN.md](PLAN.md)
 
 **Walkthrough video (recommended):** 
+[video](https://drive.google.com/file/d/1R4i9djhqMbMb0Xcr4T3YLzRhPwFEphc6/view?usp=sharing)
 
 **Blockers or open questions:**

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -34,3 +34,38 @@ https://github.com/fyf820/pathreview/commit/1ba8a122077083ccd100333fbb23b0081966
 [video](https://drive.google.com/file/d/1R4i9djhqMbMb0Xcr4T3YLzRhPwFEphc6/view?usp=sharing)
 
 **Blockers or open questions:**
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented all three sub-tasks from PLAN.md: added `_fetch_file_tree()` to `agent/tools/github_tool.py` so repo metadata includes the file paths from the default branch, created `agent/tools/repo_analyzer.py` with the `has_tests` detection logic (checks for `tests/`/`test/` directories, `pytest.ini`, and `test_*.py` files), and wired `repo_analyzer` into `Orchestrator._build_plan()` alongside `tech_detector` whenever file data is present.
+
+**Next steps:**
+Push the branch, open the PR against `ascherj/pathreview`, and get draft feedback.
+
+**Blockers:**
+The mypy pre-commit hook failed on pre-existing missing type annotations in `agent/error_handling.py`, `agent/memory/context_manager.py`, and `agent/memory/session_store.py` — files I never touched, but which get type-checked transitively because `orchestrator.py` imports them. Fixed those annotations in their own `chore` commit, separate from the feature commit, so the diff stays easy to review.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/818
+
+**Branch:** [feat/50-detect-has-tests](https://github.com/fyf820/pathreview/tree/feat/50-detect-has-tests)
+
+
+**What you built:**
+Added a new `RepoAnalyzer` tool (`agent/tools/repo_analyzer.py`) that checks a repo's file paths for a `tests/`/`test/` directory, a `pytest.ini`, or `test_*.py` files, and returns that as a `has_tests` boolean. Extended `github_tool.py` to fetch the repo's file tree so there's data to check against, and wired `repo_analyzer` into the orchestrator's plan alongside `tech_detector` whenever file data is available.
+
+**Tests added or updated:**
+- `tests/unit/test_repo_analyzer.py` — parametrized cases for detecting common test-path signals, not false-positiving on unrelated files, and defaulting to `False` when the `files` key is missing.
+- `tests/unit/test_github_tool.py` — file tree fetch is included in repo metadata, and gracefully degrades to an empty list on failure.
+- `tests/unit/test_orchestrator.py` — plan includes `repo_analyzer` when files are present and skips it otherwise.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+Scoped to the files this PR touches: `ruff`/`black`/`mypy` (via pre-commit) pass on every changed file, and the new/updated tests (`test_repo_analyzer.py`, `test_github_tool.py`, `test_orchestrator.py`, 15 tests total) pass. Repo-wide, `make check`/`make test-unit` do not pass — `ruff check .` has 174 pre-existing errors and the full unit suite has 53 pre-existing failures, both in modules unrelated to and untouched by this change (`test_review_service.py`, `test_security.py`, `test_skill_extractor.py`, etc.).
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -69,3 +69,34 @@ Added a new `RepoAnalyzer` tool (`agent/tools/repo_analyzer.py`) that checks a r
 Scoped to the files this PR touches: `ruff`/`black`/`mypy` (via pre-commit) pass on every changed file, and the new/updated tests (`test_repo_analyzer.py`, `test_github_tool.py`, `test_orchestrator.py`, 15 tests total) pass. Repo-wide, `make check`/`make test-unit` do not pass — `ruff check .` has 174 pre-existing errors and the full unit suite has 53 pre-existing failures, both in modules unrelated to and untouched by this change (`test_review_service.py`, `test_security.py`, `test_skill_extractor.py`, etc.).
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No review came in
+
+**How you responded:**
+NA
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Keeping the PR scoped to what the issue actually asked for. The detection logic itself (`repo_analyzer.py`) was the easy part. What I didn't anticipate was that wiring it into `orchestrator.py` would trip the mypy pre-commit hook on pre-existing, unrelated type-annotation gaps in three other files (`error_handling.py`, `context_manager.py`, `session_store.py`) just because `orchestrator.py` imports them and mypy checks transitively. I had to decide whether to fix that debt, work around it, or leave it — and once I did fix it, I had to go back and split it into its own commit so the feature diff didn't get muddied. On top of that, my branch already carried a few unrelated commits from earlier weeks (JOURNAL/PLAN updates, a docker-compose tweak), which made the PR's "files changed" count look much bigger than the actual fix and took some digging to explain. None of this was hard technically, it was the constant "does this belong in this PR or not" judgment call that ate the most time.
+
+**What did you learn about working in a large codebase?**
+That "the files this issue touches" is a starting point, not a boundary. The issue named two files, but the real change surface included a third (`orchestrator.py`, to actually register the tool) plus a ripple of pre-existing type-annotation debt in files I never meant to touch, surfaced only because mypy checks imports transitively. 
+
+**How did AI tools help — and where did they fall short?**
+Claude Code was most useful for the mechanical, easy-to-get-subtly-wrong parts: scaffolding `repo_analyzer.py` and its parametrized tests quickly, diffing before/after to prove which mypy errors were actually pre-existing versus introduced by me, and drafting a PR description that matched the class template section-by-section. It also caught itself on a real mistake — it had checked both self-review boxes in JOURNAL.md as passing while the sentence right below admitted they didn't, and flagged that contradiction back to me instead of leaving it. Where it fell short: a stash/reset/cherry-pick sequence to split a commit lost an earlier journal edit outright and had to be manually recovered from dangling commit objects, and it couldn't open or edit the GitHub PR directly since the `gh` CLI isn't installed in my environment, anything on the actual GitHub UI still needed me.
+
+**What would you do differently if you started over?**
+Decide up front whether pre-existing lint/type debt in files I merely import is in scope, instead of committing once, getting confused by a "13 files changed" PR diff, and reverse-engineering the split afterward. I'd also start the feature branch cleanly off `main` rather than layering code commits on top of earlier weeks' journal/plan commits, since that mixing is exactly what made the file count confusing in the first place.
+
+**What are you most proud of from this module?**
+I'm proud of how I handled the mypy debt. It would've been easy to either bypass the failing pre-commit hook with `--no-verify` or just fix everything and bury it inside the feature commit. Instead, I first verified the errors were actually pre-existing — stashing my diff and rerunning mypy against the unmodified branch to prove `error_handling.py`, `context_manager.py`, and `session_store.py` were already broken before I touched anything. Then I fixed them properly with real type annotations, and kept them in their own `chore` commit so the fix is reviewable on its own and doesn't get credited to or blamed on the `has_tests` feature.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,49 @@
+## Solution plan
+
+**Issue:** [Add a has_tests boolean to the repo analysis output #50](https://github.com/ascherj/pathreview/issues/50)
+
+### Understand
+What is the root cause of this issue? What behavior is expected vs. actual?
+
+When the agent reviews a candidate's GitHub repo, nothing checks whether the project has automated tests. A well-tested repo and an untested one currently produce identical analysis output, so this engineering-maturity signal is silently dropped. Expected behavior: the analysis output includes a `has_tests` boolean derived from the repo's file tree (presence of a `tests/`/`test/` directory, a `pytest.ini`, or `test_*.py` files). Actual behavior: no such field exists, and no detection logic exists in `agent/tools/`.
+
+### Map
+Which files, functions, or modules are involved?
+List the specific files you expect to touch.
+
+- `agent/tools/github_tool.py` — currently fetches repo metadata (`_fetch_repo_metadata`) and has a `_has_readme()` helper that hits a single GitHub endpoint. It does not yet fetch a file tree, so it needs a new helper (following the `_has_readme` pattern) that lists repo file paths via the GitHub Git Trees API, and that list needs to be included in the metadata dict returned by `_fetch_repo_metadata`.
+- `agent/tools/repo_analyzer.py` — does not exist yet. New tool module, following the shape of the existing `agent/tools/tech_detector.py` (a `BaseTool` subclass that takes a `files` list and returns a small dict), that inspects file paths and returns `{"has_tests": bool}`.
+- `agent/tools/base.py` — no changes expected; reuse existing `BaseTool`/`ToolResult`.
+- `agent/orchestrator.py` — `_build_plan()` conditionally schedules tools (e.g. `tech_detector` runs `if profile_data.get("files")`); `repo_analyzer` should be added the same way so it runs whenever file data is available.
+- `tests/unit/test_repo_analyzer.py` — new test file, mirroring `tests/unit/test_tech_detector.py`'s structure/fixtures.
+
+### Plan
+What are the steps to fix this issue?
+Break it into 3–5 concrete sub-tasks.
+
+1. Add a `_fetch_file_tree()` helper to `github_tool.py` that calls the GitHub Git Trees API (recursive) for the repo's default branch and returns a flat list of file paths; wire it into `_fetch_repo_metadata()`'s returned dict as `files`.
+2. Create `agent/tools/repo_analyzer.py` with a `RepoAnalyzer(BaseTool)` class whose `execute()` takes `{"files": [...]}` and returns `ToolResult(data={"has_tests": bool})`.
+3. Implement the detection logic: true if any path has a `tests`/`test` path segment, any filename is `pytest.ini`, or any filename matches `test_*.py`.
+4. Register `repo_analyzer` in the tool registry/orchestrator plan (`_build_plan` in `agent/orchestrator.py`) so it executes alongside `tech_detector` when file data is present.
+5. Add unit tests covering: repo with a `tests/` dir, a `test/` dir, `pytest.ini` present, `test_*.py` files present, no test signal, and an empty file list.
+
+### Inputs & outputs
+What does your fix take as input? What should it produce or change?
+
+- **Input:** a list of file paths for a repository (`files: list[str]`), sourced from GitHub's file tree.
+- **Output:** a boolean `has_tests` field added to the tool's result data, which flows into the overall analysis output alongside `primary_language`, `has_readme`, etc., for downstream scoring/feedback to consume.
+
+### Risks & unknowns
+What could go wrong? What are you still unsure about?
+
+- The GitHub Trees API truncates results for very large repos (`truncated: true` in the response) — a repo with a huge file tree might get partial data and a false negative on `has_tests`. Worth noting/logging but likely out of scope to fully solve here.
+- Rate limiting / auth: the new file-tree call adds another GitHub API request per repo, increasing the chance of hitting unauthenticated rate limits — should reuse the existing `api_token` handling already in `github_tool.py`.
+- Case sensitivity and path separators (Windows vs. POSIX-style paths from the API) need normalizing before matching directory/file names.
+
+### Edge cases
+What inputs or states should your fix handle gracefully?
+
+- Empty or missing `files` list → `has_tests` should be `False`, not an error.
+- Repo where "test" appears only as a substring (e.g. `latest_data.py`, `contest/`) but not as an actual test signal → should not false-positive; matching should be on path segments/filenames, not substrings.
+- Nested test directories (e.g. `src/module/tests/test_foo.py`) → should still be detected.
+- GitHub API failure fetching the file tree (404, 403, network error) → should degrade gracefully (empty file list / `has_tests: False`) rather than failing the whole analysis, consistent with how `_has_readme()` already swallows exceptions.

--- a/agent/error_handling.py
+++ b/agent/error_handling.py
@@ -1,14 +1,22 @@
 """Retry logic with exponential backoff."""
 
-import time
 import functools
+import time
+from collections.abc import Callable
+from typing import Any, TypeVar
+
 import structlog
 
 logger = structlog.get_logger()
 
+F = TypeVar("F", bound=Callable[..., Any])
 
-def retry_with_backoff(max_retries: int = 3, backoff_factor: float = 2.0,
-                       exceptions: tuple = (Exception,)):
+
+def retry_with_backoff(
+    max_retries: int = 3,
+    backoff_factor: float = 2.0,
+    exceptions: tuple = (Exception,),
+) -> Callable[[F], F]:
     """Decorator for retry logic with exponential backoff.
 
     Args:
@@ -19,11 +27,12 @@ def retry_with_backoff(max_retries: int = 3, backoff_factor: float = 2.0,
     Returns:
         Decorated function
     """
-    def decorator(func):
+
+    def decorator(func: F) -> F:
         @functools.wraps(func)
-        def wrapper(*args, **kwargs):
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
             attempt = 0
-            last_exception = None
+            last_exception: BaseException | None = None
 
             while attempt < max_retries:
                 try:
@@ -36,26 +45,40 @@ def retry_with_backoff(max_retries: int = 3, backoff_factor: float = 2.0,
 
                     if attempt < max_retries:
                         wait_time = backoff_factor ** (attempt - 1)
-                        logger.warning("retry_attempt", func=func.__name__,
-                                     attempt=attempt, max_retries=max_retries,
-                                     wait_seconds=wait_time, error=str(e))
+                        logger.warning(
+                            "retry_attempt",
+                            func=func.__name__,
+                            attempt=attempt,
+                            max_retries=max_retries,
+                            wait_seconds=wait_time,
+                            error=str(e),
+                        )
                         time.sleep(wait_time)
                     else:
-                        logger.error("retry_exhausted", func=func.__name__,
-                                   max_retries=max_retries, error=str(e))
+                        logger.error(
+                            "retry_exhausted",
+                            func=func.__name__,
+                            max_retries=max_retries,
+                            error=str(e),
+                        )
 
             if last_exception:
                 raise last_exception
 
-        return wrapper
+        return wrapper  # type: ignore[return-value]
+
     return decorator
 
 
 class RetryContext:
     """Context manager for retry logic with exponential backoff."""
 
-    def __init__(self, max_retries: int = 3, backoff_factor: float = 2.0,
-                 exceptions: tuple = (Exception,)):
+    def __init__(
+        self,
+        max_retries: int = 3,
+        backoff_factor: float = 2.0,
+        exceptions: tuple = (Exception,),
+    ) -> None:
         """Initialize retry context.
 
         Args:
@@ -67,13 +90,18 @@ class RetryContext:
         self.backoff_factor = backoff_factor
         self.exceptions = exceptions
         self.attempt = 0
-        self.last_exception = None
+        self.last_exception: BaseException | None = None
 
-    def __enter__(self):
+    def __enter__(self) -> "RetryContext":
         """Enter context."""
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: Any,
+    ) -> bool:
         """Exit context and handle retries."""
         if exc_type is None:
             return False
@@ -86,12 +114,20 @@ class RetryContext:
 
         if self.attempt < self.max_retries:
             wait_time = self.backoff_factor ** (self.attempt - 1)
-            logger.warning("retry_context_attempt", attempt=self.attempt,
-                         max_retries=self.max_retries, wait_seconds=wait_time,
-                         error=str(exc_val))
+            logger.warning(
+                "retry_context_attempt",
+                attempt=self.attempt,
+                max_retries=self.max_retries,
+                wait_seconds=wait_time,
+                error=str(exc_val),
+            )
             time.sleep(wait_time)
             return True  # Suppress exception and retry
 
-        logger.error("retry_context_exhausted", attempt=self.attempt,
-                   max_retries=self.max_retries, error=str(exc_val))
+        logger.error(
+            "retry_context_exhausted",
+            attempt=self.attempt,
+            max_retries=self.max_retries,
+            error=str(exc_val),
+        )
         return False  # Re-raise exception

--- a/agent/memory/context_manager.py
+++ b/agent/memory/context_manager.py
@@ -2,6 +2,8 @@
 
 import hashlib
 import json
+from typing import Any
+
 import structlog
 
 logger = structlog.get_logger()
@@ -10,12 +12,11 @@ logger = structlog.get_logger()
 class ContextManager:
     """In-memory context manager for within-session memoization."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize context manager."""
-        self.results = {}
+        self.results: dict[str, Any] = {}
 
-    def store_tool_result(self, tool_name: str, input_hash: str,
-                         result) -> None:
+    def store_tool_result(self, tool_name: str, input_hash: str, result: Any) -> None:
         """Store tool execution result.
 
         Args:
@@ -27,7 +28,7 @@ class ContextManager:
         self.results[key] = result
         logger.info("tool_result_stored", tool=tool_name, key=key)
 
-    def get_tool_result(self, tool_name: str, input_hash: str):
+    def get_tool_result(self, tool_name: str, input_hash: str) -> Any:
         """Get cached tool result.
 
         Args:

--- a/agent/memory/session_store.py
+++ b/agent/memory/session_store.py
@@ -1,9 +1,9 @@
 """Redis-backed session store."""
 
-import redis
 import json
+
+import redis
 import structlog
-from typing import Optional
 
 logger = structlog.get_logger()
 
@@ -19,7 +19,7 @@ class SessionStore:
         """
         self.redis = redis_client
 
-    def get(self, session_id: str) -> Optional[dict]:
+    def get(self, session_id: str) -> dict | None:
         """Get session data.
 
         Args:
@@ -36,7 +36,7 @@ class SessionStore:
                 logger.info("session_not_found", session_id=session_id)
                 return None
 
-            parsed = json.loads(data)
+            parsed: dict = json.loads(data)
             logger.info("session_retrieved", session_id=session_id)
             return parsed
 

--- a/agent/orchestrator.py
+++ b/agent/orchestrator.py
@@ -1,12 +1,14 @@
 """Plan-execute orchestrator for agent tools."""
 
 import time
-import structlog
-from typing import Optional
+from typing import Any
 
-from .memory.session_store import SessionStore
-from .memory.context_manager import ContextManager
+import structlog
+
 from .error_handling import retry_with_backoff
+from .memory.context_manager import ContextManager
+from .memory.session_store import SessionStore
+from .tools.base import BaseTool
 
 logger = structlog.get_logger()
 
@@ -14,8 +16,9 @@ logger = structlog.get_logger()
 class Orchestrator:
     """Orchestrate tool execution with planning and memoization."""
 
-    def __init__(self, tools: dict, session_store: Optional[SessionStore] = None,
-                 tool_timeout: float = 30.0):
+    def __init__(
+        self, tools: dict, session_store: SessionStore | None = None, tool_timeout: float = 30.0
+    ):
         """Initialize orchestrator.
 
         Args:
@@ -53,7 +56,7 @@ class Orchestrator:
         for tool_name, tool_input in plan:
             try:
                 result = self._execute_tool(tool_name, tool_input)
-                results[tool_name] = result.data if hasattr(result, 'data') else result
+                results[tool_name] = result.data if hasattr(result, "data") else result
 
                 logger.info("tool_executed", tool=tool_name, success=True)
 
@@ -66,13 +69,12 @@ class Orchestrator:
             session_state.update(results)
             self.session_store.set(profile_id, session_state)
 
-        logger.info("orchestrator_complete", profile_id=profile_id,
-                   tools_executed=len(results))
+        logger.info("orchestrator_complete", profile_id=profile_id, tools_executed=len(results))
 
         return {
             "profile_id": profile_id,
             "tool_results": results,
-            "cached_results": self.context_manager.get_all_results()
+            "cached_results": self.context_manager.get_all_results(),
         }
 
     def _build_plan(self, profile_data: dict) -> list[tuple[str, dict]]:
@@ -90,50 +92,48 @@ class Orchestrator:
         if profile_data.get("github_username"):
             for project in profile_data.get("projects", []):
                 if project.get("github_repo"):
-                    plan.append((
-                        "github_tool",
-                        {
-                            "github_username": profile_data["github_username"],
-                            "repo_name": project["github_repo"]
-                        }
-                    ))
+                    plan.append(
+                        (
+                            "github_tool",
+                            {
+                                "github_username": profile_data["github_username"],
+                                "repo_name": project["github_repo"],
+                            },
+                        )
+                    )
                     break  # Only process first repo for now
 
         # Tech detector (if files available)
         if profile_data.get("files"):
-            plan.append((
-                "tech_detector",
-                {"files": profile_data["files"]}
-            ))
+            plan.append(("tech_detector", {"files": profile_data["files"]}))
+            plan.append(("repo_analyzer", {"files": profile_data["files"]}))
 
         # README scorer
         if profile_data.get("readme_content"):
-            plan.append((
-                "readme_scorer",
-                {"readme_content": profile_data["readme_content"]}
-            ))
+            plan.append(("readme_scorer", {"readme_content": profile_data["readme_content"]}))
 
         # Skill extractor
         if profile_data.get("resume_text"):
-            plan.append((
-                "skill_extractor",
-                {
-                    "resume_text": profile_data["resume_text"],
-                    "repo_metadata": profile_data.get("repo_metadata", {})
-                }
-            ))
+            plan.append(
+                (
+                    "skill_extractor",
+                    {
+                        "resume_text": profile_data["resume_text"],
+                        "repo_metadata": profile_data.get("repo_metadata", {}),
+                    },
+                )
+            )
 
         # Market analyzer (if skills detected)
         if plan:  # Only if other tools executed
-            plan.append((
-                "market_analyzer",
-                {"detected_skills": {}}  # Will be populated by context
-            ))
+            plan.append(
+                ("market_analyzer", {"detected_skills": {}})  # Will be populated by context
+            )
 
         logger.info("plan_built", plan_size=len(plan))
         return plan
 
-    def _execute_tool(self, tool_name: str, tool_input: dict):
+    def _execute_tool(self, tool_name: str, tool_input: dict) -> Any:
         """Execute a single tool with retry and memoization.
 
         Args:
@@ -172,7 +172,9 @@ class Orchestrator:
             logger.error("tool_execution_error", tool=tool_name, error=str(e))
             raise
 
-    def _execute_with_timeout(self, tool, tool_input: dict, timeout: Optional[float] = None):
+    def _execute_with_timeout(
+        self, tool: BaseTool, tool_input: dict, timeout: float | None = None
+    ) -> Any:
         """Execute tool with timeout.
 
         Args:
@@ -189,7 +191,7 @@ class Orchestrator:
         timeout = timeout or self.tool_timeout
 
         @retry_with_backoff(max_retries=2, backoff_factor=1.5)
-        def _execute():
+        def _execute() -> Any:
             return tool.execute(tool_input)
 
         start = time.time()

--- a/agent/tools/github_tool.py
+++ b/agent/tools/github_tool.py
@@ -2,6 +2,7 @@
 
 import httpx
 import structlog
+
 from .base import BaseTool, ToolResult
 
 logger = structlog.get_logger()
@@ -35,44 +36,30 @@ class GitHubTool(BaseTool):
         repo_name = input_data.get("repo_name")
 
         if not username or not repo_name:
-            return ToolResult(
-                success=False,
-                data={},
-                error="Missing github_username or repo_name"
-            )
+            return ToolResult(success=False, data={}, error="Missing github_username or repo_name")
 
         try:
             repo_data = self._fetch_repo_metadata(username, repo_name)
             return ToolResult(success=True, data=repo_data)
 
         except httpx.HTTPStatusError as e:
-            logger.error("github_request_failed", status=e.response.status_code,
-                        username=username, repo=repo_name)
+            logger.error(
+                "github_request_failed",
+                status=e.response.status_code,
+                username=username,
+                repo=repo_name,
+            )
             if e.response.status_code == 404:
-                return ToolResult(
-                    success=False,
-                    data={},
-                    error="Repository not found"
-                )
+                return ToolResult(success=False, data={}, error="Repository not found")
             elif e.response.status_code == 403:
-                return ToolResult(
-                    success=False,
-                    data={},
-                    error="Rate limited or access denied"
-                )
+                return ToolResult(success=False, data={}, error="Rate limited or access denied")
             return ToolResult(
-                success=False,
-                data={},
-                error=f"GitHub API error: {e.response.status_code}"
+                success=False, data={}, error=f"GitHub API error: {e.response.status_code}"
             )
 
         except Exception as e:
             logger.error("github_tool_error", error=str(e))
-            return ToolResult(
-                success=False,
-                data={},
-                error=str(e)
-            )
+            return ToolResult(success=False, data={}, error=str(e))
 
     def _fetch_repo_metadata(self, username: str, repo_name: str) -> dict:
         """Fetch repository metadata from GitHub API.
@@ -94,6 +81,8 @@ class GitHubTool(BaseTool):
         response.raise_for_status()
 
         repo_json = response.json()
+        default_branch = repo_json.get("default_branch") or "main"
+        files = self._fetch_file_tree(username, repo_name, default_branch)
 
         # Extract metadata, handling null values
         metadata = {
@@ -105,14 +94,81 @@ class GitHubTool(BaseTool):
             "open_issues_count": repo_json.get("open_issues_count", 0),
             "last_commit_date": repo_json.get("pushed_at", ""),
             "has_readme": self._has_readme(username, repo_name),
+            "files": files,
             "topics": repo_json.get("topics", []),
             "homepage": repo_json.get("homepage") or "",
         }
 
-        logger.info("github_repo_fetched", username=username, repo=repo_name,
-                   language=metadata["primary_language"], stars=metadata["star_count"])
+        logger.info(
+            "github_repo_fetched",
+            username=username,
+            repo=repo_name,
+            language=metadata["primary_language"],
+            stars=metadata["star_count"],
+        )
 
         return metadata
+
+    def _fetch_file_tree(self, username: str, repo_name: str, default_branch: str) -> list[str]:
+        """Fetch a flat file tree for the repository's default branch.
+
+        Args:
+            username: GitHub username
+            repo_name: Repository name
+            default_branch: Repository default branch name
+
+        Returns:
+            Flat list of file paths, or an empty list on failure
+        """
+        headers = {}
+        if self.api_token:
+            headers["Authorization"] = f"token {self.api_token}"
+
+        try:
+            branch_url = f"{self.base_url}/repos/{username}/{repo_name}/branches/{default_branch}"
+            branch_response = httpx.get(branch_url, headers=headers, timeout=10.0)
+            branch_response.raise_for_status()
+
+            branch_json = branch_response.json()
+            tree_sha = branch_json.get("commit", {}).get("commit", {}).get("tree", {}).get("sha")
+            if not tree_sha:
+                return []
+
+            tree_url = f"{self.base_url}/repos/{username}/{repo_name}/git/trees/{tree_sha}"
+            tree_response = httpx.get(
+                tree_url,
+                headers=headers,
+                params={"recursive": "1"},
+                timeout=10.0,
+            )
+            tree_response.raise_for_status()
+
+            tree_json = tree_response.json()
+            tree_entries = tree_json.get("tree", [])
+            files = [
+                entry.get("path", "")
+                for entry in tree_entries
+                if entry.get("type") == "blob" and entry.get("path")
+            ]
+
+            if tree_json.get("truncated"):
+                logger.warning(
+                    "github_tree_truncated",
+                    username=username,
+                    repo=repo_name,
+                    file_count=len(files),
+                )
+
+            return files
+
+        except Exception as e:
+            logger.warning(
+                "github_file_tree_fetch_failed",
+                username=username,
+                repo=repo_name,
+                error=str(e),
+            )
+            return []
 
     def _has_readme(self, username: str, repo_name: str) -> bool:
         """Check if repository has a README file.
@@ -132,6 +188,6 @@ class GitHubTool(BaseTool):
 
         try:
             response = httpx.head(url, headers=headers, timeout=5.0)
-            return response.status_code == 200
+            return bool(response.status_code == 200)
         except Exception:
             return False

--- a/agent/tools/repo_analyzer.py
+++ b/agent/tools/repo_analyzer.py
@@ -1,0 +1,61 @@
+"""Repository file-tree analyzer."""
+
+from pathlib import PurePosixPath
+
+import structlog
+
+from .base import BaseTool, ToolResult
+
+logger = structlog.get_logger()
+
+
+class RepoAnalyzer(BaseTool):
+    """Analyze repository file paths for engineering signals."""
+
+    name = "repo_analyzer"
+    description = "Analyze repository file paths for test coverage signals"
+
+    def execute(self, input_data: dict) -> ToolResult:
+        """Analyze repository files for test signals.
+
+        Args:
+            input_data: Must contain 'files' (list of file paths)
+
+        Returns:
+            ToolResult with has_tests boolean
+        """
+        files = input_data.get("files", [])
+
+        if not files:
+            logger.warning("repo_analyzer_no_files")
+            return ToolResult(success=True, data={"has_tests": False})
+
+        try:
+            has_tests = self._has_tests(files)
+            return ToolResult(success=True, data={"has_tests": has_tests})
+        except Exception as e:
+            logger.error("repo_analyzer_error", error=str(e))
+            return ToolResult(success=False, data={}, error=str(e))
+
+    @staticmethod
+    def _has_tests(files: list[str]) -> bool:
+        """Return True when repository file paths indicate automated tests."""
+        for filepath in files:
+            normalized = filepath.replace("\\", "/").strip("/")
+            if not normalized:
+                continue
+
+            path = PurePosixPath(normalized)
+            parts = [part.lower() for part in path.parts]
+            filename = parts[-1] if parts else ""
+
+            if any(segment in {"test", "tests"} for segment in parts[:-1]):
+                return True
+
+            if filename == "pytest.ini":
+                return True
+
+            if filename.startswith("test_") and filename.endswith(".py"):
+                return True
+
+        return False

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,17 @@ services:
 
   vector-db:
     image: chromadb/chroma:0.4.22
+    # Override entrypoint: the image's default /docker_entrypoint.sh force-reinstalls
+    # chroma-hnswlib without pinning numpy, which pulls in numpy>=2 and breaks
+    # chromadb's own code (np.float_ was removed in NumPy 2.0).
+    command:
+      - -c
+      - |
+        pip install --force-reinstall --no-cache-dir chroma-hnswlib "numpy<2"
+        export IS_PERSISTENT=1
+        export CHROMA_SERVER_NOFILE=65535
+        exec uvicorn chromadb.app:app --workers 1 --host 0.0.0.0 --port 8000 --proxy-headers --log-config chromadb/log_config.yml --timeout-keep-alive 30
+    entrypoint: ["/bin/bash"]
     ports:
       - "8001:8000"
     volumes:
@@ -44,7 +55,7 @@ services:
     environment:
       ANONYMIZED_TELEMETRY: "false"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/api/v1/heartbeat"]
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/api/v1/heartbeat')"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -99,7 +99,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -449,7 +448,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -473,7 +471,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1561,7 +1558,6 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1579,7 +1575,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1972,7 +1967,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3507,7 +3501,6 @@
       "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^2.0.1",
         "cssstyle": "^4.0.1",
@@ -4094,7 +4087,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4107,7 +4099,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4771,7 +4762,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/tests/unit/test_github_tool.py
+++ b/tests/unit/test_github_tool.py
@@ -1,0 +1,123 @@
+"""Tests for github_tool.py"""
+
+from typing import Any
+
+import pytest
+
+from agent.tools.github_tool import GitHubTool
+
+
+class FakeResponse:
+    """Simple fake httpx response."""
+
+    def __init__(self, json_data: dict | None = None, status_code: int = 200) -> None:
+        self._json_data = json_data or {}
+        self.status_code = status_code
+
+    def json(self) -> dict:
+        return self._json_data
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            import httpx
+
+            request = httpx.Request("GET", "https://api.github.com")
+            response = httpx.Response(self.status_code, request=request)
+            raise httpx.HTTPStatusError("error", request=request, response=response)
+
+
+@pytest.mark.unit
+class TestGitHubTool:
+    """Test suite for GitHubTool."""
+
+    @pytest.fixture
+    def tool(self) -> GitHubTool:
+        """Create a GitHubTool instance."""
+        return GitHubTool(api_token="token")
+
+    def test_fetch_repo_metadata_includes_file_tree(
+        self, tool: GitHubTool, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test repo metadata includes the file tree from GitHub."""
+        repo_response = FakeResponse(
+            {
+                "name": "demo",
+                "description": "Demo repo",
+                "language": "Python",
+                "stargazers_count": 10,
+                "forks_count": 2,
+                "open_issues_count": 1,
+                "pushed_at": "2026-07-31T00:00:00Z",
+                "default_branch": "main",
+                "topics": ["demo"],
+                "homepage": "",
+            }
+        )
+        branch_response = FakeResponse(
+            {
+                "commit": {
+                    "commit": {
+                        "tree": {
+                            "sha": "tree-sha-123",
+                        }
+                    }
+                }
+            }
+        )
+        tree_response = FakeResponse(
+            {
+                "tree": [
+                    {"path": "src/app.py", "type": "blob"},
+                    {"path": "tests/test_app.py", "type": "blob"},
+                    {"path": "src", "type": "tree"},
+                ]
+            }
+        )
+        head_response = FakeResponse(status_code=200)
+
+        calls: list[str] = []
+
+        def mock_get(
+            url: str,
+            headers: dict | None = None,
+            timeout: float | None = None,
+            params: dict | None = None,
+        ) -> FakeResponse:
+            calls.append(url)
+            if url.endswith("/repos/demo-user/demo-repo"):
+                return repo_response
+            if url.endswith("/branches/main"):
+                return branch_response
+            if url.endswith("/git/trees/tree-sha-123"):
+                return tree_response
+            raise AssertionError(f"Unexpected GET url: {url}")
+
+        def mock_head(
+            url: str, headers: dict | None = None, timeout: float | None = None
+        ) -> FakeResponse:
+            calls.append(url)
+            return head_response
+
+        monkeypatch.setattr("agent.tools.github_tool.httpx.get", mock_get)
+        monkeypatch.setattr("agent.tools.github_tool.httpx.head", mock_head)
+
+        result = tool._fetch_repo_metadata("demo-user", "demo-repo")
+
+        assert result["files"] == ["src/app.py", "tests/test_app.py"]
+        assert result["has_readme"] is True
+        assert "/branches/main" in "".join(calls)
+        assert "/git/trees/tree-sha-123" in "".join(calls)
+
+    def test_fetch_file_tree_gracefully_handles_failure(
+        self, tool: GitHubTool, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test file tree failures degrade to an empty list."""
+
+        def mock_get(*args: Any, **kwargs: Any) -> None:
+            raise OSError("network down")
+
+        monkeypatch.setattr("agent.tools.github_tool.httpx.get", mock_get)
+
+        files = tool._fetch_file_tree("demo-user", "demo-repo", "main")
+
+        assert files == []

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -1,0 +1,44 @@
+"""Tests for orchestrator.py"""
+
+import pytest
+
+from agent.orchestrator import Orchestrator
+
+
+@pytest.mark.unit
+class TestOrchestrator:
+    """Test suite for Orchestrator planning."""
+
+    def test_build_plan_includes_repo_analyzer_with_files(self) -> None:
+        """Test repo_analyzer is scheduled when file data is available."""
+        orchestrator = Orchestrator(tools={})
+
+        plan = orchestrator._build_plan(
+            {
+                "github_username": "demo-user",
+                "projects": [{"github_repo": "demo-repo"}],
+                "files": ["tests/test_app.py", "src/app.py"],
+            }
+        )
+
+        tool_names = [tool_name for tool_name, _ in plan]
+
+        assert "github_tool" in tool_names
+        assert "tech_detector" in tool_names
+        assert "repo_analyzer" in tool_names
+        assert "market_analyzer" in tool_names
+
+    def test_build_plan_skips_repo_analyzer_without_files(self) -> None:
+        """Test repo_analyzer is skipped if no file list exists."""
+        orchestrator = Orchestrator(tools={})
+
+        plan = orchestrator._build_plan(
+            {
+                "github_username": "demo-user",
+                "projects": [{"github_repo": "demo-repo"}],
+            }
+        )
+
+        tool_names = [tool_name for tool_name, _ in plan]
+
+        assert "repo_analyzer" not in tool_names

--- a/tests/unit/test_repo_analyzer.py
+++ b/tests/unit/test_repo_analyzer.py
@@ -1,0 +1,56 @@
+"""Tests for repo_analyzer.py"""
+
+import pytest
+
+from agent.tools.repo_analyzer import RepoAnalyzer
+
+
+@pytest.mark.unit
+class TestRepoAnalyzer:
+    """Test suite for RepoAnalyzer."""
+
+    @pytest.fixture
+    def analyzer(self) -> RepoAnalyzer:
+        """Create a RepoAnalyzer instance."""
+        return RepoAnalyzer()
+
+    @pytest.mark.parametrize(
+        "files",
+        [
+            ["tests/test_app.py"],
+            ["test/test_app.py"],
+            ["src/app/pytest.ini"],
+            ["src/test_api.py"],
+            ["src/module/tests/test_service.py"],
+            ["src\\module\\tests\\test_service.py"],
+        ],
+    )
+    def test_detects_test_signals(self, analyzer: RepoAnalyzer, files: list[str]) -> None:
+        """Test common test-path signals set has_tests to True."""
+        result = analyzer.execute({"files": files})
+
+        assert result.success is True
+        assert result.data["has_tests"] is True
+
+    @pytest.mark.parametrize(
+        "files",
+        [
+            ["src/app.py", "README.md", "docs/guide.md"],
+            ["src/latest_data.py", "contest/results.csv"],
+            ["src/module/unit.py", "scripts/deploy.sh"],
+            [],
+        ],
+    )
+    def test_does_not_false_positive(self, analyzer: RepoAnalyzer, files: list[str]) -> None:
+        """Test unrelated file names do not trigger has_tests."""
+        result = analyzer.execute({"files": files})
+
+        assert result.success is True
+        assert result.data["has_tests"] is False
+
+    def test_missing_files_key_defaults_false(self, analyzer: RepoAnalyzer) -> None:
+        """Test missing files key returns False rather than error."""
+        result = analyzer.execute({})
+
+        assert result.success is True
+        assert result.data["has_tests"] is False


### PR DESCRIPTION

## Summary

The agent's repo review had no way to tell whether a candidate's project had automated tests, so a well-tested repo and an untested one scored identically. This PR adds a `has_tests` boolean to the analysis output, detected from the repo's actual file tree.

## Issue

Closes #50

## Changes

Root cause: `github_tool.py` only ever fetched repo metadata (name, stars, language, etc.) and never fetched the repo's file tree, so there was no data available to check for test files, and no analyzer looked for testing signals at all.

- `agent/tools/github_tool.py`: added `_fetch_file_tree()`, which resolves the default branch's tree SHA and walks the GitHub trees API, then includes the resulting file paths in `_fetch_repo_metadata()`'s output.
- `agent/tools/repo_analyzer.py` (new): `RepoAnalyzer.execute()` checks the file list for a `tests/`/`test/` directory, a `pytest.ini`, or `test_*.py` files, and returns `has_tests` as a boolean.
- `agent/orchestrator.py`: `_build_plan()` now schedules `repo_analyzer` alongside `tech_detector` whenever `files` are present in the profile data, so the new tool actually runs as part of a review.

## Testing

- [x] `pytest tests/unit/test_repo_analyzer.py tests/unit/test_github_tool.py tests/unit/test_orchestrator.py -v` (15/15 pass)
- [x] pre-commit hooks (ruff, black, mypy) pass on all touched files
- [x] `make check` / `make test-unit` repo-wide — pre-existing unrelated failures, see Notes below

tests/unit/test_repo_analyzer.py::TestRepoAnalyzer::test_detects_test_signals[files0] PASSED [  6%]
tests/unit/test_repo_analyzer.py::TestRepoAnalyzer::test_detects_test_signals[files1] PASSED [ 13%]
tests/unit/test_repo_analyzer.py::TestRepoAnalyzer::test_detects_test_signals[files2] PASSED [ 20%]
tests/unit/test_repo_analyzer.py::TestRepoAnalyzer::test_detects_test_signals[files3] PASSED [ 26%]
tests/unit/test_repo_analyzer.py::TestRepoAnalyzer::test_detects_test_signals[files4] PASSED [ 33%]
tests/unit/test_repo_analyzer.py::TestRepoAnalyzer::test_detects_test_signals[files5] PASSED [ 40%]
tests/unit/test_repo_analyzer.py::TestRepoAnalyzer::test_does_not_false_positive[files0] PASSED [ 46%]
tests/unit/test_repo_analyzer.py::TestRepoAnalyzer::test_does_not_false_positive[files1] PASSED [ 53%]
tests/unit/test_repo_analyzer.py::TestRepoAnalyzer::test_does_not_false_positive[files2] PASSED [ 60%]
tests/unit/test_repo_analyzer.py::TestRepoAnalyzer::test_does_not_false_positive[files3] PASSED [ 66%]
tests/unit/test_repo_analyzer.py::TestRepoAnalyzer::test_missing_files_key_defaults_false PASSED [ 73%]
tests/unit/test_github_tool.py::TestGitHubTool::test_fetch_repo_metadata_includes_file_tree PASSED [ 80%]
tests/unit/test_github_tool.py::TestGitHubTool::test_fetch_file_tree_gracefully_handles_failure PASSED [ 86%]
tests/unit/test_orchestrator.py::TestOrchestrator::test_build_plan_includes_repo_analyzer_with_files PASSED [ 93%]
tests/unit/test_orchestrator.py::TestOrchestrator::test_build_plan_skips_repo_analyzer_without_files PASSED [100%]

======================== 15 passed, 1 warning in 0.70s ========================


To verify:
1. Run the three test files above.
2. Or manually: call `GitHubTool()._fetch_repo_metadata(username, repo)` against a repo with a `tests/` folder and confirm `"files"` is populated; pass those files into `RepoAnalyzer().execute({"files": ...})` and confirm `has_tests` is `True`. Repeat against a repo with no test files and confirm `False`.

## Screenshots / Demo

N/A — this is a backend analysis field with no UI surface yet. The observable change is the new `has_tests: bool` key in the tool's output dict.

## Notes for Reviewers

- **Orchestrator typing debt:** `agent/orchestrator.py` had pre-existing missing type annotations on `_execute_tool`, `_execute_with_timeout`, and the inner `_execute` closure. These are unrelated to the `has_tests` feature, but since I was already touching this file to wire in `repo_analyzer`, I annotated them in the same commit rather than leaving the file half-typed.
- **Separate chore commit:** The mypy pre-commit hook also failed on pre-existing missing annotations in `agent/error_handling.py`, `agent/memory/context_manager.py`, and `agent/memory/session_store.py` — none of which this feature touches directly. They only got flagged because `orchestrator.py` imports them and mypy checks transitively. I fixed those with no behavior change and kept them in their own `chore` commit, separate from the feature commit, so you can review or skip it independently.
- `make check` and `make test-unit` don't pass repo-wide, but for reasons unrelated to this change: `ruff check .` reports 174 pre-existing errors elsewhere in the codebase, and the full `test-unit` run has 53 pre-existing failures in unrelated modules (`test_review_service.py`, `test_security.py`, `test_skill_extractor.py`, etc.). None of these touch the files this PR changes.