### PR TITLE
feat(agent): add contribution_streak field to GitHub analysis (#52)

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,20 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/52
+
+**Issue title:** Add a contribution_streak field to the GitHub analysis (longest consecutive days of commits)
+ 
+**Tier:**  Tier 2
+
+**Problem summary:**
+The current GitHub analysis reports information about a user's GitHub activity, but it does not measure contribution consistency over time. Because this metric is absent, users cannot easily demonstrate one aspect of sustained engagement with open-source projects. Consistent contribution activity is often viewed as a positive portfolio signal, so the analysis is missing information that could better represent a developer's coding habits.
+
+A successful fix would add a new contribution_streak field to the GitHub analysis. This feature would calculate the longest sequence of consecutive days containing commits, and include that value in the analysis results so it can be displayed or used alongside the existing GitHub metrics.
+
+I selected this issue because it is a well-scoped feature with a clear objective and a limited impact area. The work is on extending an existing feature by adding one additional tool that will display one additional metric rather than creating a new feature or redesigning an exisiting one. This fits in well with honing my skills of understanding existing code and integrating my code with the pre-existing test suite.
+
+**Branch name:** (https://github.com/DanielGao2766/pathreview/tree/feat/52-contribution-streak-tool)
+
+**Setup confirmation:** App runs locally at localhost:5173
+
+**Cohort ledger:** Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -35,28 +35,30 @@ I located the gap in the feature within the agent/tools folder where I found git
 ### Check-in 1 (mid-week)
 
 **Current progress:**
-[What have you implemented so far? Which sub-tasks from PLAN.md are done?]
+Implemented `_longest_contribution_streak` in `agent/tools/github_tool.py` (replacing the stub from Week 8) and wired it into `_fetch_repo_metadata` as a new `contribution_streak` field. Switched the data source from the originally planned single-repo REST commits endpoint to GitHub's GraphQL `contributionsCollection` API, since account-wide streak (not repo-scoped) is the intended semantics per the issue. Added `tests/unit/test_github_tool.py` covering all edge cases from PLAN.md (no token, zero contributions, single day, unbroken streak, gap in the middle, same-day duplicate commits, nonexistent user, request failures, and integration into `_fetch_repo_metadata`).
 
 **Next steps:**
-[What are you working on for the rest of the week?]
+Run `make check` and `make test-unit`, confirm no new failures vs. baseline, then open the PR and request review.
 
 **Blockers:**
-[Anything slowing you down? Or leave blank.]
+None.
+
 
 ---
 
 ### Check-in 2 (end of week)
 
-**PR link:** [link to your submitted pull request]
+**PR link:** (https://github.com/ascherj/pathreview/pull/839)
 
-**Branch:** [the branch name you worked on, e.g. `fix/123-short-description`]
+**Branch:** feat/52-contribution-streak-tool
 
 **What you built:**
-[1–3 sentences summarizing what your fix does and how it works]
+Added a `contribution_streak` field to GitHub analysis output that reports the longest run of consecutive days with GitHub activity for a user's account, computed via GitHub's GraphQL `contributionsCollection` API. The field is now included in the dict returned by `GitHubTool.execute()` alongside existing repo metadata.
 
 **Tests added or updated:**
-[Which test files did you touch? What do they cover?]
+Added `tests/unit/test_github_tool.py` (new file, 9 tests). Covers: no API token (bails out without a request), zero contributions, a single contribution day, an unbroken streak, a streak with a gap in the middle (verifies longest-run logic, not total days or most-recent run), multiple contributions on the same day collapsing to one day, a nonexistent user, an exception during the request, and that the field is correctly wired into `_fetch_repo_metadata`'s output.
 
-**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
 
-**Draft PR feedback received from:** [name or Slack handle, or "none"]
+**Draft PR feedback received from:** 
+None

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -43,7 +43,6 @@ Run `make check` and `make test-unit`, confirm no new failures vs. baseline, the
 **Blockers:**
 None.
 
-
 ---
 
 ### Check-in 2 (end of week)
@@ -62,3 +61,42 @@ Added `tests/unit/test_github_tool.py` (new file, 9 tests). Covers: no API token
 
 **Draft PR feedback received from:** 
 None
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+[What did reviewers comment on? Or note that no review came in.]
+
+**How you responded:**
+[What changes did you make, or what did you reply? If no feedback,
+leave blank.]
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+[Be specific — what part of the process, codebase, or workflow
+surprised you?]
+The timeline of spending two weeks planning and then one week executing made me think that the workflow would be smooth since I already documented my decision choices in my PLAN.md, but some errors within my test file (test_github_tool.py) for isolated error cases that I thought of made me spend more time that I thought I would need on fixing the feature and left me with less time that I would have liked to create the test suite for the feature (longest_contribution_streak on GitHub)
+
+**What did you learn about working in a large codebase?**
+Something that was difficult that I had to learn while working in a large codebase was that I didn't know everything while making my own code, whereas for my own project I would know everything. This meant that when I ran the test suite through 'make check' and 'make test unit' within the test folder, some of the errors that didn't pass weren't part of my issue and I wasn't able to fix which is not typical my own self projects where every test has to pass and everything has to be green .
+
+**How did AI tools help — and where did they fall short?**
+[Where was AI assistance most useful this module? Where did you need
+to go beyond what AI could give you?]
+AI tools were most useful at the beginning by helping me figure out the codebase by helping me figure out what a specific method is supposed to do as an example and helping to review my PLAN.md whether to follow the GitHub API call that was already preexisting that would only pull stats from the repo I was contributing on or making a new request to pull from each individual's own GitHub profile for the last calendar year (365 days)
+
+**What would you do differently if you started over?**
+[Issue selection, planning, implementation, or process — anything
+you'd change?]
+I would create the test suite earlier so that the timeline would be better at the end of the project since after making my feature work in agent/tool/github_tool.py I still had to make tests since I was working on a new feature, and I didn't account for how long the test suite would take in both designing and fixing my code if the test failed in test_github_tool.py with tests like _calendar_response and _test_same_day_multiple_contributions_count_once. 
+
+**What are you most proud of from this module?**
+[One thing — it doesn't have to be the PR itself.]
+I'm proud of developing my skills in being able to read and edit a large codebase, while being able to use AI effectively to help me finish my feature in a more efficient manner such as when it became a second set of eyes on my PLAN.md and helped come up with some potential errors within the code in github_tool.py so that I could put the tests in test_github_tool.py as unit tests for specific things that might cause errors such as having the GitHub user not be real that ended up with the test of test_nonexistent_user_returns_zero.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -4,7 +4,7 @@
 
 **Issue title:** Add a contribution_streak field to the GitHub analysis (longest consecutive days of commits)
  
-**Tier:**  Tier 2
+**Tier:** Tier 2
 
 **Problem summary:**
 The current GitHub analysis reports information about a user's GitHub activity, but it does not measure contribution consistency over time. Because this metric is absent, users cannot easily demonstrate one aspect of sustained engagement with open-source projects. Consistent contribution activity is often viewed as a positive portfolio signal, so the analysis is missing information that could better represent a developer's coding habits.
@@ -18,3 +18,17 @@ I selected this issue because it is a well-scoped feature with a clear objective
 **Setup confirmation:** App runs locally at localhost:5173
 
 **Cohort ledger:** Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [link to commit documenting the reproduced issue]
+
+**Reproduction summary:**
+[1–2 sentences: How did you reproduce the issue? What did you observe?]
+
+**PLAN.md link:** [link to PLAN.md in your fork]
+
+**Walkthrough video (recommended):** [link to your Loom video, ≤2 min — recommended, not graded]
+
+**Blockers or open questions:**
+[Anything you're still uncertain about going into Week 9, or leave blank]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -29,3 +29,34 @@ I located the gap in the feature within the agent/tools folder where I found git
 **PLAN.md link:** (https://github.com/DanielGao2766/pathreview/blob/feat/52-contribution-streak-tool/PLAN.md)
 
 **Blockers or open questions:**
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+[What have you implemented so far? Which sub-tasks from PLAN.md are done?]
+
+**Next steps:**
+[What are you working on for the rest of the week?]
+
+**Blockers:**
+[Anything slowing you down? Or leave blank.]
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [link to your submitted pull request]
+
+**Branch:** [the branch name you worked on, e.g. `fix/123-short-description`]
+
+**What you built:**
+[1–3 sentences summarizing what your fix does and how it works]
+
+**Tests added or updated:**
+[Which test files did you touch? What do they cover?]
+
+**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+
+**Draft PR feedback received from:** [name or Slack handle, or "none"]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -21,14 +21,11 @@ I selected this issue because it is a well-scoped feature with a clear objective
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [link to commit documenting the reproduced issue]
+**Reproduction commit link:** https://github.com/ascherj/pathreview/commit/2152eb9c36d3de8cd5a43204a205afd6cf5b6838
 
 **Reproduction summary:**
-[1–2 sentences: How did you reproduce the issue? What did you observe?]
+I located the gap in the feature within the agent/tools folder where I found github_tool.py. Since I could not find a method that calculates the longest commit streak of a user based on their github profile, I added a method stub that I will be implementing through the plan in the PLAN.md
 
-**PLAN.md link:** [link to PLAN.md in your fork]
-
-**Walkthrough video (recommended):** [link to your Loom video, ≤2 min — recommended, not graded]
+**PLAN.md link:** (https://github.com/DanielGao2766/pathreview/blob/feat/52-contribution-streak-tool/PLAN.md)
 
 **Blockers or open questions:**
-[Anything you're still uncertain about going into Week 9, or leave blank]

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,23 @@
+## Solution plan
+
+**Issue:** [issue title and link]
+
+### Understand
+What is the root cause of this issue? What behavior is expected vs. actual?
+
+### Map
+Which files, functions, or modules are involved?
+List the specific files you expect to touch.
+
+### Plan
+What are the steps to fix this issue?
+Break it into 3–5 concrete sub-tasks.
+
+### Inputs & outputs
+What does your fix take as input? What should it produce or change?
+
+### Risks & unknowns
+What could go wrong? What are you still unsure about?
+
+### Edge cases
+What inputs or states should your fix handle gracefully?

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,23 +1,40 @@
 ## Solution plan
 
-**Issue:** [issue title and link]
+**Issue:** Add a `contribution_streak` field to the GitHub analysis (longest consecutive days of commits):
+(https://github.com/ascherj/pathreview/issues/52)
 
 ### Understand
-What is the root cause of this issue? What behavior is expected vs. actual?
+`GitHubTool` (agent/tools/github_tool.py) currently only reports static repo metadata (stars, forks, language, README presence, etc.) via `_fetch_repo_metadata`. There is no signal about a contributor's consistency over time. The stubbed method `_longest_contribution_streak` (line 140) already exists as a placeholder — it takes a `username`, has no body (`pass`), and isn't wired into `_fetch_repo_metadata` or the returned `metadata` dict. A correct implementation should pull the user's commit dates (via the GitHub REST commits endpoint or the GraphQL contributions calendar), reduce them to a sorted set of unique contribution days, and compute the longest run of consecutive calendar days. The result should show up as a new `contribution_streak` integer key in the dict returned by `execute()`.
 
 ### Map
-Which files, functions, or modules are involved?
-List the specific files you expect to touch.
+- `agent/tools/github_tool.py` — `_longest_contribution_streak` (implement body), `_fetch_repo_metadata` (call it and add the key to `metadata`), `execute` (no change needed, just returns the dict)
+- `agent/tools/base.py` — `ToolResult` — unchanged, just confirming the return shape the new field flows through
+- `agent/orchestrator.py` (around line 94, `"github_tool"` invocation) — confirm no downstream code needs updating to surface the new field to callers/consumers
+- `tests/unit/` — likely need a new `test_github_tool.py` (none currently exists based on the earlier grep) to cover the streak logic
 
 ### Plan
-What are the steps to fix this issue?
-Break it into 3–5 concrete sub-tasks.
+1. Decide and implement the data source: use `GET /repos/{username}/{repo_name}/commits?author={username}` (paginated) to collect commit timestamps, since the tool is already scoped to a single repo rather than global contributions.
+2. In `_longest_contribution_streak`, convert each commit's `commit.author.date` to a `date` object, dedupe into a `set`, then sort and walk the sorted dates computing the longest run where each date is exactly one day after the previous.
+3. Handle pagination (GitHub caps commit list responses at 30/page by default, 100 max) so a long streak isn't truncated to one page of results.
+4. Wire the new method into `_fetch_repo_metadata`: call `self._longest_contribution_streak(username)` and add `"contribution_streak": streak_days` to the `metadata` dict (mirroring how `has_readme` is already computed via a helper and merged in).
+5. Add error handling consistent with the rest of the file — reuse the same `httpx.HTTPStatusError` / `Exception` handling pattern as `_has_readme` (return 0 on failure rather than raising, since `_has_readme` already sets that precedent of "degrade gracefully, don't blow up the whole tool call").
+6. Write unit tests (new `tests/unit/test_github_tool.py`) covering: no commits, one commit, an unbroken streak, and a streak with a gap.
 
 ### Inputs & outputs
-What does your fix take as input? What should it produce or change?
+- **Input:** `username` (str), plus implicitly `repo_name` since the commits endpoint is repo-scoped; reuses `self.api_token` and `self.base_url` already on the class.
+- **Output:** an `int` representing the longest run of consecutive calendar days with at least one commit authored by `username` in that repo; `0` if the user has no commits or the repo/user doesn't exist.
+- **Behavior change:** `_fetch_repo_metadata`'s returned dict gains a new key, `contribution_streak: int`, alongside the existing keys (`name`, `star_count`, etc.). This changes the shape of data that flows out of `GitHubTool.execute()` to whatever consumes it in `agent/orchestrator.py`.
 
 ### Risks & unknowns
-What could go wrong? What are you still unsure about?
+- **Rate limiting:** the commits endpoint requires pagination for active repos/users, which multiplies GitHub API calls per analysis and increases the chance of hitting the same 403 rate-limit path already handled in `execute()` — need to confirm the existing 403 handling still applies when the failure originates inside `_longest_contribution_streak` rather than `_fetch_repo_metadata`.
+- **Repo-scoped vs. account-wide streak:** the issue says "longest consecutive commit streak from their GitHub contribution history," which usually means the GitHub profile contribution graph (all repos, via GraphQL + auth token), not a single repo's commit log. Need to clarify with the issue author/maintainer whether repo-scoped (matches current tool's single-repo scope, REST-only, no extra auth) or account-wide (matches user intuition, requires GraphQL + a token with `read:user` scope) is expected — this materially changes the implementation.
+- **Timezone/date boundary edge cases:** GitHub commit timestamps are UTC; a commit at 11:59pm and another at 12:01am UTC the next day could either correctly or incorrectly count as consecutive days depending on the contributor's actual timezone — unsure if this is worth normalizing to the user's local time or if UTC-day-boundary is acceptable.
+- **Merge commits / bot commits:** unclear whether merge commits or commits authored by bots (e.g. dependabot) should count toward the streak; could inflate or deflate the result depending on repo conventions.
 
 ### Edge cases
-What inputs or states should your fix handle gracefully?
+- Username or repo has **zero commits** by that author — must return `0`, not raise or return `None`.
+- Username/repo **doesn't exist** (404) — should degrade gracefully like `_has_readme` does, returning `0` rather than propagating the exception up through `execute()`.
+- **Single commit** — streak should be `1`, not `0`.
+- Commits made **on the same calendar day but at different times** (e.g. 5 commits in one day) — should count as one day, not artificially extend the streak.
+- A **gap in the middle** of otherwise dense activity (e.g. commits on 10 consecutive days, then a 2-day gap, then 3 more consecutive days) — should return `10`, the longest run, not the total distinct days (13) or the most recent run (3).
+- **Pagination boundary** — a streak that spans more commits than fit in a single API page must still be computed correctly, not silently truncated to the first page's commits.

--- a/agent/tools/github_tool.py
+++ b/agent/tools/github_tool.py
@@ -1,7 +1,10 @@
 """GitHub repository metadata tool."""
 
+from datetime import date, timedelta
+
 import httpx
 import structlog
+
 from .base import BaseTool, ToolResult
 
 logger = structlog.get_logger()
@@ -35,44 +38,30 @@ class GitHubTool(BaseTool):
         repo_name = input_data.get("repo_name")
 
         if not username or not repo_name:
-            return ToolResult(
-                success=False,
-                data={},
-                error="Missing github_username or repo_name"
-            )
+            return ToolResult(success=False, data={}, error="Missing github_username or repo_name")
 
         try:
             repo_data = self._fetch_repo_metadata(username, repo_name)
             return ToolResult(success=True, data=repo_data)
 
         except httpx.HTTPStatusError as e:
-            logger.error("github_request_failed", status=e.response.status_code,
-                        username=username, repo=repo_name)
+            logger.error(
+                "github_request_failed",
+                status=e.response.status_code,
+                username=username,
+                repo=repo_name,
+            )
             if e.response.status_code == 404:
-                return ToolResult(
-                    success=False,
-                    data={},
-                    error="Repository not found"
-                )
+                return ToolResult(success=False, data={}, error="Repository not found")
             elif e.response.status_code == 403:
-                return ToolResult(
-                    success=False,
-                    data={},
-                    error="Rate limited or access denied"
-                )
+                return ToolResult(success=False, data={}, error="Rate limited or access denied")
             return ToolResult(
-                success=False,
-                data={},
-                error=f"GitHub API error: {e.response.status_code}"
+                success=False, data={}, error=f"GitHub API error: {e.response.status_code}"
             )
 
         except Exception as e:
             logger.error("github_tool_error", error=str(e))
-            return ToolResult(
-                success=False,
-                data={},
-                error=str(e)
-            )
+            return ToolResult(success=False, data={}, error=str(e))
 
     def _fetch_repo_metadata(self, username: str, repo_name: str) -> dict:
         """Fetch repository metadata from GitHub API.
@@ -107,10 +96,16 @@ class GitHubTool(BaseTool):
             "has_readme": self._has_readme(username, repo_name),
             "topics": repo_json.get("topics", []),
             "homepage": repo_json.get("homepage") or "",
+            "contribution_streak": self._longest_contribution_streak(username),
         }
 
-        logger.info("github_repo_fetched", username=username, repo=repo_name,
-                   language=metadata["primary_language"], stars=metadata["star_count"])
+        logger.info(
+            "github_repo_fetched",
+            username=username,
+            repo=repo_name,
+            language=metadata["primary_language"],
+            stars=metadata["star_count"],
+        )
 
         return metadata
 
@@ -135,18 +130,83 @@ class GitHubTool(BaseTool):
             return response.status_code == 200
         except Exception:
             return False
-        
-    # Missing feature that I am implementing
+
     def _longest_contribution_streak(self, username: str) -> int:
+        """Compute the longest run of consecutive days with GitHub activity.
+
+        Uses the GraphQL contributionsCollection API, which reports
+        account-wide contributions (commits, PRs, issues, reviews) rather
+        than commits to a single repo. This requires an authenticated
+        request, and the API only reports the trailing 365 days of
+        activity, so streaks that started more than a year ago will be
+        undercounted.
+
+        Args:
+            username: GitHub username
+
+        Returns:
+            Longest run of consecutive days with at least one contribution.
+            0 if there's no token to authenticate with, the user doesn't
+            exist, or the user has no contributions in the last year.
         """
-            Check the longest contribution streak of a individual's github account
-            
-            Args:
-                username: Github Username
-                
-            Returns:
-                int value corresponding to the longest contribution streak of the user
-                0 if username does not exist or nothing has been committed
+        if not self.api_token:
+            return 0
+
+        query = """
+        query($username: String!) {
+          user(login: $username) {
+            contributionsCollection {
+              contributionCalendar {
+                weeks {
+                  contributionDays {
+                    date
+                    contributionCount
+                  }
+                }
+              }
+            }
+          }
+        }
         """
-        
-      
+
+        headers = {"Authorization": f"Bearer {self.api_token}"}
+
+        try:
+            response = httpx.post(
+                f"{self.base_url}/graphql",
+                json={"query": query, "variables": {"username": username}},
+                headers=headers,
+                timeout=10.0,
+            )
+            response.raise_for_status()
+            payload = response.json()
+
+            user_data = payload.get("data", {}).get("user")
+            if payload.get("errors") or not user_data:
+                return 0
+
+            weeks = user_data["contributionsCollection"]["contributionCalendar"]["weeks"]
+            active_days = {
+                date.fromisoformat(day["date"])
+                for week in weeks
+                for day in week["contributionDays"]
+                if day["contributionCount"] > 0
+            }
+
+            if not active_days:
+                return 0
+
+            sorted_days = sorted(active_days)
+            longest = current = 1
+            for previous_day, day in zip(sorted_days, sorted_days[1:], strict=False):
+                if day - previous_day == timedelta(days=1):
+                    current += 1
+                    longest = max(longest, current)
+                else:
+                    current = 1
+
+            return longest
+
+        except Exception as e:
+            logger.error("github_contribution_streak_error", username=username, error=str(e))
+            return 0

--- a/agent/tools/github_tool.py
+++ b/agent/tools/github_tool.py
@@ -135,3 +135,18 @@ class GitHubTool(BaseTool):
             return response.status_code == 200
         except Exception:
             return False
+        
+    # Missing feature that I am implementing
+    def _longest_contribution_streak(self, username: str) -> int:
+        """
+            Check the longest contribution streak of a individual's github account
+            
+            Args:
+                username: Github Username
+                
+            Returns:
+                int value corresponding to the longest contribution streak of the user
+                0 if username does not exist or nothing has been committed
+        """
+        
+      

--- a/tests/unit/test_github_tool.py
+++ b/tests/unit/test_github_tool.py
@@ -1,0 +1,138 @@
+"""Tests for github_tool.py"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.tools.github_tool import GitHubTool
+
+
+def _calendar_response(dates_with_counts: list[tuple[str, int]]) -> MagicMock:
+    """Build a fake httpx.Response for the contributionsCollection query."""
+    response = MagicMock()
+    response.raise_for_status.return_value = None
+    response.json.return_value = {
+        "data": {
+            "user": {
+                "contributionsCollection": {
+                    "contributionCalendar": {
+                        "weeks": [
+                            {
+                                "contributionDays": [
+                                    {"date": date_str, "contributionCount": count}
+                                    for date_str, count in dates_with_counts
+                                ]
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    }
+    return response
+
+
+@pytest.mark.unit
+class TestLongestContributionStreak:
+    """Test suite for GitHubTool._longest_contribution_streak."""
+
+    @pytest.fixture
+    def tool(self):
+        """Create a GitHubTool instance with a fake token."""
+        return GitHubTool(api_token="fake-token")
+
+    def test_no_token_returns_zero_without_request(self):
+        """Without a token, the GraphQL call can't authenticate, so bail out early."""
+        tool = GitHubTool(api_token=None)
+        with patch("httpx.post") as mock_post:
+            assert tool._longest_contribution_streak("someone") == 0
+            mock_post.assert_not_called()
+
+    def test_no_contributions_returns_zero(self, tool):
+        with patch(
+            "httpx.post",
+            return_value=_calendar_response(
+                [
+                    ("2026-01-01", 0),
+                    ("2026-01-02", 0),
+                ]
+            ),
+        ):
+            assert tool._longest_contribution_streak("someone") == 0
+
+    def test_single_contribution_day_returns_one(self, tool):
+        with patch(
+            "httpx.post",
+            return_value=_calendar_response(
+                [
+                    ("2026-01-01", 0),
+                    ("2026-01-02", 3),
+                    ("2026-01-03", 0),
+                ]
+            ),
+        ):
+            assert tool._longest_contribution_streak("someone") == 1
+
+    def test_unbroken_streak(self, tool):
+        dates = [(f"2026-01-{day:02d}", 1) for day in range(1, 11)]
+        with patch("httpx.post", return_value=_calendar_response(dates)):
+            assert tool._longest_contribution_streak("someone") == 10
+
+    def test_streak_with_gap_returns_longest_not_total(self, tool):
+        # 10 consecutive days, a 2-day gap, then 3 more consecutive days.
+        dense_run = [(f"2026-01-{day:02d}", 1) for day in range(1, 11)]
+        gap = [("2026-01-11", 0), ("2026-01-12", 0)]
+        short_run = [(f"2026-01-{day:02d}", 1) for day in range(13, 16)]
+        with patch("httpx.post", return_value=_calendar_response(dense_run + gap + short_run)):
+            assert tool._longest_contribution_streak("someone") == 10
+
+    def test_same_day_multiple_contributions_counts_once(self, tool):
+        with patch(
+            "httpx.post",
+            return_value=_calendar_response(
+                [
+                    ("2026-01-01", 5),
+                ]
+            ),
+        ):
+            assert tool._longest_contribution_streak("someone") == 1
+
+    def test_nonexistent_user_returns_zero(self, tool):
+        response = MagicMock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = {
+            "data": {"user": None},
+            "errors": [{"message": "Could not resolve to a User"}],
+        }
+        with patch("httpx.post", return_value=response):
+            assert tool._longest_contribution_streak("ghost") == 0
+
+    def test_request_exception_returns_zero(self, tool):
+        with patch("httpx.post", side_effect=Exception("network error")):
+            assert tool._longest_contribution_streak("someone") == 0
+
+    def test_wired_into_repo_metadata(self, tool):
+        """_fetch_repo_metadata should include the streak alongside existing fields."""
+        repo_response = MagicMock()
+        repo_response.raise_for_status.return_value = None
+        repo_response.json.return_value = {
+            "name": "repo",
+            "description": "desc",
+            "language": "Python",
+            "stargazers_count": 1,
+            "forks_count": 0,
+            "open_issues_count": 0,
+            "pushed_at": "2026-01-01T00:00:00Z",
+            "topics": [],
+            "homepage": None,
+        }
+        readme_response = MagicMock(status_code=200)
+        streak_response = _calendar_response([("2026-01-01", 1), ("2026-01-02", 1)])
+
+        with (
+            patch("httpx.get", side_effect=[repo_response, readme_response]),
+            patch("httpx.post", return_value=streak_response),
+        ):
+            metadata = tool._fetch_repo_metadata("someone", "repo")
+
+        assert metadata["contribution_streak"] == 2


### PR DESCRIPTION
## Summary
Adds a `contribution_streak` field to GitHub repo analysis, reporting the longest run of consecutive calendar days with GitHub activity for the analyzed user. Implements the stubbed `_longest_contribution_streak` method in `agent/tools/github_tool.py` using GitHub's GraphQL `contributionsCollection` API (account-wide contributions, not just commits to the analyzed repo), since that matches how contributors intuitively think of their "streak." This requires an authenticated request; if no API token is configured, the field degrades to `0` rather than failing the whole tool call, consistent with how `_has_readme` already degrades on failure.

## Issue
Closes #52 

## Changes
- Implemented `GitHubTool._longest_contribution_streak(username)` in `agent/tools/github_tool.py`: queries the GraphQL `contributionsCollection` API, dedupes contribution days into a set, and walks the sorted dates to find the longest consecutive run.
- Wired the new field into `_fetch_repo_metadata`, adding `"contribution_streak"` to the returned metadata dict.
- Added `tests/unit/test_github_tool.py` with 9 tests covering the edge cases identified in PLAN.md.

## Testing
<!-- How did you verify your changes? -->
- [x] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`)
- [x] Linter passes (`make lint`)
- [x] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes

## Manual verification steps
1. Set a `GITHUB_TOKEN`/API token that has at least `read:user` scope (GraphQL contribution data requires auth; without a token, `contribution_streak` will correctly report `0`).
2. Run an analysis for a GitHub profile you know has recent commit activity — e.g. call `GitHubTool(api_token=<token>).execute({"github_username": "<your-username>", "repo_name": "<one-of-your-repos>"})` from a Python shell.
3. Confirm the returned dict includes `contribution_streak` as an integer, and that it roughly matches the longest run visible on `https://github.com/<username>` under your contribution graph (note: GitHub's `contributionCalendar` only covers the trailing 365 days, so very old streaks won't be reflected — documented as a known limitation in the method's docstring).
4. Optionally test the degrade-gracefully path: call the same method with no `api_token` set and confirm it returns `0` immediately without making a network request.

## Notes for Reviewers
The issue as written ("longest consecutive commit streak from GitHub contribution history") is ambiguous between repo-scoped (matches this tool's existing single-repo design, REST-only, no auth needed) and account-wide (matches the GitHub profile contribution graph, requires GraphQL + an authenticated token). I went with account-wide since that's what "contribution streak" conventionally means on GitHub — flagging this in case reviewers want repo-scoped instead, which would be a smaller/simpler change (see PLAN.md's original REST-based approach).
