### PR TITLE
Fix/148 js typescript detection

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -15,3 +15,19 @@ The `extract_skills()` method in `ingestion/parsers/skill_extractor.py` doesn't 
 
 **Cohort ledger:** [x] Issue added to cohort ledger
 
+
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [link to commit documenting the reproduced issue]
+
+**Reproduction summary:**
+Ran the repro script from issue #148 in the Python REPL. extract_skills('Wrote index.js using const arrow functions and async/await callbacks') returned []. extract_skills('Built app.tsx and types.ts with strict TypeScript interfaces') returned only ['React'], confirming JS gets no detection and TypeScript is misclassified as React.
+
+
+**PLAN.md link:** [link to PLAN.md in your fork]
+
+
+
+**Blockers or open questions:**
+[leave blank or note anything uncertain]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -25,7 +25,7 @@ The `extract_skills()` method in `ingestion/parsers/skill_extractor.py` doesn't 
 Ran the repro script from issue #148 in the Python REPL. extract_skills('Wrote index.js using const arrow functions and async/await callbacks') returned []. extract_skills('Built app.tsx and types.ts with strict TypeScript interfaces') returned only ['React'], confirming JS gets no detection and TypeScript is misclassified as React.
 
 
-**PLAN.md link:** [link to PLAN.md in your fork]
+**PLAN.md link:** (https://github.com/Crolinaa123/pathreview/blob/fix/148-js-typescript-detection/PLAN.md)
 
 
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,17 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/148
+
+**Issue title:** Skill extractor fails to detect JavaScript and TypeScript
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The `extract_skills()` method in `ingestion/parsers/skill_extractor.py` doesn't recognize the JavaScript/TypeScript language family. Text that clearly describes JavaScript work (e.g. arrow functions, async/await) returns zero skill detections, and TypeScript-specific signals like `.tsx`/`.ts` files are only picked up as "React" instead of TypeScript. Other language families (Python, DevOps, databases) detect correctly, which points to a gap specifically in the JS/TS matching rules or keyword patterns in the skill extraction logic. A successful fix would update the extractor so it correctly identifies both JavaScript and TypeScript skills, and would make the related failing tests in `tests/unit/test_skill_extractor.py` pass.
+
+**Branch name:** fix/148-js-typescript-detection
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger
+

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -31,3 +31,36 @@ Ran the repro script from issue #148 in the Python REPL. extract_skills('Wrote i
 
 **Blockers or open questions:**
 [leave blank or note anything uncertain]
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+All 5 PLAN.md sub-tasks complete. Identified the root cause in ingestion/parsers/skill_extractor.py: JS/TS detection relied on filename extension and a broken regex (require\s+ never matched require('fs')), and Docker detection only matched the literal word "docker," which never appears in real Dockerfile/docker-compose syntax. Added JavaScript detection (require() calls, ES6 import/export, const/let/var, console.log), separated TypeScript detection from JavaScript/React (interfaces, type annotations, Promise<T>), and added a new _detect_docker method for structural Dockerfile/docker-compose detection. Also fixed a mypy type-annotation issue the pre-commit hook caught along the way.
+
+**Next steps:**
+Run make check and the full make test-unit suite to confirm no regressions beyond the one known pre-existing failure, then open the PR for review.
+
+**Blockers:**
+None currently — resolved earlier issues with commits accidentally landing on main instead of the feature branch, and an indentation bug that pulled _detect_docker outside the class.
+
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/838
+
+**Branch:** fix/148-js-typescript-detection
+
+**What you built:**
+Fixed the skill extractor to correctly detect JavaScript, TypeScript, and Docker/Docker Compose usage, replacing filename-only and literal-keyword matching with evidence-based structural detection.
+
+**Tests added or updated:**
+No new tests added — the existing test_javascript_detection, test_text_with_typescript_files, test_devops_tool_detection, and test_docker_compose_detection in tests/unit/test_skill_extractor.py now all pass against the updated implementation.
+
+
+**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -19,7 +19,7 @@ The `extract_skills()` method in `ingestion/parsers/skill_extractor.py` doesn't 
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [link to commit documenting the reproduced issue]
+**Reproduction commit link:** https://github.com/Crolinaa123/pathreview/commit/d310d984a555b259476db7a5f69f11edd86f2b6a
 
 **Reproduction summary:**
 Ran the repro script from issue #148 in the Python REPL. extract_skills('Wrote index.js using const arrow functions and async/await callbacks') returned []. extract_skills('Built app.tsx and types.ts with strict TypeScript interfaces') returned only ['React'], confirming JS gets no detection and TypeScript is misclassified as React.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -64,3 +64,23 @@ No new tests added — the existing test_javascript_detection, test_text_with_ty
 **Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
 
 **Draft PR feedback received from:** none
+
+
+## Week 10 — Iteration & reflection
+
+### Reflection
+
+**What was harder than you expected?**
+Honestly, the git/GitHub workflow caused more trouble than the actual code fix. I ended up with commits landing on main instead of my feature branch, a duplicate nested repo folder, and GitHub's browser editor silently stripping the indentation off a method I added, which turned it into a standalone function outside the class instead of a real method. None of that was a coding problem; it was all workflow stuff I had to untangle with git log, fetch, cherry-pick, and revert.
+
+**What did you learn about working in a large codebase?**
+I learned that a bug isn't always as contained as the issue title suggests. This was filed as "JavaScript and TypeScript detection," but two of the four failing tests were actually about Docker — turned out they shared the same underlying design flaw (keyword-only matching that couldn't handle real code/config syntax). I also learned to tell the difference between failures that are actually mine to fix versus pre-existing bugs unrelated to my change, instead of trying to fix everything I saw failing.
+
+**How did AI tools help — and where did they fall short?**
+AI was most useful for tracing why something failed; reading a regex character by character to explain why require('fs') didn't match, or explaining a confusing git error in plain terms. Where it fell short: it couldn't see my actual files or terminal state directly, so I had to paste in outputs and file contents each time, and it couldn't catch the indentation bug until I showed it the exact committed code. It can reason well once it has the real data, but it can't observe my environment on its own.
+
+**What would you do differently if you started over?**
+Edit and commit locally in VS Code/terminal from the start instead of GitHub's web editor; that's what caused both the stripped indentation and the wrong-branch commit. I'd also check git branch --show-current before making any edit, every time, instead of assuming I was on the right branch.]
+
+**What are you most proud of from this module?**
+Actually tracing the real root cause instead of guessing, and I figured out that the Docker tests could never pass with keyword matching alone since real Dockerfiles never contain the literal word "docker," and confirming that with the actual test inputs rather than assuming.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,23 @@
+## Solution plan
+
+**Issue:** [issue title and link]
+
+### Understand
+What is the root cause of this issue? What behavior is expected vs. actual?
+
+### Map
+Which files, functions, or modules are involved?
+List the specific files you expect to touch.
+
+### Plan
+What are the steps to fix this issue?
+Break it into 3–5 concrete sub-tasks.
+
+### Inputs & outputs
+What does your fix take as input? What should it produce or change?
+
+### Risks & unknowns
+What could go wrong? What are you still unsure about?
+
+### Edge cases
+What inputs or states should your fix handle gracefully?

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,23 +1,25 @@
 ## Solution plan
 
-**Issue:** [issue title and link]
+**Issue:** Skill extractor fails to detect JavaScript and TypeScript — https://github.com/ascherj/pathreview/issues/148
 
 ### Understand
-What is the root cause of this issue? What behavior is expected vs. actual?
+Confirmed root causes (three distinct issues under one title): (1) JavaScript detection relied almost entirely on filename extension plus a broken regex requiring whitespace after `require`/`import`, so `require('fs')` never matched and the `JS_TS_KEYWORDS` set was defined but never actually used. (2) TypeScript had no dedicated detection at all — `.tsx`/`.ts` files only matched the existing React pattern. (3) Docker/DevOps detection only matched the literal word "docker" in text, but real Dockerfile and docker-compose syntax never contains that word — confirmed this was in scope since the original issue explicitly listed `test_devops_tool_detection` and `test_docker_compose_detection` as related failing tests, not a separate problem.
 
 ### Map
-Which files, functions, or modules are involved?
-List the specific files you expect to touch.
+Only one file needed changes: `ingestion/parsers/skill_extractor.py`. No test file changes were needed — the existing tests in `tests/unit/test_skill_extractor.py` already specified the correct expected behavior.
 
-### Plan
-What are the steps to fix this issue?
-Break it into 3–5 concrete sub-tasks.
+### Plan (as executed)
+1. Read the pattern-matching logic and confirmed root cause via reproduction + failing test output
+2. Rewrote JS detection to check for `require()` calls, ES6 `import...from`, `export` statements, `const`/`let`/`var`, and `console.log`
+3. Added separate TypeScript detection (interfaces, type annotations, `Promise<T>`), so TypeScript no longer gets folded into JavaScript or React
+4. Added a new `_detect_docker` method for structural Dockerfile/docker-compose detection, wired into `extract_skills`
+5. Fixed a `mypy` type-annotation issue on `detected_skills` caught by the pre-commit hook
 
 ### Inputs & outputs
-What does your fix take as input? What should it produce or change?
+Input: free text (code snippets, commit messages, config file contents) plus an optional filename. Output: a list of `SkillDetection` objects — now correctly including JavaScript, TypeScript, and Docker where applicable, with no regressions to existing Python/React/framework/database detection.
 
 ### Risks & unknowns
-What could go wrong? What are you still unsure about?
+Resolved: JS/TS pattern overlap handled by checking TypeScript-specific evidence first and only falling back to JavaScript if no TS signals are present. Resolved: `.tsx` files can still trigger both React and TypeScript, since they're stored as separate dict keys. Remaining, not in scope: `test_database_technology_detection` still fails due to a pre-existing, unrelated bug in the test file itself (references a variable before it's assigned) — documented in the PR, not fixed here.
 
 ### Edge cases
-What inputs or states should your fix handle gracefully?
+Mixed JS+TS text is handled (both evidence sets are collected; TypeScript takes priority when TS-specific signals exist). Docker detection is case-sensitive on purpose (`FROM`/`RUN`/`EXPOSE` uppercase) to avoid colliding with Python's lowercase `from`/`import`. Not yet handled: compound extensions like `.d.ts` or `.test.ts` aren't specially distinguished beyond a basic `.ts` substring check — potential follow-up.

--- a/ingestion/parsers/skill_extractor.py
+++ b/ingestion/parsers/skill_extractor.py
@@ -116,7 +116,7 @@ class SkillExtractor:
         Returns:
             List of detected skills with confidence scores
         """
-        detected_skills = {}
+        detected_skills: dict[str, SkillDetection] = {}
 
         # Detect languages first
         self._detect_languages(text, filename, detected_skills)


### PR DESCRIPTION
## Summary
This PR fixes the skill extractor's failure to detect JavaScript, TypeScript, and Docker/Docker Compose usage. The extractor previously relied on filename extensions and a broken regex for JS/TS, and on literal keyword matching for Docker (which never appears as the word "docker" in real Dockerfile or docker-compose syntax). Lastly, it also replaces both with evidence-based structural detection.

## Issue
Closes #148 

## Changes
<!-- Bullet list of the specific changes made -->
- Fixed JavaScript detection in `_detect_languages`: replaced a regex that required whitespace after `require`/`import` (so `require('fs')` was never matched) with checks for `require()` calls, ES6 `import ... from` syntax, `export` statements, `const`/`let`/`var` declarations, and `console.log` usage

- Added TypeScript-specific detection (interface declarations, type annotations, `Promise<T>` generics), so TypeScript is now distinguished from plain JavaScript and from React

- Added a new `_detect_docker` method that recognizes Dockerfile instructions (`FROM`, `RUN`, `EXPOSE`, `CMD`/`ENTRYPOINT`) and docker-compose YAML markers (`version:`, `services:`, `build:`), and wired it into `extract_skills`

- Fixed a `mypy` type-annotation issue on `detected_skills` flagged by the pre-commit hook

## Testing
<!-- How did you verify your changes? -->
- [x] `pytest tests/unit/test_skill_extractor.py -v` — 17 passed, 1 failed (`test_database_technology_detection`, a pre-existing unrelated bug — see Notes below)
- [ ] Unit tests pass (`make test-unit`) — not yet run against the full suite, only this file so far
- [x] Integration tests pass (`make test-integration`)
- [ ] Linter passes (`make lint`)
- [ ] Type checker passes (`make typecheck`)
- [x] Existing tests already cover these changes (`test_javascript_detection`, `test_text_with_typescript_files`, `test_devops_tool_detection`, `test_docker_compose_detection`); no new tests added

## Screenshots / Demo
<!-- If applicable, add screenshots or a link to a demo video -->

## Notes for Reviewers
test_database_technology_detection fails due to a pre-existing bug unrelated to this fix (line 138 has a typo, not caused by my changes). Still need to run make check and make test-unit before marking ready for review.
