### PR TITLE
Fix/150 ignore vendored build files

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -14,3 +14,17 @@
 **Setup confirmation:** [X] App runs locally at localhost:5173
 
 **Cohort ledger:** [X] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** e5fbf96
+
+**Reproduction summary:**
+Ran `.venv/bin/pytest tests/unit/test_tech_detector.py -v -m unit`. 2 of 27 tests fail: `test_node_modules_excluded` and `test_build_directory_excluded`, both expecting `primary_language == "Python"` but getting `"JavaScript"`. Root cause: `_should_skip_file` in `agent/tools/tech_detector.py` checks for substrings like `"/node_modules/"` and `"/build/"` which require a leading slash, but repo-relative paths (e.g. `node_modules/lib/index.js`, `build/bundle.js`) have no leading slash, so the skip patterns never match and vendored/build files aren't filtered out.
+
+**PLAN.md link:** [Click Here](PLAN.md)
+
+**Walkthrough video (recommended):** [link to your Loom video, ≤2 min — recommended, not graded]
+
+**Blockers or open questions:**
+[Anything you're still uncertain about going into Week 9, or leave blank]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,16 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/150
+
+**Issue title:** Tech detector counts vendored and build-output files, skewing language detection
+
+**Tier:** [X] Tier 1
+
+**Problem summary:**
+`tech_detector.py` is counting files from folders like `node_modules/` and `build/` when figuring out what the primary language a project uses. These folders usually contain downloaded libraries or generated files (i.e. not the code written by the developer) so they can make the detector pick the wrong language. For example, a Python project with bundled JavaScript files may incorrectly be detected as a JavaScript project. The fix should make the tech detector ignore these directories so that language detection is based only on the project's own source code, allowing the related tests in `tests/unit/test_tech_detector.py` to pass.
+
+**Branch name:** fix/150-ignore-vendored-build-files
+
+**Setup confirmation:** [X] App runs locally at localhost:5173
+
+**Cohort ledger:** [X] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -17,7 +17,7 @@
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** e5fbf96
+**Reproduction commit link:** c052e64
 
 **Reproduction summary:**
 Ran `.venv/bin/pytest tests/unit/test_tech_detector.py -v -m unit`. 2 of 27 tests fail: `test_node_modules_excluded` and `test_build_directory_excluded`, both expecting `primary_language == "Python"` but getting `"JavaScript"`. Root cause: `_should_skip_file` in `agent/tools/tech_detector.py` checks for substrings like `"/node_modules/"` and `"/build/"` which require a leading slash, but repo-relative paths (e.g. `node_modules/lib/index.js`, `build/bundle.js`) have no leading slash, so the skip patterns never match and vendored/build files aren't filtered out.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,6 +1,6 @@
 ## Week 7 — Issue selection
 
-**Issue link:** https://github.com/ascherj/pathreview/issues/150
+**Issue link:** [Issue #150](https://github.com/ascherj/pathreview/issues/150)
 
 **Issue title:** Tech detector counts vendored and build-output files, skewing language detection
 
@@ -46,7 +46,7 @@ None.
 
 ### Check-in 2 (end of week)
 
-**PR link:** https://github.com/ascherj/pathreview/pull/875
+**PR link:** [PR #875](https://github.com/ascherj/pathreview/pull/875)
 
 **Branch:** `fix/150-ignore-vendored-build-files`
 
@@ -59,3 +59,34 @@ None added or modified. `tests/unit/test_tech_detector.py::test_node_modules_exc
 **Self-review confirmation:** [X] make test-unit passes (`.venv/bin/pytest tests/unit/test_tech_detector.py -m unit`: 27/27 pass; full `tests/unit` suite: 51 pre-existing unrelated failures, down from 53 before this fix, confirmed on main)  [ ] make check passes (182 pre-existing lint errors repo-wide, unrelated to this change; `agent/tools/tech_detector.py` itself has one pre-existing import-sort warning, not introduced by this fix)
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No review came in on [PR #875](https://github.com/ascherj/pathreview/pull/875) yet.
+
+**How you responded:**
+N/A — no feedback to respond to.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Writing the PR description was harder than expected. Cramming enough detail to justify the fix (root cause, design tradeoffs, test evidence) into something concise, without padding it out just to look thorough, took more revision than the actual code fix did. Gave me a lot more respect for how open-source maintainers hold that bar consistently, especially pre-AI tooling.
+
+**What did you learn about working in a large codebase?**
+I didn't read the full codebase, but tracking down the files named in the issue was straightforward, and reading the source alongside the pytest tests made the bug's behavior clear quickly. The real gap versus my own projects: on my own code, I already know the layout because I built it. Here I had to lean on the issue description and test names to orient myself instead of prior context.
+
+**How did AI tools help — and where did they fall short?**
+Mainly useful for scaffolding the plan (PLAN.md) and drafting the PR/journal writeups once I'd already pinned down the root cause myself. The issue was scoped tightly enough that I didn't get much signal on where AI would fall short. I'd expect that to show up more on a harder issue with ambiguous root cause or cross-file changes.
+
+**What would you do differently if you started over?**
+Pick a harder issue, ideally something touching APIs or a multi-file change, rather than a single-function bug fix. Given more time, I'd also spend a session just reading through the codebase's architecture and system design, since that's the part I find most interesting and it's a purely additive/exploratory session.
+
+**What are you most proud of from this module?**
+Nailing down the actual root cause (leading-slash substring match silently failing on root-relative paths) before touching any code, so the fix ended up being a small, well-justified change instead of a guess-and-check patch.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -46,7 +46,7 @@ None.
 
 ### Check-in 2 (end of week)
 
-**PR link:** [not yet opened — pending push]
+**PR link:** https://github.com/ascherj/pathreview/pull/875
 
 **Branch:** `fix/150-ignore-vendored-build-files`
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -28,3 +28,34 @@ Ran `.venv/bin/pytest tests/unit/test_tech_detector.py -v -m unit`. 2 of 27 test
 
 **Blockers or open questions:**
 [Anything you're still uncertain about going into Week 9, or leave blank]
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the fix from PLAN.md: rewrote `_should_skip_file` in `agent/tools/tech_detector.py` to split each filepath on `/` and check directory segments (`parts[:-1]`) against a skip-dir set, instead of the old leading-slash substring check. Both target tests (`test_node_modules_excluded`, `test_build_directory_excluded`) now pass. Only sub-task from PLAN.md, so implementation is done.
+
+**Next steps:**
+Run full unit suite to confirm no regressions, self-review with `make check`/`make test-unit`, write PR description, push branch and open PR.
+
+**Blockers:**
+None.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [not yet opened — pending push]
+
+**Branch:** `fix/150-ignore-vendored-build-files`
+
+**What you built:**
+Fixed `_should_skip_file` in `agent/tools/tech_detector.py` so it matches skip directories (`node_modules`, `vendor`, `dist`, `build`, `.git`, `__pycache__`, `.venv`, `venv`) by path segment rather than by leading-slash substring, so vendored/build files are correctly excluded from language detection at any depth, including root-level paths.
+
+**Tests added or updated:**
+None added or modified. `tests/unit/test_tech_detector.py::test_node_modules_excluded` and `::test_build_directory_excluded` already encoded the expected behavior; the implementation fix was sufficient to make them pass.
+
+**Self-review confirmation:** [X] make test-unit passes (`.venv/bin/pytest tests/unit/test_tech_detector.py -m unit`: 27/27 pass; full `tests/unit` suite: 51 pre-existing unrelated failures, down from 53 before this fix, confirmed on main)  [ ] make check passes (182 pre-existing lint errors repo-wide, unrelated to this change; `agent/tools/tech_detector.py` itself has one pre-existing import-sort warning, not introduced by this fix)
+
+**Draft PR feedback received from:** none

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,34 @@
+## Solution plan
+
+**Issue:** Tech detector counts vendored and build-output files, skewing language detection ([#150](https://github.com/ascherj/pathreview/issues/150))
+
+### Understand
+`tech_detector.py` is supposed to ignore files under vendor/build directories (`node_modules/`, `vendor/`, `dist/`, `build/`, `.git/`, `__pycache__/`, `.venv/`, `venv/`) when detecting a repo's primary language. Actual behavior: `_should_skip_file` matches skip patterns as substrings requiring a leading slash (e.g. `"/node_modules/"` in filepath). Root-relative paths like `node_modules/lib/index.js` or `build/bundle.js` have no leading slash, so the substring check never matches and these files are never filtered. Result: a Python repo with a few vendored/bundled JS files gets misdetected as primarily JavaScript.
+
+Expected: files inside any of the listed directories, at any depth (root-level or nested), should be excluded from language detection.
+
+### Map
+- `agent/tools/tech_detector.py` — `_should_skip_file` (~line 143-164), only function needing a change.
+- `tests/unit/test_tech_detector.py` — `test_node_modules_excluded`, `test_build_directory_excluded` already encode the expected behavior; no test changes needed, just need to pass.
+
+### Plan
+1. Replace substring/slash-based matching in `_should_skip_file` with path-segment matching: split `filepath` on `/` and check if any directory segment (all parts except the filename) is in the skip-dir set.
+2. Keep the same set of directory names to skip: `node_modules`, `vendor`, `dist`, `build`, `.git`, `__pycache__`, `.venv`, `venv`.
+3. Run `.venv/bin/pytest tests/unit/test_tech_detector.py -v -m unit` and confirm all 27 tests pass.
+4. Run the exact issue repro snippet manually to confirm `primary_language == 'Python'`.
+5. Run full unit suite (`.venv/bin/pytest tests/unit -v -m unit`) to check for regressions elsewhere.
+
+### Inputs & outputs
+Input: `list[str]` of repo file paths (root-relative, forward-slash separated), passed via `execute({'files': [...]})`.
+Output: unchanged shape, `ToolResult.data` dict with `primary_language`, `all_languages`, `frameworks` — only the *values* should change (vendor/build files properly excluded from the counts feeding these).
+
+### Risks & unknowns
+- Segment-based matching must only check directory segments (`parts[:-1]`), not the filename itself, or a file literally named `build` (no extension) would be wrongly skipped.
+- Windows-style paths (`\`) aren't handled by either old or new code — out of scope, existing code already assumes `/`.
+- Case sensitivity: skip-dir names aren't lowercased; a directory named `Node_Modules` wouldn't match. Existing tests don't cover this, so not changing unless asked.
+
+### Edge cases
+- Root-level vendor dirs: `node_modules/lib/index.js` (this is the actual bug case).
+- Nested vendor dirs: `src/node_modules/lib/index.js`.
+- Empty file list and missing `files` key (already handled earlier in `execute`, unaffected by this fix).
+- File names that merely contain a skip-word as substring but aren't in that directory, e.g. `my_vendor_notes.py` or `rebuild/script.py` — should NOT be skipped (segment match avoids this false-positive; the old substring approach without leading slash would have wrongly caught these too).

--- a/agent/tools/tech_detector.py
+++ b/agent/tools/tech_detector.py
@@ -1,6 +1,7 @@
 """Technology stack detector tool."""
 
 import structlog
+
 from .base import BaseTool, ToolResult
 
 logger = structlog.get_logger()
@@ -75,7 +76,7 @@ class TechDetector(BaseTool):
                     "primary_language": "Unknown",
                     "all_languages": [],
                     "frameworks": [],
-                }
+                },
             )
 
         try:
@@ -84,11 +85,7 @@ class TechDetector(BaseTool):
 
         except Exception as e:
             logger.error("tech_detector_error", error=str(e))
-            return ToolResult(
-                success=False,
-                data={},
-                error=str(e)
-            )
+            return ToolResult(success=False, data={}, error=str(e))
 
     def _detect_tech(self, files: list[str]) -> dict:
         """Detect technologies from file list.
@@ -100,10 +97,7 @@ class TechDetector(BaseTool):
             Dict with detected languages and frameworks
         """
         # Filter out vendor/build directories
-        filtered_files = [
-            f for f in files
-            if not self._should_skip_file(f)
-        ]
+        filtered_files = [f for f in files if not self._should_skip_file(f)]
 
         languages = set()
         frameworks = set()
@@ -131,8 +125,12 @@ class TechDetector(BaseTool):
         all_languages = sorted(languages)
         all_frameworks = sorted(frameworks)
 
-        logger.info("tech_detected", primary_lang=primary,
-                   languages_count=len(all_languages), frameworks_count=len(all_frameworks))
+        logger.info(
+            "tech_detected",
+            primary_lang=primary,
+            languages_count=len(all_languages),
+            frameworks_count=len(all_frameworks),
+        )
 
         return {
             "primary_language": primary,
@@ -150,15 +148,16 @@ class TechDetector(BaseTool):
         Returns:
             True if file should be skipped
         """
-        skip_patterns = [
-            "/node_modules/",
-            "/vendor/",
-            "/dist/",
-            "/build/",
-            "/.git/",
-            "/__pycache__/",
-            "/.venv/",
-            "/venv/",
-        ]
+        skip_dirs = {
+            "node_modules",
+            "vendor",
+            "dist",
+            "build",
+            ".git",
+            "__pycache__",
+            ".venv",
+            "venv",
+        }
 
-        return any(pattern in filepath for pattern in skip_patterns)
+        parts = filepath.split("/")[:-1]
+        return any(part in skip_dirs for part in parts)


### PR DESCRIPTION
## What this fix does

Fixes #150. `_should_skip_file` in `agent/tools/tech_detector.py` used substring matching against patterns like `"/node_modules/"`, which requires a leading slash. Root-relative paths (e.g. `node_modules/lib/index.js`, `build/bundle.js`) have no leading slash, so the check never matched and vendored/build files were counted toward language detection, skewing `primary_language` (a Python repo with a few bundled JS files could get misdetected as JavaScript).

Fix: split each filepath on `/`, take the directory segments, and check membership against a skip-dir set (`node_modules`, `vendor`, `dist`, `build`, `.git`, `__pycache__`, `.venv`, `venv`). Files inside any of these directories at any depth are now excluded, whether root-level or nested.

## Design decisions

- **Segment matching over substring/regex:** splitting on `/` and checking `parts[:-1]` (directories only, excluding the filename) avoids false positives like `my_vendor_notes.py` or `rebuild/script.py`, which a naive substring match (even with slashes) could still catch under certain path shapes.
- **No change to the skip-dir list:** same eight directories as before; only the matching strategy changed.
- **No test changes:** `test_node_modules_excluded` and `test_build_directory_excluded` already encoded the correct expected behavior and were failing against the buggy implementation. Fixing the implementation was sufficient.
- **Out of scope:** Windows-style `\` separators and case-insensitive directory matching (e.g. `Node_Modules`) aren't handled — neither was the prior implementation, and no existing tests cover these cases.

## How to manually test

```bash
.venv/bin/pytest tests/unit/test_tech_detector.py -v -m unit
```
All 27 tests pass, including the two previously failing:
- `test_node_modules_excluded`
- `test_build_directory_excluded`

Full unit suite regression check:
```bash
.venv/bin/pytest tests/unit -v -m unit
```
51 failures remain, all pre-existing and unrelated (confirmed identical failures on `main` before this change, minus the 2 fixed here).

Manual repro from the issue:
```python
from agent.tools.tech_detector import TechDetector

files = ["src/main.py", "node_modules/package1/index.js", "node_modules/package2/lib.js", "utils.py"]
result = TechDetector().execute({"files": files})
print(result.data["primary_language"])  # -> "Python"
```