### PR TITLE
Fix/154 sqlalchemy healthcheck

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,42 +1,151 @@
-## Week 7 � Issue selection
+## Week 7 — Issue selection
 
-**Issue link:** https://github.com/ascherj/pathreview/issues/116
+**Issue link:** https://github.com/ascherj/pathreview/issues/154
 
-**Issue title:** SETUP.md is missing Docker Compose startup instructions for Windows users
+**Issue title:** Health check DB probe passes a raw SQL string, which fails under SQLAlchemy 2.x
 
 **Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
 
 **Problem summary:**
-SETUP.md currently assumes a Unix-like environment and doesn't account for
-Windows-specific setup steps. Windows users following the guide as written
-will hit several silent failure points: make isn't available by default in
-PowerShell and requires a separate install, Docker Desktop must be manually
-launched (the CLI alone doesn't start the engine), and there's no guidance on
-verifying containers are healthy before running migrations. Without these
-details, new contributors on Windows can lose significant time debugging
-errors (like Postgres authentication failures) that are actually just
-symptoms of Docker not being started yet. A successful fix would add a
-Windows-specific subsection to SETUP.md covering make installation,
-launching Docker Desktop, and confirming docker compose ps shows all
-services healthy before proceeding.
+The `GET /health` endpoint probes PostgreSQL with `await db.execute("SELECT 1")`,
+passing a bare Python string. SQLAlchemy 1.x coerced textual SQL implicitly, but
+SQLAlchemy 2.x — which this project pins at 2.0.51 — removed that coercion and
+raises `ArgumentError: Textual SQL expression 'SELECT 1' should be explicitly
+declared as text('SELECT 1')`. Because every probe in the handler is wrapped in a
+broad `except Exception`, the `ArgumentError` is swallowed and recorded as a
+dependency failure rather than surfacing as a crash. The endpoint therefore
+reports `postgres: unhealthy` and returns HTTP 503 even when the database is
+perfectly reachable. The failure mode is a false negative, so any infrastructure
+monitor pointed at `/health` treats the service as permanently down. A successful
+fix wraps the statement in `sqlalchemy.text()` so the probe executes and the
+endpoint returns 200 with `postgres: healthy` against a live database.
 
-**Branch name:** docs/116-windows-docker-setup-instructions
+**Branch name:** fix/154-sqlalchemy-healthcheck
 
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [ ] Issue added to cohort ledger
 
 
-## Week 8 � Reproduction & solution planning
+## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** https://github.com/gholapksh/pathreview/commit/e273ba5
+**Reproduction commit link:** https://github.com/gholapksh/pathreview/commit/53a0084
 
 **Reproduction summary:**
-I reproduced the documentation gap by executing the SETUP.md steps natively in Windows PowerShell. The environment immediately failed due to the missing make command, and database connection errors occurred because the guide lacks instructions to manually initialize and verify the Docker Desktop engine state before running migrations.
+I reproduced the defect two ways. First, by reading `core/database.py` and
+confirming the injected session is a SQLAlchemy 2.x `AsyncSession` built by
+`async_sessionmaker`, which is what makes the strict-construct requirement apply
+to `db.execute()`. Second, and more usefully, I captured the failure as an
+automated test: `test_postgres_probe_wraps_sql_in_text_construct` asserts the
+probe is called with a `TextClause` rather than a `str`. I verified this is a
+genuine regression guard by reverting the production fix and re-running the
+module — that one test fails with the fix removed and passes with it restored,
+while the other four continue to pass. I also grepped the codebase for
+`.execute("...")` to confirm this was the only raw-string call site, so the fix
+had a blast radius of exactly one line.
 
-**PLAN.md link:** https://github.com/gholapksh/pathreview/blob/docs/116-windows-docker-setup-instructions/PLAN.md
+**PLAN.md link:** https://github.com/gholapksh/pathreview/blob/fix/154-sqlalchemy-healthcheck/PLAN.md
 
-**Walkthrough video (recommended):** [Not recorded for this turn]
+**Walkthrough video (recommended):** [Not recorded]
 
 **Blockers or open questions:**
-None at the moment. The path forward for updating the documentation layout is clear.
+My local environment was broken in a way unrelated to the issue: `.venv` had been
+created from inside WSL, so `pyvenv.cfg` pointed at `/usr/bin` and every
+`.venv/Scripts/*.exe` launcher on the Windows side failed. I could not run `make`
+targets natively. Resolved by running all `make` and `pytest` invocations through
+`wsl.exe -d Ubuntu`, where the venv interpreter resolves correctly.
+
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+All five steps in PLAN.md are complete. The production fix is committed
+(`e34089c`): `api/routes/health.py` now imports `text` from `sqlalchemy` and
+wraps the probe statement, and I confirmed via grep that this was the only
+raw-string `execute()` call in the repository. The test module is committed
+(`53a0084`) with five unit tests, and I validated the regression guard by
+reverting the fix and watching that specific test fail.
+
+Two environment problems had to be cleared first. The `.venv` was created inside
+WSL, so its Windows launchers were dead; I now run every `make`/`pytest`
+invocation through WSL. The `pre-commit` hook was also unusable — it had CRLF
+line terminators (so WSL could not exec `/bin/sh\r`) and its `INSTALL_PYTHON`
+pointed at the broken Windows interpreter. I reinstalled it from WSL, which
+restored LF endings and a working interpreter path.
+
+**Next steps:**
+Finish documenting the pre-existing repository failures in the PR description,
+push the branch, and open the PR for peer review.
+
+**Blockers:**
+The `pre-commit` hook cannot pass on `api/routes/health.py` for reasons that
+predate my change: `B008` (`Depends` in an argument default) and seven mypy
+`[index]`/`[no-untyped-def]` errors. `B008` occurs 18 times across three route
+files, so it is settled convention in this codebase rather than a defect in my
+change; fixing it in `health.py` alone would make that file inconsistent with its
+siblings and would turn a tier-1 one-line fix into a typing refactor. I committed
+with `--no-verify` and documented these pre-existing failures in the PR instead.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** <!-- TODO: paste the PR URL here after opening it from the compare link -->
+
+**Branch:** `fix/154-sqlalchemy-healthcheck`
+
+**What you built:**
+`api/routes/health.py` now wraps its PostgreSQL probe statement in
+`sqlalchemy.text()`, so `await db.execute(text("SELECT 1"))` executes correctly
+under SQLAlchemy 2.x instead of raising `ArgumentError`. Because the handler
+catches all exceptions per dependency, that error was previously being reported
+as a dependency outage, which made `/health` return HTTP 503 with
+`postgres: unhealthy` against a fully reachable database. The endpoint now
+returns 200 when the database is up and reserves 503 for genuine outages.
+
+**Tests added or updated:**
+Added `tests/unit/test_health.py` — a new module, since this route had no unit
+coverage. Five tests: the probe receives a `TextClause` rather than a `str` (the
+regression guard for #154, verified to fail without the fix); the statement is
+still exactly `SELECT 1`; a reachable database yields an overall healthy
+response; an unreachable database raises HTTP 503; and the 503 body attributes
+the failure to `postgres` specifically. Tests follow the existing conventions in
+`tests/unit/` — `@pytest.mark.unit` on the class, `@pytest.mark.asyncio` per
+async test, and `AsyncMock` fixtures declared inside the class.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+Both are true in the "no new failures" sense the assignment defines, because this
+repository has substantial pre-existing failures on `main`:
+
+| Check | Baseline on `main` | With my changes |
+|---|---|---|
+| `make test-unit` | 53 failed, 375 passed | 53 failed, 380 passed |
+| `ruff check .` | 182 errors | 182 errors |
+| `black --check .` | 52 files would reformat | 52 files would reformat |
+| `mypy` (make target) | 5 errors | 5 errors |
+
+The same 53 tests fail before and after; the delta of +5 passing is exactly the
+tests I added. Within the two files I touched, my changes strictly improve
+things: `api/routes/health.py` went from 4 ruff errors to 1 (only the pre-existing
+`B008`), and `tests/unit/test_health.py` is clean on both ruff and black.
+
+One process note worth recording: my three tests were originally being silently
+deselected by `make test-unit` because they lacked the `@pytest.mark.unit` marker
+that `-m unit` filters on. They reported as "3 deselected" rather than as a
+failure, so they looked fine while never executing — and two of them were in fact
+broken, using `patch(..., create=True)` against a Pydantic model, which raises
+`AttributeError` during teardown. Adding the marker surfaced the real failures and
+I rewrote the module around a mock settings object.
+
+**Draft PR feedback received from:** none
+
+**Out of scope, but found while working:**
+`health_check` reads `settings.redis_host` and `settings.redis_port`, but
+`core/config.py` only defines `redis_url`. The Redis probe therefore always
+raises `AttributeError` and reports unhealthy. This is a separate defect from
+#154 and I left the production code untouched; the tests substitute a mock
+settings object so the Postgres probe can be tested in isolation rather than
+papering over the bug. Worth filing as its own issue.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,27 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/116
+
+**Issue title:** SETUP.md is missing Docker Compose startup instructions for Windows users
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+SETUP.md currently assumes a Unix-like environment and doesn't account for
+Windows-specific setup steps. Windows users following the guide as written
+will hit several silent failure points: make isn't available by default in
+PowerShell and requires a separate install, Docker Desktop must be manually
+launched (the CLI alone doesn't start the engine), and there's no guidance on
+verifying containers are healthy before running migrations. Without these
+details, new contributors on Windows can lose significant time debugging
+errors (like Postgres authentication failures) that are actually just
+symptoms of Docker not being started yet. A successful fix would add a
+Windows-specific subsection to SETUP.md covering make installation,
+launching Docker Desktop, and confirming docker compose ps shows all
+services healthy before proceeding.
+
+**Branch name:** docs/116-windows-docker-setup-instructions
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,4 +1,4 @@
-## Week 7 — Issue selection
+## Week 7 ï¿½ Issue selection
 
 **Issue link:** https://github.com/ascherj/pathreview/issues/116
 
@@ -25,3 +25,18 @@ services healthy before proceeding.
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [ ] Issue added to cohort ledger
+
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/gholapksh/pathreview/commit/e273ba5
+
+**Reproduction summary:**
+I reproduced the documentation gap by executing the SETUP.md steps natively in Windows PowerShell. The environment immediately failed due to the missing make command, and database connection errors occurred because the guide lacks instructions to manually initialize and verify the Docker Desktop engine state before running migrations.
+
+**PLAN.md link:** https://github.com/gholapksh/pathreview/blob/docs/116-windows-docker-setup-instructions/PLAN.md
+
+**Walkthrough video (recommended):** [Not recorded for this turn]
+
+**Blockers or open questions:**
+None at the moment. The path forward for updating the documentation layout is clear.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -149,3 +149,85 @@ raises `AttributeError` and reports unhealthy. This is a separate defect from
 #154 and I left the production code untouched; the tests substitute a mock
 settings object so the Postgres probe can be tested in isolation rather than
 papering over the bug. Worth filing as its own issue.
+
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No reviewer feedback has come in. Per the Su26 course note, reviewer feedback
+isn't a feature this term, so I did not receive maintainer comments on the PR.
+
+**How you responded:**
+N/A — no feedback arrived to respond to.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The actual production fix — one line, wrapping a string in `text()` — took
+about five minutes to identify and implement. Almost everything else took
+hours: figuring out why my `.venv` was unusable from PowerShell, discovering
+my own tests weren't even running (they were silently "deselected" instead
+of failing, which is a much scarier failure mode than an obvious red X),
+and untangling that Weeks 7–8 of my own paperwork had been written against
+the wrong issue entirely. I expected the hard part of this module to be
+understanding someone else's code. It turned out to be understanding my
+own environment and my own prior work well enough to trust it.
+
+**What did you learn about working in a large codebase?**
+The biggest lesson was that "passing" isn't a binary in a codebase with
+pre-existing debt. `main` already had 53 failing tests, 182 lint errors,
+and 52 files that would be reformatted by the formatter. If I'd run
+`make check` naively and looked for a clean pass, I'd have concluded my
+change was catastrophic. The real question wasn't "does everything pass"
+but "did I make anything worse" — which meant I had to establish a
+baseline *before* touching anything and diff against it afterward. I also
+learned that conventions I might personally disagree with (like `Depends()`
+in a function default, which `mypy`/`ruff` flag) can be load-bearing
+project-wide decisions — it showed up 18 times across three files, so
+"fixing" it in the one file I touched would have made my file inconsistent
+with its neighbors instead of more correct.
+
+**How did AI tools help — and where did they fall short?**
+AI assistance (Claude Code) was most useful for the mechanical
+forensics: grepping for every raw-string `.execute()` call to confirm the
+bug's blast radius, running the same test file under three different
+"before/after" states to prove the regression test was real and not just
+coincidentally green, and catching that my tests were being deselected
+rather than passing. That's the kind of tedious, easy-to-skip verification
+that's easy for a human to hand-wave past under time pressure.
+
+Where it fell short was judgment calls that needed my sign-off rather than
+just execution: whether to commit with `--no-verify` given pre-existing
+lint/type failures, whether to keep or discard automatic `ruff --fix`
+changes, and which of my two conflicting branches (#116 docs vs. #154 code)
+was actually the real deliverable. AI could lay out the tradeoffs clearly,
+but it explicitly stopped and asked rather than deciding for me — which in
+retrospect was the right call, because those were project-management
+decisions about *my* submission, not code-correctness decisions.
+
+**What would you do differently if you started over?**
+I'd fix my environment (the WSL/Windows venv mismatch and the broken
+`pre-commit` hook) in Week 7, before writing any code, instead of
+discovering it in Week 9 while trying to run tests under time pressure.
+I'd also add `@pytest.mark.unit` to my tests the moment I wrote them,
+since silently-skipped tests are worse than failing tests — they give you
+false confidence. And I'd keep my JOURNAL.md and PLAN.md in sync with my
+actual working branch from day one; letting the paperwork drift onto a
+different issue than my code cost me a full afternoon of retroactive
+reconciliation.
+
+**What are you most proud of from this module?**
+Catching that two of my three original unit tests were broken —
+using `patch(..., create=True)` against a Pydantic model, which raises
+`AttributeError` during teardown — and that all three had been silently
+skipped by the test runner the whole time. It would have been very easy to
+see "tests exist in the repo" and assume the job was done. Actually
+verifying the regression guard by deliberately reverting my fix and
+watching the right test (and only that test) turn red is the habit I'm
+most glad I built this module.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -123,7 +123,7 @@ repository has substantial pre-existing failures on `main`:
 | Check | Baseline on `main` | With my changes |
 |---|---|---|
 | `make test-unit` | 53 failed, 375 passed | 53 failed, 380 passed |
-| `ruff check .` | 182 errors | 182 errors |
+| `ruff check .` | 182 errors | 179 errors |
 | `black --check .` | 52 files would reformat | 52 files would reformat |
 | `mypy` (make target) | 5 errors | 5 errors |
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,28 +1,65 @@
 ## Solution plan
 
-**Issue:** [SETUP.md is missing Docker Compose startup instructions for Windows users](https://github.com/ascherj/pathreview/issues/116)
+**Issue:** [Health check DB probe passes a raw SQL string, which fails under SQLAlchemy 2.x](https://github.com/ascherj/pathreview/issues/154)
 
 ### Understand
-The root cause is that SETUP.md assumes a Unix-like shell environment and that the Docker daemon is implicitly active. On Windows (native PowerShell), make is completely unavailable by default, leading to immediate command-not-found errors. Additionally, Docker Desktop must be manually initiated by the user; otherwise, subsequent commands silently fail or throw obscure connection errors. The expected behavior is a seamless onboarding experience for Windows users; the actual behavior is an immediate blocker at the environment spin-up stage.
+The `GET /health` endpoint probes PostgreSQL by calling `await db.execute("SELECT 1")` with a
+bare Python string. SQLAlchemy 1.x accepted this and coerced it implicitly, but SQLAlchemy 2.x
+(the project pins 2.0.51) removed that coercion: `Connection.execute()` and
+`AsyncSession.execute()` now require an executable construct and raise
+`ArgumentError: Textual SQL expression 'SELECT 1' should be explicitly declared as text('SELECT 1')`.
+
+Because the probe is wrapped in a broad `except Exception`, the `ArgumentError` is swallowed and
+recorded as a dependency failure rather than surfacing as a crash. The endpoint therefore reports
+`postgres: unhealthy` and returns HTTP 503 even when the database is fully reachable — the failure
+mode is a false negative, not an outage. Any infrastructure monitor pointed at `/health` treats the
+service as permanently down.
+
+Expected behaviour: the probe succeeds against a reachable database and the endpoint returns HTTP 200
+with `postgres: healthy`. Actual behaviour: the probe always raises, and the endpoint always returns 503.
 
 ### Map
 Files to be modified:
-* SETUP.md � The main markdown onboarding guide where the new Windows subsection and troubleshooting tips will live.
+* `api/routes/health.py` — the `health_check` handler containing the PostgreSQL probe.
+* `tests/unit/test_health.py` — new test module; no unit tests covered this route previously.
+
+Files inspected but deliberately not changed:
+* `core/database.py` — confirmed the session is a SQLAlchemy 2.x `AsyncSession` from
+  `async_sessionmaker`, which is what makes the strict-construct requirement apply.
+* `core/config.py` — confirmed a separate latent bug (see Risks) that is out of scope here.
 
 ### Plan
-1. **Document make alternatives for Windows:** Research and add instructions for installing make via Windows package managers (winget or choco) or document the raw docker compose equivalents so users can bypass make entirely.
-2. **Add Docker Desktop lifecycle steps:** Insert explicit visual cues/instructions to launch the Docker Desktop GUI application and wait for the "Engine Running" status indicator before using the terminal.
-3. **Draft a service health verification step:** Provide instructions to use docker compose ps to verify that the Postgres database and app containers are fully healthy before running migrations.
-4. **Test and refine layout:** Review the Markdown layout inside SETUP.md to ensure clear visual separation (e.g., using tabs or clean headers) so Unix users aren't confused by Windows steps and vice versa.
+1. **Import the `text` construct:** add `from sqlalchemy import text` to `api/routes/health.py`.
+2. **Wrap the probe SQL:** change `await db.execute("SELECT 1")` to `await db.execute(text("SELECT 1"))`.
+3. **Confirm the blast radius is one call site:** grep the codebase for other `.execute("...")`
+   calls passing raw strings so the same defect isn't left elsewhere.
+4. **Add a regression test module:** create `tests/unit/test_health.py` asserting the probe is called
+   with a `TextClause` rather than a `str`, plus coverage of the healthy path and the 503 failure path.
+5. **Prove the test is a real guard:** revert the production fix, confirm the regression test fails,
+   then restore the fix and confirm it passes.
 
 ### Inputs & outputs
-* **Inputs:** Raw setup commands executed in a standard native Windows PowerShell environment.
-* **Outputs:** An updated, robust SETUP.md file that guides a Windows user from a fresh clone to a fully operational local setup at localhost:5173 with zero unguided errors.
+* **Inputs:** a `GET /health` request with an async DB session injected via `Depends(get_db)`.
+* **Outputs:** HTTP 200 with `status: healthy` and `dependencies.postgres: healthy` when the database
+  is reachable; HTTP 503 with `dependencies.postgres: unhealthy` only when it genuinely is not.
 
 ### Risks & unknowns
-* **Execution Policies:** Some Windows users have restrictive PowerShell Execution Policies that might block package manager installations or custom scripts. 
-* **WSL vs. Native PowerShell:** Windows users might try to mix WSL (Windows Subsystem for Linux) environments with native PowerShell paths, which could cause Docker socket binding conflicts. I need to make sure my instructions explicitly state they apply to native Windows host setups.
+* **Broad exception handling hides the real error.** The `except Exception` around each probe means a
+  programming error (like this one) is indistinguishable from a dependency outage in the response
+  body. Narrowing it would improve diagnosability but changes response semantics, so it is out of
+  scope for a tier-1 fix.
+* **Latent second bug in the Redis probe.** `health_check` reads `settings.redis_host` and
+  `settings.redis_port`, but `core/config.py` only defines `redis_url`. The Redis probe therefore
+  always raises `AttributeError` and reports unhealthy. This is a separate defect from #154 and is
+  left untouched; the unit tests substitute a mock settings object so the Postgres probe can be
+  tested in isolation rather than papering over it in production code.
+* **Pre-existing repository failures.** `make check` and `make test-unit` already fail on `main` for
+  unrelated reasons, so "passing" here means introducing no new failures.
 
 ### Edge cases
-* **Docker Engine not running:** The guide must handle the scenario where the user runs the startup commands while Docker Desktop is closed, explicitly detailing the expected error message and fix.
-* **Port conflicts:** If a Windows user already has a local instance of PostgreSQL running natively on port 5432, the Docker container will fail to bind. I should add a quick troubleshooting note for identifying and stopping conflicting local services.
+* **Database genuinely unreachable:** the endpoint must still report 503 — the fix must not turn a
+  real outage into a false healthy. Covered by `test_raises_503_when_postgres_probe_fails`.
+* **Failing dependency correctly attributed:** the 503 body must name Postgres specifically rather
+  than reporting a generic failure. Covered by `test_503_detail_reports_postgres_unhealthy`.
+* **SQL text preserved:** wrapping in `text()` must not alter the statement sent to the database.
+  Covered by `test_postgres_probe_executes_select_1`.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,28 @@
+## Solution plan
+
+**Issue:** [SETUP.md is missing Docker Compose startup instructions for Windows users](https://github.com/ascherj/pathreview/issues/116)
+
+### Understand
+The root cause is that SETUP.md assumes a Unix-like shell environment and that the Docker daemon is implicitly active. On Windows (native PowerShell), make is completely unavailable by default, leading to immediate command-not-found errors. Additionally, Docker Desktop must be manually initiated by the user; otherwise, subsequent commands silently fail or throw obscure connection errors. The expected behavior is a seamless onboarding experience for Windows users; the actual behavior is an immediate blocker at the environment spin-up stage.
+
+### Map
+Files to be modified:
+* SETUP.md — The main markdown onboarding guide where the new Windows subsection and troubleshooting tips will live.
+
+### Plan
+1. **Document make alternatives for Windows:** Research and add instructions for installing make via Windows package managers (winget or choco) or document the raw docker compose equivalents so users can bypass make entirely.
+2. **Add Docker Desktop lifecycle steps:** Insert explicit visual cues/instructions to launch the Docker Desktop GUI application and wait for the "Engine Running" status indicator before using the terminal.
+3. **Draft a service health verification step:** Provide instructions to use docker compose ps to verify that the Postgres database and app containers are fully healthy before running migrations.
+4. **Test and refine layout:** Review the Markdown layout inside SETUP.md to ensure clear visual separation (e.g., using tabs or clean headers) so Unix users aren't confused by Windows steps and vice versa.
+
+### Inputs & outputs
+* **Inputs:** Raw setup commands executed in a standard native Windows PowerShell environment.
+* **Outputs:** An updated, robust SETUP.md file that guides a Windows user from a fresh clone to a fully operational local setup at localhost:5173 with zero unguided errors.
+
+### Risks & unknowns
+* **Execution Policies:** Some Windows users have restrictive PowerShell Execution Policies that might block package manager installations or custom scripts. 
+* **WSL vs. Native PowerShell:** Windows users might try to mix WSL (Windows Subsystem for Linux) environments with native PowerShell paths, which could cause Docker socket binding conflicts. I need to make sure my instructions explicitly state they apply to native Windows host setups.
+
+### Edge cases
+* **Docker Engine not running:** The guide must handle the scenario where the user runs the startup commands while Docker Desktop is closed, explicitly detailing the expected error message and fix.
+* **Port conflicts:** If a Windows user already has a local instance of PostgreSQL running natively on port 5432, the Docker container will fail to bind. I should add a quick troubleshooting note for identifying and stopping conflicting local services.

--- a/api/routes/health.py
+++ b/api/routes/health.py
@@ -1,6 +1,8 @@
-from fastapi import APIRouter, HTTPException, status, Depends
+from datetime import datetime
+
 import structlog
-from datetime import datetime, timedelta
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import text
 
 from core.database import get_db
 
@@ -28,7 +30,7 @@ async def health_check(db=Depends(get_db)):
 
     try:
         # Check PostgreSQL
-        await db.execute("SELECT 1")
+        await db.execute(text("SELECT 1"))
         health_status["dependencies"]["postgres"] = "healthy"
         log.debug("postgres_health_check_passed")
     except Exception as exc:
@@ -39,6 +41,7 @@ async def health_check(db=Depends(get_db)):
     try:
         # Check Redis (if available)
         import redis
+
         from core.config import settings
 
         r = redis.Redis(

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -1,0 +1,100 @@
+"""Tests for the /health endpoint dependency probes."""
+
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import TextClause
+
+from api.routes.health import health_check
+
+
+@pytest.mark.unit
+class TestHealthCheck:
+    """Test suite for the health_check route handler."""
+
+    @pytest.fixture
+    def mock_db_session(self):
+        """Create a mock async database session."""
+        session = AsyncMock()
+        session.execute = AsyncMock()
+        return session
+
+    @pytest.fixture
+    def mock_settings(self):
+        """Create a stand-in for core.config.settings used by the probes.
+
+        ``health_check`` imports ``settings`` inside the request body, so
+        patching the module attribute is enough to intercept it.
+        """
+        settings = Mock()
+        settings.redis_host = "localhost"
+        settings.redis_port = 6379
+        settings.vector_db_url = "http://localhost:8001"
+        return settings
+
+    @pytest.fixture
+    def healthy_dependencies(self, mock_settings):
+        """Patch Redis and settings so Postgres is the only probe under test."""
+        with patch("core.config.settings", mock_settings), patch("redis.Redis") as mock_redis_cls:
+            mock_redis_cls.return_value.ping = Mock(return_value=True)
+            yield mock_redis_cls
+
+    @pytest.mark.asyncio
+    async def test_postgres_probe_wraps_sql_in_text_construct(
+        self, mock_db_session, healthy_dependencies
+    ):
+        """Regression test for #154: the probe must pass a text() construct.
+
+        SQLAlchemy 2.x rejects a bare string with ArgumentError, which made the
+        endpoint report a reachable database as down.
+        """
+        await health_check(db=mock_db_session)
+
+        mock_db_session.execute.assert_called_once()
+        call_arg = mock_db_session.execute.call_args[0][0]
+        assert isinstance(call_arg, TextClause)
+        assert not isinstance(call_arg, str)
+
+    @pytest.mark.asyncio
+    async def test_postgres_probe_executes_select_1(self, mock_db_session, healthy_dependencies):
+        """Test the probe still issues SELECT 1 after being wrapped in text()."""
+        await health_check(db=mock_db_session)
+
+        call_arg = mock_db_session.execute.call_args[0][0]
+        assert str(call_arg) == "SELECT 1"
+
+    @pytest.mark.asyncio
+    async def test_returns_healthy_when_all_probes_succeed(
+        self, mock_db_session, healthy_dependencies
+    ):
+        """Test a reachable database yields an overall healthy response."""
+        result = await health_check(db=mock_db_session)
+
+        assert result["status"] == "healthy"
+        assert result["dependencies"]["postgres"] == "healthy"
+
+    @pytest.mark.asyncio
+    async def test_raises_503_when_postgres_probe_fails(
+        self, mock_db_session, healthy_dependencies
+    ):
+        """Test an unreachable database surfaces as HTTP 503."""
+        mock_db_session.execute = AsyncMock(side_effect=Exception("connection refused"))
+
+        with pytest.raises(HTTPException) as exc_info:
+            await health_check(db=mock_db_session)
+
+        assert exc_info.value.status_code == 503
+
+    @pytest.mark.asyncio
+    async def test_503_detail_reports_postgres_unhealthy(
+        self, mock_db_session, healthy_dependencies
+    ):
+        """Test the 503 body identifies Postgres as the failing dependency."""
+        mock_db_session.execute = AsyncMock(side_effect=Exception("connection refused"))
+
+        with pytest.raises(HTTPException) as exc_info:
+            await health_check(db=mock_db_session)
+
+        assert exc_info.value.detail["status"] == "unhealthy"
+        assert exc_info.value.detail["dependencies"]["postgres"] == "unhealthy"


### PR DESCRIPTION
## Summary

The `GET /health` endpoint probed PostgreSQL with `await db.execute("SELECT 1")`, passing a bare Python string. SQLAlchemy 1.x coerced textual SQL implicitly, but SQLAlchemy 2.x (pinned here at 2.0.51) removed that coercion and raises `ArgumentError: Textual SQL expression 'SELECT 1' should be explicitly declared as text('SELECT 1')`. Because each dependency probe in the handler is wrapped in a broad `except Exception`, that `ArgumentError` was swallowed and recorded as a dependency failure rather than surfacing as a crash — so the endpoint reported `postgres: unhealthy` and returned HTTP 503 even when the database was fully reachable. The failure mode was a false negative, meaning any infrastructure monitor pointed at `/health` treated the service as permanently down. This PR wraps the statement in `sqlalchemy.text()` and adds unit test coverage for the route, which previously had none.

## Issue
Closes #154

## Changes
- `api/routes/health.py`: import `text` from `sqlalchemy` and wrap the probe statement as `await db.execute(text("SELECT 1"))`.
- `api/routes/health.py`: applied the repository's own `pre-commit` `ruff --fix` output to the touched file — sorted the two import blocks and removed the unused `timedelta` import. This drops the file from 4 ruff errors to 1.
- `tests/unit/test_health.py`: new test module (5 tests) covering the regression and the surrounding behaviour of the handler.
- `PLAN.md` / `JOURNAL.md`: coursework artifacts documenting the investigation.

I grepped the codebase for other raw-string `.execute("...")` calls to confirm the same defect wasn't present elsewhere — this was the only call site, so the production change is a single line.

## Testing

- [x] Unit tests pass (`make test-unit`) — *no new failures; see the baseline table below*
- [ ] Integration tests pass (`make test-integration`) — **not run**; these require live Docker services and I did not have them running. The change is covered at the unit level.
- [x] Linter passes (`make lint`) — *no new failures; the one remaining error in the touched file is pre-existing*
- [x] Type checker passes (`make typecheck`) — *no new failures*
- [x] New/updated tests cover the changes

### Pre-existing failures in this repository

This repository has substantial failures on `main` that are unrelated to this issue. I recorded a baseline before starting and re-ran everything afterward:

| Check | Baseline on `main` | With this PR |
|---|---|---|
| `make test-unit` | 53 failed, 375 passed | 53 failed, **380** passed |
| `ruff check .` | 182 errors | **179** errors |
| `black --check .` | 52 files would reformat | 52 files would reformat |
| `mypy` (`make typecheck` target) | 5 errors | 5 errors |

The same 53 tests fail before and after this change; the `+5` passing delta is exactly the tests added here. **These changes do not affect the pre-existing failures.**

Scoped to the two files this PR touches, the change is a net improvement:

| File | ruff | black |
|---|---|---|
| `api/routes/health.py` | 4 errors → **1** (pre-existing `B008`) | clean |
| `tests/unit/test_health.py` | clean | clean |

### Verifying the regression guard

I confirmed `test_postgres_probe_wraps_sql_in_text_construct` is a real guard rather than a test that merely passes: with the `text()` wrapper reverted, that test fails and the other four still pass. With the fix restored, all five pass.

## Screenshots / Demo

N/A — no user-facing surface. The behavioural change is the HTTP status and JSON body of `GET /health`.

## Notes for Reviewers

Three things worth your attention:

1. **Why `make check` was not run as-is.** The `check` target invokes `format`, which runs `black .` rather than `black --check .`. On this repository that rewrites 52 unrelated files. I ran `ruff`, `black --check`, and `mypy` individually and applied `black` only to the files in this PR, to keep the diff scoped.

2. **`--no-verify` was used to commit, deliberately.** The `pre-commit` hook cannot pass on `api/routes/health.py` for reasons that predate this change: `B008` (`Depends` in an argument default) plus seven mypy `[index]` / `[no-untyped-def]` errors. `B008` occurs **18 times across three route files** (`health.py`, `profiles.py`, `reviews.py`), so it is established convention in this codebase rather than a defect introduced here — silencing it in `health.py` alone would make that file inconsistent with its siblings and would expand a tier-1 one-line fix into a typing refactor. Happy to fold either in if you'd prefer.

3. **A separate latent bug I deliberately left alone.** `health_check` reads `settings.redis_host` and `settings.redis_port`, but `core/config.py` only defines `redis_url`. The Redis probe therefore always raises `AttributeError` and reports `redis: unhealthy`, independently of this issue. I did not touch it, as it is out of scope for #154 and deserves its own issue. It does shape the tests, though: rather than patching those non-existent attributes into place (which raises during teardown, since `Settings` is a Pydantic model), the tests substitute a mock settings object so the Postgres probe can be exercised in isolation. If you'd like, I can file that as a follow-up issue.
