### PR TITLE
fix: improve JavaScript and TypeScript language detection

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -33,3 +33,27 @@ I reproduced issue number 148 by running the existing skill extractor unit tests
 There are many potential things that could cause these issues. I still need to determine whether the failure is caused by missing language patterns, incorrect filename extension handling, etc. The issue could potentially be caused by other less obvious areas as well, such as normalization, confidenct thresholds, etc. 
 
 I'm still investigating which JavaScript and TypeScript language features the extractor is intended to recognize. The existing tests rely on code snippets rather than plain-language descriptions, so I need to trace how SkillExtractor detects language-specific syntax before implementing a fix.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+I have researched the differences between TypeScript and JavaScript in order to better understand their distinguishing deatures. I have compared the issue description from GitHub with the existing failing tests in order to understand which tests are elevant, and to better understand the scope of the full issue. I traced inputs through skill_extractor.py in order to identify why detections were failing. I have implemented logic changes that achieve the following:
+
+- The SkillDetector can now recognize .js, .ts, and .tsx filenames in input text.
+- The SkillDetector can now recognize the literal word TypeScript in input text.
+-The SkillDetector now recognizes common JavaScript and TypeScript syntax.
+
+I also implemented a test for each logic change that I made in skill_extractor.py.  The tests are as follows:
+- test_javascript_detection_from_filename_in_text verifies that JavaScript is detected when a .js filename is mentioned directly in the input text.
+- test_typescript_detection_from_ts_filename_in_text verifies that TypeScript is detected when a .ts filename is mentioned directly in the input text.
+- test_typescript_detection_from_tsx_filename_in_text verifies that a .tsx filename is recognized as TypeScript evidence, while preserving the existing React detection.
+- test_typescript_detection_from_language_name_in_text verifies that TypeScript is detected when the literal language name appears in the input text.
+
+I also verified that the existing test_javascript_detection and test_text_with_typescript_files tests now pass. The complete test_skill_extractor.py file currently has 19 passing tests and three pre-existing failures related to database, Docker, and Docker Compose detection.
+
+**Next steps:**
+Now that my implementation is complete, my next step is to open my pull request, request peer feedback, and submit for review. I'll also update JOURNAL.md.
+
+**Blockers:**

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -77,3 +77,39 @@ I updated tests/unit/test_skill_extractor.py by adding targeted regression tests
 make check and make test-unit report pre-existing failures outside the scope of Issue #148. I verified my changes by running the focused checks for skill_extractor.py and the complete tests/unit/test_skill_extractor.py test suite.
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [X] No — still awaiting review
+
+**Summary of feedback:**
+No review came in.
+
+**How you responded:**
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+When I first read the issue description and saw that it listed related tests in the test_skill_extractor test suite, I thought this would be an easy way to reproduce the issue and test my fixes. However, I found that the tests in test_skill_extractor were related, but didn't cover the exact issues described in the issue. I ended up writing my own tests to reproduce those cases. Committing my work also ended up being much harder than I expected. When I tried to commit, mypy would sometimes block my commits because of type-checking errors that were unrelated to the part of the codebase I was working on.
+
+**What did you learn about working in a large codebase?**
+I learned that I have to understand a project's conventions and follow them. I hadn't thought much about that before. In group projects that I completed in school, everyone did their own part, mostly using their own conventions, and at the end we put the pieces together. Here, the project was already built and conventions were established, so part of my work was learning and following the project's existing style and development conventions. I also found that the codebase was easier to navigate than I thought it would be. When I first opened it, because we had already learned about RAG pipelines, it was easy for me to figure out that skill_extractor.py would likely be in the ingestion folder.
+
+**How did AI tools help — and where did they fall short?**
+I found AI tools extremely helpful for stress-testing my ideas. I wanted to debug the issue myself, so I instructed my AI assistant not to generate the answer, but instead to collaborate with me and help me refine my ideas. There were several times when I disagreed with the AI assistant, and after I explained my reasoning, it agreed that my approach was reasonable.
+
+For example, I was writing a test for TypeScript detection in SkillExtractor. The goal was for SkillExtractor to recognize TypeScript filename endings in the input text. The AI assistant suggested a test sentence that was full of TypeScript syntax and also included a .ts filename. I pointed out that if the text contained a lot of TypeScript syntax, it would be impossible to tell whether my new .ts filename detection was actually working or whether another part of the TypeScript detection logic was responsible for the result. I was somewhat surprised when the AI assistant agreed with my reasoning and said that the more isolated test was a better approach. This reinforced for me that AI suggestions still need to be evaluated rather than accepted automatically.
+
+**What would you do differently if you started over?**
+When I read the issue description and saw that it listed related failing tests, I assumed those tests would directly recreate the issue. Later, after reading the test_skill_extractor file more carefully, I found that this was not the case. It wasn't a major problem because I was able to create my own tests, but in the future I would read the relevant test files in more detail before selecting an issue to make sure I understand exactly what is already covered.
+
+Also, for this particular assignment, I initially found it difficult to tell which parts of the planning process were supposed to be completed before reading the code and which were supposed to be completed afterward. This led to me spending a lot of time trying to come up with a plan without looking at the implementation. I eventually realized that I could examine the code, so I deleted my original draft and rewrote my plan after reading it. If I were starting over, I would read the relevant code much earlier in the process.
+
+Regarding my implementation, while exploring skill_extractor.py, I found sets at the top of the file (PYTHON_KEYWORDS, JS_TS_KEYWORDS, etc.) that list keywords for different programming languages. However, these sets were not used by the original implementation. I chose not to refactor the detection logic to use these sets because I felt that would go beyond the scope of the issue I selected. However, using those existing sets could potentially improve other parts of the skill detection logic. If I had more time, I would investigate whether the detector should be refactored to use them.
+
+**What are you most proud of from this module?**
+I am most proud of opening my first PR and learning the workflow for making an open-source contribution. The issue itself wasn't too difficult to debug, but I enjoyed going through the entire process step by step: creating tests to reproduce the issue, developing a plan, implementing the fix, testing it, and making sure I didn't introduce regressions related to my changes. I was also initially intimidated by the idea of navigating a large and unfamiliar codebase, but I found it much easier to understand and work with than I expected.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -17,3 +17,19 @@ I chose this issue because it has a clearly defined problem, is reproducible, an
 **Setup confirmation:** [X] App runs locally at localhost:5173
 
 **Cohort ledger:** [X] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [link to commit documenting the reproduced issue]
+
+**Reproduction summary:**
+I reproduced issue number 148 by running the existing skill extractor unit tests and the examples from the GitHub issue description. To run the SkillExtractor tests, I ran pytest tests/unit/test_skill_extractor.py -v. I also ran the example text from the GitHub issue description using SkillExtractor.extract_skills(). The JavaScript example returned no detected skills, and the TypeScript example detected React but did not detect TypeScript or JavaScript. The existing test_javascript_detection and test_text_with_typescript_files tests also failed for the same missing detections.
+
+**PLAN.md link:** [link to PLAN.md in your fork]
+
+**Walkthrough video (recommended):**
+
+**Blockers or open questions:**
+There are many potential things that could cause these issues. I still need to determine whether the failure is caused by missing language patterns, incorrect filename extension handling, etc. The issue could potentially be caused by other less obvious areas as well, such as normalization, confidenct thresholds, etc. 
+
+I'm still investigating which JavaScript and TypeScript language features the extractor is intended to recognize. The existing tests rely on code snippets rather than plain-language descriptions, so I need to trace how SkillExtractor detects language-specific syntax before implementing a fix.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,19 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/148
+
+**Issue title:** Skill extractor fails to detect JavaScript and TypeScript
+
+**Tier:** [X] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The function extract_skills() isn't detecting text that describes JavaScript work. It also is returning 'React' for text that specifically mentions TypeScript. Similarly, it is returning "React' for text that contains file endings such as .tsx or .ts, which should indicate a TypeScript file. The issue appears to affect the SkillExtractor component in the ingestion pipeline. A successful fix would allow the SkillExtractor to correctly identify JavaScript and TypeScript while not affecting the existing skill detection behavior for other technologies.
+
+**Selection notes**
+I chose this issue because it has a clearly defined problem, is reproducible, and has existing unit tests that can be used to verify a solution. The scope appears to be manageable, as the issue appears to be limited to the SkillExtractor component. My plan is to identify why JavaScript and TypeScript are not being detected, create a targeted fix, and verify that the existing tests pass without introducing side effects in other skill detection logic.
+
+**Branch name:** fix/148-js-ts-skill-detection
+
+**Setup confirmation:** [X] App runs locally at localhost:5173
+
+**Cohort ledger:** [X] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -20,12 +20,12 @@ I chose this issue because it has a clearly defined problem, is reproducible, an
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [link to commit documenting the reproduced issue]
+**Reproduction commit link:** https://github.com/OzzyT26/pathreview/commit/40488ff41e7c9b951eb2d3343933c178faa548b5
 
 **Reproduction summary:**
 I reproduced issue number 148 by running the existing skill extractor unit tests and the examples from the GitHub issue description. To run the SkillExtractor tests, I ran pytest tests/unit/test_skill_extractor.py -v. I also ran the example text from the GitHub issue description using SkillExtractor.extract_skills(). The JavaScript example returned no detected skills, and the TypeScript example detected React but did not detect TypeScript or JavaScript. The existing test_javascript_detection and test_text_with_typescript_files tests also failed for the same missing detections.
 
-**PLAN.md link:** [link to PLAN.md in your fork]
+**PLAN.md link:** https://github.com/OzzyT26/pathreview/commit/6c34856
 
 **Walkthrough video (recommended):**
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -57,3 +57,23 @@ I also verified that the existing test_javascript_detection and test_text_with_t
 Now that my implementation is complete, my next step is to open my pull request, request peer feedback, and submit for review. I'll also update JOURNAL.md.
 
 **Blockers:**
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/836
+
+**Branch:** `fix/148-js-ts-skill-detection`
+
+**What you built:**
+I updated SkillExtractor so that JavaScript and TypeScript are detected when evidence appears directly in the input text instead of relying only on the optional filename parameter. The detector now recognizes .js, .ts, and .tsx filenames in text, the literal word TypeScript, and additional JavaScript and TypeScript syntax while preserving the existing detection behavior for other languages and frameworks.
+
+**Tests added or updated:**
+I updated tests/unit/test_skill_extractor.py by adding targeted regression tests for JavaScript detection from .js filenames in text, TypeScript detection from .ts and .tsx filenames in text, and TypeScript detection from the literal word TypeScript. I also reran the full test_skill_extractor.py test suite to verify that the related JavaScript and TypeScript tests now pass.
+
+**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+
+make check and make test-unit report pre-existing failures outside the scope of Issue #148. I verified my changes by running the focused checks for skill_extractor.py and the complete tests/unit/test_skill_extractor.py test suite.
+
+**Draft PR feedback received from:** none

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,64 @@
+## Solution plan
+**Issue:**
+    Title: Skill extractor fails to detect JavaScript and TypeScript
+    Link: https://github.com/ascherj/pathreview/issues/148 
+
+### Understand
+The extract_skills() function should detect text that clearly describes JavaScript work, such as: "Wrote index.js using const arrow functions and async/await callbacks." However, it currently returns no detections for this example.
+
+It should also return "TypeScript" for samples that mention .tsx or .ts files and explicitly use the word TypeScript, such as: "Built app.tsx and types.ts with strict TypeScript interfaces." Instead, it currently returns only "React".
+
+Inside extract_skills(), several helper functions are called to identify languages, frameworks, databases, and tools. In _detect_languages(), JavaScript and TypeScript evidence is collected together in js_evidence. The final language is chosen based only on whether the optional filename argument contains .ts; otherwise, the detection is labeled as JavaScript.
+
+The .tsx extension appears only in REACT_INDICATORS. In _detect_react(), the input text is searched for .tsx, so a sentence containing a .tsx filename can produce a React detection. However, _detect_languages() does not recognize .tsx as TypeScript evidence.
+
+The .ts and .js extension checks in _detect_languages() also look only at the optional filename argument. They do not search for filenames mentioned inside the input text. Because the reproduction examples pass filenames such as index.js, app.tsx, and types.ts as part of the text rather than through the filename argument, those extensions are not used as JavaScript or TypeScript evidence.
+
+The issue description also states that extract_skills() should detect TypeScript when the word "TypeScript" appears in the input. However, the JavaScript and TypeScript section of _detect_languages() does not check for the literal word "TypeScript".
+
+Finally, the JavaScript and TypeScript detection logic relies on a limited pattern that searches only for import or require. While require is a useful JavaScript indicator, import is not unique to JavaScript because Python also uses it. The current logic also misses stronger JavaScript clues in the reproduction example, such as const, arrow functions, and the .js filename mentioned in the text.
+
+### Map
+Files I expect to touch:
+- ingestion/parsers/skill_extractor.py - Contains the SkillExtractor class and the extract_skills() function which are responsible for detecting skills. Inside this file, I expect to investigate the _detect_languages() function, where the JavaScript and TypeScript langauge detection is implemented. Similarly, I will investigate the _detect_react() function, which does the React language detection and is currently detecting React for some TypeScript inputs.
+- tests/unit/test_skill_extractor.py - Contains test_javascript_detection and test_text_with_typescript_files tests that were indicated as failing related tests in the issue description. I will use these tests to verify my fix. I will also run the entire test file to make sure my fix doesn't introduce side effects/regressions. If I notice a lack of coverage on important JavaScript/TypeScript scenarios, I will add additional tests.
+
+### Plan
+1. Continue researching the differences between JavaScript and TypeScript, including their syntax, keywords, file extensions, and common code patterns. Use this research to determine which language features extract_skills() should recognize and which features are unique enough to distinguish the two languages.
+2. Compare the GitHub issue description with the existing failing tests in tests/unit/test_skill_extractor.py to make sure I understand all of the JavaScript and TypeScript cases the extractor is expected to handle.
+3. Continue tracing the JavaScript and TypeScript detection logic in ingestion/parsers/skill_extractor.py to determine why some language features are not being recognized and identify the best place to implement the fix.
+4. Update the JavaScript and TypeScript detection logic so that it correctly recognizes the expected language features while preserving the existing behavior for other languages, frameworks, and technologies.
+5. Rerun tests/unit/test_skill_extractor.py to verify that the JavaScript and TypeScript tests pass and that the previously passing tests continue to pass. If I identify important JavaScript or TypeScript scenarios that are not covered by the current tests, I will add targeted regression tests.
+
+### Inputs & outputs
+What does your fix take as input? What should it produce or change?
+**Function I'm changing**
+_detect_languages(
+        self,
+        text: str,
+        filename: Optional[str],
+        skills_dict: dict,
+    ) -> None:
+
+**Inputs**
+- text: The text to be analyzed for programming language evidence.
+- filename (optional): optional filename whose file extention can be analyzed for additional evidence.
+- skills_dict: dictionary that stores detected skills and confidence scores.
+
+**Expected Change**
+The fix should allow _detect_languages() to recognize JavaScript and TypeScript evidence found in the input text, rather than relying only on the optional filename argument or the limited import|require pattern.
+
+**Output**
+The function will continue to return None. Instead, it should update skills_dict with the correct language and confidence score.
+
+### Risks & unknowns
+- JavaScript and TypeScript share many language features, so changing the detection logic may make it more difficult to distinguish between the two without introducing false positives.
+- It is not yet clear whether JavaScript and TypeScript detection should rely primarily on filenames, language keywords, code syntax, or a combination of these signals. I will need to determine which approach best matches the expected behavior described in the issue.
+- Changes to the JavaScript and TypeScript detection logic could unintentionally affect detection for other technologies, such as React, since some indicators (for example, .tsx) are associated with multiple technologies.
+- The existing tests reproduce the reported issue, but it is unclear whether they cover all important JavaScript and TypeScript cases. After implementing a fix, I may need to add regression tests for additional scenarios to help prevent similar issues in the future.
+
+### Edge cases
+- filename is None, so file-extension checks cannot be used.
+- The text contains evidence for more than one programming language.
+- The text contains language features that are shared by multiple languages (for - example, import, async, or await).
+- The text references filenames such as .js, .ts, or .tsx instead of providing them through the filename argument.

--- a/ingestion/parsers/skill_extractor.py
+++ b/ingestion/parsers/skill_extractor.py
@@ -185,12 +185,17 @@ class SkillExtractor:
         typescript_filename_in_text = bool(re.search(r"\b[\w.-]+\.tsx?\b", text_lower))
         if typescript_filename_in_text:
             js_evidence.append("TypeScript filename in text (.ts or .tsx)")
+        typescript_literal_in_text = "typescript" in text_lower
+        if typescript_literal_in_text:
+            js_evidence.append("TypeScript mentioned in text")
 
         if js_evidence:
             confidence = min(0.95, 0.6 + len(js_evidence) * 0.1)
             lang = (
                 "TypeScript"
-                if ".ts" in str(filename or "").lower() or typescript_filename_in_text
+                if ".ts" in str(filename or "").lower()
+                or typescript_filename_in_text
+                or typescript_literal_in_text
                 else "JavaScript"
             )
             skills_dict[lang] = SkillDetection(

--- a/ingestion/parsers/skill_extractor.py
+++ b/ingestion/parsers/skill_extractor.py
@@ -182,9 +182,9 @@ class SkillExtractor:
             js_evidence.append("JavaScript filename in text (.js)")
         if "package.json" in text_lower:
             js_evidence.append("package.json found")
-        typescript_filename_in_text = bool(re.search(r"\b[\w.-]+\.ts\b", text_lower))
+        typescript_filename_in_text = bool(re.search(r"\b[\w.-]+\.tsx?\b", text_lower))
         if typescript_filename_in_text:
-            js_evidence.append("TypeScript filename in text (.ts)")
+            js_evidence.append("TypeScript filename in text (.ts or .tsx)")
 
         if js_evidence:
             confidence = min(0.95, 0.6 + len(js_evidence) * 0.1)

--- a/ingestion/parsers/skill_extractor.py
+++ b/ingestion/parsers/skill_extractor.py
@@ -182,10 +182,17 @@ class SkillExtractor:
             js_evidence.append("JavaScript filename in text (.js)")
         if "package.json" in text_lower:
             js_evidence.append("package.json found")
+        typescript_filename_in_text = bool(re.search(r"\b[\w.-]+\.ts\b", text_lower))
+        if typescript_filename_in_text:
+            js_evidence.append("TypeScript filename in text (.ts)")
 
         if js_evidence:
             confidence = min(0.95, 0.6 + len(js_evidence) * 0.1)
-            lang = "TypeScript" if ".ts" in str(filename or "").lower() else "JavaScript"
+            lang = (
+                "TypeScript"
+                if ".ts" in str(filename or "").lower() or typescript_filename_in_text
+                else "JavaScript"
+            )
             skills_dict[lang] = SkillDetection(
                 name=lang,
                 category="Language",

--- a/ingestion/parsers/skill_extractor.py
+++ b/ingestion/parsers/skill_extractor.py
@@ -1,11 +1,11 @@
 import re
 from dataclasses import dataclass
-from typing import Optional
 
 
 @dataclass
 class SkillDetection:
     """Result of detecting a skill."""
+
     name: str
     category: str
     confidence: float
@@ -105,7 +105,7 @@ class SkillExtractor:
         "ansible": 0.85,
     }
 
-    def extract_skills(self, text: str, filename: Optional[str] = None) -> list[SkillDetection]:
+    def extract_skills(self, text: str, filename: str | None = None) -> list[SkillDetection]:
         """
         Extract skills from source code or documentation text.
 
@@ -116,7 +116,7 @@ class SkillExtractor:
         Returns:
             List of detected skills with confidence scores
         """
-        detected_skills = {}
+        detected_skills: dict[str, SkillDetection] = {}
 
         # Detect languages first
         self._detect_languages(text, filename, detected_skills)
@@ -143,7 +143,7 @@ class SkillExtractor:
     def _detect_languages(
         self,
         text: str,
-        filename: Optional[str],
+        filename: str | None,
         skills_dict: dict,
     ) -> None:
         """Detect programming languages."""
@@ -178,6 +178,8 @@ class SkillExtractor:
             js_evidence.append("TypeScript file extension (.ts)")
         if re.search(r"\b(import|require)\s+", text):
             js_evidence.append("CommonJS or ES6 imports")
+        if re.search(r"\b[\w.-]+\.js\b", text_lower):
+            js_evidence.append("JavaScript filename in text (.js)")
         if "package.json" in text_lower:
             js_evidence.append("package.json found")
 

--- a/ingestion/parsers/skill_extractor.py
+++ b/ingestion/parsers/skill_extractor.py
@@ -176,10 +176,12 @@ class SkillExtractor:
             js_evidence.append("JavaScript file extension (.js)")
         if ".ts" in str(filename or "").lower():
             js_evidence.append("TypeScript file extension (.ts)")
-        if re.search(r"\b(import|require)\s+", text):
+        if re.search(r"\bimport\s+|\brequire\s*\(", text):
             js_evidence.append("CommonJS or ES6 imports")
         if re.search(r"\b[\w.-]+\.js\b", text_lower):
             js_evidence.append("JavaScript filename in text (.js)")
+        if re.search(r"\b(const|let)\b", text):
+            js_evidence.append("JavaScript variable declarations")
         if "package.json" in text_lower:
             js_evidence.append("package.json found")
         typescript_filename_in_text = bool(re.search(r"\b[\w.-]+\.tsx?\b", text_lower))

--- a/ingestion/parsers/skill_extractor.py
+++ b/ingestion/parsers/skill_extractor.py
@@ -190,6 +190,11 @@ class SkillExtractor:
         typescript_literal_in_text = "typescript" in text_lower
         if typescript_literal_in_text:
             js_evidence.append("TypeScript mentioned in text")
+        typescript_syntax_in_text = bool(
+            re.search(r"\b(interface|enum)\s+\w+|\btype\s+\w+\s*=", text_lower)
+        )
+        if typescript_syntax_in_text:
+            js_evidence.append("TypeScript declaration syntax")
 
         if js_evidence:
             confidence = min(0.95, 0.6 + len(js_evidence) * 0.1)
@@ -198,6 +203,7 @@ class SkillExtractor:
                 if ".ts" in str(filename or "").lower()
                 or typescript_filename_in_text
                 or typescript_literal_in_text
+                or typescript_syntax_in_text
                 else "JavaScript"
             )
             skills_dict[lang] = SkillDetection(

--- a/tests/unit/test_skill_extractor.py
+++ b/tests/unit/test_skill_extractor.py
@@ -61,6 +61,16 @@ class TestSkillExtractor:
         # Should detect TypeScript
         assert any("typescript" in s.lower() for s in skill_names)
 
+    def test_typescript_detection_from_language_name_in_text(self, extractor):
+        """Test TypeScript detection from the language name in text."""
+        text = """
+        Built the application using TypeScript.
+        """
+        result = extractor.extract_skills(text)
+
+        skill_names = [s.name for s in result]
+        assert "TypeScript" in skill_names
+
     def test_jupyter_ipynb_detection(self, extractor):
         """Test Python/Jupyter detection from .ipynb reference."""
         text = """

--- a/tests/unit/test_skill_extractor.py
+++ b/tests/unit/test_skill_extractor.py
@@ -192,6 +192,16 @@ class TestSkillExtractor:
         skill_names = [s.name for s in result]
         assert "JavaScript" in skill_names
 
+    def test_typescript_detection_from_ts_filename_in_text(self, extractor):
+        """Test TypeScript detection of .ts filename in text."""
+        text = """
+        Defined shared types in types.ts.
+        """
+        result = extractor.extract_skills(text)
+
+        skill_names = [s.name for s in result]
+        assert "TypeScript" in skill_names
+
     def test_docker_compose_detection(self, extractor):
         """Test Docker and Docker Compose detection."""
         text = """

--- a/tests/unit/test_skill_extractor.py
+++ b/tests/unit/test_skill_extractor.py
@@ -202,6 +202,16 @@ class TestSkillExtractor:
         skill_names = [s.name for s in result]
         assert "TypeScript" in skill_names
 
+    def test_typescript_detection_from_tsx_filename_in_text(self, extractor):
+        """Test TypeScript detection from a .tsx filename in text."""
+        text = """
+        Built the main interface in app.tsx.
+        """
+        result = extractor.extract_skills(text)
+
+        skill_names = [s.name for s in result]
+        assert "TypeScript" in skill_names
+
     def test_docker_compose_detection(self, extractor):
         """Test Docker and Docker Compose detection."""
         text = """

--- a/tests/unit/test_skill_extractor.py
+++ b/tests/unit/test_skill_extractor.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from ingestion.parsers.skill_extractor import SkillExtractor, SkillDetection
+from ingestion.parsers.skill_extractor import SkillDetection, SkillExtractor
 
 
 @pytest.mark.unit
@@ -135,7 +135,7 @@ class TestSkillExtractor:
         """
         result = extractor.extract_skills(text)
 
-        skill_names = [s.name for s in skill_names]
+        skill_names = [s.name for s in result]
         # Should detect PostgreSQL
         assert any("postgres" in s.lower() or "sql" in s.lower() for s in skill_names)
 
@@ -181,6 +181,16 @@ class TestSkillExtractor:
 
         skill_names = [s.name for s in result]
         assert any("javascript" in s.lower() or "js" in s.lower() for s in skill_names)
+
+    def test_javascript_detection_from_filename_in_text(self, extractor):
+        """Test JavaScript detection of .js filename in text."""
+        text = """
+        See implementation in index.js.
+        """
+        result = extractor.extract_skills(text)
+
+        skill_names = [s.name for s in result]
+        assert "JavaScript" in skill_names
 
     def test_docker_compose_detection(self, extractor):
         """Test Docker and Docker Compose detection."""
@@ -232,10 +242,7 @@ class TestSkillExtractor:
     def test_skill_detection_dataclass(self):
         """Test SkillDetection dataclass structure."""
         skill = SkillDetection(
-            name="Python",
-            category="Language",
-            confidence=0.95,
-            evidence=["import statement"]
+            name="Python", category="Language", confidence=0.95, evidence=["import statement"]
         )
 
         assert skill.name == "Python"


### PR DESCRIPTION
## Summary
SkillExtractor did not detect JavaScript or TypeScript when evidence appeared directly in the input text instead of the optional filename parameter. As a result, JavaScript examples such as .js filenames and TypeScript examples containing .ts, .tsx, or the word TypeScript were not correctly identified. This PR expands JavaScript and TypeScript detection to recognize filenames, language names, and language-specific syntax found in the input text while preserving the existing detection behavior for other languages and frameworks.

## Issue
Closes #148

## Changes
Root cause: The original JavaScript and TypeScript detection logic relied primarily on the optional filename parameter and a small set of detection patterns. As a result, filenames such as .js, .ts, and .tsx were ignored when they were referenced directly in the input text. The literal word TypeScript was not recognized as language evidence, and common JavaScript and TypeScript syntax was not considered when determining the detected language.
- ingestion/parsers/skill_extractor.py - _detect_languages()
    - Now recognizes .js, .ts, and .tsx filenames when referenced directly in the input text.
    - Detects the literal word TypeScript when it appears in the input text.
    - Expanded JavaScript detection to recognize additional JavaScript syntax, including require(...) statements and common JavaScript keywords.
    - Expanded TypeScript detection to recognize language-specific syntax such as interface, enum, and type declarations.
    - Updated the language-selection logic so that TypeScript evidence found in the input text is considered when determining the detected language.
- tests/unit/test_skill_extractor.py
    - Added test_javascript_detection_from_filename_in_text.
        - Verifies JavaScript detection from .js filenames referenced in the input text.
    - Added test_typescript_detection_from_ts_filename_in_text.
        - Verifies TypeScript detection from .ts filenames referenced in the input text.
    - Added test_typescript_detection_from_tsx_filename_in_text.
        - Verifies TypeScript detection from .tsx filenames referenced in the input text.
    - Added test_typescript_detection_from_language_name_in_text.
        - Verifies TypeScript detection from the literal word TypeScript in the input text.

## Testing
<!-- How did you verify your changes? -->
- [ ] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`)
- [ ] Linter passes (`make lint`)
- [ ] Type checker passes (`make typecheck`)
- [X] New/updated tests cover the changes

### Reproduce the original issue (before the fix):

from ingestion.parsers.skill_extractor import SkillExtractor

e = SkillExtractor()

print(e.extract_skills(
    "Wrote index.js using const arrow functions and async/await callbacks"
))

print([
    d.name
    for d in e.extract_skills(
        "Built app.tsx and types.ts with strict TypeScript interfaces"
    )
])

Observed:

[]
['React']

### Verify the fix (on this branch):

Run the same code on this branch.

Expected output:

['JavaScript']
['TypeScript', 'React']

### Additional verification performed:
- Ran python -m pytest tests/unit/test_skill_extractor.py -v
- Ran python -m ruff check ingestion/parsers/skill_extractor.py tests/unit/test_skill_extractor.py
- Ran python -m black --check ingestion/parsers/skill_extractor.py tests/unit/test_skill_extractor.py
- Ran python -m mypy ingestion/parsers/skill_extractor.py

## Screenshots / Demo
N/A - backend only change. The behavior is demonstrated by the new unit tests and the issue reproduction examples above.

## Notes for Reviewers
While verifying this change, tests/unit/test_skill_extractor.py still contains three unrelated failing tests:
- test_database_technology_detection
- test_devops_tool_detection
- test_docker_compose_detection
Repository-wide make test-unit also reports additional pre-existing failures outside the scope of Issue #148. This PR only modifies the JavaScript and TypeScript detection logic and its associated unit tests.
