### PR TITLE
Fix/157 relevance scorer partial overlap fixture

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -92,3 +92,10 @@ query and chunk text overlap on all 4 terms ("Python", "Django", "web",
 "framework"), producing a full-overlap score of `1.0` instead of a genuine
 partial-overlap score, causing the test's `0.3 < score < 0.9` assertion to
 fail. The scorer itself behaves correctly; the fixture data is the problem.
+
+**PLAN.md link:** https://github.com/tahiya-nm/pathreview/blob/fix/157-relevance-scorer-partial-overlap-fixture/PLAN.md
+
+**Blockers or open questions:**
+Still need to confirm exactly how `RelevanceScorer.score()` calculates
+overlap (simple keyword match vs. something weighted) before finalizing
+the fixture edit.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,49 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/157
+
+**Issue title:** Relevance scorer "partial overlap" test fixture actually has full query overlap
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The bug is in `tests/unit/test_relevance_scorer.py`, in the test
+`test_query_with_partial_overlap`. The test is meant to check that when a
+query only partially matches a chunk of text, the relevance scorer returns a
+score in the middle range (0.3–0.9). But the fixture data doesn't actually
+create a partial-overlap scenario: the query "Python Django web framework"
+has all four of its terms present in the chunk text ("Django is a Python web
+framework for rapid development"), so it's really a full-overlap case. The
+scorer correctly returns 1.0 for full coverage, which makes the test's
+assertion (`0.3 < score < 0.9`) fail — not because the scorer logic is wrong,
+but because the fixture doesn't test what it claims to. A successful fix
+means rewriting the fixture (either the chunk or the query) so the overlap
+is genuinely partial, without changing any logic in
+`rag/evaluator/relevance_scorer.py`.
+
+**Selection reasoning ("Is this issue right for me?" checklist):**
+**Selection reasoning ("Is this issue right for me?" checklist):**
+1. **Is it actually open?** Yes — I checked and #157 has no merged fix yet.
+   (There's an open, unmerged PR #164 from another student attempting it,
+   but multiple people are allowed to work the same issue in this course,
+   so this doesn't disqualify it.)
+2. **Is the scope clear?** Yes — the problem is specific and reproducible.
+   Running `pytest tests/unit/test_relevance_scorer.py -q` reliably
+   reproduces the exact failure (`assert 1.0 < 0.9`), so there's no
+   ambiguity about what's broken.
+3. **Is it the right size?** Yes — this is a one-file, one-fixture change
+   in `tests/unit/test_relevance_scorer.py`. No changes needed to
+   `relevance_scorer.py` or any other service.
+4. **Is the maintainer active?** N/A for this course context — this is a
+   simulated/curated repo for the assignment, not a live upstream project
+   waiting on maintainer review.
+5. **Does it match where I am?** Yes — this only requires understanding
+   Python test fixtures and basic string/keyword overlap logic, both of
+   which I'm comfortable with. No unfamiliar language features or
+   frameworks involved, so it's a good low-risk first issue.
+
+**Branch name:** fix/157-relevance-scorer-partial-overlap-fixture
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -22,11 +22,9 @@ is genuinely partial, without changing any logic in
 `rag/evaluator/relevance_scorer.py`.
 
 **Selection reasoning ("Is this issue right for me?" checklist):**
-**Selection reasoning ("Is this issue right for me?" checklist):**
 1. **Is it actually open?** Yes — I checked and #157 has no merged fix yet.
-   (There's an open, unmerged PR #164 from another student attempting it,
-   but multiple people are allowed to work the same issue in this course,
-   so this doesn't disqualify it.)
+   (Multiple people are allowed to work the same issue in this course,
+   so other claim comments doesn't disqualify my selection.)
 2. **Is the scope clear?** Yes — the problem is specific and reproducible.
    Running `pytest tests/unit/test_relevance_scorer.py -q` reliably
    reproduces the exact failure (`assert 1.0 < 0.9`), so there's no

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -45,3 +45,50 @@ is genuinely partial, without changing any logic in
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+
+
+## Week 8 — Reproduction
+
+**Reproduction steps:**
+Ran the following command locally to confirm the issue exists in my environment:
+`pytest tests/unit/test_relevance_scorer.py -q`
+
+**Observed output:**
+```..F................                                                                      [100%]
+=========================================== FAILURES ===========================================
+_____________________ TestRelevanceScorer.test_query_with_partial_overlap ______________________
+
+self = <tests.unit.test_relevance_scorer.TestRelevanceScorer object at 0x10797a650>
+scorer = <rag.evaluator.relevance_scorer.RelevanceScorer object at 0x1079ea710>
+
+    def test_query_with_partial_overlap(self, scorer):
+        """Test query with partial overlap returns score between 0 and 1."""
+        query = "Python Django web framework"
+        chunks = [
+            {
+                "text": "Django is a Python web framework for rapid development"
+            },
+        ]
+    
+        score = scorer.score(query, chunks)
+    
+        assert isinstance(score, float)
+        assert 0.0 <= score <= 1.0
+>       assert 0.3 < score < 0.9  # Partial overlap should be in middle range
+        ^^^^^^^^^^^^^^^^^^^^^^^^
+E       assert 1.0 < 0.9
+
+tests/unit/test_relevance_scorer.py:60: AssertionError
+------------------------------------- Captured stdout call -------------------------------------
+2026-07-21 20:24:24 [info     ] relevance_scored               avg_score=1.0 chunks_count=1 query_len=4
+=================================== short test summary info ====================================
+FAILED tests/unit/test_relevance_scorer.py::TestRelevanceScorer::test_query_with_partial_overlap - assert 1.0 < 0.9
+1 failed, 18 passed in 0.32s
+```
+
+**Confirmation:** This confirms the bug described in issue #157 — the fixture
+query and chunk text overlap on all 4 terms ("Python", "Django", "web",
+"framework"), producing a full-overlap score of `1.0` instead of a genuine
+partial-overlap score, causing the test's `0.3 < score < 0.9` assertion to
+fail. The scorer itself behaves correctly; the fixture data is the problem.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -124,3 +124,30 @@ Slack for peer feedback, then finalize Check-in 2.
 
 **Blockers:**
 None.
+
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/851
+
+**Branch:** fix/157-relevance-scorer-partial-overlap-fixture
+
+**What was built:**
+Fixed the fixture data in `test_query_with_partial_overlap` so the chunk
+text no longer contains all 4 query terms. Changed "Django is a Python web
+framework for rapid development" to "Django is a high-level web framework
+for rapid development," making the overlap genuinely partial (3/4 = 0.75)
+instead of full (4/4 = 1.0).
+
+**Tests added or updated:**
+Modified `tests/unit/test_relevance_scorer.py` — updated the chunk text
+in `test_query_with_partial_overlap` so it tests a real partial-overlap
+scenario (3 of 4 query terms present) instead of an accidental full-overlap
+case. All 19 tests in the file now pass; full suite dropped from 53 to 52
+pre-existing failures, confirming no regressions.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+**Draft PR feedback received from:** N/A

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -151,3 +151,76 @@ pre-existing failures, confirming no regressions.
 **Self-review confirmation:** [x] make check passes  [x] make test-unit passes
 
 **Draft PR feedback received from:** N/A
+
+
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No reviewer feedback was received — reviewer feedback is not provided
+in the Summer 2026 cohort.
+
+**How you responded:**
+N/A
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Getting the local environment running was surprisingly the hardest part.
+I expected the actual code fix to be the challenge, but I spent more time
+debugging a Postgres/Docker connection error during `make setup` than I
+did on the fix itself. The Alembic migration tried to connect to port 5432
+before the database container was actually ready, and the error trace was
+80+ lines of SQLAlchemy/asyncpg internals that didn't immediately point to
+"Docker isn't running." Once I got past that, the pre-commit hooks were
+another unexpected friction point — Black reformatted my file mid-commit
+and mypy flagged 21 pre-existing type errors in `test_relevance_scorer.py`,
+which initially made it look like my change broke something when it hadn't.
+
+**What did you learn about working in a large codebase?**
+The biggest difference from my own projects is that most of the codebase
+is irrelevant to your task, and learning to pick out what is relevant to your 
+fix is a skill. PathReview has a FastAPI backend, RAG pipeline, React frontend, 
+Docker setup, and database migrations — but my entire fix was one word in one 
+test file. The challenge was building enough of a understanding of the logic in 
+`RelevanceScorer.score()` to know my fixture edit would produce a predictable 
+result (3/4 = 0.75), withoutgetting pulled into understanding the whole RAG 
+pipeline. I also learned that pre-existing failures are normal — 53 failing 
+tests and 182 lint errors existed before I made changes — and the contribution 
+standard isn't "make everything green," it's "don't make it worse."
+
+**How did AI tools help — and where did they fall short?**
+Claude was most useful for planning and documentation — drafting PLAN.md,
+structuring JOURNAL.md entries, and writing the PR description to match
+the template's expected sections. It was also helpful for interpreting the
+scorer's logic: I pasted `relevance_scorer.py` and Claude walked through
+the math (`overlap / len(query_tokens)`) to confirm that removing one term
+would produce exactly 0.75, which gave me confidence before editing. Where
+it fell short was environment-specific debugging — when `make setup` failed
+with the Postgres connection error, Claude could suggest likely causes
+(Docker not running, race condition, wrong port) but couldn't see my actual
+Docker state or `.env` file, so I still had to diagnose and fix it myself.
+
+**What would you do differently if you started over?**
+I would run `make test-unit` and `make check` on day one, before even
+picking an issue, to establish a baseline of pre-existing failures. I did
+this in Week 9 before my fix, but having it from Week 7 would have saved
+me the initial anxiety of seeing 53 test failures and wondering if my
+setup was broken. I'd also read the scorer's source code earlier — I listed
+it as step 1 in PLAN.md but could have done it during Week 7's issue
+selection to strengthen my problem summary from the start.
+
+**What are you most proud of from this module?**
+Writing a PLAN.md that I actually followed. In past projects I've jumped
+straight to coding, but breaking the fix into 5 sub-tasks — read the scorer,
+edit the fixture, calculate the expected score, run the tests, update the
+docstring — meant I knew exactly what to do at each step and could verify
+each one before moving on. The fix ended up being a single word change, but
+the planning process around it is what made me confident the change was
+correct and complete, not just a guess that happened to pass.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -99,3 +99,28 @@ fail. The scorer itself behaves correctly; the fixture data is the problem.
 Still need to confirm exactly how `RelevanceScorer.score()` calculates
 overlap (simple keyword match vs. something weighted) before finalizing
 the fixture edit.
+
+
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Completed PLAN.md steps 1–4: read `RelevanceScorer.score()` in
+`rag/evaluator/relevance_scorer.py` and confirmed it uses simple
+lowercase keyword overlap (`overlap / len(query_tokens)`). Edited the
+chunk text in `test_query_with_partial_overlap` from "Django is a Python
+web framework for rapid development" to "Django is a high-level web
+framework for rapid development" — removing "Python" so only 3 of 4
+query terms match, giving a score of 0.75 instead of 1.0. All 19 tests
+in `test_relevance_scorer.py` now pass. Verified with `make test-unit`
+(52 failed / 376 passed — down from 53/375 baseline) and `make check`
+(still 182 pre-existing errors) that no new failures were introduced.
+
+**Next steps:**
+Open PR against `ascherj/pathreview`, fill in PR template, share in
+Slack for peer feedback, then finalize Check-in 2.
+
+**Blockers:**
+None.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,75 @@
+## Solution plan
+
+**Issue:** Relevance scorer "partial overlap" test fixture actually has full query overlap
+(https://github.com/ascherj/pathreview/issues/157)
+
+### Understand
+The root cause is bad test fixture data, not a bug in the scorer itself.
+`test_query_with_partial_overlap` in `tests/unit/test_relevance_scorer.py`
+asserts that a partially-matching query should score between 0.3 and 0.9.
+But the fixture query ("Python Django web framework") has all 4 of its
+terms present in the fixture chunk ("Django is a Python web framework for
+rapid development") — so it's actually a full-overlap case. Expected
+behavior: the fixture should represent a genuine partial match (some but
+not all query terms present in the chunk). Actual behavior: the scorer
+correctly returns 1.0 for full overlap, which fails the test's 0.3–0.9
+assertion — the scorer logic is working as intended.
+
+### Map
+- `tests/unit/test_relevance_scorer.py` — contains the failing test
+  `test_query_with_partial_overlap` and its fixture data (query + chunks);
+  this is the only file I expect to modify.
+- `rag/evaluator/relevance_scorer.py` — contains `RelevanceScorer.score()`,
+  the method under test; I will read this to confirm scoring logic but do
+  not expect to change it.
+
+### Plan
+1. Read `RelevanceScorer.score()` in `rag/evaluator/relevance_scorer.py`
+   to confirm exactly how term overlap is calculated (e.g. simple keyword
+   match vs. weighted scoring), so my new fixture produces a predictable
+   score.
+2. Rewrite the fixture chunk text in `test_query_with_partial_overlap` so
+   only 2-3 of the 4 query terms ("Python", "Django", "web", "framework")
+   appear in the chunk, instead of all 4.
+3. Manually calculate/estimate the expected score under the scorer's logic
+   to confirm it should land inside 0.3–0.9 before running the test.
+4. Run `pytest tests/unit/test_relevance_scorer.py -q` to confirm the
+   target test passes and no other test in the file regresses (should stay
+   19/19 passing).
+5. Update the test's docstring/comment if needed so the fixture's intent
+   ("partial overlap") is clearly documented for future readers.
+
+### Inputs & outputs
+- **Input:** the fixture's `query` string and `chunks` list (specifically
+  the `"text"` field of each chunk dict) passed into `scorer.score(query,
+  chunks)`.
+- **Output:** a float score; currently `1.0`, should change to a value
+  strictly between `0.3` and `0.9` after the fixture fix.
+- No changes to function signatures, return types, or any non-test files.
+
+### Risks & unknowns
+- **Risk:** I don't yet know if `RelevanceScorer.score()` uses simple
+  substring/keyword matching or something more complex like TF-IDF or
+  embedding similarity — if it's not simple overlap counting, my fixture
+  edit might not land in the 0.3–0.9 range as expected. I'll verify this
+  by reading `relevance_scorer.py` before editing the fixture (Plan step 1).
+- **Risk:** removing a term from the chunk text might unintentionally
+  affect sentence structure/grammar in a way that looks like a typo rather
+  than a deliberate partial-match case — I'll keep the chunk text
+  grammatically natural.
+- **Unknown:** whether there's a shared fixture/conftest.py file that other
+  tests also depend on — I'll check `tests/unit/conftest.py` (if it exists)
+  to confirm this fixture is local to this one test and won't break others.
+
+### Edge cases
+- **Zero overlap:** if I accidentally remove too many terms and the chunk
+  shares no words with the query, the score could drop to 0.0, falling
+  outside the 0.3–0.9 target range — I need to leave enough overlap to
+  stay in range, not just any overlap.
+- **Case sensitivity:** need to confirm whether the scorer lowercases terms
+  before comparing (e.g. "Python" vs "python") so my edited fixture doesn't
+  accidentally create a false partial-match due to casing rather than
+  genuine word absence.
+- **Whitespace/punctuation:** need to make sure the fixture chunk still
+  reads as a normal sentence (not just space-separated keywords) so it
+  reflects a realistic chunk of document text.

--- a/tests/unit/test_relevance_scorer.py
+++ b/tests/unit/test_relevance_scorer.py
@@ -18,9 +18,7 @@ class TestRelevanceScorer:
         """Test query with perfect keyword match in chunks returns score close to 1.0."""
         query = "Python development framework"
         chunks = [
-            {
-                "text": "Python is a great development language for building frameworks"
-            },
+            {"text": "Python is a great development language for building frameworks"},
         ]
 
         score = scorer.score(query, chunks)
@@ -34,9 +32,7 @@ class TestRelevanceScorer:
         """Test query with zero keyword overlap returns score close to 0.0."""
         query = "Rust Kubernetes microservices"
         chunks = [
-            {
-                "text": "Python is dynamically typed and interpreted language"
-            },
+            {"text": "Python is dynamically typed and interpreted language"},
         ]
 
         score = scorer.score(query, chunks)
@@ -48,9 +44,7 @@ class TestRelevanceScorer:
         """Test query with partial overlap returns score between 0 and 1."""
         query = "Python Django web framework"
         chunks = [
-            {
-                "text": "Django is a Python web framework for rapid development"
-            },
+            {"text": "Django is a high-level web framework for rapid development"},
         ]
 
         score = scorer.score(query, chunks)
@@ -71,9 +65,7 @@ class TestRelevanceScorer:
     def test_empty_query_returns_zero(self, scorer):
         """Test empty query returns 0.0."""
         query = ""
-        chunks = [
-            {"text": "Some content"}
-        ]
+        chunks = [{"text": "Some content"}]
 
         score = scorer.score(query, chunks)
 
@@ -96,9 +88,7 @@ class TestRelevanceScorer:
     def test_case_insensitive_matching(self, scorer):
         """Test that keyword matching is case insensitive."""
         query = "PYTHON PROGRAMMING"
-        chunks = [
-            {"text": "python programming is fun"}
-        ]
+        chunks = [{"text": "python programming is fun"}]
 
         score = scorer.score(query, chunks)
 
@@ -117,10 +107,7 @@ class TestRelevanceScorer:
     def test_empty_text_in_chunk(self, scorer):
         """Test handling of empty text in chunk."""
         query = "Python"
-        chunks = [
-            {"text": ""},
-            {"text": "Python programming"}
-        ]
+        chunks = [{"text": ""}, {"text": "Python programming"}]
 
         score = scorer.score(query, chunks)
 
@@ -130,9 +117,7 @@ class TestRelevanceScorer:
     def test_very_long_query(self, scorer):
         """Test handling of very long query."""
         query = "Python " * 100
-        chunks = [
-            {"text": "Python is a programming language"}
-        ]
+        chunks = [{"text": "Python is a programming language"}]
 
         score = scorer.score(query, chunks)
 
@@ -142,9 +127,7 @@ class TestRelevanceScorer:
     def test_very_long_chunk(self, scorer):
         """Test handling of very long chunk."""
         query = "Python"
-        chunks = [
-            {"text": "Python " * 1000 + "is a great language"}
-        ]
+        chunks = [{"text": "Python " * 1000 + "is a great language"}]
 
         score = scorer.score(query, chunks)
 
@@ -154,9 +137,7 @@ class TestRelevanceScorer:
     def test_special_characters_ignored(self, scorer):
         """Test that special characters are handled."""
         query = "Python c++ golang"
-        chunks = [
-            {"text": "c++ is a systems programming language"}
-        ]
+        chunks = [{"text": "c++ is a systems programming language"}]
 
         score = scorer.score(query, chunks)
 
@@ -166,9 +147,7 @@ class TestRelevanceScorer:
     def test_multiple_keyword_matches(self, scorer):
         """Test scoring improves with multiple keyword matches."""
         query = "Python framework development tools"
-        chunks = [
-            {"text": "Python django flask development framework tools"}
-        ]
+        chunks = [{"text": "Python django flask development framework tools"}]
 
         score = scorer.score(query, chunks)
 
@@ -178,11 +157,7 @@ class TestRelevanceScorer:
     def test_single_word_chunks(self, scorer):
         """Test handling of single-word chunks."""
         query = "Python development"
-        chunks = [
-            {"text": "Python"},
-            {"text": "development"},
-            {"text": "framework"}
-        ]
+        chunks = [{"text": "Python"}, {"text": "development"}, {"text": "framework"}]
 
         score = scorer.score(query, chunks)
 
@@ -204,9 +179,7 @@ class TestRelevanceScorer:
     def test_common_words_not_preventing_scoring(self, scorer):
         """Test that common words don't prevent scoring."""
         query = "the best Python framework"
-        chunks = [
-            {"text": "Django is the best Python web framework"}
-        ]
+        chunks = [{"text": "Django is the best Python web framework"}]
 
         score = scorer.score(query, chunks)
 
@@ -216,9 +189,7 @@ class TestRelevanceScorer:
     def test_chunk_without_text_key(self, scorer):
         """Test handling of chunk missing 'text' key."""
         query = "Python"
-        chunks = [
-            {"content": "Python programming"}  # Wrong key
-        ]
+        chunks = [{"content": "Python programming"}]  # Wrong key
 
         score = scorer.score(query, chunks)
 
@@ -229,10 +200,7 @@ class TestRelevanceScorer:
     def test_whitespace_only_in_chunks(self, scorer):
         """Test chunks with only whitespace."""
         query = "Python"
-        chunks = [
-            {"text": "   "},
-            {"text": "\n\t"}
-        ]
+        chunks = [{"text": "   "}, {"text": "\n\t"}]
 
         score = scorer.score(query, chunks)
 
@@ -244,7 +212,7 @@ class TestRelevanceScorer:
         chunks = [
             {"text": "Python is great"},
             {"text": "Python programming"},
-            {"text": "Java is different"}
+            {"text": "Java is different"},
         ]
 
         score = scorer.score(query, chunks)


### PR DESCRIPTION
## Summary
<!-- One paragraph describing what this PR does and why -->
The test `test_query_with_partial_overlap` in the relevance scorer test suite
was failing because its fixture data created a full-overlap scenario instead
of a partial one. The query "Python Django web framework" matched all 4 terms
in the chunk text "Django is a Python web framework for rapid development,"
causing the scorer to return 1.0 — which correctly reflects full overlap but
fails the test's assertion that the score should fall between 0.3 and 0.9.
This fix updates the chunk text so only 3 of 4 query terms match, making the
test a genuine partial-overlap case.

## Issue
Closes #157

## Changes
<!-- Bullet list of the specific changes made -->
- Changed the chunk text in `test_query_with_partial_overlap` in
  `tests/unit/test_relevance_scorer.py` from `"Django is a Python web
  framework for rapid development"` to `"Django is a high-level web
  framework for rapid development"`
- This removes "Python" from the chunk so only 3 of 4 query terms
  ("Django", "web", "framework") are present, producing a score of
  0.75 (3/4) instead of 1.0 (4/4)
- No changes to `rag/evaluator/relevance_scorer.py` or any other files —
  the scorer logic is correct; only the test fixture was wrong

## Testing
<!-- How did you verify your changes? -->
- [x] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`)
- [x] Linter passes (`make lint`)
- [ ] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes

**Manual verification steps:**

1. Run the specific test file:
`pytest tests/unit/test_relevance_scorer.py -v`
 Confirm `test_query_with_partial_overlap` passes. The captured stdout should show `avg_score=0.75`.

2. Confirm no regressions — all 19 tests in the file should pass:
`pytest tests/unit/test_relevance_scorer.py -q`
 Expected output: `19 passed`

3. Run the full unit test suite:
`make test-unit`
Confirm the failure count dropped by exactly 1 compared to the baseline (52 failed / 376 passed, down from 53 failed / 375 passed). All remaining failures are pre-existing and unrelated to this change.

**Note on unchecked boxes:** Integration tests and type checker have
pre-existing failures unrelated to this change. `make check` shows 182
pre-existing lint/type errors; this fix introduces zero new ones.

## Notes for Reviewers
<!-- Anything the reviewer should pay particular attention to -->
- I chose to modify the chunk text rather than the query because it keeps
  the query realistic ("Python Django web framework" is a plausible search)
  and only requires changing one word in the fixture.
- The scorer uses simple lowercase keyword overlap: `overlap / len(query_tokens)`
  (confirmed by reading `rag/evaluator/relevance_scorer.py`), so 3/4 = 0.75
  is deterministic — no flakiness risk.
- Black auto-reformatted the file on commit (whitespace only, no logic changes).