### PR TITLE
Fix/34 re ranking llm retriever step

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,17 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/jamjamgobambam/pathreview/issues/34
+
+**Issue title:** Implement a re-ranking step that uses an LLM to score retrieved chunks before generation
+ #34
+
+**Tier:** [ ] Tier 1  [ ] Tier 2  [X] Tier 3
+
+**Problem summary:**
+This issue calls for another layer of chunk ranking in the retrieval step of the `rag` (Retrieval-Augmented Generation) portion of the codebase. Essentially, it requests the addition of a light-weight LLM ranker which will go above the current top-k chunk retrieval layer which only uses vector similarity and keyword scores. Once successfully added, this LLM-based enchancment to the retrieval process will strengthen the validity of top-k chunks, specifically in terms of their ranked relevance to the query.
+
+**Branch name:** fix/34-re-ranking-LLM-retriever-step
+
+**Setup confirmation:** [X] App runs locally at localhost:5173
+
+**Cohort ledger:** [X] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -8,10 +8,26 @@
 **Tier:** [ ] Tier 1  [ ] Tier 2  [X] Tier 3
 
 **Problem summary:**
-This issue calls for another layer of chunk ranking in the retrieval step of the `rag` (Retrieval-Augmented Generation) portion of the codebase. Essentially, it requests the addition of a light-weight LLM ranker which will go above the current top-k chunk retrieval layer which only uses vector similarity and keyword scores. Once successfully added, this LLM-based enchancment to the retrieval process will strengthen the validity of top-k chunks, specifically in terms of their ranked relevance to the query.
+This issue calls for another layer of chunk ranking in the retrieval step of the `rag` (Retrieval-Augmented Generation) portion of the codebase. Essentially, it requests the addition of a light-weight LLM ranker which will go above the current top-k chunk retrieval layer which only uses vector similarity and keyword scores. Once successfully added, this LLM-based enhancement to the retrieval process will strengthen the validity of top-k chunks, specifically in terms of their ranked relevance to the query.
 
 **Branch name:** fix/34-re-ranking-LLM-retriever-step
 
 **Setup confirmation:** [X] App runs locally at localhost:5173
 
 **Cohort ledger:** [X] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/neparkes-81/ai201-finalproject-pathreview/blob/fix/34-re-ranking-LLM-retriever-step/JOURNAL.md
+
+**Reproduction summary:**<!-- [1–2 sentences: How did you reproduce the issue? What did you observe?] -->
+This issue did not require reproduction as it is an enhancement, but I did run the code the visualize how it is currently functioning.
+
+**PLAN.md link:** https://github.com/neparkes-81/ai201-finalproject-pathreview/blob/fix/34-re-ranking-LLM-retriever-step/PLAN.md
+
+**Walkthrough video (recommended):** ...
+
+**Blockers or open questions:** ...
+<!-- [Anything you're still uncertain about going into Week 9, or leave blank] -->
+
+*Note*: The current handling of chunks can be found in `rag/retriever/hybrid.py`. I gather how this process works and I will need to build upon the output of `_get_all_chunks()` to fill the issue gap.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -31,3 +31,34 @@ This issue did not require reproduction as it is an enhancement, but I did run t
 <!-- [Anything you're still uncertain about going into Week 9, or leave blank] -->
 
 *Note*: The current handling of chunks can be found in `rag/retriever/hybrid.py`. I gather how this process works and I will need to build upon the output of `_get_all_chunks()` to fill the issue gap.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+In terms of my `PLAN.md`, I completed the first 2 steps. These essentially consist of configuration and step up of my LLM reranker as a standalone entity.
+
+**Next steps:**
+Connecting my reranker to the entire rag pipeline, specifically through `hybrid.py`. Then, creating tests to validate code.
+
+**Blockers:**
+As the llm_provider defaults to "mock", in the case that this is to run offline I need to incorporate some sort of "MockReranker", something deterministic and doesn't require no network. Otherwise, my current code will run into errors. Also, I ran into linter errors so I need to clean up my code to align with anticipated style.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [link to your submitted pull request]
+
+**Branch:** [the branch name you worked on, e.g. `fix/123-short-description`]
+
+**What you built:**
+[1–3 sentences summarizing what your fix does and how it works]
+
+**Tests added or updated:**
+[Which test files did you touch? What do they cover?]
+
+**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+
+**Draft PR feedback received from:** [name or Slack handle, or "none"]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -49,16 +49,16 @@ As the llm_provider defaults to "mock", in the case that this is to run offline 
 
 ### Check-in 2 (end of week)
 
-**PR link:** [link to your submitted pull request]
+**PR link:** [https://github.com/ascherj/pathreview/pull/862](https://github.com/ascherj/pathreview/pull/862)
 
-**Branch:** [the branch name you worked on, e.g. `fix/123-short-description`]
+**Branch:** `fix/34-re-ranking-LLM-retriever-step`
 
 **What you built:**
-[1–3 sentences summarizing what your fix does and how it works]
+I built a mandatory second layer to the chunking algorithm within the RAG feature of this project. This new layer uses an LLM to reranker retrieved chunks in order of relevance. I also implemented a mock reranker that permits the layer to run without connection to a network/LLM API.
 
 **Tests added or updated:**
-[Which test files did you touch? What do they cover?]
+I added tests in their own separate file for the reranker under the name `test_reranker.py`. The test suite utilized a non-network reliant mock client and data to probe reranker behavior in various scenarios and edge cases.
 
-**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+**Self-review confirmation:** [X] make check passes  [X] make test-unit passes
 
-**Draft PR feedback received from:** [name or Slack handle, or "none"]
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -62,3 +62,34 @@ I added tests in their own separate file for the reranker under the name `test_r
 **Self-review confirmation:** [X] make check passes  [X] make test-unit passes
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [X] No — still awaiting review
+
+**Summary of feedback:**
+No feedback was received.
+
+**How you responded:**
+
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+I found it harder than I expected to wrap my head around how the issue code fit into the project as a whole. Specifically, when it came to testing, I had to really take my time to understand what problems arose from my specific issue and not others, to avoid scope-creep. 
+
+**What did you learn about working in a large codebase?**
+Working in a large codebase takes a lot of mindful backtracking. When it is your own personal project, which you built from the ground up, it is easier to isolate issues as you know how each part is set up. Although, joining and contributing to a large codebase invites a lot of unknowns that requires you to need to take the time to figure out how one change might impact other parts of the project.
+
+**How did AI tools help — and where did they fall short?**
+I utilized AI tools to help build out the integration of my code into the current chunking pipeline of the rag system. I wanted to ensure that I was covering all my bases in terms of files and functions I would need to alter. I had to take things into my own hands when it came to testing decisions as the AI hoped to push fixes into other sectors outside my concern.
+
+**What would you do differently if you started over?**
+If I could start over, I would change my approach to how I went about planning. I did not build out my steps very detailed and I think this made me do more work than I anticipated in the actual build process. Whereas if I made it more detailed, it would have streamlined the creation process with clear steps and expectations.
+
+**What are you most proud of from this module?**
+I am proud of how I was able to take everything I have learned and genuinely implement it into this project. It felt like a full-circle moment and I look forward to what I will be capable of following this class.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,35 @@
+## Solution plan
+
+**Issue:** [Implement a re-ranking step that uses an LLM to score retrieved chunks before generation - #34](https://github.com/jamjamgobambam/pathreview/issues/34)
+
+### Understand
+<!-- What is the root cause of this issue? What behavior is expected vs. actual? -->
+This issue seeks to fill a gap in the implementation. Currently, the application's rag functionally utilizes a hybrid approach of vector similarity and BM25 keyword search to isolate the top-k relevant chunks. Chunks are then fetched as provided by this retriever. This issue requests the addition of a light-weight LLM ranker which will go above this current chunk retrieval layer, organizing top chunks by relevance.
+
+### Map
+<!-- Which files, functions, or modules are involved?
+List the specific files you expect to touch. -->
+This issue involves the following files:
+* `rag/retriever/hybrid.py`
+*` rag/retriever/reranker.py` *(to be created)*
+
+
+### Plan
+<!-- What are the steps to fix this issue?
+Break it into 3–5 concrete sub-tasks. -->
+1. Decide LMM for the reranker and set up environment variable (api key, etc.).
+2. Implement reranker in a standalone file, defining LLM system prompt and conforming input output to the current chunking process.
+3. Incorporate reranker into the current chunking process, making use of import between relevant files.
+
+### Inputs & outputs
+<!-- What does your fix take as input? What should it produce or change? -->
+* **Input:** The top-k chunks provided by the current hybrid approach retriever. A list of dictionaries each corresponding to a chunk.
+* **Output:** A reorganized list of chunks.
+
+### Risks & unknowns
+<!-- What could go wrong? What are you still unsure about? -->
+With using an LLM there is some ambiguity on the reasoning behind the top-k chunk order it may produce. This poses a point where things may go wrong. It will rely heavily on my system prompt to successfully produce successfully.
+
+### Edge cases
+<!-- What inputs or states should your fix handle gracefully? -->
+I will likely want to consider situations in which the input is empty, contains near duplicates, or contains only one chunks as these make reranker either difficult or obsolete.

--- a/rag/retriever/hybrid.py
+++ b/rag/retriever/hybrid.py
@@ -1,8 +1,10 @@
 """Hybrid retriever combining vector and keyword search."""
 
 import structlog
-from .vector_store import VectorStore
+
 from .keyword_search import KeywordSearcher
+from .reranker import Reranker
+from .vector_store import VectorStore
 
 logger = structlog.get_logger()
 
@@ -10,23 +12,37 @@ logger = structlog.get_logger()
 class HybridRetriever:
     """Combines vector similarity and BM25 keyword search."""
 
-    def __init__(self, vector_store: VectorStore, keyword_searcher: KeywordSearcher,
-                 vector_weight: float = 0.7, keyword_weight: float = 0.3):
+    def __init__(
+        self,
+        vector_store: VectorStore,
+        keyword_searcher: KeywordSearcher,
+        reranker: Reranker,
+        vector_weight: float = 0.7,
+        keyword_weight: float = 0.3,
+    ):
         """Initialize hybrid retriever.
 
         Args:
             vector_store: VectorStore instance
             keyword_searcher: KeywordSearcher instance
+            reranker: Reranker applied to the candidate pool on every retrieval
             vector_weight: Weight for vector scores (0-1)
             keyword_weight: Weight for keyword scores (0-1)
         """
         self.vector_store = vector_store
         self.keyword_searcher = keyword_searcher
+        self.reranker = reranker
         self.vector_weight = vector_weight
         self.keyword_weight = keyword_weight
 
-    def retrieve(self, query: str, profile_id: str, query_embedding: list[float],
-                 max_chunks: int = 10, min_score: float = 0.3) -> list[dict]:
+    def retrieve(
+        self,
+        query: str,
+        profile_id: str,
+        query_embedding: list[float],
+        max_chunks: int = 10,
+        min_score: float = 0.3,
+    ) -> list[dict]:
         """Retrieve chunks using hybrid approach.
 
         Args:
@@ -67,18 +83,23 @@ class HybridRetriever:
             keyword_score = 0.0
 
             if chunk_id in vector_map:
-                vector_score = (vector_map[chunk_id]["score"] / vector_scores_max) if vector_scores_max > 0 else 0
+                vector_score = (
+                    (vector_map[chunk_id]["score"] / vector_scores_max)
+                    if vector_scores_max > 0
+                    else 0
+                )
                 base_chunk = vector_map[chunk_id]
             else:
                 base_chunk = keyword_map[chunk_id]
 
             if chunk_id in keyword_map:
-                keyword_score = (keyword_map[chunk_id].get("bm25_score", 0) / keyword_scores_max) if keyword_scores_max > 0 else 0
+                keyword_score = (
+                    (keyword_map[chunk_id].get("bm25_score", 0) / keyword_scores_max)
+                    if keyword_scores_max > 0
+                    else 0
+                )
 
-            blended_score = (
-                self.vector_weight * vector_score +
-                self.keyword_weight * keyword_score
-            )
+            blended_score = self.vector_weight * vector_score + self.keyword_weight * keyword_score
 
             blended[chunk_id] = {
                 "id": chunk_id,
@@ -86,20 +107,27 @@ class HybridRetriever:
                 "metadata": base_chunk.get("metadata", {}),
                 "score": blended_score,
                 "vector_score": vector_score,
-                "keyword_score": keyword_score
+                "keyword_score": keyword_score,
             }
 
         # Filter by min_score and sort
         results = [r for r in blended.values() if r["score"] >= min_score]
         results.sort(key=lambda x: x["score"], reverse=True)
 
-        # Return top max_chunks
-        final_results = results[:max_chunks]
+        # LLM re-ranking pass over the candidate pool, then truncate to
+        # max_chunks. The reranker short-circuits the 0/1-chunk cases and
+        # falls back to the hybrid order if the LLM is unavailable.
+        final_results = self.reranker.rerank(query, results, top_k=max_chunks)
 
-        logger.info("hybrid_retrieval_complete", query_len=len(query),
-                   vector_results=len(vector_results), keyword_results=len(keyword_results),
-                   blended_count=len(blended), filtered_count=len(results),
-                   final_count=len(final_results))
+        logger.info(
+            "hybrid_retrieval_complete",
+            query_len=len(query),
+            vector_results=len(vector_results),
+            keyword_results=len(keyword_results),
+            blended_count=len(blended),
+            filtered_count=len(results),
+            final_count=len(final_results),
+        )
 
         return final_results
 
@@ -117,13 +145,7 @@ class HybridRetriever:
 
         chunks = []
         for doc_id, text, metadata in zip(
-            all_docs["ids"],
-            all_docs["documents"],
-            all_docs["metadatas"]
+            all_docs["ids"], all_docs["documents"], all_docs["metadatas"], strict=False
         ):
-            chunks.append({
-                "id": doc_id,
-                "text": text,
-                "metadata": metadata
-            })
+            chunks.append({"id": doc_id, "text": text, "metadata": metadata})
         return chunks

--- a/rag/retriever/reranker.py
+++ b/rag/retriever/reranker.py
@@ -1,0 +1,244 @@
+"""LLM-based re-ranking of retrieved chunks.
+
+The reranking stage runs on every retrieval. It scores each candidate
+chunk's relevance to the query and reorders the top-k before those chunks
+reach the generator. The provider behind the stage is selected by the
+application's ``llm_provider`` setting: ``"mock"`` yields a deterministic,
+network-free reranker for tests/CI, while any other value uses a real LLM.
+
+Reranking is only skipped for the degenerate cases where it is meaningless
+(zero or one chunk) or impossible (LLM unreachable), in which case the
+original hybrid order is preserved so the pipeline never breaks.
+"""
+
+import json
+import re
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any
+
+import structlog
+
+logger = structlog.get_logger()
+
+
+SYSTEM_PROMPT = (
+    "You are a search relevance judge. Given a user query and a list of "
+    "candidate text chunks, score how well each chunk answers the query. "
+    "Score each chunk from 0 (irrelevant) to 10 (directly answers the query). "
+    "Respond with ONLY a JSON object mapping each chunk id to its integer "
+    'score, e.g. {"id-1": 8, "id-2": 3}. Do not include any other text.'
+)
+
+
+@dataclass
+class RerankConfig:
+    """Configuration for the LLM reranker.
+
+    Mirrors ``ReviewConfig`` in the generator. ``temperature`` and
+    ``max_tokens`` are reranker-specific defaults and are not environment
+    configurable; ``api_key``, ``base_url`` and ``model`` are expected to be
+    supplied from the existing ``openrouter_*`` application settings.
+    """
+
+    api_key: str
+    base_url: str
+    model: str
+    temperature: float = 0.0
+    max_tokens: int = 500
+
+
+class Reranker(ABC):
+    """Abstract base class for chunk rerankers."""
+
+    @abstractmethod
+    def rerank(self, query: str, chunks: list[dict], top_k: int) -> list[dict]:
+        """Reorder ``chunks`` by relevance to ``query`` and return the top-k.
+
+        Args:
+            query: The text query the chunks were retrieved for.
+            chunks: Candidate chunks (dicts with at least ``id`` and ``text``).
+            top_k: Maximum number of chunks to return.
+
+        Returns:
+            A reordered list of at most ``top_k`` chunks.
+        """
+        raise NotImplementedError("Subclasses must implement rerank()")
+
+    @staticmethod
+    def _is_trivial(chunks: list[dict]) -> bool:
+        """Return True when reranking is meaningless (0 or 1 chunk)."""
+        return len(chunks) <= 1
+
+
+class MockReranker(Reranker):
+    """Deterministic, network-free reranker for tests and CI.
+
+    Scores each chunk from a stable hash of the query and chunk text, so the
+    same inputs always produce the same ordering. This lets tests assert that
+    the reranking stage ran and reordered chunks without needing an LLM or an
+    API key.
+    """
+
+    def rerank(self, query: str, chunks: list[dict], top_k: int) -> list[dict]:
+        if not chunks:
+            return []
+        if self._is_trivial(chunks):
+            return list(chunks[:top_k])
+
+        scored = []
+        for chunk in chunks:
+            score = self._score(query, chunk.get("text", ""))
+            scored.append({**chunk, "rerank_score": score})
+
+        scored.sort(key=lambda c: c["rerank_score"], reverse=True)
+
+        logger.info(
+            "rerank_complete",
+            provider="mock",
+            candidate_count=len(chunks),
+            returned_count=min(top_k, len(scored)),
+        )
+        return scored[:top_k]
+
+    @staticmethod
+    def _score(query: str, text: str) -> float:
+        """Deterministic pseudo-relevance score in ``[0, 10]``."""
+        import hashlib
+
+        digest = hashlib.sha256(f"{query}\x00{text}".encode()).digest()
+        # Map the first 4 bytes to a stable float in [0, 10].
+        return int.from_bytes(digest[:4], byteorder="big") / 0xFFFFFFFF * 10
+
+
+class LLMReranker(Reranker):
+    """Reranker that prompts an LLM to score chunk relevance.
+
+    The OpenAI-compatible client is injectable so tests can supply a fake and
+    exercise the parsing/fallback logic without a network call.
+    """
+
+    def __init__(self, config: RerankConfig, client: Any = None):
+        """Initialize the reranker.
+
+        Args:
+            config: Reranker configuration (API key, base URL, model, ...).
+            client: Optional OpenAI-compatible client. When omitted, a real
+                ``openai.OpenAI`` client is constructed from ``config``.
+        """
+        self.config = config
+        if client is None:
+            import openai
+
+            client = openai.OpenAI(api_key=config.api_key, base_url=config.base_url)
+        self.client = client
+
+    def rerank(self, query: str, chunks: list[dict], top_k: int) -> list[dict]:
+        if not chunks:
+            return []
+        if self._is_trivial(chunks):
+            return list(chunks[:top_k])
+
+        try:
+            scores = self._score_chunks(query, chunks)
+        except Exception as e:
+            # Graceful degradation: keep the incoming hybrid order.
+            logger.warning("rerank_failed", error=str(e), candidate_count=len(chunks))
+            return list(chunks[:top_k])
+
+        ranked = [
+            {**chunk, "rerank_score": scores.get(chunk.get("id", ""), 0.0)} for chunk in chunks
+        ]
+        ranked.sort(key=lambda c: c["rerank_score"], reverse=True)
+
+        logger.info(
+            "rerank_complete",
+            provider="llm",
+            model=self.config.model,
+            candidate_count=len(chunks),
+            returned_count=min(top_k, len(ranked)),
+        )
+        return ranked[:top_k]
+
+    def _score_chunks(self, query: str, chunks: list[dict]) -> dict[str, float]:
+        """Call the LLM and return a mapping of chunk id -> relevance score."""
+        prompt = self._build_prompt(query, chunks)
+
+        response = self.client.chat.completions.create(
+            model=self.config.model,
+            messages=[
+                {"role": "system", "content": SYSTEM_PROMPT},
+                {"role": "user", "content": prompt},
+            ],
+            temperature=self.config.temperature,
+            max_tokens=self.config.max_tokens,
+        )
+        content = response.choices[0].message.content
+        return self._parse_scores(content)
+
+    @staticmethod
+    def _build_prompt(query: str, chunks: list[dict]) -> str:
+        """Render the query and candidate chunks into the user prompt."""
+        parts = [f"Query: {query}", "", "Chunks:"]
+        for chunk in chunks:
+            chunk_id = chunk.get("id", "")
+            text = chunk.get("text", "").replace("\n", " ").strip()
+            # Truncate to keep the prompt bounded for the small model.
+            if len(text) > 500:
+                text = text[:500] + "..."
+            parts.append(f"- id: {chunk_id}\n  text: {text}")
+        return "\n".join(parts)
+
+    @staticmethod
+    def _parse_scores(content: str | None) -> dict[str, float]:
+        """Parse the LLM response into a ``{id: score}`` mapping.
+
+        Tolerant of models that wrap the JSON in prose or code fences. Raises
+        ``ValueError`` if no JSON object can be recovered so the caller falls
+        back to the original order.
+        """
+        if not content:
+            raise ValueError("empty rerank response")
+
+        try:
+            data = json.loads(content)
+        except json.JSONDecodeError:
+            match = re.search(r"\{.*\}", content, re.DOTALL)
+            if not match:
+                raise ValueError("no JSON object found in rerank response") from None
+            data = json.loads(match.group(0))
+
+        if not isinstance(data, dict):
+            raise ValueError("rerank response was not a JSON object")
+
+        scores: dict[str, float] = {}
+        for chunk_id, score in data.items():
+            try:
+                scores[str(chunk_id)] = float(score)
+            except (TypeError, ValueError):
+                # Skip unparseable entries; missing ids default to 0 later.
+                continue
+        return scores
+
+
+def get_reranker(provider_name: str, config: RerankConfig | None = None) -> Reranker:
+    """Factory returning a reranker for the given provider.
+
+    Args:
+        provider_name: Application ``llm_provider`` value ("mock" or a real
+            provider such as "openai"/"openrouter").
+        config: Required for non-mock providers; supplies the API credentials
+            and model.
+
+    Returns:
+        A ``Reranker`` instance.
+
+    Raises:
+        ValueError: If a non-mock provider is requested without a config.
+    """
+    name = provider_name.lower().strip()
+    if name == "mock":
+        return MockReranker()
+    if config is None:
+        raise ValueError(f"RerankConfig is required for the '{provider_name}' reranker provider")
+    return LLMReranker(config)

--- a/tests/unit/test_reranker.py
+++ b/tests/unit/test_reranker.py
@@ -1,0 +1,225 @@
+"""Tests for the LLM re-ranking stage (rag/retriever/reranker.py)."""
+
+import pytest
+
+from rag.retriever.reranker import (
+    LLMReranker,
+    MockReranker,
+    RerankConfig,
+    Reranker,
+    get_reranker,
+)
+
+# ---------------------------------------------------------------------------
+# Fake OpenAI-compatible client for exercising LLMReranker without a network.
+# ---------------------------------------------------------------------------
+
+
+class _FakeMessage:
+    def __init__(self, content):
+        self.content = content
+
+
+class _FakeChoice:
+    def __init__(self, content):
+        self.message = _FakeMessage(content)
+
+
+class _FakeResponse:
+    def __init__(self, content):
+        self.choices = [_FakeChoice(content)]
+
+
+class _FakeCompletions:
+    def __init__(self, content=None, exc=None):
+        self._content = content
+        self._exc = exc
+        self.calls = []
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        if self._exc is not None:
+            raise self._exc
+        return _FakeResponse(self._content)
+
+
+class _FakeChat:
+    def __init__(self, content=None, exc=None):
+        self.completions = _FakeCompletions(content=content, exc=exc)
+
+
+class FakeClient:
+    """Minimal stand-in for ``openai.OpenAI`` used by LLMReranker."""
+
+    def __init__(self, content=None, exc=None):
+        self.chat = _FakeChat(content=content, exc=exc)
+
+
+def make_chunks(*ids: str) -> list[dict]:
+    """Build a list of chunk dicts with distinct text per id."""
+    return [{"id": i, "text": f"text for {i}", "score": 0.5} for i in ids]
+
+
+@pytest.fixture
+def config() -> RerankConfig:
+    return RerankConfig(api_key="test-key", base_url="http://test", model="test-model")
+
+
+# ---------------------------------------------------------------------------
+# MockReranker
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestMockReranker:
+    """Deterministic, network-free reranker behavior."""
+
+    def test_empty_returns_empty(self):
+        assert MockReranker().rerank("q", [], top_k=5) == []
+
+    def test_single_chunk_returned_as_is(self):
+        chunks = make_chunks("a")
+        result = MockReranker().rerank("q", chunks, top_k=5)
+        assert [c["id"] for c in result] == ["a"]
+
+    def test_single_chunk_not_scored(self):
+        """The 0/1 short-circuit skips scoring entirely."""
+        chunks = make_chunks("a")
+        result = MockReranker().rerank("q", chunks, top_k=5)
+        assert "rerank_score" not in result[0]
+
+    def test_all_chunks_get_scores(self):
+        chunks = make_chunks("a", "b", "c")
+        result = MockReranker().rerank("q", chunks, top_k=5)
+        assert all("rerank_score" in c for c in result)
+
+    def test_output_is_permutation_of_input(self):
+        chunks = make_chunks("a", "b", "c", "d")
+        result = MockReranker().rerank("q", chunks, top_k=10)
+        assert sorted(c["id"] for c in result) == ["a", "b", "c", "d"]
+
+    def test_deterministic_across_calls(self):
+        chunks = make_chunks("a", "b", "c", "d", "e")
+        rr = MockReranker()
+        first = [c["id"] for c in rr.rerank("q", chunks, top_k=5)]
+        second = [c["id"] for c in rr.rerank("q", chunks, top_k=5)]
+        assert first == second
+
+    def test_respects_top_k(self):
+        chunks = make_chunks("a", "b", "c", "d", "e")
+        result = MockReranker().rerank("q", chunks, top_k=2)
+        assert len(result) == 2
+
+    def test_scores_sorted_descending(self):
+        chunks = make_chunks("a", "b", "c", "d")
+        result = MockReranker().rerank("q", chunks, top_k=10)
+        scores = [c["rerank_score"] for c in result]
+        assert scores == sorted(scores, reverse=True)
+
+
+# ---------------------------------------------------------------------------
+# LLMReranker
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestLLMReranker:
+    """LLM-driven reranking with an injected fake client."""
+
+    def test_reorders_by_llm_scores(self, config):
+        # Incoming order a, b, c; LLM says c > a > b.
+        chunks = make_chunks("a", "b", "c")
+        client = FakeClient(content='{"a": 5, "b": 1, "c": 9}')
+        result = LLMReranker(config, client=client).rerank("q", chunks, top_k=3)
+        assert [c["id"] for c in result] == ["c", "a", "b"]
+
+    def test_attaches_rerank_score(self, config):
+        chunks = make_chunks("a", "b")
+        client = FakeClient(content='{"a": 7, "b": 2}')
+        result = LLMReranker(config, client=client).rerank("q", chunks, top_k=2)
+        assert result[0]["rerank_score"] == 7.0
+        assert result[1]["rerank_score"] == 2.0
+
+    def test_respects_top_k(self, config):
+        chunks = make_chunks("a", "b", "c", "d")
+        client = FakeClient(content='{"a": 1, "b": 2, "c": 3, "d": 4}')
+        result = LLMReranker(config, client=client).rerank("q", chunks, top_k=2)
+        assert [c["id"] for c in result] == ["d", "c"]
+
+    def test_missing_id_defaults_to_zero_and_sorts_last(self, config):
+        chunks = make_chunks("a", "b", "c")
+        # LLM omits "c"; it should default to 0 and rank last.
+        client = FakeClient(content='{"a": 4, "b": 8}')
+        result = LLMReranker(config, client=client).rerank("q", chunks, top_k=3)
+        assert [c["id"] for c in result] == ["b", "a", "c"]
+        assert result[-1]["rerank_score"] == 0.0
+
+    def test_parses_json_wrapped_in_prose(self, config):
+        chunks = make_chunks("a", "b")
+        client = FakeClient(content='Here are the scores:\n```json\n{"a": 2, "b": 9}\n```\nDone.')
+        result = LLMReranker(config, client=client).rerank("q", chunks, top_k=2)
+        assert [c["id"] for c in result] == ["b", "a"]
+
+    def test_malformed_json_falls_back_to_input_order(self, config):
+        chunks = make_chunks("a", "b", "c")
+        client = FakeClient(content="not json at all")
+        result = LLMReranker(config, client=client).rerank("q", chunks, top_k=3)
+        assert [c["id"] for c in result] == ["a", "b", "c"]
+
+    def test_empty_content_falls_back_to_input_order(self, config):
+        chunks = make_chunks("a", "b")
+        client = FakeClient(content=None)
+        result = LLMReranker(config, client=client).rerank("q", chunks, top_k=2)
+        assert [c["id"] for c in result] == ["a", "b"]
+
+    def test_client_exception_falls_back_to_input_order(self, config):
+        chunks = make_chunks("a", "b", "c")
+        client = FakeClient(exc=RuntimeError("API down"))
+        result = LLMReranker(config, client=client).rerank("q", chunks, top_k=3)
+        assert [c["id"] for c in result] == ["a", "b", "c"]
+
+    def test_empty_returns_empty_without_calling_llm(self, config):
+        client = FakeClient(content='{"a": 1}')
+        result = LLMReranker(config, client=client).rerank("q", [], top_k=5)
+        assert result == []
+        assert client.chat.completions.calls == []
+
+    def test_single_chunk_returned_without_calling_llm(self, config):
+        client = FakeClient(content='{"a": 1}')
+        chunks = make_chunks("a")
+        result = LLMReranker(config, client=client).rerank("q", chunks, top_k=5)
+        assert [c["id"] for c in result] == ["a"]
+        assert client.chat.completions.calls == []
+
+    def test_passes_model_and_temperature_to_client(self, config):
+        chunks = make_chunks("a", "b")
+        client = FakeClient(content='{"a": 1, "b": 2}')
+        LLMReranker(config, client=client).rerank("q", chunks, top_k=2)
+        call = client.chat.completions.calls[0]
+        assert call["model"] == "test-model"
+        assert call["temperature"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# get_reranker factory
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestGetReranker:
+    def test_mock_provider_returns_mock_reranker(self):
+        assert isinstance(get_reranker("mock"), MockReranker)
+
+    def test_mock_provider_case_insensitive(self):
+        assert isinstance(get_reranker("  MOCK  "), MockReranker)
+
+    def test_real_provider_returns_llm_reranker(self, config):
+        assert isinstance(get_reranker("openai", config), LLMReranker)
+
+    def test_real_provider_without_config_raises(self):
+        with pytest.raises(ValueError):
+            get_reranker("openai")
+
+    def test_returned_rerankers_are_reranker_instances(self, config):
+        assert isinstance(get_reranker("mock"), Reranker)
+        assert isinstance(get_reranker("openai", config), Reranker)


### PR DESCRIPTION
## Summary
<!-- One paragraph describing what this PR does and why --> This PR provides code additions and edits which contributes  the addition of a light-weight LLM ranker which will go above this current chunk retrieval layer, organizing top chunks by relevance. This also includes a mock reranker for use if API is inaccessible and a test suite to ensure that this new feature runs smoothly.

## Issue
Closes #34 

## Changes
<!-- Bullet list of the specific changes made -->
- added `rag/retriever/reranker.py` which includes the functionality for the LLM-powered reranking layer in the chuncking section of the RAG agent.
- edited `rag/retriever/hybrid.py` to incorporate the newly added reranker into the chunk retrieval pipeline.
- added `tests\unit\test_reranker.py`, a test suite specific to this new reranker feature.
- Added documentation of what is added and my process in the files `PLAN.md` and `JOURNAL.md`.
## Testing
<!-- How did you verify your changes? -->
- [X] Unit tests pass (`make test-unit`)
- [X] Integration tests pass (`make test-integration`)
- [X] Linter passes (`make lint`)
- [X] Type checker passes (`make typecheck`)
- [X] New/updated tests cover the changes

## Screenshots / Demo
<!-- If applicable, add screenshots or a link to a demo video -->
N/A

## Notes for Reviewers
<!-- Anything the reviewer should pay particular attention to -->
There seemed to be some issues that were picked on the tests, but these were there before and are unrelated to my issue. I just made sure everything passed as initial presented suggesting my added feature did not create any new issues beyond what may have already been present.
