### PR TITLE
test: implement real snapshot hash check for prompt templates

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,16 @@
+## Week 7 — Issue selection
+
+**Issue link:** [\[Issue #37 link\]](https://github.com/ascherj/pathreview/issues/37)
+
+**Issue title:** Add snapshot tests for prompt templates to catch accidental changes
+
+**Tier:** [*] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+Prompt changes can greatly affect review quality. This issue requests that we save a fingerprint of each prompt as a baseline, and add a test that compares the current prompt against that saved baseline. When the test passes, the prompt is unchanged; when it fails, it warns that the prompt has changed. If the change was intentional, the prompt requires a version bump. The test would be added in tests/unit/test_prompt_templates.py, which checks the prompts defined in rag/generator/prompt_templates.py.
+
+**Branch name:** test/37-prompt-template-snapshots-tests
+
+**Setup confirmation:** [Yes] App runs locally at localhost:5173
+
+**Cohort ledger:** [Yes] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -71,3 +71,36 @@ Fixed the hollow `test_template_snapshot_content_hash` test, which computed a ha
 _(Note: the codebase has documented pre-existing failures — `make check` reports 176 pre-existing ruff errors and `make test-unit` has failures in `test_resume_parser.py` and `test_review_service.py`, all in files unrelated to this change. Per the pre-existing-failures guidance, "passes" here means my change introduces no new failures.)_
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [X] No — still awaiting review
+
+**Summary of feedback:**
+[What did reviewers comment on? Or note that no review came in.]
+N/A
+
+**How you responded:**
+[What changes did you make, or what did you reply? If no feedback,
+leave blank.]
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The environment setup and Git workflow were much harder than the actual code fix. The fix itself was only a few lines, but getting to the point where I could commit it meant working through installing Docker on a shared office machine, `docker` and `make` not being found because they were on the PATH in Git Bash but not PowerShell, and even a bracketed-paste issue that turned a pasted command into gibberish. The single hardest moment was when my commit was blocked by the pre-commit hooks, which failed on the whole file over pre-existing lint and type errors that weren't mine.
+
+**What did you learn about working in a large codebase?**
+That you inherit the codebase as-is — including its existing failures — and your responsibility is not to make it worse, not to fix everything. In my own projects, a green test suite is a given; here, `make check` reported 176 pre-existing ruff errors and some unit tests were already failing before I touched anything. Learning to tell which failures were pre-existing versus mine, and to document that baseline clearly, was a new skill. I also came to appreciate the conventions (branch naming, commit format, PR template) that keep many contributors aligned on someone else's production code.
+
+**How did AI tools help — and where did they fall short?**
+AI was most useful for explaining unfamiliar concepts in plain terms (what a snapshot test and a hash actually are, the difference between Git remotes and branches), diagnosing environment problems (PATH issues, the paste bug), and helping me pinpoint the exact defect which was the two assertions that only checked the hash's type and length instead of comparing it to a baseline. It fell short on judgment calls that depended on my cohort's specific rules: whether to bypass the hooks, how to fill the self-review checkboxes honestly, and the "don't make it worse" policy. Those required reading the actual program instructions. The AI's first instinct was to fix the whole file, which wasn't what was expected.
+
+**What would you do differently if you started over?**
+I'd run `make check` and `make test-unit` to capture the pre-existing baseline *before* making any changes, so my before/after comparison would be clean rather than reconstructed after the fact. I'd also finish setting up the whole environment (Docker, and the right tools on PATH in the shell I actually use) before starting the issue, instead of fixing setup problems in the middle of the work.
+
+**What are you most proud of from this module?**
+That I understood the problem well enough to reproduce it and explain it in my own words before writing a single line of code and that the final fix was small and focused, with a clear failure message that tells the next developer exactly what to do, instead of a large or messy change.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -40,3 +40,35 @@ Conclusion: A change to a prompt template produced no test failure. This confirm
 
 **Blockers or open questions:**
 [Anything you're still uncertain about going into Week 9, or leave blank]
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Corrected the test_snapshot_content_hash by adding a comparison between a new hash and an older hash. If the hash numbers are different, that means a different prompt has been used and a test fails.
+
+**Next steps:**
+Verify the fix both ways (test passes on unchanged templates, fails when a template is edited), run `make check` and `make test-unit` to record the pre-existing baseline, then commit, push, and open the PR.
+
+**Blockers:**
+The pre-commit hooks (ruff/black/mypy) block the commit because the whole file — including pre-existing tests I didn't write — has lint/type issues (e.g. missing `-> None` return types). Per the project's "pre-existing failures" guidance, I'm not required to fix the entire codebase, only to avoid adding new failures, so I'll commit with `--no-verify` and document the pre-existing baseline in the PR.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [link to your submitted pull request]
+
+**Branch:** `test/37-prompt-template-snapshots-tests`
+
+**What you built:**
+Fixed the hollow `test_template_snapshot_content_hash` test, which computed a hash but only checked that it was a 32-character string — so it never actually detected changes. It now stores a baseline MD5 hash for each template version in `EXPECTED_TEMPLATE_HASHES` and compares every template's current hash against it, failing with a clear "bump the version" message when a template's text changes. It also fails if a template version is added or removed without updating the baseline.
+
+**Tests added or updated:**
+`tests/unit/test_prompt_templates.py` — added the `EXPECTED_TEMPLATE_HASHES` baseline and rewrote `test_template_snapshot_content_hash` to do a real per-template comparison. Verified it passes on the unchanged templates and fails when a template is edited. All 37 tests in the file pass.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+_(Note: the codebase has documented pre-existing failures — `make check` reports 176 pre-existing ruff errors and `make test-unit` has failures in `test_resume_parser.py` and `test_review_service.py`, all in files unrelated to this change. Per the pre-existing-failures guidance, "passes" here means my change introduces no new failures.)_
+
+**Draft PR feedback received from:** [name or Slack handle, or "none"]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -70,4 +70,4 @@ Fixed the hollow `test_template_snapshot_content_hash` test, which computed a ha
 **Self-review confirmation:** [x] make check passes  [x] make test-unit passes
 _(Note: the codebase has documented pre-existing failures — `make check` reports 176 pre-existing ruff errors and `make test-unit` has failures in `test_resume_parser.py` and `test_review_service.py`, all in files unrelated to this change. Per the pre-existing-failures guidance, "passes" here means my change introduces no new failures.)_
 
-**Draft PR feedback received from:** [name or Slack handle, or "none"]
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -58,8 +58,7 @@ The pre-commit hooks (ruff/black/mypy) block the commit because the whole file â
 
 ### Check-in 2 (end of week)
 
-**PR link:** [link to your submitted pull request]
-
+**PR link:** https://github.com/ascherj/pathreview/pull/825
 **Branch:** `test/37-prompt-template-snapshots-tests`
 
 **What you built:**

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -14,3 +14,29 @@ Prompt changes can greatly affect review quality. This issue requests that we sa
 **Setup confirmation:** [Yes] App runs locally at localhost:5173
 
 **Cohort ledger:** [Yes] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [link to commit documenting the reproduced issue]
+
+**Reproduction summary:**
+Problem area: the test_template_snapshot_content_hash test in tests/unit/test_prompt_templates.py.
+
+Reproduction steps:
+
+1. Baseline check — I ran the snapshot test on its own to confirm it passed before any change (the expected starting state):
+.venv/Scripts/python.exe -m pytest tests/unit/test_prompt_templates.py::TestPromptTemplates::test_template_snapshot_content_hash -v
+The test passed, as expected.
+
+2. Introduce a change — I edited the first_impression template in rag/generator/prompt_templates.py, changing the word "summary" to "summarized" (line 111).
+
+3. Re-run the snapshot test — with the prompt now altered, the test should have failed. Instead, it passed again.
+
+Conclusion: A change to a prompt template produced no test failure. This confirms the snapshot test isn't working as intended. It computes a hash but never compares it against a stored baseline, so it can't actually detect content changes.
+
+**PLAN.md link:** [link to PLAN.md in your fork]
+
+**Walkthrough video (recommended):** [\[Reproduction of Issue #37\]](https://www.loom.com/share/07d034ff6d1c4e299dce0cf19ac1a2c5)
+
+**Blockers or open questions:**
+[Anything you're still uncertain about going into Week 9, or leave blank]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -34,7 +34,7 @@ The test passed, as expected.
 
 Conclusion: A change to a prompt template produced no test failure. This confirms the snapshot test isn't working as intended. It computes a hash but never compares it against a stored baseline, so it can't actually detect content changes.
 
-**PLAN.md link:** [link to PLAN.md in your fork]
+**PLAN.md link:** [\[link to PLAN.md in your fork\]](https://github.com/Natwange/pathreview/blob/test/37-prompt-template-snapshots-tests/PLAN.MD)
 
 **Walkthrough video (recommended):** [\[Reproduction of Issue #37\]](https://www.loom.com/share/07d034ff6d1c4e299dce0cf19ac1a2c5)
 

--- a/PLAN.MD
+++ b/PLAN.MD
@@ -1,0 +1,42 @@
+## Solution plan
+
+**Issue:** #37 — Add snapshot tests that fail when a prompt template's content changes without a version bump (`tests/unit/test_prompt_templates.py`)
+
+### Understand
+Prompt templates directly affect review quality, so a silent edit to a template can degrade every review the app produces without anyone noticing. The issue asks for a snapshot test that **fails** whenever a template's text changes, forcing the developer to consciously version the template instead of editing it silently.
+
+A snapshot test that appears to do this already exists — `test_template_snapshot_content_hash` in `tests/unit/test_prompt_templates.py` — but it is hollow:
+
+- **Expected behavior:** editing a template's text should make the snapshot test fail, with a message telling the developer to bump the version.
+- **Actual behavior:** the test computes an MD5 hash of all template content, then only asserts `isinstance(content_hash, str)` and `len(content_hash) == 32`. Both are *always* true regardless of template content, so the computed hash is never compared to a stored baseline. Any template change passes silently.
+
+**Root cause:** the test never compares the freshly computed hash against a stored expected hash (baseline). The one value that would reveal a change — the hash itself — is discarded.
+
+### Map
+Files involved:
+
+- **`tests/unit/test_prompt_templates.py`** — where the fix lives. The target is `test_template_snapshot_content_hash` (~lines 175–188). This is the only file that needs changing for the core fix.
+- **`rag/generator/prompt_templates.py`** — the file being *guarded* (not edited as part of the fix). Holds `PROMPT_TEMPLATES` (5 templates: `skills_feedback`, `projects_feedback`, `presentation_feedback`, `gaps_feedback`, `first_impression`, each at version `v1`) and `get_template(name, version="v1")`. The test reads template content from here.
+
+### Plan
+1. **Capture the baseline hash.** Compute the current MD5 hash of the concatenated, sorted template content (reusing the existing hashing logic) and store it as an expected constant the test can compare against — e.g. a per-template mapping or a single combined hash, documented as the intentional snapshot.
+2. **Make the assertion real.** Replace the two meaningless assertions with an equality check comparing the freshly computed hash to the stored baseline.
+3. **Write a helpful failure message.** On mismatch, the assertion message should tell the developer: the template content changed; if intentional, bump the template version and update the stored hash.
+4. **Prove it works both ways.** Confirm the test passes on unchanged templates, then temporarily edit a template and confirm it now fails (the reproduction from earlier, now caught). Revert the edit.
+5. **Verify the whole file still passes** and the new behavior reads clearly for the next contributor.
+
+### Inputs & outputs
+- **Input:** the current content of all templates in `PROMPT_TEMPLATES`, plus a stored expected hash (the baseline snapshot).
+- **Output:** a test that **passes** when template content matches the baseline and **fails** with a clear "bump the version and update the hash" message when it doesn't. No production/runtime code changes — this is a test-only guardrail that runs locally and in CI.
+
+### Risks & unknowns
+- **Hash granularity:** one combined hash for all templates is simplest but a failure won't say *which* template changed; a per-template hash gives clearer failures at the cost of more bookkeeping. Decide which the issue intends.
+- **MD5 choice:** the existing code uses MD5. It's fine for change-detection (not security), so keeping it is reasonable and consistent — but worth a conscious note.
+- **Baseline drift:** every intentional template edit now requires updating the stored hash. This is the *intended* friction, but the failure message must make that obvious or it will confuse contributors.
+- **Ordering stability:** the hash depends on iterating templates/versions in a stable (sorted) order; non-deterministic ordering would cause false failures.
+
+### Edge cases
+- **New template added** or **new version added** (e.g. `v2`) — the baseline should account for it deliberately, not break unexpectedly.
+- **Whitespace-only edits** (a trailing space, reflow) — these *do* change the hash and *should* fail; that's correct behavior (whitespace can affect model output).
+- **Reordering templates** without changing text — sorted iteration should keep the hash stable so this doesn't cause a false failure.
+- **Intentional change flow** — after a real edit, updating the stored hash must make the test green again, confirming the "bump + update" path works end to end.

--- a/tests/unit/test_prompt_templates.py
+++ b/tests/unit/test_prompt_templates.py
@@ -1,9 +1,24 @@
 """Tests for prompt_templates.py - Snapshot tests"""
 
-import pytest
 import hashlib
 
+import pytest
+
 from rag.generator.prompt_templates import PROMPT_TEMPLATES, get_template
+
+# Baseline snapshot of each template's content hash, keyed by "name:version".
+# If a template's text changes, its hash no longer matches and the snapshot test
+# below fails. When a change is intentional, add a NEW version (e.g. "v2") to
+# PROMPT_TEMPLATES and record its hash here, rather than silently editing an
+# existing version in place. Only update the hash for an existing key when you
+# have deliberately decided to change that exact version.
+EXPECTED_TEMPLATE_HASHES = {
+    "first_impression:v1": "ef6429d3a6d426b3c9913381020dd7e4",
+    "gaps_feedback:v1": "e5bfd6644fd62a0fe01f60c9aa456762",
+    "presentation_feedback:v1": "43549ee59818dfc8eb3627554a563b2e",
+    "projects_feedback:v1": "d346d01b24ee7aad92594014a46557af",
+    "skills_feedback:v1": "f93103d823482a2e65decc6653e4ee5c",
+}
 
 
 @pytest.mark.unit
@@ -52,7 +67,9 @@ class TestPromptTemplates:
         """Test each template contains {context} placeholder."""
         for template_name, versions in PROMPT_TEMPLATES.items():
             for version, template_text in versions.items():
-                assert "{context}" in template_text, f"{template_name} v{version} missing {{context}}"
+                assert (
+                    "{context}" in template_text
+                ), f"{template_name} v{version} missing {{context}}"
 
     def test_each_template_contains_github_username_placeholder(self):
         """Test each template contains {github_username} placeholder."""
@@ -151,19 +168,32 @@ class TestPromptTemplates:
         """Test gaps_feedback template mentions missing/gap concepts."""
         template = PROMPT_TEMPLATES["gaps_feedback"]["v1"]
 
-        assert "gap" in template.lower() or "missing" in template.lower() or "demand" in template.lower()
+        assert (
+            "gap" in template.lower()
+            or "missing" in template.lower()
+            or "demand" in template.lower()
+        )
 
     def test_presentation_feedback_mentions_readme(self):
         """Test presentation_feedback template mentions README or presentation."""
         template = PROMPT_TEMPLATES["presentation_feedback"]["v1"]
 
-        assert "readme" in template.lower() or "presentation" in template.lower() or "organization" in template.lower()
+        assert (
+            "readme" in template.lower()
+            or "presentation" in template.lower()
+            or "organization" in template.lower()
+        )
 
     def test_first_impression_is_concise(self):
         """Test first_impression template instructs concise output."""
         template = PROMPT_TEMPLATES["first_impression"]["v1"]
 
-        assert "2" in template or "3" in template or "sentence" in template.lower() or "summary" in template.lower()
+        assert (
+            "2" in template
+            or "3" in template
+            or "sentence" in template.lower()
+            or "summary" in template.lower()
+        )
 
     def test_get_template_default_version(self):
         """Test get_template() defaults to v1 when version not specified."""
@@ -173,19 +203,39 @@ class TestPromptTemplates:
         assert template_default == template_v1
 
     def test_template_snapshot_content_hash(self):
-        """Snapshot test: verify template content hash."""
-        # Create hash of all template content
-        template_content = ""
-        for name in sorted(PROMPT_TEMPLATES.keys()):
-            for version in sorted(PROMPT_TEMPLATES[name].keys()):
-                template_content += PROMPT_TEMPLATES[name][version]
+        """Snapshot test: fail if a template's content changes without a version bump.
 
-        content_hash = hashlib.md5(template_content.encode()).hexdigest()
+        Each template version has a recorded baseline hash in
+        EXPECTED_TEMPLATE_HASHES. Editing a template's text changes its hash and
+        fails this test, forcing a conscious decision: add a new version (and its
+        hash) rather than silently editing an existing one.
+        """
+        current_hashes = {
+            f"{name}:{version}": hashlib.md5(text.encode("utf-8")).hexdigest()
+            for name, versions in PROMPT_TEMPLATES.items()
+            for version, text in versions.items()
+        }
 
-        # Expected hash - update if templates intentionally change
-        # This helps detect unintended changes to templates
-        assert isinstance(content_hash, str)
-        assert len(content_hash) == 32  # MD5 hash length
+        # A new or removed template version must be reflected in the baseline on
+        # purpose, so the set of known versions must match exactly.
+        assert set(current_hashes) == set(EXPECTED_TEMPLATE_HASHES), (
+            "Set of prompt template versions changed.\n"
+            f"  added:   {sorted(set(current_hashes) - set(EXPECTED_TEMPLATE_HASHES))}\n"
+            f"  removed: {sorted(set(EXPECTED_TEMPLATE_HASHES) - set(current_hashes))}\n"
+            "If intentional, update EXPECTED_TEMPLATE_HASHES to match (add the new "
+            "version's hash, or remove the deleted one)."
+        )
+
+        # Existing template content must match its recorded baseline hash.
+        changed = [
+            key for key, digest in current_hashes.items() if digest != EXPECTED_TEMPLATE_HASHES[key]
+        ]
+        assert not changed, (
+            f"Prompt template content changed for: {changed}.\n"
+            "If this change is intentional, bump the template version (add a new "
+            "'vN' entry in PROMPT_TEMPLATES) instead of editing an existing version "
+            "in place, then record its hash in EXPECTED_TEMPLATE_HASHES."
+        )
 
     def test_skills_feedback_requests_json_format(self):
         """Test skills_feedback requests JSON output."""
@@ -216,7 +266,11 @@ class TestPromptTemplates:
         template = PROMPT_TEMPLATES["first_impression"]["v1"]
 
         # Should specify format (JSON or plain text)
-        assert "json" in template.lower() or "text" in template.lower() or "summary" in template.lower()
+        assert (
+            "json" in template.lower()
+            or "text" in template.lower()
+            or "summary" in template.lower()
+        )
 
     def test_templates_have_portfolio_context(self):
         """Test templates mention portfolio or context."""
@@ -230,7 +284,8 @@ class TestPromptTemplates:
         # Import logger to verify it's used
         with pytest.MonkeyPatch.context() as mp:
             from unittest.mock import patch
-            with patch('rag.generator.prompt_templates.logger') as mock_logger:
+
+            with patch("rag.generator.prompt_templates.logger") as mock_logger:
                 get_template("skills_feedback")
                 # Should log template retrieval
 
@@ -267,7 +322,8 @@ class TestPromptTemplates:
             for version, template_text in versions.items():
                 # All placeholders should use {name} syntax
                 import re
-                placeholders = re.findall(r'\{(\w+)\}', template_text)
+
+                placeholders = re.findall(r"\{(\w+)\}", template_text)
                 assert "context" in placeholders
                 assert "github_username" in placeholders
                 assert "project_count" in placeholders


### PR DESCRIPTION
## Summary
The `test_template_snapshot_content_hash` test was meant to catch accidental
edits to prompt templates, but it only checked that the hash was a 32-character
string. It never compared against a stored baseline, so any template could be
edited silently, and the test still passed. This PR makes it work: it stores a
baseline hash per template version and fails when a template changes without a
version bump.

## Issue
Closes #37

## Changes
- Added `EXPECTED_TEMPLATE_HASHES`, a `"name:version"` → MD5 baseline for every
  template in `PROMPT_TEMPLATES`.
- Rewrote `test_template_snapshot_content_hash` to compare each template's current
  hash against the baseline, failing with a message to bump the version and update
  the hash.
- Added a guard so adding/removing a template version without updating the baseline
  also fails instead of passing silently.

## Testing
- [x] New/updated tests cover the changes
- [x] `test_prompt_templates.py` passes (37/37) — verified it passes on the current
  templates and fails when a template is edited
- [ ] `make lint` / `make test-unit` / `make typecheck` — see pre-existing failures below

## Pre-existing failures (not introduced by this PR)
Observed on `main`, unrelated to this change:
- **`make lint`** — 176 pre-existing ruff errors across many files (`rag/retriever/*`,
  `safety/*`, several `tests/unit/*`), types `E501`, `I001`, `F401`, `F841`, `B007`,
  `B905`, `N806`. Lint fails before typecheck runs.
- **`make test-unit`** — failures in files I did not touch: `test_resume_parser.py`
  (markdown stripping / section detection) and `test_review_service.py`
  (`AttributeError: 'coroutine' object has no attribute 'first'/'all'` from async
  mock setup).

**This PR only changes `tests/unit/test_prompt_templates.py` (plus my cohort
`JOURNAL.md` / `PLAN.MD`), which passes 37/37. It introduces no new lint errors or
test failures and does not affect any of the pre-existing failures above.** I left
those checkboxes unchecked to reflect the literal `make` results.
