### PR TITLE
docs(api): add service method docstrings

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -23,4 +23,4 @@ The public service functions in `core/services/` have only brief descriptions in
 
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
-**Cohort ledger:** [ ] Issue added to cohort ledger
+**Cohort ledger:** [x] Issue added to the [AI201 Su26 PathReview Cohort Issue Ledger](https://docs.google.com/spreadsheets/d/1oclK-70-klhGofiaw6krk8-zV_wZiumsR-Xnd_l5ZR8/edit)

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -24,3 +24,17 @@ The public service functions in `core/services/` have only brief descriptions in
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to the [AI201 Su26 PathReview Cohort Issue Ledger](https://docs.google.com/spreadsheets/d/1oclK-70-klhGofiaw6krk8-zV_wZiumsR-Xnd_l5ZR8/edit)
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [Commit 4cc4f43 — reproduce incomplete service docstrings](https://github.com/wazimmerman/pathreview/commit/4cc4f43acafcb4e2499e73f26573e0d3a348fb08)
+
+**Reproduction summary:**
+I ran an AST-based audit over every public function in `core/services/` and reproduced the gap with eight failures: all eight functions lack the requested Google-style `Args`, `Returns`, and `Raises` sections. The reproduction also confirmed that the issue's named `notification_service.py` file is absent, leaving four public functions in `profile_service.py` and four in `review_service.py` as the current scope.
+
+**PLAN.md link:** [Issue #119 solution plan](https://github.com/wazimmerman/pathreview/blob/docs/119-add-service-docstrings/PLAN.md)
+
+**Walkthrough video (recommended):** Not recorded (recommended, not graded).
+
+**Blockers or open questions:**
+The issue names `core/services/notification_service.py`, but that file does not exist in this checkout, so I plan not to create a new service unless the maintainer identifies a renamed or omitted target. I also want to confirm whether the issue expects a literal `Raises:` section on `process_review`; that function catches ordinary processing exceptions and records failure internally, so claiming that those exceptions propagate would be inaccurate.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,26 @@
+# PathReview Contribution Journal
+
+## Week 7 — Issue selection
+
+**Issue link:** [Issue #119 — Add inline docstrings to all public methods in `core/services/`](https://github.com/ascherj/pathreview/issues/119)
+
+**Issue title:** Add inline docstrings to all public methods in `core/services/`
+
+**Tier:** [ ] Tier 1  [x] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The public service functions in `core/services/` have only brief descriptions instead of complete Google-style docstrings. Their parameters, return values, and possible exceptions are therefore not documented for contributors or generated API documentation. The current checkout contains public functions in `profile_service.py` and `review_service.py`; the `notification_service.py` named in the issue does not currently exist, so creating a new service would be outside this documentation-only scope. A successful contribution will document every existing public service function with accurate descriptions and applicable `Args`, `Returns`, and `Raises` sections without changing runtime behavior.
+
+**Selection notes — “Is this right for me?” checklist:**
+
+- [x] I confirmed the issue is open, labeled `tier-2` and `docs`, and already claimed it with a comment from my GitHub account.
+- [x] I reviewed the named service modules and identified a bounded documentation-only change across two existing files.
+- [x] Tier 2 is a good fit for my comfort level: the edits are approachable, while accurately documenting database sessions, ownership checks, return types, and exceptions requires understanding several connected models and schemas.
+- [x] The expected outcome and validation are clear: preserve behavior, use the repository's required Google-style format, and run the documentation/code-quality checks.
+- [x] I accounted for the missing `notification_service.py` and will not expand the task by inventing a new service; I would confirm that interpretation with the maintainer if implementation begins before clarification is posted.
+
+**Branch name:** `docs/119-add-service-docstrings`
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -38,3 +38,56 @@ I ran an AST-based audit over every public function in `core/services/` and repr
 
 **Blockers or open questions:**
 The issue names `core/services/notification_service.py`, but that file does not exist in this checkout, so I plan not to create a new service unless the maintainer identifies a renamed or omitted target. I also want to confirm whether the issue expects a literal `Raises:` section on `process_review`; that function catches ordinary processing exceptions and records failure internally, so claiming that those exceptions propagate would be inaccurate.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+I completed the three implementation sub-tasks from `PLAN.md`: added a failing
+AST-based regression test, documented all four public profile service functions,
+and documented all four public review service functions. The focused test now
+passes, and I opened [draft PR #859](https://github.com/ascherj/pathreview/pull/859)
+for early review.
+
+**Next steps:**
+Push the three local implementation commits so they appear in the draft PR,
+request peer or mentor feedback in the cohort Slack channel, address any agreed
+feedback, rerun the focused and repository-wide verification commands, and mark
+the PR ready for review.
+
+**Blockers:**
+The repository baseline has 182 Ruff errors, and `make test-unit` has 52 failures
+plus 31 errors unrelated to this documentation-only issue. The Week 9 comparison
+will confirm that this branch introduces no additional failures. Pushing also
+requires the local SSH-key password, so I must perform that step directly.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [PR #859 — add service method docstrings](https://github.com/ascherj/pathreview/pull/859)
+
+**Branch:** `docs/119-add-service-docstrings`
+
+**What you built:**
+I added complete Google-style contracts to all eight existing public functions
+in `core/services/`, covering their arguments, return values, and raised
+exceptions without changing runtime behavior. I also added structural regression
+coverage that automatically checks every current and future public service
+function for the required sections.
+
+**Tests added or updated:**
+Added `tests/unit/test_service_docstrings.py`, an AST-only unit test that discovers
+public top-level functions under `core/services/` and requires a summary plus
+`Args:`, `Returns:`, and `Raises:` sections. The focused test passes without
+importing the application or requiring external services.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+Per the course's pre-existing-failure policy, “passes” means this contribution
+introduces no new failures. `make check` improved from 182 to 180 existing Ruff
+errors, while `make test-unit` remained at 52 failures and 31 errors and increased
+from 345 to 346 passing tests because the new focused test passes.
+
+**Draft PR feedback received from:** Pending peer or mentor review

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -90,4 +90,5 @@ introduces no new failures. `make check` improved from 182 to 180 existing Ruff
 errors, while `make test-unit` remained at 52 failures and 31 errors and increased
 from 345 to 346 passing tests because the new focused test passes.
 
-**Draft PR feedback received from:** Pending peer or mentor review
+**Draft PR feedback received from:** None — cohort guidance confirmed that peer
+review is not required for this submission.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,396 @@
+# Core Service Docstrings Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add accurate Google-style docstrings to every public function currently present in `core/services/` without changing application behavior.
+
+**Architecture:** Keep the change documentation-only in the two existing service modules. Add a small AST-based unit test that validates docstring structure without importing the application or requiring database services, then update the four public profile functions and four public review functions in separate reviewable commits.
+
+**Tech Stack:** Python 3.11+, `ast`, pytest, Ruff, Black, mypy, SQLAlchemy async-session semantics.
+
+## Global constraints
+
+- Follow issue #119: public service functions need Google-style descriptions plus `Args`, `Returns`, and accurate `Raises` documentation.
+- Do not change function signatures, database queries, status transitions, exception handling, or other runtime behavior.
+- Do not create `core/services/notification_service.py`; it is named by the issue but does not exist in the current checkout.
+- Exclude private helpers whose names begin with `_` from issue scope.
+- Use the repository's Conventional Commit format and run `make check && make test-unit` before Week 9 submission.
+
+---
+
+## Solution plan
+
+**Issue:** [Add inline docstrings to all public methods in `core/services/`](https://github.com/ascherj/pathreview/issues/119)
+
+### Understand
+
+The eight public async functions in `core/services/profile_service.py` and `core/services/review_service.py` already have short descriptions, but they do not document parameters, return values, or propagated failures in the repository's required Google style. The local reproduction in `REPRODUCTION.md` uses Python's AST to inspect all public top-level functions and reports `public_functions=8 failures=8` because every function is missing `Args:`, `Returns:`, and `Raises:` markers.
+
+Expected behavior is complete, semantically accurate developer documentation with no runtime changes. Most functions can propagate SQLAlchemy session failures; `delete_profile` rolls back and re-raises caught exceptions, while `process_review` catches ordinary processing exceptions and records/logs failure instead of propagating them.
+
+### Map
+
+- Create `tests/unit/test_service_docstrings.py`: AST-only regression coverage for public service docstrings; no application imports or external services.
+- Modify `core/services/profile_service.py:13`: `create_profile` docstring.
+- Modify `core/services/profile_service.py:36`: `get_profile` docstring.
+- Modify `core/services/profile_service.py:51`: `update_profile` docstring.
+- Modify `core/services/profile_service.py:75`: `delete_profile` docstring.
+- Modify `core/services/review_service.py:15`: `create_review` docstring.
+- Modify `core/services/review_service.py:35`: `get_review` docstring.
+- Modify `core/services/review_service.py:50`: `list_reviews` docstring.
+- Modify `core/services/review_service.py:82`: `process_review` docstring.
+- Reference `core/database.py:18`: confirms service callers provide an async SQLAlchemy session.
+- Reference `api/routes/profiles.py` and `api/routes/reviews.py`: confirms how IDs, schemas, return values, and the background `process_review` task are consumed.
+- Reference `docs/CONTRIBUTING.md`: defines Google-style docstrings and the required verification commands.
+
+### Plan
+
+#### Task 1: Add a failing structural docstring test
+
+**Files:**
+
+- Create: `tests/unit/test_service_docstrings.py`
+- Inspect: `core/services/profile_service.py`
+- Inspect: `core/services/review_service.py`
+
+**Interfaces:**
+
+- Consumes: Python source files under `core/services/`.
+- Produces: pytest assertions that every public top-level function has a description, `Args:`, and `Returns:`, plus `Raises:` when ordinary exceptions can propagate.
+
+- [ ] **Step 1: Create the AST-based test.**
+
+```python
+"""Structural tests for public service docstrings."""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+SERVICE_DIR = Path("core/services")
+NO_PROPAGATED_EXCEPTIONS = {"review_service.py:process_review"}
+
+
+def _public_functions(path: Path) -> list[ast.FunctionDef | ast.AsyncFunctionDef]:
+    """Return public top-level functions declared in a Python module."""
+    tree = ast.parse(path.read_text())
+    return [
+        node
+        for node in tree.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and not node.name.startswith("_")
+    ]
+
+
+@pytest.mark.unit
+def test_public_service_functions_have_google_style_docstrings() -> None:
+    """Require descriptions and input/output sections on public services."""
+    discovered = 0
+
+    for path in sorted(SERVICE_DIR.glob("*.py")):
+        for function in _public_functions(path):
+            discovered += 1
+            docstring = ast.get_docstring(function)
+            qualified_name = f"{path.name}:{function.name}"
+
+            assert docstring, f"{qualified_name} has no docstring"
+            assert docstring.splitlines()[0].strip(), (
+                f"{qualified_name} has no summary description"
+            )
+            assert "\nArgs:" in docstring, f"{qualified_name} has no Args section"
+            assert "\nReturns:" in docstring, (
+                f"{qualified_name} has no Returns section"
+            )
+
+            if qualified_name not in NO_PROPAGATED_EXCEPTIONS:
+                assert "\nRaises:" in docstring, (
+                    f"{qualified_name} has no Raises section"
+                )
+
+    assert discovered == 8, f"expected 8 public service functions, found {discovered}"
+```
+
+- [ ] **Step 2: Run the focused test and verify the reproduction remains red.**
+
+Run:
+
+```bash
+.venv/bin/pytest tests/unit/test_service_docstrings.py -v
+```
+
+Expected: one failing test whose first assertion identifies `profile_service.py:create_profile` as missing `Args:`. The failure proves the test detects the reproduced gap before docstrings are changed.
+
+- [ ] **Step 3: Commit the red test.**
+
+```bash
+git add tests/unit/test_service_docstrings.py
+git commit -m "test: require Google-style service docstrings"
+```
+
+#### Task 2: Document the public profile service functions
+
+**Files:**
+
+- Modify: `core/services/profile_service.py:13-104`
+- Test: `tests/unit/test_service_docstrings.py`
+
+**Interfaces:**
+
+- Consumes: `AsyncSession`-compatible `db`, UUID ownership identifiers, `ProfileCreate`, and `ProfileUpdate`.
+- Produces: unchanged `Profile`, `Profile | None`, and `bool` runtime results with accurate developer-facing contracts.
+
+- [ ] **Step 1: Replace the four short profile docstrings with these Google-style contracts.**
+
+```python
+"""Create and persist a profile for a user.
+
+Args:
+    db: Async SQLAlchemy session used to persist the profile.
+    user_id: Unique identifier of the user who owns the profile.
+    data: Validated GitHub username and portfolio URL values.
+    resume_filename: Original resume filename, or None when unavailable.
+    resume_text: Extracted resume text, or None when unavailable.
+
+Returns:
+    The newly persisted and refreshed profile.
+
+Raises:
+    SQLAlchemyError: If the profile cannot be committed or refreshed.
+"""
+```
+
+```python
+"""Return a profile when it exists and belongs to the requesting user.
+
+Args:
+    db: Async SQLAlchemy session used to query profiles.
+    profile_id: Unique identifier of the profile to retrieve.
+    user_id: Unique identifier of the expected profile owner.
+
+Returns:
+    The matching profile, or None when no owned profile is found.
+
+Raises:
+    SQLAlchemyError: If the profile query fails.
+"""
+```
+
+```python
+"""Update editable fields on a profile owned by the requesting user.
+
+Args:
+    db: Async SQLAlchemy session used to query and persist the profile.
+    profile_id: Unique identifier of the profile to update.
+    user_id: Unique identifier of the expected profile owner.
+    data: Validated profile fields; None-valued fields remain unchanged.
+
+Returns:
+    The refreshed profile, or None when no owned profile is found.
+
+Raises:
+    SQLAlchemyError: If querying, committing, or refreshing fails.
+"""
+```
+
+```python
+"""Delete an owned profile and its reviews and ingested sources.
+
+Args:
+    db: Async SQLAlchemy session used for the cascade deletion.
+    profile_id: Unique identifier of the profile to delete.
+    user_id: Unique identifier of the expected profile owner.
+
+Returns:
+    True when the profile is deleted, or False when it is not found.
+
+Raises:
+    Exception: Re-raised after rollback if a delete or commit operation fails.
+"""
+```
+
+- [ ] **Step 2: Run the focused test.**
+
+Run:
+
+```bash
+.venv/bin/pytest tests/unit/test_service_docstrings.py -v
+```
+
+Expected: still FAIL because the public functions in `review_service.py` remain undocumented. No profile-service function should appear in the failure.
+
+- [ ] **Step 3: Commit the profile documentation.**
+
+```bash
+git add core/services/profile_service.py
+git commit -m "docs: document public profile services"
+```
+
+#### Task 3: Document the public review service functions
+
+**Files:**
+
+- Modify: `core/services/review_service.py:15-168`
+- Test: `tests/unit/test_service_docstrings.py`
+
+**Interfaces:**
+
+- Consumes: `AsyncSession`-compatible `db`, review/profile/user UUIDs, and pagination integers.
+- Produces: unchanged `Review`, `Review | None`, `tuple[list[Review], int]`, and `None` runtime results with accurate status/error-handling documentation.
+
+- [ ] **Step 1: Replace the four short review docstrings with these Google-style contracts.**
+
+```python
+"""Create and persist a pending review for a profile.
+
+Args:
+    db: Async SQLAlchemy session used to persist the review.
+    profile_id: Unique identifier of the profile being reviewed.
+    user_id: Identifier of the authenticated user initiating the review.
+
+Returns:
+    The newly persisted and refreshed pending review.
+
+Raises:
+    SQLAlchemyError: If the review cannot be committed or refreshed.
+"""
+```
+
+```python
+"""Return a review when its profile belongs to the requesting user.
+
+Args:
+    db: Async SQLAlchemy session used to query reviews.
+    review_id: Unique identifier of the review to retrieve.
+    user_id: Unique identifier of the expected profile owner.
+
+Returns:
+    The matching review, or None when no owned review is found.
+
+Raises:
+    SQLAlchemyError: If the review query fails.
+"""
+```
+
+```python
+"""Return one page of a user's reviews and the unpaginated count.
+
+Args:
+    db: Async SQLAlchemy session used to query reviews.
+    user_id: Unique identifier of the profile owner.
+    page: One-based page number used to calculate the query offset.
+    page_size: Maximum number of reviews returned on the page.
+
+Returns:
+    A tuple containing the page of reviews and total matching review count.
+
+Raises:
+    SQLAlchemyError: If either review query fails.
+"""
+```
+
+```python
+"""Process a review through ingestion, analysis, RAG, and safety checks.
+
+The review advances from pending to processing and then to complete. Missing
+records, failed safety checks, and caught processing errors leave or set the
+review to failed and are logged instead of being propagated to the caller.
+
+Args:
+    db: Async SQLAlchemy session used throughout review processing.
+    review_id: Unique identifier of the review being processed.
+    profile_id: Unique identifier of the source profile.
+
+Returns:
+    None.
+"""
+```
+
+- [ ] **Step 2: Run the focused test and verify it turns green.**
+
+Run:
+
+```bash
+.venv/bin/pytest tests/unit/test_service_docstrings.py -v
+```
+
+Expected: PASS with one test passed and no external services required.
+
+- [ ] **Step 3: Commit the review documentation.**
+
+```bash
+git add core/services/review_service.py
+git commit -m "docs: document public review services"
+```
+
+#### Task 4: Verify documentation quality and repository compatibility
+
+**Files:**
+
+- Verify: `core/services/profile_service.py`
+- Verify: `core/services/review_service.py`
+- Verify: `tests/unit/test_service_docstrings.py`
+- Update after implementation: `PLAN.md` and `JOURNAL.md`
+
+**Interfaces:**
+
+- Consumes: the completed docstrings and structural test from Tasks 1–3.
+- Produces: formatter-, linter-, type-checker-, and unit-test evidence suitable for the Week 9 journal and pull request.
+
+- [ ] **Step 1: Confirm the semantic AST regression test reports no undocumented public functions.**
+
+Run:
+
+```bash
+.venv/bin/pytest tests/unit/test_service_docstrings.py -v
+```
+
+Expected: PASS. The original reproduction audit in `REPRODUCTION.md` intentionally mirrors the issue's literal all-sections wording; the regression test applies the semantically accurate exception for `process_review`, which catches ordinary processing exceptions instead of propagating them.
+
+- [ ] **Step 2: Run the repository's complete required checks.**
+
+```bash
+make check && make test-unit
+```
+
+Expected: Ruff, Black, mypy, and all unit tests exit 0.
+
+- [ ] **Step 3: Review the final diff for documentation-only scope.**
+
+```bash
+git diff main...HEAD -- core/services tests/unit/test_service_docstrings.py
+git diff --check
+```
+
+Expected: only the new structural test and docstring bodies differ; no function signature, query, status transition, or control-flow change appears, and `git diff --check` exits 0.
+
+- [ ] **Step 4: Record final commands and any plan changes in the Week 9 journal entry, then commit.**
+
+```bash
+git add PLAN.md JOURNAL.md
+git commit -m "docs: record issue 119 implementation results"
+```
+
+### Inputs & outputs
+
+**Inputs:** The eight existing public async functions, their current parameters and annotations, SQLAlchemy session behavior, UUID ownership identifiers, profile schemas, review status transitions, and the repository's Google-style documentation requirement.
+
+**Outputs:** Complete public-function docstrings that state purpose, parameter meaning, return semantics, and genuinely propagated exceptions; an AST-based unit test that prevents regression; no changes to function signatures, return values, database behavior, or API behavior.
+
+### Risks & unknowns
+
+- `core/services/notification_service.py` is named in issue #119 but absent from the branch. Creating it would expand a documentation issue into a new feature, so the plan excludes it; confirm with the maintainer if that file was renamed or omitted accidentally.
+- The issue wording lists `Raises` for all methods, but `process_review` catches ordinary `Exception` instances and records failure internally. Adding a false `Raises` section would be misleading, so the plan documents its suppression behavior and exempts only that function from the structural `Raises:` assertion unless maintainers require an explicit no-propagation convention.
+- `create_review` accepts `user_id` but does not read it. The docstring must describe it as caller context without claiming the function currently performs an ownership check; changing that behavior is outside issue #119.
+- SQLAlchemy may wrap driver-specific failures as different subclasses. Use `SQLAlchemyError` as the public documentation boundary for uncaught query/commit/refresh failures, and do not promise narrower exception classes without a targeted failure test.
+- `resume_filename` and `resume_text` default to `None` despite being annotated as `str`. Document the observed optional behavior but leave annotation cleanup for a separately scoped issue.
+
+### Edge cases
+
+- `get_profile`, `update_profile`, and `get_review` return `None` for missing or non-owned records; docstrings must not imply these cases raise not-found errors.
+- `delete_profile` returns `False` when the profile is absent but rolls back and re-raises operational failures during the cascade.
+- `list_reviews` can return an empty list with total `0`, and its total is calculated before pagination.
+- `process_review` can return early for a missing review, set failed for a missing profile or failed safety check, and catch/log processing failures without propagating them.
+- Optional resume values and partially populated `ProfileUpdate` values must be described without implying fields are always present.
+- Private `_run_ingestion_pipeline`, `_run_agent_orchestration`, `_run_rag_retrieval_generation`, and `_run_safety_checks` helpers remain outside public-method scope.
+- Any future public function added under `core/services/` should be discovered automatically by the AST regression test and held to the same documentation contract.

--- a/PLAN.md
+++ b/PLAN.md
@@ -58,7 +58,7 @@ Expected behavior is complete, semantically accurate developer documentation wit
 - Consumes: Python source files under `core/services/`.
 - Produces: pytest assertions that every public top-level function has a description, `Args:`, and `Returns:`, plus `Raises:` when ordinary exceptions can propagate.
 
-- [ ] **Step 1: Create the AST-based test.**
+- [x] **Step 1: Create the AST-based test.**
 
 ```python
 """Structural tests for public service docstrings."""
@@ -69,7 +69,6 @@ from pathlib import Path
 import pytest
 
 SERVICE_DIR = Path("core/services")
-NO_PROPAGATED_EXCEPTIONS = {"review_service.py:process_review"}
 
 
 def _public_functions(path: Path) -> list[ast.FunctionDef | ast.AsyncFunctionDef]:
@@ -103,15 +102,14 @@ def test_public_service_functions_have_google_style_docstrings() -> None:
                 f"{qualified_name} has no Returns section"
             )
 
-            if qualified_name not in NO_PROPAGATED_EXCEPTIONS:
-                assert "\nRaises:" in docstring, (
-                    f"{qualified_name} has no Raises section"
-                )
+            assert "\nRaises:" in docstring, (
+                f"{qualified_name} has no Raises section"
+            )
 
     assert discovered == 8, f"expected 8 public service functions, found {discovered}"
 ```
 
-- [ ] **Step 2: Run the focused test and verify the reproduction remains red.**
+- [x] **Step 2: Run the focused test and verify the reproduction remains red.**
 
 Run:
 
@@ -121,7 +119,7 @@ Run:
 
 Expected: one failing test whose first assertion identifies `profile_service.py:create_profile` as missing `Args:`. The failure proves the test detects the reproduced gap before docstrings are changed.
 
-- [ ] **Step 3: Commit the red test.**
+- [x] **Step 3: Commit the red test.**
 
 ```bash
 git add tests/unit/test_service_docstrings.py
@@ -140,7 +138,7 @@ git commit -m "test: require Google-style service docstrings"
 - Consumes: `AsyncSession`-compatible `db`, UUID ownership identifiers, `ProfileCreate`, and `ProfileUpdate`.
 - Produces: unchanged `Profile`, `Profile | None`, and `bool` runtime results with accurate developer-facing contracts.
 
-- [ ] **Step 1: Replace the four short profile docstrings with these Google-style contracts.**
+- [x] **Step 1: Replace the four short profile docstrings with these Google-style contracts.**
 
 ```python
 """Create and persist a profile for a user.
@@ -209,7 +207,7 @@ Raises:
 """
 ```
 
-- [ ] **Step 2: Run the focused test.**
+- [x] **Step 2: Run the focused test.**
 
 Run:
 
@@ -219,7 +217,7 @@ Run:
 
 Expected: still FAIL because the public functions in `review_service.py` remain undocumented. No profile-service function should appear in the failure.
 
-- [ ] **Step 3: Commit the profile documentation.**
+- [x] **Step 3: Commit the profile documentation.**
 
 ```bash
 git add core/services/profile_service.py
@@ -238,7 +236,7 @@ git commit -m "docs: document public profile services"
 - Consumes: `AsyncSession`-compatible `db`, review/profile/user UUIDs, and pagination integers.
 - Produces: unchanged `Review`, `Review | None`, `tuple[list[Review], int]`, and `None` runtime results with accurate status/error-handling documentation.
 
-- [ ] **Step 1: Replace the four short review docstrings with these Google-style contracts.**
+- [x] **Step 1: Replace the four short review docstrings with these Google-style contracts.**
 
 ```python
 """Create and persist a pending review for a profile.
@@ -303,10 +301,13 @@ Args:
 
 Returns:
     None.
+
+Raises:
+    CancelledError: If the background task is cancelled during processing.
 """
 ```
 
-- [ ] **Step 2: Run the focused test and verify it turns green.**
+- [x] **Step 2: Run the focused test and verify it turns green.**
 
 Run:
 
@@ -316,7 +317,7 @@ Run:
 
 Expected: PASS with one test passed and no external services required.
 
-- [ ] **Step 3: Commit the review documentation.**
+- [x] **Step 3: Commit the review documentation.**
 
 ```bash
 git add core/services/review_service.py
@@ -337,7 +338,7 @@ git commit -m "docs: document public review services"
 - Consumes: the completed docstrings and structural test from Tasks 1–3.
 - Produces: formatter-, linter-, type-checker-, and unit-test evidence suitable for the Week 9 journal and pull request.
 
-- [ ] **Step 1: Confirm the semantic AST regression test reports no undocumented public functions.**
+- [x] **Step 1: Confirm the semantic AST regression test reports no undocumented public functions.**
 
 Run:
 
@@ -345,17 +346,22 @@ Run:
 .venv/bin/pytest tests/unit/test_service_docstrings.py -v
 ```
 
-Expected: PASS. The original reproduction audit in `REPRODUCTION.md` intentionally mirrors the issue's literal all-sections wording; the regression test applies the semantically accurate exception for `process_review`, which catches ordinary processing exceptions instead of propagating them.
+Expected: PASS. `process_review` documents task cancellation, which is not
+caught by its ordinary-exception handler, while its description explains that
+ordinary processing failures are recorded rather than propagated.
 
-- [ ] **Step 2: Run the repository's complete required checks.**
+- [x] **Step 2: Run the repository's complete required checks.**
 
 ```bash
 make check && make test-unit
 ```
 
-Expected: Ruff, Black, mypy, and all unit tests exit 0.
+Expected: No failures beyond the baseline recorded before implementation. The
+current checkout starts with 182 Ruff errors and 52 unit-test failures plus 31
+errors, so Week 9 success means this documentation-only change introduces no
+additional failures.
 
-- [ ] **Step 3: Review the final diff for documentation-only scope.**
+- [x] **Step 3: Review the final diff for documentation-only scope.**
 
 ```bash
 git diff main...HEAD -- core/services tests/unit/test_service_docstrings.py
@@ -364,7 +370,7 @@ git diff --check
 
 Expected: only the new structural test and docstring bodies differ; no function signature, query, status transition, or control-flow change appears, and `git diff --check` exits 0.
 
-- [ ] **Step 4: Record final commands and any plan changes in the Week 9 journal entry, then commit.**
+- [x] **Step 4: Record final commands and any plan changes in the Week 9 journal entry, then commit.**
 
 ```bash
 git add PLAN.md JOURNAL.md
@@ -380,7 +386,7 @@ git commit -m "docs: record issue 119 implementation results"
 ### Risks & unknowns
 
 - `core/services/notification_service.py` is named in issue #119 but absent from the branch. Creating it would expand a documentation issue into a new feature, so the plan excludes it; confirm with the maintainer if that file was renamed or omitted accidentally.
-- The issue wording lists `Raises` for all methods, but `process_review` catches ordinary `Exception` instances and records failure internally. Adding a false `Raises` section would be misleading, so the plan documents its suppression behavior and exempts only that function from the structural `Raises:` assertion unless maintainers require an explicit no-propagation convention.
+- The issue wording lists `Raises` for all methods, but `process_review` catches ordinary `Exception` instances and records failure internally. Its `Raises:` section therefore documents task cancellation, which derives from `BaseException` and remains intentionally uncaught, while the description explains the suppression of ordinary failures.
 - `create_review` accepts `user_id` but does not read it. The docstring must describe it as caller context without claiming the function currently performs an ownership check; changing that behavior is outside issue #119.
 - SQLAlchemy may wrap driver-specific failures as different subclasses. Use `SQLAlchemyError` as the public documentation boundary for uncaught query/commit/refresh failures, and do not promise narrower exception classes without a targeted failure test.
 - `resume_filename` and `resume_text` default to `None` despite being annotated as `str`. Document the observed optional behavior but leave annotation cleanup for a separately scoped issue.

--- a/REPRODUCTION.md
+++ b/REPRODUCTION.md
@@ -1,0 +1,59 @@
+# Issue #119 reproduction
+
+**Issue:** [Add inline docstrings to all public methods in `core/services/`](https://github.com/ascherj/pathreview/issues/119)
+
+**Reproduced:** 2026-07-21 on branch `docs/119-add-service-docstrings`
+
+## Gap reproduced
+
+The repository requires Google-style docstrings for public functions, and issue #119 specifically calls for descriptions plus `Args`, `Returns`, and `Raises` sections in `core/services/`. The existing service functions have short descriptive text, but none of the eight public functions contains any of those three sections.
+
+Run this audit from the repository root:
+
+```bash
+.venv/bin/python - <<'PY'
+import ast
+from pathlib import Path
+
+required = ("Args:", "Returns:", "Raises:")
+failures = 0
+
+for path in sorted(Path("core/services").glob("*.py")):
+    tree = ast.parse(path.read_text())
+    for node in tree.body:
+        is_public_function = isinstance(
+            node, (ast.FunctionDef, ast.AsyncFunctionDef)
+        ) and not node.name.startswith("_")
+        if not is_public_function:
+            continue
+
+        docstring = ast.get_docstring(node) or ""
+        missing = [section for section in required if section not in docstring]
+        status = "PASS" if not missing else "FAIL missing " + ", ".join(missing)
+        print(f"{path}:{node.lineno} {node.name}: {status}")
+        failures += bool(missing)
+
+print(f"public_functions=8 failures={failures}")
+raise SystemExit(bool(failures))
+PY
+```
+
+Observed output:
+
+```text
+core/services/profile_service.py:13 create_profile: FAIL missing Args:, Returns:, Raises:
+core/services/profile_service.py:36 get_profile: FAIL missing Args:, Returns:, Raises:
+core/services/profile_service.py:51 update_profile: FAIL missing Args:, Returns:, Raises:
+core/services/profile_service.py:75 delete_profile: FAIL missing Args:, Returns:, Raises:
+core/services/review_service.py:15 create_review: FAIL missing Args:, Returns:, Raises:
+core/services/review_service.py:35 get_review: FAIL missing Args:, Returns:, Raises:
+core/services/review_service.py:50 list_reviews: FAIL missing Args:, Returns:, Raises:
+core/services/review_service.py:82 process_review: FAIL missing Args:, Returns:, Raises:
+public_functions=8 failures=8
+```
+
+The command exits with status 1, reproducing the documentation gap without changing application behavior.
+
+## Scope finding
+
+The issue also names `core/services/notification_service.py`, but that file does not exist in this checkout. The current implementation scope is therefore the four public functions in `profile_service.py` and the four public functions in `review_service.py`; private helpers beginning with `_` are outside the stated public-method scope.

--- a/core/services/profile_service.py
+++ b/core/services/profile_service.py
@@ -1,11 +1,12 @@
 from uuid import UUID
+
 import structlog
 from sqlalchemy import select
 
+from api.schemas.profile import ProfileCreate, ProfileUpdate
+from core.models.ingested_source import IngestedSource
 from core.models.profile import Profile
 from core.models.review import Review
-from core.models.ingested_source import IngestedSource
-from api.schemas.profile import ProfileCreate, ProfileUpdate
 
 log = structlog.get_logger()
 
@@ -17,8 +18,20 @@ async def create_profile(
     resume_filename: str = None,
     resume_text: str = None,
 ) -> Profile:
-    """
-    Create a new profile for a user.
+    """Create and persist a profile for a user.
+
+    Args:
+        db: Async SQLAlchemy session used to persist the profile.
+        user_id: Unique identifier of the user who owns the profile.
+        data: Validated GitHub username and portfolio URL values.
+        resume_filename: Original resume filename, or None when unavailable.
+        resume_text: Extracted resume text, or None when unavailable.
+
+    Returns:
+        The newly persisted and refreshed profile.
+
+    Raises:
+        SQLAlchemyError: If the profile cannot be committed or refreshed.
     """
     profile = Profile(
         user_id=user_id,
@@ -38,12 +51,20 @@ async def get_profile(
     profile_id: UUID,
     user_id: UUID,
 ) -> Profile | None:
+    """Return a profile when it exists and belongs to the requesting user.
+
+    Args:
+        db: Async SQLAlchemy session used to query profiles.
+        profile_id: Unique identifier of the profile to retrieve.
+        user_id: Unique identifier of the expected profile owner.
+
+    Returns:
+        The matching profile, or None when no owned profile is found.
+
+    Raises:
+        SQLAlchemyError: If the profile query fails.
     """
-    Get a profile by ID, checking ownership.
-    """
-    stmt = select(Profile).where(
-        (Profile.id == profile_id) & (Profile.user_id == user_id)
-    )
+    stmt = select(Profile).where((Profile.id == profile_id) & (Profile.user_id == user_id))
     result = await db.execute(stmt)
     return result.scalars().first()
 
@@ -54,8 +75,19 @@ async def update_profile(
     user_id: UUID,
     data: ProfileUpdate,
 ) -> Profile | None:
-    """
-    Update a profile, checking ownership.
+    """Update editable fields on a profile owned by the requesting user.
+
+    Args:
+        db: Async SQLAlchemy session used to query and persist the profile.
+        profile_id: Unique identifier of the profile to update.
+        user_id: Unique identifier of the expected profile owner.
+        data: Validated profile fields; None-valued fields remain unchanged.
+
+    Returns:
+        The refreshed profile, or None when no owned profile is found.
+
+    Raises:
+        SQLAlchemyError: If querying, committing, or refreshing fails.
     """
     profile = await get_profile(db, profile_id, user_id)
     if not profile:
@@ -77,9 +109,18 @@ async def delete_profile(
     profile_id: UUID,
     user_id: UUID,
 ) -> bool:
-    """
-    Delete a profile and cascade delete reviews and ingested sources.
-    Returns True if deleted, False if not found.
+    """Delete an owned profile and its reviews and ingested sources.
+
+    Args:
+        db: Async SQLAlchemy session used for the cascade deletion.
+        profile_id: Unique identifier of the profile to delete.
+        user_id: Unique identifier of the expected profile owner.
+
+    Returns:
+        True when the profile is deleted, or False when it is not found.
+
+    Raises:
+        Exception: Re-raised after rollback if a delete or commit operation fails.
     """
     profile = await get_profile(db, profile_id, user_id)
     if not profile:

--- a/core/services/review_service.py
+++ b/core/services/review_service.py
@@ -1,13 +1,14 @@
-from uuid import UUID
-import structlog
 import json
 from datetime import datetime
-from sqlalchemy import select, and_
+from uuid import UUID
 
-from core.models.review import Review
-from core.models.profile import Profile
-from core.models.ingested_source import IngestedSource
+import structlog
+from sqlalchemy import and_, select
+
 from api.schemas.review import FeedbackSection
+from core.models.ingested_source import IngestedSource
+from core.models.profile import Profile
+from core.models.review import Review
 
 log = structlog.get_logger()
 
@@ -17,8 +18,18 @@ async def create_review(
     profile_id: UUID,
     user_id: UUID,
 ) -> Review:
-    """
-    Create a new review with status="pending".
+    """Create and persist a pending review for a profile.
+
+    Args:
+        db: Async SQLAlchemy session used to persist the review.
+        profile_id: Unique identifier of the profile being reviewed.
+        user_id: Identifier of the authenticated user initiating the review.
+
+    Returns:
+        The newly persisted and refreshed pending review.
+
+    Raises:
+        SQLAlchemyError: If the review cannot be committed or refreshed.
     """
     review = Review(
         profile_id=profile_id,
@@ -37,11 +48,21 @@ async def get_review(
     review_id: UUID,
     user_id: UUID,
 ) -> Review | None:
+    """Return a review when its profile belongs to the requesting user.
+
+    Args:
+        db: Async SQLAlchemy session used to query reviews.
+        review_id: Unique identifier of the review to retrieve.
+        user_id: Unique identifier of the expected profile owner.
+
+    Returns:
+        The matching review, or None when no owned review is found.
+
+    Raises:
+        SQLAlchemyError: If the review query fails.
     """
-    Get a review by ID, checking that it belongs to the user's profile.
-    """
-    stmt = select(Review).join(Profile).where(
-        and_(Review.id == review_id, Profile.user_id == user_id)
+    stmt = (
+        select(Review).join(Profile).where(and_(Review.id == review_id, Profile.user_id == user_id))
     )
     result = await db.execute(stmt)
     return result.scalars().first()
@@ -53,9 +74,19 @@ async def list_reviews(
     page: int = 1,
     page_size: int = 20,
 ) -> tuple[list[Review], int]:
-    """
-    List reviews for a user with pagination.
-    Returns (reviews, total_count).
+    """Return one page of a user's reviews and the unpaginated count.
+
+    Args:
+        db: Async SQLAlchemy session used to query reviews.
+        user_id: Unique identifier of the profile owner.
+        page: One-based page number used to calculate the query offset.
+        page_size: Maximum number of reviews returned on the page.
+
+    Returns:
+        A tuple containing the page of reviews and total matching review count.
+
+    Raises:
+        SQLAlchemyError: If either review query fails.
     """
     offset = (page - 1) * page_size
 
@@ -84,16 +115,22 @@ async def process_review(
     review_id: UUID,
     profile_id: UUID,
 ) -> None:
-    """
-    Background task to process a review.
-    Steps:
-    1. Set status="processing"
-    2. Run ingestion pipeline on profile's sources
-    3. Run agent orchestration
-    4. Run RAG retrieval + generation
-    5. Run safety checks on output
-    6. Set status="complete", store sections in review.sections
-    7. On exception: set status="failed", log error
+    """Process a review through ingestion, analysis, RAG, and safety checks.
+
+    The review advances from pending to processing and then to complete. Missing
+    records, failed safety checks, and ordinary processing errors leave or set
+    the review to failed and are logged instead of being propagated.
+
+    Args:
+        db: Async SQLAlchemy session used throughout review processing.
+        review_id: Unique identifier of the review being processed.
+        profile_id: Unique identifier of the source profile.
+
+    Returns:
+        None.
+
+    Raises:
+        CancelledError: If the background task is cancelled during processing.
     """
     try:
         # Get the review

--- a/tests/unit/test_service_docstrings.py
+++ b/tests/unit/test_service_docstrings.py
@@ -1,0 +1,39 @@
+"""Structural tests for public service docstrings."""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+SERVICE_DIR = Path("core/services")
+
+
+def _public_functions(path: Path) -> list[ast.FunctionDef | ast.AsyncFunctionDef]:
+    """Return public top-level functions declared in a Python module."""
+    tree = ast.parse(path.read_text())
+    return [
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef)
+        and not node.name.startswith("_")
+    ]
+
+
+@pytest.mark.unit
+def test_public_service_functions_have_google_style_docstrings() -> None:
+    """Require descriptions and contract sections on public services."""
+    discovered = 0
+
+    for path in sorted(SERVICE_DIR.glob("*.py")):
+        for function in _public_functions(path):
+            discovered += 1
+            docstring = ast.get_docstring(function)
+            qualified_name = f"{path.name}:{function.name}"
+
+            assert docstring, f"{qualified_name} has no docstring"
+            assert docstring.splitlines()[0].strip(), f"{qualified_name} has no summary description"
+            assert "\nArgs:" in docstring, f"{qualified_name} has no Args section"
+            assert "\nReturns:" in docstring, f"{qualified_name} has no Returns section"
+            assert "\nRaises:" in docstring, f"{qualified_name} has no Raises section"
+
+    assert discovered == 8, f"expected 8 public service functions, found {discovered}"


### PR DESCRIPTION
## Summary
Adds complete Google-style contracts to all eight existing public service functions in `core/services/`, documenting arguments, return values, and raised exceptions without changing runtime behavior. Adds an AST-based unit regression test so future public services cannot omit the required sections.

## Issue
Closes #119

## Changes
- Document all public functions in `profile_service.py`.
- Document all public functions in `review_service.py`.
- Add an AST-only unit test for public service docstring structure.
- Keep the missing `notification_service.py` outside scope because it does not exist on the current base branch.

## Testing
- [ ] Unit tests pass (`make test-unit`) — repository has documented pre-existing failures; this PR introduces none
- [ ] Integration tests pass (`make test-integration`) — not run for this documentation-only change
- [ ] Linter passes (`make lint`) — repository has documented pre-existing failures; this PR introduces none
- [ ] Type checker passes (`make typecheck`) — existing service-module annotation errors remain unchanged
- [x] New/updated tests cover the changes

Focused verification:
- `.venv/bin/pytest tests/unit/test_service_docstrings.py -v`: 1 passed.
- Ruff and Black checks on both changed service modules and the new test: passed.

Repository-wide baseline and final comparison:
- `make check`: 182 baseline Ruff errors; 180 after this change. No new failures.
- `make test-unit`: baseline 52 failed / 345 passed / 31 errors; final 52 failed / 346 passed / 31 errors. The additional passing test is the new regression test.

## Screenshots / Demo
Not applicable; this is a documentation-only service-layer change.

## Notes for Reviewers
Please review the semantic accuracy of the documented return and exception behavior, particularly that `process_review` catches ordinary processing exceptions and only allows task cancellation to propagate. The issue also names `notification_service.py`, but that file is absent from the current checkout, so no new service was invented.