### PR TITLE
test: restore basic sample profile fixture (#106)

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -33,3 +33,32 @@ Several test and evaluation flows expect a sample profile at `tests/fixtures/sam
 **Walkthrough video (recommended):** Not recorded (recommended, not graded).
 
 **Blockers or open questions:** `scripts/run_evals.py` currently contains only a TODO for loading benchmark profiles, so the exact JSON contract is not yet enforced in code. I will use the issue requirements and the existing profile model as the starting point, then make the fixture structure explicit in a focused validation test.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:** I completed the first three implementation tasks from `PLAN.md`: defined the fixture contract, created `tests/fixtures/sample_profiles/basic_profile.json` with a fictional resume and two repositories, and added `tests/unit/test_basic_profile_fixture.py`. The focused test loads the JSON from a path anchored to the test file and verifies the required fields, nonblank content, repository count, and unique repository names.
+
+**Next steps:** Run the JSON parser, focused test, `make test-unit`, and `make check`; compare the full-suite results with the pre-change baseline; then push the implementation and open a ready-for-review pull request with manual verification steps.
+
+**Blockers:** The benchmark loader in `scripts/run_evals.py` is still a TODO, so it does not define an authoritative JSON schema. I addressed that uncertainty by documenting a minimal contract in the focused test and calling out the field-shape decision for reviewers instead of expanding the issue into evaluation-runner work.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/858
+
+**Branch:** `test/106-restore-sample-profile-fixture`
+
+**What you built:** I restored the missing shared sample portfolio with a fictional GitHub username, a populated resume, and exactly two realistic repositories. I also added a focused unit test that loads the fixture independently of the working directory and rejects missing, malformed, incomplete, blank, or duplicate repository data.
+
+**Tests added or updated:** Added `tests/unit/test_basic_profile_fixture.py`. Its `test_basic_profile_fixture_has_expected_shape` test covers JSON loading, the required `github_username` and resume fields, exactly two repositories, nonblank repository metadata and README content, and unique repository names.
+
+**Self-review confirmation:**
+
+- [x] `make check` passes under the course's pre-existing-failure rule: the repository reports the same 182 existing Ruff findings before and after the change, while the new test file passes Ruff, Black, and the commit's mypy hook.
+- [x] `make test-unit` passes under the course's pre-existing-failure rule: the same 53 existing tests fail before and after the change, and the passing count increases from 375 to 376 because the new test passes.
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -62,3 +62,27 @@ Several test and evaluation flows expect a sample profile at `tests/fixtures/sam
 - [x] `make test-unit` passes under the course's pre-existing-failure rule: the same 53 existing tests fail before and after the change, and the passing count increases from 375 to 376 because the new test passes.
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:** No reviewer or maintainer feedback has arrived on PR #858. This matches the Summer 2026 course note that reviewer feedback is not being provided, so there were no requested changes to document.
+
+**How you responded:** No review response or follow-up code changes were needed. I left the pull request open and ready for review with the fixture schema decision and manual verification steps clearly documented for any future reviewer.
+
+---
+
+### Reflection
+
+**What was harder than you expected?** Defining the JSON shape was harder than simply creating the missing file because `scripts/run_evals.py` only contains a TODO and does not specify a contract. I compared the issue requirements with `core/models/profile.py`, `api/schemas/profile.py`, and the existing fixtures in `tests/conftest.py`, then chose a small nested structure and documented that decision in `test_basic_profile_fixture_has_expected_shape`.
+
+**What did you learn about working in a large codebase?** I learned that the source of truth can be spread across an issue, models, schemas, tests, and unfinished scripts instead of living in one place. Tracing those references before editing helped me keep issue #106 limited to `tests/fixtures/sample_profiles/basic_profile.json` and its validation test instead of expanding the work into implementing the entire evaluation runner.
+
+**How did AI tools help — and where did they fall short?** AI tools helped me locate relevant files, compare the profile fields, organize the risks in `PLAN.md`, and turn the fixture requirements into concrete validation checks. They could not determine an authoritative schema that the repository itself does not define, and they could not replace running the project commands, so I still had to reproduce the `FileNotFoundError`, inspect the actual code, and compare the 53 unit-test failures and 182 lint findings before and after my change.
+
+**What would you do differently if you started over?** I would run the full `make test-unit` and `make check` baseline at the start of Week 7 instead of waiting until implementation, because that would make the repository's pre-existing failures less surprising. I would also open the pull request earlier in Week 9 so the schema choice for the `resume` and `repositories` fields had more time to receive feedback.
+
+**What are you most proud of from this module?** I am most proud that I turned a vague missing-fixture issue into a deterministic sample portfolio and a focused test that checks meaningful edge cases without depending on exact sample wording. I also documented the unchanged test and lint baselines clearly in JOURNAL.md and PR #858, which makes the contribution easier for another developer to evaluate.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,23 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/106
+
+**Issue title:** Shared test fixture for a sample user profile is missing from `tests/fixtures/`
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+Several test and evaluation flows expect a sample profile at `tests/fixtures/sample_profiles/basic_profile.json`, but that fixture is missing from the repository. Without it, tests that need a realistic portfolio cannot run against consistent input and may be skipped or fail before exercising the application behavior. The change is limited to restoring well-formed test data containing a GitHub username, resume information, and two repositories. A successful fix will give the test suite a stable, reusable profile that matches the project's expected data shape.
+
+**Branch name:** `test/106-restore-sample-profile-fixture`
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger
+
+### Selection notes — “Is this issue right for me?” checklist
+
+- **Understanding:** I can explain the missing behavior and define “done” as adding a valid, realistic JSON fixture that can be reused by the affected test and evaluation flows.
+- **Tier fit:** I chose a Tier 1 issue because this is my first contribution to this large codebase. The work is localized to one new fixture file, does not require an architectural change, and the issue estimates only 1–2 hours of implementation work.
+- **Codebase readiness:** I confirmed that the target fixture is absent, found the reference to sample profiles in `scripts/run_evals.py`, reviewed the profile fields in `api/schemas/profile.py`, and read the existing fixture and test patterns in `tests/conftest.py` and `tests/unit/test_review_service.py`.
+- **Scope and time:** I checked the issue comments and the cohort ledger's claim count. Claims are non-exclusive, the issue has no listed blockers or unresolved dependencies, and the small file scope is realistic to complete and test before the Week 9 deadline.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -21,3 +21,15 @@ Several test and evaluation flows expect a sample profile at `tests/fixtures/sam
 - **Tier fit:** I chose a Tier 1 issue because this is my first contribution to this large codebase. The work is localized to one new fixture file, does not require an architectural change, and the issue estimates only 1–2 hours of implementation work.
 - **Codebase readiness:** I confirmed that the target fixture is absent, found the reference to sample profiles in `scripts/run_evals.py`, reviewed the profile fields in `api/schemas/profile.py`, and read the existing fixture and test patterns in `tests/conftest.py` and `tests/unit/test_review_service.py`.
 - **Scope and time:** I checked the issue comments and the cohort ledger's claim count. Claims are non-exclusive, the issue has no listed blockers or unresolved dependencies, and the small file scope is realistic to complete and test before the Week 9 deadline.
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** This reproduction note is introduced by the current commit; its permanent GitHub link will be added in the planning commit.
+
+**Reproduction summary:** I reproduced the missing-fixture gap from the repository root by checking `tests/fixtures/sample_profiles/basic_profile.json` and attempting to read it with `pathlib.Path.read_text()`. The path reported `exists=False`, and the read failed with `FileNotFoundError`, confirming that the benchmark profile referenced by `scripts/run_evals.py` is not available locally.
+
+**PLAN.md link:** Will be added after `PLAN.md` is introduced in the next commit.
+
+**Walkthrough video (recommended):** Not recorded (recommended, not graded).
+
+**Blockers or open questions:** `scripts/run_evals.py` currently contains only a TODO for loading benchmark profiles, so the exact JSON contract is not yet enforced in code. I will use the issue requirements and the existing profile model as the starting point, then make the fixture structure explicit in a focused validation test.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -24,11 +24,11 @@ Several test and evaluation flows expect a sample profile at `tests/fixtures/sam
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** This reproduction note is introduced by the current commit; its permanent GitHub link will be added in the planning commit.
+**Reproduction commit link:** https://github.com/Rithinteja/pathreview/commit/80325449f07e0955296ea4773fb816ec3cfc5cd3
 
 **Reproduction summary:** I reproduced the missing-fixture gap from the repository root by checking `tests/fixtures/sample_profiles/basic_profile.json` and attempting to read it with `pathlib.Path.read_text()`. The path reported `exists=False`, and the read failed with `FileNotFoundError`, confirming that the benchmark profile referenced by `scripts/run_evals.py` is not available locally.
 
-**PLAN.md link:** Will be added after `PLAN.md` is introduced in the next commit.
+**PLAN.md link:** https://github.com/Rithinteja/pathreview/blob/test/106-restore-sample-profile-fixture/PLAN.md
 
 **Walkthrough video (recommended):** Not recorded (recommended, not graded).
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,61 @@
+## Solution plan
+
+**Issue:** [#106 — Shared test fixture for a sample user profile is missing from `tests/fixtures/`](https://github.com/ascherj/pathreview/issues/106)
+
+### Understand
+
+The repository is missing `tests/fixtures/sample_profiles/basic_profile.json`, even though issue #106 and the benchmark runner's TODO in `scripts/run_evals.py` identify that directory as the source of reusable sample portfolios. I reproduced the gap locally: the expected path does not exist, and reading it raises `FileNotFoundError`. This prevents any test or evaluation flow that expects the shared profile from loading consistent portfolio data.
+
+The fix should restore a valid, deterministic JSON document at the exact requested path. It should represent one fictional GitHub user, a realistic resume, and exactly two distinct repositories so consumers can exercise a complete portfolio without network calls or ad hoc mocks. The current repository does not enforce a benchmark JSON schema yet, so the validation test added with the fixture will make the chosen contract explicit.
+
+### Map
+
+Files and code paths involved:
+
+- `tests/fixtures/sample_profiles/basic_profile.json` — create the missing shared portfolio fixture with the GitHub username, resume data, and two repositories required by the issue.
+- `tests/unit/test_basic_profile_fixture.py` — create a focused test that loads the JSON, verifies its required structure, and produces clear failures if the fixture is missing or malformed.
+- `scripts/run_evals.py` — existing future consumer; its `main()` TODO names `tests/fixtures/sample_profiles/` as the benchmark input directory. I will use this path as the source of truth without expanding the issue into implementing the evaluation runner.
+- `core/models/profile.py` — reference for the existing profile concepts and field names, especially `github_username`, `resume_filename`, and `resume_text`.
+- `api/schemas/profile.py` — reference for the public profile representation and username constraints.
+- `tests/conftest.py` — reference for the tone and content of the existing fictional resume and README fixtures; it will remain unchanged unless implementation work reveals a direct reuse opportunity.
+
+### Plan
+
+1. Define the smallest explicit JSON contract that satisfies issue #106 and matches the concepts already present in `core/models/profile.py`: a non-empty `github_username`, a `resume` object with `filename` and `text`, and a `repositories` array containing exactly two objects.
+2. Create `tests/fixtures/sample_profiles/basic_profile.json` with fictional, deterministic data. Give both repositories unique names and URLs plus non-empty descriptions, primary languages, and README text so downstream tests have meaningful content to analyze.
+3. Add `tests/unit/test_basic_profile_fixture.py`. Resolve the fixture path from `Path(__file__)` rather than the process working directory, load it with `json.loads()`, and assert the required keys, value types, non-blank strings, exactly two repositories, and unique repository names.
+4. Validate the artifact directly with `python -m json.tool tests/fixtures/sample_profiles/basic_profile.json`, then run the focused test with `pytest tests/unit/test_basic_profile_fixture.py`.
+5. Run `make test-unit` and `make check` to catch regressions, formatting problems, or type errors. If a later implementation of `scripts/run_evals.py` establishes a different schema, update the fixture and focused test together rather than adding a second incompatible profile format.
+
+### Inputs & outputs
+
+The fix is a data artifact rather than a production function change.
+
+- **Input path:** `tests/fixtures/sample_profiles/basic_profile.json`
+- **Input format:** UTF-8 JSON object
+- **Required top-level data:**
+  - `github_username: str`
+  - `resume: {"filename": str, "text": str}`
+  - `repositories: list[dict]`
+- **Required repository data:** each of the two entries will contain non-empty `name`, `url`, `description`, `primary_language`, and `readme` strings.
+- **Output on success:** `json.loads()` returns a reusable dictionary describing one complete sample portfolio. Tests and future evaluation code can consume it without GitHub access, file uploads, database records, or generated values.
+- **Validation behavior:** `test_basic_profile_fixture_has_expected_shape() -> None` passes only when the file exists, parses successfully, contains the required fields, and has exactly two distinct repositories. Missing or invalid data produces a focused assertion or JSON decoding failure that points back to the fixture.
+
+No API response, database schema, or runtime user behavior should change as part of this issue.
+
+### Risks & unknowns
+
+1. **The exact benchmark JSON schema is not implemented.** `scripts/run_evals.py` only contains a TODO, so it does not yet define whether resume and repository data should be nested or flat. I will use a minimal documented structure based on issue #106 and `core/models/profile.py`, and keep the schema assertion in `tests/unit/test_basic_profile_fixture.py` so future changes happen in one visible place.
+2. **The repository has two fixture conventions.** Existing text fixtures live in `tests/conftest.py`, while issue #106 explicitly requires a JSON file under `tests/fixtures/sample_profiles/`. I will follow the issue's exact path and leave the Python fixtures intact, avoiding an unrelated migration or duplicate pytest fixture.
+3. **A validation test could become too coupled to sample wording.** In `tests/unit/test_basic_profile_fixture.py`, I will validate structure, types, counts, and non-blank content rather than exact prose. This keeps the data editable while preserving the contract.
+4. **Relative paths can work locally but fail under a different test working directory.** The new test will derive the repository-relative fixture path from its own file location instead of assuming pytest was launched from the project root.
+5. **Realistic data could accidentally include real personal information.** `basic_profile.json` will use clearly fictional names, usernames, URLs, and resume details while still providing representative technical content.
+
+### Edge cases
+
+- The fixture file is absent, renamed, or placed in the wrong directory: the focused test should fail at the exact expected path.
+- The file contains malformed JSON, a trailing comma, or invalid escaping in multiline resume/README content: `json.loads()` and `python -m json.tool` should fail clearly.
+- `github_username`, resume text, or a repository field is empty or whitespace-only: the validation test should reject it.
+- `repositories` is missing, is not a list, contains fewer or more than two entries, or repeats the same repository name: the validation test should reject it.
+- A repository has valid metadata but no README content: the validation test should reject it because the evaluation pipeline needs analyzable project text.
+- Resume and README strings contain punctuation or line breaks: the JSON must preserve them as valid strings and load without data loss.

--- a/tests/fixtures/sample_profiles/basic_profile.json
+++ b/tests/fixtures/sample_profiles/basic_profile.json
@@ -1,0 +1,23 @@
+{
+  "github_username": "alexrivera-dev",
+  "resume": {
+    "filename": "alex_rivera_resume.md",
+    "text": "# Alex Rivera\n\nSoftware engineer focused on accessible web applications and reliable APIs.\n\n## Experience\n- Software Engineering Intern, Civic Tech Lab (2025)\n  - Built FastAPI endpoints and added pytest coverage for community-services data.\n  - Improved a React search flow for keyboard and screen-reader users.\n\n## Education\n- B.S. in Computer Science, Lakeside University (Expected 2027)\n\n## Skills\nPython, TypeScript, FastAPI, React, PostgreSQL, Docker, GitHub Actions"
+  },
+  "repositories": [
+    {
+      "name": "community-events-api",
+      "url": "https://github.com/alexrivera-dev/community-events-api",
+      "description": "A REST API for finding and managing local community events.",
+      "primary_language": "Python",
+      "readme": "# Community Events API\n\nA FastAPI service for searchable community events.\n\n## Features\n- Location and date filters\n- Organizer authentication\n- PostgreSQL persistence\n- Pytest unit tests"
+    },
+    {
+      "name": "accessible-study-planner",
+      "url": "https://github.com/alexrivera-dev/accessible-study-planner",
+      "description": "A keyboard-friendly study planner with progress tracking.",
+      "primary_language": "TypeScript",
+      "readme": "# Accessible Study Planner\n\nA React application for organizing assignments and study sessions.\n\n## Features\n- Keyboard-accessible task controls\n- Deadline and progress views\n- Local-first data storage\n- Vitest component tests"
+    }
+  ]
+}

--- a/tests/unit/test_basic_profile_fixture.py
+++ b/tests/unit/test_basic_profile_fixture.py
@@ -1,0 +1,46 @@
+"""Tests for the shared basic sample profile fixture."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+FIXTURE_PATH = (
+    Path(__file__).resolve().parents[1] / "fixtures" / "sample_profiles" / "basic_profile.json"
+)
+REQUIRED_REPOSITORY_FIELDS = {
+    "name",
+    "url",
+    "description",
+    "primary_language",
+    "readme",
+}
+
+
+@pytest.mark.unit
+def test_basic_profile_fixture_has_expected_shape() -> None:
+    """Verify the shared profile is complete, deterministic, and reusable."""
+    profile = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+
+    assert isinstance(profile, dict)
+    assert isinstance(profile.get("github_username"), str)
+    assert profile["github_username"].strip()
+
+    resume = profile.get("resume")
+    assert isinstance(resume, dict)
+    assert set(resume) == {"filename", "text"}
+    assert all(isinstance(resume[field], str) for field in ("filename", "text"))
+    assert all(resume[field].strip() for field in ("filename", "text"))
+
+    repositories = profile.get("repositories")
+    assert isinstance(repositories, list)
+    assert len(repositories) == 2
+
+    for repository in repositories:
+        assert isinstance(repository, dict)
+        assert set(repository) == REQUIRED_REPOSITORY_FIELDS
+        assert all(isinstance(value, str) for value in repository.values())
+        assert all(value.strip() for value in repository.values())
+
+    repository_names = [repository["name"] for repository in repositories]
+    assert len(repository_names) == len(set(repository_names))


### PR DESCRIPTION
## Summary

Restores the missing shared sample portfolio at `tests/fixtures/sample_profiles/basic_profile.json` so tests and future evaluation code have deterministic, realistic input. The fixture includes a fictional GitHub username, resume information, and exactly two repositories, and a focused unit test protects the file's expected structure.

## Issue

Closes #106.

## Changes

- Added `tests/fixtures/sample_profiles/basic_profile.json` with a fictional GitHub profile, a complete resume, and two distinct repositories.
- Added `tests/unit/test_basic_profile_fixture.py` to load the file from a path anchored to the test location.
- Validated required keys, nonblank string values, exactly two repositories, and unique repository names.
- Kept production APIs, database schemas, and runtime behavior unchanged.

## Testing

- [x] Unit test for this change passes: `.venv/Scripts/pytest tests/unit/test_basic_profile_fixture.py -v`.
- [x] Unit-test baseline is unchanged: `make test-unit` reports the same 53 pre-existing failures, with 376 passing tests after this change versus 375 before it.
- [x] Lint baseline is unchanged: `make check` stops at the same 182 pre-existing Ruff findings before and after this change; the new test file passes both `ruff check` and `black --check`.
- [x] Pre-commit checks for the committed files pass: Ruff, Black, and mypy.
- [x] New tests cover the fixture contract.
- [ ] Integration tests were not run because this fixture-only change does not modify an implemented integration flow; `scripts/run_evals.py` still contains a future-consumer TODO.

Manual verification:

1. Check out `test/106-restore-sample-profile-fixture`.
2. Run `.venv/Scripts/python -m json.tool tests/fixtures/sample_profiles/basic_profile.json` and confirm the JSON parses.
3. Run `.venv/Scripts/pytest tests/unit/test_basic_profile_fixture.py -v` and confirm the test passes.
4. Open the fixture and confirm it contains `github_username`, a populated `resume`, and exactly two populated `repositories` entries with different names.

## Screenshots / Demo

Not applicable; this is a test-data change with no user-interface impact.

## Notes for Reviewers

The benchmark loader in `scripts/run_evals.py` is still a TODO, so the repository does not currently enforce a sample-profile JSON schema. This PR makes the smallest explicit contract required by #106 and keeps that contract visible in one focused test. Please pay particular attention to the nested `resume` object and repository field names in case the planned evaluation runner expects a different shape.