### PR TITLE
Fix phone_us regex to redact parenthesized US phone numbers (#146)

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -27,11 +27,11 @@ the existing `test_us_phone_number_redaction` test.
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [paste after you push]
+**Reproduction commit link:** https://github.com/bimalitani100/pathreview/commit/106cb12df5fcac6fe088e5a16514e3df1d177f95
 
 **Reproduction summary:** Ran the scrub()/detect() snippets from issue #146 locally — confirmed `(555) 123-4567` passes through scrub() unredacted while `555-123-4567` in the same string is correctly redacted, and detect() returns [] for the parenthesized number. Confirmed via pytest that 4 of 6 phone-related tests fail (test_us_phone_number_redaction, test_us_phone_formats, test_detect_phone_pii, test_phone_at_start_of_text); the other 2 (international, phone-at-end) pass.
 
-**PLAN.md link:** [paste after you push]
+**PLAN.md link:** https://github.com/bimalitani100/pathreview/blob/fix/146-pii-scrubber-parenthesized-phone/PLAN.md
 
 **Walkthrough video (recommended):** [optional]
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -23,3 +23,17 @@ the existing `test_us_phone_number_redaction` test.
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [paste after you push]
+
+**Reproduction summary:** Ran the scrub()/detect() snippets from issue #146 locally — confirmed `(555) 123-4567` passes through scrub() unredacted while `555-123-4567` in the same string is correctly redacted, and detect() returns [] for the parenthesized number. Confirmed via pytest that 4 of 6 phone-related tests fail (test_us_phone_number_redaction, test_us_phone_formats, test_detect_phone_pii, test_phone_at_start_of_text); the other 2 (international, phone-at-end) pass.
+
+**PLAN.md link:** [paste after you push]
+
+**Walkthrough video (recommended):** [optional]
+
+**Blockers or open questions:**
+Unclear whether "+1 555 123 4567" (space-separated international-style format) needs a separate fix beyond the parenthesis issue — will check when implementing next week.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,25 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/146
+
+**Issue title:** PII scrubber fails to redact parenthesized US phone numbers
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The PII scrubber's phone-number regex in `safety/pii_scrubber.py` matches
+dashed formats like `555-123-4567` but misses parenthesized formats like
+`(555) 123-4567`, because the pattern allows an optional closing paren but
+no whitespace after it before the next digit group. As a result, `scrub()`
+leaves parenthesized phone numbers in the output unredacted and `detect()`
+fails to flag them as PII at all — a real privacy gap since parenthesized
+format is one of the most common ways US phone numbers are written. A
+correct fix updates the `phone_us` pattern to tolerate the space (or other
+separator) after the area code parenthesis, and should be validated against
+the existing `test_us_phone_number_redaction` test.
+
+**Branch name:** fix/146-pii-scrubber-parenthesized-phone
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -68,3 +68,34 @@ tests/unit/test_pii_scrubber.py — added test_parenthesized_phone_edge_cases co
 (no new failures introduced — pre-existing failures documented in PR description)
 
 **Draft PR feedback received from:** None
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No reviewer feedback was provided — per the Summer 2026 course note, reviewer feedback is not a feature this term.
+
+**How you responded:**
+N/A — no feedback to respond to this term.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The actual regex fix was one line and took very little time. What was harder was everything around it: confirming that failing tests and lint errors were pre-existing rather than caused by my change (I had to stash my fix and re-run tests against the original code to prove it), and getting comfortable with pre-commit hooks — I once interrupted a slow mypy run mid-commit with Ctrl+C, which cancelled the commit entirely without me realizing it at first. None of that was code — it was process and verification, and it took more time than the fix itself.
+
+**What did you learn about working in a large codebase?**
+The codebase already had ~180 pre-existing lint errors and ~49 pre-existing failing tests across modules I never touched, spanning bias detection, review services, resume parsing, and more. Contributing to it meant learning to isolate my change's blast radius precisely — proving what my one-line edit did and didn't affect — rather than assuming a clean slate like a solo project. I also had to work through project-specific setup (activating a `.venv`, understanding `make check` and `make test-unit` targets) that a from-scratch project wouldn't require.
+
+**How did AI tools help — and where did they fall short?**
+AI was most useful for quickly diagnosing the two separate regex bugs stacked in one pattern (the `\b` boundary issue and the missing whitespace in separator classes) once I had the actual line of code and failing test output in front of it. It was also useful for explaining git/pre-commit behavior when I hit the interrupted-commit issue. Where it fell short: it couldn't fetch or read the actual source file from GitHub directly, so I had to run `grep` locally and paste the regex back for diagnosis — meaning I still needed to drive the terminal work myself throughout.
+
+**What would you do differently if you started over?**
+I'd activate the `.venv` and get oriented in the Makefile targets (`make check`, `make test-unit`) before writing any reproduction code, since I hit the same "wrong environment" error twice. I'd also run the full pre-existing test suite once, up front, right after cloning — so I'd have a baseline to compare against from day one instead of discovering pre-existing failures reactively while debugging my own change.
+
+**What are you most proud of from this module?**
+Verifying, rather than assuming, that my change didn't introduce regressions — actually stashing my fix and re-running tests against the original code to prove which failures were pre-existing before writing that into the PR description. That felt like the most "real engineering" part of the whole module.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -37,3 +37,17 @@ the existing `test_us_phone_number_redaction` test.
 
 **Blockers or open questions:**
 Unclear whether "+1 555 123 4567" (space-separated international-style format) needs a separate fix beyond the parenthesis issue — will check when implementing next week.
+
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the fix for issue #146: updated the `phone_us` regex in `safety/pii_scrubber.py` (changed leading `\b` to `(?<!\d)`, added whitespace to the separator classes). All 4 previously-failing phone tests now pass, plus a new test covering additional parenthesized-format edge cases. Ran `make check` and `make test-unit` — confirmed my change introduces no new failures; pre-existing failures exist in bias_detector, review_service, resume_parser, and other files I didn't touch, plus pre-existing lint/type errors unrelated to my change.
+
+**Next steps:**
+Finalize PR description documenting the pre-existing failures, open the PR for peer/mentor review.
+
+**Blockers:**
+None.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -51,3 +51,20 @@ Finalize PR description documenting the pre-existing failures, open the PR for p
 
 **Blockers:**
 None.
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/872
+
+**Branch:** fix/146-pii-scrubber-parenthesized-phone
+
+**What you built:**
+Fixed the phone_us regex in safety/pii_scrubber.py so parenthesized US phone numbers (e.g. (555) 123-4567) are correctly redacted and detected, matching the behavior already working for dashed formats.
+
+**Tests added or updated:**
+tests/unit/test_pii_scrubber.py — added test_parenthesized_phone_edge_cases covering no-space and dash-after-paren variants; confirmed the 4 previously-failing tests now pass.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+(no new failures introduced — pre-existing failures documented in PR description)
+
+**Draft PR feedback received from:** None

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,55 @@
+## Solution plan
+
+**Issue:** PII scrubber fails to redact parenthesized US phone numbers — https://github.com/ascherj/pathreview/issues/146
+
+### Understand
+Root cause (two parts, found via testing): (1) the `phone_us` regex starts with
+`\b`, which requires a word/non-word boundary — but `(` is a non-word char, so
+when preceded by a space (also non-word), no boundary exists and the match
+never starts. (2) `\)?[-.]?` after the area code doesn't include whitespace, so
+even where the match starts, the space in "(555) 123" isn't consumed. Expected:
+scrub() redacts and detect() flags parenthesized numbers like dashed ones.
+Actual: they pass through completely untouched in both scrub() and detect().
+
+### Map
+- `safety/pii_scrubber.py` line 15 — the `phone_us` pattern needs its leading
+  `\b` replaced with `(?<!\d)`, and `[-.\s]?` added after the optional closing
+  paren
+- `tests/unit/test_pii_scrubber.py` — 4 tests must pass:
+  test_us_phone_number_redaction, test_us_phone_formats, test_detect_phone_pii,
+  test_phone_at_start_of_text
+
+### Plan
+1. Replace the `phone_us` regex at line 15 with:
+   `r"(?<!\d)(?:\+?1[-.]?)?\(?([0-9]{3})\)?[-.\s]?([0-9]{3})[-.]?([0-9]{4})\b"`
+2. Re-run test_us_phone_number_redaction and test_phone_at_start_of_text,
+   confirm parenthesized format now redacts
+3. Re-run test_detect_phone_pii, confirm detect() flags it (uses same pattern)
+4. Re-run test_us_phone_formats fully — check whether "+1 555 123 4567"
+   (space-separated, no dashes) also needs a separate fix, since that format
+   uses spaces between all groups, not just after the parenthesis
+5. Run the full test_pii_scrubber.py suite (all 25 tests) to confirm no
+   regressions on the 2 currently-passing formats or other PII types
+
+### Inputs & outputs
+Input: free-text strings potentially containing US phone numbers in any
+supported format. Output: scrub() returns text with phone numbers replaced by
+[REDACTED]; detect() returns a list of PII matches with type and position.
+
+### Risks & unknowns
+- Changing `\b` to `(?<!\d)` is more permissive at the start — need to check it
+  doesn't cause the pattern to match inside larger digit sequences (e.g. part
+  of a longer ID number)
+- Unclear whether "+1 555 123 4567" (all-space-separated) is in scope for this
+  issue or needs a follow-up fix — test_us_phone_formats includes it in the
+  same test, so it may surface as a new failure once the paren case is fixed
+- Need to confirm detect() calls the same phone_us pattern as scrub() (looks
+  likely from the shared PATTERNS dict, but worth verifying in the class body)
+
+### Edge cases
+- (555) 123-4567 (space after paren — reported case)
+- (555)123-4567 (no space after paren)
+- (555)-123-4567 (dash after paren)
+- Parenthesized number at the very start of a string
+- Parenthesized number immediately followed by punctuation, e.g. "(555) 123-4567."
+- Multiple phone numbers of mixed formats in the same string

--- a/safety/pii_scrubber.py
+++ b/safety/pii_scrubber.py
@@ -1,6 +1,7 @@
 """PII detection and scrubbing."""
 
 import re
+
 import structlog
 
 logger = structlog.get_logger()
@@ -12,7 +13,7 @@ class PIIScrubber:
     # Regex patterns for common PII
     PII_PATTERNS = {
         "email": r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b",
-        "phone_us": r"\b(?:\+?1[-.]?)?\(?([0-9]{3})\)?[-.]?([0-9]{3})[-.]?([0-9]{4})\b",
+        "phone_us": r"(?<!\d)(?:\+?1[-.\s]?)?\(?([0-9]{3})\)?[-.\s]?([0-9]{3})[-.\s]?([0-9]{4})\b",
         "phone_intl": r"\+[0-9]{1,3}[-.]?[0-9]{1,14}",
         "ssn": r"\b(?!000|666)[0-9]{3}-(?!00)[0-9]{2}-(?!0000)[0-9]{4}\b",
         "street_address": r"\b\d+\s+[A-Za-z\s]+(?:Street|St|Avenue|Ave|Road|Rd|Boulevard|Blvd|Drive|Dr|Lane|Ln|Court|Ct|Circle|Cir|Park|Pl|Plaza|Place|Drive|Dr|Way|Parkway|Pkwy|Point|Pt|Pike|Run|Summit|Summit|Terrace|Ter|Trail|Trl|Tunnel|Turnpike|View|Vista|Vlg|Village|Vly|Valley)",
@@ -47,13 +48,17 @@ class PIIScrubber:
 
         for pii_type, pattern in self.PII_PATTERNS.items():
             for match in re.finditer(pattern, text, flags=re.IGNORECASE):
-                detected.append({
-                    "type": pii_type,
-                    "value": match.group(),
-                    "start": match.start(),
-                    "end": match.end()
-                })
+                detected.append(
+                    {
+                        "type": pii_type,
+                        "value": match.group(),
+                        "start": match.start(),
+                        "end": match.end(),
+                    }
+                )
 
-        logger.info("pii_detected", count=len(detected), types=len(set(d["type"] for d in detected)))
+        logger.info(
+            "pii_detected", count=len(detected), types=len(set(d["type"] for d in detected))
+        )
 
         return detected

--- a/tests/unit/test_pii_scrubber.py
+++ b/tests/unit/test_pii_scrubber.py
@@ -53,6 +53,18 @@ class TestPIIScrubber:
             scrubbed = scrubber.scrub(text)
             assert "[REDACTED]" in scrubbed
 
+    def test_parenthesized_phone_edge_cases(self, scrubber):
+        """Test parenthesized phone numbers with varying separators (issue #146)."""
+        formats = [
+            "(555)123-4567",  # no space after closing paren
+            "(555)-123-4567",  # dash after closing paren
+        ]
+
+        for phone in formats:
+            text = f"Contact: {phone}"
+            scrubbed = scrubber.scrub(text)
+            assert "[REDACTED]" in scrubbed
+
     def test_international_phone_redaction(self, scrubber):
         """Test international phone number is redacted."""
         text = "Reach me at +44 20 7946 0958"


### PR DESCRIPTION
## Summary
Fixes #146. The `phone_us` regex in `safety/pii_scrubber.py` matched dashed
phone formats (e.g. `555-123-4567`) but failed on parenthesized formats
(e.g. `(555) 123-4567`), leaving them unredacted by `scrub()` and undetected
by `detect()`.

## Root cause
Two issues in the `phone_us` pattern:
1. The leading `\b` boundary failed to match when `(` was preceded by a
   space (both are non-word characters, so no boundary exists).
2. The separator class after the optional closing paren (`[-.]?`) didn't
   include whitespace, so formats like `(555) 123-4567` and
   `+1 555 123 4567` weren't fully matched even where matching started.

## Fix
- Changed the leading `\b` to `(?<!\d)` (blocks matching only when directly
  preceded by a digit, doesn't care about other preceding characters)
- Added `\s` to the separator character classes after the optional closing
  paren and before the final digit group

## Tests
Added `test_parenthesized_phone_edge_cases` covering `(555)123-4567` (no
space) and `(555)-123-4567` (dash) variants. All 4 previously-failing tests
now pass: `test_us_phone_number_redaction`, `test_us_phone_formats`,
`test_detect_phone_pii`, `test_phone_at_start_of_text`.

## Pre-existing failures (unrelated to this change)
`make check` and `make test-unit` both show pre-existing failures unrelated
to this fix — confirmed by running them against the code before my change.
- `test_mixed_pii_and_text` in `test_pii_scrubber.py` fails both before and
  after my change (unrelated regex/text-overlap issue elsewhere in the file)
- ~180 pre-existing lint errors across the codebase (unsorted imports,
  missing type hints, etc.), none on the lines I edited
- ~48 pre-existing failing tests in other modules (`bias_detector`,
  `review_service`, `resume_parser`, `tech_detector`, etc.) that I did not
  touch
My change introduces no new failures — verified by stashing my fix and
confirming these failures pre-date it.