### PR TITLE
Fix/153 faithfulness checker none text

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -81,7 +81,7 @@ reformatting unrelated code.
 
 ### Submission check-in
 
-**PR link:** [REPLACE_WITH_PR_URL]
+**PR link:** https://github.com/ascherj/pathreview/pull/854
 
 **What I built:** A scoped fix for issue #153 plus two edge-case tests and inline
 documentation explaining why `None` text is coerced to `""`.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -104,3 +104,72 @@ one — `test_none_context_chunk_text` — see the scoping note in the mid-week 
 **Blockers or open questions:**
 None. Pre-existing scoring failures and repo-wide formatting are documented above
 as out of scope for this issue.
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No reviewer or maintainer comments came in. PR #854 remained open with no review
+comments, review threads, or requested changes through the end of the week. (Per
+the Summer 2026 cohort guidance, peer/maintainer review was not a required part of
+the process this term.)
+
+**How you responded:**
+No feedback to respond to. I did a final self-review of the diff before the deadline
+to confirm it was still minimal and correctly scoped.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The hardest part wasn't the fix — it was everything around it. The one-line change
+(`chunk.get("text", "")` → `chunk.get("text") or ""`) was clear from the issue. What
+surprised me was the ambiguity of "does the build pass?" in a real repo: `make check`
+was already red repo-wide because the existing code isn't `black`/`ruff` formatted,
+and three scoring tests in the same module fail on `main` for reasons unrelated to my
+bug. Figuring out which failures were mine versus pre-existing, and being able to
+prove it, took more care than writing the fix. The upstream repo had also been renamed
+(`jamjamgobambam` → `ascherj`), so even pointing my remotes and PR at the right target
+was a small investigation.
+
+**What did you learn about working in a large codebase?**
+Contributing to someone else's production code is mostly about restraint. On my own
+project I'd have "cleaned up" the formatting and maybe touched the scoring logic while
+I was in there. Here, the right move was the opposite: keep the diff to exactly what
+issue #153 needed, match the file's existing style instead of reformatting, and
+document the pre-existing failures rather than silently absorbing them into my PR.
+I also learned to read the *tests* to understand expected behavior — the existing
+`test_none_context_chunk_text` told me precisely what a correct fix looked like before
+I wrote a line. Scope discipline and being able to defend "this is out of scope" turned
+out to be the real skills.
+
+**How did AI tools help — and where did they fall short?**
+AI was most useful for navigation and verification: exploring an unfamiliar codebase,
+discovering the repo had moved, confirming via the GitHub API that no PR existed yet,
+distinguishing my test results from pre-existing failures, and drafting the PR
+description and journal entries against the templates. Where it fell short was
+judgment: deciding *which* fix idiom to use, deciding what to leave out of scope, and
+confirming the honest framing of "passes = no new failures." It also can't do the
+parts that are actually mine to own — opening the PR, marking it ready, and submitting
+the branch URL to the portal. AI accelerated the mechanical work; the decisions still
+had to be mine.
+
+**What would you do differently if you started over?**
+I'd open the draft PR earlier in the week instead of near the deadline, so the "PR is
+live" step wasn't the last thing standing between me and being done. I'd also verify
+the canonical upstream repo up front rather than discovering the rename mid-process,
+and I'd keep my working tree clean from the start — a couple of stray files (`=0.29.0`,
+a `package-lock.json` change) crept in and had to be stashed out before the PR so they
+wouldn't leak in.
+
+**What are you most proud of from this module?**
+Not the fix itself, but the honesty of the submission. Instead of checking every box
+and pretending a red repo was green, I documented exactly which failures pre-existed,
+proved my change removed one failure and added none, and kept the diff small enough
+that a reviewer could verify it in under a minute. Learning to make a clean, defensible,
+tightly-scoped contribution to a codebase I didn't write is the thing I'll actually
+carry forward.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -50,3 +50,49 @@ crashes the faithfulness evaluation exactly as issue #153 describes.
 None blocking. Open question for Week 9: whether to coerce `None` with
 `chunk.get("text") or ""` (simplest) vs. an explicit `is not None` check, and
 whether to add a mixed None/valid multi-chunk test to strengthen coverage.
+
+## Week 9 — Implementation & PR submission
+
+### Mid-week check-in
+
+**Progress:**
+Implemented the fix in `rag/evaluator/faithfulness_checker.py`: the context
+concatenation now uses `chunk.get("text") or ""`, so a chunk whose `text` is
+`None` (or missing) is coerced to an empty string before `" ".join(...)`. Added
+two edge-case tests following the existing patterns in
+`tests/unit/test_faithfulness_checker.py`: `test_none_text_mixed_with_valid_chunks`
+(a `None` chunk must not discard valid sibling chunks) and
+`test_all_chunks_none_text` (all-`None` context returns a valid float, no crash).
+
+**Verification:** `test_none_context_chunk_text` now passes, as do the two new
+tests. The faithfulness module went from 18 passed / 4 failed to 21 passed /
+3 failed.
+
+**Scoping note (honest self-assessment):** The 3 still-failing tests
+(`test_partial_support_returns_middle_score`, `test_multiple_context_chunks`,
+`test_multiple_claims_varying_support`) are **pre-existing and unrelated** to
+issue #153 — they fail because of the scoring threshold in `_is_supported`
+(requires 2+ meaningful token overlaps), not the `None` crash. They fail on the
+base branch before my change, so I am intentionally leaving them out of scope.
+Likewise, CI runs `black --check .` and `ruff check .` repo-wide, and the
+existing codebase is not black-formatted, so those jobs are already red on
+`main`. I kept my diff minimal and matched the file's existing style rather than
+reformatting unrelated code.
+
+### Submission check-in
+
+**PR link:** [REPLACE_WITH_PR_URL]
+
+**What I built:** A scoped fix for issue #153 plus two edge-case tests and inline
+documentation explaining why `None` text is coerced to `""`.
+
+**Files changed:**
+- `rag/evaluator/faithfulness_checker.py` — coerce `None`/missing text to `""`
+- `tests/unit/test_faithfulness_checker.py` — two new edge-case tests
+
+**How to test:**
+`python -m pytest tests/unit/test_faithfulness_checker.py -k "none" -v`
+
+**Blockers or open questions:**
+None. Pre-existing scoring failures and repo-wide formatting are documented above
+as out of scope for this issue.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -32,7 +32,7 @@ low. Good first contribution to a large codebase.
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** https://github.com/JoshuaE92/pathreview/commit/de20ceda92dadedcfc158a06bfb31164387594b6
+**Reproduction commit link:** https://github.com/JoshuaE92/pathreview/commit/a4365836decf9ccece65d182affc7902ec6dc1cb
 
 **Reproduction summary:**
 I ran the existing failing test with

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -93,6 +93,14 @@ documentation explaining why `None` text is coerced to `""`.
 **How to test:**
 `python -m pytest tests/unit/test_faithfulness_checker.py -k "none" -v`
 
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+(In this codebase "passes" means my changes introduce no new failures. `make check`
+is already red repo-wide on pre-existing `ruff`/`black` formatting, and 3 pre-existing
+scoring tests in this module fail on `main`; my change adds no new failures and removes
+one — `test_none_context_chunk_text` — see the scoping note in the mid-week check-in.)
+
+**Draft PR feedback received from:** none (cohort was told peer review is not required)
+
 **Blockers or open questions:**
 None. Pre-existing scoring failures and repo-wide formatting are documented above
 as out of scope for this issue.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -29,3 +29,24 @@ failing test are all named in the issue, so scope is clear and small — a
 one-line-ish fix in a single file plus verifying one existing test. It needs no
 Chroma or external services to reproduce or fix, which keeps the setup burden
 low. Good first contribution to a large codebase.
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/JoshuaE92/pathreview/commit/de20ceda92dadedcfc158a06bfb31164387594b6
+
+**Reproduction summary:**
+I ran the existing failing test with
+`python -m pytest tests/unit/test_faithfulness_checker.py::TestFaithfulnessChecker::test_none_context_chunk_text -v`.
+It fails at `rag/evaluator/faithfulness_checker.py:34` with
+`TypeError: sequence item 0: expected str instance, NoneType found`, confirming
+that a context chunk with `text: None` reaches `" ".join(...)` as `None` and
+crashes the faithfulness evaluation exactly as issue #153 describes.
+
+**PLAN.md link:** https://github.com/JoshuaE92/pathreview/blob/fix/153-faithfulness-checker-none-text/PLAN.md
+
+**Walkthrough video (recommended):** [optional — add Loom link if recorded]
+
+**Blockers or open questions:**
+None blocking. Open question for Week 9: whether to coerce `None` with
+`chunk.get("text") or ""` (simplest) vs. an explicit `is not None` check, and
+whether to add a mixed None/valid multi-chunk test to strengthen coverage.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,31 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/jamjamgobambam/pathreview/issues/153
+
+**Issue title:** Faithfulness checker crashes when a context chunk has text: None
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The FaithfulnessChecker's `check()` method builds its context by reading each
+chunk's text with `chunk.get("text", "")`. That empty-string default only
+applies when the `"text"` key is missing — if the key exists but holds `None`,
+`.get()` returns `None`, which then gets passed into `" ".join(...)`. Since
+`join` only accepts strings, it raises a `TypeError` instead of handling the
+chunk. So any retrieved context chunk with a null text value crashes the
+faithfulness evaluation in `rag/evaluator/faithfulness_checker.py`. A successful
+fix treats a `None` text the same as empty/missing (coerce to `""` or skip it)
+so the join succeeds and the existing `test_none_context_chunk_text` passes.
+
+**Branch name:** fix/153-faithfulness-checker-none-text
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger
+
+**Selection notes ("Is this right for me?"):**
+Tier 1, tightly scoped. The bug, its cause, a reproduction, and the exact
+failing test are all named in the issue, so scope is clear and small — a
+one-line-ish fix in a single file plus verifying one existing test. It needs no
+Chroma or external services to reproduce or fix, which keeps the setup burden
+low. Good first contribution to a large codebase.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,72 @@
+## Solution plan
+
+**Issue:** Faithfulness checker crashes when a context chunk has `text: None` — https://github.com/jamjamgobambam/pathreview/issues/153
+
+### Understand
+**Root cause.** `FaithfulnessChecker.check()` concatenates the context by reading
+each chunk with `chunk.get("text", "")`. The `""` default only applies when the
+`"text"` **key is missing**. When the key is present but its value is `None`
+(a real case for retrieved chunks that were stored with a null body),
+`.get("text", "")` returns `None`. That `None` is then passed into
+`" ".join([...])`, and since `str.join` only accepts strings, Python raises
+`TypeError: sequence item 0: expected str instance, NoneType found`.
+
+**Expected vs. actual.**
+- Expected: a chunk with `text: None` is treated the same as an empty/missing
+  text — it contributes nothing to the context and the scoring continues.
+- Actual: the whole `check()` call crashes with a `TypeError`, so any retrieved
+  context containing a null-text chunk aborts the faithfulness evaluation.
+
+### Map
+Files/functions involved:
+- `rag/evaluator/faithfulness_checker.py` — `FaithfulnessChecker.check()`,
+  specifically the context concatenation at lines 34–36. **(the fix)**
+- `tests/unit/test_faithfulness_checker.py` — already contains
+  `test_none_context_chunk_text` (line 231, currently failing) and
+  `test_missing_text_key_in_chunk` (line 244, passing). **(verification)**
+
+Files I expect to touch:
+- `rag/evaluator/faithfulness_checker.py` (the one-line-ish fix)
+- Possibly `tests/unit/test_faithfulness_checker.py` (only if I add a
+  multi-chunk mixed None/valid case to strengthen coverage)
+
+### Plan
+1. **Confirm the failing test** reproduces the `TypeError`
+   (`pytest tests/unit/test_faithfulness_checker.py::TestFaithfulnessChecker::test_none_context_chunk_text`).
+2. **Fix the coercion** in `check()`: change the list comprehension so a `None`
+   text is coerced to `""` (e.g. `chunk.get("text") or ""`), treating null the
+   same as empty/missing.
+3. **Run the targeted test** and confirm it now passes and returns a float
+   in `[0.0, 1.0]`.
+4. **Run the full faithfulness test module** to confirm no regressions
+   (all existing passing tests stay green).
+5. **Optionally add** a test with mixed chunks (one `None`, one valid) to lock
+   in the behavior that a null chunk doesn't wipe out valid context.
+
+### Inputs & outputs
+- **Input:** `feedback: str` and `context_chunks: list[dict]`, where a chunk may
+  have `text` missing, `text: None`, or `text: <string>`.
+- **Output:** a faithfulness score `float` in `[0.0, 1.0]`. After the fix, a
+  chunk with `text: None` contributes no text (like `""`) instead of raising,
+  so `check()` always returns a valid score for well-formed chunk lists.
+
+### Risks & unknowns
+- **Silent data loss vs. crash:** coercing `None → ""` hides that a chunk had no
+  body. That's the behavior the issue asks for, but I should confirm no upstream
+  code relies on the crash to surface bad ingestion data. (Low risk — the issue
+  explicitly wants graceful handling.)
+- **`or ""` vs. `if ... is not None`:** using `chunk.get("text") or ""` also
+  coerces other falsy values (e.g. empty string stays `""`, which is fine). No
+  numeric/text falsy edge cases are expected here since `text` should be a
+  string, but I'll note this in the fix.
+- **Non-dict chunks:** the signature is `list[dict]`, so I'll assume dicts; I am
+  not planning to defend against non-dict chunk entries unless a test requires
+  it.
+
+### Edge cases the fix should handle gracefully
+- Chunk with `text: None` → treated as empty, no crash.
+- Chunk with `text` key missing → already handled (`""` default), stays working.
+- Multiple chunks where some are `None` and some valid → valid text still counts.
+- All chunks have `None`/empty text → context is empty; scoring proceeds and
+  returns a valid float (unsupported claims → low score).
+- Empty `context_chunks` list → already returns `0.0` early (unchanged).

--- a/rag/evaluator/faithfulness_checker.py
+++ b/rag/evaluator/faithfulness_checker.py
@@ -30,9 +30,11 @@ class FaithfulnessChecker:
             logger.info("faithfulness_no_claims_extracted")
             return 0.5  # Default to neutral if no extractable claims
 
-        # Concatenate context text
+        # Concatenate context text. A chunk may be missing "text" or have it
+        # set to None (e.g. a retrieved chunk stored with a null body); coerce
+        # both to "" so the join never receives a non-string and never crashes.
         context_text = " ".join([
-            chunk.get("text", "") for chunk in context_chunks
+            chunk.get("text") or "" for chunk in context_chunks
         ])
 
         # Check each claim for support

--- a/tests/unit/test_faithfulness_checker.py
+++ b/tests/unit/test_faithfulness_checker.py
@@ -241,6 +241,35 @@ class TestFaithfulnessChecker:
         assert isinstance(score, float)
         assert 0.0 <= score <= 1.0
 
+    def test_none_text_mixed_with_valid_chunks(self, checker):
+        """Test that a None-text chunk doesn't discard valid sibling chunks."""
+        feedback = "The developer has Python and Docker skills."
+        context_chunks = [
+            {"text": None},
+            {"text": "Python and Docker expertise demonstrated in projects."},
+        ]
+
+        score = checker.check(feedback, context_chunks)
+
+        # The None chunk is ignored; the valid chunk still supports the claim.
+        assert isinstance(score, float)
+        assert 0.0 <= score <= 1.0
+        assert score > 0.0
+
+    def test_all_chunks_none_text(self, checker):
+        """Test that context of all-None chunks scores without crashing."""
+        feedback = "The developer has Python skills."
+        context_chunks = [
+            {"text": None},
+            {"text": None},
+        ]
+
+        score = checker.check(feedback, context_chunks)
+
+        # No usable context -> unsupported claims -> low score, but no crash.
+        assert isinstance(score, float)
+        assert 0.0 <= score <= 1.0
+
     def test_missing_text_key_in_chunk(self, checker):
         """Test handling of missing 'text' key in context chunk."""
         feedback = "Has Python skills"


### PR DESCRIPTION
## Summary
The `FaithfulnessChecker.check()` method built its context string with
`chunk.get("text", "")`. The `""` default only applies when the `"text"` key is
missing — if the key exists but holds `None`, `.get()` returns `None`, which is
then passed into `" ".join(...)` and raises `TypeError: sequence item 0:
expected str instance, NoneType found`. This crashes faithfulness evaluation for
any retrieved chunk stored with a null body. This PR coerces both missing and
`None` text to `""` so the join always receives strings.

## Issue
Closes #153

## Changes
- `rag/evaluator/faithfulness_checker.py`: changed `chunk.get("text", "")` to
  `chunk.get("text") or ""` so a `None` (or missing) `text` value is treated as
  empty instead of crashing the join. Added an inline comment explaining why.
- `tests/unit/test_faithfulness_checker.py`: added two edge-case tests matching
  the existing patterns:
  - `test_none_text_mixed_with_valid_chunks` — a `None` chunk must not discard
    valid sibling chunks.
  - `test_all_chunks_none_text` — an all-`None` context returns a valid float
    with no crash.

## Testing
- [x] Unit tests pass (`make test-unit`) — see note below re: pre-existing failures
- [ ] Integration tests pass (`make test-integration`) — not run (unrelated to this change)
- [ ] Linter passes (`make lint`) — pre-existing repo-wide failures, see note
- [ ] Type checker passes (`make typecheck`) — pre-existing, see note
- [x] New/updated tests cover the changes

Verified locally with `.venv/bin/python -m pytest tests/unit/test_faithfulness_checker.py`:
the issue's `test_none_context_chunk_text` now passes, as do both new tests. The
module went from 18 passed / 4 failed to **21 passed / 3 failed**.

## Notes for Reviewers
**Pre-existing failures (out of scope, not introduced by this PR):**
- The 3 remaining failures in this module — `test_partial_support_returns_middle_score`,
  `test_multiple_context_chunks`, `test_multiple_claims_varying_support` — fail on
  `main` before this change. They stem from the scoring threshold in `_is_supported`
  (requires 2+ meaningful token overlaps), **not** the `None` crash this PR fixes.
- `make lint` / `make format` run `ruff` / `black --check` repo-wide, and the
  existing codebase is not fully formatted, so those jobs are already red on `main`.
  I kept the diff minimal and matched the file's existing style rather than
  reformatting unrelated code.

My change introduces no new failures; it removes one (`test_none_context_chunk_text`).
The fix is a one-line change plus two tests, tightly scoped to issue #153.
