### PR TITLE
Feature: Add Comparison View

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -18,3 +18,20 @@ For users who have completed multiple reviews, they might want to view their pro
 **Setup confirmation:** [✓] App runs locally at localhost:5173
 
 **Cohort ledger:** [✓] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/janielcaday/pathreview/commit/8769cc4eabb82a244b426e4e51fa9231a365772d
+
+**Reproduction summary:**
+[1–2 sentences: How did you reproduce the issue? What did you observe?]
+I reproduced the issue by simply starting up the app, and using one of the pre-seeded credentials who already have reviews completed. I observed that there was in fact *no* feature supported for retroactive review comparison.
+
+**PLAN.md link:** https://github.com/janielcaday/pathreview/blob/feat/102-add-comparison-view/PLAN.md
+
+**Walkthrough video (recommended):** [link to your Loom video, ≤2 min — recommended, not graded]
+N/A
+
+**Blockers or open questions:**
+[Anything you're still uncertain about going into Week 9, or leave blank]
+- I will need to investigate database structure, whether reviews have a unique ID, how the code gathers all reviews associated with a user, etc. This is the primary foundation needed for figuring out how to add the comparison feature without breaking anything else in the repo.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,20 @@
+# PathReivew – JOURNAL.md
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/102
+
+**Issue title:** Add a before/after comparison view for users who have completed multiple reviews
+- Issue description: https://github.com/ascherj/pathreview/issues/102#issue-4117413267
+
+**Tier:** [ ] Tier 1  [ ] Tier 2  [✓] Tier 3 
+
+**Problem summary:**
+[In 3–5 sentences, in your own words: what the issue is (not a copy-paste of the title), what is currently broken or missing, and what a successful fix would accomplish. Naming the part of the codebase it affects is helpful context.]
+For users who have completed multiple reviews, they might want to view their progress between two reviews. Adding a comparison view would allow the user to select two exiting reviews, and initiate a comparison review between the two. The comparison review would cover metrics, whether stats went up or down in certain areas, and maybe even what exactly was submitted in said reviews. I haven't looked into the codebase too much yet, but showing previous state might be out of scope for this issue since we would need to save what was submitted into a database, and call it back when a comaprison review is triggered. As for the part of the codebase it affects, we would need to make a new page, `frontend/src/pages/ComparisonView.tsx` for a user-friendly UI, and `frontend/src/utils/diffFormatter` to fill in elements, calculate statistical differences, etc. I am a platform engineer during the day, and creating new frontend tooling aligns with my skillset.
+
+**Branch name:** feat/102-add-comparison-view
+
+**Setup confirmation:** [✓] App runs locally at localhost:5173
+
+**Cohort ledger:** [✓] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -35,3 +35,34 @@ N/A
 **Blockers or open questions:**
 [Anything you're still uncertain about going into Week 9, or leave blank]
 - I will need to investigate database structure, whether reviews have a unique ID, how the code gathers all reviews associated with a user, etc. This is the primary foundation needed for figuring out how to add the comparison feature without breaking anything else in the repo.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Got sub-tasks 1-4 from PLAN.md mostly done. Added the compare route + entry point on ReviewHistoryPage (checkbox select + compare button), built out ComparisonView.tsx to pull both reviews and render them, and wrote the diffFormatter.ts logic to diff sections and score deltas. Also pulled some of the render logic into a new ComparisonSection.tsx component so ComparisonView isn't one giant file.
+
+**Next steps:**
+Need to write tests for diffFormatter (started the test file but not filled in yet), handle loading/error states properly, and cover the edge cases from PLAN.md (mismatched sections, pending reviews, <2 reviews).
+
+**Blockers:**
+None major, just need to double check how section_name matching behaves when agent output varies between reviews.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [link to your submitted pull request]
+
+**Branch:** feat/102-add-comparison-view
+
+**What you built:**
+A before/after comparison view — users pick two completed reviews from ReviewHistoryPage, hit "Compare", and land on ComparisonView.tsx which shows overall score delta plus a per-section diff (added/removed/unchanged) computed by diffFormatter.ts.
+
+**Tests added or updated:**
+frontend/src/utils/__tests__/diffFormatter.test.ts — covers section diffing and score delta calc, including mismatched sections and identical-review edge case.
+
+**Self-review confirmation:** [✓] make check passes  [✓] make test-unit passes
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -53,7 +53,7 @@ None major, just need to double check how section_name matching behaves when age
 
 ### Check-in 2 (end of week)
 
-**PR link:** [link to your submitted pull request]
+**PR link:** [Link to PR](https://github.com/janielcaday/pathreview/pull/1)
 
 **Branch:** feat/102-add-comparison-view
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -66,3 +66,42 @@ frontend/src/utils/__tests__/diffFormatter.test.ts — covers section diffing an
 **Self-review confirmation:** [✓] make check passes  [✓] make test-unit passes
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [✓] No — still awaiting review
+
+**Summary of feedback:**
+[What did reviewers comment on? Or note that no review came in.]
+
+No reviewer feedback was received/given.
+
+**How you responded:**
+[What changes did you make, or what did you reply? If no feedback,
+leave blank.]
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+
+Section matching uses exact section_name string match, so if wording drifts between review runs, sections show as fully added/removed instead of diffed — a known limitation, not fuzzy matching.
+
+**What did you learn about working in a large codebase?**
+
+I had to actually trace how reviews get stored and associated with a user before touching anything, instead of just building the UI first. In my own projects I'd usually wing it, but here breaking review history for existing users would've been bad. Also learned to lean on existing patterns (like how ReviewHistoryPage already fetched data) instead of reinventing my own fetch logic.
+
+**How did AI tools help — and where did they fall short?**
+
+AI was great for scaffolding — generating the ComparisonView.tsx skeleton, boilerplate for diffFormatter.ts, and test cases for straightforward scenarios. Fell short on the score-delta edge cases (mismatched sections, identical reviews) — those needed me to actually reason through the data shape myself and adjust the AI's first pass.
+
+**What would you do differently if you started over?**
+
+I'd plan for section-name drift up front instead of assuming exact string matches would hold. Right now diffSections keys sections by exact section_name, so if the agent phrases a section title even slightly differently between two review runs, it shows up as one section removed and a new one added instead of an actual diff. I'd rather have designed some fuzzy/normalized matching (lowercase, trim, maybe similarity threshold) from the start instead of realizing after the fact that exact-match was too brittle.
+
+**What are you most proud of from this module?**
+
+It was satisfying to see the whole thing come together end to end — from picking checkboxes on ReviewHistoryPage, through the diffing logic in diffFormatter.ts, all the way to a rendered comparison on ComparisonView.tsx. It's a small feature, but tracing it through every layer (data fetch, diff computation, UI) and having it actually work with real seeded review data felt like a solid full-stack win, especially since most of my day job is platform-side infra, not frontend feature work.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,44 @@
+# Pathreview - PLAN.md
+
+## Solution plan
+
+**Issue:** [Add a before/after comparison view for users who have completed multiple reviews](https://github.com/ascherj/pathreview/issues/102)
+
+### Understand
+What is the root cause of this issue? What behavior is expected vs. actual?
+Users may want to view their progress, or compare past reviews with more recent reviews. The current issue is that Pathreview has no support for this. Expected behavior is that there IS support, and actual behavior is that there is NO support.
+
+### Map
+Which files, functions, or modules are involved?
+List the specific files you expect to touch.
+
+The below files are completely new files that need to be added in order to support this feature.
+- frontend/src/pages/ComparisonView.tsx
+- frontend/src/utils/diffFormatter.ts
+
+### Plan
+What are the steps to fix this issue?
+Break it into 3–5 concrete sub-tasks.
+
+1. Add `/reviews/compare` route + entry point (e.g. "Compare" button on ReviewHistoryPage, enabled when 2+ reviews selected via checkboxes), wired to `ComparisonView.tsx`.
+2. In `ComparisonView.tsx`, read two review IDs (older/newer) from route state or query params, fetch both full reviews via `apiClient.getReview(id)`.
+3. Build `diffFormatter.ts`: given two `Review` objects, produce a per-section diff — matched by `section_name`, with score delta and content/suggestions diff (added/removed/unchanged lines).
+4. Render comparison UI: side-by-side or unified before/after layout, overall score delta banner, per-section diff using `diffFormatter` output, reusing `StatusBadge`/`ReviewSection`-style components where reasonable.
+5. Handle loading/error states for both reviews and add basic tests for `diffFormatter.ts`.
+
+### Inputs & outputs
+What does your fix take as input? What should it produce or change?
+**Input:** two review IDs (older review, newer review) for the same profile, obtained from `apiClient.getReview(id)`.
+**Output:** a rendered comparison page showing overall score delta and a per-section text/suggestion diff; no backend or data model changes required — purely a new frontend page + formatting util consuming existing `Review` API responses.
+
+### Risks & unknowns
+What could go wrong? What are you still unsure about?
+- Section names may not match exactly between two reviews (agent output can vary), so diffing "by section_name" may leave orphan sections on either side.
+- No existing multi-select UI on ReviewHistoryPage — will need a function to check if there are more than two existing reviews associated with the profile and add selection state without breaking existing table/pagination behavior.
+
+### Edge cases
+What inputs or states should your fix handle gracefully?
+- Fewer than 2 completed reviews available (disable/hide compare entry point).
+- One or both reviews still `pending`/`failed` (we should block comparison for this).
+- Reviews with mismatched sections (section present in one but not the other).
+- Identical reviews (no diff / "no changes" state).

--- a/PLAN.md
+++ b/PLAN.md
@@ -4,6 +4,13 @@
 
 **Issue:** [Add a before/after comparison view for users who have completed multiple reviews](https://github.com/ascherj/pathreview/issues/102)
 
+**Description:** Users who review their portfolio at two different points in time have no way to see how their scores changed. Add a comparison view that shows side-by-side diffs of two selected reviews.
+
+Relevant files:
+
+- frontend/src/pages/ComparisonView.tsx
+- frontend/src/utils/diffFormatter.ts
+
 ### Understand
 What is the root cause of this issue? What behavior is expected vs. actual?
 Users may want to view their progress, or compare past reviews with more recent reviews. The current issue is that Pathreview has no support for this. Expected behavior is that there IS support, and actual behavior is that there is NO support.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -99,7 +99,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -449,7 +448,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -473,7 +471,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1561,7 +1558,6 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1579,7 +1575,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1972,7 +1967,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3507,7 +3501,6 @@
       "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^2.0.1",
         "cssstyle": "^4.0.1",
@@ -4094,7 +4087,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4107,7 +4099,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4771,7 +4762,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import { DashboardPage } from './pages/DashboardPage'
 import { NewProfilePage } from './pages/NewProfilePage'
 import { ReviewPage } from './pages/ReviewPage'
 import { ReviewHistoryPage } from './pages/ReviewHistoryPage'
+import { ComparisonView } from './pages/ComparisonView'
 
 const ProtectedRoute: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const { user, isLoading } = useAuth()
@@ -73,6 +74,14 @@ function App() {
           element={
             <ProtectedRoute>
               <ReviewHistoryPage />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/reviews/compare"
+          element={
+            <ProtectedRoute>
+              <ComparisonView />
             </ProtectedRoute>
           }
         />

--- a/frontend/src/components/ComparisonSection.tsx
+++ b/frontend/src/components/ComparisonSection.tsx
@@ -1,0 +1,74 @@
+import React from 'react'
+import type { SectionDiff, LineDiff } from '../utils/diffFormatter'
+
+interface ComparisonSectionProps {
+  diff: SectionDiff
+}
+
+const lineStyles: Record<LineDiff['type'], string> = {
+  added: 'bg-green-50 text-green-800',
+  removed: 'bg-red-50 text-red-800',
+  unchanged: 'text-gray-700'
+}
+
+const linePrefix: Record<LineDiff['type'], string> = {
+  added: '+',
+  removed: '-',
+  unchanged: ' '
+}
+
+const DiffLines: React.FC<{ lines: LineDiff[] }> = ({ lines }) => (
+  <div className="font-mono text-sm rounded border border-gray-200 overflow-hidden">
+    {lines.map((line, index) => (
+      <div key={index} className={`px-3 py-1 whitespace-pre-wrap ${lineStyles[line.type]}`}>
+        <span className="select-none text-gray-400 mr-2">{linePrefix[line.type]}</span>
+        {line.text}
+      </div>
+    ))}
+  </div>
+)
+
+export const ComparisonSection: React.FC<ComparisonSectionProps> = ({ diff }) => {
+  const confidencePct = (value?: number) => (value !== undefined ? `${(value * 100).toFixed(0)}%` : '—')
+
+  return (
+    <div className="border border-gray-200 rounded-lg p-4 bg-white">
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="text-lg font-semibold text-gray-900">{diff.section_name}</h3>
+        <div className="flex items-center gap-2 text-sm">
+          <span className="px-2 py-1 bg-blue-100 text-blue-800 rounded font-medium">
+            {confidencePct(diff.confidenceA)} → {confidencePct(diff.confidenceB)}
+          </span>
+          {diff.confidenceDelta !== undefined && diff.confidenceDelta !== 0 && (
+            <span
+              className={`px-2 py-1 rounded font-medium ${
+                diff.confidenceDelta > 0 ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'
+              }`}
+            >
+              {diff.confidenceDelta > 0 ? '+' : ''}
+              {(diff.confidenceDelta * 100).toFixed(0)}%
+            </span>
+          )}
+        </div>
+      </div>
+
+      {!diff.presentInA && (
+        <p className="text-sm text-green-700 mb-2">New section in this review.</p>
+      )}
+      {!diff.presentInB && (
+        <p className="text-sm text-red-700 mb-2">Section removed in the newer review.</p>
+      )}
+
+      <div className="mb-3">
+        <DiffLines lines={diff.contentDiff} />
+      </div>
+
+      {diff.suggestionsDiff.length > 0 && (
+        <div>
+          <h4 className="font-semibold text-gray-900 mb-2 text-sm">Suggestions</h4>
+          <DiffLines lines={diff.suggestionsDiff} />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/ComparisonView.tsx
+++ b/frontend/src/pages/ComparisonView.tsx
@@ -1,0 +1,1 @@
+// New page goes here

--- a/frontend/src/pages/ComparisonView.tsx
+++ b/frontend/src/pages/ComparisonView.tsx
@@ -1,1 +1,165 @@
-// New page goes here
+import React, { useEffect, useState } from 'react'
+import { useSearchParams, useNavigate } from 'react-router-dom'
+import { ArrowLeft } from 'lucide-react'
+import { apiClient } from '../services/api'
+import { Review } from '../types'
+import { StatusBadge } from '../components/StatusBadge'
+import { ComparisonSection } from '../components/ComparisonSection'
+import { formatDate } from '../utils/dateFormatters'
+import { compareReviews, ReviewComparison } from '../utils/diffFormatter'
+
+const BackLink: React.FC = () => {
+  const navigate = useNavigate()
+  return (
+    <button
+      onClick={() => navigate('/reviews')}
+      className="inline-flex items-center gap-2 text-gray-600 hover:text-gray-900 mb-8 font-medium"
+    >
+      <ArrowLeft className="w-5 h-5" />
+      Back to Review History
+    </button>
+  )
+}
+
+const Message: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <div className="p-8 bg-white rounded-lg shadow text-center">
+    <p className="text-gray-700">{children}</p>
+  </div>
+)
+
+export const ComparisonView: React.FC = () => {
+  const [searchParams] = useSearchParams()
+  const idA = searchParams.get('a')
+  const idB = searchParams.get('b')
+
+  const [reviewA, setReviewA] = useState<Review | null>(null)
+  const [reviewB, setReviewB] = useState<Review | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    if (!idA || !idB || idA === idB) {
+      setIsLoading(false)
+      return
+    }
+
+    const fetchReviews = async () => {
+      try {
+        const [a, b] = await Promise.all([apiClient.getReview(idA), apiClient.getReview(idB)])
+        setReviewA(a)
+        setReviewB(b)
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to load reviews')
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    fetchReviews()
+  }, [idA, idB])
+
+  let content: React.ReactNode
+
+  if (!idA || !idB) {
+    content = <Message>Select two reviews to compare.</Message>
+  } else if (idA === idB) {
+    content = <Message>Select two different reviews to compare.</Message>
+  } else if (isLoading) {
+    content = <Message>Loading comparison...</Message>
+  } else if (error) {
+    content = <Message>{error}</Message>
+  } else if (reviewA && reviewB) {
+    const incomplete = [reviewA, reviewB].filter((r) => r.status !== 'complete')
+    if (incomplete.length > 0) {
+      content = (
+        <Message>
+          Both reviews must be complete to compare. {incomplete.length} review
+          {incomplete.length > 1 ? 's are' : ' is'} not yet complete.
+        </Message>
+      )
+    } else {
+      const [older, newer] =
+        new Date(reviewA.created_at).getTime() <= new Date(reviewB.created_at).getTime()
+          ? [reviewA, reviewB]
+          : [reviewB, reviewA]
+      const comparison: ReviewComparison = compareReviews(older, newer)
+      const olderPct =
+        comparison.older.overall_score !== undefined
+          ? Math.round(comparison.older.overall_score * 100)
+          : undefined
+      const newerPct =
+        comparison.newer.overall_score !== undefined
+          ? Math.round(comparison.newer.overall_score * 100)
+          : undefined
+      const deltaPct =
+        comparison.overallScoreDelta !== undefined ? Math.round(comparison.overallScoreDelta * 100) : undefined
+
+      content = (
+        <>
+          <div className="mb-8 bg-white rounded-lg shadow p-6">
+            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+              <div>
+                <p className="text-sm text-gray-600">Older review</p>
+                <p className="font-medium text-gray-900">{formatDate(older.created_at)}</p>
+                <StatusBadge status={older.status} />
+              </div>
+              <div>
+                <p className="text-sm text-gray-600">Newer review</p>
+                <p className="font-medium text-gray-900">{formatDate(newer.created_at)}</p>
+                <StatusBadge status={newer.status} />
+              </div>
+            </div>
+
+            <div className="mt-6 pt-6 border-t border-gray-200 flex items-center gap-4">
+              <div>
+                <p className="text-sm text-gray-600">Overall score</p>
+                <p className="text-2xl font-bold text-gray-900">
+                  {olderPct ?? '—'} → {newerPct ?? '—'}
+                </p>
+              </div>
+              {deltaPct !== undefined && (
+                <span
+                  className={`px-3 py-1 rounded-full text-sm font-medium ${
+                    deltaPct > 0
+                      ? 'bg-green-100 text-green-800'
+                      : deltaPct < 0
+                        ? 'bg-red-100 text-red-800'
+                        : 'bg-gray-100 text-gray-800'
+                  }`}
+                >
+                  {deltaPct > 0 ? '+' : ''}
+                  {deltaPct}
+                </span>
+              )}
+            </div>
+          </div>
+
+          {!comparison.hasAnyDiff ? (
+            <Message>No changes between these reviews.</Message>
+          ) : (
+            <div className="space-y-6">
+              {comparison.sections.map((section) => (
+                <ComparisonSection key={section.section_name} diff={section} />
+              ))}
+            </div>
+          )}
+        </>
+      )
+    }
+  } else {
+    content = null
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        <BackLink />
+        <div className="mb-8">
+          <h1 className="text-3xl font-bold text-gray-900">Compare Reviews</h1>
+          <p className="text-gray-600 mt-2">See how your portfolio review changed over time</p>
+        </div>
+        {content}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/ReviewHistoryPage.tsx
+++ b/frontend/src/pages/ReviewHistoryPage.tsx
@@ -14,7 +14,15 @@ export const ReviewHistoryPage: React.FC = () => {
   const [total, setTotal] = useState(0)
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState('')
+  const [selectedIds, setSelectedIds] = useState<string[]>([])
+  const [toast, setToast] = useState('')
   const pageSize = 10
+
+  useEffect(() => {
+    if (!toast) return
+    const timer = setTimeout(() => setToast(''), 3000)
+    return () => clearTimeout(timer)
+  }, [toast])
 
   useEffect(() => {
     const fetchReviews = async () => {
@@ -31,7 +39,19 @@ export const ReviewHistoryPage: React.FC = () => {
     }
 
     fetchReviews()
+    setSelectedIds([])
   }, [currentPage])
+
+  const toggleSelect = (id: string) => {
+    setSelectedIds((prev) => {
+      if (prev.includes(id)) return prev.filter((x) => x !== id)
+      if (prev.length >= 2) {
+        setToast('You can only compare two reviews at a time.')
+        return prev
+      }
+      return [...prev, id]
+    })
+  }
 
   const filteredReviews = reviews.filter((review) => {
     const searchLower = searchTerm.toLowerCase()
@@ -48,21 +68,43 @@ export const ReviewHistoryPage: React.FC = () => {
 
   return (
     <div className="min-h-screen bg-gray-50">
+      {toast && (
+        <div
+          role="status"
+          className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 px-4 py-3 bg-gray-900 text-white text-sm font-medium rounded-lg shadow-lg"
+        >
+          {toast}
+        </div>
+      )}
       <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
         <div className="mb-8">
           <h1 className="text-3xl font-bold text-gray-900">Review History</h1>
           <p className="text-gray-600 mt-2">View and manage all your portfolio reviews</p>
         </div>
 
-        <div className="mb-6 relative">
-          <Search className="absolute left-4 top-1/2 transform -translate-y-1/2 w-5 h-5 text-gray-400" />
-          <input
-            type="text"
-            placeholder="Search by review ID, profile ID, or status..."
-            value={searchTerm}
-            onChange={(e) => setSearchTerm(e.target.value)}
-            className="w-full pl-12 pr-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-          />
+        <div className="mb-6 flex flex-col sm:flex-row items-stretch sm:items-center gap-3">
+          <div className="relative flex-1">
+            <Search className="absolute left-4 top-1/2 transform -translate-y-1/2 w-5 h-5 text-gray-400" />
+            <input
+              type="text"
+              placeholder="Search by review ID, profile ID, or status..."
+              value={searchTerm}
+              onChange={(e) => setSearchTerm(e.target.value)}
+              className="w-full pl-12 pr-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            />
+          </div>
+          <div className="flex flex-col items-start sm:items-end">
+            <button
+              onClick={() => navigate(`/reviews/compare?a=${selectedIds[0]}&b=${selectedIds[1]}`)}
+              disabled={selectedIds.length !== 2}
+              className="px-4 py-3 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-lg disabled:opacity-50 disabled:cursor-not-allowed transition-colors whitespace-nowrap"
+            >
+              Compare Selected ({selectedIds.length}/2)
+            </button>
+            {selectedIds.length < 2 && (
+              <p className="text-xs text-gray-500 mt-1">Select 2 completed reviews to compare.</p>
+            )}
+          </div>
         </div>
 
         {error && (
@@ -96,6 +138,7 @@ export const ReviewHistoryPage: React.FC = () => {
                 <table className="w-full">
                   <thead className="bg-gray-50 border-b border-gray-200">
                     <tr>
+                      <th className="px-6 py-3 text-left text-sm font-semibold text-gray-900 w-10"></th>
                       <th className="px-6 py-3 text-left text-sm font-semibold text-gray-900">Review ID</th>
                       <th className="px-6 py-3 text-left text-sm font-semibold text-gray-900">Profile ID</th>
                       <th className="px-6 py-3 text-left text-sm font-semibold text-gray-900">Status</th>
@@ -107,6 +150,20 @@ export const ReviewHistoryPage: React.FC = () => {
                   <tbody className="divide-y divide-gray-200">
                     {filteredReviews.map((review) => (
                       <tr key={review.id} className="hover:bg-gray-50 transition-colors">
+                        <td className="px-6 py-4">
+                          <input
+                            type="checkbox"
+                            checked={selectedIds.includes(review.id)}
+                            disabled={review.status !== 'complete'}
+                            onChange={() => toggleSelect(review.id)}
+                            title={
+                              review.status !== 'complete'
+                                ? 'Only completed reviews can be compared'
+                                : undefined
+                            }
+                            className="w-4 h-4 disabled:cursor-not-allowed"
+                          />
+                        </td>
                         <td className="px-6 py-4 text-sm font-medium text-gray-900">{review.id.slice(0, 12)}...</td>
                         <td className="px-6 py-4 text-sm text-gray-600">{review.profile_id.slice(0, 12)}...</td>
                         <td className="px-6 py-4">

--- a/frontend/src/utils/__tests__/diffFormatter.test.ts
+++ b/frontend/src/utils/__tests__/diffFormatter.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest'
+import { compareReviews, diffLines } from '../diffFormatter'
+import type { Review } from '../../types'
+
+function makeReview(overrides: Partial<Review> = {}): Review {
+  return {
+    id: 'review-1',
+    profile_id: 'profile-1',
+    status: 'complete',
+    overall_score: 0.75,
+    sections: [
+      {
+        section_name: 'Code Quality',
+        content: 'Line one.\nLine two.',
+        suggestions: ['Add tests.'],
+        confidence: 0.8
+      }
+    ],
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides
+  }
+}
+
+describe('diffLines', () => {
+  it('marks identical strings as all unchanged', () => {
+    expect(diffLines('a\nb\nc', 'a\nb\nc')).toEqual([
+      { type: 'unchanged', text: 'a' },
+      { type: 'unchanged', text: 'b' },
+      { type: 'unchanged', text: 'c' }
+    ])
+  })
+
+  it('marks an appended line as added, keeping the prefix unchanged', () => {
+    expect(diffLines('a\nb', 'a\nb\nc')).toEqual([
+      { type: 'unchanged', text: 'a' },
+      { type: 'unchanged', text: 'b' },
+      { type: 'added', text: 'c' }
+    ])
+  })
+
+  it('handles empty strings without throwing', () => {
+    expect(diffLines('', '')).toEqual([{ type: 'unchanged', text: '' }])
+  })
+})
+
+describe('compareReviews', () => {
+  it('reports no diff for identical reviews', () => {
+    const older = makeReview()
+    const newer = makeReview()
+    const result = compareReviews(older, newer)
+
+    expect(result.hasAnyDiff).toBe(false)
+    expect(result.sections.every((s) => s.isIdentical)).toBe(true)
+  })
+
+  it('computes overallScoreDelta when only the score changed', () => {
+    const older = makeReview({ overall_score: 0.75 })
+    const newer = makeReview({ overall_score: 0.85 })
+    const result = compareReviews(older, newer)
+
+    expect(result.hasAnyDiff).toBe(true)
+    expect(result.overallScoreDelta).toBeCloseTo(0.1)
+    expect(result.sections.every((s) => s.isIdentical)).toBe(true)
+  })
+
+  it('marks a section only present in the newer review as fully added', () => {
+    const older = makeReview({ sections: [] })
+    const newer = makeReview()
+    const result = compareReviews(older, newer)
+
+    const section = result.sections[0]
+    expect(section.presentInA).toBe(false)
+    expect(section.presentInB).toBe(true)
+    expect(section.contentDiff.every((d) => d.type === 'added')).toBe(true)
+    expect(section.suggestionsDiff.every((d) => d.type === 'added')).toBe(true)
+    expect(section.isIdentical).toBe(false)
+  })
+
+  it('marks a section only present in the older review as fully removed', () => {
+    const older = makeReview()
+    const newer = makeReview({ sections: [] })
+    const result = compareReviews(older, newer)
+
+    const section = result.sections[0]
+    expect(section.presentInA).toBe(true)
+    expect(section.presentInB).toBe(false)
+    expect(section.contentDiff.every((d) => d.type === 'removed')).toBe(true)
+    expect(section.suggestionsDiff.every((d) => d.type === 'removed')).toBe(true)
+    expect(section.isIdentical).toBe(false)
+  })
+
+  it('diffs confidence and content when a shared section changes', () => {
+    const older = makeReview()
+    const newer = makeReview({
+      sections: [
+        {
+          section_name: 'Code Quality',
+          content: 'Line one.\nLine three.',
+          suggestions: ['Add tests.'],
+          confidence: 0.9
+        }
+      ]
+    })
+    const result = compareReviews(older, newer)
+
+    const section = result.sections[0]
+    expect(section.confidenceDelta).toBeCloseTo(0.1)
+    expect(section.contentDiff).toEqual([
+      { type: 'unchanged', text: 'Line one.' },
+      { type: 'removed', text: 'Line two.' },
+      { type: 'added', text: 'Line three.' }
+    ])
+    expect(section.isIdentical).toBe(false)
+  })
+
+  it('leaves overallScoreDelta undefined when a score is missing, without throwing', () => {
+    const older = makeReview({ overall_score: undefined })
+    const newer = makeReview({ overall_score: 0.8 })
+
+    expect(() => compareReviews(older, newer)).not.toThrow()
+    expect(compareReviews(older, newer).overallScoreDelta).toBeUndefined()
+
+    const bothMissing = compareReviews(
+      makeReview({ overall_score: undefined }),
+      makeReview({ overall_score: undefined })
+    )
+    expect(bothMissing.overallScoreDelta).toBeUndefined()
+  })
+})

--- a/frontend/src/utils/diffFormatter.ts
+++ b/frontend/src/utils/diffFormatter.ts
@@ -1,0 +1,1 @@
+// difference logic goes here

--- a/frontend/src/utils/diffFormatter.ts
+++ b/frontend/src/utils/diffFormatter.ts
@@ -1,1 +1,142 @@
-// difference logic goes here
+import type { Review, FeedbackSection } from '../types'
+
+export type LineDiffType = 'added' | 'removed' | 'unchanged'
+
+export interface LineDiff {
+  type: LineDiffType
+  text: string
+}
+
+export interface SectionDiff {
+  section_name: string
+  presentInA: boolean
+  presentInB: boolean
+  confidenceA?: number
+  confidenceB?: number
+  confidenceDelta?: number
+  contentDiff: LineDiff[]
+  suggestionsDiff: LineDiff[]
+  isIdentical: boolean
+}
+
+export interface ReviewComparison {
+  older: Review
+  newer: Review
+  overallScoreDelta?: number
+  sections: SectionDiff[]
+  hasAnyDiff: boolean
+}
+
+function diffArrays(oldItems: string[], newItems: string[]): LineDiff[] {
+  let start = 0
+  while (
+    start < oldItems.length &&
+    start < newItems.length &&
+    oldItems[start] === newItems[start]
+  ) {
+    start++
+  }
+
+  let endOld = oldItems.length - 1
+  let endNew = newItems.length - 1
+  while (endOld >= start && endNew >= start && oldItems[endOld] === newItems[endNew]) {
+    endOld--
+    endNew--
+  }
+
+  const result: LineDiff[] = []
+  for (let i = 0; i < start; i++) {
+    result.push({ type: 'unchanged', text: oldItems[i] })
+  }
+  for (let i = start; i <= endOld; i++) {
+    result.push({ type: 'removed', text: oldItems[i] })
+  }
+  for (let i = start; i <= endNew; i++) {
+    result.push({ type: 'added', text: newItems[i] })
+  }
+  for (let i = endOld + 1; i < oldItems.length; i++) {
+    result.push({ type: 'unchanged', text: oldItems[i] })
+  }
+
+  return result
+}
+
+export function diffLines(oldText: string, newText: string): LineDiff[] {
+  return diffArrays(oldText.split('\n'), newText.split('\n'))
+}
+
+export function diffSections(
+  a: FeedbackSection[] | undefined,
+  b: FeedbackSection[] | undefined
+): SectionDiff[] {
+  const sectionsA = a ?? []
+  const sectionsB = b ?? []
+  const mapA = new Map(sectionsA.map((s) => [s.section_name, s]))
+  const mapB = new Map(sectionsB.map((s) => [s.section_name, s]))
+
+  const orderedNames: string[] = []
+  for (const s of sectionsA) orderedNames.push(s.section_name)
+  for (const s of sectionsB) {
+    if (!mapA.has(s.section_name)) orderedNames.push(s.section_name)
+  }
+
+  return orderedNames.map((name) => {
+    const sectionA = mapA.get(name)
+    const sectionB = mapB.get(name)
+    const presentInA = !!sectionA
+    const presentInB = !!sectionB
+
+    let contentDiff: LineDiff[]
+    let suggestionsDiff: LineDiff[]
+
+    if (sectionA && sectionB) {
+      contentDiff = diffLines(sectionA.content, sectionB.content)
+      suggestionsDiff = diffArrays(sectionA.suggestions, sectionB.suggestions)
+    } else if (sectionA) {
+      contentDiff = sectionA.content.split('\n').map((text) => ({ type: 'removed' as const, text }))
+      suggestionsDiff = sectionA.suggestions.map((text) => ({ type: 'removed' as const, text }))
+    } else {
+      contentDiff = sectionB!.content.split('\n').map((text) => ({ type: 'added' as const, text }))
+      suggestionsDiff = sectionB!.suggestions.map((text) => ({ type: 'added' as const, text }))
+    }
+
+    const confidenceA = sectionA?.confidence
+    const confidenceB = sectionB?.confidence
+    const confidenceDelta =
+      presentInA && presentInB ? (confidenceB as number) - (confidenceA as number) : undefined
+
+    const isIdentical =
+      presentInA &&
+      presentInB &&
+      confidenceDelta === 0 &&
+      contentDiff.every((d) => d.type === 'unchanged') &&
+      suggestionsDiff.every((d) => d.type === 'unchanged')
+
+    return {
+      section_name: name,
+      presentInA,
+      presentInB,
+      confidenceA,
+      confidenceB,
+      confidenceDelta,
+      contentDiff,
+      suggestionsDiff,
+      isIdentical
+    }
+  })
+}
+
+export function compareReviews(older: Review, newer: Review): ReviewComparison {
+  const overallScoreDelta =
+    older.overall_score !== undefined && newer.overall_score !== undefined
+      ? newer.overall_score - older.overall_score
+      : undefined
+
+  const sections = diffSections(older.sections, newer.sections)
+
+  const hasAnyDiff =
+    (overallScoreDelta !== undefined && overallScoreDelta !== 0) ||
+    sections.some((s) => !s.isIdentical)
+
+  return { older, newer, overallScoreDelta, sections, hasAnyDiff }
+}


### PR DESCRIPTION
## Summary
Adds a before/after comparison view for users with two or more completed reviews. Users select two reviews from the review history page and are taken to a comparison view that shows the overall score delta and a per-section diff (added/removed/unchanged content and suggestions) between the two reviews. This closes the gap where a user's score history was implicitly recorded but had no way to be inspected or compared.

## Issue
Closes # 102

## Changes
- Added multi-select (checkbox) UI and a "Compare" entry point on `ReviewHistoryPage.tsx`, enabled only when exactly two completed reviews are selected.
- Added a `/reviews/compare` route in `App.tsx` wired to `ComparisonView.tsx`.
- Built out `ComparisonView.tsx` to fetch both selected reviews and render the comparison, including loading/error states.
- Added `diffFormatter.ts` with `compareReviews()` and `diffLines()`: matches sections by `section_name`, computes per-section content/suggestion diffs and confidence delta, and an overall score delta; handles sections present in only one review and identical reviews gracefully.
- Extracted per-section rendering into a new `ComparisonSection.tsx` component to keep `ComparisonView.tsx` readable.
- Added `frontend/src/utils/__tests__/diffFormatter.test.ts` covering the diffing logic (see Testing below).

## Testing
<!-- How did you verify your changes? -->
- [x] Unit tests pass (`make test-unit`) ✓
- [x] Integration tests pass (`make test-integration`)
- [x] Linter passes (`make lint`)
- [x] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes

## Screenshots / Demo
[Comparison View Demo](https://drive.google.com/file/d/1pyF7-VMiftYVWdjltr9GvnfIfBiQ4bDD/view?usp=sharing)

## Notes for Reviewers
- section matching is exact-name — renamed section = removed+added, not modified.
