### PR TITLE
test(safety): add property-based PII scrubber tests

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -112,42 +112,43 @@ test file, and pre-commit mypy reports missing annotations throughout the existi
 **Feedback received:** [ ] Yes  [x] No — still awaiting review
 
 **Summary of feedback:**
-No reviewer feedback has been received yet. Pull request #843 is awaiting peer or mentor review.
+
+No reviewer feedback has been received. The Summer 2026 course instructions note that reviewer feedback is not provided this term, and pull request #843 currently has no review submissions or review comments.
 
 **How you responded:**
-No reviewer-directed changes have been made yet. I completed a detailed self-review, strengthened
-the properties so partial redaction cannot pass, reran the focused tests, and documented existing
-repository failures in the pull request.
+
+Because no reviewer feedback was available, no reviewer-directed changes were necessary. I used the week to complete a detailed self-review, rerun the focused property-based tests, review the final diff, and document the repository's pre-existing test, lint, and type-check failures in the pull request.
 
 ---
 
 ### Reflection
 
 **What was harder than you expected?**
-The hardest part was separating failures introduced by my work from failures already present in the
-repository. The focused property tests passed, but the complete PII test file exposed existing phone
-and address regex problems. Hypothesis also showed that checking only whether the original value
-disappeared was too weak because partial redaction could satisfy that assertion.
+
+The hardest part was separating problems introduced by my work from problems that already existed in the repository. The focused property tests passed, but the complete PII scrubber test file contained failures caused by existing phone-number and street-address regex behavior. The quality checks also reported existing lint and type-annotation problems in the test file. Understanding which failures actually belonged to issue #111 required inspecting the implementation, reviewing the full diff, and running progressively narrower checks.
+
+Hypothesis also exposed a subtle testing problem: simply checking that the original PII value disappeared was not strong enough, because a partial redaction could satisfy that assertion without fully removing the sensitive value.
 
 **What did you learn about working in a large codebase?**
-I learned to establish the current behavior and baseline before editing, preserve unrelated work,
-and keep a pull request focused even when nearby defects are discovered. Contributing to someone
-else's codebase requires following its existing contract and documenting issues that belong in
-separate follow-up work.
+
+I learned that contributing to an existing codebase requires understanding its current contract and baseline before making changes. A test should verify behavior the application actually claims to support rather than silently expanding that behavior.
+
+I also learned the importance of preserving unrelated work, following repository conventions, checking whether failures reproduce before my changes, and keeping a pull request focused even when nearby defects are discovered. In my own project I could immediately change both the tests and implementation, but in a shared production codebase those changes may belong to separate issues and need to be justified independently.
 
 **How did AI tools help — and where did they fall short?**
-AI tools helped locate the relevant implementation and configuration, design component-based
-Hypothesis strategies, interpret minimized examples, and review the final diff. They fell short when
-repository-wide commands were suggested before accounting for the Windows environment and stale
-virtual-environment launchers. I still needed to evaluate the output, distinguish generator mistakes
-from production bugs, and make scope decisions.
+
+AI tools helped me explore the repository, locate the PII implementation, understand its regular expressions, design Hypothesis strategies, review the diff, and interpret minimized failing examples. They were especially useful for identifying partial-redaction cases that simple example-based tests could miss and for quickly comparing generated inputs with the scrubber's supported behavior.
+
+AI assistance fell short when it initially suggested repository-wide commands without accounting for my Windows environment and the repository's stale virtual-environment launchers. It also could not replace the judgment needed to distinguish a genuine scrubber defect from an invalid generator assumption or decide whether a discovered problem belonged in this pull request. I still needed to inspect the actual output, verify commands locally, compare against the baseline, and make the final scope decisions myself.
 
 **What would you do differently if you started over?**
-I would create the correct issue branch first, run and save baseline test and quality-check results,
-and verify the development environment before implementing anything. I would also begin with strict
-complete-output assertions instead of first checking only that the original PII value disappeared.
+
+I would first create the correct issue branch from the latest `main`, then run and save the baseline focused tests, relevant unit tests, lint checks, and type checks before editing. I would also verify the local development tools and virtual environment before reaching the commit stage.
+
+During implementation, I would begin with strict properties that verify the complete scrubbed output rather than only checking that the original PII value disappeared. That would make it easier to identify partial-redaction behavior earlier and distinguish implementation limitations from generator mistakes.
 
 **What are you most proud of from this module?**
-I am most proud that the strategies construct realistic PII from meaningful components rather than
-copying the production regular expressions. This gives the randomized tests a better chance of
-detecting regressions and helped reveal subtle partial-redaction behavior during development.
+
+I am most proud of creating property-based strategies that are independent from the production regular expressions. Instead of copying the implementation with `st.from_regex()`, the tests construct realistic emails, phone numbers, Social Security numbers, and street addresses from meaningful components.
+
+This makes the tests more valuable for detecting future regressions rather than simply reproducing the implementation's assumptions, and it helped expose subtle partial-redaction behavior that fixed examples could easily miss.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,153 @@
+# PathReview Contribution Journal
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/111
+
+**Issue title:** No property-based tests for the PII scrubber
+
+**Tier:** [ ] Tier 1  [x] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The PII scrubber supports five categories of personal information, but its unit tests used only a
+small number of hard-coded examples. Issue #111 asks for Hypothesis strategies that generate
+randomized supported PII and verify that the scrubber reliably removes it. A successful solution
+adds meaningful randomized coverage without duplicating implementation regexes or changing the
+production scrubbing API.
+
+**Branch name:** `test/111-pii-scrubber-property-tests`
+
+**Setup confirmation:** [x] Python test environment is available and focused unit tests run locally
+
+**Cohort ledger:** [ ] Issue added to cohort ledger
+
+### “Is this right for me?” checklist reasoning
+
+- The issue is labeled Tier 2 and has an estimated effort of 4–6 hours.
+- The requested change is focused on one existing unit-test file.
+- The current scrubber implementation and example tests clearly identify the behavior to test.
+- Hypothesis is already available in the development dependency group.
+- The change can be verified locally without network access or running the application stack.
+- The main risk is accidentally generating unsupported formats or writing generators that simply
+  reproduce the implementation regexes.
+
+### Setup notes
+
+- Used the existing fork with `origin` pointing to `menukaghalan/pathreview` and `upstream`
+  pointing to `ascherj/pathreview`.
+- Created `test/111-pii-scrubber-property-tests` from the upstream `main` branch.
+- Repaired stale Windows virtual-environment launchers so pytest and pre-commit could run locally.
+- Verified that Hypothesis was already declared in `pyproject.toml`.
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** No separate reproduction commit was created. The missing Hypothesis
+coverage was confirmed by inspecting the original `tests/unit/test_pii_scrubber.py`; the completed
+test implementation is commit
+https://github.com/menukaghalan/pathreview/commit/3a51568d63684b8a4c14ca6f3d9a6da6fcf48460.
+
+**Reproduction summary:**
+I inspected `tests/unit/test_pii_scrubber.py` and confirmed that it contained example-based tests but
+no Hypothesis imports, strategies, or `@given` tests. I then inspected `safety/pii_scrubber.py` and
+identified five supported categories: email, US phone, international phone, SSN, and street address.
+
+**PLAN.md link:**
+https://github.com/menukaghalan/pathreview/blob/test/111-pii-scrubber-property-tests/PLAN.md
+
+**Walkthrough video (recommended):** Not recorded.
+
+**Blockers or open questions:**
+The repository already had failing PII scrubber examples and existing lint/type-check findings.
+These were documented separately so the test-only change would not expand into production regex
+work.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+I inspected the implementation, existing tests, testing configuration, and development dependencies.
+I defined independent bounded strategies for all five supported PII categories and added primary
+redaction properties.
+
+**Next steps:**
+Run Hypothesis, inspect minimized failures, tighten any generator assumptions, add secondary
+idempotence and robustness properties, and prepare a draft pull request.
+
+**Blockers:**
+The Windows virtual environment contained stale executable launchers, and the repository had
+pre-existing PII test, Ruff, and mypy failures.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/843
+
+**Branch:** `test/111-pii-scrubber-property-tests`
+
+**What you built:**
+I added bounded Hypothesis strategies and property-based tests for every PII category currently
+supported by the scrubber. The properties verify complete redaction, preservation of safe context,
+idempotence, and robustness against bounded arbitrary Unicode input.
+
+**Tests added or updated:**
+Updated `tests/unit/test_pii_scrubber.py` with seven property-based tests covering emails, US and
+international phone numbers, SSNs, street addresses, idempotence, and arbitrary-text robustness.
+The focused run completed with 7 passed and 25 deselected.
+
+**Self-review confirmation:** [ ] `make check` passes  [ ] `make test-unit` passes
+
+The new focused tests pass, Black passes, and `git diff --check` passes. The boxes remain unchecked
+because repository-wide checks have documented pre-existing failures: five existing PII examples
+fail against current production regex behavior, Ruff reports two existing unused assignments in the
+test file, and pre-commit mypy reports missing annotations throughout the existing test file.
+
+**Draft PR feedback received from:** none — still awaiting review
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No reviewer feedback has been received yet. Pull request #843 is awaiting peer or mentor review.
+
+**How you responded:**
+No reviewer-directed changes have been made yet. I completed a detailed self-review, strengthened
+the properties so partial redaction cannot pass, reran the focused tests, and documented existing
+repository failures in the pull request.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The hardest part was separating failures introduced by my work from failures already present in the
+repository. The focused property tests passed, but the complete PII test file exposed existing phone
+and address regex problems. Hypothesis also showed that checking only whether the original value
+disappeared was too weak because partial redaction could satisfy that assertion.
+
+**What did you learn about working in a large codebase?**
+I learned to establish the current behavior and baseline before editing, preserve unrelated work,
+and keep a pull request focused even when nearby defects are discovered. Contributing to someone
+else's codebase requires following its existing contract and documenting issues that belong in
+separate follow-up work.
+
+**How did AI tools help — and where did they fall short?**
+AI tools helped locate the relevant implementation and configuration, design component-based
+Hypothesis strategies, interpret minimized examples, and review the final diff. They fell short when
+repository-wide commands were suggested before accounting for the Windows environment and stale
+virtual-environment launchers. I still needed to evaluate the output, distinguish generator mistakes
+from production bugs, and make scope decisions.
+
+**What would you do differently if you started over?**
+I would create the correct issue branch first, run and save baseline test and quality-check results,
+and verify the development environment before implementing anything. I would also begin with strict
+complete-output assertions instead of first checking only that the original PII value disappeared.
+
+**What are you most proud of from this module?**
+I am most proud that the strategies construct realistic PII from meaningful components rather than
+copying the production regular expressions. This gives the randomized tests a better chance of
+detecting regressions and helped reveal subtle partial-redaction behavior during development.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,86 @@
+# Week 8 — Issue Reproduction & Solution Planning
+
+## Issue
+
+**Issue:** #111 — No property-based tests for the PII scrubber
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/111
+
+**Branch:** `test/111-pii-scrubber-property-tests`
+
+## Reproduction
+
+### Expected Behavior
+
+The PII scrubber test suite should use property-based tests to generate many valid examples of
+every supported PII category and verify that each value is removed. The tests should exercise the
+public `PIIScrubber.scrub()` behavior without copying its regular expressions into the generators.
+
+### Actual Behavior
+
+Before this change, `tests/unit/test_pii_scrubber.py` contained only example-based tests with a
+small set of hard-coded values. The scrubber supported email addresses, US phone numbers, compact
+international phone numbers, Social Security numbers, and US street addresses, but no Hypothesis
+strategies generated variations of those values.
+
+### Steps to Reproduce
+
+1. Open `tests/unit/test_pii_scrubber.py`.
+2. Search for imports from `hypothesis`, `@given`, or custom Hypothesis strategies.
+3. Confirm that the file contains example-based tests but no property-based tests.
+4. Open `safety/pii_scrubber.py` and identify the five configured PII categories.
+5. Confirm that `hypothesis` is already included in the `dev` dependency group in
+   `pyproject.toml`.
+
+## Root Cause
+
+The existing suite was written around selected examples. It did not include independently
+constructed generators capable of exercising meaningful variations within the scrubber's current
+supported formats.
+
+## Solution Plan
+
+### Files to Change
+
+- `tests/unit/test_pii_scrubber.py`
+- `PLAN.md`
+- `JOURNAL.md`
+
+### Implementation Steps
+
+1. Inspect the scrubber implementation, existing tests, dependency configuration, and test style.
+2. Define the supported formats and `[REDACTED]` replacement contract.
+3. Create bounded component-based strategies for emails, US phones, international phones, SSNs,
+   and street addresses.
+4. Add one primary property per category verifying complete redaction and preservation of known
+   safe surrounding text.
+5. Add an idempotence property for generated PII.
+6. Add a robustness property for reasonably sized arbitrary Unicode strings.
+7. Run the focused property tests and review any minimized failing examples.
+8. Constrain generators when a case falls outside the current fully supported contract rather
+   than changing production behavior for a test-only issue.
+9. Run formatting, linting, diff, and focused test checks and document pre-existing failures.
+
+## Risks and Edge Cases
+
+- Generators must not duplicate the implementation regexes because that would make the tests
+  unable to catch many regex defects.
+- Generated values must stay within formats the current implementation fully redacts.
+- Merely asserting that the original string disappeared can allow partial redaction to pass, so
+  primary properties should verify the complete expected output.
+- Phone patterns can overlap because US phone redaction runs before international phone redaction.
+- Some address suffix alternatives partially match longer suffixes, so generated suffixes should
+  be limited to values that the current behavior replaces completely.
+- Strategies must remain bounded so normal Hypothesis runs stay fast in CI.
+- Existing test, lint, and type-check failures must be recorded separately from failures introduced
+  by this change.
+
+## Verification Plan
+
+- Run the new properties with:
+  `python -m pytest tests/unit/test_pii_scrubber.py -q -k "generated or bounded"`.
+- Run the complete PII scrubber test file and document pre-existing failures.
+- Run Black against `tests/unit/test_pii_scrubber.py`.
+- Run Ruff against the changed test file and distinguish existing findings from new findings.
+- Run `git diff --check`.
+- Review the final diff and confirm that production code and dependencies remain unchanged.

--- a/tests/unit/test_pii_scrubber.py
+++ b/tests/unit/test_pii_scrubber.py
@@ -1,8 +1,105 @@
 """Tests for pii_scrubber.py"""
 
 import pytest
+from hypothesis import given
+from hypothesis import strategies as st
 
 from safety.pii_scrubber import PIIScrubber
+
+ASCII_LETTERS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+LOWERCASE_LETTERS = "abcdefghijklmnopqrstuvwxyz"
+EMAIL_ATOM_CHARACTERS = f"{ASCII_LETTERS}0123456789"
+STREET_SUFFIXES = (
+    "Street",
+    "St",
+    "Avenue",
+    "Ave",
+    "Road",
+    "Rd",
+    "Boulevard",
+    "Blvd",
+    "Drive",
+    "Dr",
+    "Lane",
+    "Court",
+    "Circle",
+    "Way",
+    "Terrace",
+    "Trail",
+)
+
+
+def ascii_word(min_size=1, max_size=12):
+    """Build a bounded ASCII word accepted by the scrubber's PII formats."""
+    return st.text(alphabet=LOWERCASE_LETTERS, min_size=min_size, max_size=max_size)
+
+
+@st.composite
+def email_addresses(draw):
+    """Generate practical email addresses in the scrubber's supported domain."""
+    local_parts = draw(
+        st.lists(
+            st.text(alphabet=EMAIL_ATOM_CHARACTERS, min_size=1, max_size=8),
+            min_size=1,
+            max_size=3,
+        )
+    )
+    local_separator = draw(st.sampled_from((".", "_", "+", "-")))
+    local = local_separator.join(local_parts)
+    domain_parts = draw(st.lists(ascii_word(), min_size=1, max_size=3))
+    top_level_domain = draw(ascii_word(min_size=2, max_size=8))
+    return f"{local}@{'.'.join(domain_parts)}.{top_level_domain}"
+
+
+@st.composite
+def us_phone_numbers(draw):
+    """Generate US phone formats explicitly supported by the scrubber."""
+    digits = draw(st.text(alphabet="0123456789", min_size=10, max_size=10))
+    area, exchange, subscriber = digits[:3], digits[3:6], digits[6:]
+    phone_format = draw(st.sampled_from(("plain", "hyphen", "dot")))
+
+    if phone_format == "plain":
+        return digits
+
+    separator = "-" if phone_format == "hyphen" else "."
+    country_code = draw(st.sampled_from(("", "1", "1" + separator)))
+    return f"{country_code}{area}{separator}{exchange}{separator}{subscriber}"
+
+
+@st.composite
+def international_phone_numbers(draw):
+    """Generate international numbers in the scrubber's compact supported form."""
+    country_code = draw(st.text(alphabet="0123456789", min_size=1, max_size=3))
+    national_number = draw(st.text(alphabet="0123456789", min_size=4, max_size=6))
+    separator = draw(st.sampled_from(("", "-", ".")))
+    return f"+{country_code}{separator}{national_number}"
+
+
+@st.composite
+def social_security_numbers(draw):
+    """Generate structurally valid SSNs accepted by the scrubber."""
+    area = draw(st.one_of(st.integers(min_value=1, max_value=665), st.integers(667, 999)))
+    group = draw(st.integers(min_value=1, max_value=99))
+    serial = draw(st.integers(min_value=1, max_value=9999))
+    return f"{area:03d}-{group:02d}-{serial:04d}"
+
+
+@st.composite
+def street_addresses(draw):
+    """Generate simple US street addresses in the scrubber's supported form."""
+    number = draw(st.integers(min_value=1, max_value=99999))
+    street_name = " ".join(draw(st.lists(ascii_word(), min_size=1, max_size=3)))
+    suffix = draw(st.sampled_from(STREET_SUFFIXES))
+    return f"{number} {street_name} {suffix}"
+
+
+PII_VALUES = st.one_of(
+    email_addresses(),
+    us_phone_numbers(),
+    international_phone_numbers(),
+    social_security_numbers(),
+    street_addresses(),
+)
 
 
 @pytest.mark.unit
@@ -13,6 +110,61 @@ class TestPIIScrubber:
     def scrubber(self):
         """Create a PIIScrubber instance."""
         return PIIScrubber()
+
+    @given(email=email_addresses())
+    def test_generated_emails_are_redacted(self, email):
+        """Every generated supported email is removed without losing safe context."""
+        scrubbed = PIIScrubber().scrub(f"Contact email: {email}\nEnd of contact.")
+
+        assert email not in scrubbed
+        assert scrubbed == "Contact email: [REDACTED]\nEnd of contact."
+
+    @given(phone=us_phone_numbers())
+    def test_generated_us_phone_numbers_are_redacted(self, phone):
+        """Every generated supported US phone number is removed."""
+        scrubbed = PIIScrubber().scrub(f"Call this number: {phone}; thanks.")
+
+        assert phone not in scrubbed
+        assert scrubbed == "Call this number: [REDACTED]; thanks."
+
+    @given(phone=international_phone_numbers())
+    def test_generated_international_phone_numbers_are_redacted(self, phone):
+        """Every generated supported international phone number is removed."""
+        scrubbed = PIIScrubber().scrub(f"International contact: {phone}\nPlease call.")
+
+        assert phone not in scrubbed
+        assert scrubbed == "International contact: [REDACTED]\nPlease call."
+
+    @given(ssn=social_security_numbers())
+    def test_generated_ssns_are_redacted(self, ssn):
+        """Every generated structurally valid SSN is removed."""
+        scrubbed = PIIScrubber().scrub(f"Tax identifier: {ssn}. Keep private.")
+
+        assert ssn not in scrubbed
+        assert scrubbed == "Tax identifier: [REDACTED]. Keep private."
+
+    @given(address=street_addresses())
+    def test_generated_street_addresses_are_redacted(self, address):
+        """Every generated supported street address is removed."""
+        scrubbed = PIIScrubber().scrub(f"Mail to: {address}; recipient on file.")
+
+        assert address not in scrubbed
+        assert scrubbed == "Mail to: [REDACTED]; recipient on file."
+
+    @given(pii=PII_VALUES)
+    def test_scrubbing_generated_pii_is_idempotent(self, pii):
+        """Scrubbing generated PII twice has no additional effect."""
+        scrubber = PIIScrubber()
+        scrubbed = scrubber.scrub(f"Sensitive value: {pii}")
+
+        assert scrubber.scrub(scrubbed) == scrubbed
+
+    @given(text=st.text(max_size=200))
+    def test_scrubbing_bounded_arbitrary_text_does_not_crash(self, text):
+        """Reasonably sized arbitrary Unicode text can always be scrubbed."""
+        result = PIIScrubber().scrub(text)
+
+        assert isinstance(result, str)
 
     def test_email_redaction(self, scrubber):
         """Test email address is redacted."""


### PR DESCRIPTION
## Summary

Adds property-based tests using Hypothesis to verify that the PII scrubber reliably removes randomized supported PII while preserving surrounding non-PII text. These tests supplement the existing example-based test suite and add coverage for idempotence and arbitrary bounded input.

## Issue

Closes #111

## Changes

- Added bounded Hypothesis strategies for:
  - Email addresses
  - US phone numbers
  - Compact international phone numbers
  - Social Security numbers
  - US street addresses
- Added properties verifying complete PII redaction.
- Verified preservation of safe surrounding text.
- Added an idempotence property.
- Added robustness coverage for arbitrary bounded Unicode input.
- Preserved all existing example-based tests.
- Made no production-code or dependency changes.

## Testing

- [ ] Unit tests pass (`make test-unit`) — existing unrelated PII scrubber tests fail against current regex behavior
- [ ] Integration tests pass (`make test-integration`) — not run because this is a unit-test-only change
- [ ] Linter passes (`make lint`) — two pre-existing unused assignments remain in the test file
- [ ] Type checker passes (`make typecheck`) — pre-commit mypy reports missing annotations throughout the existing test file
- [x] New/updated tests cover the changes

Focused property-test result:

```text
7 passed, 25 deselected in 1.52s
```

Additional verification:

- Black passed.
- `git diff --check` passed.
- No debug statements, generated files, or unrelated changes were added.

## Screenshots / Demo

Not applicable. This PR only adds unit tests.

## Notes for Reviewers

The complete PII scrubber test file currently has five pre-existing failures involving spaced parenthesized phone numbers and false-positive street-address matching. This PR intentionally tests the scrubber’s existing supported behavior and does not modify the production regular expressions.

The Hypothesis strategies construct supported values independently instead of generating inputs from the implementation regexes. All inputs are bounded to keep CI execution fast and reproducible.