### PR TITLE
Fix/68 add a safety event count to the health check endpoint

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -14,3 +14,15 @@ The issue is that the The /health API endpoint returns service status but doesn'
 **Setup confirmation:** [X] App runs locally at localhost:5173
 
 **Cohort ledger:** [X] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/ascherj/pathreview/commit/e7f5832e3ecb9e2baa20782a788c2384aa696a34 
+
+**Reproduction summary:**
+I inspected health.py and confirmed safety_events_last_hour was hardcoded to 0 with a comment noting it was a placeholder, never calling into SafetyMonitor. Since I didn't have a live Redis/Postgres environment to hit /health directly, I reproduced the underlying logic gap in isolation — stubbing redis and structlog and driving SafetyMonitor.log_event() / get_event_count() directly — which confirmed the old single-key-with-resetting-TTL design had no way to return a true "last hour" count; it could only return an unbounded rolling total.
+
+**PLAN.md link:** https://github.com/proy19/pathreview/blob/fix/68-Add-a-safety-event-count-to-the-health-check-endpoint/PLAN.md 
+
+
+**Blockers or open questions:**

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,16 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/68
+
+**Issue title:** Add a safety event count to the health check endpoint
+
+**Tier:** [X] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The issue is that the The /health API endpoint returns service status but doesn't surface safety metrics. What is missing is a safety_events_last_hour field to the health check response. The fix would be adding a safety_events_last_hour field to the endpoint so that the so operators can monitor safety system activity without querying the monitoring dashboard. It affects safety/monitoring.py and api/routes/health.py part of the codebase. 
+
+**Branch name:** https://github.com/proy19/pathreview/tree/fix/68-Add-a-safety-event-count-to-the-health-check-endpoint
+
+**Setup confirmation:** [X] App runs locally at localhost:5173
+
+**Cohort ledger:** [X] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -76,3 +76,33 @@ My fix populates the previously hardcoded safety_events_last_hour field in the /
 **Self-review confirmation:** [X] make check passes  [X] make test-unit passes
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [X] No — still awaiting review
+
+**Summary of feedback:**
+No review has come in
+
+**How you responded:**
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Setting up my local environment and reproducing the issue was harder than expected. I kept running into errors. I eventually 
+
+**What did you learn about working in a large codebase?**
+I learned that that when you contribute in a large codebase, there's a different syntax in code that you must follow. It also can be time consuming to set it up on your local environment. 
+
+**How did AI tools help — and where did they fall short?**
+AI tools helped me my understand the issue and which steps I would require to solve it. They fell short when it comes to actually understanding the codebase. AI would often give suggestions that doesn't align with the exising codebase, like using a package that doesn't exist or not following the proper coding format. 
+
+**What would you do differently if you started over?**
+I would've definitely added more tests, specifically integration tests. 
+
+**What are you most proud of from this module?**
+I am proud of being able to fix my issue and opening a complete PR. I also learned a lot about open source contribution. 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -49,9 +49,9 @@ My next steps are adding tests to check my changes. I want to add the following 
 
 ### Check-in 2 (end of week)
 
-**PR link:** [link to your submitted pull request]
+**PR link:** https://github.com/ascherj/pathreview/pull/871
 
-**Branch:** [the branch name you worked on, e.g. `fix/123-short-description`]
+**Branch:** https://github.com/proy19/pathreview/tree/fix/68-Add-a-safety-event-count-to-the-health-check-endpoint
 
 **What you built:**
 My fix populates the previously hardcoded safety_events_last_hour field in the /health endpoint with a real count, by reworking SafetyMonitor to store events in hourly Redis buckets (safety:events:{event_type}:{YYYYMMDDHH}) instead of a single counter with a resetting TTL. health.py now instantiates SafetyMonitor with the same Redis client used for the Redis dependency check and calls a new get_total_event_count(window_hours=1) method, which sums the relevant hourly buckets across all event types; if Redis is unreachable, the field returns None instead of a misleading 0.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -26,3 +26,53 @@ I inspected health.py and confirmed safety_events_last_hour was hardcoded to 0 w
 
 
 **Blockers or open questions:**
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+- **`safety/monitoring.py`** — Reworked `SafetyMonitor` to store events in hourly Redis buckets (`safety:events:{event_type}:{YYYYMMDDHH}`, 48h expiry) instead of a single counter with a resetting TTL. Rewrote `get_event_count(event_type, window_hours)` to sum the buckets covering the requested window, and added `get_total_event_count(window_hours)` to aggregate counts across all event types.
+
+- **`api/routes/health.py`** — Wired `SafetyMonitor` into the `/health` endpoint: it's now instantiated with the same Redis client used for the Redis dependency check, and `safety_events_last_hour` is set from `get_total_event_count(window_hours=1)` instead of a hardcoded `0`. If Redis is unreachable, the field returns `None` rather than a misleading `0`.
+
+**Next steps:**
+My next steps are adding tests to check my changes. I want to add the following tests:
+
+- **`tests/test_safety_monitoring.py`** — Unit tests for the bucketed counting logic (correct bucket keys, expiry, per-type isolation, window inclusion/exclusion, Redis-failure handling).
+
+- **`tests/test_health.py`** — Endpoint tests verifying `/health` wiring: the field comes from `SafetyMonitor`, reuses the existing Redis client, and degrades gracefully (`None`) on Redis/SafetyMonitor failures.
+
+**Blockers:**
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [link to your submitted pull request]
+
+**Branch:** [the branch name you worked on, e.g. `fix/123-short-description`]
+
+**What you built:**
+My fix populates the previously hardcoded safety_events_last_hour field in the /health endpoint with a real count, by reworking SafetyMonitor to store events in hourly Redis buckets (safety:events:{event_type}:{YYYYMMDDHH}) instead of a single counter with a resetting TTL. health.py now instantiates SafetyMonitor with the same Redis client used for the Redis dependency check and calls a new get_total_event_count(window_hours=1) method, which sums the relevant hourly buckets across all event types; if Redis is unreachable, the field returns None instead of a misleading 0.
+
+**Tests added or updated:**
+**`tests/test_safety_monitoring.py`** — Unit tests for `SafetyMonitor` (`safety/monitoring.py`), using a dict-backed mock Redis client and frozen time. Covers:
+- `log_event` writes to the correct hourly bucket key and sets the 48h expiry
+- same-type events in the same hour accumulate; different types get separate keys
+- unknown event types are ignored and never written to Redis
+- Redis failures in `log_event`/`get_event_count` are caught, not raised
+- `get_event_count` correctly includes/excludes hours based on `window_hours` — the core regression test for the old unbounded-rolling-total bug
+- `get_total_event_count` sums correctly across all five event types, respects the window, and isn't broken by one flaky event type
+
+**`tests/test_health.py`** — Endpoint tests for `/health` (`api/routes/health.py`) using FastAPI's `TestClient`, with `SafetyMonitor` mocked so these stay focused on wiring rather than duplicating the logic above. Covers:
+- `safety_events_last_hour` reflects `SafetyMonitor.get_total_event_count(window_hours=1)`, not a hardcoded value
+- `SafetyMonitor` is constructed with the same Redis client used for the Redis dependency check
+- Postgres down → 503 with `postgres: unhealthy`
+- Redis down → `safety_events_last_hour` is `None` (not `0`), and `SafetyMonitor` is never constructed
+- missing `vector_db_url` → `unavailable`, doesn't flip overall status
+- `get_total_event_count` raising mid-request → degrades to `None` instead of a 500
+
+**Self-review confirmation:** [X] make check passes  [X] make test-unit passes
+
+**Draft PR feedback received from:** none

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,39 @@
+## Solution plan
+
+**Issue:** Add a safety event count to the health check endpoint
+https://github.com/ascherj/pathreview/issues/68 
+
+## Understand
+Root cause: /health never actually queried safety event data — safety_events_last_hour was a hardcoded placeholder (0), and even if it had called into SafetyMonitor, that class had no concept of a time window. It stored one counter per event type whose 24h TTL reset on every increment, so it could only ever produce an unbounded rolling total, not "events in the last hour."
+Expected behavior: /health returns an accurate count of safety events (summed across all types) that occurred in the last hour, so operators can spot elevated safety activity from the health endpoint alone.
+Actual behavior (before fix): Always returns 0, regardless of real activity.
+
+## Map
+safety/monitoring.py — SafetyMonitor class, specifically log_event(), get_event_count(); needed a new get_total_event_count().
+api/routes/health.py — health_check(); needed to instantiate SafetyMonitor and populate the field from real data instead of a literal.
+(Open item) — confirm actual import path for SafetyMonitor in the real codebase, since safety/monitoring.py was an assumption.
+
+## Plan
+Rework SafetyMonitor.log_event() to write to hourly-bucketed Redis keys (safety:events:{event_type}:{YYYYMMDDHH}) instead of a single key with a resetting TTL.
+Rewrite get_event_count(event_type, window_hours) to sum the hourly buckets covering the requested window, rather than reading one unscoped key.
+Add get_total_event_count(window_hours) to sum counts across all VALID_EVENT_TYPES into one aggregate number.
+In health.py, keep the Redis client already created for the Redis dependency check accessible, instantiate SafetyMonitor(redis_client), and set safety_events_last_hour = safety_monitor.get_total_event_count(window_hours=1).
+Fix the SafetyMonitor import path once the real module location is confirmed, and re-verify against a live Redis instance rather than stubs.
+
+## Inputs & outputs
+Input: the Redis client already live from the health check's Redis ping, current UTC time (internal), window_hours (defaults to 1).
+Output: an integer written to health_status["safety_events_last_hour"] in the /health JSON response, or None if Redis is unreachable (so "zero events" and "couldn't check" aren't conflated).
+
+## Risks & unknowns
+Bucketing relies on datetime.utcnow(); clock skew across instances could cause inconsistent hour-boundary behavior.
+get_total_event_count does up to 5 Redis GETs per health check (one per event type); fine for window_hours=1, but larger windows add more calls and latency.
+Old-style keys from before this change (no hour suffix) won't be read by the new logic — a short gap in historical visibility right after deploy, though not a regression since the old scheme wasn't windowed either.
+Only verified with stubbed redis/structlog in this environment (no network access to install real packages) — needs a real integration test before merging.
+Still unsure whether operators want just the 1-hour aggregate, or also a per-event-type breakdown / additional windows (e.g., 24h) in the same response.
+
+## Edge cases
+Redis unreachable → safety_events_last_hour set to None, not a misleading 0.
+Unknown/invalid event_type passed to log_event() → already logged as a warning and skipped, doesn't pollute the count.
+No events in the window → clean 0 (missing Redis keys return None, treated as 0).
+Window spanning a day boundary (e.g., checked at 00:30) → bucket keys roll over correctly via strftime.
+Concurrent log_event() calls under load → Redis INCR is atomic per key, so no lost increments.

--- a/api/routes/health.py
+++ b/api/routes/health.py
@@ -75,7 +75,7 @@ async def health_check(db=Depends(get_db)):
     # Count safety events in last hour (placeholder)
     try:
         # This would be populated by actual safety event logging
-        health_status["safety_events_last_hour"] = 0
+        health_status["safety_events_last_hour"] = 0 # safety_event_last_hour is defaulted to 0
     except Exception as exc:
         log.error("safety_events_check_failed", error=str(exc))
 

--- a/api/routes/health.py
+++ b/api/routes/health.py
@@ -3,6 +3,7 @@ import structlog
 from datetime import datetime, timedelta
 
 from core.database import get_db
+from safety.monitoring import SafetyMonitor
 
 log = structlog.get_logger()
 
@@ -36,18 +37,19 @@ async def health_check(db=Depends(get_db)):
         health_status["dependencies"]["postgres"] = "unhealthy"
         health_status["status"] = "unhealthy"
 
+    redis_client = None
     try:
         # Check Redis (if available)
         import redis
         from core.config import settings
 
-        r = redis.Redis(
+        redis_client = redis.Redis(
             host=settings.redis_host,
             port=settings.redis_port,
             db=0,
             decode_responses=True,
         )
-        r.ping()
+        redis_client.ping()
         health_status["dependencies"]["redis"] = "healthy"
         log.debug("redis_health_check_passed")
     except Exception as exc:
@@ -72,12 +74,19 @@ async def health_check(db=Depends(get_db)):
         health_status["dependencies"]["vector_db"] = "unhealthy"
         health_status["status"] = "unhealthy"
 
-    # Count safety events in last hour (placeholder)
+    # Count safety events in the last hour
     try:
-        # This would be populated by actual safety event logging
-        health_status["safety_events_last_hour"] = 0 # safety_event_last_hour is defaulted to 0
+        if redis_client is not None:
+            safety_monitor = SafetyMonitor(redis_client)
+            health_status["safety_events_last_hour"] = safety_monitor.get_total_event_count(
+                window_hours=1
+            )
+        else:
+            # Redis is unavailable, so safety event counts can't be retrieved.
+            health_status["safety_events_last_hour"] = None
     except Exception as exc:
         log.error("safety_events_check_failed", error=str(exc))
+        health_status["safety_events_last_hour"] = None
 
     # Return 503 if any critical dependency is down
     if health_status["status"] == "unhealthy":

--- a/safety/monitoring.py
+++ b/safety/monitoring.py
@@ -38,37 +38,67 @@ class SafetyMonitor:
             logger.warning("unknown_event_type", event_type=event_type)
             return
 
-        timestamp = datetime.utcnow().isoformat()
+        now = datetime.utcnow()
+        timestamp = now.isoformat()
 
         try:
             # Log to structlog
             logger.warning("safety_event", event_type=event_type, **details)
 
-            # Store count in Redis for monitoring
-            key = f"safety:events:{event_type}"
+            # Store count in an hourly bucket so it can later be scoped to a
+            # specific time window (e.g. "last hour") instead of an
+            # unbounded/rolling total.
+            key = self._hour_bucket_key(event_type, now)
             self.redis.incr(key)
-            # Set expiry to 24 hours
-            self.redis.expire(key, 86400)
+            # Keep buckets around for 48 hours, comfortably longer than any
+            # window we currently query, then let them expire.
+            self.redis.expire(key, 172800)
 
         except Exception as e:
             logger.error("safety_monitor_error", error=str(e))
 
+    def _hour_bucket_key(self, event_type: str, when: datetime) -> str:
+        """Build the Redis key for the hourly bucket containing `when`."""
+        hour_bucket = when.strftime("%Y%m%d%H")
+        return f"safety:events:{event_type}:{hour_bucket}"
+
     def get_event_count(self, event_type: str, window_hours: int = 1) -> int:
-        """Get count of safety events.
+        """Get count of safety events of a given type in the last `window_hours`.
 
         Args:
             event_type: Type of event
-            window_hours: Time window in hours (not enforced here; for reference)
+            window_hours: Time window in hours to sum counts over
 
         Returns:
             Count of events in the window
         """
-        key = f"safety:events:{event_type}"
+        now = datetime.utcnow()
+        total = 0
 
         try:
-            count = self.redis.get(key)
-            return int(count) if count else 0
+            for i in range(window_hours):
+                bucket_time = now - timedelta(hours=i)
+                key = self._hour_bucket_key(event_type, bucket_time)
+                count = self.redis.get(key)
+                if count:
+                    total += int(count)
+            return total
 
         except Exception as e:
             logger.error("event_count_error", event_type=event_type, error=str(e))
             return 0
+
+    def get_total_event_count(self, window_hours: int = 1) -> int:
+        """Get count of safety events across all event types in the last
+        `window_hours`.
+
+        Args:
+            window_hours: Time window in hours to sum counts over
+
+        Returns:
+            Total count of events of any type in the window
+        """
+        total = 0
+        for event_type in self.VALID_EVENT_TYPES:
+            total += self.get_event_count(event_type, window_hours=window_hours)
+        return total

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -1,0 +1,169 @@
+import pytest
+from unittest.mock import Mock, MagicMock, patch, AsyncMock
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.routes import health as health_module
+from core.database import get_db
+
+
+@pytest.mark.unit
+class TestHealthCheck:
+    """Test suite for the /health endpoint."""
+
+    @pytest.fixture
+    def mock_db(self):
+        """Create a mock async DB session that succeeds by default."""
+        db = AsyncMock()
+        return db
+
+    @pytest.fixture
+    def mock_settings(self):
+        """Create mock settings with a healthy redis host and vector db url."""
+        settings = MagicMock()
+        settings.redis_host = "localhost"
+        settings.redis_port = 6379
+        settings.vector_db_url = "http://vector-db:8000"
+        return settings
+
+    @pytest.fixture
+    def mock_redis_client(self):
+        """Create a mock Redis client whose ping() succeeds."""
+        client = Mock()
+        client.ping = Mock(return_value=True)
+        return client
+
+    @pytest.fixture
+    def app(self, mock_db):
+        """Create a FastAPI app with only the health router mounted."""
+        app = FastAPI()
+        app.include_router(health_module.router)
+
+        async def _fake_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = _fake_get_db
+        return app
+
+    @pytest.fixture
+    def client(self, app):
+        """Create a TestClient for the health app."""
+        return TestClient(app)
+
+    def test_returns_200_when_all_dependencies_healthy(
+        self, client, mock_settings, mock_redis_client
+    ):
+        """Test that a fully healthy system returns 200 with all deps healthy."""
+        with patch("redis.Redis", return_value=mock_redis_client), \
+             patch("core.config.settings", mock_settings), \
+             patch.object(health_module, "SafetyMonitor") as mock_monitor_cls:
+
+            mock_monitor_cls.return_value.get_total_event_count.return_value = 4
+
+            response = client.get("/health")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["status"] == "healthy"
+        assert body["dependencies"]["postgres"] == "healthy"
+        assert body["dependencies"]["redis"] == "healthy"
+        assert body["dependencies"]["vector_db"] == "healthy"
+
+    def test_safety_events_last_hour_comes_from_safety_monitor(
+        self, client, mock_settings, mock_redis_client
+    ):
+        """Test that safety_events_last_hour reflects SafetyMonitor's total count."""
+        with patch("redis.Redis", return_value=mock_redis_client), \
+             patch("core.config.settings", mock_settings), \
+             patch.object(health_module, "SafetyMonitor") as mock_monitor_cls:
+
+            mock_monitor_cls.return_value.get_total_event_count.return_value = 7
+
+            response = client.get("/health")
+
+        assert response.json()["safety_events_last_hour"] == 7
+        mock_monitor_cls.return_value.get_total_event_count.assert_called_once_with(
+            window_hours=1
+        )
+
+    def test_safety_monitor_reuses_the_health_check_redis_client(
+        self, client, mock_settings, mock_redis_client
+    ):
+        """Test that SafetyMonitor is built from the same client used to check Redis."""
+        with patch("redis.Redis", return_value=mock_redis_client), \
+             patch("core.config.settings", mock_settings), \
+             patch.object(health_module, "SafetyMonitor") as mock_monitor_cls:
+
+            mock_monitor_cls.return_value.get_total_event_count.return_value = 0
+
+            client.get("/health")
+
+        mock_monitor_cls.assert_called_once_with(mock_redis_client)
+
+    def test_postgres_down_returns_503(self, app, client, mock_db, mock_settings, mock_redis_client):
+        """Test that a Postgres failure returns a 503 with postgres marked unhealthy."""
+        mock_db.execute.side_effect = Exception("connection refused")
+
+        with patch("redis.Redis", return_value=mock_redis_client), \
+             patch("core.config.settings", mock_settings), \
+             patch.object(health_module, "SafetyMonitor") as mock_monitor_cls:
+
+            mock_monitor_cls.return_value.get_total_event_count.return_value = 0
+
+            response = client.get("/health")
+
+        assert response.status_code == 503
+        assert response.json()["detail"]["dependencies"]["postgres"] == "unhealthy"
+
+    def test_redis_down_marks_unhealthy_and_safety_events_is_none(
+        self, client, mock_settings
+    ):
+        """Test that a Redis outage returns null safety_events_last_hour, not 0."""
+        with patch("redis.Redis", side_effect=ConnectionError("no redis")), \
+             patch("core.config.settings", mock_settings), \
+             patch.object(health_module, "SafetyMonitor") as mock_monitor_cls:
+
+            response = client.get("/health")
+
+        assert response.status_code == 503
+        detail = response.json()["detail"]
+        assert detail["dependencies"]["redis"] == "unhealthy"
+        assert detail["safety_events_last_hour"] is None
+        mock_monitor_cls.assert_not_called()
+
+    def test_vector_db_url_missing_is_unavailable_not_unhealthy(
+        self, client, mock_redis_client
+    ):
+        """Test that a missing vector_db_url is reported as unavailable, not unhealthy."""
+        settings = MagicMock()
+        settings.redis_host = "localhost"
+        settings.redis_port = 6379
+        settings.vector_db_url = None
+
+        with patch("redis.Redis", return_value=mock_redis_client), \
+             patch("core.config.settings", settings), \
+             patch.object(health_module, "SafetyMonitor") as mock_monitor_cls:
+
+            mock_monitor_cls.return_value.get_total_event_count.return_value = 0
+
+            response = client.get("/health")
+
+        body = response.json()
+        assert body["dependencies"]["vector_db"] == "unavailable"
+        assert body["status"] == "healthy"
+
+    def test_safety_monitor_error_falls_back_to_none_not_crash(
+        self, client, mock_settings, mock_redis_client
+    ):
+        """Test that a SafetyMonitor failure degrades to null instead of a 500."""
+        with patch("redis.Redis", return_value=mock_redis_client), \
+             patch("core.config.settings", mock_settings), \
+             patch.object(health_module, "SafetyMonitor") as mock_monitor_cls:
+
+            mock_monitor_cls.return_value.get_total_event_count.side_effect = Exception("boom")
+
+            response = client.get("/health")
+
+        assert response.status_code == 200
+        assert response.json()["safety_events_last_hour"] is None

--- a/tests/unit/test_safety_monitoring.py
+++ b/tests/unit/test_safety_monitoring.py
@@ -1,0 +1,187 @@
+import pytest
+from unittest.mock import Mock, MagicMock, patch
+from datetime import datetime
+
+from safety.monitoring import SafetyMonitor
+
+
+FROZEN_NOW = datetime(2026, 8, 4, 10, 30, 0)
+
+
+class _FrozenDateTime(datetime):
+    """datetime subclass whose utcnow() always returns a fixed instant."""
+
+    @classmethod
+    def utcnow(cls):
+        return FROZEN_NOW
+
+
+@pytest.mark.unit
+class TestSafetyMonitor:
+    """Test suite for SafetyMonitor."""
+
+    @pytest.fixture(autouse=True)
+    def freeze_time(self, monkeypatch):
+        """Freeze safety.monitoring.datetime.utcnow() for every test."""
+        monkeypatch.setattr("safety.monitoring.datetime", _FrozenDateTime)
+
+    @pytest.fixture
+    def mock_redis_client(self):
+        """Create a mock Redis client backed by an in-memory dict store."""
+        store = {}
+
+        def incr(key):
+            store[key] = store.get(key, 0) + 1
+            return store[key]
+
+        def get(key):
+            value = store.get(key)
+            return str(value) if value is not None else None
+
+        def expire(key, seconds):
+            return True
+
+        client = Mock()
+        client.incr = Mock(side_effect=incr)
+        client.get = Mock(side_effect=get)
+        client.expire = Mock(side_effect=expire)
+        client.store = store
+        return client
+
+    @pytest.fixture
+    def monitor(self, mock_redis_client):
+        """Create a SafetyMonitor instance."""
+        return SafetyMonitor(mock_redis_client)
+
+    def test_valid_event_increments_current_hour_bucket(self, monitor, mock_redis_client):
+        """Test that logging a valid event increments the current hour's bucket."""
+        monitor.log_event("pii_detected", {"user": "alice"})
+
+        expected_key = "safety:events:pii_detected:2026080410"
+        assert mock_redis_client.store[expected_key] == 1
+        mock_redis_client.incr.assert_called_once_with(expected_key)
+
+    def test_multiple_events_same_type_same_hour_accumulate(self, monitor, mock_redis_client):
+        """Test that repeated events of the same type in the same hour accumulate."""
+        monitor.log_event("pii_detected", {"user": "alice"})
+        monitor.log_event("pii_detected", {"user": "bob"})
+
+        expected_key = "safety:events:pii_detected:2026080410"
+        assert mock_redis_client.store[expected_key] == 2
+
+    def test_sets_expiry_on_the_bucket_key(self, monitor, mock_redis_client):
+        """Test that the hourly bucket key is given a 48 hour expiry."""
+        monitor.log_event("rate_limited", {})
+
+        expected_key = "safety:events:rate_limited:2026080410"
+        mock_redis_client.expire.assert_called_once_with(expected_key, 172800)
+
+    def test_unknown_event_type_is_ignored(self, monitor, mock_redis_client):
+        """Test that an unrecognized event type is not written to Redis."""
+        monitor.log_event("not_a_real_event_type", {"foo": "bar"})
+
+        mock_redis_client.incr.assert_not_called()
+        mock_redis_client.expire.assert_not_called()
+        assert mock_redis_client.store == {}
+
+    def test_different_event_types_get_separate_keys(self, monitor, mock_redis_client):
+        """Test that different event types are tracked under separate keys."""
+        monitor.log_event("pii_detected", {})
+        monitor.log_event("injection_attempt", {})
+
+        assert mock_redis_client.store["safety:events:pii_detected:2026080410"] == 1
+        assert mock_redis_client.store["safety:events:injection_attempt:2026080410"] == 1
+
+    def test_redis_failure_on_log_is_caught_and_does_not_raise(self, monitor, mock_redis_client):
+        """Test that a Redis failure during log_event is caught rather than raised."""
+        mock_redis_client.incr.side_effect = ConnectionError("redis unreachable")
+
+        monitor.log_event("pii_detected", {"user": "alice"})
+
+    def test_get_event_count_returns_zero_when_no_events_logged(self, monitor):
+        """Test that get_event_count returns 0 when nothing has been logged."""
+        assert monitor.get_event_count("pii_detected", window_hours=1) == 0
+
+    def test_get_event_count_counts_events_in_current_hour(self, monitor):
+        """Test that get_event_count sums events logged in the current hour."""
+        monitor.log_event("pii_detected", {})
+        monitor.log_event("pii_detected", {})
+        monitor.log_event("pii_detected", {})
+
+        assert monitor.get_event_count("pii_detected", window_hours=1) == 3
+
+    def test_get_event_count_window_includes_prior_hours(self, monitor, mock_redis_client):
+        """Test that widening the window includes counts from earlier hours."""
+        mock_redis_client.store["safety:events:pii_detected:2026080409"] = 5
+        monitor.log_event("pii_detected", {})
+
+        assert monitor.get_event_count("pii_detected", window_hours=1) == 1
+        assert monitor.get_event_count("pii_detected", window_hours=2) == 6
+
+    def test_get_event_count_excludes_hours_outside_window(self, monitor, mock_redis_client):
+        """Test that hours outside the requested window are not counted."""
+        mock_redis_client.store["safety:events:pii_detected:2026080407"] = 100
+        monitor.log_event("pii_detected", {})
+
+        assert monitor.get_event_count("pii_detected", window_hours=2) == 1
+
+    def test_get_event_count_different_event_types_are_independent(self, monitor):
+        """Test that counts for one event type do not affect another."""
+        monitor.log_event("pii_detected", {})
+        monitor.log_event("injection_attempt", {})
+        monitor.log_event("injection_attempt", {})
+
+        assert monitor.get_event_count("pii_detected", window_hours=1) == 1
+        assert monitor.get_event_count("injection_attempt", window_hours=1) == 2
+
+    def test_get_event_count_redis_failure_returns_zero(self, monitor, mock_redis_client):
+        """Test that a Redis failure during get_event_count returns 0, not an exception."""
+        mock_redis_client.get.side_effect = ConnectionError("redis unreachable")
+
+        assert monitor.get_event_count("pii_detected", window_hours=1) == 0
+
+    def test_get_total_event_count_returns_zero_when_no_events(self, monitor):
+        """Test that get_total_event_count returns 0 when nothing has been logged."""
+        assert monitor.get_total_event_count(window_hours=1) == 0
+
+    def test_get_total_event_count_sums_across_all_event_types(self, monitor):
+        """Test that get_total_event_count aggregates counts across every event type."""
+        monitor.log_event("pii_detected", {})
+        monitor.log_event("pii_detected", {})
+        monitor.log_event("injection_attempt", {})
+        monitor.log_event("content_filtered", {})
+        monitor.log_event("bias_detected", {})
+        monitor.log_event("rate_limited", {})
+
+        assert monitor.get_total_event_count(window_hours=1) == 6
+
+    def test_get_total_event_count_ignores_unknown_event_types(self, monitor):
+        """Test that unknown event types never contribute to the total."""
+        monitor.log_event("pii_detected", {})
+        monitor.log_event("bogus_type", {})
+
+        assert monitor.get_total_event_count(window_hours=1) == 1
+
+    def test_get_total_event_count_respects_window_hours(self, monitor, mock_redis_client):
+        """Test that get_total_event_count only includes hours within the window."""
+        mock_redis_client.store["safety:events:pii_detected:2026080405"] = 10
+        monitor.log_event("injection_attempt", {})
+
+        assert monitor.get_total_event_count(window_hours=1) == 1
+        assert monitor.get_total_event_count(window_hours=6) == 11
+
+    def test_get_total_event_count_one_failing_type_does_not_break_total(self, monitor, mock_redis_client):
+        """Test that a Redis failure for one event type doesn't break the aggregate."""
+        monitor.log_event("pii_detected", {})
+        monitor.log_event("injection_attempt", {})
+
+        original_get = mock_redis_client.get.side_effect
+
+        def flaky_get(key):
+            if "injection_attempt" in key:
+                raise ConnectionError("boom")
+            return original_get(key)
+
+        mock_redis_client.get.side_effect = flaky_get
+
+        assert monitor.get_total_event_count(window_hours=1) == 1


### PR DESCRIPTION
## Summary
My fix populates the previously hardcoded safety_events_last_hour field in the /health endpoint with a real count, by reworking SafetyMonitor to store events in hourly Redis buckets (safety:events:{event_type}:{YYYYMMDDHH}) instead of a single counter with a resetting TTL. health.py now instantiates SafetyMonitor with the same Redis client used for the Redis dependency check and calls a new get_total_event_count(window_hours=1) method, which sums the relevant hourly buckets across all event types; if Redis is unreachable, the field returns None instead of a misleading 0.

## Issue
https://github.com/ascherj/pathreview/issues/68

## Changes
- safety/monitoring.py - Reworked SafetyMonitor to store events in hourly Redis buckets (safety:events:{event_type}:{YYYYMMDDHH}, 48h expiry) instead of a single counter with a resetting TTL. 
- Rewrote get_event_count(event_type, window_hours) to sum the buckets covering the requested window, and added get_total_event_count(window_hours) to aggregate counts across all event types.
- api/routes/health.py - Wired SafetyMonitor into the /health endpoint: it's now instantiated with the same Redis client used for the Redis dependency check, and safety_events_last_hour is set from  get_total_event_count(window_hours=1) instead of a hardcoded 0. If Redis is unreachable, the field returns None rather than a misleading 0.
-  Added tests/test_safety_monitoring.py — Unit tests for the bucketed counting logic (correct bucket keys, expiry, per-type isolation, window inclusion/exclusion, Redis-failure handling).
- Added tests/test_health.py  — Endpoint tests verifying /health wiring: the field comes from SafetyMonitor, reuses the existing Redis client, and degrades gracefully (None) on Redis/SafetyMonitor failures.

## Testing
<!-- How did you verify your changes? -->
- [X] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`)
- [X] Linter passes (`make lint`)
- [X] Type checker passes (`make typecheck`)
- [X] New/updated tests cover the changes

## Notes for Reviewers
To run the tests, install dependencies first using these command: pip install pytest pytest-mock fastapi httpx redis structlog
