### PR TITLE
fix: skip re-embedding unchanged README content

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -52,3 +52,21 @@ Next I need to review the full diff, create logical commits, push the branch, op
 **Blockers:**
 
 There are no blockers specific to Issue #13. `make test-unit` currently reports 53 unrelated failures outside the changed Issue #13 test file, and `make check` currently reports 178 unrelated repository-wide Ruff errors. The changed Issue #13 files pass their focused tests, Ruff, Black, and diff validation.
+
+### Check-in 2 (end of week)
+
+**What I completed:**
+
+I completed the implementation for Issue #13 and opened PR #873. The ingestion pipeline now stores full SHA-256 content hashes and skips parsing, chunking, and embedding when the same README content has already been processed for the same profile and repository. I also added focused unit tests for unchanged content, changed content, different profiles, different repositories, persisted metadata, byte input, and database lookup failures.
+
+**Validation results:**
+
+The 7 focused ingestion pipeline tests pass. Ruff and Black pass on the changed Python files, and `git diff --check` passes. The full repository commands still report unrelated pre-existing failures outside the files changed for Issue #13.
+
+**Feedback and changes:**
+
+I requested feedback on the draft pull request. No feedback was received before submission, so no additional code changes were required.
+
+**Final PR:**
+
+https://github.com/ascherj/pathreview/pull/873

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -19,3 +19,20 @@ The issue has a defined outcome, identifies the main files involved, and is esti
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/AhmadM2409/pathreview/commit/b99efe6
+
+**Reproduction summary:**
+
+I reproduced the issue with a failing unit test that submits the same README twice through the ingestion pipeline. The test showed that both submissions were parsed, chunked, and embedded because the pipeline does not persist ingestion metadata for the duplicate check.
+
+**PLAN.md link:** https://github.com/AhmadM2409/pathreview/blob/feat/13-content-hash-skip-reembedding/PLAN.md
+
+**Walkthrough video (recommended):** Not recorded
+
+**Blockers or open questions:**
+
+I still need to confirm the project’s database transaction convention before deciding whether `_record_ingested_source()` should call `flush()` or `commit()`. I also need to determine which fields should identify a duplicate README so identical content from different repositories or profiles is not skipped incorrectly.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -57,15 +57,15 @@ There are no blockers specific to Issue #13. `make test-unit` currently reports 
 
 **What I completed:**
 
-I completed the implementation for Issue #13 and opened PR #873. The ingestion pipeline now stores full SHA-256 content hashes and skips parsing, chunking, and embedding when the same README content has already been processed for the same profile and repository. I also added focused unit tests for unchanged content, changed content, different profiles, different repositories, persisted metadata, byte input, and database lookup failures.
+I completed the implementation for Issue #13 and opened PR #873. The ingestion pipeline now stores full SHA-256 content hashes and skips parsing, chunking, and embedding when unchanged README content has already been processed for the same profile and repository. I also added focused tests for duplicate content, changed content, different profiles, different repositories, persisted metadata, byte input, and database lookup failures.
 
 **Validation results:**
 
 The 7 focused ingestion pipeline tests pass. Ruff and Black pass on the changed Python files, and `git diff --check` passes. The full repository commands still report unrelated pre-existing failures outside the files changed for Issue #13.
 
-**Feedback and changes:**
+**Feedback received:**
 
-I requested feedback on the draft pull request. No feedback was received before submission, so no additional code changes were required.
+A classmate reviewed the pull request and confirmed that the duplicate lookup is correctly scoped, the skip occurs before unnecessary processing, and the tests cover the important cases. No blocking issues were identified, so no additional code changes were needed.
 
 **Final PR:**
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -36,3 +36,19 @@ I reproduced the issue with a failing unit test that submits the same README twi
 **Blockers or open questions:**
 
 I still need to confirm the project’s database transaction convention before deciding whether `_record_ingested_source()` should call `flush()` or `commit()`. I also need to determine which fields should identify a duplicate README so identical content from different repositories or profiles is not skipped incorrectly.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+
+I implemented full SHA-256 README deduplication in the ingestion pipeline. The pipeline now queries and saves the real `IngestedSource` model, scopes duplicate checks by profile, repository, source type, and content hash, and stores the repository name in `source_url`. The focused ingestion tests now pass with 7 tests covering duplicate skips, changed content, different profiles, different repositories, persisted metadata, byte hashing, and lookup failure handling.
+
+**Next steps:**
+
+Next I need to review the full diff, create logical commits, push the branch, open a draft PR, request peer or mentor feedback, address any agreed feedback, rerun validation, complete Check-in 2, and finalize the PR.
+
+**Blockers:**
+
+There are no blockers specific to Issue #13. `make test-unit` currently reports 53 unrelated failures outside the changed Issue #13 test file, and `make check` currently reports 178 unrelated repository-wide Ruff errors. The changed Issue #13 files pass their focused tests, Ruff, Black, and diff validation.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -70,3 +70,41 @@ A classmate reviewed the pull request and confirmed that the duplicate lookup is
 **Final PR:**
 
 https://github.com/ascherj/pathreview/pull/873
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+
+No official maintainer review or requested changes were received before the Week 10 reflection. The pull request remains open and ready for review. A classmate reviewed the implementation during the Week 9 peer-feedback process and did not identify any blocking issues, but no additional maintainer feedback required code changes.
+
+**How you responded:**
+
+No additional code changes were required because no official maintainer feedback was received.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+
+The hardest part was understanding how the existing ingestion pipeline, database model, and transaction ownership fit together before making the change. At first, the issue sounded like simply creating a SHA-256 hash and comparing it. The more difficult part was determining where the hash should be persisted, which fields should define the identity of an already-ingested README, and whether the pipeline should commit, flush, or only add the database record. I also had to separate failures caused by my change from existing repository-wide test, Ruff, and mypy failures.
+
+**What did you learn about working in a large codebase?**
+
+I learned that making a small change in a larger codebase requires understanding the surrounding conventions before writing code. In my own projects, I can choose how transactions, models, and tests are structured. In PathReview, I needed to inspect existing service patterns and follow the design already used by the project. I also learned that passing one focused test is not enough by itself. I had to check the broader diff, formatting, linting, transaction behavior, and whether the change could affect other profiles or repositories.
+
+**How did AI tools help — and where did they fall short?**
+
+AI tools were most useful for exploring the repository, tracing the ingestion flow, identifying relevant files, explaining unfamiliar patterns, creating focused tests, and reviewing the final diff. They also helped me break the work into smaller steps instead of trying to implement everything at once. The limitation was that AI could not automatically know which project conventions were correct without inspecting the actual code. I still had to verify transaction ownership, model fields, existing failures, Git state, and the final GitHub PR myself. AI suggestions were useful starting points, but they still needed to be checked against the repository.
+
+**What would you do differently if you started over?**
+
+I would begin with a smaller reproduction test and spend more time tracing the database flow before thinking about the implementation. Early on, I focused on the hashing behavior, but the important design questions were how the ingestion record was stored and how duplicate identity should be scoped. Understanding those pieces earlier would have reduced some back-and-forth and made the implementation more direct.
+
+**What are you most proud of from this module?**
+
+I am most proud that I took an issue from reproduction through planning, implementation, testing, documentation, and a real pull request against an existing project. The final change stayed focused on Issue #13 and included tests for duplicate content, changed content, different profiles, and different repositories instead of only testing the easiest successful case.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,21 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/13
+
+**Issue title:** Add a content hash to detect unchanged documents and skip re-embedding
+
+**Tier:** [ ] Tier 1  [x] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+
+The ingestion pipeline currently reprocesses and re-embeds a README even when the submitted content has not changed. This creates unnecessary embedding work and may result in avoidable API usage. The issue affects the ingestion pipeline and the `IngestedSource` model, which need a reliable way to store and compare a content hash. A successful fix will detect identical content and skip the embedding step while continuing normal processing when the document has changed.
+
+**Selection notes — “Is this issue right for me?” checklist:**
+
+The issue has a defined outcome, identifies the main files involved, and is estimated at 4–6 hours. It requires Python, database-model, ingestion-pipeline, and testing work, which are within my current experience. The scope appears limited to hashing submitted content, recording the hash, comparing it during later ingestion attempts, and verifying the behavior with tests. I understand that a database migration may be needed if the model does not already contain a suitable content-hash field.
+
+**Branch name:** feat/13-content-hash-skip-reembedding
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/PLAN.md
+++ b/PLAN.md
@@ -19,21 +19,21 @@ Expected files and code paths involved:
 * `core/models/ingested_source.py`
 
   * Existing `IngestedSource` model
-  * Existing `content_hash` field
+  * Existing `source_url`, `content_hash`, and `chunk_count` fields
 * `tests/unit/test_ingestion_pipeline.py`
 
   * Reproduction test for submitting an identical README twice
   * Additional tests for changed content and database behavior
-* Potentially an existing database-session or model-import module if required to avoid circular imports
+* Existing service code that shows the caller owns database commits
 
-A database migration is not currently expected because the `IngestedSource` model already contains a `content_hash` column.
+A database migration is not needed because the `IngestedSource` model and initial Alembic migration already contain the required fields.
 
 ### Plan
 
 1. Import and use the actual `IngestedSource` SQLAlchemy model in the ingestion pipeline instead of querying the string `"IngestedSource"`.
 2. Compute the full content hash once during ingestion and pass it separately to the duplicate-check and persistence methods.
-3. Update `_check_skip()` so it queries for a matching ingested source using the relevant identity fields, including `profile_id`, `source_type`, and `content_hash`.
-4. Update `_record_ingested_source()` so it creates an `IngestedSource` record, adds it to the database session, and commits or flushes it according to the project’s existing transaction conventions.
+3. Update `_check_skip()` so it queries for a matching ingested source using `profile_id`, `source_type`, `source_url`, and `content_hash`.
+4. Update `_record_ingested_source()` so it creates an `IngestedSource` record and adds it to the database session without committing, because the service or caller layer owns the transaction.
 5. Expand `tests/unit/test_ingestion_pipeline.py` so it verifies:
 
    * the first README ingestion is processed;
@@ -65,11 +65,12 @@ A database migration is not currently expected because the `IngestedSource` mode
 
 ### Risks & unknowns
 
-* The pipeline may currently rely on transaction ownership outside `_record_ingested_source()`, so calling `commit()` directly could conflict with existing session-management conventions. I need to inspect how other services add and persist SQLAlchemy models before choosing between `add()`, `flush()`, and `commit()`.
-* Duplicate matching may need more than `profile_id`, `source_type`, and `content_hash`. README records may also need repository identity such as `source_url`, `filename`, or repository name to avoid incorrectly treating the same content in two different repositories as one source.
-* The current `source_id` is not represented as a field on `IngestedSource`, so the skip implementation may need to rely entirely on model fields rather than the generated `source_id`.
-* Resume and repository metadata ingestion use the same placeholder helper methods. Changing shared methods could affect those ingestion paths, so tests should verify that the implementation remains compatible with all source types.
-* Importing `IngestedSource` directly into `ingestion/pipeline.py` could expose a circular import, which must be checked before implementation.
+* Resolved: the pipeline should call `db_session.add()` but should not call `commit()`, because existing service code owns transaction commits.
+* Resolved: README duplicate matching uses `profile_id`, `source_type`, `source_url` with `repo_name`, and the full SHA-256 `content_hash`.
+* Resolved: the current `source_id` is not represented as a field on `IngestedSource`, so duplicate lookup relies on real persisted model fields.
+* Resolved: importing `IngestedSource` directly into `ingestion/pipeline.py` did not create a circular import.
+* Focused tests now confirm unchanged README content is skipped while changed content, different profiles, and different repositories are processed.
+* Repository-wide unit and lint failures remain pre-existing and unrelated to Issue #13.
 
 ### Edge cases
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,84 @@
+## Solution plan
+
+**Issue:** [Add a content hash to detect unchanged documents and skip re-embedding](https://github.com/ascherj/pathreview/issues/13)
+
+### Understand
+
+The ingestion pipeline already computes a SHA-256-based content hash and includes a shortened version of that hash in each `source_id`. However, duplicate detection does not work because `_check_skip()` does not query the actual `IngestedSource` SQLAlchemy model, and `_record_ingested_source()` only logs the ingestion instead of saving a database record. As a result, when the same README is submitted again, the pipeline parses, chunks, and embeds it a second time rather than returning a skipped result. The expected behavior is for the first ingestion to store metadata about the source and for later ingestion attempts with the same profile, source type, repository, and content hash to skip embedding.
+
+### Map
+
+Expected files and code paths involved:
+
+* `ingestion/pipeline.py`
+
+  * `IngestionPipeline.ingest_readme()`
+  * `IngestionPipeline._hash_content()`
+  * `IngestionPipeline._check_skip()`
+  * `IngestionPipeline._record_ingested_source()`
+* `core/models/ingested_source.py`
+
+  * Existing `IngestedSource` model
+  * Existing `content_hash` field
+* `tests/unit/test_ingestion_pipeline.py`
+
+  * Reproduction test for submitting an identical README twice
+  * Additional tests for changed content and database behavior
+* Potentially an existing database-session or model-import module if required to avoid circular imports
+
+A database migration is not currently expected because the `IngestedSource` model already contains a `content_hash` column.
+
+### Plan
+
+1. Import and use the actual `IngestedSource` SQLAlchemy model in the ingestion pipeline instead of querying the string `"IngestedSource"`.
+2. Compute the full content hash once during ingestion and pass it separately to the duplicate-check and persistence methods.
+3. Update `_check_skip()` so it queries for a matching ingested source using the relevant identity fields, including `profile_id`, `source_type`, and `content_hash`.
+4. Update `_record_ingested_source()` so it creates an `IngestedSource` record, adds it to the database session, and commits or flushes it according to the project’s existing transaction conventions.
+5. Expand `tests/unit/test_ingestion_pipeline.py` so it verifies:
+
+   * the first README ingestion is processed;
+   * the second identical README ingestion is skipped;
+   * changed README content is processed;
+   * the embedding processor is not called for skipped content;
+   * ingestion metadata is persisted with the expected hash and chunk count.
+
+### Inputs & outputs
+
+**Inputs:**
+
+* `profile_id`
+* repository name
+* README content as `str` or `bytes`
+* database session
+* embedding provider and vector database dependencies
+
+**Outputs and changes:**
+
+* First-time content should be parsed, chunked, embedded, and recorded in `ingested_sources`.
+* Identical content submitted again should return an `IngestResult` with:
+
+  * `skipped=True`
+  * `chunk_count=0`
+  * a clear skip reason
+* Changed content should produce a different hash and proceed through embedding normally.
+* The database should contain enough metadata to identify previously ingested content.
+
+### Risks & unknowns
+
+* The pipeline may currently rely on transaction ownership outside `_record_ingested_source()`, so calling `commit()` directly could conflict with existing session-management conventions. I need to inspect how other services add and persist SQLAlchemy models before choosing between `add()`, `flush()`, and `commit()`.
+* Duplicate matching may need more than `profile_id`, `source_type`, and `content_hash`. README records may also need repository identity such as `source_url`, `filename`, or repository name to avoid incorrectly treating the same content in two different repositories as one source.
+* The current `source_id` is not represented as a field on `IngestedSource`, so the skip implementation may need to rely entirely on model fields rather than the generated `source_id`.
+* Resume and repository metadata ingestion use the same placeholder helper methods. Changing shared methods could affect those ingestion paths, so tests should verify that the implementation remains compatible with all source types.
+* Importing `IngestedSource` directly into `ingestion/pipeline.py` could expose a circular import, which must be checked before implementation.
+
+### Edge cases
+
+* Empty README content
+* README content provided as bytes instead of a string
+* Same content submitted for two different profiles
+* Same content submitted for two different repositories
+* Changed content for the same profile and repository
+* Database lookup failure
+* Database persistence failure after embeddings have already been generated
+* Existing legacy records with `content_hash=None`
+* Duplicate submissions occurring close together before the first transaction is committed

--- a/ingestion/pipeline.py
+++ b/ingestion/pipeline.py
@@ -1,8 +1,9 @@
 import hashlib
 from dataclasses import dataclass
-from typing import Optional
 
 import structlog
+
+from core.models.ingested_source import IngestedSource
 
 from .chunking.strategy_selector import StrategySelector
 from .embeddings.batch_processor import BatchEmbeddingProcessor
@@ -11,17 +12,17 @@ from .parsers.readme_parser import ReadmeParser
 from .parsers.repo_analyzer import RepoAnalyzer
 from .parsers.resume_parser import ResumeParser
 
-
 logger = structlog.get_logger()
 
 
 @dataclass
 class IngestResult:
     """Result of ingesting a source."""
+
     source_id: str
     chunk_count: int
     skipped: bool
-    skip_reason: Optional[str] = None
+    skip_reason: str | None = None
 
 
 class IngestionPipeline:
@@ -69,7 +70,8 @@ class IngestionPipeline:
         Returns:
             IngestResult with ingestion status
         """
-        source_id = f"resume_{profile_id}_{self._hash_content(content)}"
+        content_hash = self._hash_content(content)
+        source_id = f"resume_{profile_id}_{content_hash[:16]}"
 
         logger.info(
             "Starting resume ingestion",
@@ -79,23 +81,34 @@ class IngestionPipeline:
         )
 
         # Check if already ingested
-        skip_result = self._check_skip(source_id, "resume")
+        skip_result = self._check_skip(
+            source_id=source_id,
+            source_type="resume",
+            profile_id=profile_id,
+            source_url=None,
+            content_hash=content_hash,
+        )
         if skip_result:
             return skip_result
 
         try:
             # Parse resume
             parse_result = self.resume_parser.parse(content)
-            logger.info("Resume parsed successfully", sections=parse_result.metadata.get("detected_sections"))
+            logger.info(
+                "Resume parsed successfully",
+                sections=parse_result.metadata.get("detected_sections"),
+            )
 
             # Prepare metadata
             metadata = parse_result.metadata.copy()
-            metadata.update({
-                "source_id": source_id,
-                "profile_id": profile_id,
-                "filename": filename,
-                "source_type": "resume",
-            })
+            metadata.update(
+                {
+                    "source_id": source_id,
+                    "profile_id": profile_id,
+                    "filename": filename,
+                    "source_type": "resume",
+                }
+            )
 
             # Chunk the content
             chunks = self.strategy_selector.chunk(parse_result.text, metadata)
@@ -106,7 +119,15 @@ class IngestionPipeline:
             logger.info("Resume embeddings stored", chunk_count=len(chunks))
 
             # Record in database
-            self._record_ingested_source(source_id, "resume", profile_id, len(chunks))
+            self._record_ingested_source(
+                source_id=source_id,
+                source_type="resume",
+                profile_id=profile_id,
+                source_url=None,
+                content_hash=content_hash,
+                chunk_count=len(chunks),
+                filename=filename,
+            )
 
             return IngestResult(
                 source_id=source_id,
@@ -140,7 +161,8 @@ class IngestionPipeline:
         Returns:
             IngestResult with ingestion status
         """
-        source_id = f"readme_{profile_id}_{repo_name}_{self._hash_content(content)}"
+        content_hash = self._hash_content(content)
+        source_id = f"readme_{profile_id}_{repo_name}_{content_hash[:16]}"
 
         logger.info(
             "Starting README ingestion",
@@ -150,7 +172,13 @@ class IngestionPipeline:
         )
 
         # Check if already ingested
-        skip_result = self._check_skip(source_id, "readme")
+        skip_result = self._check_skip(
+            source_id=source_id,
+            source_type="readme",
+            profile_id=profile_id,
+            source_url=repo_name,
+            content_hash=content_hash,
+        )
         if skip_result:
             return skip_result
 
@@ -165,12 +193,14 @@ class IngestionPipeline:
 
             # Prepare metadata
             metadata = parse_result.metadata.copy()
-            metadata.update({
-                "source_id": source_id,
-                "profile_id": profile_id,
-                "repo_name": repo_name,
-                "source_type": "readme",
-            })
+            metadata.update(
+                {
+                    "source_id": source_id,
+                    "profile_id": profile_id,
+                    "repo_name": repo_name,
+                    "source_type": "readme",
+                }
+            )
 
             # Chunk the content
             chunks = self.strategy_selector.chunk(parse_result.text, metadata)
@@ -181,7 +211,14 @@ class IngestionPipeline:
             logger.info("README embeddings stored", chunk_count=len(chunks))
 
             # Record in database
-            self._record_ingested_source(source_id, "readme", profile_id, len(chunks))
+            self._record_ingested_source(
+                source_id=source_id,
+                source_type="readme",
+                profile_id=profile_id,
+                source_url=repo_name,
+                content_hash=content_hash,
+                chunk_count=len(chunks),
+            )
 
             return IngestResult(
                 source_id=source_id,
@@ -214,7 +251,8 @@ class IngestionPipeline:
             IngestResult with ingestion status
         """
         repo_name = repo_data.get("name", "unknown")
-        source_id = f"repo_{profile_id}_{repo_name}_{self._hash_content(str(repo_data))}"
+        content_hash = self._hash_content(str(repo_data))
+        source_id = f"repo_{profile_id}_{repo_name}_{content_hash[:16]}"
 
         logger.info(
             "Starting repo metadata ingestion",
@@ -224,7 +262,13 @@ class IngestionPipeline:
         )
 
         # Check if already ingested
-        skip_result = self._check_skip(source_id, "repo")
+        skip_result = self._check_skip(
+            source_id=source_id,
+            source_type="repo",
+            profile_id=profile_id,
+            source_url=repo_name,
+            content_hash=content_hash,
+        )
         if skip_result:
             return skip_result
 
@@ -239,11 +283,13 @@ class IngestionPipeline:
 
             # Prepare metadata
             metadata = parse_result.metadata.copy()
-            metadata.update({
-                "source_id": source_id,
-                "profile_id": profile_id,
-                "source_type": "repo",
-            })
+            metadata.update(
+                {
+                    "source_id": source_id,
+                    "profile_id": profile_id,
+                    "source_type": "repo",
+                }
+            )
 
             # Chunk the content
             chunks = self.strategy_selector.chunk(parse_result.text, metadata)
@@ -254,7 +300,14 @@ class IngestionPipeline:
             logger.info("Repository embeddings stored", chunk_count=len(chunks))
 
             # Record in database
-            self._record_ingested_source(source_id, "repo", profile_id, len(chunks))
+            self._record_ingested_source(
+                source_id=source_id,
+                source_type="repo",
+                profile_id=profile_id,
+                source_url=repo_name,
+                content_hash=content_hash,
+                chunk_count=len(chunks),
+            )
 
             return IngestResult(
                 source_id=source_id,
@@ -275,20 +328,32 @@ class IngestionPipeline:
         """Generate a hash of content for deduplication."""
         if isinstance(content, str):
             content = content.encode()
-        return hashlib.sha256(content).hexdigest()[:16]
+        return hashlib.sha256(content).hexdigest()
 
-    def _check_skip(self, source_id: str, source_type: str) -> Optional[IngestResult]:
+    def _check_skip(
+        self,
+        source_id: str,
+        source_type: str,
+        profile_id: str,
+        source_url: str | None,
+        content_hash: str,
+    ) -> IngestResult | None:
         """
         Check if source has already been ingested.
 
         Returns IngestResult if should skip, None if should proceed.
         """
         try:
-            # Query database for existing source
-            # This assumes a table/model named IngestedSource
-            existing = self.db_session.query(
-                "IngestedSource"  # Placeholder - actual query depends on ORM
-            ).filter_by(source_id=source_id).first()
+            existing = (
+                self.db_session.query(IngestedSource)
+                .filter_by(
+                    profile_id=profile_id,
+                    source_type=source_type,
+                    source_url=source_url,
+                    content_hash=content_hash,
+                )
+                .first()
+            )
 
             if existing:
                 logger.info("Source already ingested, skipping", source_id=source_id)
@@ -296,7 +361,7 @@ class IngestionPipeline:
                     source_id=source_id,
                     chunk_count=0,
                     skipped=True,
-                    skip_reason="Source already ingested",
+                    skip_reason="Source content has not changed",
                 )
         except Exception as e:
             logger.warning(
@@ -312,7 +377,10 @@ class IngestionPipeline:
         source_id: str,
         source_type: str,
         profile_id: str,
+        source_url: str | None,
+        content_hash: str,
         chunk_count: int,
+        filename: str | None = None,
     ) -> None:
         """
         Record that a source has been ingested.
@@ -321,11 +389,21 @@ class IngestionPipeline:
             source_id: Unique ID for the source
             source_type: Type of source (resume, readme, repo)
             profile_id: ID of profile owner
+            source_url: Source URL or repository identity
+            content_hash: Full SHA-256 hash of the source content
             chunk_count: Number of chunks created
+            filename: Optional filename for uploaded sources
         """
         try:
-            # This is a placeholder for actual database recording
-            # In a real implementation, would create IngestedSource record
+            record = IngestedSource(
+                profile_id=profile_id,
+                source_type=source_type,
+                source_url=source_url,
+                filename=filename,
+                content_hash=content_hash,
+                chunk_count=chunk_count,
+            )
+            self.db_session.add(record)
             logger.info(
                 "Recording ingested source",
                 source_id=source_id,

--- a/tests/unit/test_ingestion_pipeline.py
+++ b/tests/unit/test_ingestion_pipeline.py
@@ -1,0 +1,56 @@
+"""Reproduction tests for ingestion pipeline deduplication."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from ingestion.pipeline import IngestionPipeline
+
+
+@pytest.mark.unit
+def test_identical_readme_is_not_embedded_twice(sample_readme_text: str) -> None:
+    """
+    Reproduce issue #13.
+
+    Submitting the same README twice should skip the second embedding,
+    but the current pipeline processes it twice because ingestion
+    metadata is not actually persisted.
+    """
+    vector_db = MagicMock()
+    db_session = MagicMock()
+    db_session.query.return_value.filter_by.return_value.first.return_value = None
+    embedding_provider = MagicMock()
+
+    pipeline = IngestionPipeline(
+        vector_db=vector_db,
+        db_session=db_session,
+        embedding_provider=embedding_provider,
+    )
+
+    # Isolate the test from parsing and chunking details.
+    parse_result = MagicMock()
+    parse_result.text = sample_readme_text
+    parse_result.metadata = {
+        "heading_count": 2,
+        "word_count": 20,
+    }
+
+    pipeline.readme_parser.parse = MagicMock(return_value=parse_result)  # type: ignore[method-assign]
+    pipeline.strategy_selector.chunk = MagicMock(return_value=[MagicMock()])  # type: ignore[method-assign]
+    pipeline.batch_processor.process = MagicMock()  # type: ignore[method-assign]
+
+    first_result = pipeline.ingest_readme(
+        profile_id="profile-123",
+        repo_name="weather-app",
+        content=sample_readme_text,
+    )
+
+    second_result = pipeline.ingest_readme(
+        profile_id="profile-123",
+        repo_name="weather-app",
+        content=sample_readme_text,
+    )
+
+    assert first_result.skipped is False
+    assert second_result.skipped is True
+    assert pipeline.batch_processor.process.call_count == 1

--- a/tests/unit/test_ingestion_pipeline.py
+++ b/tests/unit/test_ingestion_pipeline.py
@@ -1,33 +1,66 @@
-"""Reproduction tests for ingestion pipeline deduplication."""
+"""Tests for ingestion pipeline deduplication."""
 
+import hashlib
+from typing import cast
 from unittest.mock import MagicMock
 
 import pytest
 
+from core.models.ingested_source import IngestedSource
 from ingestion.pipeline import IngestionPipeline
 
 
-@pytest.mark.unit
-def test_identical_readme_is_not_embedded_twice(sample_readme_text: str) -> None:
-    """
-    Reproduce issue #13.
+class FakeQuery:
+    """Small query helper for matching records added to the fake session."""
 
-    Submitting the same README twice should skip the second embedding,
-    but the current pipeline processes it twice because ingestion
-    metadata is not actually persisted.
-    """
-    vector_db = MagicMock()
-    db_session = MagicMock()
-    db_session.query.return_value.filter_by.return_value.first.return_value = None
-    embedding_provider = MagicMock()
+    def __init__(self, records: list[IngestedSource]) -> None:
+        self.records = records
+        self.filters: dict[str, object] = {}
 
+    def filter_by(self, **filters: object) -> "FakeQuery":
+        """Store equality filters for the later first() call."""
+        self.filters = filters
+        return self
+
+    def first(self) -> IngestedSource | None:
+        """Return the first record matching all filter values."""
+        for record in self.records:
+            if all(getattr(record, field) == value for field, value in self.filters.items()):
+                return record
+        return None
+
+
+class FakeSession:
+    """In-memory stand-in for the SQLAlchemy calls used by the pipeline."""
+
+    def __init__(self, fail_lookup: bool = False) -> None:
+        self.records: list[IngestedSource] = []
+        self.fail_lookup = fail_lookup
+
+    def query(self, model: type[IngestedSource]) -> FakeQuery:
+        """Return a query object or simulate a database lookup failure."""
+        if self.fail_lookup:
+            raise RuntimeError("database lookup failed")
+        assert model is IngestedSource
+        return FakeQuery(self.records)
+
+    def add(self, record: IngestedSource) -> None:
+        """Persist a record in memory."""
+        self.records.append(record)
+
+
+def build_pipeline(
+    sample_readme_text: str,
+    db_session: FakeSession | None = None,
+) -> tuple[IngestionPipeline, FakeSession]:
+    """Create an ingestion pipeline with parsing, chunking, and embedding mocked."""
+    session = db_session or FakeSession()
     pipeline = IngestionPipeline(
-        vector_db=vector_db,
-        db_session=db_session,
-        embedding_provider=embedding_provider,
+        vector_db=MagicMock(),
+        db_session=session,
+        embedding_provider=MagicMock(),
     )
 
-    # Isolate the test from parsing and chunking details.
     parse_result = MagicMock()
     parse_result.text = sample_readme_text
     parse_result.metadata = {
@@ -36,15 +69,76 @@ def test_identical_readme_is_not_embedded_twice(sample_readme_text: str) -> None
     }
 
     pipeline.readme_parser.parse = MagicMock(return_value=parse_result)  # type: ignore[method-assign]
-    pipeline.strategy_selector.chunk = MagicMock(return_value=[MagicMock()])  # type: ignore[method-assign]
+    pipeline.strategy_selector.chunk = MagicMock(  # type: ignore[method-assign]
+        return_value=[MagicMock(), MagicMock()]
+    )
     pipeline.batch_processor.process = MagicMock()  # type: ignore[method-assign]
+    return pipeline, session
+
+
+def expected_sha256(content: str | bytes) -> str:
+    """Return the full SHA-256 hash for test assertions."""
+    if isinstance(content, str):
+        content = content.encode()
+    return hashlib.sha256(content).hexdigest()
+
+
+def parse_call_count(pipeline: IngestionPipeline) -> int:
+    """Return how many times the README parser mock was called."""
+    return cast("MagicMock", pipeline.readme_parser.parse).call_count
+
+
+def chunk_call_count(pipeline: IngestionPipeline) -> int:
+    """Return how many times the chunking mock was called."""
+    return cast("MagicMock", pipeline.strategy_selector.chunk).call_count
+
+
+def embedding_call_count(pipeline: IngestionPipeline) -> int:
+    """Return how many times the embedding processor mock was called."""
+    return cast("MagicMock", pipeline.batch_processor.process).call_count
+
+
+@pytest.mark.unit
+def test_first_readme_ingestion_processes_and_records_source(
+    sample_readme_text: str,
+) -> None:
+    """First README ingestion should parse, embed, and record metadata."""
+    pipeline, session = build_pipeline(sample_readme_text)
+
+    result = pipeline.ingest_readme(
+        profile_id="profile-123",
+        repo_name="weather-app",
+        content=sample_readme_text,
+    )
+
+    assert result.skipped is False
+    assert result.chunk_count == 2
+    assert parse_call_count(pipeline) == 1
+    assert chunk_call_count(pipeline) == 1
+    assert embedding_call_count(pipeline) == 1
+
+    assert len(session.records) == 1
+    record = session.records[0]
+    assert record.profile_id == "profile-123"
+    assert record.source_type == "readme"
+    assert record.source_url == "weather-app"
+    assert record.content_hash == expected_sha256(sample_readme_text)
+    assert len(record.content_hash or "") == 64
+    assert record.chunk_count == 2
+
+
+@pytest.mark.unit
+def test_same_readme_same_profile_and_repo_is_skipped_without_processing_again(
+    sample_readme_text: str,
+) -> None:
+    """Duplicate README content for the same profile and repo should skip work."""
+    pipeline, session = build_pipeline(sample_readme_text)
 
     first_result = pipeline.ingest_readme(
         profile_id="profile-123",
         repo_name="weather-app",
         content=sample_readme_text,
     )
-
     second_result = pipeline.ingest_readme(
         profile_id="profile-123",
         repo_name="weather-app",
@@ -53,4 +147,120 @@ def test_identical_readme_is_not_embedded_twice(sample_readme_text: str) -> None
 
     assert first_result.skipped is False
     assert second_result.skipped is True
-    assert pipeline.batch_processor.process.call_count == 1
+    assert second_result.chunk_count == 0
+    assert second_result.skip_reason == "Source content has not changed"
+    assert parse_call_count(pipeline) == 1
+    assert chunk_call_count(pipeline) == 1
+    assert embedding_call_count(pipeline) == 1
+    assert len(session.records) == 1
+
+
+@pytest.mark.unit
+def test_changed_readme_content_is_processed(sample_readme_text: str) -> None:
+    """Changed content should create a new hash and run embedding again."""
+    pipeline, session = build_pipeline(sample_readme_text)
+    changed_readme = f"{sample_readme_text}\n## Deployment\nHosted on Vercel."
+
+    first_result = pipeline.ingest_readme(
+        profile_id="profile-123",
+        repo_name="weather-app",
+        content=sample_readme_text,
+    )
+    second_result = pipeline.ingest_readme(
+        profile_id="profile-123",
+        repo_name="weather-app",
+        content=changed_readme,
+    )
+
+    assert first_result.skipped is False
+    assert second_result.skipped is False
+    assert embedding_call_count(pipeline) == 2
+    assert len(session.records) == 2
+    assert session.records[0].content_hash != session.records[1].content_hash
+
+
+@pytest.mark.unit
+def test_same_readme_content_for_different_profile_is_processed(
+    sample_readme_text: str,
+) -> None:
+    """The same README text should not be skipped for a different profile."""
+    pipeline, session = build_pipeline(sample_readme_text)
+
+    first_result = pipeline.ingest_readme(
+        profile_id="profile-123",
+        repo_name="weather-app",
+        content=sample_readme_text,
+    )
+    second_result = pipeline.ingest_readme(
+        profile_id="profile-456",
+        repo_name="weather-app",
+        content=sample_readme_text,
+    )
+
+    assert first_result.skipped is False
+    assert second_result.skipped is False
+    assert embedding_call_count(pipeline) == 2
+    assert len(session.records) == 2
+
+
+@pytest.mark.unit
+def test_same_readme_content_for_different_repo_is_processed(
+    sample_readme_text: str,
+) -> None:
+    """The same README text should not be skipped for a different repository."""
+    pipeline, session = build_pipeline(sample_readme_text)
+
+    first_result = pipeline.ingest_readme(
+        profile_id="profile-123",
+        repo_name="weather-app",
+        content=sample_readme_text,
+    )
+    second_result = pipeline.ingest_readme(
+        profile_id="profile-123",
+        repo_name="forecast-dashboard",
+        content=sample_readme_text,
+    )
+
+    assert first_result.skipped is False
+    assert second_result.skipped is False
+    assert embedding_call_count(pipeline) == 2
+    assert len(session.records) == 2
+    assert session.records[0].source_url != session.records[1].source_url
+
+
+@pytest.mark.unit
+def test_string_and_byte_content_produce_same_full_hash(
+    sample_readme_text: str,
+) -> None:
+    """Equivalent string and byte content should hash to the same full value."""
+    pipeline, _session = build_pipeline(sample_readme_text)
+
+    string_hash = pipeline._hash_content(sample_readme_text)
+    byte_hash = pipeline._hash_content(sample_readme_text.encode())
+
+    assert string_hash == byte_hash
+    assert string_hash == expected_sha256(sample_readme_text)
+    assert len(string_hash) == 64
+
+
+@pytest.mark.unit
+def test_database_lookup_failure_does_not_report_duplicate(
+    sample_readme_text: str,
+) -> None:
+    """A lookup error should allow processing instead of falsely skipping."""
+    pipeline, session = build_pipeline(
+        sample_readme_text,
+        db_session=FakeSession(fail_lookup=True),
+    )
+
+    result = pipeline.ingest_readme(
+        profile_id="profile-123",
+        repo_name="weather-app",
+        content=sample_readme_text,
+    )
+
+    assert result.skipped is False
+    assert parse_call_count(pipeline) == 1
+    assert chunk_call_count(pipeline) == 1
+    assert embedding_call_count(pipeline) == 1
+    assert len(session.records) == 1


### PR DESCRIPTION
## Summary
- Save full SHA-256 README content hashes in `IngestedSource`.
- Check profile, source type, repository identity, and content hash before processing.
- Skip parsing, chunking, and embedding when README content is unchanged.
- Preserve normal processing for changed content, different profiles, and different repositories.

## Tests
- Added 7 focused ingestion pipeline tests.
- Covers first ingestion, duplicate content, changed content, profile and repository separation, persisted hash fields, equivalent string/byte hashing, and database lookup failure.

## Validation
- Focused ingestion pipeline tests: 7 passed.
- Ruff passed on `ingestion/pipeline.py` and `tests/unit/test_ingestion_pipeline.py`.
- Black passed on both changed Python files.
- `git diff --check` passed.

## Pre-existing failures
- `make test-unit` reports 53 failures outside the Issue #13 test file.
- `make check` reports 178 repository-wide Ruff errors outside the changed files.
- This change introduces no new focused-test, Ruff, Black, or diff-validation failures.

Closes #13