### PR TITLE
fix(rag): handle None text in faithfulness checker context chunks

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -24,3 +24,54 @@ with missing or null text without crashing.
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+**Scope-fit reasoning:**
+I worked through the "Is this right for me?" checklist before claiming this issue.
+
+- *Understanding the issue:* I can restate the bug without re-reading it -
+  `check()` builds context via `chunk.get("text", "")`, but `.get()`'s default
+  only applies when a key is missing, not when it's present with value `None`.
+  A chunk with `{"text": None}` causes `" ".join(...)` to raise `TypeError`.
+  "Done" means the checker returns a valid score instead of crashing when
+  `text` is `None`.
+
+- *Tier fit:* This is my first contribution to a codebase this size, so Tier 1
+  is the right level - the fix is isolated to one function in one file and
+  doesn't require understanding how the RAG pipeline fits together end to end.
+
+- *Codebase readiness:* I located and read `check()` in
+  `rag/evaluator/faithfulness_checker.py`, including the surrounding context
+  needed to understand how chunks flow into the join call. I also read
+  `tests/unit/test_faithfulness_checker.py` end to end, including
+  `test_none_context_chunk_text` (text present but `None`) and the adjacent
+  `test_missing_text_key_in_chunk` (text key missing entirely) - these are
+  separate tests because they exercise different code paths even though both
+  expect the checker to return a valid float score rather than crash.
+
+- *Scope and time:* I checked the issue comments and the cohort ledger's
+  Claims count for #153 and I'm comfortable with how many others are on it.
+  This is a small, contained fix with a repro and existing tests already
+  defined, so I estimate 3-6 hours of focused work is realistic within
+  Weeks 8-9. There are no blockers or dependencies noted on the issue.
+
+
+  ## Week 8 - Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/Clearxheaded/pathreview/commit/5c8e0fd5e726ecdd0b598c0f3e9521f900a91e8a
+
+**Reproduction summary:**
+I reproduced the bug by calling `FaithfulnessChecker().check('Knows Python.', [{'text': None}])`
+directly, which raised `TypeError: sequence item 0: expected str instance,
+NoneType found` at the `" ".join(...)` call in `check()`. I also ran the
+existing test suite and confirmed `test_none_context_chunk_text` fails with
+the same error, while the adjacent `test_missing_text_key_in_chunk` already
+passes - confirming the bug is specific to a `None` value, not a missing key.
+
+**PLAN.md link:** https://github.com/Clearxheaded/pathreview/blob/fix/153-faithfulness-checker-none-text/PLAN.md
+
+**Walkthrough video (recommended):** [not recorded]
+
+**Blockers or open questions:**
+None currently. Still deciding whether to search for similar `.get("text", ...)`
+patterns elsewhere in the codebase during implementation, or keep scope
+strictly limited to this one file for the Tier 1 fix.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,26 @@
+## Week 7 - Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/153
+
+**Issue title:** Faithfulness checker crashes when a context chunk has `text: None`
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The `check()` method in `rag/evaluator/faithfulness_checker.py` builds
+its context by calling `chunk.get("text", "")` on each context chunk,
+assuming this will always yield a string. However, `.get()`'s default
+value only kicks in when the key is missing entirely - if a chunk
+dictionary has the key `"text"` present but explicitly set to `None`,
+`.get()` returns `None` instead of the default empty string. This
+`None` then gets passed into `" ".join(...)`, which raises a
+`TypeError` since `join` expects a list of strings. A successful fix
+will make the checker handle `None` values gracefully (coercing them
+to empty strings before joining) so it can process context chunks
+with missing or null text without crashing.
+
+**Branch name:** fix/153-faithfulness-checker-none-text
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -98,6 +98,36 @@ received, then mark the PR ready for review and complete Check-in 2.
 **Blockers:**
 None currently.
 
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/846
+
+**Branch:** fix/153-faithfulness-checker-none-text
+
+**What you built:**
+Fixed a `TypeError` in `FaithfulnessChecker.check()` that occurred when a
+context chunk's `"text"` key was present but set to `None`. Changed
+`chunk.get("text", "")` to `chunk.get("text") or ""` in
+`rag/evaluator/faithfulness_checker.py`, since `.get()`'s default only
+applies to a missing key, not a present key with value `None`. This handles
+both the missing-key and `None`-value cases identically.
+
+**Tests added or updated:**
+No new test files were needed - `tests/unit/test_faithfulness_checker.py`
+already contained `test_none_context_chunk_text` (previously failing) and
+`test_missing_text_key_in_chunk` (previously passing). Both now pass.
+Confirmed 3 pre-existing, unrelated test failures in the same file remain
+identical before and after my change (verified via `git stash`).
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+(Note: `make check` and `make test-unit` both surface pre-existing failures
+unrelated to this change - documented in the PR description. Scoped
+`ruff`/`black`/`mypy` runs on the changed file pass cleanly, and the 2
+relevant unit tests for this issue pass.)
+
+**Draft PR feedback received from:** none
+
 ## Week 10 - Iteration & reflection
 
 ### Reviewer feedback

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -75,3 +75,25 @@ passes - confirming the bug is specific to a `None` value, not a missing key.
 None currently. Still deciding whether to search for similar `.get("text", ...)`
 patterns elsewhere in the codebase during implementation, or keep scope
 strictly limited to this one file for the Tier 1 fix.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the fix for issue #153: changed `chunk.get("text", "")` to
+`chunk.get("text") or ""` in `rag/evaluator/faithfulness_checker.py` so that
+both a missing `"text"` key and a present-but-`None` value are handled
+gracefully. Confirmed `test_none_context_chunk_text` and
+`test_missing_text_key_in_chunk` both pass. Ran the full test file (22 tests)
+and confirmed 3 pre-existing failures are unrelated to this change (verified
+identical before/after via `git stash`). Ran `ruff`, `black`, and `mypy`
+scoped to the changed file - all pass. Opened a draft PR:
+https://github.com/ascherj/pathreview/pull/846
+
+**Next steps:**
+Share the draft PR in Slack for peer/mentor feedback, address any feedback
+received, then mark the PR ready for review and complete Check-in 2.
+
+**Blockers:**
+None currently.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -97,3 +97,68 @@ received, then mark the PR ready for review and complete Check-in 2.
 
 **Blockers:**
 None currently.
+
+## Week 10 - Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No - still awaiting review
+
+**Summary of feedback:**
+No reviewer feedback was available this term (reviewer feedback is not a
+feature in Summer 2026, per the course note).
+
+**How you responded:**
+N/A - no feedback to respond to.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Environment setup took far longer than I expected, and it wasn't the code
+that was hard, it was the local infrastructure. I hit a real Docker port
+conflict from leftover containers from other projects that silently
+prevented `docker compose up -d` from starting anything, with no obvious
+error message pointing to the cause. 
+
+**What did you learn about working in a large codebase?**
+The habit that mattered most wasn't reading code faster, it was verifying
+assumptions before acting on them. When I hit test failures after my fix, I
+didn't just assume my change broke something; I used `git stash` to compare
+before/after and confirmed the failures were pre-existing and unrelated.
+I also learned that a fix which looks like a one-line change still requires understanding the whole function's
+contract (what should `check()` return in every case?) and checking whether
+the same buggy pattern exists elsewhere in the codebase, even if I choose
+not to fix those instances now.
+
+**How did AI tools help - and where did they fall short?**
+AI assistance was most useful for methodically working through infrastructure
+failures - reading long stack traces, Docker logs, and pytest output and
+narrowing down what actually mattered versus what was noise (like the
+harmless `docker-compose.yml` version warning or the bcrypt version-reading
+warning during seeding). It was also useful for keeping the documentation
+work (JOURNAL.md, PLAN.md, PR description) structured and consistent with
+what each week's rubric actually asked for. Where it fell short: it couldn't
+run my Docker containers or see my actual file state - I still had to run
+every command myself, paste back real output, and correct course when the
+file wasn't what we expected (like the empty JOURNAL.md commit, or the
+encoding issue with the em dash). The actual verification - does this test
+pass, is this the right branch, did this file save correctly - always had
+to come from me actually running things, not from assuming the AI's
+suggestion worked.
+
+**What would you do differently if you started over?**
+I'd budget significantly more time for environment setup up front, and I'd
+run `docker ps -a` and `docker compose ps` earlier to check for leftover
+containers from other projects before assuming a fresh `docker compose up`
+would just work. I'd also fix editor/encoding settings (UTF-8) before
+writing my first JOURNAL.md entry instead of fighting garbled em dashes
+after the fact.
+
+**What are you most proud of from this module?**
+Catching that my fix didn't break the three already-failing tests, by
+actually stashing my change and re-running instead of just assuming. Sounds
+small, but that's the exact kind of check that separates "believes their fix
+is safe" from "confirmed their fix is safe" - and it made my PR description
+something I could stand behind with evidence instead of hope.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,66 @@
+## Solution plan
+
+**Issue:** Faithfulness checker crashes when a context chunk has `text: None` (#153)
+https://github.com/ascherj/pathreview/issues/153
+
+### Understand
+`check()` builds a combined context string with `chunk.get("text", "")` for
+each chunk in `context_chunks`. Python's `dict.get(key, default)` only
+returns `default` when `key` is absent - if the key exists but its value is
+`None`, `.get()` returns `None`. When a chunk is `{"text": None}`, the list
+comprehension produces `[None]`, and `" ".join([None])` raises `TypeError:
+sequence item 0: expected str instance, NoneType found`. Expected behavior:
+the checker should treat a `None` text value the same as an empty string and
+return a valid faithfulness score (a float between 0.0 and 1.0) instead of
+crashing.
+
+### Map
+- `rag/evaluator/faithfulness_checker.py` - the `check()` method, specifically
+  the context-concatenation line (~line 34). This is the only file that needs
+  a code change.
+- `tests/unit/test_faithfulness_checker.py` - contains the two relevant
+  existing tests: `test_none_context_chunk_text` (currently failing) and
+  `test_missing_text_key_in_chunk` (currently passing). No new test file is
+  needed, but I'll re-run the full suite to check for regressions.
+
+### Plan
+1. Reproduce the crash locally and confirm via the existing failing test
+   (done - see reproduction commit).
+2. Change `chunk.get("text", "")` to `chunk.get("text") or ""` so that both a
+   missing key and a `None` value fall through to an empty string.
+3. Run `test_none_context_chunk_text` and `test_missing_text_key_in_chunk`
+   together to confirm both pass.
+4. Run the full test suite (`make test-unit`) to check for regressions in
+   other tests that call `check()`.
+5. Search the codebase for other `.get("text", ...)` or similar patterns on
+   chunk dictionaries (e.g. in ingestion or other RAG modules) to see if the
+   same bug class exists elsewhere, and note any findings for a follow-up
+   issue if they're out of scope for this fix.
+
+### Inputs & outputs
+- **Input:** `feedback: str` and `context_chunks: list[dict]`, where each
+  dict may have a `"text"` key that is a string, `None`, or missing.
+- **Output:** a `float` faithfulness score between 0.0 and 1.0, computed the
+  same way as today, but without crashing when `text` is `None`.
+
+### Risks & unknowns
+- Using `or ""` will also treat an existing empty string `""` as falsy and
+  fall through to `""` - this is a no-op for that case, so it should be safe,
+  but worth double-checking no test relies on distinguishing `""` from a
+  missing/`None` value.
+- Unsure whether similar `.get("text", ...)` patterns exist in other files
+  (e.g. `ingestion/` or other evaluator modules) - if so, this fix wouldn't
+  cover them, and that may be worth flagging as a separate issue rather than
+  expanding scope here.
+- `make check` (ruff/black/mypy) needs to pass on the changed line - low risk
+  since it's a small change, but I'll confirm before opening the PR.
+
+### Edge cases
+- `{"text": None}` - the reported bug case, must return a valid float.
+- `{"content": "..."}` (missing `"text"` key entirely) - already passes today,
+  must keep passing.
+- `{"text": ""}` - empty string value, should behave the same as before (no
+  regression).
+- Multiple chunks where some have `None` and others have valid text - should
+  still concatenate correctly, skipping only the `None` ones' contribution to
+  empty string.

--- a/rag/evaluator/faithfulness_checker.py
+++ b/rag/evaluator/faithfulness_checker.py
@@ -1,6 +1,7 @@
 """Check if generated feedback is supported by retrieved context."""
 
 import re
+
 import structlog
 
 logger = structlog.get_logger()
@@ -20,8 +21,11 @@ class FaithfulnessChecker:
             Faithfulness score 0.0-1.0 (ratio of supported claims)
         """
         if not feedback or not context_chunks:
-            logger.info("faithfulness_empty_input", has_feedback=bool(feedback),
-                       has_chunks=bool(context_chunks))
+            logger.info(
+                "faithfulness_empty_input",
+                has_feedback=bool(feedback),
+                has_chunks=bool(context_chunks),
+            )
             return 0.0
 
         # Extract key claims from feedback (sentences)
@@ -31,9 +35,10 @@ class FaithfulnessChecker:
             return 0.5  # Default to neutral if no extractable claims
 
         # Concatenate context text
-        context_text = " ".join([
-            chunk.get("text", "") for chunk in context_chunks
-        ])
+        # REPRODUCED (Week 8): TypeError when chunk["text"] is None - .get()'s
+        # default only applies when the key is missing, not when it's present
+        # with value None. See issue #153.
+        context_text = " ".join([chunk.get("text", "") for chunk in context_chunks])
 
         # Check each claim for support
         supported = 0
@@ -43,8 +48,9 @@ class FaithfulnessChecker:
 
         score = supported / len(claims) if claims else 0.0
 
-        logger.info("faithfulness_checked", claims_count=len(claims),
-                   supported_count=supported, score=score)
+        logger.info(
+            "faithfulness_checked", claims_count=len(claims), supported_count=supported, score=score
+        )
 
         return score
 
@@ -59,7 +65,7 @@ class FaithfulnessChecker:
             List of claims (sentences)
         """
         # Split by sentence (simple regex)
-        sentences = re.split(r'[.!?]+', text)
+        sentences = re.split(r"[.!?]+", text)
         claims = [s.strip() for s in sentences if s.strip() and len(s.strip()) > 10]
         return claims[:10]  # Limit to 10 claims for scoring
 
@@ -81,8 +87,25 @@ class FaithfulnessChecker:
         # Require at least some meaningful overlap
         overlap = claim_tokens & context_tokens
         # Filter out common stop words
-        stop_words = {'a', 'an', 'the', 'is', 'are', 'was', 'were', 'be', 'been',
-                     'and', 'or', 'but', 'in', 'of', 'to', 'for', 'that'}
+        stop_words = {
+            "a",
+            "an",
+            "the",
+            "is",
+            "are",
+            "was",
+            "were",
+            "be",
+            "been",
+            "and",
+            "or",
+            "but",
+            "in",
+            "of",
+            "to",
+            "for",
+            "that",
+        }
         meaningful_overlap = overlap - stop_words
 
         return len(meaningful_overlap) >= 2

--- a/rag/evaluator/faithfulness_checker.py
+++ b/rag/evaluator/faithfulness_checker.py
@@ -35,10 +35,10 @@ class FaithfulnessChecker:
             return 0.5  # Default to neutral if no extractable claims
 
         # Concatenate context text
-        # REPRODUCED (Week 8): TypeError when chunk["text"] is None - .get()'s
-        # default only applies when the key is missing, not when it's present
-        # with value None. See issue #153.
-        context_text = " ".join([chunk.get("text", "") for chunk in context_chunks])
+        # FIX (issue #153): use `or ""` instead of `.get("text", "")` so both
+        # a missing "text" key and a present-but-None value fall through to
+        # an empty string. `.get()`'s default only covers the missing-key case.
+        context_text = " ".join([chunk.get("text") or "" for chunk in context_chunks])
 
         # Check each claim for support
         supported = 0


### PR DESCRIPTION
## Summary
Fixes a `TypeError` in `FaithfulnessChecker.check()` that occurred when a
context chunk's `"text"` key was present but set to `None`. The method used
`chunk.get("text", "")` to build the combined context string, but `.get()`'s
default value only applies when a key is missing entirely — not when it's
present with value `None`. This meant a chunk like `{"text": None}` would
cause `" ".join(...)` to crash instead of being handled gracefully.

## Issue
Closes #153

## Changes
- Changed `chunk.get("text", "")` to `chunk.get("text") or ""` in
  `rag/evaluator/faithfulness_checker.py` so that both a missing `"text"`
  key and a present-but-`None` value fall through to an empty string.
- Updated the inline comment to document the fix and its rationale.

## Testing
- [x] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`)
- [x] Linter passes (`make lint`) — scoped to changed file; see note below
- [x] Type checker passes (`make typecheck`) — scoped to changed file
- [x] New/updated tests cover the changes

Verified `test_none_context_chunk_text` and `test_missing_text_key_in_chunk`
(both in `tests/unit/test_faithfulness_checker.py`) now pass. Ran the full
`test_faithfulness_checker.py` suite (22 tests): 19 pass, 3 fail
(`test_partial_support_returns_middle_score`, `test_multiple_context_chunks`,
`test_multiple_claims_varying_support`). Confirmed via `git stash` that these
3 failures are pre-existing and identical with or without this change — they
stem from unrelated scoring behavior in `_is_supported()`, not from this fix.

`make check` reports pre-existing lint/type errors across unrelated files
(e.g. `safety/`, `ingestion/`, several test files). Ran `ruff check`,
`black --check`, and `mypy` scoped specifically to
`rag/evaluator/faithfulness_checker.py` — all pass cleanly. This change
introduces no new lint, format, or type errors.

## Screenshots / Demo
N/A - backend logic fix, no UI changes.

## Notes for Reviewers
- Integration tests checkbox left unchecked: `make test-integration` collects
  0 tests in this repo currently (no integration test suite exists yet), so
  it's not applicable to this change.
- The three pre-existing unit test failures noted above are unrelated to this
  issue; flagging here so reviewers don't mistake them for regressions from
  this PR.
- Considered whether similar `.get("text", ...)` patterns exist elsewhere in
  the codebase (e.g. ingestion or other RAG modules) that could hit the same
  bug class, but kept this fix scoped to the reported issue. Happy to open a
  follow-up issue if reviewers think a broader sweep is warranted.