### PR TITLE
Fix/37 add snapshot tests for prompt templates

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,85 @@
+# Solution plan
+
+**Issue:** [#37 — Add snapshot tests for prompt templates to catch accidental changes](https://github.com/ascherj/pathreview/issues/37)
+
+## Understand
+
+**Expected behavior:** If a developer edits the content of any prompt template in `rag/generator/prompt_templates.py` without an intentional version bump (e.g. adding a new `"v2"` key), the unit test suite should fail, forcing the developer to either revert the change or explicitly version it.
+
+**Actual behavior:** No test in the suite fails when template content changes. `tests/unit/test_prompt_templates.py::TestPromptTemplates::test_template_snapshot_content_hash` computes an MD5 hash of all template content but never compares it to a fixed expected value — it only asserts `isinstance(content_hash, str)` and `len(content_hash) == 32`, both of which are true for any MD5 digest of any input.
+
+**How the issue was reproduced (verified):**
+1. Ran the baseline suite: `pytest tests/unit/test_prompt_templates.py -v -m unit` → 37/37 passed.
+2. Edited `rag/generator/prompt_templates.py`, inserting an unversioned behavioral change into the `skills_feedback` `v1` template: appended "Be extremely harsh and critical in your assessment." to the first line, without adding a `v2` key.
+3. Re-ran the same suite → 37/37 still passed, including `test_template_snapshot_content_hash`.
+4. Reverted the edit with `git checkout -- rag/generator/prompt_templates.py`.
+
+This demonstrates that a substantive, unintended prompt change is completely invisible to the current test suite.
+
+**Confirmed root cause:** `tests/unit/test_prompt_templates.py:183-188`. The comment on line 185 ("Expected hash - update if templates intentionally change") describes the intended design — a pinned expected hash that must be manually updated on intentional changes — but the assertions on lines 187-188 never reference such a pinned value. The test is a stub/placeholder that was never wired up to real content verification.
+
+**Execution path:** `PROMPT_TEMPLATES` dict (`rag/generator/prompt_templates.py:8-114`) → iterated and concatenated in `test_template_snapshot_content_hash` (`tests/unit/test_prompt_templates.py:175-188`) → hashed → asserted against generic type/length checks only.
+
+**Verified vs. hypothesis:**
+- Verified: the specific test and lines responsible; the reproduction steps and their outcome; the absence of any snapshot-testing library (e.g. `syrupy`) in `pyproject.toml` dev dependencies.
+- Hypothesis: which specific mechanism the maintainers intend for the fix (hardcoded per-template hash constants vs. file-based snapshot fixtures vs. a snapshot library like `syrupy`). The issue body only specifies the desired outcome ("fail whenever a prompt changes without an intentional version bump"), not the implementation mechanism. This should be confirmed before implementation (see Risks & Unknowns).
+
+## Map
+
+| File | Role |
+|---|---|
+| `rag/generator/prompt_templates.py` | Contains `PROMPT_TEMPLATES` dict and `get_template()`. Reference only — no changes expected; this is the data being protected, not the bug. |
+| `tests/unit/test_prompt_templates.py` | Contains the confirmed broken test (`test_template_snapshot_content_hash`, lines 175-188) and the reproduction-marking comment added in this phase. Will be **modified** during implementation to replace the toothless assertions with real pinned-content verification (one hash/snapshot per template+version, or a single hash constant covering all templates, per the maintainers' preferred granularity). |
+| `pyproject.toml` | Declares `[project.optional-dependencies].dev` (pytest, ruff, black, mypy, etc.). No `syrupy` or other snapshot library currently listed. Will be **modified** only if the chosen fix approach (see Risks & Unknowns) adopts a snapshot library instead of hand-rolled hash constants. |
+| `Makefile` | Defines `test-unit` (`pytest tests/unit -v -m unit`). Used only for **testing/verification**, not modified. |
+| `docs/JOURNAL.md` | Assignment/course journal. **Modified** to add the Week 8 entry (this phase) and will later need a Week 9+ entry once the fix lands. |
+| `PLAN.md` (this file) | **Added** in this phase; living document, updated as implementation proceeds. |
+
+No other files reference `PROMPT_TEMPLATES` or `get_template()` outside `rag/generator/prompt_templates.py` and its test file (confirmed via repository search); the blast radius of a fix is contained to these two files.
+
+## Plan
+
+1. **Decide the pinning mechanism** (blocks the rest of the plan). *File:* `tests/unit/test_prompt_templates.py`. Choose between (a) a single hardcoded expected MD5 constant (matches the existing hash-based approach, smallest diff) or (b) per-template-version hash constants (more precise failure messages, more code) or (c) adopting a snapshot library such as `syrupy` (adds a dev dependency but gives human-readable diffs on failure). Verification: no code yet — this is a design decision to confirm, ideally with the maintainer/issue author, before writing the fix.
+
+2. **Replace the toothless assertion with a real pinned comparison.** *File:* `tests/unit/test_prompt_templates.py`, function `test_template_snapshot_content_hash` (or a renamed/split equivalent). Change the assertion from `isinstance(...)`/`len(...)` checks to `assert content_hash == EXPECTED_HASH`, where `EXPECTED_HASH` is computed once from the current (intentional) template content and stored as a module-level constant (or per-template dict, per decision in step 1). This directly addresses the root cause: the test will now fail whenever `content_hash` diverges from the pinned value. Verification: run `pytest tests/unit/test_prompt_templates.py -v -m unit`; the new test must pass against current templates.
+
+3. **Prove the fix actually catches drift.** *File:* temporary local edit to `rag/generator/prompt_templates.py` (not committed) — repeat the exact reproduction from the Understand section (append text to `skills_feedback` `v1` without a version bump) and confirm the updated test now **fails**. Then revert. Verification: manual — `pytest tests/unit/test_prompt_templates.py -v -m unit` shows the specific test failing with a clear diff/message, then passing again after revert.
+
+4. **Add/adjust documentation for the versioning workflow.** *File:* a docstring or comment above `EXPECTED_HASH`/the fixed test in `tests/unit/test_prompt_templates.py` explaining how to intentionally update the pinned value when a template is deliberately changed (e.g. "bump the template to a new version key AND regenerate this hash by running `python -c '...'`"). This addresses the issue's requirement that "prompt updates are reviewed and versioned deliberately" — without a documented update path, developers will be tempted to blindly copy the new hash without reviewing the diff. Verification: manual review; optionally have a teammate follow the documented steps.
+
+5. **Run full verification and update the journal.** *Files:* none changed beyond test/doc files above; `docs/JOURNAL.md` gets a follow-up entry once merged. Run `make test-unit` and `make check` (lint + format + typecheck) to confirm no regressions elsewhere. Verification: both commands exit 0; `test_all_5_templates_exist` and all other pre-existing tests in the file still pass unchanged.
+
+## Inputs & outputs
+
+- **Inputs:** the `PROMPT_TEMPLATES` dict literal in `rag/generator/prompt_templates.py` (5 template names × 1 version each today); no external inputs, arguments, or configuration — this is a pure static-data test.
+- **Current flow:** dict → concatenated in test → MD5 hash → asserted to be *a* valid-looking string (always true) → test passes regardless of content.
+- **Current output:** test suite green, no signal, regardless of whether templates changed.
+- **Expected output after fix:** test suite green only when `PROMPT_TEMPLATES` content matches the last reviewed/pinned state; red (with a clear failure message pointing at which template diverged) whenever content changes without updating the pinned value.
+- **Compatibility constraints:** `get_template(name, version)` public signature (`rag/generator/prompt_templates.py:117`) must not change — nothing outside the test file should need to change. The fix is test-only.
+
+## Risks & unknowns
+
+- **Unknown: intended pinning mechanism.** The issue doesn't specify hardcoded hash vs. snapshot library vs. per-file fixtures. *Resolution:* ask in the issue/PR thread, or default to the smallest-diff option (hardcoded expected hash, extending the existing approach) if no response is available before the implementation deadline.
+- **Unknown: intended granularity of "version."** Templates currently only have a `v1` key each; the issue implies future template edits should either bump to `v2` or fail the test. It's unclear whether the real fix should also add tooling/documentation enforcing "if `v2` exists, `v1` must remain unchanged," or if that's out of scope for issue #37. *Resolution:* clarify scope with the issue author; default to test-only scope if unclear.
+- **Brittle test risk:** if the pinned hash is a single value covering all 5 templates concatenated together (current pattern), *any* single-template edit will fail the test, but the failure message won't say which template changed. This could be confusing for a legitimate future contributor and lead to broad hash-copying without careful review. *Resolution:* prefer per-template-version hashes (step 1, option b) or a snapshot library with readable diffs to reduce this risk, per further discussion.
+- **No maintainers'-intent documentation found:** searched `docs/` for a design doc or ADR about prompt versioning; none exists beyond the issue body itself. Treat the issue body as the sole source of truth for intended behavior.
+- **Branch name mismatch:** `docs/JOURNAL.md` Week 7 entry records the branch name as `test/issue-37-prompt-template-snapshots`, but the actual local/pushed branch is `fix/37-add-snapshot-tests-for-prompt-templates`. This doesn't affect the reproduction or fix itself, but should be reconciled (confirm which name is authoritative for submission) before the final PR.
+
+## Edge cases
+
+- **Template content unchanged:** fixed test must continue passing — covered by re-running the full suite after the fix (step 3/5).
+- **Intentional template edit with version bump (e.g. adding `v2`):** the pinned hash for `v1` should remain valid; a new pinned value would be needed only if `v2`'s content is also hashed. The fix should make it clear (via the step-4 documentation) how to add coverage for a new version without breaking `v1`'s snapshot.
+- **Accidental edit to any one of the 5 templates:** must cause the fixed test to fail (this is the core case demonstrated in the reproduction).
+- **Whitespace-only or formatting-only edits:** since the hash is computed over raw string content, even a single whitespace change will change the hash and fail the test. This is arguably correct (any content change should be reviewed) but is worth flagging as a potential source of false-positive-feeling failures (e.g., an editor auto-strips trailing whitespace). Document this in step 4.
+- **Addition or removal of an entire template name/version:** `test_all_5_templates_exist` (line 13-24) already partially covers structural changes (adding/removing a template name), but changing the *set of versions* under an existing template name is not separately asserted; the concatenation-based hash would still catch it as a content change, but a clearer per-template test might be preferable (see per-template-version option in step 1).
+
+## Verification strategy
+
+- **Existing tests that must continue to pass unchanged:** all other 36 tests in `tests/unit/test_prompt_templates.py` (structural/content-assertion tests unrelated to the snapshot hash), plus the rest of `make test-unit`.
+- **Regression test that should fail before the fix and pass after:** `test_template_snapshot_content_hash` itself, once rewritten — reproduced via steps in "Understand" (currently always passes regardless of content; after the fix, it must fail against the mutated-template reproduction from step 3, then pass again once reverted).
+- **Manual verification:** repeat the exact reproduction (edit `skills_feedback` `v1`, run tests, observe failure, revert, observe pass) against the fixed test, as described in Plan step 3.
+- **Commands to run:**
+  - `pytest tests/unit/test_prompt_templates.py -v -m unit`
+  - `make test-unit`
+  - `make check` (ruff + black + mypy) — note: `tests/unit/test_prompt_templates.py` currently has 19 pre-existing `ruff` findings unrelated to this issue (unsorted imports, long lines, unused loop variables); these should not be silently fixed as part of this issue's scope unless the maintainer asks for it, since it would broaden the diff beyond the snapshot-test fix.
+- **Regression confirmation:** re-run the full `make test-all` after the fix to confirm no other suite (integration, etc.) depends on the current (broken) behavior of this test.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -1,0 +1,1 @@
+# JOURNAL.md

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -1,1 +1,17 @@
-# JOURNAL.md
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/37
+
+**Issue title:** Add snapshot tests for prompt templates to catch accidental changes
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The application’s prompt templates directly influence the quality and consistency of generated reviews, but there are currently no snapshot tests protecting their content. This means a developer could accidentally modify a prompt template without updating its version, causing unexpected behavior that may be difficult to notice during review. The issue affects the prompt-template unit tests in `tests/unit/test_prompt_templates.py`. A successful fix will add snapshot tests that fail whenever a prompt changes without an intentional version bump, ensuring prompt updates are reviewed and versioned deliberately.
+
+**Branch name:** `test/issue-37-prompt-template-snapshots`
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -60,3 +60,33 @@ Fixed issue #37 by rewriting `test_template_snapshot_content_hash` in `tests/uni
 *(Both commands still surface only the same pre-existing, unrelated failures documented in the PR description — 19 pre-existing `ruff` findings in this file, 53 pre-existing unit-test failures repo-wide, none touching `prompt_templates.py` — with zero new failures introduced.)*
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+
+**Summary of feedback:**
+As of this entry, PR #853 is still in draft with no comments beyond my own PR description, no reviewers requested, and no approvals or change requests on GitHub.
+
+**How you responded:**
+N/A — no feedback is needed for this iteration.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Understanding the bug itself took longer than I expected, mostly because the broken test didn't look obviously broken. `test_template_snapshot_content_hash` computes a real MD5 hash of the template content, so at a glance it looks like a working snapshot test. The actual problem is that it only asserts `isinstance(content_hash, str)` and `len(content_hash) == 32` — both true for any hash of any input — so it never compares against a pinned value. I only really believed this once I reproduced it myself: temporarily appending a sentence to the `skills_feedback` v1 template, rerunning `pytest tests/unit/test_prompt_templates.py -v -m unit`, and watching all 37 tests pass anyway, including the "snapshot" one. Seeing a test suite go green on a change that should have been caught was more convincing than just reading the assertion lines.
+
+**What did you learn about working in a large codebase?**
+Before touching anything, I had to confirm that `PROMPT_TEMPLATES` and `get_template()` weren't used anywhere outside `rag/generator/prompt_templates.py` and its test file — otherwise a "test-only" fix could have had a wider blast radius than it looked like. I also ran into a real inconsistency between the project's layers of tooling: CI's `typecheck` job only runs `mypy` against `api/ core/ ingestion/ rag/ agent/ safety/`, but the local pre-commit hook runs `mypy` with `disallow_untyped_defs = true` against whatever file is staged, tests included. That meant a commit could fail locally for reasons CI would never flag. I hadn't thought about "passing checks" as something that could differ between environments in the same repo. I also had to be careful about scope creep that wasn't really about my change at all — an unrelated `frontend/package-lock.json` diff had gotten staged from a stray `npm install`, and a chunk of `black` reformatting on lines I never touched crept into the diff. Reverting both to keep the diff to just the fix was as much a part of "editing a shared codebase" as writing the fix itself.
+
+**How did AI tools help — and where did they fall short?**
+The AI did most of the mechanical work this week: reproducing the bug, drafting the three possible fix designs (a single combined hash, per-template-version hashes, or adopting a snapshot library like `syrupy`), writing the actual test rewrite, and later machine-editing all 37 test methods to add `-> None` annotations once the pre-commit hook demanded it. My own role was mostly making the calls it surfaced — picking per-template hashes over the other two options, deciding to fix the pre-existing lint/type issues rather than bypass the hook with `--no-verify`, and reviewing the diffs it showed me before approving each step. I didn't personally catch a specific mistake in what it produced this week; I mostly reviewed and agreed with what it proposed. That's worth being honest about as a limitation of how I used it: I got a working, well-tested fix, but I have less hands-on memory of things like resolving the `ruff` findings or writing the `mypy` fix myself than I would if I'd done that part by hand. The AI also couldn't finish the job on its own — it had no GitHub credentials in its environment, so I had to personally push the branch and open the PR.
+
+**What would you do differently if you started over?**
+I'd spend more time exploring `test_prompt_templates.py` and `prompt_templates.py` directly during the planning weeks, before locking in a plan. Since understanding the bug was the hardest part for me, getting more comfortable with exactly how `PROMPT_TEMPLATES`, `get_template()`, and the existing test patterns fit together earlier would have made the implementation week faster and made me rely less on the AI to explain things I could have figured out myself with more upfront reading.
+
+**What are you most proud of from this module?**
+I'm most proud that I understood the root cause well enough to actually direct the fix instead of just accepting whatever came first. When the AI laid out three different ways to pin the template hashes, I could reason about the tradeoff — a single combined hash would fail without saying which template changed, while per-template hashes would name the exact one — and pick the option that mattered for someone debugging a real failure later. That's a small decision, but it's the part of this module that felt like actual engineering judgment rather than just following instructions.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -37,7 +37,7 @@ Confirmed that `tests/unit/test_prompt_templates.py::TestPromptTemplates::test_t
 Implemented the fix from `PLAN.md`'s Plan steps 1-4: replaced the toothless `isinstance`/`len()` assertions in `test_template_snapshot_content_hash` with real per-(template, version) pinned MD5 hashes (`EXPECTED_TEMPLATE_HASHES`), plus a companion assertion that catches a template/version being added or removed without a corresponding hash entry. Verified the fix actually catches drift by repeating the Week 8 reproduction (appending text to `skills_feedback` v1) against the *fixed* test — it now fails with a message naming the exact template, then passes again after reverting. Ran full `make check` / `make test-unit` baselines before and after: identical 53 pre-existing test failures and 19 pre-existing `ruff` findings in the touched file, both unrelated to this issue — no new failures introduced. Also caught and reverted an unrelated `frontend/package-lock.json` diff that had been accidentally staged.
 
 **Next steps:**
-Self-review against `docs/CONTRIBUTING.md` is done (see Check-in 2). Remaining: get the student's go-ahead to commit, push, and open the PR; then request peer/mentor feedback in Slack per Phase 8.
+Self-review against `docs/CONTRIBUTING.md` is done (see Check-in 2). Commit pushed and draft PR opened (#853). Remaining: request peer/mentor feedback in the instructor Slack channel per Phase 8, address any feedback, then mark the PR ready for review.
 
 **Blockers:**
 None — the two open questions from Week 8 (branch name, pinning mechanism) are resolved above.
@@ -46,7 +46,7 @@ None — the two open questions from Week 8 (branch name, pinning mechanism) are
 
 ### Check-in 2 (end of week)
 
-**PR link:** [PENDING — not yet opened; awaiting approval to push and open the PR]
+**PR link:** https://github.com/ascherj/pathreview/pull/853
 
 **Branch:** `fix/37-add-snapshot-tests-for-prompt-templates`
 

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -15,3 +15,48 @@ The application’s prompt templates directly influence the quality and consiste
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/KhoaDao03/pathreview/commit/8bd84c3f522af587345310e36a61bf355cd80108
+
+**Reproduction summary:**
+Confirmed that `tests/unit/test_prompt_templates.py::TestPromptTemplates::test_template_snapshot_content_hash` computes an MD5 hash of all prompt template content but only asserts `isinstance(content_hash, str)` and `len(content_hash) == 32` — it never compares the hash to a pinned expected value. Verified by temporarily appending an unversioned behavioral change to the `skills_feedback` `v1` template in `rag/generator/prompt_templates.py` and re-running `pytest tests/unit/test_prompt_templates.py -v -m unit`: all 37 tests still passed, proving no test currently catches an accidental prompt-template change. Change was reverted after confirming; a comment marking the confirmed root-cause lines (183-188) was added as the reproduction artifact.
+
+**PLAN.md link:** https://github.com/KhoaDao03/pathreview/blob/fix/37-add-snapshot-tests-for-prompt-templates/PLAN.md
+
+**Blockers or open questions:**
+- ~~Branch name mismatch~~ — Resolved: `fix/37-add-snapshot-tests-for-prompt-templates` is authoritative (matches `docs/CONTRIBUTING.md`'s `<type>/<issue-number>-<short-description>` convention and is the branch actually pushed to origin).
+- ~~Pinning mechanism unknown~~ — Resolved in Week 9: implemented per-template-version pinned hashes (`EXPECTED_TEMPLATE_HASHES`), chosen over a single combined hash or adopting `syrupy`, so a failure names exactly which template drifted.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the fix from `PLAN.md`'s Plan steps 1-4: replaced the toothless `isinstance`/`len()` assertions in `test_template_snapshot_content_hash` with real per-(template, version) pinned MD5 hashes (`EXPECTED_TEMPLATE_HASHES`), plus a companion assertion that catches a template/version being added or removed without a corresponding hash entry. Verified the fix actually catches drift by repeating the Week 8 reproduction (appending text to `skills_feedback` v1) against the *fixed* test — it now fails with a message naming the exact template, then passes again after reverting. Ran full `make check` / `make test-unit` baselines before and after: identical 53 pre-existing test failures and 19 pre-existing `ruff` findings in the touched file, both unrelated to this issue — no new failures introduced. Also caught and reverted an unrelated `frontend/package-lock.json` diff that had been accidentally staged.
+
+**Next steps:**
+Self-review against `docs/CONTRIBUTING.md` is done (see Check-in 2). Remaining: get the student's go-ahead to commit, push, and open the PR; then request peer/mentor feedback in Slack per Phase 8.
+
+**Blockers:**
+None — the two open questions from Week 8 (branch name, pinning mechanism) are resolved above.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [PENDING — not yet opened; awaiting approval to push and open the PR]
+
+**Branch:** `fix/37-add-snapshot-tests-for-prompt-templates`
+
+**What you built:**
+Fixed issue #37 by rewriting `test_template_snapshot_content_hash` in `tests/unit/test_prompt_templates.py` to compare each prompt template's MD5 hash against a pinned per-(name, version) expected value (`EXPECTED_TEMPLATE_HASHES`), instead of only checking that the hash is *a* valid-looking string. An accidental edit to any template now fails the test with a message identifying exactly which template and version changed; a companion key-set assertion also catches templates/versions added or removed without updating the pinned hashes.
+
+**Tests added or updated:**
+- `tests/unit/test_prompt_templates.py::TestPromptTemplates::test_template_snapshot_content_hash` — rewritten to assert real pinned-hash equality per template/version (previously a no-op check). Confirmed it fails on unversioned drift and passes on the current, reviewed template content.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+*(Both commands still surface only the same pre-existing, unrelated failures documented in the PR description — 19 pre-existing `ruff` findings in this file, 53 pre-existing unit-test failures repo-wide, none touching `prompt_templates.py` — with zero new failures introduced.)*
+
+**Draft PR feedback received from:** none

--- a/tests/unit/test_prompt_templates.py
+++ b/tests/unit/test_prompt_templates.py
@@ -1,16 +1,36 @@
 """Tests for prompt_templates.py - Snapshot tests"""
 
-import pytest
 import hashlib
 
+import pytest
+
 from rag.generator.prompt_templates import PROMPT_TEMPLATES, get_template
+
+# Pinned content hashes, one per (template, version). Guards against
+# accidental edits to PROMPT_TEMPLATES: any content change flips the
+# corresponding hash and fails test_template_snapshot_content_hash below.
+#
+# To update intentionally: after reviewing the diff to the template text,
+# regenerate the hash for the changed (name, version) pair with:
+#   python -c "import hashlib; from rag.generator.prompt_templates import PROMPT_TEMPLATES; \
+#       print(hashlib.md5(PROMPT_TEMPLATES['<name>']['<version>'].encode()).hexdigest())"
+# and replace only that entry below. Prefer adding a new version key (e.g.
+# "v2") over silently overwriting "v1" so older callers of get_template()
+# keep their pinned behavior.
+EXPECTED_TEMPLATE_HASHES = {
+    ("first_impression", "v1"): "ef6429d3a6d426b3c9913381020dd7e4",
+    ("gaps_feedback", "v1"): "e5bfd6644fd62a0fe01f60c9aa456762",
+    ("presentation_feedback", "v1"): "43549ee59818dfc8eb3627554a563b2e",
+    ("projects_feedback", "v1"): "d346d01b24ee7aad92594014a46557af",
+    ("skills_feedback", "v1"): "f93103d823482a2e65decc6653e4ee5c",
+}
 
 
 @pytest.mark.unit
 class TestPromptTemplates:
     """Test suite for prompt templates."""
 
-    def test_all_5_templates_exist(self):
+    def test_all_5_templates_exist(self) -> None:
         """Test all 5 templates exist in PROMPT_TEMPLATES."""
         expected_templates = {
             "skills_feedback",
@@ -23,38 +43,40 @@ class TestPromptTemplates:
         actual_templates = set(PROMPT_TEMPLATES.keys())
         assert actual_templates == expected_templates
 
-    def test_skills_feedback_template_exists(self):
+    def test_skills_feedback_template_exists(self) -> None:
         """Test skills_feedback template exists."""
         assert "skills_feedback" in PROMPT_TEMPLATES
         assert "v1" in PROMPT_TEMPLATES["skills_feedback"]
 
-    def test_projects_feedback_template_exists(self):
+    def test_projects_feedback_template_exists(self) -> None:
         """Test projects_feedback template exists."""
         assert "projects_feedback" in PROMPT_TEMPLATES
         assert "v1" in PROMPT_TEMPLATES["projects_feedback"]
 
-    def test_presentation_feedback_template_exists(self):
+    def test_presentation_feedback_template_exists(self) -> None:
         """Test presentation_feedback template exists."""
         assert "presentation_feedback" in PROMPT_TEMPLATES
         assert "v1" in PROMPT_TEMPLATES["presentation_feedback"]
 
-    def test_gaps_feedback_template_exists(self):
+    def test_gaps_feedback_template_exists(self) -> None:
         """Test gaps_feedback template exists."""
         assert "gaps_feedback" in PROMPT_TEMPLATES
         assert "v1" in PROMPT_TEMPLATES["gaps_feedback"]
 
-    def test_first_impression_template_exists(self):
+    def test_first_impression_template_exists(self) -> None:
         """Test first_impression template exists."""
         assert "first_impression" in PROMPT_TEMPLATES
         assert "v1" in PROMPT_TEMPLATES["first_impression"]
 
-    def test_each_template_contains_context_placeholder(self):
+    def test_each_template_contains_context_placeholder(self) -> None:
         """Test each template contains {context} placeholder."""
         for template_name, versions in PROMPT_TEMPLATES.items():
             for version, template_text in versions.items():
-                assert "{context}" in template_text, f"{template_name} v{version} missing {{context}}"
+                assert (
+                    "{context}" in template_text
+                ), f"{template_name} v{version} missing {{context}}"
 
-    def test_each_template_contains_github_username_placeholder(self):
+    def test_each_template_contains_github_username_placeholder(self) -> None:
         """Test each template contains {github_username} placeholder."""
         for template_name, versions in PROMPT_TEMPLATES.items():
             for version, template_text in versions.items():
@@ -62,7 +84,7 @@ class TestPromptTemplates:
                     "{github_username}" in template_text
                 ), f"{template_name} v{version} missing {{github_username}}"
 
-    def test_each_template_contains_project_count_placeholder(self):
+    def test_each_template_contains_project_count_placeholder(self) -> None:
         """Test each template contains {project_count} placeholder."""
         for template_name, versions in PROMPT_TEMPLATES.items():
             for version, template_text in versions.items():
@@ -70,7 +92,7 @@ class TestPromptTemplates:
                     "{project_count}" in template_text
                 ), f"{template_name} v{version} missing {{project_count}}"
 
-    def test_get_template_returns_correct_template(self):
+    def test_get_template_returns_correct_template(self) -> None:
         """Test get_template() returns correct template."""
         template = get_template("skills_feedback", "v1")
 
@@ -78,182 +100,211 @@ class TestPromptTemplates:
         assert "{context}" in template
         assert "skills" in template.lower()
 
-    def test_get_template_projects_feedback(self):
+    def test_get_template_projects_feedback(self) -> None:
         """Test get_template for projects_feedback."""
         template = get_template("projects_feedback", "v1")
 
         assert isinstance(template, str)
         assert "project" in template.lower()
 
-    def test_get_template_presentation_feedback(self):
+    def test_get_template_presentation_feedback(self) -> None:
         """Test get_template for presentation_feedback."""
         template = get_template("presentation_feedback", "v1")
 
         assert isinstance(template, str)
         assert "presentation" in template.lower() or "readme" in template.lower()
 
-    def test_get_template_gaps_feedback(self):
+    def test_get_template_gaps_feedback(self) -> None:
         """Test get_template for gaps_feedback."""
         template = get_template("gaps_feedback", "v1")
 
         assert isinstance(template, str)
         assert "gap" in template.lower() or "skill" in template.lower()
 
-    def test_get_template_first_impression(self):
+    def test_get_template_first_impression(self) -> None:
         """Test get_template for first_impression."""
         template = get_template("first_impression", "v1")
 
         assert isinstance(template, str)
         assert "impression" in template.lower() or "summary" in template.lower()
 
-    def test_get_template_unknown_name_raises_error(self):
+    def test_get_template_unknown_name_raises_error(self) -> None:
         """Test get_template() raises KeyError/ValueError for unknown template."""
         with pytest.raises((KeyError, ValueError)):
             get_template("nonexistent_template")
 
-    def test_get_template_unknown_version_raises_error(self):
+    def test_get_template_unknown_version_raises_error(self) -> None:
         """Test get_template() raises KeyError/ValueError for unknown version."""
         with pytest.raises((KeyError, ValueError)):
             get_template("skills_feedback", "v999")
 
-    def test_all_templates_have_v1(self):
+    def test_all_templates_have_v1(self) -> None:
         """Test all templates have v1 version."""
-        for template_name in PROMPT_TEMPLATES.keys():
+        for template_name in PROMPT_TEMPLATES:
             assert "v1" in PROMPT_TEMPLATES[template_name]
 
-    def test_templates_are_strings(self):
+    def test_templates_are_strings(self) -> None:
         """Test all templates are strings."""
-        for template_name, versions in PROMPT_TEMPLATES.items():
-            for version, template_text in versions.items():
+        for _template_name, versions in PROMPT_TEMPLATES.items():
+            for _version, template_text in versions.items():
                 assert isinstance(template_text, str)
                 assert len(template_text) > 0
 
-    def test_templates_have_reasonable_length(self):
+    def test_templates_have_reasonable_length(self) -> None:
         """Test templates have reasonable length."""
         for template_name, versions in PROMPT_TEMPLATES.items():
             for version, template_text in versions.items():
                 # Templates should be at least 100 chars
                 assert len(template_text) > 100, f"{template_name} v{version} too short"
 
-    def test_skills_feedback_mentions_technical_skills(self):
+    def test_skills_feedback_mentions_technical_skills(self) -> None:
         """Test skills_feedback template mentions technical skills."""
         template = PROMPT_TEMPLATES["skills_feedback"]["v1"]
 
         assert "skill" in template.lower()
 
-    def test_projects_feedback_mentions_code_quality(self):
+    def test_projects_feedback_mentions_code_quality(self) -> None:
         """Test projects_feedback template mentions code quality."""
         template = PROMPT_TEMPLATES["projects_feedback"]["v1"]
 
         assert "project" in template.lower() or "quality" in template.lower()
 
-    def test_gaps_feedback_mentions_missing_skills(self):
+    def test_gaps_feedback_mentions_missing_skills(self) -> None:
         """Test gaps_feedback template mentions missing/gap concepts."""
         template = PROMPT_TEMPLATES["gaps_feedback"]["v1"]
 
-        assert "gap" in template.lower() or "missing" in template.lower() or "demand" in template.lower()
+        assert (
+            "gap" in template.lower()
+            or "missing" in template.lower()
+            or "demand" in template.lower()
+        )
 
-    def test_presentation_feedback_mentions_readme(self):
+    def test_presentation_feedback_mentions_readme(self) -> None:
         """Test presentation_feedback template mentions README or presentation."""
         template = PROMPT_TEMPLATES["presentation_feedback"]["v1"]
 
-        assert "readme" in template.lower() or "presentation" in template.lower() or "organization" in template.lower()
+        assert (
+            "readme" in template.lower()
+            or "presentation" in template.lower()
+            or "organization" in template.lower()
+        )
 
-    def test_first_impression_is_concise(self):
+    def test_first_impression_is_concise(self) -> None:
         """Test first_impression template instructs concise output."""
         template = PROMPT_TEMPLATES["first_impression"]["v1"]
 
-        assert "2" in template or "3" in template or "sentence" in template.lower() or "summary" in template.lower()
+        assert (
+            "2" in template
+            or "3" in template
+            or "sentence" in template.lower()
+            or "summary" in template.lower()
+        )
 
-    def test_get_template_default_version(self):
+    def test_get_template_default_version(self) -> None:
         """Test get_template() defaults to v1 when version not specified."""
         template_default = get_template("skills_feedback")
         template_v1 = get_template("skills_feedback", "v1")
 
         assert template_default == template_v1
 
-    def test_template_snapshot_content_hash(self):
-        """Snapshot test: verify template content hash."""
-        # Create hash of all template content
-        template_content = ""
-        for name in sorted(PROMPT_TEMPLATES.keys()):
-            for version in sorted(PROMPT_TEMPLATES[name].keys()):
-                template_content += PROMPT_TEMPLATES[name][version]
+    def test_template_snapshot_content_hash(self) -> None:
+        """Snapshot test: each template+version's content hash must match its pinned value.
 
-        content_hash = hashlib.md5(template_content.encode()).hexdigest()
+        Fails whenever a template's content changes without also updating
+        EXPECTED_TEMPLATE_HASHES, forcing an intentional review of the change
+        (see the comment above EXPECTED_TEMPLATE_HASHES for the update steps).
+        """
+        actual_keys = {
+            (name, version) for name, versions in PROMPT_TEMPLATES.items() for version in versions
+        }
+        assert actual_keys == set(EXPECTED_TEMPLATE_HASHES), (
+            "PROMPT_TEMPLATES keys and EXPECTED_TEMPLATE_HASHES keys have diverged "
+            f"(added: {actual_keys - set(EXPECTED_TEMPLATE_HASHES)}, "
+            f"removed: {set(EXPECTED_TEMPLATE_HASHES) - actual_keys}). "
+            "Add or remove the corresponding pinned hash."
+        )
 
-        # Expected hash - update if templates intentionally change
-        # This helps detect unintended changes to templates
-        assert isinstance(content_hash, str)
-        assert len(content_hash) == 32  # MD5 hash length
+        for (name, version), expected_hash in EXPECTED_TEMPLATE_HASHES.items():
+            template_text = PROMPT_TEMPLATES[name][version]
+            actual_hash = hashlib.md5(template_text.encode()).hexdigest()
+            assert actual_hash == expected_hash, (
+                f"{name} {version} content changed unexpectedly (got {actual_hash}, "
+                f"expected {expected_hash}). If this is intentional, review the diff "
+                "and update EXPECTED_TEMPLATE_HASHES."
+            )
 
-    def test_skills_feedback_requests_json_format(self):
+    def test_skills_feedback_requests_json_format(self) -> None:
         """Test skills_feedback requests JSON output."""
         template = PROMPT_TEMPLATES["skills_feedback"]["v1"]
 
         assert "json" in template.lower()
 
-    def test_projects_feedback_requests_json_format(self):
+    def test_projects_feedback_requests_json_format(self) -> None:
         """Test projects_feedback requests JSON output."""
         template = PROMPT_TEMPLATES["projects_feedback"]["v1"]
 
         assert "json" in template.lower()
 
-    def test_presentation_feedback_requests_json_format(self):
+    def test_presentation_feedback_requests_json_format(self) -> None:
         """Test presentation_feedback requests JSON output."""
         template = PROMPT_TEMPLATES["presentation_feedback"]["v1"]
 
         assert "json" in template.lower()
 
-    def test_gaps_feedback_requests_json_format(self):
+    def test_gaps_feedback_requests_json_format(self) -> None:
         """Test gaps_feedback requests JSON output."""
         template = PROMPT_TEMPLATES["gaps_feedback"]["v1"]
 
         assert "json" in template.lower()
 
-    def test_first_impression_plain_text(self):
+    def test_first_impression_plain_text(self) -> None:
         """Test first_impression may request plain text."""
         template = PROMPT_TEMPLATES["first_impression"]["v1"]
 
         # Should specify format (JSON or plain text)
-        assert "json" in template.lower() or "text" in template.lower() or "summary" in template.lower()
+        assert (
+            "json" in template.lower()
+            or "text" in template.lower()
+            or "summary" in template.lower()
+        )
 
-    def test_templates_have_portfolio_context(self):
+    def test_templates_have_portfolio_context(self) -> None:
         """Test templates mention portfolio or context."""
-        for name in PROMPT_TEMPLATES.keys():
+        for name in PROMPT_TEMPLATES:
             template = PROMPT_TEMPLATES[name]["v1"]
             # All should have context mention or portfolio mention
             assert "{context}" in template or "portfolio" in template.lower()
 
-    def test_template_get_logs_retrieval(self):
+    def test_template_get_logs_retrieval(self) -> None:
         """Test that get_template logs retrieval."""
         # Import logger to verify it's used
-        with pytest.MonkeyPatch.context() as mp:
+        with pytest.MonkeyPatch.context():
             from unittest.mock import patch
-            with patch('rag.generator.prompt_templates.logger') as mock_logger:
+
+            with patch("rag.generator.prompt_templates.logger"):
                 get_template("skills_feedback")
                 # Should log template retrieval
 
-    def test_each_template_name_is_valid_identifier(self):
+    def test_each_template_name_is_valid_identifier(self) -> None:
         """Test template names are valid Python identifiers."""
-        for name in PROMPT_TEMPLATES.keys():
+        for name in PROMPT_TEMPLATES:
             assert name.isidentifier()
             assert "_" in name  # Should use snake_case
 
-    def test_template_versions_are_strings(self):
+    def test_template_versions_are_strings(self) -> None:
         """Test template version keys are strings."""
-        for template_name, versions in PROMPT_TEMPLATES.items():
+        for _template_name, versions in PROMPT_TEMPLATES.items():
             assert isinstance(versions, dict)
-            for version_key in versions.keys():
+            for version_key in versions:
                 assert isinstance(version_key, str)
                 assert version_key.startswith("v")
 
-    def test_no_hardcoded_usernames_in_templates(self):
+    def test_no_hardcoded_usernames_in_templates(self) -> None:
         """Test templates don't contain hardcoded test usernames."""
         forbidden = ["john", "jane", "test", "demo"]
 
-        for name, versions in PROMPT_TEMPLATES.items():
-            for version, template_text in versions.items():
+        for _name, versions in PROMPT_TEMPLATES.items():
+            for _version, template_text in versions.items():
                 for forbidden_word in forbidden:
                     # Should use {github_username} placeholder instead
                     assert not (
@@ -261,13 +312,14 @@ class TestPromptTemplates:
                         and "{github_username}" not in template_text
                     )
 
-    def test_templates_use_consistent_placeholders(self):
+    def test_templates_use_consistent_placeholders(self) -> None:
         """Test all templates use consistent placeholder syntax."""
-        for name, versions in PROMPT_TEMPLATES.items():
-            for version, template_text in versions.items():
+        for _name, versions in PROMPT_TEMPLATES.items():
+            for _version, template_text in versions.items():
                 # All placeholders should use {name} syntax
                 import re
-                placeholders = re.findall(r'\{(\w+)\}', template_text)
+
+                placeholders = re.findall(r"\{(\w+)\}", template_text)
                 assert "context" in placeholders
                 assert "github_username" in placeholders
                 assert "project_count" in placeholders


### PR DESCRIPTION
## Summary
`test_template_snapshot_content_hash` computed an MD5 hash of all prompt template content but only asserted `isinstance(hash, str)` and `len(hash) == 32` — true for any content, so it never caught an accidental edit to a prompt template. This PR pins each template's hash so drift is actually caught.

## Issue
Closes #37

## Changes
- Replace the toothless assertions in `test_template_snapshot_content_hash` with a per-`(template, version)` pinned hash comparison (`EXPECTED_TEMPLATE_HASHES`), so a failure names exactly which template/version drifted.
- Add a companion assertion that the set of `(template, version)` keys in `PROMPT_TEMPLATES` matches `EXPECTED_TEMPLATE_HASHES`, catching a template or version being added/removed without updating the pinned hashes.
- Document the intentional-update workflow in a comment above `EXPECTED_TEMPLATE_HASHES` (how to regenerate a hash after a reviewed template change).
- Fix pre-existing `ruff` (`SIM118`/`B007`/`F841`) and `mypy` (missing `-> None`) findings in this file — required to get the local pre-commit hook to pass; unrelated to the fix itself but blocking any commit to this file.

## Testing
- [x] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`) — not applicable, no integration surface for this fix
- [x] Linter passes (`make lint`) for the touched file (`tests/unit/test_prompt_templates.py`, `rag/generator/prompt_templates.py` — unchanged)
- [x] Type checker passes (`make typecheck`) for the touched file
- [x] New/updated tests cover the changes

**Details:**
- `pytest tests/unit/test_prompt_templates.py -v -m unit`: 37/37 pass.
- Reproduced the original bug against the *fixed* test: appended text to `skills_feedback` v1 without a version bump → test failed with `skills_feedback v1 content changed unexpectedly...`. Reverted → test passes again. Confirms this is a real regression test, not a placeholder.
- `make test-unit` (full repo): 53 failed / 375 passed, both before and after this change — identical failing-test set (diffed by test ID). All 53 are pre-existing and unrelated to `prompt_templates.py` (e.g. `test_bias_detector.py`, `test_pii_scrubber.py`, `test_review_service.py`).
- `make check` (full repo lint/format/typecheck): fails on 176 pre-existing `ruff` findings, all in files this PR doesn't touch. Note: `ruff check .` / `black --check .` run repo-wide in CI, so CI's lint job will likely still be red — that's pre-existing repo debt, not introduced here.
- This PR introduces **no new lint, formatting, typing, or test failures**.

## Screenshots / Demo
N/A — test-only change, no UI surface.

## Notes for Reviewers
- The pinning-mechanism choice (per-template-version hashes vs. a single combined hash vs. adopting `syrupy`) is discussed in `PLAN.md`'s Risks & Unknowns section. Went with per-template-version hashes for clearer failure messages.
- `get_template()`'s public signature is unchanged — this is a test-only fix.
- Commit: `0340dc5241e4a2323e3c610b66bd9ea63476ea51`
