### PR TITLE
test: extend README scorer fixture to legitimately reach comprehensive word count

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -55,14 +55,9 @@ I chose this issue because it is small, well-defined, and only involves updating
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** 
+**Reproduction commit link:** https://github.com/SarahMa12/pathreview/commit/7762bc7bbaee1e4376746b28e08b5485b1b90c85
 
 **Reproduction summary:**
 Ran `.venv/bin/pytest tests/unit/test_readme_scorer.py -v -k test_readme_with_all_quality_signals` locally and confirmed the test fails every time: the inline fixture README is only 51 words, so `assert data["word_count"] > 100` fails immediately  before the test even reaches the `word_count_category == "comprehensive"` check. Scorer output (`category=minimal score=0.87 word_count=51`) confirms the scoring logic itself is working correctly.
 
-**PLAN.md link:** [link to PLAN.md in your fork]
-
-**Walkthrough video (recommended):** [link to your Loom video, ≤2 min — recommended, not graded]
-
-**Blockers or open questions:**
-[Anything you're still uncertain about going into Week 9, or leave blank]
+**PLAN.md link:** https://github.com/SarahMa12/pathreview/blob/test/156-extend-readme-fixture-word-count/PLAN.md

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -74,3 +74,22 @@ Add tests for the exact word count boundaries (0, 1, 99, 100, 499, 500, 501, and
 
 **Blockers:**
 None.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/832
+
+**Branch:** `test/156-extend-readme-fixture-word-count`
+
+**What you built:**
+The test `test_readme_with_all_quality_signals` expected the README fixture to be over 100 words and classified as `"comprehensive"`, but the fixture was only about 50 words, so the test failed even though the scoring logic was correct. I expanded the fixture to over 500 words so it meets the scorer's "comprehensive" threshold while still including all the quality signals the test checks (installation, usage, badges, demo link, and tech stack). No production code was changed.
+
+**Tests added or updated:**
+Updated only `tests/unit/test_readme_scorer.py` by expanding the README fixture from about 50 words to over 500 words. I didn't have time to add the planned boundary tests (0, 1, 99, 100, 499, 500, 501, and 1000 words), so that can be done in a future PR.
+
+**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+These aren't fully passing on this branch because there are existing unrelated issues (`make lint`, `make typecheck`, and `make test-unit`). However, `tests/unit/test_readme_scorer.py` passes all 23 tests.
+
+**Draft PR feedback received from:** None

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -61,3 +61,16 @@ I chose this issue because it is small, well-defined, and only involves updating
 Ran `.venv/bin/pytest tests/unit/test_readme_scorer.py -v -k test_readme_with_all_quality_signals` locally and confirmed the test fails every time: the inline fixture README is only 51 words, so `assert data["word_count"] > 100` fails immediately  before the test even reaches the `word_count_category == "comprehensive"` check. Scorer output (`category=minimal score=0.87 word_count=51`) confirms the scoring logic itself is working correctly.
 
 **PLAN.md link:** https://github.com/SarahMa12/pathreview/blob/test/156-extend-readme-fixture-word-count/PLAN.md
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+I completed the fix in `PLAN.md` by expanding the README test fixture in `tests/unit/test_readme_scorer.py` from about 50 words to over 500 words. I kept all the existing quality signals, including the installation and usage code blocks, badges, demo link, and tech stack, while adding more realistic content. I ran `tests/unit/test_readme_scorer.py`, and all 23 tests now pass. The previously failing test now reports a `"comprehensive"` word count category with a score of over 0.99.
+
+**Next steps:**
+Add tests for the exact word count boundaries (0, 1, 99, 100, 499, 500, 501, and 1000 words) to make sure the scorer correctly classifies README files as `"minimal"`, `"adequate"`, or `"comprehensive"` at each cutoff. After that, open the PR with the reproduction and plan links from Weeks 7–8 and include this fix.
+
+**Blockers:**
+None.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,54 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/156
+
+**Issue title:** README scorer test fixture is too short for its own word-count assertion
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:** The test test_readme_with_all_quality_signals in tests/unit/test_readme_scorer.py uses an inline fixture README that contains only ~51 words, but asserts word_count > 100 and word_count_category == "comprehensive". Looking at the scoring logic in agent/tools/readme_scorer.py, word counts are bucketed as "minimal" (<100), "adequate" (<500), or "comprehensive" (≥500), so the fixture actually needs to reach at least 500 words, not just past 100, for the assertion to hold. Currently the test fails not because of a scorer bug, but because the fixture content doesn't match what the assertions claim to validate. A successful fix extends the fixture README with enough realistic prose/content (while keeping all the quality signals: installation, usage, badges, demo link, tech stack) to legitimately cross the 500-word "comprehensive" threshold, so the test exercises the intended code path instead of asserting against under-sized input. This only touches the test fixture in tests/unit/test_readme_scorer.py—no production code in agent/tools/readme_scorer.py needs to change.
+
+**Branch name:** test/156-extend-readme-fixture-word-count
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger
+
+## Is This Issue Right for Me? Checklist
+
+### Part 1 — Understanding the Issue
+
+- [x] **I can explain the problem and the expected behavior in 2–3 sentences without reading the issue.**
+  The test `test_readme_with_all_quality_signals` expects the sample README to have a high word count and be classified as `"comprehensive"`. However, the README fixture only has about 51 words, so it does not meet the scorer's requirements. The scoring logic is working correctly—the test data just needs to be updated.
+
+- [x] **I've located the relevant files and confirmed they exist in the codebase.**
+  I found both `tests/unit/test_readme_scorer.py`, which contains the failing test, and `agent/tools/readme_scorer.py`, which contains the README scoring logic.
+
+- [x] **I can describe a concrete before-and-after.**
+  Before, the test fails because the README fixture is too short to be considered `"comprehensive"`. After extending the fixture to more than 500 words, the test should pass while correctly testing the intended behavior.
+
+### Part 2 — Tier Fit
+
+- [x] **Tier is a realistic match for where I am.** Selected **Tier 1**.
+  This issue only requires updating a test fixture in one file without changing any production code, so it fits the scope of a Tier 1 task.
+
+### Part 3 — Codebase Readiness
+
+- [x] **I've found and read the specific code the issue references.**
+  I read the `_score_readme` function in `agent/tools/readme_scorer.py` and confirmed that a README needs at least 500 words to be classified as `"comprehensive"`.
+
+- [x] **I understand the surrounding code well enough to write a rough plan.**
+  My plan is to expand the README fixture so it passes the 500-word threshold while keeping the existing sections, badges, demo link, and other content the test already checks.
+
+- [x] **I've read the relevant test file, end-to-end for at least one test.**
+  I read the `TestReadmeScorer` test file, including the failing test and the other word-count tests, to understand how the scorer is expected to behave.
+
+### Part 4 — Scope and Time
+
+- [x] **Claims/crowding check.** I didn't find any open blockers or competing work on the issue.
+- [x] **Scope is realistic for Weeks 8–9.** This should take about 1–2 hours since it's only a test fixture update and running the tests afterward.
+- [x] **No open blockers or dependencies.** The issue can be completed independently.
+
+### Selection Notes — Scope Reasoning
+
+I chose this issue because it is small, well-defined, and only involves updating a test fixture instead of modifying the actual scoring logic since this is my first time. The main thing to watch out for is making sure the README reaches the correct 500-word threshold, since adding just enough words to get over 100 would still cause the test to fail.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -52,3 +52,17 @@
 ### Selection Notes — Scope Reasoning
 
 I chose this issue because it is small, well-defined, and only involves updating a test fixture instead of modifying the actual scoring logic since this is my first time. The main thing to watch out for is making sure the README reaches the correct 500-word threshold, since adding just enough words to get over 100 would still cause the test to fail.
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** 
+
+**Reproduction summary:**
+Ran `.venv/bin/pytest tests/unit/test_readme_scorer.py -v -k test_readme_with_all_quality_signals` locally and confirmed the test fails every time: the inline fixture README is only 51 words, so `assert data["word_count"] > 100` fails immediately  before the test even reaches the `word_count_category == "comprehensive"` check. Scorer output (`category=minimal score=0.87 word_count=51`) confirms the scoring logic itself is working correctly.
+
+**PLAN.md link:** [link to PLAN.md in your fork]
+
+**Walkthrough video (recommended):** [link to your Loom video, ≤2 min — recommended, not graded]
+
+**Blockers or open questions:**
+[Anything you're still uncertain about going into Week 9, or leave blank]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -93,3 +93,34 @@ Updated only `tests/unit/test_readme_scorer.py` by expanding the README fixture 
 These aren't fully passing on this branch because there are existing unrelated issues (`make lint`, `make typecheck`, and `make test-unit`). However, `tests/unit/test_readme_scorer.py` passes all 23 tests.
 
 **Draft PR feedback received from:** None
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+n/a
+
+**How you responded:**
+n/a
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Even though the fix was small and only changed one file, understanding the codebase took longer than I expected. There were a lot of folders and files, so it wasn't clear which ones mattered. I started with the failing test, followed it to the scoring code, and made sure nothing else depended on the same logic before making any changes.
+
+**What did you learn about working in a large codebase?**
+I learned that it's better to start with the failing test instead of trying to understand the whole project. Following the error message and searching for specific code helped me find the right files much faster. Running the test first also showed me that the scoring code was correct and the test data was the real problem. Reading the rest of the test file helped me understand the pattern and avoid breaking other tests.
+
+**How did AI tools help — and where did they fall short?**
+AI helped me find the right files and explain how the scoring worked, which saved a lot of time. It also helped me write the longer README fixture once I knew what was needed. However, I still had to decide whether the issue was really just a test problem, make sure the new fixture made sense, and run the tests myself to confirm everything worked.
+
+**What would you do differently if you started over?**
+I would spend less time trying to understand the entire codebase and instead focus on the failing test right away. I would also add the boundary-value tests during the same PR instead of leaving them for later.
+
+**What are you most proud of from this module?**
+I'm most proud of completing my first "real" pull request in someone else's production codebase. I found the real cause of the problem, kept the fix small and focused, and successfully fixed the issue without changing the production code.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,34 @@
+## Solution plan
+
+**Issue:** [README scorer test fixture is too short for its own word-count assertion](https://github.com/ascherj/pathreview/issues/156)
+
+### Understand
+`test_readme_with_all_quality_signals` in `tests/unit/test_readme_scorer.py` asserts `word_count > 100` and `word_count_category == "comprehensive"`, but its inline fixture README is only 51 words. The logic in `agent/tools/readme_scorer.py`, `word_count_category` is `"minimal"` if it is below 100 words, `"adequate"` from 100–499 words, and `"comprehensive"` only at 500+ words. So the fixture needs 500+ words, not just over 100, for the assertion to pass. Expected: test passes and meets the "comprehensive" path. Actual: test fails at `assert data["word_count"] > 100` (currently 51), so the "comprehensive" branch is never even reached.
+
+### Map
+- `tests/unit/test_readme_scorer.py` (`test_readme_with_all_quality_signals`), update the README test fixture (only file I except to change).
+- `agent/tools/readme_scorer.py` (`ReadmeScorer._score_readme`) reference only to confirm the 500-word requirement and the patterns for installation, usage, badges, demo link, and tech stack.
+
+### Plan
+1. Add more realistic content to the README fixture so it is over 500 words.
+2. Keep all the existing sections that the test checks, including:
+    -  ## Installation with a code block
+    - ## Usage with a code block
+    - badges (![...](...))
+    - ## Tech Stack
+    - a demo link ([Try it here](...))
+3. Run `.venv/bin/pytest tests/unit/test_readme_scorer.py -v -k test_readme_with_all_quality_signals` to make sure that test passes.
+4. Run the full `tests/unit/test_readme_scorer.py` file to make sure the other README scorer tests still pass.
+5. Check that the overall score is still above `0.7` now that the README gets full credit for being over 500 words.
+
+### Inputs & outputs
+- Input: The README string inside `test_readme_with_all_quality_signals`.
+- Output: A longer README fixture (500+ words) with the same sections and formatting. No changes to `agent/tools/readme_scorer.py`.
+
+### Risks & unknowns
+- Adding too much new formatting or extra headings could accidentally stop one of the regex checks from matching, so most of the added content should just be normal paragraphs.
+- If the README ends up just under 500 words, the test could still fail. Aim for around 550 words to leave some room for future edits.
+
+### Edge cases
+- Count words the same way the scorer does by using whitespace-separated words (`str.split()`).
+- Keep the existing Markdown format, including code blocks and bullet lists, since they already work with the scorer.

--- a/PLAN.md
+++ b/PLAN.md
@@ -12,10 +12,10 @@
 ### Plan
 1. Add more realistic content to the README fixture so it is over 500 words.
 2. Keep all the existing sections that the test checks, including:
-    -  ## Installation with a code block
-    - ## Usage with a code block
+    - Installation with a code block
+    - Usage with a code block
     - badges (![...](...))
-    - ## Tech Stack
+    - Tech Stack
     - a demo link ([Try it here](...))
 3. Run `.venv/bin/pytest tests/unit/test_readme_scorer.py -v -k test_readme_with_all_quality_signals` to make sure that test passes.
 4. Run the full `tests/unit/test_readme_scorer.py` file to make sure the other README scorer tests still pass.

--- a/tests/unit/test_readme_scorer.py
+++ b/tests/unit/test_readme_scorer.py
@@ -18,34 +18,90 @@ class TestReadmeScorer:
         """Test README with all quality signals returns high score."""
         readme = """
         # Project Name
-        A comprehensive project description.
+
+        ![Build Status](https://example.com/badge.svg)
+        ![Coverage](https://example.com/coverage.svg)
+
+        A comprehensive project description. This project is a full-stack
+        application designed to help developers track, review, and improve
+        the quality of their open source contributions over time. It began
+        as a small internal tool and has grown into a project used by
+        several teams to standardize how code reviews are performed across
+        many repositories. The goal is to give contributors fast, actionable
+        feedback on documentation, test coverage, and overall code health so
+        that they can spend less time on manual review and more time on
+        writing good software.
+
+        The application is built around a simple idea: most of the friction
+        in code review comes from inconsistent expectations. By automating
+        the parts of review that can be automated, such as checking whether
+        a README has the right sections, whether tests exist, and whether
+        the code style matches project conventions, reviewers can focus
+        their attention on the parts of a change that actually require
+        human judgment. This has proven to be a valuable approach in
+        practice, since many pull requests are held up on things that could
+        have been caught automatically.
 
         ## Installation
+        Clone the repository and install the dependencies using the command
+        below. The setup process only takes a couple of minutes on a modern
+        machine and works on macOS, Linux, and Windows through WSL.
         ```bash
+        git clone https://example.com/project.git
+        cd project
         pip install package
         ```
 
         ## Usage
+        Once installed, you can run the tool from the command line. The
+        example below shows a minimal quickstart that scores a single
+        repository, but the tool also supports batch mode for scoring many
+        repositories at once.
         ```python
         import package
         package.run()
         ```
 
         ## Features
-        - Feature 1
-        - Feature 2
-        - Feature 3
+        - Feature 1: Automated README quality scoring, including checks for
+          installation instructions, usage examples, and badges.
+        - Feature 2: Test coverage analysis that reports which modules are
+          missing meaningful test coverage.
+        - Feature 3: Code style and linting checks that run automatically
+          on every pull request.
+        - Feature 4: A dashboard that summarizes review history so teams
+          can see trends in code quality over time.
 
         ## Tech Stack
+        This project is built with a modern, well-supported technology
+        stack chosen for reliability and ease of contribution.
         - Python 3.9
         - FastAPI
         - PostgreSQL
+        - React for the frontend dashboard
+        - Docker for local development and deployment
 
-        ![Build Status](https://example.com/badge.svg)
-        ![Coverage](https://example.com/coverage.svg)
+        ## Contributing
+        Contributions are welcome from developers of all experience levels.
+        Please open an issue before starting work on a large change so that
+        the maintainers can provide feedback on the approach. Smaller fixes,
+        such as documentation improvements or bug fixes, can be submitted
+        directly as a pull request.
 
         ## Live Demo
-        [Try it here](https://demo.example.com)
+        [Try it here](https://demo.example.com) to see the dashboard in
+        action with a set of sample repositories already scored.
+
+        ## Roadmap
+        Planned improvements include support for additional languages
+        beyond Python and JavaScript, deeper integration with continuous
+        integration providers, and a plugin system that allows teams to
+        define their own custom scoring rules. Feedback from early adopters
+        has been overwhelmingly positive, and the maintainers are actively
+        looking for contributors interested in helping shape the next set
+        of features. If you have ideas for how this project could better
+        support your team's workflow, please open a discussion thread so it
+        can be considered for a future release.
         """
 
         result = scorer.execute({"readme_content": readme})
@@ -157,9 +213,10 @@ class TestReadmeScorer:
 
         result = scorer.execute({"readme_content": readme})
         # "Getting Started" matches the pattern
-        assert result.data["has_installation_section"] is True or result.data[
-            "has_usage_section"
-        ] is True
+        assert (
+            result.data["has_installation_section"] is True
+            or result.data["has_usage_section"] is True
+        )
 
     def test_quickstart_counts_as_usage(self, scorer):
         """Test that 'quickstart' counts as usage."""
@@ -218,7 +275,8 @@ class TestReadmeScorer:
 
     def test_overall_score_calculation(self, scorer):
         """Test that overall score aggregates components."""
-        readme = """
+        readme = (
+            """
         # Good README
 
         ## Installation
@@ -233,7 +291,9 @@ class TestReadmeScorer:
         ![Build](https://example.com/build.svg)
 
         This readme has lots of content here.
-        """ * 3  # Make it comprehensive
+        """
+            * 3
+        )  # Make it comprehensive
 
         result = scorer.execute({"readme_content": readme})
 


### PR DESCRIPTION
## Summary
**test_readme_with_all_quality_signals** was failing because its inline README fixture only had about 50 words, even though the test expected it to be classified as comprehensive. I expanded the fixture to over 500 words while keeping all of the quality signals (installation, usage, badges, demo link, and tech stack) the test checks.

## Issue
Closes #156

## Changes
The README scorer classifies READMEs as:

- Minimal: fewer than 100 words
- Adequate: 100–499 words
- Comprehensive: 500+ words

The test fixture only had about 50 words, so it was always classified as minimal and failed before it could test the comprehensive case.

Changes made:

- Expanded the inline README fixture in tests/unit/test_readme_scorer.py to over 500 words.

## Testing
<!-- How did you verify your changes? -->
- [x] Unit tests pass (`make test-unit`): Not fully clean, but pytest tests/unit/test_readme_scorer.py -v passes all 23 tests, including the previously failing test_readme_with_all_quality_signals. make test-unit still has 52 pre-existing failures in unrelated modules.
- [ ] Integration tests pass (`make test-integration`)
- [ ] Linter passes (`make lint`)
- [ ] Type checker passes (`make typecheck`)
- [ ] New/updated tests cover the changes

Manual reproduction:
1. Check out the commit before this fix (or stash this change).
2. Run **pytest tests/unit/test_readme_scorer.py -v -k test_readme_with_all_quality_signals**
3. The test fails because the README fixture only has 51 words, so it's classified as minimal. 
4. Restore this change.
5. Run the same command again. The test passes because the fixture is now over 500 words and is classified as comprehensive.

## Screenshots / Demo
Not applicable. This change only updates test data, so the only visible difference is that the test now passes.

## Notes for Reviewers
**make check** and **make test-unit** still fail because of existing issues unrelated to this change.

- **make check** reports pre-existing lint errors in other files.
- **make test-unit** has pre-existing failures in unrelated test modules.
- **tests/unit/test_readme_scorer.py** passes all 23 tests.

Also, there are unrelated unstaged changes to **Makefile** and **frontend/package-lock.json**. Those should be kept out of this PR so it only contains the README fixture update.
