### PR TITLE
feat(agent): add has_tests boolean to repo analysis output

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -61,7 +61,7 @@ None specific to #50. Worth noting: `make check` and `make test-unit` both fail 
 
 ### Check-in 2 (end of week)
 
-**PR link:** _pending — not yet opened. Open via https://github.com/Kunalkrk/pathreview/pull/new/feat/50-has-tests-boolean and paste the link here._
+**PR link:** https://github.com/ascherj/pathreview/pull/848
 
 **Branch:** feat/50-has-tests-boolean
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -73,3 +73,22 @@ Added a `has_tests` boolean to `TechDetector`'s output, detected by scanning the
 
 **Self-review confirmation:** [x] make check passes  [x] make test-unit passes
 _(scoped to the files this branch touches — `agent/tools/tech_detector.py` and its test file; repo-wide `make check`/`make test-unit` still fail on plain `main` due to pre-existing, unrelated issues — see Blockers above.)_
+
+## Week 10 — Iteration & reflection
+
+### Reflection
+
+**What was harder than you expected?**
+Getting the environment running at all. Virtualization was disabled at the BIOS level, which cascaded into WSL2 having zero installed distros and Docker Desktop refusing to start — none of it was a code problem, just infrastructure I had to work through before writing a single line. Separately, the issue itself wasn't as trustworthy as I expected: it pointed at `agent/tools/repo_analyzer.py`, which doesn't exist. There's a same-named file in a completely different pipeline (`ingestion/parsers/repo_analyzer.py`) that already has its own unrelated `has_tests`. Figuring out that the issue's stated file was stale, and that `tech_detector.py` was the real target, took more digging than I expected for a "tier 1" issue.
+
+**What did you learn about working in a large codebase?**
+Issue descriptions and labels aren't ground truth — they can go stale after refactors, so I had to verify claims against the actual code rather than start implementing against the issue text at face value. I also learned that a small, well-scoped PR still needs to prove a negative: I only found out how much pre-existing debt already lived on `main` (173 lint/type errors, 53 failing unit tests, none related to my change) when I ran the full suite, and had to diff against `main` directly to show my branch introduced zero new failures. That's not a check you'd ever think to do on a personal greenfield project.
+
+**How did AI tools help — and where did they fall short?**
+AI was most useful for fast investigation: tracing the real location of `has_tests` logic across two same-named files, checking whether `TechDetector` was actually wired into the live review pipeline (it isn't — `_run_agent_orchestration` is a hardcoded placeholder), and running the full test/lint suite against both branches to prove no regressions. It also matched existing conventions well once shown the pattern — the new test cases and the `_detect_has_tests` method mirror the file's existing style closely. Where it fell short was scope judgment: deciding what *not* to fix (the two pre-existing `tech_detector` bugs, the 53 unrelated failing tests) was a call only I could make about the issue's actual boundaries. I also had to push back more than once when a first draft was more than I'd asked for — deciding what actually belonged in a deliverable was on me, not the tool.
+
+**What would you do differently if you started over?**
+I'd open the issue's referenced files before trusting them, rather than after — that would've caught the phantom `repo_analyzer.py` path immediately instead of partway through investigation. I'd also run a full `make check`/`make test-unit` baseline against `main` back in Week 7, so the scale of pre-existing debt was known going in rather than discovered while trying to commit.
+
+**What are you most proud of from this module?**
+Catching the stale issue reference and the two-files-with-the-same-name mixup, and actually confirming with evidence (reading both files, tracing the orchestrator) which one was real — instead of just coding against what the issue said and finding out later.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,26 @@
+# Journal
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/50
+
+**Issue title:** Add a `has_tests` boolean to the repo analysis output
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The agent's repo analysis pipeline currently has no way to tell whether a scanned
+repository includes any testing infrastructure, so that signal is missing from
+the output profile it builds for a candidate's project. A successful fix adds
+detection logic that looks for common markers of tests — a `tests/` or `test/`
+directory, a `pytest.ini` file, or files matching `test_*.py` — and exposes the
+result as a new `has_tests` boolean field on the analysis output. This affects
+the agent/tooling side of the codebase (likely a new or extended tool under
+`agent/tools/`), and once done it lets downstream scoring and profile-building
+logic account for whether a project demonstrates testing practices.
+
+**Branch name:** feat/50-has-tests-boolean
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -24,3 +24,10 @@ logic account for whether a project demonstrates testing practices.
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+**"Is this right for me?" checklist reasoning:**
+- Understanding: clear — add `has_tests` to analysis output based on `tests/`, `pytest.ini`, or `test_*.py`.
+- Scope note: issue names `agent/tools/repo_analyzer.py`, which doesn't exist. Real fit is `agent/tools/tech_detector.py` (already scans a `files` list the same way).
+- Tier: confirmed Tier 1 via GitHub labels; matches "first contribution" fit.
+- Codebase: read `tech_detector.py` and its 26-test suite — new logic/test slot in with the existing pattern.
+- Time/blockers: no assignees/comments/blockers on the issue; 2–4 hr estimate fits the Week 8–9 window.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -23,4 +23,4 @@ logic account for whether a project demonstrates testing practices.
 
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
-**Cohort ledger:** [ ] Issue added to cohort ledger
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -43,3 +43,33 @@ Added a test in `tests/unit/test_tech_detector.py` calling `TechDetector.execute
 
 **Blockers or open questions:**
 While fixing lint issues to get the reproduction test committed, found two pre-existing, unrelated test failures in the same file (`test_node_modules_excluded`, `test_build_directory_excluded`) — `_should_skip_file` doesn't match root-level `node_modules/`/`build/` paths (only nested ones). Not touching it for #50, but flagging in case it interacts with test-file detection.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+All 4 sub-tasks from PLAN.md are done: added `_detect_has_tests` to `TechDetector` (checks for a `tests/`/`test/` dir segment, `pytest.ini`, or `test_*.py`), wired it into `_detect_tech()` and the empty-files early return, confirmed the reproduction test now passes, and added 4 more tests (negative case, false-positive avoidance, case-insensitivity, empty-file-list).
+
+**Next steps:**
+Open the PR against upstream and do a final pass against CONTRIBUTING.md conventions. Still need to decide the open question from PLAN.md — whether to match JS/TS test conventions (`__tests__/`, `spec/`) or stay strictly to the issue's stated Python markers — before or shortly after submitting.
+
+**Blockers:**
+None specific to #50. Worth noting: `make check` and `make test-unit` both fail on plain `main` (173 lint/type errors, 53 unit test failures across unrelated modules) — pre-existing repo debt, not something introduced by this branch. Confirmed via a baseline diff that my branch adds 0 new failures.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** _pending — not yet opened. Open via https://github.com/Kunalkrk/pathreview/pull/new/feat/50-has-tests-boolean and paste the link here._
+
+**Branch:** feat/50-has-tests-boolean
+
+**What you built:**
+Added a `has_tests` boolean to `TechDetector`'s output, detected by scanning the already vendor/build-filtered file list for a `tests/`/`test/` directory segment, a `pytest.ini` file, or a `test_*.py` filename (case-insensitive, with false-positive guards against names like `latest.py`).
+
+**Tests added or updated:**
+`tests/unit/test_tech_detector.py` — `test_has_tests_detection` (positive case), `test_has_tests_false_when_no_test_markers`, `test_has_tests_ignores_similar_filenames`, `test_has_tests_case_insensitive`, `test_has_tests_empty_file_list`.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+_(scoped to the files this branch touches — `agent/tools/tech_detector.py` and its test file; repo-wide `make check`/`make test-unit` still fail on plain `main` due to pre-existing, unrelated issues — see Blockers above.)_

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -31,3 +31,15 @@ logic account for whether a project demonstrates testing practices.
 - Tier: confirmed Tier 1 via GitHub labels; matches "first contribution" fit.
 - Codebase: read `tech_detector.py` and its 26-test suite — new logic/test slot in with the existing pattern.
 - Time/blockers: no assignees/comments/blockers on the issue; 2–4 hr estimate fits the Week 8–9 window.
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/Kunalkrk/pathreview/commit/2914f8ffb18b380721c2edc256d9f0c967b426e0
+
+**Reproduction summary:**
+Added a test in `tests/unit/test_tech_detector.py` calling `TechDetector.execute()` on files that clearly include `tests/`, `test_*.py`, and `pytest.ini`. The test fails: `has_tests` is not in the returned dict at all.
+
+**PLAN.md link:** https://github.com/Kunalkrk/pathreview/blob/feat/50-has-tests-boolean/PLAN.md
+
+**Blockers or open questions:**
+While fixing lint issues to get the reproduction test committed, found two pre-existing, unrelated test failures in the same file (`test_node_modules_excluded`, `test_build_directory_excluded`) — `_should_skip_file` doesn't match root-level `node_modules/`/`build/` paths (only nested ones). Not touching it for #50, but flagging in case it interacts with test-file detection.

--- a/PLAN.md
+++ b/PLAN.md
@@ -3,68 +3,30 @@
 **Issue:** [Add a `has_tests` boolean to the repo analysis output (#50)](https://github.com/ascherj/pathreview/issues/50)
 
 ### Understand
-
-Root cause: `TechDetector` (the agent tool that turns a repo's file list into
-`primary_language`/`all_languages`/`frameworks`) never had test-detection logic added.
-It isn't a regression — the field simply doesn't exist yet.
-
-- Expected: analysis output includes `has_tests: bool`, true when the repo has a
-  `tests/`/`test/` directory, a `pytest.ini`, or `test_*.py` files.
-- Actual: `has_tests` is absent from the output entirely, confirmed by the failing
-  test added in the reproduction commit
-  ([2914f8f](https://github.com/Kunalkrk/pathreview/commit/2914f8ffb18b380721c2edc256d9f0c967b426e0)).
+`TechDetector` never had test-detection logic added — expected output includes `has_tests: bool` (true for a `tests/`/`test/` dir, `pytest.ini`, or `test_*.py`); actual output has no such field, confirmed by a failing test ([2914f8f](https://github.com/Kunalkrk/pathreview/commit/2914f8ffb18b380721c2edc256d9f0c967b426e0)).
 
 ### Map
-
-- `agent/tools/tech_detector.py` — primary file to change. `_detect_tech()` builds
-  the result dict from a pre-filtered file list (`_should_skip_file` already strips
-  vendor/build noise); `has_tests` detection slots in here as a new helper method.
-- `tests/unit/test_tech_detector.py` — already has `test_has_tests_detection`
-  (currently failing); needs a negative-case test added alongside it.
-- `ingestion/parsers/repo_analyzer.py` — has its own unrelated `_detect_tests()` for
-  the ingestion/RAG pipeline. Reference only, not touched.
+- `agent/tools/tech_detector.py` — add detection here.
+- `tests/unit/test_tech_detector.py` — has a failing test to fix, plus a negative case to add.
+- `ingestion/parsers/repo_analyzer.py` — has its own unrelated `has_tests`; reference only.
 
 ### Plan
-
-1. Add `_detect_has_tests(filtered_files)` to `TechDetector`, checking each path for
-   a `tests/`/`test/` directory segment, a `pytest.ini` filename, or a `test_*.py`
-   filename match (case-insensitive).
-2. Call it from `_detect_tech()` and add `has_tests` to the returned dict — including
-   the early-return branch in `execute()` for when no files are provided.
-3. Confirm the existing `test_has_tests_detection` test now passes; add a negative
-   test (no test markers → `has_tests is False`).
-4. Run `make check && make test-unit` to confirm lint/type/test pass.
+1. Add `_detect_has_tests(filtered_files)` checking for test dir/`pytest.ini`/`test_*.py`.
+2. Wire it into `_detect_tech()` and the empty-files early return.
+3. Confirm `test_has_tests_detection` passes; add a negative-case test.
+4. Run `make check && make test-unit`.
 
 ### Inputs & outputs
-
-- Input: same as today — `input_data["files"]`, a `list[str]` of repo paths. No new
-  input required.
-- Output: one new key, `has_tests: bool`, added to the existing result dict on every
-  code path (including the empty-files early return). No existing fields change.
+Input: same `files: list[str]` already passed in. Output: one new `has_tests: bool` key, no other fields change.
 
 ### Risks & unknowns
-
-- Naive substring matching would false-positive on names like `latest.py` or
-  `contest.js` — matching needs to check path segments/filename patterns, not a bare
-  `"test" in path` check.
-- Open question: the issue only lists Python markers (`pytest.ini`, `test_*.py`).
-  `ingestion/parsers/repo_analyzer.py` also treats `__tests__/` and `spec/` (JS/TS
-  conventions) as test markers. Unclear if `has_tests` here should match scope, or
-  stay strictly to the issue's stated criteria.
-- Unrelated pre-existing bug: `_should_skip_file` doesn't match root-level
-  `node_modules/`/`build/` paths (only nested ones) — shouldn't affect `tests/`
-  detection directly, but worth double-checking once implemented.
-- `TechDetector` isn't yet wired into the live review pipeline (`review_service.py`
-  currently hardcodes `_run_agent_orchestration`'s output), so this fix will only be
-  verifiable via unit tests, not by exercising the running app end-to-end.
+- Naive substring match would false-positive on `latest.py`/`contest.js` — need path/filename-aware matching.
+- Open question: issue only lists Python markers; should JS/TS conventions (`__tests__/`, `spec/`) count too?
+- Unrelated pre-existing bug: `_should_skip_file` misses root-level `node_modules/`/`build/` paths.
+- `TechDetector` isn't wired into the live review pipeline yet, so this is only verifiable via unit tests for now.
 
 ### Edge cases
-
-- Empty file list → `has_tests: False`, no crash (matches current behavior for other
-  fields).
-- Mixed case paths (`TESTS/`, `Test_Main.PY`) → still detected, consistent with the
-  existing case-insensitive extension matching.
-- Test-like filenames outside a real test directory/pattern (`latest.py`) → must NOT
-  be flagged as `has_tests`.
-- Test files nested inside excluded vendor/build paths → already filtered out via
-  `_should_skip_file` before detection runs.
+- Empty file list → `has_tests: False`, no crash.
+- Mixed-case paths still detected.
+- Test-like filenames outside a real test path (`latest.py`) must not be flagged.
+- Test files under vendor/build paths already filtered via `_should_skip_file`.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,70 @@
+## Solution plan
+
+**Issue:** [Add a `has_tests` boolean to the repo analysis output (#50)](https://github.com/ascherj/pathreview/issues/50)
+
+### Understand
+
+Root cause: `TechDetector` (the agent tool that turns a repo's file list into
+`primary_language`/`all_languages`/`frameworks`) never had test-detection logic added.
+It isn't a regression — the field simply doesn't exist yet.
+
+- Expected: analysis output includes `has_tests: bool`, true when the repo has a
+  `tests/`/`test/` directory, a `pytest.ini`, or `test_*.py` files.
+- Actual: `has_tests` is absent from the output entirely, confirmed by the failing
+  test added in the reproduction commit
+  ([2914f8f](https://github.com/Kunalkrk/pathreview/commit/2914f8ffb18b380721c2edc256d9f0c967b426e0)).
+
+### Map
+
+- `agent/tools/tech_detector.py` — primary file to change. `_detect_tech()` builds
+  the result dict from a pre-filtered file list (`_should_skip_file` already strips
+  vendor/build noise); `has_tests` detection slots in here as a new helper method.
+- `tests/unit/test_tech_detector.py` — already has `test_has_tests_detection`
+  (currently failing); needs a negative-case test added alongside it.
+- `ingestion/parsers/repo_analyzer.py` — has its own unrelated `_detect_tests()` for
+  the ingestion/RAG pipeline. Reference only, not touched.
+
+### Plan
+
+1. Add `_detect_has_tests(filtered_files)` to `TechDetector`, checking each path for
+   a `tests/`/`test/` directory segment, a `pytest.ini` filename, or a `test_*.py`
+   filename match (case-insensitive).
+2. Call it from `_detect_tech()` and add `has_tests` to the returned dict — including
+   the early-return branch in `execute()` for when no files are provided.
+3. Confirm the existing `test_has_tests_detection` test now passes; add a negative
+   test (no test markers → `has_tests is False`).
+4. Run `make check && make test-unit` to confirm lint/type/test pass.
+
+### Inputs & outputs
+
+- Input: same as today — `input_data["files"]`, a `list[str]` of repo paths. No new
+  input required.
+- Output: one new key, `has_tests: bool`, added to the existing result dict on every
+  code path (including the empty-files early return). No existing fields change.
+
+### Risks & unknowns
+
+- Naive substring matching would false-positive on names like `latest.py` or
+  `contest.js` — matching needs to check path segments/filename patterns, not a bare
+  `"test" in path` check.
+- Open question: the issue only lists Python markers (`pytest.ini`, `test_*.py`).
+  `ingestion/parsers/repo_analyzer.py` also treats `__tests__/` and `spec/` (JS/TS
+  conventions) as test markers. Unclear if `has_tests` here should match scope, or
+  stay strictly to the issue's stated criteria.
+- Unrelated pre-existing bug: `_should_skip_file` doesn't match root-level
+  `node_modules/`/`build/` paths (only nested ones) — shouldn't affect `tests/`
+  detection directly, but worth double-checking once implemented.
+- `TechDetector` isn't yet wired into the live review pipeline (`review_service.py`
+  currently hardcodes `_run_agent_orchestration`'s output), so this fix will only be
+  verifiable via unit tests, not by exercising the running app end-to-end.
+
+### Edge cases
+
+- Empty file list → `has_tests: False`, no crash (matches current behavior for other
+  fields).
+- Mixed case paths (`TESTS/`, `Test_Main.PY`) → still detected, consistent with the
+  existing case-insensitive extension matching.
+- Test-like filenames outside a real test directory/pattern (`latest.py`) → must NOT
+  be flagged as `has_tests`.
+- Test files nested inside excluded vendor/build paths → already filtered out via
+  `_should_skip_file` before detection runs.

--- a/agent/tools/tech_detector.py
+++ b/agent/tools/tech_detector.py
@@ -1,6 +1,9 @@
 """Technology stack detector tool."""
 
+import re
+
 import structlog
+
 from .base import BaseTool, ToolResult
 
 logger = structlog.get_logger()
@@ -56,6 +59,9 @@ class TechDetector(BaseTool):
         "cmake": ("CMake", "Build"),
     }
 
+    # Matches a test_*.py filename, e.g. "tests/test_main.py" or "test_utils.py"
+    TEST_FILENAME_PATTERN = re.compile(r"(^|/)test_[^/]+\.py$", re.IGNORECASE)
+
     def execute(self, input_data: dict) -> ToolResult:
         """Detect tech stack from files.
 
@@ -75,7 +81,8 @@ class TechDetector(BaseTool):
                     "primary_language": "Unknown",
                     "all_languages": [],
                     "frameworks": [],
-                }
+                    "has_tests": False,
+                },
             )
 
         try:
@@ -84,11 +91,7 @@ class TechDetector(BaseTool):
 
         except Exception as e:
             logger.error("tech_detector_error", error=str(e))
-            return ToolResult(
-                success=False,
-                data={},
-                error=str(e)
-            )
+            return ToolResult(success=False, data={}, error=str(e))
 
     def _detect_tech(self, files: list[str]) -> dict:
         """Detect technologies from file list.
@@ -100,10 +103,7 @@ class TechDetector(BaseTool):
             Dict with detected languages and frameworks
         """
         # Filter out vendor/build directories
-        filtered_files = [
-            f for f in files
-            if not self._should_skip_file(f)
-        ]
+        filtered_files = [f for f in files if not self._should_skip_file(f)]
 
         languages = set()
         frameworks = set()
@@ -130,15 +130,48 @@ class TechDetector(BaseTool):
 
         all_languages = sorted(languages)
         all_frameworks = sorted(frameworks)
+        has_tests = self._detect_has_tests(filtered_files)
 
-        logger.info("tech_detected", primary_lang=primary,
-                   languages_count=len(all_languages), frameworks_count=len(all_frameworks))
+        logger.info(
+            "tech_detected",
+            primary_lang=primary,
+            languages_count=len(all_languages),
+            frameworks_count=len(all_frameworks),
+        )
 
         return {
             "primary_language": primary,
             "all_languages": all_languages,
             "frameworks": all_frameworks,
+            "has_tests": has_tests,
         }
+
+    @classmethod
+    def _detect_has_tests(cls, files: list[str]) -> bool:
+        """Check if the repo has test infrastructure.
+
+        Looks for a tests/ or test/ directory segment, a pytest.ini file, or a
+        test_*.py filename (already-filtered files, so vendor/build noise is
+        excluded upstream).
+
+        Args:
+            files: List of (already-filtered) file paths
+
+        Returns:
+            True if any test marker is found
+        """
+        for filepath in files:
+            path_parts = filepath.lower().split("/")
+            basename = path_parts[-1]
+
+            if "tests" in path_parts[:-1] or "test" in path_parts[:-1]:
+                return True
+            if basename == "pytest.ini":
+                return True
+            if cls.TEST_FILENAME_PATTERN.search(filepath):
+                return True
+
+        return False
 
     @staticmethod
     def _should_skip_file(filepath: str) -> bool:

--- a/tests/unit/test_tech_detector.py
+++ b/tests/unit/test_tech_detector.py
@@ -10,11 +10,11 @@ class TestTechDetector:
     """Test suite for TechDetector."""
 
     @pytest.fixture
-    def detector(self):
+    def detector(self) -> TechDetector:
         """Create a TechDetector instance."""
         return TechDetector()
 
-    def test_single_language_repo(self, detector):
+    def test_single_language_repo(self, detector: TechDetector) -> None:
         """Test single-language repo correctly identifies primary_language."""
         files = [
             "main.py",
@@ -30,7 +30,7 @@ class TestTechDetector:
         assert data["primary_language"] == "Python"
         assert "Python" in data["all_languages"]
 
-    def test_mixed_language_repo_python_primary(self, detector):
+    def test_mixed_language_repo_python_primary(self, detector: TechDetector) -> None:
         """Test mixed-language repo with Python as primary."""
         files = [
             "main.py",
@@ -47,7 +47,7 @@ class TestTechDetector:
         assert "Python" in data["all_languages"]
         assert "JavaScript" in data["all_languages"]
 
-    def test_ipynb_counted_as_python_not_json(self, detector):
+    def test_ipynb_counted_as_python_not_json(self, detector: TechDetector) -> None:
         """Test .ipynb files are counted as Python/Jupyter, NOT as JSON."""
         files = [
             "analysis.ipynb",
@@ -60,10 +60,9 @@ class TestTechDetector:
         data = result.data
         assert "Python" in data["all_languages"]
         # Should not include JSON or data-only language
-        detected_lower = [lang.lower() for lang in data["all_languages"]]
         # .ipynb should be treated as Python, not JSON
 
-    def test_node_modules_excluded(self, detector):
+    def test_node_modules_excluded(self, detector: TechDetector) -> None:
         """Test node_modules/ directory is excluded from counts."""
         files = [
             "src/main.py",
@@ -78,7 +77,7 @@ class TestTechDetector:
         assert data["primary_language"] == "Python"
         # node_modules shouldn't dominate
 
-    def test_vendor_files_excluded(self, detector):
+    def test_vendor_files_excluded(self, detector: TechDetector) -> None:
         """Test vendor files are excluded."""
         files = [
             "src/main.py",
@@ -87,11 +86,11 @@ class TestTechDetector:
             "app.py",
         ]
 
-        result = detector.execute({"files": files})
+        detector.execute({"files": files})
 
         # Python should be primary despite vendor files
 
-    def test_build_directory_excluded(self, detector):
+    def test_build_directory_excluded(self, detector: TechDetector) -> None:
         """Test build directory is excluded."""
         files = [
             "src/main.py",
@@ -104,7 +103,7 @@ class TestTechDetector:
         data = result.data
         assert data["primary_language"] == "Python"
 
-    def test_config_file_detection(self, detector):
+    def test_config_file_detection(self, detector: TechDetector) -> None:
         """Test detection from config files."""
         files = [
             "package.json",
@@ -117,7 +116,7 @@ class TestTechDetector:
         data = result.data
         assert "Node.js" in data["all_languages"] or "JavaScript" in data["all_languages"]
 
-    def test_dockerfile_detection(self, detector):
+    def test_dockerfile_detection(self, detector: TechDetector) -> None:
         """Test Docker file detection."""
         files = [
             "Dockerfile",
@@ -125,34 +124,33 @@ class TestTechDetector:
             "main.py",
         ]
 
-        result = detector.execute({"files": files})
+        detector.execute({"files": files})
 
         # Should detect Python as primary language
 
-    def test_github_actions_detection(self, detector):
+    def test_github_actions_detection(self, detector: TechDetector) -> None:
         """Test GitHub Actions detection."""
         files = [
             ".github/workflows/test.yml",
             "main.py",
         ]
 
-        result = detector.execute({"files": files})
+        detector.execute({"files": files})
 
-        data = result.data
         # Should detect both Python and CI/CD
 
-    def test_makefile_detection(self, detector):
+    def test_makefile_detection(self, detector: TechDetector) -> None:
         """Test Makefile detection."""
         files = [
             "Makefile",
             "src/main.py",
         ]
 
-        result = detector.execute({"files": files})
+        detector.execute({"files": files})
 
         # Should detect Makefile as build tool
 
-    def test_typescript_detection(self, detector):
+    def test_typescript_detection(self, detector: TechDetector) -> None:
         """Test TypeScript detection."""
         files = [
             "src/main.ts",
@@ -165,7 +163,7 @@ class TestTechDetector:
         data = result.data
         assert "TypeScript" in data["all_languages"]
 
-    def test_go_detection(self, detector):
+    def test_go_detection(self, detector: TechDetector) -> None:
         """Test Go language detection."""
         files = [
             "main.go",
@@ -179,7 +177,7 @@ class TestTechDetector:
         assert "Go" in data["all_languages"]
         assert data["primary_language"] == "Go"
 
-    def test_rust_detection(self, detector):
+    def test_rust_detection(self, detector: TechDetector) -> None:
         """Test Rust detection."""
         files = [
             "src/main.rs",
@@ -192,7 +190,7 @@ class TestTechDetector:
         data = result.data
         assert "Rust" in data["all_languages"]
 
-    def test_java_detection(self, detector):
+    def test_java_detection(self, detector: TechDetector) -> None:
         """Test Java detection."""
         files = [
             "Main.java",
@@ -205,7 +203,7 @@ class TestTechDetector:
         data = result.data
         assert "Java" in data["all_languages"]
 
-    def test_multiple_python_files(self, detector):
+    def test_multiple_python_files(self, detector: TechDetector) -> None:
         """Test counting multiple Python files."""
         files = [
             "main.py",
@@ -220,7 +218,7 @@ class TestTechDetector:
         assert data["primary_language"] == "Python"
         assert "Python" in data["all_languages"]
 
-    def test_empty_file_list(self, detector):
+    def test_empty_file_list(self, detector: TechDetector) -> None:
         """Test with empty file list."""
         result = detector.execute({"files": []})
 
@@ -228,14 +226,14 @@ class TestTechDetector:
         assert data["primary_language"] == "Unknown"
         assert data["all_languages"] == []
 
-    def test_no_files_key(self, detector):
+    def test_no_files_key(self, detector: TechDetector) -> None:
         """Test with no files key in input."""
         result = detector.execute({})
 
         data = result.data
         assert data["primary_language"] == "Unknown"
 
-    def test_result_structure(self, detector):
+    def test_result_structure(self, detector: TechDetector) -> None:
         """Test result has required structure."""
         files = ["main.py", "app.js"]
         result = detector.execute({"files": files})
@@ -245,7 +243,7 @@ class TestTechDetector:
         assert "all_languages" in data
         assert "frameworks" in data
 
-    def test_framework_detection(self, detector):
+    def test_framework_detection(self, detector: TechDetector) -> None:
         """Test framework detection from files."""
         files = [
             "requirements.txt",  # Could indicate Python
@@ -253,11 +251,11 @@ class TestTechDetector:
             "main.py",
         ]
 
-        result = detector.execute({"files": files})
+        detector.execute({"files": files})
 
         # Should detect frameworks
 
-    def test_unknown_extensions(self, detector):
+    def test_unknown_extensions(self, detector: TechDetector) -> None:
         """Test handling of unknown file extensions."""
         files = [
             "file.unknown",
@@ -272,7 +270,7 @@ class TestTechDetector:
         # Should still work with Python file present
         assert data["primary_language"] == "Python"
 
-    def test_case_insensitive_extension_matching(self, detector):
+    def test_case_insensitive_extension_matching(self, detector: TechDetector) -> None:
         """Test case-insensitive file extension matching."""
         files = [
             "Main.PY",
@@ -280,12 +278,11 @@ class TestTechDetector:
             "Index.JS",
         ]
 
-        result = detector.execute({"files": files})
+        detector.execute({"files": files})
 
-        data = result.data
         # Should still detect languages despite case
 
-    def test_multiple_extensions_same_file(self, detector):
+    def test_multiple_extensions_same_file(self, detector: TechDetector) -> None:
         """Test file with multiple dots in name."""
         files = [
             "my.test.py",
@@ -297,7 +294,7 @@ class TestTechDetector:
         data = result.data
         assert len(data["all_languages"]) > 0
 
-    def test_all_languages_sorted(self, detector):
+    def test_all_languages_sorted(self, detector: TechDetector) -> None:
         """Test that all_languages list is sorted."""
         files = [
             "main.rs",
@@ -312,7 +309,7 @@ class TestTechDetector:
         # Should be sorted
         assert data["all_languages"] == sorted(data["all_languages"])
 
-    def test_frameworks_sorted(self, detector):
+    def test_frameworks_sorted(self, detector: TechDetector) -> None:
         """Test that frameworks list is sorted."""
         files = [
             "requirements.txt",
@@ -327,7 +324,7 @@ class TestTechDetector:
         if len(data["frameworks"]) > 1:
             assert data["frameworks"] == sorted(data["frameworks"])
 
-    def test_ruby_detection(self, detector):
+    def test_ruby_detection(self, detector: TechDetector) -> None:
         """Test Ruby language detection."""
         files = [
             "main.rb",
@@ -339,7 +336,7 @@ class TestTechDetector:
         data = result.data
         assert "Ruby" in data["all_languages"]
 
-    def test_csharp_detection(self, detector):
+    def test_csharp_detection(self, detector: TechDetector) -> None:
         """Test C# language detection."""
         files = [
             "Program.cs",
@@ -351,7 +348,7 @@ class TestTechDetector:
         data = result.data
         assert "C#" in data["all_languages"]
 
-    def test_cpp_detection(self, detector):
+    def test_cpp_detection(self, detector: TechDetector) -> None:
         """Test C++ detection."""
         files = [
             "main.cpp",
@@ -359,7 +356,25 @@ class TestTechDetector:
             "header.h",
         ]
 
+        detector.execute({"files": files})
+
+        # Should detect C++ (from .cpp files)
+
+    def test_has_tests_detection(self, detector: TechDetector) -> None:
+        """Reproduces #50: has_tests is missing from tech_detector output.
+
+        Expected to fail until has_tests detection is implemented.
+        """
+        files = [
+            "main.py",
+            "utils.py",
+            "tests/test_main.py",
+            "tests/test_utils.py",
+            "pytest.ini",
+        ]
+
         result = detector.execute({"files": files})
 
         data = result.data
-        # Should detect C++ (from .cpp files)
+        assert "has_tests" in data
+        assert data["has_tests"] is True

--- a/tests/unit/test_tech_detector.py
+++ b/tests/unit/test_tech_detector.py
@@ -361,10 +361,7 @@ class TestTechDetector:
         # Should detect C++ (from .cpp files)
 
     def test_has_tests_detection(self, detector: TechDetector) -> None:
-        """Reproduces #50: has_tests is missing from tech_detector output.
-
-        Expected to fail until has_tests detection is implemented.
-        """
+        """Test has_tests is True when tests/ files and pytest.ini are present (#50)."""
         files = [
             "main.py",
             "utils.py",
@@ -378,3 +375,48 @@ class TestTechDetector:
         data = result.data
         assert "has_tests" in data
         assert data["has_tests"] is True
+
+    def test_has_tests_false_when_no_test_markers(self, detector: TechDetector) -> None:
+        """Test has_tests is False when no test directory/file markers exist."""
+        files = [
+            "main.py",
+            "utils.py",
+            "models.py",
+        ]
+
+        result = detector.execute({"files": files})
+
+        data = result.data
+        assert data["has_tests"] is False
+
+    def test_has_tests_ignores_similar_filenames(self, detector: TechDetector) -> None:
+        """Test filenames that merely contain "test" aren't false positives."""
+        files = [
+            "latest.py",
+            "contest.js",
+            "attestation.py",
+        ]
+
+        result = detector.execute({"files": files})
+
+        data = result.data
+        assert data["has_tests"] is False
+
+    def test_has_tests_case_insensitive(self, detector: TechDetector) -> None:
+        """Test has_tests detection is case-insensitive."""
+        files = [
+            "Main.py",
+            "TESTS/Test_Main.PY",
+        ]
+
+        result = detector.execute({"files": files})
+
+        data = result.data
+        assert data["has_tests"] is True
+
+    def test_has_tests_empty_file_list(self, detector: TechDetector) -> None:
+        """Test has_tests is False (not missing) on the empty-files early return."""
+        result = detector.execute({"files": []})
+
+        data = result.data
+        assert data["has_tests"] is False


### PR DESCRIPTION
## Summary
Adds a `has_tests` boolean to `TechDetector`'s output, so the agent's repo
analysis can signal whether a project has test infrastructure. Detected by
scanning the already vendor/build-filtered file list for a `tests/`/`test/`
directory segment, a `pytest.ini` file, or a `test_*.py` filename.

## Issue
Closes #50

## Changes
- Add `_detect_has_tests` classmethod and `TEST_FILENAME_PATTERN` to `TechDetector`
- Wire `has_tests` into `_detect_tech()`'s return dict and the empty-files early
  return in `execute()`
- Add 5 tests covering the positive case, no-markers case, false-positive
  avoidance (`latest.py`/`contest.js`/`attestation.py`), case-insensitivity, and
  the empty-file-list path

## Testing
- [x] Unit tests pass (`make test-unit`) — scoped to this change; see note below
- [ ] Integration tests pass (`make test-integration`)
- [x] Linter passes (`make lint`) — scoped to `agent/tools/tech_detector.py` and
      its test file
- [x] Type checker passes (`make typecheck`) — same scope
- [x] New/updated tests cover the changes

## Screenshots / Demo
No UI changes — this is a backend-only tool change. Demo via test output:

$ pytest tests/unit/test_tech_detector.py -v -k has_tests
test_has_tests_detection PASSED
test_has_tests_false_when_no_test_markers PASSED
test_has_tests_ignores_similar_filenames PASSED
test_has_tests_case_insensitive PASSED
test_has_tests_empty_file_list PASSED
5 passed

## Notes for Reviewers
- The issue names `agent/tools/repo_analyzer.py`, which doesn't exist. There's a
  same-named file at `ingestion/parsers/repo_analyzer.py` with its own unrelated
  `has_tests` for the ingestion/RAG pipeline — this PR only touches the
  agent-tools side (`tech_detector.py`), which is what the "repo analysis output"
  in the issue actually refers to.
- Repo-wide `make check`/`make test-unit` currently fail on plain `main` (173
  lint/type errors, 53 unit test failures across unrelated modules) — pre-existing
  debt, confirmed via a baseline diff that this branch introduces zero new
  failures.
