### PR TITLE
fix(api): wrap health check DB probe in sqlalchemy.text()

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -46,3 +46,28 @@ endpoint returns 200 when the database is up.
 
 **Conclusion:** Good fit — clear cause, single-file change, easily tested, and
 independent of external services.
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/Prasanna401623/pathreview/commit/8de9e4b8953a0f84b4fc16ad5cc89ecb7430803b
+
+**Reproduction summary:**
+I added a focused unit test (`tests/unit/test_health_check.py`) using an
+in-memory SQLite engine on the app's own SQLAlchemy 2.0.51, and confirmed that
+`execute("SELECT 1")` raises `ObjectNotExecutableError: Not an executable
+object: 'SELECT 1'`, while `execute(text("SELECT 1"))` returns `1`. End-to-end,
+hitting `GET /health` locally returned HTTP 503 with `"postgres": "unhealthy"`
+even though the Docker database container was healthy — exactly the false
+"database down" report described in the issue.
+
+**PLAN.md link:** https://github.com/Prasanna401623/pathreview/blob/fix/154-health-check-db-probe/PLAN.md
+
+**Walkthrough video (recommended):** Not recorded (optional / not graded).
+
+**Blockers or open questions:**
+- The same endpoint has a separate bug (#155, `settings.redis_host`), so my
+  Week 9 test must assert specifically on the `postgres` dependency rather than
+  the overall 200, to avoid coupling to someone else's issue.
+- `aiosqlite` isn't installed, so I still need to decide how to drive the async
+  probe in a test — a FastAPI dependency override with a stub session, or an
+  integration test against the local Postgres.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,48 @@
+# PathReview — Module 3 Journal
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/154
+
+**Issue title:** Health check DB probe passes a raw SQL string, which fails under SQLAlchemy 2.x
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The `/health` endpoint checks that PostgreSQL is reachable by running
+`await db.execute("SELECT 1")`, passing the query as a plain Python string.
+SQLAlchemy 2.x no longer accepts raw string SQL in `execute()` — the statement
+must be wrapped in `sqlalchemy.text()` — so this call raises an error and the
+Postgres probe is reported as `unhealthy` even when the database is perfectly
+fine. Because any unhealthy dependency flips the overall status, the endpoint
+then returns HTTP 503, which can falsely trip uptime monitors and deployment
+health gates. A successful fix wraps the query in `text()` (and imports it) so
+the probe executes correctly and reports the true database status. The change
+is isolated to `api/routes/health.py`, backed by a unit test asserting the
+endpoint returns 200 when the database is up.
+
+**Branch name:** fix/154-health-check-db-probe
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger
+
+### Selection notes — "Is this right for me?" checklist
+
+- **Scope is small and well-bounded.** The defect and its fix live in a single
+  file (`api/routes/health.py`, line 31). I confirmed this by reading the file
+  directly rather than trusting the title.
+- **I understand the root cause.** SQLAlchemy 2.x removed implicit autocommit
+  and "plain string" execution; textual SQL must go through `text()`. This is a
+  well-documented, canonical migration issue, not an obscure edge case.
+- **The fix is verifiable.** I can prove the fix with a focused unit test on the
+  health endpoint (expect 200 + `postgres: "healthy"` when the DB is up), which
+  fits the project's "every change includes a test" standard.
+- **No hidden dependencies.** The fix doesn't touch the LLM/RAG/agent pipeline,
+  so it doesn't require an OpenRouter API key or model access to validate.
+- **Right difficulty for a first contribution.** Labeled `good first issue` /
+  `tier-1`, estimated at 1–2 hours, and it teaches a real, transferable lesson
+  about the SQLAlchemy 1.x → 2.x API change.
+
+**Conclusion:** Good fit — clear cause, single-file change, easily tested, and
+independent of external services.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -167,3 +167,153 @@ The most useful thing this week wasn't the one-line fix — it was discovering m
 Week 8 tests were both deselected *and* incapable of failing. "The tests pass"
 means nothing until you've watched them fail for the right reason. Reverting the
 fix to confirm the tests break is now a step I'll always do.
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No review came in. PR
+[ascherj/pathreview#869](https://github.com/ascherj/pathreview/pull/869) has been
+open since Aug 5 and is still `OPEN` with zero review comments and zero submitted
+reviews (`reviewDecision: REVIEW_REQUIRED`, no line comments, no maintainer
+reply). Per the Summer 2026 course note, reviewer feedback isn't part of this
+term, so this is the expected outcome rather than a stalled PR.
+
+**How you responded:**
+Nothing to respond to, so I did the next best thing and reviewed the PR against
+itself. I re-read my own diff cold, confirmed the branch still applies to
+`upstream/main` without conflict, and re-ran the verification I'd claimed in the
+PR description — reverting `api/routes/health.py` to `await db.execute("SELECT 1")`
+and watching 2 of the 6 tests in `tests/unit/test_health_check.py` fail, then
+restoring the fix and watching all 6 pass. I made no new commits to the fix
+itself; changing working code with no reviewer asking for it would only make the
+diff harder to review when someone does pick it up. The one thing I'd have
+pre-empted a reviewer on is already in the PR body: the before/after baseline
+table showing the repo's 182 ruff errors and 53 failing unit tests are unchanged
+by my branch, and the note that I committed with `--no-verify` because the
+project's own pre-commit hook cannot pass on that file.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Two things, neither of them the actual bug.
+
+The first was that the repository has no green baseline. I assumed "make check
+passes" was a state I could reach; it isn't. On an untouched clone, `make lint`
+reports 182 ruff errors, `make typecheck` reports 5, and `make test-unit` reports
+53 failures. So "my change is clean" had to be redefined as "my change introduces
+no new failures," which meant capturing a baseline *before* editing anything and
+diffing the sorted `FAILED` lines before and after. I didn't think to do that
+until Week 9, and if I'd edited first I would have had no way to prove which
+failures were mine. Worse, the project's own `pre-commit` hook cannot pass on
+`api/routes/health.py` — ruff flags `B008` for `Depends()` in an argument
+default, which is the standard FastAPI idiom, and mypy flags pre-existing untyped
+dicts. Deciding to commit with `--no-verify` and document it, rather than
+"fixing" a function my issue wasn't about, was a genuinely uncomfortable call.
+
+The second was discovering my Week 8 reproduction tests were worthless in two
+independent ways at once. They had no `@pytest.mark.unit` marker, so `make
+test-unit` (which runs `-m unit`) was silently deselecting them — they showed as
+`2 deselected` and had never once run in the suite. And even if they had run,
+they only exercised SQLAlchemy against a SQLite engine; they never imported
+`health.py`, so they would have passed identically whether or not the bug was
+fixed. I had written a test that could not fail. Nothing in the output told me
+this. I found it only because the deselection count looked wrong.
+
+The smaller surprise: `api/routes/health.py` contains *two* unrelated bugs. Mine
+(#154, the Postgres probe) and #155 (`settings.redis_host` doesn't exist on
+`Settings`), about ten lines apart. Because #155 independently forces the
+endpoint to 503, I couldn't write the obvious test — "assert `GET /health`
+returns 200." I had to assert on
+`health_status["dependencies"]["postgres"]` specifically, and leave a bug I could
+see and could have fixed in about two minutes completely alone.
+
+**What did you learn about working in a large codebase?**
+That the code is the easy part. My actual change is two lines: an import and a
+`text()` wrapper. Everything else — three weeks of it — was figuring out what
+"done" means in someone else's house.
+
+In my own projects I'm both the author and the standard. `CLAUDE.md` in my
+personal repo says ESLint and `tsc --noEmit` must be clean before every commit,
+and they are, because I wrote that rule and I've never let it rot. In PathReview
+the equivalent rule exists on paper and the repo has drifted a long way from it,
+and I don't get to decide that's unacceptable — I get to leave it exactly as I
+found it and prove I did. Contributing means your diff is judged relative to the
+repo's current state, not relative to ideal.
+
+Scope discipline turned out to be a real skill and not just etiquette. Fixing
+#155 while I was already in the file would have felt helpful and would have made
+my PR strictly worse: it would have mixed two issues, made the diff harder to
+review, and stepped on whoever was assigned #155. The instinct to "clean up while
+I'm here" is the right instinct in my own repo and the wrong one in someone
+else's.
+
+And the project's conventions are load-bearing and invisible. The pytest marker
+that decides whether your test runs at all isn't announced anywhere in the test
+file; it's a config detail you either notice or don't. I now read the Makefile
+and the pytest config before writing a single test, because they define what
+"running the tests" actually means.
+
+**How did AI tools help — and where did they fall short?**
+Most useful on the parts with a known right answer. The SQLAlchemy 1.x → 2.x
+migration — why bare strings stopped executing, what `ObjectNotExecutableError`
+means, that `text()` is the canonical fix — I got in a couple of minutes instead
+of half an hour of docs. It was also good at mechanical scaffolding: drafting the
+`StubAsyncSession` and `StubResult` shape, writing the docstrings, and helping me
+turn a wall of pytest output into a clean sorted diff of failures.
+
+Where it fell short is the more interesting half. In Week 8 the suggested testing
+paths were an in-memory async SQLite engine or a FastAPI dependency override —
+both reasonable in the abstract, and the first was flatly impossible because
+`aiosqlite` isn't installed in this project. That's the pattern: confident advice
+about a generic FastAPI app, not about *this* one. The stub-session approach I
+eventually used, which mimics SQLAlchemy 2.x's strictness by raising
+`ObjectNotExecutableError` on a bare string, came from reasoning about what my
+test actually needed to be capable of catching, and it's better than either
+suggestion because a regression to `execute("SELECT 1")` fails it loudly.
+
+Nothing flagged that my Week 8 tests were deselected, and nothing flagged that
+they were incapable of failing — the code looked like a test and read like a
+test. Only reverting the fix and watching what happened proved otherwise. Same
+with #155: recognizing that the second bug in the file was someone else's and
+that it had to change how I wrote my assertion was a judgment about the project
+and the cohort, not about the code. AI was a fast reference and a decent
+drafting partner; it was not a substitute for running the thing and for knowing
+where the boundaries of my change were.
+
+**What would you do differently if you started over?**
+Capture the baseline in Week 7, in the same sitting as the setup confirmation.
+Running `make check` and `make test-unit` on an untouched clone and saving the
+output takes five minutes and would have saved me a genuinely anxious hour in
+Week 9 wondering how many of those 53 failures I had caused.
+
+Write the reproduction test against the real function immediately. My Week 8
+"reproduction" proved that SQLAlchemy rejects bare strings, which is a fact about
+SQLAlchemy, not about PathReview. It should have imported `health_check` from day
+one. The rule I'd give my Week 8 self: if reverting the fix wouldn't break your
+test, you haven't reproduced anything.
+
+Run the project's own test command, not `pytest`, from the very first test. The
+marker problem was invisible under a bare `pytest` invocation and obvious under
+`make test-unit`.
+
+And I'd open the PR as a draft. I opened #869 ready-for-review because it *was*
+ready, which was technically correct and tactically wrong — a draft is the
+posture that actually invites a peer to look, and I gave up my one shot at
+feedback in exchange for nothing.
+
+**What are you most proud of from this module?**
+Catching that my own tests couldn't fail, and then proving the replacements
+could. It would have been very easy not to notice: the suite was green, the fix
+was correct, the PR would have looked identical from the outside. I'd have
+shipped a real fix guarded by a test that would never catch its regression, and
+felt fine about it. Instead I reverted `health.py` to the buggy line, confirmed
+that 2 of the 6 tests fail without the fix and all 6 pass with it, and wrote that
+verification into the PR description so a reviewer doesn't have to take my word
+for it. The two-line fix is the deliverable; knowing the difference between a
+test that passes and a test that works is the thing I actually took away.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -71,3 +71,99 @@ even though the Docker database container was healthy — exactly the false
 - `aiosqlite` isn't installed, so I still need to decide how to drive the async
   probe in a test — a FastAPI dependency override with a stub session, or an
   integration test against the local Postgres.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Sub-tasks 1, 2 and 4 from `PLAN.md` are done. I added
+`from sqlalchemy import text` to `api/routes/health.py` and changed the Postgres
+probe from `await db.execute("SELECT 1")` to `await db.execute(text("SELECT 1"))`,
+leaving the surrounding `try`/`except` intact so real outages are still reported.
+I also captured a **baseline** of `make check` and `make test-unit` on the
+unmodified file before touching anything, because the repo turned out to have a
+lot of pre-existing breakage (182 ruff errors, 53 failing unit tests) that has
+nothing to do with #154.
+
+Two things I found that weren't in the plan:
+- My Week 8 reproduction tests had **no `@pytest.mark.unit` marker**, so
+  `make test-unit` (which runs `-m unit`) was silently deselecting them. They
+  showed up as `2 deselected` and had never actually run in the suite.
+- Those Week 8 tests only exercised SQLAlchemy in isolation with a SQLite
+  engine. They never imported `health.py`, so they'd have passed whether or not
+  the bug was fixed. They weren't real regression tests.
+
+**Next steps:**
+Sub-task 3 — rewrite `tests/unit/test_health_check.py` to drive `health_check()`
+directly. I resolved the open question from Week 8 (how to drive the async probe
+without `aiosqlite`): rather than a FastAPI dependency override or a live
+Postgres, I'm writing a `StubAsyncSession` that mimics SQLAlchemy 2.x
+`execute()` strictness by raising `ObjectNotExecutableError` when handed a bare
+string. That keeps the test a true unit test and makes a regression to
+`execute("SELECT 1")` fail loudly. Then sub-task 5, and open the PR.
+
+**Blockers:**
+None blocking. One annoyance: the project's `pre-commit` hook can't pass on
+`api/routes/health.py` at all — `ruff` trips on `B008` (`Depends()` in an
+argument default, the standard FastAPI idiom) and `mypy` trips on pre-existing
+untyped-dict errors. Both pre-date my change. I'll commit with `--no-verify` and
+document it in the PR rather than re-typing a function this issue isn't about.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/869
+
+**Branch:** `fix/154-health-check-db-probe`
+
+**What you built:**
+The `/health` PostgreSQL probe passed raw SQL as a plain Python string, which
+SQLAlchemy 2.x refuses to execute — so the probe raised on every request, the
+broad `except Exception` swallowed the real error and marked the database
+`"unhealthy"`, and `GET /health` returned HTTP 503 even when Postgres was
+completely fine. The fix wraps the statement in `sqlalchemy.text()`, so the
+probe now reports the database's actual state instead of its own bug. The
+`try`/`except` is unchanged, so genuine outages still report unhealthy.
+
+**Tests added or updated:**
+`tests/unit/test_health_check.py` — rewritten. `TestPostgresHealthProbe` (4
+tests) drives `health_check()` itself through a `StubAsyncSession` that rejects
+bare strings the way SQLAlchemy 2.x does: a reachable DB reports `"healthy"`,
+the probe hands over a `TextClause` rather than a string, a genuine outage still
+reports `"unhealthy"`, and that outage still surfaces as HTTP 503.
+`TestSqlAlchemyTextRequirement` (2 tests) keeps the root-cause documentation and
+justifies the stub's strictness. Both classes are now marked `unit` so the suite
+actually selects them.
+
+I verified the tests are real by reverting `health.py` to the buggy version:
+2 of the 6 fail without the fix and all 6 pass with it. The tests assert on
+`health_status["dependencies"]["postgres"]` rather than an overall HTTP 200,
+because the Redis probe in the same endpoint is independently broken by #155 —
+which I deliberately did not touch.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+Both in the "introduces no new failures" sense, which is what this codebase
+allows — I documented the baseline in the PR description:
+
+| Command | Before | After |
+| --- | --- | --- |
+| `make lint` | 182 ruff errors | 182 ruff errors |
+| `make typecheck` | 5 errors in 4 files | 5 errors in 4 files |
+| `make test-unit` | 53 failed, 375 passed, 2 deselected | 53 failed, 381 passed, 0 deselected |
+
+The 53 failures are byte-for-byte identical before and after (`diff` of the
+sorted `FAILED` lines is empty), and none are in files I touched. My changes add
+6 passing tests and reduce `api/routes/health.py` from 4 ruff errors to 1.
+
+**Draft PR feedback received from:** none — I opened the PR ready-for-review
+rather than as a draft, so I have not yet had a peer look at it. I'll post it in
+the cohort Slack channel and fold in any feedback as review commits.
+
+**What I learned:**
+The most useful thing this week wasn't the one-line fix — it was discovering my
+Week 8 tests were both deselected *and* incapable of failing. "The tests pass"
+means nothing until you've watched them fail for the right reason. Reverting the
+fix to confirm the tests break is now a step I'll always do.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,90 @@
+## Solution plan
+
+**Issue:** Health check DB probe passes a raw SQL string, which fails under SQLAlchemy 2.x — https://github.com/ascherj/pathreview/issues/154
+
+### Understand
+
+**Root cause.** In `api/routes/health.py` (line 31) the PostgreSQL probe runs
+`await db.execute("SELECT 1")`, passing the query as a plain Python string.
+SQLAlchemy 2.x no longer executes bare strings — textual SQL must be wrapped in
+`sqlalchemy.text()`. Verified locally on SQLAlchemy 2.0.51: `execute("SELECT 1")`
+raises `sqlalchemy.exc.ObjectNotExecutableError: Not an executable object:
+'SELECT 1'`, while `execute(text("SELECT 1"))` returns `1` correctly.
+
+**Expected vs. actual.**
+- *Expected:* when Postgres is reachable, the probe succeeds and reports
+  `postgres: "healthy"`, and `GET /health` returns HTTP 200.
+- *Actual:* the probe always raises, the broad `except Exception` marks
+  `postgres: "unhealthy"`, the overall status flips to `unhealthy`, and the
+  endpoint returns HTTP 503 — even when the database is fully up. Confirmed by
+  hitting `GET /health` locally: 503 with `"postgres": "unhealthy"` while the
+  Docker `db` container reported healthy.
+
+### Map
+
+Modules/files involved:
+- **`api/routes/health.py`** — contains the bug (`health_check()`, line 31) and
+  the broad `try/except`. **Primary file I will change.**
+- **`tests/unit/test_health_check.py`** — my reproduction test (added in Week 8).
+  **I will extend this** with a test that asserts the Postgres probe reports
+  healthy after the fix.
+- `core/database.py` — defines `get_db()` and the async `AsyncSession`. Reference
+  only, to understand what `db` is; **no change needed**.
+- `core/config.py` — `Settings`. Reference only; relevant to the *separate* #155
+  bug, which I must not touch.
+
+**Files I expect to touch:** `api/routes/health.py`, `tests/unit/test_health_check.py`.
+
+### Plan
+
+1. **Add the import.** At the top of `api/routes/health.py`, add
+   `from sqlalchemy import text`.
+2. **Fix the probe.** Change `await db.execute("SELECT 1")` to
+   `await db.execute(text("SELECT 1"))` (line 31). Leave the surrounding
+   `try/except` intact so genuine DB outages are still reported.
+3. **Add a regression test.** Extend `tests/unit/test_health_check.py` with a
+   test that drives the Postgres probe and asserts it reports
+   `postgres: "healthy"` when the database is reachable, using a dependency
+   override so the test does not depend on a live Postgres.
+4. **Verify locally.** Run `make check && make test-unit`; all lint, type, and
+   unit checks must pass.
+5. **Confirm end-to-end.** With services up, `curl localhost:8000/health` and
+   confirm the `postgres` dependency now reports `"healthy"`.
+
+### Inputs & outputs
+
+- **Input:** an async SQLAlchemy `AsyncSession` (`db`) yielded by `get_db()`, and
+  a reachable PostgreSQL instance.
+- **Output / change:** the probe executes `text("SELECT 1")` successfully and
+  sets `health_status["dependencies"]["postgres"] = "healthy"`. When all
+  dependencies are healthy, `GET /health` returns HTTP 200 instead of 503. No
+  API schema change, no new response fields, no new dependencies.
+
+### Risks & unknowns
+
+- **Scope collision with #155 (same file).** `api/routes/health.py` also has a
+  separate bug in the Redis block (`settings.redis_host` / `settings.redis_port`
+  don't exist on `Settings`, ~lines 44–45), which independently causes a 503.
+  Risk: my change accidentally touches the Redis block, or my endpoint test
+  asserts a full 200 (which would still fail because of #155). Mitigation: change
+  only the Postgres line, and assert specifically on the `postgres` dependency
+  value rather than the overall status code.
+- **Async testing approach is undecided.** `aiosqlite` is not installed, so I
+  can't spin up an in-memory async DB. I'll either use a FastAPI dependency
+  override with a stub/real async session, or an integration test against the
+  local Postgres. Need to pick one in Week 9.
+- **Broad `except Exception` masks errors.** It swallows the specific exception,
+  so I must verify the fix by confirming the probe no longer enters the `except`
+  branch (probe returns "healthy"), not just that no error is printed.
+
+### Edge cases
+
+- **Database genuinely down / unreachable:** the probe must still report
+  `postgres: "unhealthy"` and the endpoint must still return 503 — the fix must
+  not swallow real failures, so the `try/except` stays.
+- **Missing/incorrect import:** if `text` isn't imported, the code raises
+  `NameError`; the import must be added alongside the change.
+- **No regression to other probes:** the Redis (#155) and vector-DB checks must
+  behave exactly as before — my change is limited to the Postgres line.
+- **Trivial result handling:** `SELECT 1` returns a single scalar; the fix only
+  needs the statement to execute, so it must not assume a particular row shape.

--- a/api/routes/health.py
+++ b/api/routes/health.py
@@ -1,6 +1,8 @@
-from fastapi import APIRouter, HTTPException, status, Depends
+from datetime import datetime
+
 import structlog
-from datetime import datetime, timedelta
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import text
 
 from core.database import get_db
 
@@ -28,7 +30,7 @@ async def health_check(db=Depends(get_db)):
 
     try:
         # Check PostgreSQL
-        await db.execute("SELECT 1")
+        await db.execute(text("SELECT 1"))
         health_status["dependencies"]["postgres"] = "healthy"
         log.debug("postgres_health_check_passed")
     except Exception as exc:
@@ -39,6 +41,7 @@ async def health_check(db=Depends(get_db)):
     try:
         # Check Redis (if available)
         import redis
+
         from core.config import settings
 
         r = redis.Redis(

--- a/tests/unit/test_health_check.py
+++ b/tests/unit/test_health_check.py
@@ -1,39 +1,144 @@
-"""Reproduction test for issue #154.
+"""Tests for the PostgreSQL probe in ``api/routes/health.py`` (issue #154).
 
 https://github.com/ascherj/pathreview/issues/154
 
-The health check in ``api/routes/health.py`` verifies PostgreSQL by running
-``await db.execute("SELECT 1")`` -- passing the query as a plain Python string.
-SQLAlchemy 2.x refuses to execute a bare string; textual SQL must be wrapped in
-``sqlalchemy.text()``. Because of this, the Postgres probe raises, the health
-check reports the database as "unhealthy", and ``GET /health`` returns HTTP 503
-even when the database is actually up.
+The health check verified PostgreSQL by running ``await db.execute("SELECT 1")``
+-- passing the query as a plain Python string. SQLAlchemy 2.x refuses to execute
+a bare string; textual SQL must be wrapped in ``sqlalchemy.text()``. Because of
+this the Postgres probe always raised, the health check reported the database as
+"unhealthy", and ``GET /health`` returned HTTP 503 even when the database was up.
 
-These tests reproduce that root cause with an in-memory SQLite engine (the same
-SQLAlchemy library the app uses, so no external database is required) and pin
-down the fix that Week 9 will apply to ``health.py``.
+These tests drive ``health_check()`` with a stub async session that enforces the
+same rule SQLAlchemy 2.x does, so no live PostgreSQL is required. They assert
+specifically on the ``postgres`` dependency value rather than the overall status
+code, because the Redis probe in the same endpoint has a separate, unrelated bug
+(issue #155) that independently forces the endpoint to 503.
 """
 
 import pytest
+from fastapi import HTTPException
 from sqlalchemy import create_engine, text
-from sqlalchemy.exc import ObjectNotExecutableError
+from sqlalchemy.exc import ObjectNotExecutableError, OperationalError
+from sqlalchemy.sql.elements import TextClause
+
+from api.routes.health import health_check
 
 
-def test_raw_string_select_is_rejected_by_sqlalchemy_2x() -> None:
-    """Issue #154: this is exactly what health.py does today, and it fails.
+class StubResult:
+    """Minimal stand-in for a SQLAlchemy ``Result``."""
 
-    ``db.execute("SELECT 1")`` raises ``ObjectNotExecutableError`` under
-    SQLAlchemy 2.x, which is why the Postgres health probe wrongly reports the
-    database as unhealthy.
+    def scalar(self) -> int:
+        """Return the single value a ``SELECT 1`` probe would produce."""
+        return 1
+
+
+class StubAsyncSession:
+    """Async session stub that mimics SQLAlchemy 2.x ``execute()`` strictness.
+
+    Records every statement it is handed and rejects bare strings the same way
+    SQLAlchemy 2.x does, so a regression back to ``execute("SELECT 1")`` fails
+    these tests instead of silently passing.
+
+    Args:
+        raise_on_execute: Optional exception raised by ``execute()``, used to
+            simulate a database that is genuinely unreachable.
     """
-    engine = create_engine("sqlite://")
-    with engine.connect() as conn, pytest.raises(ObjectNotExecutableError):
-        conn.execute("SELECT 1")
+
+    def __init__(self, raise_on_execute: Exception | None = None) -> None:
+        self.executed: list[object] = []
+        self._raise_on_execute = raise_on_execute
+
+    async def execute(self, statement: object) -> StubResult:
+        """Record and "run" a statement, rejecting non-executable objects."""
+        if self._raise_on_execute is not None:
+            raise self._raise_on_execute
+        if isinstance(statement, str):
+            raise ObjectNotExecutableError(statement)
+        self.executed.append(statement)
+        return StubResult()
 
 
-def test_text_wrapped_select_executes_correctly() -> None:
-    """The Week 9 fix: wrapping the query in ``text()`` executes correctly."""
-    engine = create_engine("sqlite://")
-    with engine.connect() as conn:
-        result = conn.execute(text("SELECT 1"))
-        assert result.scalar() == 1
+async def _run_health_check(db: StubAsyncSession) -> dict:
+    """Call the endpoint and return its payload whether it returns 200 or 503.
+
+    The endpoint raises ``HTTPException`` when any dependency is unhealthy, and
+    the Redis probe is independently broken by issue #155. Unwrapping the detail
+    lets these tests assert on the Postgres probe alone.
+
+    Args:
+        db: The stub session to inject as the ``db`` dependency.
+
+    Returns:
+        The health status payload produced by ``health_check()``.
+    """
+    try:
+        return await health_check(db=db)
+    except HTTPException as exc:
+        assert isinstance(exc.detail, dict)
+        return exc.detail
+
+
+@pytest.mark.unit
+class TestPostgresHealthProbe:
+    """Test suite for the PostgreSQL dependency probe."""
+
+    @pytest.mark.asyncio
+    async def test_postgres_reported_healthy_when_database_reachable(self) -> None:
+        """Issue #154: a reachable database must be reported as healthy."""
+        db = StubAsyncSession()
+
+        health_status = await _run_health_check(db)
+
+        assert health_status["dependencies"]["postgres"] == "healthy"
+
+    @pytest.mark.asyncio
+    async def test_probe_wraps_query_in_text_clause(self) -> None:
+        """The probe must pass a ``TextClause``, not a raw string."""
+        db = StubAsyncSession()
+
+        await _run_health_check(db)
+
+        assert len(db.executed) == 1
+        statement = db.executed[0]
+        assert isinstance(statement, TextClause)
+        assert str(statement) == "SELECT 1"
+
+    @pytest.mark.asyncio
+    async def test_postgres_reported_unhealthy_when_database_down(self) -> None:
+        """A genuine outage must still be reported: the fix must not mask it."""
+        outage = OperationalError("SELECT 1", None, Exception("connection refused"))
+        db = StubAsyncSession(raise_on_execute=outage)
+
+        health_status = await _run_health_check(db)
+
+        assert health_status["dependencies"]["postgres"] == "unhealthy"
+        assert health_status["status"] == "unhealthy"
+
+    @pytest.mark.asyncio
+    async def test_endpoint_returns_503_when_database_down(self) -> None:
+        """A database outage must still surface as HTTP 503."""
+        outage = OperationalError("SELECT 1", None, Exception("connection refused"))
+        db = StubAsyncSession(raise_on_execute=outage)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await health_check(db=db)
+
+        assert exc_info.value.status_code == 503
+
+
+@pytest.mark.unit
+class TestSqlAlchemyTextRequirement:
+    """Root-cause tests documenting the SQLAlchemy 2.x rule behind issue #154."""
+
+    def test_raw_string_select_is_rejected(self) -> None:
+        """A bare string is not executable, which is what broke the probe."""
+        engine = create_engine("sqlite://")
+        with engine.connect() as conn, pytest.raises(ObjectNotExecutableError):
+            conn.execute("SELECT 1")
+
+    def test_text_wrapped_select_executes(self) -> None:
+        """Wrapping the query in ``text()`` executes correctly -- the fix."""
+        engine = create_engine("sqlite://")
+        with engine.connect() as conn:
+            result = conn.execute(text("SELECT 1"))
+            assert result.scalar() == 1

--- a/tests/unit/test_health_check.py
+++ b/tests/unit/test_health_check.py
@@ -1,0 +1,39 @@
+"""Reproduction test for issue #154.
+
+https://github.com/ascherj/pathreview/issues/154
+
+The health check in ``api/routes/health.py`` verifies PostgreSQL by running
+``await db.execute("SELECT 1")`` -- passing the query as a plain Python string.
+SQLAlchemy 2.x refuses to execute a bare string; textual SQL must be wrapped in
+``sqlalchemy.text()``. Because of this, the Postgres probe raises, the health
+check reports the database as "unhealthy", and ``GET /health`` returns HTTP 503
+even when the database is actually up.
+
+These tests reproduce that root cause with an in-memory SQLite engine (the same
+SQLAlchemy library the app uses, so no external database is required) and pin
+down the fix that Week 9 will apply to ``health.py``.
+"""
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.exc import ObjectNotExecutableError
+
+
+def test_raw_string_select_is_rejected_by_sqlalchemy_2x() -> None:
+    """Issue #154: this is exactly what health.py does today, and it fails.
+
+    ``db.execute("SELECT 1")`` raises ``ObjectNotExecutableError`` under
+    SQLAlchemy 2.x, which is why the Postgres health probe wrongly reports the
+    database as unhealthy.
+    """
+    engine = create_engine("sqlite://")
+    with engine.connect() as conn, pytest.raises(ObjectNotExecutableError):
+        conn.execute("SELECT 1")
+
+
+def test_text_wrapped_select_executes_correctly() -> None:
+    """The Week 9 fix: wrapping the query in ``text()`` executes correctly."""
+    engine = create_engine("sqlite://")
+    with engine.connect() as conn:
+        result = conn.execute(text("SELECT 1"))
+        assert result.scalar() == 1


### PR DESCRIPTION
## Summary

The `/health` endpoint checked PostgreSQL by running `await db.execute("SELECT 1")`, passing the query as a plain string. SQLAlchemy 2.x does not accept plain strings, so this raised `ObjectNotExecutableError` on every request. The `except Exception` block hid the real error and marked the database as unhealthy, so `GET /health` returned 503 even when the database was fine. This PR wraps the query in `sqlalchemy.text()` so the check reports the real state of the database.

## Issue

Closes #154

## Changes

- `api/routes/health.py`: wrapped the query in `sqlalchemy.text()` and added the import. I left the `try`/`except` alone so real outages are still reported.
- `api/routes/health.py`: the import block got reordered and the unused `timedelta` import was removed. The project's ruff pre-commit hook did this on its own when I staged the file. Nothing about the behavior changed. I can split this into its own commit if you want the fix to be a single line.
- `tests/unit/test_health_check.py`: replaced my earlier reproduction tests with tests that call `health_check()` directly.

## Testing

- [x] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`)
- [x] Linter passes (`make lint`)
- [x] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes

The tests call `health_check()` with a `StubAsyncSession` that rejects plain strings the same way SQLAlchemy 2.x does. This means no running database is needed, and going back to `execute("SELECT 1")` would fail the tests. They check three things: a working database is reported as healthy, the query is passed as a `TextClause` instead of a string, and a real outage is still reported as unhealthy with a 503.

I also checked that the tests can fail. When I put the old buggy line back, 2 of the 6 tests fail. With the fix, all 6 pass.

### Pre-existing failures

This repo already has failures that are not related to this issue, so I recorded a baseline before making any changes.

| Command | Before | After |
| --- | --- | --- |
| `make lint` | 182 ruff errors | 182 ruff errors |
| `make typecheck` | 5 errors in 4 files | 5 errors in 4 files |
| `make test-unit` | 53 failed, 375 passed, 2 deselected | 53 failed, 381 passed, 0 deselected |

The same 53 tests fail before and after my changes. I compared the sorted list of failures and it is identical. None of them are in the files I edited. The mypy errors are missing type stubs for third-party packages. My changes add no new failures and add 6 passing tests.

The 2 deselected tests were my own from last week. They were missing the `unit` marker that `make test-unit` filters on, so they were never actually running.

## Screenshots / Demo

Nothing user facing. Here is the `postgres` value in `GET /health` with the database running:

```
before:  "postgres": "unhealthy"   (HTTP 503)
after:   "postgres": "healthy"
```

## Notes for Reviewers

- I kept this change small on purpose, and `GET /health` will still return 503 after it merges. The same endpoint has a second unrelated bug where `settings.redis_host` and `settings.redis_port` do not exist on `Settings` (#155). That bug causes a 503 on its own and I did not touch it. Because of that, my tests check the `postgres` value inside the response instead of checking for an overall 200. They will keep passing whenever #155 gets fixed.
- Both code commits used `--no-verify`. The pre-commit hook cannot pass on this file. Ruff reports `B008` because `Depends()` is used in an argument default, which is the normal FastAPI pattern, and mypy reports errors on the untyped `health_status` dict. Both existed before my change. Fixing them would mean adding type annotations to a function that this issue is not about, but I am happy to do that in a follow-up if you want.
