### PR TITLE
docs: add POST /profiles body schema to API reference

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -45,3 +45,24 @@ exactly what's missing.
 Issue #89 mentions both POST /profiles and POST /reviews, but I scoped this
 to /profiles only, matching the issue title — flagged in PLAN.md's Risks
 section.
+
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the fix from PLAN.md — updated the `POST /profiles` entry in
+`docs/API.md` with the full request schema: content type
+(`multipart/form-data`), a field table (github_username, portfolio_url,
+resume_file with types and required/optional status), an example curl
+request, and the 422 error case for invalid resume file types. Ran
+`make check` and `make test-unit` before and after my change to confirm
+I introduced no new failures.
+
+**Next steps:**
+Open a draft PR and get feedback from a peer or mentor in Slack before
+marking it ready for review.
+
+**Blockers:**
+None at them moment. 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -14,3 +14,14 @@ The API reference doc (docs/API.md) lists the POST /profiles endpoint but only g
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [ ] Issue added to cohort ledger
+
+
+
+**Selection notes:**
+I initially looked at #97, #87, and #101. #87 was Tier 3 (new webhook infrastructure) 
+and #97 turned out to be Tier 3 as well, despite reading like a smaller frontend fix — 
+its label was the deciding factor. #101 was Tier 2. Since this is my first open source 
+contribution, the checklist says to stick with Tier 1, so I went back to the tracker 
+filtered by tier-1 and found #89. It's confined to one doc file, has a clear before/after 
+(missing schema vs. documented schema), and I confirmed the actual request body by reading 
+api/routes/profiles.py before claiming it.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -66,3 +66,26 @@ marking it ready for review.
 
 **Blockers:**
 None at them moment. 
+
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/830
+
+**Branch:** docs/89-profiles-request-body-schema
+
+**What you built:**
+Added the missing request body schema for POST /profiles to docs/API.md —
+content type (multipart/form-data), a field table (github_username,
+portfolio_url, resume_file with types and required/optional status), an
+example curl request, and the 422 error case for invalid resume file types.
+
+**Tests added or updated:**
+None — docs-only change, no testable code. Ran `make check` and
+`make test-unit` before and after to confirm no new failures (182
+pre-existing lint errors, 53 pre-existing test failures, both unrelated to
+this change).
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+**Draft PR feedback received from:** no one answered, but that's on me I asked a bit too late

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -89,3 +89,70 @@ this change).
 **Self-review confirmation:** [x] make check passes  [x] make test-unit passes
 
 **Draft PR feedback received from:** no one answered, but that's on me I asked a bit too late
+
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [x] Yes  [ ] No — still awaiting review
+
+**Summary of feedback:**
+Reviewer praised the completeness of the PR template and the specificity
+of my Testing section notes on pre-existing failures. Suggested
+improvements: make the PR title more specific, expand the Summary section
+to explain why the schema matters for developers/users, explicitly write
+"N/A — <reason>" in empty sections instead of leaving them blank, and —
+for future issues — reach out to the issue creator if the title and
+description scope mismatch, rather than silently picking one
+interpretation.
+
+**How you responded:**
+Replied on the PR thanking the reviewer, then updated the title to
+"docs: add POST /profiles body schema to API reference", expanded the
+Summary section to explain the practical impact of the missing schema on
+developers, and updated Screenshots/Demo to an explicit
+"N/A — documentation-only change, no UI or visual output to demo."
+Acknowledged the scope-mismatch suggestion for future issues.
+
+
+**What was harder than you expected?**
+Reading the output of `make check` and `make test-unit` for the first time
+was more overwhelming than I expected — 182 lint errors and 53 test
+failures looked like I had broken something, even though I'd only edited
+a markdown file. I had to learn to actually scan the output for whether
+any of it touched files I'd changed, rather than assuming a wall of red
+text meant I'd done something wrong.
+
+**What did you learn about working in a large codebase?**
+Documentation can somewhat drift from the actual code without anyone noticing. For example, the docs/API.md never mentioned that POST /profiles used multipart/form-data
+instead of JSON. I had to read the route handler
+directly rather than trusting the schema file (I assumed this would be the right place to check but it wasn't). I also learned that a codebase can carry pre-existing, unrelated failures (182 lint errors, 53 test failures) that aren't your
+responsibility to fix, just not add onto it. 
+
+**How did AI tools help — and where did they fall short?**
+Claude was really helpful for pulling the actual repo code so I didn't
+have to dig through GitHub manually, and for turning my messy notes into
+the actual PLAN.md/PR format the grader wanted. It was also good for
+walking me through git stuff step by step when I got confused (like
+auth issues when pushing, or figuring out branch tracking). Where it
+fell short is it can't actually do the investigation for me — I still
+had to be the one to read the route code, decide what the real request
+shape was, and figure out how to scope the issue myself. It also
+couldn't tell me whether make check's errors were mine or not, I had to
+actually look and compare line by line.
+
+**What would you do differently if you started over?**
+I'd actually read CONTRIBUTING.md before making my very first commit
+instead of finding out about the branch naming and commit message rules
+partway through Week 9 — my early commits weren't quite right because I
+just didn't know the convention yet. Also, when I got feedback that the
+issue mentioned two endpoints but I only did one, the reviewer pointed
+out I should've just asked the issue creator to clarify instead of
+guessing and picking one myself. I'll actually do that next time instead
+of assuming my interpretation is right.
+
+**What are you most proud of from this module?**
+Honestly just finishing. Nothing too elaborate, I'm just happy I was able
+to get through the whole thing and actually navigate all the instructions
+without giving up somewhere in the middle.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -25,3 +25,23 @@ contribution, the checklist says to stick with Tier 1, so I went back to the tra
 filtered by tier-1 and found #89. It's confined to one doc file, has a clear before/after 
 (missing schema vs. documented schema), and I confirmed the actual request body by reading 
 api/routes/profiles.py before claiming it.
+
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/AliceInWonderland61/pathreview/commit/96ebed43cdd8394b1fa270aef3e6911a2f470a7a
+
+**Reproduction summary:**
+Confirmed `docs/API.md` documents no request body schema for `POST /profiles`
+by reading `api/routes/profiles.py` — the endpoint actually expects
+`multipart/form-data` with three optional fields, one of which is a file
+upload with its own validation. Committed a note in `docs/API.md` marking
+exactly what's missing.
+
+**PLAN.md link:** https://github.com/AliceInWonderland61/pathreview/blob/docs/89-profiles-request-body-schema/PLAN.md
+
+
+**Blockers or open questions:**
+Issue #89 mentions both POST /profiles and POST /reviews, but I scoped this
+to /profiles only, matching the issue title — flagged in PLAN.md's Risks
+section.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,16 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/89
+
+**Issue title:** API reference doc is missing the POST /profiles request body schema
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The API reference doc (docs/API.md) lists the POST /profiles endpoint but only gives a one-line description with no request body details. Looking at the actual route in api/routes/profiles.py, the endpoint accepts three optional fields — github_username, portfolio_url, and resume_file — sent as multipart/form-data rather than JSON, since resume_file is a file upload. None of that is documented, so a developer reading the API reference has no way to know what to actually send without opening the code or the Swagger UI themselves. The fix is to update the POST /profiles entry in API.md to list each field, its type, whether it's optional, and the multipart/form-data content type.
+
+**Branch name:** docs/89-profiles-request-body-schema
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,97 @@
+## Solution plan
+
+**Issue:** #89 — API reference doc is missing the `POST /profiles` request body schema
+
+### Understand
+`docs/API.md` lists the `POST /profiles` endpoint with only a one-line description
+and no request body details. Looking at the actual implementation in
+`api/routes/profiles.py` (`create_profile_endpoint`), the endpoint expects
+`multipart/form-data`, not JSON, because it accepts a file upload alongside
+two form fields:
+- `github_username` (optional, string, max 255 chars)
+- `portfolio_url` (optional, string, max 500 chars)
+- `resume_file` (optional, file — must be `application/pdf`, `text/markdown`,
+  or `text/plain`, otherwise the endpoint returns 422)
+
+None of this is documented, so a developer reading `docs/API.md` has no way to
+know the endpoint takes form data with a file, what fields are expected, or
+what happens if the resume file is the wrong type. The fix is to add the full
+request body schema to the `POST /profiles` entry: field names, types,
+required/optional status, the `multipart/form-data` content type, an example
+request, and a note about the 422 case for invalid file types.
+
+**Root cause:** `docs/API.md` was never updated with request body details when
+`POST /profiles` was implemented — it only documents endpoint existence, not
+request shape, for any endpoint in the file.
+
+
+### Map
+Files I expect to touch:
+- `docs/API.md` — the `POST /profiles` entry under the "Profiles" section.
+  This is where I'll add the full request body schema, replacing my
+  reproduction comment.
+
+Files I'm using as source of truth (not editing):
+- `api/routes/profiles.py`, lines 23-30 — `create_profile_endpoint`, where
+  `github_username`, `portfolio_url`, and `resume_file` are defined as
+  `Form`/`File` parameters (lines 25-27). This is the real request shape.
+  Lines 43-51 show the 422 error raised when `resume_file`'s content type
+  isn't `application/pdf`, `text/markdown`, or `text/plain`.
+- `api/schemas/profile.py` — defines `ProfileCreate`, which looks like it
+  might be the request schema but isn't used directly for the request body
+  (the endpoint reads the form fields individually, then builds a
+  `ProfileCreate` internally at line ~76). Worth noting so I don't document
+  this model as if it were the literal request body.
+
+
+### Plan
+1. Re-read `api/routes/profiles.py` lines 23-30 and 43-51 one more time to
+   lock in exact field names, types, defaults, and the file-type validation
+   list before writing anything.
+2. Draft the `POST /profiles` doc section in `docs/API.md`: content type
+   (`multipart/form-data`), each field with its type and optional/required
+   status, matching what's in the route.
+3. Add an example request showing all three fields, including a realistic
+   filename for `resume_file`.
+4. Document the 422 error case: what triggers it (invalid file MIME type)
+   and what the response looks like.
+5. Remove my reproduction comment and proofread the final section against
+   the route one more time to check for drift.
+
+### Inputs & outputs
+**File I'm changing:** `docs/API.md`
+
+**Input to my change:** the actual behavior of `create_profile_endpoint` in
+`api/routes/profiles.py` — I'm not changing any code, just documenting what
+already exists.
+
+**Output:** an updated `POST /profiles` section in `docs/API.md` containing:
+- Content type: `multipart/form-data`
+- Field list: `github_username` (optional, string, max 255), `portfolio_url`
+  (optional, string, max 500), `resume_file` (optional, file — PDF, Markdown,
+  or plain text)
+- An example request
+- A note on the 422 response when `resume_file`'s type is invalid
+
+### Risks & unknowns
+1. **Scoping to /profiles only.** Issue #89 mentions both `POST /profiles`
+   and `POST /reviews`, but my JOURNAL.md and this plan only cover
+   `/profiles`, matching the issue title. Flagging this so it reads as a
+   deliberate choice, not a missed requirement.
+2. **Doc formatting consistency.** `docs/API.md` currently has a very sparse
+   style (one-line descriptions, no schemas anywhere). I'm not sure how
+   detailed to make the new section without it looking out of place next to
+   the other entries — I'll check if there's a formatting convention in
+   `docs/CONTRIBUTING.md` before finalizing.
+3. **Example values.** I need to pick a realistic example for `resume_file`
+   (filename, maybe a fake GitHub username) — nothing in the codebase gives
+   me a canonical example to copy, so I'm making a reasonable one up.
+
+### Edge cases
+- All fields optional means a technically valid request could send an empty
+  body — worth noting in the docs so readers don't assume something is
+  required when it isn't.
+- `resume_file` omitted entirely: profile still gets created, just without
+  resume text/filename.
+- `resume_file` present but wrong MIME type (not PDF/Markdown/plain text):
+  422 response, documented separately from the happy path.

--- a/docs/API.md
+++ b/docs/API.md
@@ -35,6 +35,8 @@ curl -X POST http://localhost:8000/profiles \
 
 **Errors:**
 - `422 Unprocessable Entity` — returned if `resume_file` is provided but is not a PDF, Markdown, or plain text file.
+
+
 `GET /profiles/{profile_id}` — Retrieve a profile.
 `DELETE /profiles/{profile_id}` — Delete a profile and associated data.
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -16,14 +16,25 @@ Base URL: `http://localhost:8000`
 ### Profiles
 
 `POST /profiles` — Create a profile with resume and GitHub username.
-<!-- REPRODUCTION NOTE (Issue #89): No request body schema documented.
-Actual endpoint (api/routes/profiles.py, create_profile_endpoint) expects
-multipart/form-data with:
-  - github_username (optional, string, max 255)
-  - portfolio_url (optional, string, max 500)
-  - resume_file (optional, file — must be application/pdf, text/markdown,
-    or text/plain, else 422)
-This will be replaced with the full documented schema below. -->
+**Request:** `multipart/form-data`
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `github_username` | string | optional | max 255 characters |
+| `portfolio_url` | string | optional | max 500 characters |
+| `resume_file` | file | optional | must be `application/pdf`, `text/markdown`, or `text/plain` |
+
+**Example request:**
+```bash
+curl -X POST http://localhost:8000/profiles \
+  -H "Authorization: Bearer <token>" \
+  -F "github_username=octocat" \
+  -F "portfolio_url=https://octocat.dev" \
+  -F "resume_file=@resume.pdf"
+```
+
+**Errors:**
+- `422 Unprocessable Entity` — returned if `resume_file` is provided but is not a PDF, Markdown, or plain text file.
 `GET /profiles/{profile_id}` — Retrieve a profile.
 `DELETE /profiles/{profile_id}` — Delete a profile and associated data.
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -16,6 +16,14 @@ Base URL: `http://localhost:8000`
 ### Profiles
 
 `POST /profiles` — Create a profile with resume and GitHub username.
+<!-- REPRODUCTION NOTE (Issue #89): No request body schema documented.
+Actual endpoint (api/routes/profiles.py, create_profile_endpoint) expects
+multipart/form-data with:
+  - github_username (optional, string, max 255)
+  - portfolio_url (optional, string, max 500)
+  - resume_file (optional, file — must be application/pdf, text/markdown,
+    or text/plain, else 422)
+This will be replaced with the full documented schema below. -->
 `GET /profiles/{profile_id}` — Retrieve a profile.
 `DELETE /profiles/{profile_id}` — Delete a profile and associated data.
 


### PR DESCRIPTION
## Summary
<!-- One paragraph describing what this PR does and why --> This Pull Request adds the missing request body schema for `POST /profiles` to the docs/API.md

## Issue
Closes #89 

## Changes
<!-- Bullet list of the specific changes made -->

- docs/API.md: I added a request schema table which included the field names, types, required/optional status, an example curl request. and the 422 error case for when there is an invalid resume file types for the POST /profiles entry



## Testing
<!-- How did you verify your changes? -->
The was a change is the `docs/API.md` so no code was modified or edited. I ran a `make check` and the `make test-unit` before I did any modifications and I ran it once more once I edited the `docs/API.md` just to make sure no new failures occurred.
- [x] Unit tests pass (`make test-unit`)- there are 53 pre-existing failures that currently exist but they are not related to the changes I made on the `docs/API.md`
- [ ] Integration tests pass (`make test-integration`)- Didn't run this one since I didn't change any code 
- [x] Linter passes (`make lint`)-there are 182 pre-existing errors that were not relevant to the change I made. 
- [ ] Type checker passes (`make typecheck`)- Didn't run this one either since no code was modified 
- [x] New/updated tests cover the changes

## Screenshots / Demo
<!-- If applicable, add screenshots or a link to a demo video -->

## Notes for Reviewers
<!-- Anything the reviewer should pay particular attention to -->
I noticed that for Issue #89 it mentions both the `POST /profiles` and the `POST /reviews`, but since the title only mentions the profiles that's the issue I solved for. 
