### PR TITLE
fix(agent): persist state across API restarts

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -21,3 +21,24 @@ I reviewed the issue scope and confirmed that the affected area is mainly the ag
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:**
+(To be added after pushing this commit.)
+
+**Reproduction summary:**
+
+I ran the application locally and traced the complete review workflow. By inspecting the orchestrator and session store, I found that session state is loaded before execution but saved only after all tools complete. This means intermediate progress may be lost if the API restarts before the final save.
+
+**PLAN.md link:**
+(To be added after pushing.)
+
+**Walkthrough video (recommended):**
+Not recorded.
+
+**Blockers or open questions:**
+
+I still need to verify the best checkpoint strategy and whether completed tools should be skipped when resuming a saved session.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,23 @@
+# JOURNAL.md
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/47
+
+**Issue title:** Agent state isn't persisted across API restarts
+
+**Tier:** [ ] Tier 1  [ ] Tier 2  [x] Tier 3
+
+**Problem summary:**
+
+The agent currently stores its state only in memory while it is processing a review. If the API server restarts, the running review loses its progress and has to start over. This issue affects the agent orchestration and state management components, where the workflow state is not persisted. A successful fix will save the agent's progress so long-running reviews can continue after a restart instead of starting over.
+
+**Issue selection reasoning:**
+
+I reviewed the issue scope and confirmed that the affected area is mainly the agent orchestration and state management code. The issue is larger than a small bug because it may require persistence, restart recovery, and tests, but the expected behavior is clearly described. I am comfortable working with Python backend code and Redis, and I can divide the work into smaller steps such as understanding the current state flow, adding persistence, and testing recovery after a restart. Although it is a Tier 3 issue, I believe it is challenging but realistic within the Module 3 timeline.
+
+**Branch name:** fix/47-agent-state-persistence
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -98,3 +98,43 @@ The repository contains pre-existing unrelated mypy errors and failing unit test
 **Draft PR feedback received from:**
 
 None
+
+
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+
+No reviewer or maintainer feedback was received before the end of the module. My pull request remains open for future review.
+
+**How you responded:**
+
+N/A
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+
+I expected writing the code to be the hardest part, but it wasn't. The hardest part was understanding a codebase that someone else had written. At first, I couldn't even tell where the review process started or how the orchestrator, session store, and different tools were connected. I spent a lot more time reading code and tracing the execution flow than actually writing my solution. Once I understood the flow, the implementation itself felt much more manageable.
+
+**What did you learn about working in a large codebase?**
+
+When I work on my own projects, I already know why every file exists because I created it. Here, I had to understand other people's design decisions before making any changes. I learned that it's important not to jump into coding immediately. Spending time reading the existing code, looking at related modules, and understanding how everything fits together saves a lot of time later and reduces the chances of breaking something unintentionally.
+
+**How did AI tools help — and where did they fall short?**
+
+AI helped me understand unfamiliar code much faster. It was useful for explaining classes, suggesting where to look next, and helping me think through different implementation ideas. But it couldn't tell me the correct solution just by looking at the issue. I still had to verify everything against the actual codebase, understand why the bug existed, and decide whether a suggested change really fit the existing architecture.
+
+**What would you do differently if you started over?**
+
+I would spend the first day just exploring the codebase instead of trying to solve the issue immediately. I also think I chose a fairly challenging Tier 3 issue for my first open source contribution. Even though I managed to complete it, I underestimated how much time it would take just to understand the existing system. Next time, I would plan more time for reading and debugging before writing any code.
+
+**What are you most proud of from this module?**
+
+I'm most proud that I didn't give up when the project felt overwhelming at the beginning. There were times when I was confused about how everything connected, but by breaking the problem into smaller pieces, I was able to understand the workflow, implement the fix, write tests, and submit a real pull request. That gave me much more confidence about contributing to codebases that I didn't build myself.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -27,18 +27,74 @@ I reviewed the issue scope and confirmed that the affected area is mainly the ag
 ## Week 8 — Reproduction & solution planning
 
 **Reproduction commit link:**
-(To be added after pushing this commit.)
+https://github.com/GargiBhise/pathreview/commit/c17a60d
 
 **Reproduction summary:**
 
 I ran the application locally and traced the complete review workflow. By inspecting the orchestrator and session store, I found that session state is loaded before execution but saved only after all tools complete. This means intermediate progress may be lost if the API restarts before the final save.
 
 **PLAN.md link:**
-(To be added after pushing.)
+https://github.com/GargiBhise/pathreview/blob/fix/47-agent-state-persistence/PLAN.md
 
 **Walkthrough video (recommended):**
 Not recorded.
 
 **Blockers or open questions:**
+No blockers. The implementation was completed and submitted as PR #834.
 
-I still need to verify the best checkpoint strategy and whether completed tools should be skipped when resuming a saved session.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+
+- Investigated the orchestrator flow and identified where session state is loaded and persisted.
+- Implemented checkpoint-based session persistence after each successful tool execution.
+- Verified that previously completed tool results can be restored from the session store.
+
+**Next steps:**
+
+- Add unit tests for checkpointing and resume behavior.
+- Run validation checks.
+- Open the pull request and update documentation.
+
+**Blockers:**
+
+The repository contains pre-existing mypy errors and unrelated failing unit tests that are outside the scope of this issue.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:**
+
+https://github.com/ascherj/pathreview/pull/834
+
+**Branch:**
+
+`fix/47-agent-state-persistence`
+
+**What you built:**
+
+Implemented incremental session checkpointing so completed tool results are saved after each successful tool execution. When the API restarts, the orchestrator restores the saved session state and skips tools that have already completed, allowing the workflow to resume instead of restarting from the beginning.
+
+**Tests added or updated:**
+
+Created `tests/unit/test_orchestrator.py` covering:
+
+- checkpoint persistence after successful tool execution
+- restoring completed tools from session state
+- execution without a session store
+
+**Self-review confirmation:**
+
+- [x] Focused orchestrator unit tests pass
+- [x] Ruff checks pass
+- [x] Python syntax validation passes
+
+The repository contains pre-existing unrelated mypy errors and failing unit tests that were not introduced by this PR.
+
+**Draft PR feedback received from:**
+
+None

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,61 @@
+# Solution Plan
+
+**Issue:** Issue #47 - Agent state isn't persisted across API restarts
+(Link: <PASTE_GITHUB_ISSUE_LINK>)
+
+## Understand
+
+The orchestrator loads existing session state from Redis before executing tools, but it only saves the updated session after all tools finish executing.
+
+If the API restarts during execution, completed tool results remain only in memory and are lost before they are written to Redis. The workflow cannot resume from where it stopped.
+
+Expected behavior:
+- Completed tool results should be checkpointed and survive an API restart.
+- The orchestrator should resume instead of restarting the entire workflow.
+
+Actual behavior:
+- Session state is written only after all tools complete.
+- Intermediate progress may be lost if the process stops before the final save.
+
+## Map
+
+Files involved:
+
+- `agent/orchestrator.py`
+  - `Orchestrator.run()`
+- `agent/memory/session_store.py`
+- `agent/memory/context_manager.py`
+- Orchestrator tests (existing or new)
+
+## Plan
+
+1. Add a test that simulates an interrupted workflow.
+2. Save session state after each successful tool execution.
+3. Skip tools whose results already exist in Redis.
+4. Verify the workflow resumes correctly after restart.
+
+## Inputs & Outputs
+
+Inputs:
+- profile_id
+- profile_data
+- existing Redis session
+
+Outputs:
+- checkpointed session after each completed tool
+- resumed workflow after restart
+- final review containing all completed tool results
+
+## Risks & Unknowns
+
+- Additional Redis writes may affect performance.
+- Some tool results may not be JSON serializable.
+- Need to determine how failed tools should behave after restart.
+
+## Edge Cases
+
+- Redis unavailable
+- Missing session
+- Corrupted session
+- Partial execution
+- Multiple reviews for the same profile

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,7 +1,7 @@
 # Solution Plan
 
 **Issue:** Issue #47 - Agent state isn't persisted across API restarts
-(Link: <PASTE_GITHUB_ISSUE_LINK>)
+Link: https://github.com/ascherj/pathreview/issues/47
 
 ## Understand
 

--- a/agent/orchestrator.py
+++ b/agent/orchestrator.py
@@ -1,12 +1,12 @@
 """Plan-execute orchestrator for agent tools."""
 
 import time
-import structlog
-from typing import Optional
 
-from .memory.session_store import SessionStore
-from .memory.context_manager import ContextManager
+import structlog
+
 from .error_handling import retry_with_backoff
+from .memory.context_manager import ContextManager
+from .memory.session_store import SessionStore
 
 logger = structlog.get_logger()
 
@@ -14,8 +14,9 @@ logger = structlog.get_logger()
 class Orchestrator:
     """Orchestrate tool execution with planning and memoization."""
 
-    def __init__(self, tools: dict, session_store: Optional[SessionStore] = None,
-                 tool_timeout: float = 30.0):
+    def __init__(
+        self, tools: dict, session_store: SessionStore | None = None, tool_timeout: float = 30.0
+    ):
         """Initialize orchestrator.
 
         Args:
@@ -48,31 +49,52 @@ class Orchestrator:
         if self.session_store:
             session_state = self.session_store.get(profile_id) or {}
 
-        # Execute plan
-        results = {}
+        # Execute plan, starting with any restored results
+        results = dict(session_state)
+
         for tool_name, tool_input in plan:
+            if tool_name in session_state:
+                logger.info(
+                    "tool_restored_from_session",
+                    tool=tool_name,
+                    profile_id=profile_id,
+                )
+                continue
+
             try:
                 result = self._execute_tool(tool_name, tool_input)
-                results[tool_name] = result.data if hasattr(result, 'data') else result
+                results[tool_name] = result.data if hasattr(result, "data") else result
 
-                logger.info("tool_executed", tool=tool_name, success=True)
+                if self.session_store:
+                    session_state[tool_name] = results[tool_name]
+                    self.session_store.set(
+                        profile_id,
+                        dict(session_state),
+                    )
+
+                logger.info(
+                    "tool_executed",
+                    tool=tool_name,
+                    success=True,
+                )
 
             except Exception as e:
-                logger.error("tool_execution_failed", tool=tool_name, error=str(e))
-                results[tool_name] = {"error": str(e), "success": False}
+                logger.error(
+                    "tool_execution_failed",
+                    tool=tool_name,
+                    error=str(e),
+                )
+                results[tool_name] = {
+                    "error": str(e),
+                    "success": False,
+                }
 
-        # Persist state
-        if self.session_store:
-            session_state.update(results)
-            self.session_store.set(profile_id, session_state)
-
-        logger.info("orchestrator_complete", profile_id=profile_id,
-                   tools_executed=len(results))
+        logger.info("orchestrator_complete", profile_id=profile_id, tools_executed=len(results))
 
         return {
             "profile_id": profile_id,
             "tool_results": results,
-            "cached_results": self.context_manager.get_all_results()
+            "cached_results": self.context_manager.get_all_results(),
         }
 
     def _build_plan(self, profile_data: dict) -> list[tuple[str, dict]]:
@@ -90,45 +112,42 @@ class Orchestrator:
         if profile_data.get("github_username"):
             for project in profile_data.get("projects", []):
                 if project.get("github_repo"):
-                    plan.append((
-                        "github_tool",
-                        {
-                            "github_username": profile_data["github_username"],
-                            "repo_name": project["github_repo"]
-                        }
-                    ))
+                    plan.append(
+                        (
+                            "github_tool",
+                            {
+                                "github_username": profile_data["github_username"],
+                                "repo_name": project["github_repo"],
+                            },
+                        )
+                    )
                     break  # Only process first repo for now
 
         # Tech detector (if files available)
         if profile_data.get("files"):
-            plan.append((
-                "tech_detector",
-                {"files": profile_data["files"]}
-            ))
+            plan.append(("tech_detector", {"files": profile_data["files"]}))
 
         # README scorer
         if profile_data.get("readme_content"):
-            plan.append((
-                "readme_scorer",
-                {"readme_content": profile_data["readme_content"]}
-            ))
+            plan.append(("readme_scorer", {"readme_content": profile_data["readme_content"]}))
 
         # Skill extractor
         if profile_data.get("resume_text"):
-            plan.append((
-                "skill_extractor",
-                {
-                    "resume_text": profile_data["resume_text"],
-                    "repo_metadata": profile_data.get("repo_metadata", {})
-                }
-            ))
+            plan.append(
+                (
+                    "skill_extractor",
+                    {
+                        "resume_text": profile_data["resume_text"],
+                        "repo_metadata": profile_data.get("repo_metadata", {}),
+                    },
+                )
+            )
 
         # Market analyzer (if skills detected)
         if plan:  # Only if other tools executed
-            plan.append((
-                "market_analyzer",
-                {"detected_skills": {}}  # Will be populated by context
-            ))
+            plan.append(
+                ("market_analyzer", {"detected_skills": {}})  # Will be populated by context
+            )
 
         logger.info("plan_built", plan_size=len(plan))
         return plan
@@ -172,7 +191,7 @@ class Orchestrator:
             logger.error("tool_execution_error", tool=tool_name, error=str(e))
             raise
 
-    def _execute_with_timeout(self, tool, tool_input: dict, timeout: Optional[float] = None):
+    def _execute_with_timeout(self, tool, tool_input: dict, timeout: float | None = None):
         """Execute tool with timeout.
 
         Args:

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -1,0 +1,131 @@
+"""Tests for orchestrator state persistence and resume behavior."""
+
+from unittest.mock import Mock
+
+from agent.orchestrator import Orchestrator
+
+
+class FakeTool:
+    """Simple tool used in orchestrator tests."""
+
+    def __init__(self, name: str, result: dict):
+        self.name = name
+        self.result = result
+        self.execute_count = 0
+
+    def execute(self, input_data: dict) -> dict:
+        """Return the configured result and count executions."""
+        self.execute_count += 1
+        return self.result
+
+
+class FixedPlanOrchestrator(Orchestrator):
+    """Orchestrator with a fixed execution plan for tests."""
+
+    def _build_plan(self, profile_data: dict) -> list[tuple[str, dict]]:
+        """Return a deterministic two-tool plan."""
+        return [
+            ("first_tool", {"value": 1}),
+            ("second_tool", {"value": 2}),
+        ]
+
+
+def test_checkpoints_after_each_successful_tool() -> None:
+    """Each completed tool should be persisted immediately."""
+    first_tool = FakeTool("first_tool", {"first": "complete"})
+    second_tool = FakeTool("second_tool", {"second": "complete"})
+
+    session_store = Mock()
+    session_store.get.return_value = None
+
+    orchestrator = FixedPlanOrchestrator(
+        tools={
+            "first_tool": first_tool,
+            "second_tool": second_tool,
+        },
+        session_store=session_store,
+    )
+
+    result = orchestrator.run("profile-123", {})
+
+    assert first_tool.execute_count == 1
+    assert second_tool.execute_count == 1
+    assert session_store.set.call_count == 2
+
+    assert session_store.set.call_args_list[0].args == (
+        "profile-123",
+        {"first_tool": {"first": "complete"}},
+    )
+
+    assert session_store.set.call_args_list[1].args == (
+        "profile-123",
+        {
+            "first_tool": {"first": "complete"},
+            "second_tool": {"second": "complete"},
+        },
+    )
+
+    assert result["tool_results"] == {
+        "first_tool": {"first": "complete"},
+        "second_tool": {"second": "complete"},
+    }
+
+
+def test_resumes_without_rerunning_completed_tool() -> None:
+    """Previously completed tools should be restored and skipped."""
+    first_tool = FakeTool("first_tool", {"new": "result"})
+    second_tool = FakeTool("second_tool", {"second": "complete"})
+
+    session_store = Mock()
+    session_store.get.return_value = {
+        "first_tool": {"first": "restored"},
+    }
+
+    orchestrator = FixedPlanOrchestrator(
+        tools={
+            "first_tool": first_tool,
+            "second_tool": second_tool,
+        },
+        session_store=session_store,
+    )
+
+    result = orchestrator.run("profile-123", {})
+
+    assert first_tool.execute_count == 0
+    assert second_tool.execute_count == 1
+
+    session_store.set.assert_called_once_with(
+        "profile-123",
+        {
+            "first_tool": {"first": "restored"},
+            "second_tool": {"second": "complete"},
+        },
+    )
+
+    assert result["tool_results"] == {
+        "first_tool": {"first": "restored"},
+        "second_tool": {"second": "complete"},
+    }
+
+
+def test_runs_without_session_store() -> None:
+    """The orchestrator should still work when persistence is disabled."""
+    first_tool = FakeTool("first_tool", {"first": "complete"})
+    second_tool = FakeTool("second_tool", {"second": "complete"})
+
+    orchestrator = FixedPlanOrchestrator(
+        tools={
+            "first_tool": first_tool,
+            "second_tool": second_tool,
+        }
+    )
+
+    result = orchestrator.run("profile-123", {})
+
+    assert first_tool.execute_count == 1
+    assert second_tool.execute_count == 1
+
+    assert result["tool_results"] == {
+        "first_tool": {"first": "complete"},
+        "second_tool": {"second": "complete"},
+    }


### PR DESCRIPTION
## Summary

This PR improves agent state persistence across API restarts by restoring previously saved session state, skipping tools that have already completed, and checkpointing progress after each successful tool execution.

## Issue

Closes #47

## Changes

- Restored previously saved session state before executing the plan.
- Initialized execution with restored results instead of an empty result set.
- Skipped tools that had already completed in a previous session.
- Persisted session state after each successful tool execution.
- Added unit tests covering checkpointing, resume behavior, and execution without a session store.

## Testing

### Focused verification
- ✅ `pytest tests/unit/test_orchestrator.py -v` (3 tests passed)
- ✅ `python -m py_compile agent/orchestrator.py`
- ✅ Ruff and Black checks passed for modified files

### Full test suite

I also ran the full unit test suite. The repository currently contains multiple pre-existing failures (53 failing tests) in unrelated modules such as `review_service`, `skill_extractor`, `tech_detector`, `pii_scrubber`, and `security`, as well as existing mypy/type-checking issues.

This PR only modifies:

- `agent/orchestrator.py`
- `tests/unit/test_orchestrator.py`

and does not affect those unrelated components or introduce new failures in the areas modified by this change.

## Screenshots / Demo

N/A (backend-only change)

## Notes for Reviewers

This implementation checkpoints state after each successful tool execution so that completed tools are restored and are not re-executed after an API restart, reducing lost work during interrupted executions.