### PR TITLE
fix(agent): checkpoint orchestrator state incrementally per step

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,19 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/47
+
+**Issue title:** Agent state isn't persisted across API restarts, causing in-progress reviews to be lost
+
+**Tier:** [ ] Tier 1  [ ] Tier 2  [x] Tier 3
+
+**Selection notes:**
+I selected issue #47 as a Tier 3 issue because I wanted to push past a beginner-level fix and take on a challenging problem like agent state persistence across restarts. This problem touches concurrency, idempotency, and system reliability, which are skills I want to build.
+
+**Problem summary:**
+When the agent processes a review, its progress lives only in memory: `agent/orchestrator.py` runs through a plan of tool calls (GitHub analysis, tech detection, README scoring, skill extraction, etc.), and `agent/memory/context_manager.py` caches each tool's output as it goes, but none of this is written to Redis until the entire plan finishes. If the API server restarts partway through, everything completed up to that point is discarded, since there's no partial state saved anywhere durable. A successful fix would save the orchestrator's progress to Redis after each tool step completes rather than only at the end, and on restart, check that saved state to skip steps already done instead of re-running them, while making sure a crash mid-save can't leave the stored state half-written or inconsistent.
+
+**Branch name:** fix/47-agent-state-not-persisted-on-restart
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -17,3 +17,17 @@ When the agent processes a review, its progress lives only in memory: `agent/orc
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/krishan-g/pathreview/commit/e04cbe7
+
+**Reproduction summary:**
+I wrote `scripts/repro_issue47.py` / `scripts/repro_issue47_worker.py`, which run `Orchestrator.run()` directly against real local Redis over a fixed 3-tool plan, hard-killing the process (`os._exit`) partway through to simulate an API restart. I observed that after the crash Redis has nothing saved for the profile even though one tool had already completed, and that re-running afterward re-executes every tool from scratch instead of resuming.
+
+**PLAN.md link:** https://github.com/krishan-g/pathreview/blob/fix/47-agent-state-not-persisted-on-restart/PLAN.md
+
+**Walkthrough video (recommended):** Not recorded yet.
+
+**Blockers or open questions:**
+`Orchestrator` currently has no callers anywhere in the live app — `core/services/review_service.py` uses a hardcoded placeholder instead of calling into `agent/orchestrator.py`. I'm not yet sure whether wiring `Orchestrator` into the real review pipeline is part of this issue's scope or a separate follow-up; I want to raise this with a mentor before Week 9.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -31,3 +31,36 @@ I wrote `scripts/repro_issue47.py` / `scripts/repro_issue47_worker.py`, which ru
 
 **Blockers or open questions:**
 `Orchestrator` currently has no callers anywhere in the live app — `core/services/review_service.py` uses a hardcoded placeholder instead of calling into `agent/orchestrator.py`. I'm not yet sure whether wiring `Orchestrator` into the real review pipeline is part of this issue's scope or a separate follow-up; I want to raise this with a mentor before Week 9.
+
+## Week 9 - Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+All 5 sub-tasks from PLAN.md are implemented in `agent/orchestrator.py` and `agent/memory/session_store.py`. `Orchestrator.run()` now checkpoints each tool's result to Redis right after that tool finishes (keyed by tool name plus a hash of its input), instead of only writing once at the very end. On a resumed run, any step whose key is already in the checkpointed state gets skipped instead of re-executed. `SessionStore.set()` now returns True or False instead of silently swallowing write failures, and the orchestrator logs clearly if a checkpoint write fails. I also added two test files, `tests/unit/test_orchestrator_checkpointing.py` and `tests/unit/test_session_store.py`, covering per-step checkpoint timing, resume-skip behavior, input-hash differentiation, and checkpoint failure visibility.
+
+**Next steps:**
+I ran `make check` and `make test-unit` and compared results against a clean baseline of the unmodified code to confirm nothing new broke. Next I need to write the PR description (documenting the pre-existing failures I found, per the instructions), open a draft PR, and share it in Slack for peer or mentor feedback.
+
+**Blockers:**
+`make typecheck`'s full command (`mypy api/ core/ ingestion/ rag/ agent/ safety/`) currently cannot complete on my machine. It crashes almost immediately because a numpy stub file uses Python 3.12+ syntax that conflicts with the project's mypy config (`python_version = "3.11"`), combined with my venv running Python 3.14 (pyenv's pinned 3.11.9 has a broken system library on my machine and I did not want to modify system libraries to fix it). I confirmed this crash also happens on the unmodified codebase, so it is pre-existing and unrelated to my change. To still verify my work, I scoped mypy to `agent/` directly (which does not touch numpy) and confirmed the same 18 pre-existing errors exist before and after my change, with no new ones added.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** Pending. I have not opened the PR yet; will fill this in once it is submitted.
+
+**Branch:** `fix/47-agent-state-not-persisted-on-restart`
+
+**What you built:**
+I changed `Orchestrator.run()` to checkpoint each tool's result to Redis immediately after that tool succeeds, instead of writing the entire session state once at the end of the plan. A resumed run now checks each step against the checkpointed state (keyed by tool name and input hash) and skips anything already completed, so an API restart mid-review no longer loses finished work or forces a full re-run.
+
+**Tests added or updated:**
+`tests/unit/test_orchestrator_checkpointing.py` (5 tests: per-step checkpoint timing, resume skips completed steps, different input is not treated as already done, checkpoint write failures are logged, and an interrupted-then-resumed run matches an uninterrupted run) and `tests/unit/test_session_store.py` (4 tests covering the new True/False return value on `SessionStore.set()`).
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+Note on what "passes" means here: this codebase has documented pre-existing failures (182 pre-existing ruff errors, 52 files needing black formatting, 18 pre-existing mypy errors under `agent/`, and 53 pre-existing failing unit tests, none in files I touched). I confirmed my changes introduce zero new failures in any of these categories, and my own changed and added files are fully clean under ruff, black, and mypy. `make typecheck`'s full invocation cannot complete at all due to the pre-existing numpy/Python version issue described in Check-in 1, so I verified type safety with a scoped `mypy agent/` run instead.
+
+**Draft PR feedback received from:** Pending, will update once I have shared the draft PR in Slack.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -43,13 +43,13 @@ All 5 sub-tasks from PLAN.md are implemented in `agent/orchestrator.py` and `age
 I ran `make check` and `make test-unit` and compared results against a clean baseline of the unmodified code to confirm nothing new broke. Next I need to write the PR description (documenting the pre-existing failures I found, per the instructions), open a draft PR, and share it in Slack for peer or mentor feedback.
 
 **Blockers:**
-`make typecheck`'s full command (`mypy api/ core/ ingestion/ rag/ agent/ safety/`) currently cannot complete on my machine. It crashes almost immediately because a numpy stub file uses Python 3.12+ syntax that conflicts with the project's mypy config (`python_version = "3.11"`), combined with my venv running Python 3.14 (pyenv's pinned 3.11.9 has a broken system library on my machine and I did not want to modify system libraries to fix it). I confirmed this crash also happens on the unmodified codebase, so it is pre-existing and unrelated to my change. To still verify my work, I scoped mypy to `agent/` directly (which does not touch numpy) and confirmed the same 18 pre-existing errors exist before and after my change, with no new ones added.
+`make typecheck`'s full command (`mypy api/ core/ ingestion/ rag/ agent/ safety/`) currently cannot complete on my machine. It crashes almost immediately because a numpy stub file uses Python 3.12+ syntax that conflicts with the project's mypy config (`python_version = "3.11"`), combined with my venv running Python 3.14 (pyenv's pinned 3.11.9 has a broken system library on my machine and I did not want to modify system libraries to fix it). I confirmed this crash also happens on the unmodified codebase, so it is pre-existing and unrelated to my change. To still verify my work, I scoped mypy to `agent/` directly (which does not touch numpy) and confirmed the same pre-existing errors exist before and after my change, with no new ones added (see Check-in 2 for the exact count used by the actual pre-commit gate).
 
 ---
 
 ### Check-in 2 (end of week)
 
-**PR link:** Pending. I have not opened the PR yet; will fill this in once it is submitted.
+**PR link:** https://github.com/ascherj/pathreview/pull/877
 
 **Branch:** `fix/47-agent-state-not-persisted-on-restart`
 
@@ -61,6 +61,6 @@ I changed `Orchestrator.run()` to checkpoint each tool's result to Redis immedia
 
 **Self-review confirmation:** [x] make check passes  [x] make test-unit passes
 
-Note on what "passes" means here: this codebase has documented pre-existing failures (182 pre-existing ruff errors, 52 files needing black formatting, 18 pre-existing mypy errors under `agent/`, and 53 pre-existing failing unit tests, none in files I touched). I confirmed my changes introduce zero new failures in any of these categories, and my own changed and added files are fully clean under ruff, black, and mypy. `make typecheck`'s full invocation cannot complete at all due to the pre-existing numpy/Python version issue described in Check-in 1, so I verified type safety with a scoped `mypy agent/` run instead.
+Note on what "passes" means here: this codebase has documented pre-existing failures (182 pre-existing ruff errors, 52 files needing black formatting, 13 pre-existing mypy errors in `error_handling.py`, `context_manager.py`, and two `orchestrator.py` functions I did not modify, and 53 pre-existing failing unit tests, none in files I touched). I confirmed my changes introduce zero new failures in any of these categories, and my own changed and added files are fully clean under ruff, black, and mypy. `make typecheck`'s full invocation cannot complete at all due to the pre-existing numpy/Python version issue described in Check-in 1, so I verified type safety with a scoped `mypy agent/` run and the actual pre-commit mypy hook instead. One commit (`620c68b`) uses `--no-verify` because of these pre-existing errors; documented in the commit message reasoning and in the PR description.
 
-**Draft PR feedback received from:** Pending, will update once I have shared the draft PR in Slack.
+**Draft PR feedback received from:** none.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -64,3 +64,34 @@ I changed `Orchestrator.run()` to checkpoint each tool's result to Redis immedia
 Note on what "passes" means here: this codebase has documented pre-existing failures (182 pre-existing ruff errors, 52 files needing black formatting, 13 pre-existing mypy errors in `error_handling.py`, `context_manager.py`, and two `orchestrator.py` functions I did not modify, and 53 pre-existing failing unit tests, none in files I touched). I confirmed my changes introduce zero new failures in any of these categories, and my own changed and added files are fully clean under ruff, black, and mypy. `make typecheck`'s full invocation cannot complete at all due to the pre-existing numpy/Python version issue described in Check-in 1, so I verified type safety with a scoped `mypy agent/` run and the actual pre-commit mypy hook instead. One commit (`620c68b`) uses `--no-verify` because of these pre-existing errors; documented in the commit message reasoning and in the PR description.
 
 **Draft PR feedback received from:** none.
+
+## Week 10 - Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No, still awaiting review
+
+**Summary of feedback:**
+No feedback has come in on PR #877. Per the course note, reviewer feedback isn't a feature for Summer 2026, so this is expected.
+
+**How you responded:**
+N/A, no feedback to respond to.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Navigating and understanding the codebase itself was the hard part, not the fix. Once I understood what was going on, the actual change was straightforward: check the tool's state after each individual tool runs instead of waiting until all tools finish, since waiting until the end is exactly what made an in-progress run vulnerable to losing everything on a crash. But getting to that understanding took real work. Figuring out how the codebase was laid out, where `SessionStore` was actually defined, what methods each object exposed, and how the pieces called into each other took longer than I expected before I could even start reasoning about the fix.
+
+**What did you learn about working in a large codebase?**
+Getting properly oriented before touching anything matters a lot more than it seems like it should. One specific moment made this real for me: while investigating in Week 8, I found that `Orchestrator` had zero callers anywhere in the live app, `core/services/review_service.py` called a hardcoded placeholder stub instead of actually invoking `agent/orchestrator.py`. If I had jumped straight into fixing `Orchestrator`'s checkpointing logic without first tracing whether it was even wired into the app, I would have missed that my fix, as scoped, doesn't yet affect any review a real user could trigger. That's the kind of thing you only catch by mapping out the codebase first instead of assuming a file named in the issue is already connected the way it looks like it should be.
+
+**How did AI tools help, and where did they fall short?**
+AI tools were most useful for tracing how `Orchestrator`, `ContextManager`, and `SessionStore` connected to each other before I could reason about where to add checkpointing, and for quickly answering "where is X defined" type questions. I wouldn't say they fell short exactly, they did what they were supposed to do. But the moment that mattered most was still something I had to do myself: actually running `scripts/repro_issue47.py` against my fixed code and reading the real output line by line to confirm `tool_a` wasn't re-executed on the simulated restart, before I trusted the fix enough to write it into the PR's manual verification steps. Asking an AI to explain the code isn't a substitute for watching the actual behavior change with my own eyes.
+
+**What would you do differently if you started over?**
+I'd spend more time in the earlier weeks actually understanding the problem and the codebase in depth, rather than doing close to the minimum required for each week's deliverable. That approach ended up pushing a lot of the real understanding to the point where I actually had to implement the fix, which made that stage harder than it needed to be. Front-loading that understanding earlier would have made the whole process smoother, even though nothing about it was especially hard in an absolute sense.
+
+**What are you most proud of from this module?**
+Opening a real pull request against a codebase that closely resembles a real-world production repository, not a toy project. Even knowing it's a simulated repo, going through the full cycle (issue selection, reproduction, planning, implementation, and a properly documented PR) gave me real confidence that I could contribute to an actual open source project.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,54 @@
+## Solution plan
+
+**Issue:** Agent state isn't persisted across API restarts, causing in-progress reviews to be lost — https://github.com/ascherj/pathreview/issues/47
+
+### Understand
+
+`Orchestrator.run()` (`agent/orchestrator.py:31-76`) executes a review as a sequential loop over a list of tool calls (e.g. `github_tool`, `tech_detector`, `readme_scorer`, `skill_extractor`, `market_analyzer`). Each tool's result is accumulated in a local `results` dict and also cached in `ContextManager.results` (`agent/memory/context_manager.py:15`) — both plain in-process Python dicts with no durable backing. The only write to Redis happens once, after the entire loop finishes (`agent/orchestrator.py:65-67`).
+
+**Expected behavior:** if the API server restarts while a review is partway through its tool plan, the review should be resumable — already-completed tool results should be checkpointed durably, and restarting should skip re-running those steps.
+
+**Actual behavior (confirmed via local reproduction, see `scripts/repro_issue47.py`):** killing the process mid-plan leaves Redis with nothing at all for that profile, even though some tools already succeeded. On the next run, every tool re-executes from the beginning — there is no notion of "already done" to check against.
+
+**Root cause:** persistence is an all-or-nothing operation tied to full-plan completion, not an incremental per-step checkpoint. `ContextManager` provides memoization only within a single process's lifetime; it has no Redis/disk backing at all.
+
+### Map
+
+Files I expect to touch:
+- `agent/orchestrator.py` — `run()` (where/when persistence happens), `_execute_tool()` (where each tool's result becomes available and could be checkpointed)
+- `agent/memory/context_manager.py` — `ContextManager` (currently in-memory only; needs to either gain durable backing or be replaced as the source of truth by `session_state`)
+- `agent/memory/session_store.py` — `SessionStore.get/set/delete` (Redis key format `session:{id}`, `ttl_seconds=3600` default); note `set()` currently swallows all exceptions and only logs (`session_store.py:65-66`) — a checkpoint write that silently fails would defeat the fix
+- `scripts/repro_issue47.py`, `scripts/repro_issue47_worker.py` — existing reproduction, will double as a regression check
+- Likely new: `tests/unit/test_orchestrator_checkpointing.py` (no orchestrator tests exist today)
+
+Out of scope for this issue, but noted as related debt: `core/services/review_service.py:process_review` has an analogous gap — it only writes `Review.status` to Postgres at start (`"processing"`) and end (`"complete"`/`"failed"`), with no per-stage checkpoint between ingestion/orchestration/RAG/safety-check. Also, `Orchestrator` currently has no callers anywhere in the codebase (`_run_agent_orchestration` in `review_service.py` is a hardcoded stub) — see Risks below.
+
+### Plan
+
+1. Add a per-step checkpoint: inside the `for tool_name, tool_input in plan` loop in `run()`, call `session_store.set(...)` immediately after each tool's result is computed, not only after the loop exits.
+2. Track completion explicitly: persist a `completed_steps` (or similar) structure alongside `tool_results` in the session state, keyed by `tool_name` + `ContextManager.hash_input(tool_input)`, so a resumed run can tell "done" from "not yet attempted" for the exact same input.
+3. Make plan execution resumable: when `run()` loads `session_state` at the top (`orchestrator.py:47-49`), check each planned step against `completed_steps` before calling `_execute_tool()`, and skip steps whose result is already checkpointed for that exact input hash.
+4. Make checkpoint writes safe to interrupt: ensure a crash during a Redis write can't leave `session_state` half-updated — write the full updated state in one atomic `SETEX` call (the current `SessionStore.set()` already does this per-call), and decide how to surface/retry a failed checkpoint write instead of silently swallowing it (`session_store.py:65-66`).
+5. Add a regression test that: runs a fixed multi-step plan, hard-kills the process partway through (reusing the pattern in `scripts/repro_issue47_worker.py`), restarts, and asserts the previously-completed step is not re-executed and the final result matches an uninterrupted run.
+
+### Inputs & outputs
+
+- **Input:** unchanged — `Orchestrator.run(profile_id: str, profile_data: dict)`.
+- **New output/side effect:** `session_store` now receives a write after every individual tool step, not just once at the end; the persisted `session_state` gains a marker of which `(tool_name, input_hash)` pairs are complete.
+- **On resume:** calling `run()` again with the same `profile_id` after an interruption should read the checkpointed state, skip already-completed steps, and produce the same final `tool_results` as an uninterrupted run would have.
+
+### Risks & unknowns
+
+- `SessionStore.set()` catches all exceptions and only logs (`session_store.py:65-66`) — today, a failed checkpoint write fails silently. Adding more frequent writes without addressing this means checkpoint failures could go unnoticed, undermining the whole fix. Need to decide whether to raise, retry, or surface this differently.
+- `Orchestrator` is not currently wired into the live app — `core/services/review_service.py:_run_agent_orchestration` is a hardcoded placeholder stub and never imports `agent.orchestrator` (confirmed via repo-wide grep: zero callers of `Orchestrator(`). Fixing `Orchestrator`'s persistence alone won't change production behavior until/unless it's wired into `process_review`. Need to confirm with mentors whether wiring it in is part of this issue's scope or a separate follow-up.
+- Default Redis TTL is 3600s (`session_store.py:56`). A long review that pauses between checkpoints for longer than an hour could have earlier partial state expire before it resumes. Need to decide whether each incremental checkpoint should refresh the TTL.
+- No existing tests cover `orchestrator.py`, `context_manager.py`, or `session_store.py` — test scaffolding (fake tools, real or fake Redis) has to be built essentially from scratch; `scripts/repro_issue47.py` is the only precedent so far.
+- Multiple workers/processes checkpointing the same `profile_id` concurrently could race on the same Redis key (read-modify-write on `session_state` isn't currently atomic across the get/set pair) — unclear yet whether this is a realistic scenario for this codebase's deployment model.
+
+### Edge cases
+
+- Process crashes before the very first tool in the plan runs (no checkpoint exists yet) — resume must behave like a fresh run, not error on a missing/empty session state.
+- Process crashes during or immediately after the very last tool, before the (to-be-removed) final `session_store.set()` — once checkpointing is per-step, this should resolve naturally, but needs a test to confirm the last step's checkpoint and the "plan complete" marker land correctly.
+- The same `tool_name` is requested again with different `tool_input` after a restart (e.g. `profile_data` changed between the interrupted and resumed run) — the skip-if-already-done check must key off `tool_name` + `input_hash` together (matching how `ContextManager.hash_input` already works), not `tool_name` alone, or a stale result could be returned for changed input.
+- A tool that eventually succeeded after internal retries (`retry_with_backoff` in `agent/error_handling.py`) — the checkpoint must store only the final successful result, not an intermediate failed attempt.
+- Redis temporarily unreachable during a checkpoint write — must not silently proceed as though the checkpoint succeeded (see Risks above); needs explicit handling rather than the current swallow-and-log behavior.

--- a/agent/memory/session_store.py
+++ b/agent/memory/session_store.py
@@ -1,9 +1,9 @@
 """Redis-backed session store."""
 
-import redis
 import json
+
+import redis
 import structlog
-from typing import Optional
 
 logger = structlog.get_logger()
 
@@ -19,7 +19,7 @@ class SessionStore:
         """
         self.redis = redis_client
 
-    def get(self, session_id: str) -> Optional[dict]:
+    def get(self, session_id: str) -> dict | None:
         """Get session data.
 
         Args:
@@ -47,13 +47,22 @@ class SessionStore:
             logger.error("session_get_error", session_id=session_id, error=str(e))
             return None
 
-    def set(self, session_id: str, data: dict, ttl_seconds: int = 3600) -> None:
+    def set(self, session_id: str, data: dict, ttl_seconds: int = 3600) -> bool:
         """Store session data.
+
+        Writes the full value in one SETEX call, so Redis itself never
+        exposes a partially-written value even if this process crashes
+        mid-call: either the old value stays, or the new one fully lands.
 
         Args:
             session_id: Session identifier
             data: Session data dict
             ttl_seconds: Time to live in seconds (default 1 hour)
+
+        Returns:
+            True if the write succeeded, False otherwise. Callers that
+            need to know a checkpoint actually landed (rather than best-
+            effort session caching) should check this.
         """
         key = f"session:{session_id}"
 
@@ -61,9 +70,11 @@ class SessionStore:
             json_data = json.dumps(data)
             self.redis.setex(key, ttl_seconds, json_data)
             logger.info("session_stored", session_id=session_id, ttl_seconds=ttl_seconds)
+            return True
 
         except Exception as e:
             logger.error("session_set_error", session_id=session_id, error=str(e))
+            return False
 
     def delete(self, session_id: str) -> None:
         """Delete session data.

--- a/agent/orchestrator.py
+++ b/agent/orchestrator.py
@@ -1,12 +1,12 @@
 """Plan-execute orchestrator for agent tools."""
 
 import time
-import structlog
-from typing import Optional
 
-from .memory.session_store import SessionStore
-from .memory.context_manager import ContextManager
+import structlog
+
 from .error_handling import retry_with_backoff
+from .memory.context_manager import ContextManager
+from .memory.session_store import SessionStore
 
 logger = structlog.get_logger()
 
@@ -14,8 +14,9 @@ logger = structlog.get_logger()
 class Orchestrator:
     """Orchestrate tool execution with planning and memoization."""
 
-    def __init__(self, tools: dict, session_store: Optional[SessionStore] = None,
-                 tool_timeout: float = 30.0):
+    def __init__(
+        self, tools: dict, session_store: SessionStore | None = None, tool_timeout: float = 30.0
+    ):
         """Initialize orchestrator.
 
         Args:
@@ -43,37 +44,71 @@ class Orchestrator:
         # Build execution plan
         plan = self._build_plan(profile_data)
 
-        # Load previous session state if available
+        # Load previous session state if available. `completed` maps
+        # "tool_name:input_hash" -> the tool's result data, so a resumed
+        # run can tell exactly which steps already finished successfully.
         session_state = {}
         if self.session_store:
             session_state = self.session_store.get(profile_id) or {}
+        completed = session_state.setdefault("completed", {})
 
         # Execute plan
         results = {}
         for tool_name, tool_input in plan:
+            step_key = self._step_key(tool_name, tool_input)
+
+            if step_key in completed:
+                logger.info("tool_step_resumed", tool=tool_name, key=step_key)
+                results[tool_name] = completed[step_key]
+                continue
+
             try:
                 result = self._execute_tool(tool_name, tool_input)
-                results[tool_name] = result.data if hasattr(result, 'data') else result
+                data = result.data if hasattr(result, "data") else result
+                results[tool_name] = data
 
                 logger.info("tool_executed", tool=tool_name, success=True)
+
+                # Checkpoint immediately so a restart before the next step
+                # doesn't lose this result. Only successful steps are
+                # checkpointed -- a failed step should be retried on resume,
+                # not permanently frozen as "done".
+                completed[step_key] = data
+                if self.session_store:
+                    persisted = self.session_store.set(profile_id, session_state)
+                    if not persisted:
+                        logger.error(
+                            "checkpoint_write_failed", profile_id=profile_id, tool=tool_name
+                        )
 
             except Exception as e:
                 logger.error("tool_execution_failed", tool=tool_name, error=str(e))
                 results[tool_name] = {"error": str(e), "success": False}
 
-        # Persist state
-        if self.session_store:
-            session_state.update(results)
-            self.session_store.set(profile_id, session_state)
-
-        logger.info("orchestrator_complete", profile_id=profile_id,
-                   tools_executed=len(results))
+        logger.info("orchestrator_complete", profile_id=profile_id, tools_executed=len(results))
 
         return {
             "profile_id": profile_id,
             "tool_results": results,
-            "cached_results": self.context_manager.get_all_results()
+            "cached_results": self.context_manager.get_all_results(),
         }
+
+    @staticmethod
+    def _step_key(tool_name: str, tool_input: dict) -> str:
+        """Build the checkpoint key for a plan step.
+
+        Keying on both tool name and input hash (not just tool name) means
+        a step whose input changed since the last run is correctly treated
+        as not yet done, instead of returning a stale cached result.
+
+        Args:
+            tool_name: Name of the tool
+            tool_input: Input dict for the tool
+
+        Returns:
+            Checkpoint key string
+        """
+        return f"{tool_name}:{ContextManager.hash_input(tool_input)}"
 
     def _build_plan(self, profile_data: dict) -> list[tuple[str, dict]]:
         """Build execution plan based on available data.
@@ -90,45 +125,42 @@ class Orchestrator:
         if profile_data.get("github_username"):
             for project in profile_data.get("projects", []):
                 if project.get("github_repo"):
-                    plan.append((
-                        "github_tool",
-                        {
-                            "github_username": profile_data["github_username"],
-                            "repo_name": project["github_repo"]
-                        }
-                    ))
+                    plan.append(
+                        (
+                            "github_tool",
+                            {
+                                "github_username": profile_data["github_username"],
+                                "repo_name": project["github_repo"],
+                            },
+                        )
+                    )
                     break  # Only process first repo for now
 
         # Tech detector (if files available)
         if profile_data.get("files"):
-            plan.append((
-                "tech_detector",
-                {"files": profile_data["files"]}
-            ))
+            plan.append(("tech_detector", {"files": profile_data["files"]}))
 
         # README scorer
         if profile_data.get("readme_content"):
-            plan.append((
-                "readme_scorer",
-                {"readme_content": profile_data["readme_content"]}
-            ))
+            plan.append(("readme_scorer", {"readme_content": profile_data["readme_content"]}))
 
         # Skill extractor
         if profile_data.get("resume_text"):
-            plan.append((
-                "skill_extractor",
-                {
-                    "resume_text": profile_data["resume_text"],
-                    "repo_metadata": profile_data.get("repo_metadata", {})
-                }
-            ))
+            plan.append(
+                (
+                    "skill_extractor",
+                    {
+                        "resume_text": profile_data["resume_text"],
+                        "repo_metadata": profile_data.get("repo_metadata", {}),
+                    },
+                )
+            )
 
         # Market analyzer (if skills detected)
         if plan:  # Only if other tools executed
-            plan.append((
-                "market_analyzer",
-                {"detected_skills": {}}  # Will be populated by context
-            ))
+            plan.append(
+                ("market_analyzer", {"detected_skills": {}})  # Will be populated by context
+            )
 
         logger.info("plan_built", plan_size=len(plan))
         return plan
@@ -172,7 +204,7 @@ class Orchestrator:
             logger.error("tool_execution_error", tool=tool_name, error=str(e))
             raise
 
-    def _execute_with_timeout(self, tool, tool_input: dict, timeout: Optional[float] = None):
+    def _execute_with_timeout(self, tool, tool_input: dict, timeout: float | None = None):
         """Execute tool with timeout.
 
         Args:

--- a/scripts/repro_issue47.py
+++ b/scripts/repro_issue47.py
@@ -1,0 +1,59 @@
+"""Reproduction driver for issue #47 (agent state not persisted on restart).
+
+Run 1: simulates the API server dying partway through a review's tool plan
+        -- tool_a succeeds, then the process is killed during tool_b.
+Run 2: simulates the server restarting and the same review being re-attempted.
+
+What this proves:
+  - After the crash, Redis has NOTHING saved for the profile, even though
+    tool_a completed successfully -- because Orchestrator.run() only writes
+    to session_store at the very end of the loop (agent/orchestrator.py:65-67).
+  - On the "restart" run, tool_a executes again from scratch. There is no
+    checkpoint to consult, so no already-completed step can be skipped.
+
+Prereq: Redis reachable at localhost:6379 (`docker compose up -d redis`).
+Run:    .venv/bin/python scripts/repro_issue47.py
+"""
+
+import os
+import subprocess
+import sys
+
+import redis
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+WORKER = os.path.join(REPO_ROOT, "scripts", "repro_issue47_worker.py")
+LOG_FILE = "/tmp/repro_issue47_log.txt"
+PROFILE_ID = "repro-profile-1"
+
+
+def run_worker(crash_on: str) -> None:
+    subprocess.run([sys.executable, WORKER, crash_on])
+
+
+def main() -> None:
+    if os.path.exists(LOG_FILE):
+        os.remove(LOG_FILE)
+
+    client = redis.Redis(host="localhost", port=6379, db=0, decode_responses=True)
+    client.delete(f"session:{PROFILE_ID}")
+
+    print("=== Run 1: server crashes during tool_b (after tool_a succeeded) ===")
+    run_worker(crash_on="tool_b")
+
+    saved = client.get(f"session:{PROFILE_ID}")
+    print(f"Redis state after crash: {saved!r}\n")
+
+    print("=== Run 2: server 'restarts', same review re-attempted ===")
+    run_worker(crash_on="")
+
+    saved = client.get(f"session:{PROFILE_ID}")
+    print(f"Redis state after run 2: {saved!r}\n")
+
+    print("=== Execution log across both runs ===")
+    with open(LOG_FILE) as f:
+        print(f.read())
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/repro_issue47_worker.py
+++ b/scripts/repro_issue47_worker.py
@@ -1,0 +1,71 @@
+"""Worker process for issue #47 repro.
+
+Runs ONE Orchestrator.run() pass over a fixed 3-step plan (tool_a, tool_b,
+tool_c). If invoked with a tool name as argv[1], that tool hard-crashes the
+process (os._exit) right after logging that it ran -- simulating the API
+server dying mid-review, before Orchestrator.run() ever reaches its final
+session_store.set() call.
+
+Usage: python scripts/repro_issue47_worker.py [crash_on_tool_name]
+"""
+
+import os
+import sys
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, REPO_ROOT)
+
+import redis  # noqa: E402
+
+from agent.memory.session_store import SessionStore  # noqa: E402
+from agent.orchestrator import Orchestrator  # noqa: E402
+from agent.tools.base import BaseTool, ToolResult  # noqa: E402
+
+LOG_FILE = "/tmp/repro_issue47_log.txt"
+PROFILE_ID = "repro-profile-1"
+
+
+def log(msg: str) -> None:
+    with open(LOG_FILE, "a") as f:
+        f.write(msg + "\n")
+
+
+class FakeTool(BaseTool):
+    def __init__(self, name: str, crash: bool):
+        self.name = name
+        self.description = f"fake tool {name}"
+        self.crash = crash
+
+    def execute(self, input_data: dict) -> ToolResult:
+        log(f"EXECUTED {self.name}")
+        if self.crash:
+            log(f"CRASHING during {self.name} (simulating server restart)")
+            os._exit(1)
+        return ToolResult(success=True, data={"tool": self.name})
+
+
+class FixedPlanOrchestrator(Orchestrator):
+    """Skips the real _build_plan (which reads profile_data shape) and just
+    always runs a fixed 3-step plan, so we can isolate the persistence bug."""
+
+    def _build_plan(self, profile_data: dict) -> list[tuple[str, dict]]:
+        return [("tool_a", {}), ("tool_b", {}), ("tool_c", {})]
+
+
+def main() -> None:
+    crash_on = sys.argv[1] if len(sys.argv) > 1 else None
+
+    tools = {
+        name: FakeTool(name, crash=(name == crash_on)) for name in ("tool_a", "tool_b", "tool_c")
+    }
+
+    client = redis.Redis(host="localhost", port=6379, db=0, decode_responses=True)
+    store = SessionStore(client)
+    orch = FixedPlanOrchestrator(tools=tools, session_store=store)
+
+    result = orch.run(PROFILE_ID, {})
+    log(f"RUN COMPLETED: {sorted(result['tool_results'].keys())}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_orchestrator_checkpointing.py
+++ b/tests/unit/test_orchestrator_checkpointing.py
@@ -1,0 +1,185 @@
+"""Tests for Orchestrator per-step checkpointing and resume behavior (issue #47)."""
+
+from unittest.mock import Mock
+
+import pytest
+
+from agent.memory.session_store import SessionStore
+from agent.orchestrator import Orchestrator
+from agent.tools.base import BaseTool, ToolResult
+
+
+class FakeRedis:
+    """In-memory stand-in for redis.Redis, backed by a plain dict.
+
+    Implements just the subset of the redis-py API that SessionStore uses,
+    so tests exercise the real SessionStore (including its JSON
+    serialization) instead of mocking it away. It does not subclass
+    redis.Redis, so constructing a SessionStore with one needs a type:
+    ignore at each call site below.
+    """
+
+    def __init__(self) -> None:
+        self.store: dict = {}
+
+    def get(self, key: str) -> str | None:
+        return self.store.get(key)
+
+    def setex(self, key: str, ttl_seconds: int, value: str) -> None:
+        self.store[key] = value
+
+    def delete(self, key: str) -> None:
+        self.store.pop(key, None)
+
+
+class CountingTool(BaseTool):
+    """Fake tool that records how many times it was executed."""
+
+    def __init__(self, name: str, fail_times: int = 0):
+        self.name = name
+        self.description = f"counting tool {name}"
+        self.call_count = 0
+        self.fail_times = fail_times
+
+    def execute(self, input_data: dict) -> ToolResult:
+        self.call_count += 1
+        if self.call_count <= self.fail_times:
+            raise RuntimeError(f"{self.name} simulated failure")
+        return ToolResult(success=True, data={"tool": self.name, "call": self.call_count})
+
+
+@pytest.mark.unit
+class TestOrchestratorCheckpointing:
+    """Test suite for per-step checkpointing and resume behavior."""
+
+    @pytest.fixture
+    def fake_redis(self) -> FakeRedis:
+        return FakeRedis()
+
+    @pytest.fixture
+    def session_store(self, fake_redis: FakeRedis) -> SessionStore:
+        return SessionStore(fake_redis)  # type: ignore[arg-type]
+
+    def _orchestrator(self, tools: dict, session_store: SessionStore) -> Orchestrator:
+        """Build an Orchestrator with a fixed plan, bypassing _build_plan's
+        profile_data-shape logic so tests can drive an exact plan directly."""
+        orch = Orchestrator(tools=tools, session_store=session_store)
+        orch._build_plan = lambda profile_data: [(name, {}) for name in tools]  # type: ignore[method-assign]
+        return orch
+
+    def test_checkpoints_after_each_step_not_only_at_end(
+        self, session_store: SessionStore, fake_redis: FakeRedis
+    ) -> None:
+        """Redis should hold the first step's result while the second step is
+        still running, proving the checkpoint isn't deferred to the end of
+        the whole plan (the old, buggy behavior)."""
+        seen_during_second_step: dict = {}
+
+        class SpyTool(CountingTool):
+            def execute(self, input_data: dict) -> ToolResult:
+                # Snapshot Redis state as observed while tool_b is running,
+                # i.e. after tool_a's loop iteration (and its checkpoint
+                # write) has already completed, but before tool_b's own
+                # checkpoint write happens.
+                seen_during_second_step["state"] = session_store.get("profile-1")
+                return super().execute(input_data)
+
+        tools = {"tool_a": CountingTool("tool_a"), "tool_b": SpyTool("tool_b")}
+        orch = self._orchestrator(tools, session_store)
+
+        orch.run("profile-1", {})
+
+        state = seen_during_second_step["state"]
+        assert state is not None
+        assert any(key.startswith("tool_a:") for key in state["completed"])
+        assert not any(key.startswith("tool_b:") for key in state["completed"])
+
+    def test_resume_skips_already_completed_steps(self, session_store: SessionStore) -> None:
+        """A tool that already succeeded should not be re-executed on a resumed run."""
+        tool_a = CountingTool("tool_a")
+        # Exhausts _execute_with_timeout's internal retry budget (max_retries=2)
+        # within the first run() call, so the step genuinely fails and is
+        # never checkpointed -- simulating a step that hadn't finished when
+        # the process was interrupted.
+        tool_b = CountingTool("tool_b", fail_times=2)
+
+        tools = {"tool_a": tool_a, "tool_b": tool_b}
+        orch = self._orchestrator(tools, session_store)
+
+        first = orch.run("profile-1", {})
+        assert first["tool_results"]["tool_a"] == {"tool": "tool_a", "call": 1}
+        assert first["tool_results"]["tool_b"]["success"] is False
+        assert tool_a.call_count == 1
+        assert tool_b.call_count == 2
+
+        # Simulate a restart: fresh Orchestrator instance (fresh in-memory
+        # ContextManager), same session_store (same "Redis").
+        resumed_orch = self._orchestrator(tools, session_store)
+        second = resumed_orch.run("profile-1", {})
+
+        # tool_a must NOT run again -- its checkpointed result is reused.
+        assert tool_a.call_count == 1
+        assert second["tool_results"]["tool_a"] == {"tool": "tool_a", "call": 1}
+
+        # tool_b, which never checkpointed (it failed), retries and succeeds
+        # on the third call overall (its first successful attempt).
+        assert tool_b.call_count == 3
+        assert second["tool_results"]["tool_b"] == {"tool": "tool_b", "call": 3}
+
+    def test_different_input_is_not_treated_as_already_done(
+        self, session_store: SessionStore
+    ) -> None:
+        """Same tool name with different input must not reuse a stale checkpoint."""
+        tool = CountingTool("tool_a")
+        orch = Orchestrator(tools={"tool_a": tool}, session_store=session_store)
+        orch._build_plan = lambda profile_data: [("tool_a", {"x": 1})]  # type: ignore[method-assign]
+
+        orch.run("profile-1", {})
+        assert tool.call_count == 1
+
+        orch._build_plan = lambda profile_data: [("tool_a", {"x": 2})]  # type: ignore[method-assign]
+        orch.run("profile-1", {})
+
+        # Different input hash -> treated as a new step, not a cache hit.
+        assert tool.call_count == 2
+
+    def test_checkpoint_write_failure_is_logged_not_silent(
+        self, session_store: SessionStore
+    ) -> None:
+        """A failed Redis write during checkpointing should be surfaced via logging,
+        not swallowed without any signal, and should not crash the run."""
+        session_store.set = Mock(return_value=False)  # type: ignore[method-assign]
+        tool = CountingTool("tool_a")
+        orch = self._orchestrator({"tool_a": tool}, session_store)
+
+        with pytest.MonkeyPatch.context() as mp:
+            logged: dict = {}
+            mp.setattr(
+                "agent.orchestrator.logger.error",
+                lambda event, **kwargs: logged.setdefault(event, kwargs),
+            )
+            result = orch.run("profile-1", {})
+
+        assert "checkpoint_write_failed" in logged
+        assert result["tool_results"]["tool_a"] == {"tool": "tool_a", "call": 1}
+
+    def test_uninterrupted_run_matches_result_of_interrupted_then_resumed_run(
+        self, session_store: SessionStore
+    ) -> None:
+        """An interrupted-then-resumed run should end up with the same final
+        results as a run that never got interrupted in the first place."""
+        clean_tools = {"tool_a": CountingTool("tool_a"), "tool_b": CountingTool("tool_b")}
+        clean_orch = self._orchestrator(clean_tools, SessionStore(FakeRedis()))  # type: ignore[arg-type]
+        clean_result = clean_orch.run("profile-1", {})
+
+        interrupted_tools = {"tool_a": CountingTool("tool_a"), "tool_b": CountingTool("tool_b")}
+        interrupted_orch = self._orchestrator(
+            {"tool_a": interrupted_tools["tool_a"]}, session_store
+        )
+        interrupted_orch.run("profile-1", {})
+
+        resumed_orch = self._orchestrator(interrupted_tools, session_store)
+        resumed_result = resumed_orch.run("profile-1", {})
+
+        assert resumed_result["tool_results"] == clean_result["tool_results"]
+        assert interrupted_tools["tool_a"].call_count == 1

--- a/tests/unit/test_session_store.py
+++ b/tests/unit/test_session_store.py
@@ -1,0 +1,60 @@
+"""Tests for session_store.py"""
+
+from unittest.mock import Mock
+
+import pytest
+
+from agent.memory.session_store import SessionStore
+
+
+@pytest.mark.unit
+class TestSessionStore:
+    """Test suite for SessionStore."""
+
+    @pytest.fixture
+    def mock_redis(self) -> Mock:
+        """Create a mock Redis client."""
+        return Mock()
+
+    @pytest.fixture
+    def store(self, mock_redis: Mock) -> SessionStore:
+        """Create a SessionStore instance with mocked Redis."""
+        return SessionStore(mock_redis)
+
+    def test_set_returns_true_on_success(self, store: SessionStore, mock_redis: Mock) -> None:
+        """Test set() returns True when the Redis write succeeds."""
+        mock_redis.setex = Mock()
+
+        result = store.set("session-1", {"a": 1})
+
+        assert result is True
+
+    def test_set_returns_false_on_redis_error(self, store: SessionStore, mock_redis: Mock) -> None:
+        """Test set() returns False (not an exception) when Redis errors."""
+        mock_redis.setex = Mock(side_effect=Exception("Redis unavailable"))
+
+        result = store.set("session-1", {"a": 1})
+
+        assert result is False
+
+    def test_set_uses_single_setex_call(self, store: SessionStore, mock_redis: Mock) -> None:
+        """Test the full value is written in one atomic SETEX call, so a
+        crash mid-write can't leave a partially-written value in Redis."""
+        mock_redis.setex = Mock()
+
+        store.set("session-1", {"a": 1}, ttl_seconds=120)
+
+        mock_redis.setex.assert_called_once()
+        call_args = mock_redis.setex.call_args
+        assert call_args[0][0] == "session:session-1"
+        assert call_args[0][1] == 120
+
+    def test_get_returns_none_when_write_never_happened(
+        self, store: SessionStore, mock_redis: Mock
+    ) -> None:
+        """Test get() behaves correctly for a session that was never stored."""
+        mock_redis.get = Mock(return_value=None)
+
+        result = store.get("session-1")
+
+        assert result is None


### PR DESCRIPTION
## Summary
Orchestrator.run() previously only wrote session state to Redis once, after its entire tool plan finished. If the API server restarted while a review was partway through its plan, everything completed up to that point was lost, since it was never written anywhere durable, and the next attempt had no way to know what already ran, so it re-executed the whole plan from scratch. This PR makes checkpointing incremental: each tool step's result is written to Redis immediately after it succeeds, and a resumed run skips steps that are already checkpointed instead of re-running them.

## Issue
Closes #47

## Changes
- `Orchestrator.run()` now checkpoints each step's result to Redis right after that step succeeds, instead of writing the full session state once at the end of the loop
- Added `Orchestrator._step_key()`, which keys a checkpoint by tool name plus a hash of that tool's input, so a step with changed input after a restart is correctly treated as not yet done rather than reusing a stale result
- A resumed run checks each planned step against the checkpointed state and skips it if already present
- A step that fails is not checkpointed, so it retries on the next run instead of being permanently frozen in a failed state
- `SessionStore.set()` now returns `True`/`False` instead of silently swallowing write failures, so a failed checkpoint write is logged (`checkpoint_write_failed`) instead of disappearing without any signal
- Added `tests/unit/test_orchestrator_checkpointing.py` (5 tests) and `tests/unit/test_session_store.py` (4 tests)

## Testing
- [x] Unit tests pass (`make test-unit`) — see note below on pre-existing failures
- [ ] Integration tests (`make test-integration`) — not run; this change has no integration test coverage in the repo currently
- [x] Linter passes (`make lint`) — all files I added or changed are clean under ruff
- [ ] Type checker (`make typecheck`) — see note below
- [x] New/updated tests cover the changes

**Pre-existing failures (verified before and after my change, confirmed unaffected):**
- 53 unit tests fail on `main` today, in files unrelated to this change (identical failing test names before and after my diff, confirmed by diffing the exact list)
- 182 pre-existing ruff errors and 52 files needing black formatting exist elsewhere in the repo; none in files I touched
- `make typecheck`'s full command (`mypy api/ core/ ingestion/ rag/ agent/ safety/`) currently cannot complete at all in a Python 3.14 environment: a numpy stub file uses 3.12+ syntax that conflicts with this project's `mypy` config (`python_version = "3.11"`). This reproduces identically on unmodified `main`, so it's a pre-existing environment issue, not something this PR introduces.
- Scoping mypy to `agent/` directly (which avoids the numpy issue) shows 13 pre-existing errors in `error_handling.py`, `context_manager.py`, and two `orchestrator.py` functions I did not modify. Same count and same errors before and after my change. My own new code (the checkpointing logic and both new test files) is fully typed and mypy-clean.

### How to verify manually
1. Start Redis locally: `docker compose up -d redis`
2. Run the reproduction script: `.venv/bin/python scripts/repro_issue47.py`
3. Observe the output:
   - After "Run 1" (which simulates a server crash during `tool_b`, right after `tool_a` succeeded), "Redis state after crash" shows a `completed` entry for `tool_a` — proving its result was checkpointed durably, not just held in memory.
   - The "Execution log across both runs" section shows `EXECUTED tool_a` only once, in Run 1. Run 2 (the simulated restart) shows only `EXECUTED tool_b` and `EXECUTED tool_c` — `tool_a` is skipped because it's already checkpointed, instead of being re-executed from scratch.
   - Before this fix, "Redis state after crash" printed `None`, and `EXECUTED tool_a` appeared twice in the log (once per run), since nothing survived the crash.

## Screenshots / Demo
N/A — backend-only change to agent orchestration; no UI changes.

## Notes for Reviewers
- `Orchestrator` currently has no callers anywhere in the live app (`core/services/review_service.py` uses a hardcoded placeholder instead of calling into `agent/orchestrator.py`). This fix addresses the bug as described in #47, but wiring `Orchestrator` into the actual review pipeline appears to be a separate, unaddressed gap. Flagging in case that's expected to be part of this fix.
- Redis's `SETEX` already writes the full value in one atomic command, so a crash mid-write can't leave a partially-written checkpoint in Redis; the real gap was that write failures were silently swallowed with no signal, which is what the `SessionStore.set()` return-value change addresses.
- One commit (`620c68b`) uses `--no-verify` to skip the pre-commit mypy hook, specifically because of the pre-existing errors described above in files I didn't author. Happy to add annotations to those files too if that's preferred over leaving them as documented pre-existing debt.
