### PR TITLE
ci: add database migration validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,34 @@ jobs:
           REDIS_URL: redis://localhost:6379/0
           LLM_PROVIDER: mock
 
+  migrations:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: pathreview
+          POSTGRES_PASSWORD: pathreview
+          POSTGRES_DB: pathreview_test
+        ports: ["5432:5432"]
+        options: >-
+          --health-cmd "pg_isready -U pathreview"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - run: pip install -e ".[dev]"
+      - name: Validate database migrations
+        run: bash scripts/validate_migrations.sh
+        env:
+          DATABASE_URL: postgresql+asyncpg://pathreview:pathreview@localhost:5432/pathreview_test
+          LLM_PROVIDER: mock
+
   frontend:
     runs-on: ubuntu-latest
     steps:

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -41,3 +41,48 @@ remove only the redundant `uq_users_email` constraint while preserving the
 unique `ix_users_email` index that still enforces email uniqueness. The same
 successful-failure sequence must then be reproduced in GitHub Actions to prove
 the new CI job is using the intended async PostgreSQL connection.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:** I traced the drift to migration `001`, which creates both
+a unique constraint and a unique index for `users.email`, while the current
+SQLAlchemy metadata expects only the unique index. I added a new corrective
+migration instead of modifying published migration history, and started a
+reusable validation script plus a separate PostgreSQL-backed CI job.
+
+**Next steps:** Add focused tests, recreate a clean PostgreSQL database, run the
+full migration chain and schema comparison, then self-review the final diff.
+
+**Blockers:** The repository's existing test and lint suites are not green, so I
+need to compare before-and-after results and demonstrate that this change adds
+no new failures rather than claiming to fix unrelated baseline problems.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** To be added after the pull request is opened.
+
+**Branch:** `feat/129-database-migration-validation`
+
+**What you built:** I added migration `003` to remove the redundant
+`uq_users_email` constraint without removing the unique index, a fail-fast shell
+script that runs `alembic upgrade head` followed by `alembic check`, and a new
+GitHub Actions job that executes this workflow against fresh PostgreSQL 16.
+
+**Tests added or updated:** I added four unit tests for the complete revision
+chain, the corrective migration's upgrade and downgrade operations, and the
+validation script's missing-`DATABASE_URL` behavior. All four pass. I also ran
+the real workflow against a recreated local database: migrations `001` through
+`003`, rollback and reapplication of `003`, and the final schema comparison all
+passed. The full unit-suite baseline remained unchanged at 52 failures and 31
+errors, with passing tests increasing from 345 to 349.
+
+**Self-review confirmation:** [ ] `make check` passes [ ] `make test-unit`
+passes. Both commands still fail on documented pre-existing repository issues;
+focused Ruff, Black, shell syntax, and the four new tests pass, and no new full
+suite failures were introduced.
+
+**Draft PR feedback received from:** None yet.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -63,7 +63,7 @@ no new failures rather than claiming to fix unrelated baseline problems.
 
 ### Check-in 2 (end of week)
 
-**PR link:** To be added after the pull request is opened.
+**PR link:** https://github.com/ascherj/pathreview/pull/849
 
 **Branch:** `feat/129-database-migration-validation`
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -17,3 +17,29 @@ I can identify the relevant CI, Alembic, and SQLAlchemy files and explain the di
 **Setup confirmation:** [ ] App runs locally at localhost:5173
 
 **Cohort Ledger:** [x] Issue added to cohort ledger
+
+## Week 8 - Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/CocoYang10/pathreview/commit/9c902bc
+
+**Reproduction summary:**
+I reproduced this as a missing CI safeguard: the repository has an ordered
+Alembic history (`001 -> 002`) and can generate the full PostgreSQL upgrade SQL,
+but `.github/workflows/ci.yml` never runs Alembic. The integration job starts
+PostgreSQL and then runs tests directly, so a green build currently does not
+prove that migrations execute successfully or that their final schema matches
+the SQLAlchemy models.
+
+**PLAN.md link:** https://github.com/CocoYang10/pathreview/blob/feat/129-database-migration-validation/PLAN.md
+
+**Walkthrough video (recommended):** Not recorded.
+
+**Blockers or open questions:**
+My local machine does not currently have Docker or PostgreSQL, so my
+reproduction confirms the missing validation path and generates the migration
+SQL offline, but does not claim a live database result. My first Week 9 step is
+to run `alembic upgrade head` and `alembic check` against the disposable
+PostgreSQL service in GitHub Actions. I also need to determine whether the
+unique constraint and unique index created for `users.email` represent genuine
+pre-existing schema drift before deciding whether a corrective migration is
+in scope.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -24,22 +24,20 @@ I can identify the relevant CI, Alembic, and SQLAlchemy files and explain the di
 
 **Reproduction summary:**
 I reproduced this as a missing CI safeguard: the repository has an ordered
-Alembic history (`001 -> 002`) and can generate the full PostgreSQL upgrade SQL,
-but `.github/workflows/ci.yml` never runs Alembic. The integration job starts
-PostgreSQL and then runs tests directly, so a green build currently does not
-prove that migrations execute successfully or that their final schema matches
-the SQLAlchemy models.
+Alembic history (`001 -> 002`), but `.github/workflows/ci.yml` never runs it. On
+a fresh local PostgreSQL 16 database, both migrations applied successfully,
+but `alembic check` then detected an extra `uq_users_email` constraint, proving
+that the migrated schema already drifts from the SQLAlchemy models while the
+current CI has no check that reports it.
 
 **PLAN.md link:** https://github.com/CocoYang10/pathreview/blob/feat/129-database-migration-validation/PLAN.md
 
 **Walkthrough video (recommended):** Not recorded.
 
 **Blockers or open questions:**
-My local machine does not currently have Docker or PostgreSQL, so my
-reproduction confirms the missing validation path and generates the migration
-SQL offline, but does not claim a live database result. My first Week 9 step is
-to run `alembic upgrade head` and `alembic check` against the disposable
-PostgreSQL service in GitHub Actions. I also need to determine whether the
-unique constraint and unique index created for `users.email` represent genuine
-pre-existing schema drift before deciding whether a corrective migration is
-in scope.
+The live database reproduction is complete. The remaining implementation
+question is how narrowly to correct the confirmed drift: the new revision must
+remove only the redundant `uq_users_email` constraint while preserving the
+unique `ix_users_email` index that still enforces email uniqueness. The same
+successful-failure sequence must then be reproduced in GitHub Actions to prove
+the new CI job is using the intended async PostgreSQL connection.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -20,7 +20,7 @@ I can identify the relevant CI, Alembic, and SQLAlchemy files and explain the di
 
 ## Week 8 - Reproduction & solution planning
 
-**Reproduction commit link:** https://github.com/CocoYang10/pathreview/commit/9c902bc
+**Reproduction commit link:** https://github.com/CocoYang10/pathreview/commit/a25a659
 
 **Reproduction summary:**
 I reproduced this as a missing CI safeguard: the repository has an ordered

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,19 @@
+## Week 7 - Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/129
+
+**Issue title:** Add a database migration validation step to CI that checks all migrations can be applied cleanly
+
+**Tier:** [ ] Tier 1 [ ] Tier 2 [x] Tier 3
+
+**Problem summary:**
+PathReview has SQLAlchemy models and Alembic migration files, but its CI workflow does not currently verify the database migration history. A migration can therefore be syntactically valid while failing against a clean PostgreSQL database or leaving the database schema inconsistent with the application models. The requested change will create a fresh database in CI, apply every migration in order, and compare the resulting schema with the SQLAlchemy metadata. This will catch migration failures and schema drift before a pull request is merged.
+
+**Selection rationale:**
+I can identify the relevant CI, Alembic, and SQLAlchemy files and explain the difference between application models, migration history, and the live database schema. The issue is a stretch because it crosses PostgreSQL, Alembic, shell scripting, and GitHub Actions, but the repository currently has a short two-migration history and a working PostgreSQL service pattern in the existing integration-test job. I chose it to build database and CI skills that complement my Python, SQL, statistics, and machine-learning background. The main scope risk is defining a reliable schema-consistency check and reproducing the same behavior locally and in GitHub Actions.
+
+**Branch name:** feat/129-database-migration-validation
+
+**Setup confirmation:** [ ] App runs locally at localhost:5173
+
+**Cohort Ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -86,3 +86,78 @@ focused Ruff, Black, shell syntax, and the four new tests pass, and no new full
 suite failures were introduced.
 
 **Draft PR feedback received from:** None yet.
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes [x] No — still awaiting review
+
+**Summary of feedback:**
+No review feedback has come in on PR #849. I checked the PR again before
+completing this reflection and found no reviewer comments, submitted reviews,
+or inline review threads.
+
+**How you responded:**
+No response or code change was needed because no feedback was received.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The hardest part was understanding that there are three related but different
+versions of the database structure: the SQLAlchemy models, the Alembic migration
+history, and the schema that actually exists in PostgreSQL. At first, I assumed
+that if `alembic upgrade head` completed successfully, the migrations were
+correct. The surprising part was that revisions `001` and `002` both ran, but
+`alembic check` still found schema drift because `users.email` had both a unique
+constraint and a unique index. I also had to learn how to judge my change in a
+repository whose full test and lint suites already had many failures. Comparing
+the baseline before and after my work was more useful than treating every red
+result as something caused by my PR.
+
+**What did you learn about working in a large codebase?**
+I learned that one issue can cross more modules than its title suggests. This
+issue involved GitHub Actions, a shell script, Alembic configuration and revision
+files, SQLAlchemy models, PostgreSQL, and tests. I could not make a responsible
+change by reading only `.github/workflows/ci.yml`; I had to trace how the
+database URL is loaded, how Alembic imports the model metadata, and how the
+existing migrations build the schema. I also learned why contributors should
+not rewrite an old migration that may already have run in other environments.
+Adding revision `003` preserved the shared history and corrected existing
+databases through the same ordered process.
+
+**How did AI tools help — and where did they fall short?**
+AI tools were most helpful for explaining unfamiliar concepts in smaller steps,
+mapping the relevant files, and turning the issue into a testable plan. They
+also helped me compare CI, Alembic, SQLAlchemy, and PostgreSQL as parts of one
+workflow instead of isolated tools. However, an explanation or suggested patch
+was not evidence that the migration really worked. I still needed to inspect
+the repository, install and run PostgreSQL, reproduce the drift, and test the
+upgrade, check, downgrade, and re-upgrade myself. AI also could not decide that
+the repository's existing failures were harmless without a before-and-after
+baseline. The useful boundary was to use AI for orientation and reasoning, then
+use the actual code and database as the source of truth.
+
+**What would you do differently if you started over?**
+I would run and record the repository's complete test and lint baseline at the
+very beginning. I eventually did this, but doing it before implementation would
+have made the scope clearer and reduced confusion when the full checks failed.
+I would also draw the relationship between models, migrations, and the live
+schema before changing code. That mental model became the key to the issue, and
+having it earlier would have made my reproduction and implementation more
+direct. Finally, I would plan the real PostgreSQL validation from the start
+instead of first thinking about the problem mostly through configuration and
+static code.
+
+**What are you most proud of from this module?**
+I am most proud that I took an area I had almost no experience with—database
+migrations and CI—and followed it through as a complete workflow rather than
+stopping when the script appeared to work. I reproduced a real schema mismatch,
+fixed it without rewriting migration history, added an automatic check for
+future pull requests, and tested the change against a fresh PostgreSQL database.
+The most valuable result for me is not only PR #849; it is that I can now explain
+the connection between application models, migration history, the real
+database, tests, and CI, and I know how to verify each part instead of assuming
+they agree.

--- a/PLAN.md
+++ b/PLAN.md
@@ -109,3 +109,23 @@ check, with Alembic's output explaining the failure.
   early and explain the configuration problem.
 - The database is already at head: validation should remain safe and
   repeatable, although CI will normally provide an empty database.
+
+## Implementation results
+
+- Added revision `003`, which removes only the redundant
+  `uq_users_email` constraint. The existing unique `ix_users_email` index still
+  enforces email uniqueness.
+- Added `scripts/validate_migrations.sh` as the single local and CI entry point
+  for `alembic upgrade head` and `alembic check`.
+- Added an isolated `migrations` GitHub Actions job backed by PostgreSQL 16.
+- Added four unit tests covering the revision chain, upgrade and downgrade
+  operations, and the script's missing-configuration failure.
+- Recreated the local validation database from scratch. Revisions `001`, `002`,
+  and `003` applied successfully, and `alembic check` reported
+  `No new upgrade operations detected`. Revision `003` was also downgraded and
+  reapplied successfully.
+- The focused test file passes (`4 passed`). The full unit suite has the same
+  pre-existing failure baseline before and after this work: 52 failures and 31
+  errors; the passing count increased from 345 to 349. Ruff still reports the
+  same 182 pre-existing repository errors, while all changed Python files pass
+  focused Ruff and Black checks.

--- a/PLAN.md
+++ b/PLAN.md
@@ -50,15 +50,15 @@ Files I need to understand and use, but do not currently expect to change:
    repository's PostgreSQL 16 service pattern, install the project on Python
    3.11, and pass a `postgresql+asyncpg://` URL because `alembic/env.py` creates
    an async engine.
-3. Run the validation against a disposable, empty PostgreSQL database. Record
-   the successful base-to-head path and deliberately introduce a temporary,
-   controlled model/migration mismatch to verify the job becomes red. Remove
-   that temporary change after the check is proven.
-4. Investigate any mismatch reported by `alembic check`. In particular,
-   migration `001` creates both `uq_users_email` and a unique
-   `ix_users_email`, while the current model declares `unique=True,
-   index=True`. Determine from the live comparison whether this is genuine
-   drift. If it is, correct it with a new revision rather than editing `001`.
+3. Run the validation against a disposable, empty PostgreSQL database. The
+   local reproduction has already shown that revisions `001` and `002` execute
+   successfully and that `alembic check` then fails on a real mismatch. Repeat
+   the same experiment in GitHub Actions to prove the CI wiring is correct.
+4. Correct the confirmed `users.email` drift. Migration `001` creates both
+   `uq_users_email` and a unique `ix_users_email`, while the current model's
+   `unique=True, index=True` describes the unique index. Add a new revision
+   that removes the redundant constraint rather than editing the
+   already-applied `001`, then confirm `alembic check` passes.
 5. Run focused validation and review the CI diff for unrelated changes. Update
    `JOURNAL.md` with results, risks discovered, and links before opening the
    Week 9 pull request.
@@ -79,9 +79,10 @@ check, with Alembic's output explaining the failure.
 
 ## Risks & unknowns
 
-- The current migration history may already differ from the models. A new check
-  can correctly expose an old problem, so I need to distinguish a validation
-  bug from genuine pre-existing drift.
+- The current migration history already differs from the models:
+  `alembic check` detected the extra `uq_users_email` unique constraint after
+  revisions `001` and `002` were applied to fresh PostgreSQL 16. The correction
+  must preserve the existing unique index and must not rewrite revision `001`.
 - `alembic/env.py` uses `create_async_engine`; a plain `postgresql://` URL may
   select an incompatible synchronous driver. CI should use
   `postgresql+asyncpg://`.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,110 @@
+# Solution plan
+
+**Issue:** [#129 — Add a database migration validation step to CI that checks all migrations can be applied cleanly](https://github.com/ascherj/pathreview/issues/129)
+
+## Understand
+
+PathReview represents its database in three related places: SQLAlchemy models
+describe the schema the application expects now, Alembic revisions describe how
+an older database reaches that schema, and PostgreSQL holds the schema that
+actually exists. The current CI workflow tests several parts of the application
+and even starts PostgreSQL for integration tests, but it never runs Alembic.
+Therefore, CI does not prove either that revisions `001` and `002` can be
+applied in order or that their final schema matches `core.models.Base.metadata`.
+
+The expected behavior is that each pull request gets a fresh database and CI
+turns red for either of two failure classes: a migration that cannot execute, or
+a migration that executes but produces schema drift. The actual behavior is
+that both cases can be outside the checks currently run by CI.
+
+## Map
+
+Files I expect to change:
+
+- `.github/workflows/ci.yml`: add an isolated migration-validation job with a
+  temporary PostgreSQL service and an async database URL.
+- `scripts/validate_migrations.sh`: add the reusable, fail-fast entry point that
+  runs the two Alembic validations.
+- `alembic/versions/003_*.py`: only if the new consistency check reveals a real
+  mismatch that must be corrected without rewriting an already-applied
+  revision.
+
+Files I need to understand and use, but do not currently expect to change:
+
+- `alembic/env.py`: connects Alembic through an async SQLAlchemy engine and sets
+  `target_metadata = Base.metadata`.
+- `alembic/versions/001_initial_schema.py` and
+  `alembic/versions/002_add_error_message_to_reviews.py`: the complete migration
+  history that CI must exercise.
+- `core/models/*.py`: the expected schema used by `alembic check`.
+- `core/config.py`: loads `DATABASE_URL`; its async driver requirements must
+  match the CI environment.
+
+## Plan
+
+1. Create `scripts/validate_migrations.sh`. Make it fail clearly when
+   `DATABASE_URL` is absent, then run `alembic upgrade head` followed by
+   `alembic check`. Preserve each command's non-zero exit status so GitHub
+   Actions marks the job failed.
+2. Add a separate migration job to `.github/workflows/ci.yml`. Reuse the
+   repository's PostgreSQL 16 service pattern, install the project on Python
+   3.11, and pass a `postgresql+asyncpg://` URL because `alembic/env.py` creates
+   an async engine.
+3. Run the validation against a disposable, empty PostgreSQL database. Record
+   the successful base-to-head path and deliberately introduce a temporary,
+   controlled model/migration mismatch to verify the job becomes red. Remove
+   that temporary change after the check is proven.
+4. Investigate any mismatch reported by `alembic check`. In particular,
+   migration `001` creates both `uq_users_email` and a unique
+   `ix_users_email`, while the current model declares `unique=True,
+   index=True`. Determine from the live comparison whether this is genuine
+   drift. If it is, correct it with a new revision rather than editing `001`.
+5. Run focused validation and review the CI diff for unrelated changes. Update
+   `JOURNAL.md` with results, risks discovered, and links before opening the
+   Week 9 pull request.
+
+## Inputs & outputs
+
+The validation takes:
+
+- a `DATABASE_URL` that points to a fresh, disposable PostgreSQL database;
+- the ordered files in `alembic/versions`;
+- the SQLAlchemy metadata imported by `alembic/env.py`.
+
+It produces no application data or UI change. Its primary output is a process
+exit code: zero when all revisions apply and the final schema matches the
+models, non-zero when migration execution or schema comparison fails. In
+GitHub Actions, that exit code becomes a visible green or red pull-request
+check, with Alembic's output explaining the failure.
+
+## Risks & unknowns
+
+- The current migration history may already differ from the models. A new check
+  can correctly expose an old problem, so I need to distinguish a validation
+  bug from genuine pre-existing drift.
+- `alembic/env.py` uses `create_async_engine`; a plain `postgresql://` URL may
+  select an incompatible synchronous driver. CI should use
+  `postgresql+asyncpg://`.
+- A reused or partially migrated database could produce misleading results.
+  The CI job must receive a new isolated service database on every run.
+- `alembic check` depends on all relevant model modules being registered in
+  `Base.metadata`. An incomplete model import could create a false comparison.
+- PostgreSQL may be started but not ready to accept connections. The service
+  health check must gate the validation step.
+- Existing unrelated CI failures must not be presented as failures introduced
+  or fixed by this change.
+
+## Edge cases
+
+- A revision contains invalid SQL or refers to a missing table/column:
+  `alembic upgrade head` should fail the job.
+- A model changes without a matching revision: `alembic check` should fail the
+  job after the existing revisions are applied.
+- Two contributors create separate heads: validation should report the
+  ambiguous history rather than silently choosing one branch.
+- A revision references an unknown `down_revision`: the upgrade must fail with
+  a useful Alembic error.
+- `DATABASE_URL` is absent or points to the wrong driver: the script should exit
+  early and explain the configuration problem.
+- The database is already at head: validation should remain safe and
+  repeatable, although CI will normally provide an empty database.

--- a/REPRODUCTION.md
+++ b/REPRODUCTION.md
@@ -1,0 +1,45 @@
+# Issue #129 reproduction
+
+## What I am reproducing
+
+Issue #129 is a missing CI safeguard rather than a user-facing bug. PathReview has
+an Alembic migration history, but the current GitHub Actions workflow never runs
+that history or checks the resulting database schema against the SQLAlchemy
+models. This means a pull request can pass the checks that currently exist
+without proving that a database can be upgraded safely.
+
+## Steps and observations
+
+1. I inspected `.github/workflows/ci.yml`. It defines lint, typecheck, unit-test,
+   integration-test, and frontend jobs. The integration job starts PostgreSQL,
+   but it only runs `pytest tests/integration`; there is no `alembic upgrade
+   head`, `alembic check`, or dedicated migration-validation job.
+2. I ran `.venv/bin/alembic heads` and observed one current head: `002`.
+3. I ran `.venv/bin/alembic history` and observed the ordered history
+   `<base> -> 001 -> 002`.
+4. I ran `.venv/bin/alembic upgrade head --sql`. Alembic successfully generated
+   88 lines of PostgreSQL DDL for both revisions, showing that the migration
+   path exists. Because `--sql` is offline mode, this only generates SQL; it
+   does not prove that the statements execute successfully against PostgreSQL
+   or that the resulting schema matches `Base.metadata`.
+5. I searched the CI workflow for `alembic` and `migration` and received no
+   matches. Therefore, none of the current automatic checks exercises the
+   migration path found in steps 2–4.
+
+## Expected vs. actual
+
+**Expected:** On every pull request, CI should create an isolated PostgreSQL
+database, run every migration from base to head, and fail if the resulting
+schema differs from the SQLAlchemy models.
+
+**Actual:** CI can start PostgreSQL and run integration tests without ever
+executing Alembic. A green build currently means the existing checks passed; it
+does not mean the migration history is executable or free of schema drift.
+
+## Current limitation
+
+My machine does not currently have Docker, `psql`, or a PostgreSQL server, so
+this reproduction does not claim a live database result. The first
+implementation step will use the disposable PostgreSQL service in GitHub
+Actions (or an equivalent local container) to run `alembic upgrade head` and
+`alembic check` end to end.

--- a/REPRODUCTION.md
+++ b/REPRODUCTION.md
@@ -17,14 +17,25 @@ without proving that a database can be upgraded safely.
 2. I ran `.venv/bin/alembic heads` and observed one current head: `002`.
 3. I ran `.venv/bin/alembic history` and observed the ordered history
    `<base> -> 001 -> 002`.
-4. I ran `.venv/bin/alembic upgrade head --sql`. Alembic successfully generated
-   88 lines of PostgreSQL DDL for both revisions, showing that the migration
-   path exists. Because `--sql` is offline mode, this only generates SQL; it
-   does not prove that the statements execute successfully against PostgreSQL
-   or that the resulting schema matches `Base.metadata`.
+4. I first ran `.venv/bin/alembic upgrade head --sql`. Alembic successfully
+   generated 88 lines of PostgreSQL DDL for both revisions, confirming the
+   intended migration path before I executed it.
 5. I searched the CI workflow for `alembic` and `migration` and received no
    matches. Therefore, none of the current automatic checks exercises the
    migration path found in steps 2–4.
+6. I installed PostgreSQL 16.14 locally and created a new empty database named
+   `pathreview_migration_test`. With `DATABASE_URL` pointed at that database, I
+   ran `.venv/bin/alembic upgrade head`. Revisions `001` and `002` both executed
+   successfully, and `.venv/bin/alembic current` reported `002 (head)`.
+7. I then ran `.venv/bin/alembic check` against the migrated database. It failed
+   with `Detected removed unique constraint 'uq_users_email' on 'users'`,
+   proving that the schema produced by the migrations does not currently match
+   the SQLAlchemy metadata.
+8. A read-only PostgreSQL query confirmed that `users.email` has both a
+   `uq_users_email` unique constraint and a separate unique
+   `ix_users_email` index. The model's `unique=True, index=True` describes the
+   unique index, so the additional constraint is the pre-existing drift that
+   the missing CI validation currently allows.
 
 ## Expected vs. actual
 
@@ -36,10 +47,10 @@ schema differs from the SQLAlchemy models.
 executing Alembic. A green build currently means the existing checks passed; it
 does not mean the migration history is executable or free of schema drift.
 
-## Current limitation
+## Reproduced result
 
-My machine does not currently have Docker, `psql`, or a PostgreSQL server, so
-this reproduction does not claim a live database result. The first
-implementation step will use the disposable PostgreSQL service in GitHub
-Actions (or an equivalent local container) to run `alembic upgrade head` and
-`alembic check` end to end.
+The migration execution check passed, but the schema-consistency check failed
+on a real, fresh PostgreSQL 16 database. This separates the two failure classes
+the fix must cover: migrations may fail while executing, or they may execute
+successfully and still produce the wrong final schema. The current CI runs
+neither check, so it cannot report this real drift.

--- a/alembic/versions/003_drop_redundant_users_email_constraint.py
+++ b/alembic/versions/003_drop_redundant_users_email_constraint.py
@@ -1,0 +1,28 @@
+"""Drop the redundant unique constraint on users.email.
+
+Revision ID: 003
+Revises: 002
+Create Date: 2026-08-04 00:00:00.000000
+
+The SQLAlchemy model defines users.email with both ``unique=True`` and
+``index=True``. Alembic represents that definition as a unique index. The
+initial migration also created a separate unique constraint, which causes
+``alembic check`` to report schema drift. This corrective migration removes
+only the redundant constraint; the unique index continues to enforce email
+uniqueness.
+"""
+
+from alembic import op  # type: ignore[attr-defined]
+
+revision = "003"
+down_revision = "002"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_constraint("uq_users_email", "users", type_="unique")
+
+
+def downgrade() -> None:
+    op.create_unique_constraint("uq_users_email", "users", ["email"])

--- a/scripts/validate_migrations.sh
+++ b/scripts/validate_migrations.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ -z "${DATABASE_URL:-}" ]]; then
+  echo "DATABASE_URL must be set to a disposable PostgreSQL database." >&2
+  exit 1
+fi
+
+echo "Applying all Alembic migrations to the validation database..."
+alembic upgrade head
+
+echo "Comparing the migrated schema with the SQLAlchemy models..."
+alembic check
+
+echo "Migration validation passed."

--- a/tests/unit/test_migration_validation.py
+++ b/tests/unit/test_migration_validation.py
@@ -1,0 +1,94 @@
+"""Unit tests for the database migration validation workflow."""
+
+import ast
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+VERSIONS_DIR = REPO_ROOT / "alembic" / "versions"
+CORRECTIVE_MIGRATION = VERSIONS_DIR / "003_drop_redundant_users_email_constraint.py"
+
+
+def _parse_migration(path: Path) -> ast.Module:
+    return ast.parse(path.read_text(), filename=str(path))
+
+
+def _assignment_value(tree: ast.Module, name: str) -> str | None:
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if any(isinstance(target, ast.Name) and target.id == name for target in node.targets):
+            return ast.literal_eval(node.value)
+    raise AssertionError(f"{name} is not declared in the migration")
+
+
+def _operation_calls(tree: ast.Module, function_name: str) -> list[ast.Call]:
+    function = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == function_name
+    )
+    return [node for node in ast.walk(function) if isinstance(node, ast.Call)]
+
+
+@pytest.mark.unit
+def test_migration_history_has_one_complete_revision_chain() -> None:
+    revisions: dict[str, str | None] = {}
+    for path in VERSIONS_DIR.glob("[0-9]*.py"):
+        tree = _parse_migration(path)
+        revisions[_assignment_value(tree, "revision")] = _assignment_value(tree, "down_revision")
+
+    assert revisions == {"001": None, "002": "001", "003": "002"}
+
+
+@pytest.mark.unit
+def test_corrective_migration_drops_only_redundant_constraint() -> None:
+    calls = _operation_calls(_parse_migration(CORRECTIVE_MIGRATION), "upgrade")
+
+    assert len(calls) == 1
+    call = calls[0]
+    assert isinstance(call.func, ast.Attribute)
+    assert call.func.attr == "drop_constraint"
+    assert [ast.literal_eval(argument) for argument in call.args] == [
+        "uq_users_email",
+        "users",
+    ]
+    assert {keyword.arg: ast.literal_eval(keyword.value) for keyword in call.keywords} == {
+        "type_": "unique"
+    }
+
+
+@pytest.mark.unit
+def test_corrective_migration_restores_constraint_on_downgrade() -> None:
+    calls = _operation_calls(_parse_migration(CORRECTIVE_MIGRATION), "downgrade")
+
+    assert len(calls) == 1
+    call = calls[0]
+    assert isinstance(call.func, ast.Attribute)
+    assert call.func.attr == "create_unique_constraint"
+    assert [ast.literal_eval(argument) for argument in call.args] == [
+        "uq_users_email",
+        "users",
+        ["email"],
+    ]
+
+
+@pytest.mark.unit
+def test_validation_script_rejects_missing_database_url() -> None:
+    environment = os.environ.copy()
+    environment.pop("DATABASE_URL", None)
+
+    result = subprocess.run(
+        ["bash", "scripts/validate_migrations.sh"],
+        cwd=REPO_ROOT,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "DATABASE_URL must be set" in result.stderr


### PR DESCRIPTION
## Summary

This PR adds a database migration validation step to CI.

Before this change, CI ran the existing tests, but it did not apply the Alembic migrations to a real PostgreSQL database. Because of that, a migration problem or a difference between the database schema and the SQLAlchemy models could be missed.

While reproducing the issue locally, I found that the migrations could run, but `alembic check` still reported schema drift for `users.email`. Migration `001` created both a unique constraint and a unique index, while the current SQLAlchemy model expects the unique index. I added migration `003` to remove the redundant constraint while keeping the unique index.

## Issue

Closes #129

## Changes

- Added a script that runs `alembic upgrade head` and `alembic check`.
- Added a PostgreSQL migration validation job to GitHub Actions.
- Added migration `003` to fix the existing `users.email` schema drift.
- Added tests for the migration chain, upgrade and downgrade behavior, and missing `DATABASE_URL`.

## Testing

- [ ] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`)
- [ ] Linter passes (`make lint`)
- [ ] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes

I tested the new workflow on a fresh local PostgreSQL 16 database. Migrations `001`, `002`, and `003` were applied successfully, and `alembic check` found no remaining schema changes. I also tested downgrading and reapplying migration `003`.

The four new unit tests pass. The full repository test suite still has the same 52 failures and 31 errors that existed before this change, so I left the full-suite checkboxes unchecked.

## Screenshots / Demo

Not applicable because this change is for database migrations and CI.

## Notes for Reviewers

This is my first time working with Alembic migrations and database validation in CI. I would especially appreciate feedback on whether using a separate CI job and a corrective migration is the right approach for this project.