### PR TITLE
test(rag): add integration test for the full RAG pipeline against a mock LLM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ htmlcov/
 .claude
 CLAUDE.md
 p7_docs/
+p8_docs/

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,8 @@ htmlcov/
 
 # Build artifacts
 *.pyc
+
+# Local tooling / course files (not part of the project)
+.claude
+CLAUDE.md
+p7_docs/

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ htmlcov/
 CLAUDE.md
 p7_docs/
 p8_docs/
+p9_docs/

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ CLAUDE.md
 p7_docs/
 p8_docs/
 p9_docs/
+p10_docs/

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -102,7 +102,7 @@ $ curl -s -o /dev/null -w "%{http_code}" http://localhost:8000/docs
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [to be filled in with this commit's URL after pushing]
+**Reproduction commit link:** https://github.com/GurupavanSudhakar/pathreview/commit/6a3e495
 
 **Reproduction summary:**
 Issue #38 is a feature gap, not a crash, so "reproducing" it means confirming the gap is

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -99,3 +99,35 @@ $ curl -s -o /dev/null -w "%{http_code}" http://localhost:8000/docs
 - The `chromadb/chroma:0.4.22` container image crashes on boot (`AttributeError: np.float_
   was removed in the NumPy 2.0 release`). Neither issue blocks the app from loading at
   `localhost:5173`, and both are outside the scope of issue #38.
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [to be filled in with this commit's URL after pushing]
+
+**Reproduction summary:**
+Issue #38 is a feature gap, not a crash, so "reproducing" it means confirming the gap is
+real. Ran `.venv/Scripts/python.exe -m pytest tests/integration -v -m integration` and
+got `no tests ran in 4.22s` (exit code 5, 0 items collected) — `tests/integration/`
+contains only `__init__.py`. A repo-wide grep for `HybridRetriever`, `ReviewGenerator`,
+and `parse_review_output` shows each class/function is referenced only inside its own
+defining file (`rag/retriever/hybrid.py`, `rag/generator/review_generator.py`,
+`rag/generator/output_parser.py`, plus `parse_review_output`'s own unit test) — nothing
+in the codebase currently exercises retrieval → generation → parsing together, exactly
+the seam-level coverage gap the issue describes.
+
+**PLAN.md link:** [PLAN.md](./PLAN.md)
+
+**Walkthrough video (recommended):** Not recorded — not part of the grade for this
+milestone, per the course guidance for Week 8.
+
+**Blockers or open questions:**
+While mapping the pipeline for `PLAN.md`, found two divergences from the issue text
+worth flagging for Week 9: (1) there is no reranking stage anywhere in `rag/` — the
+issue's "retrieval → reranking → generation → parsing" phrasing doesn't match the
+codebase, so the Week 9 test will cover retrieval → generation → parsing only; (2)
+there's no real mock **LLM** (chat) provider — `core/config.py`'s `llm_provider` setting
+is never branched on anywhere, and the only existing mock is `MockEmbeddingProvider`
+(embeddings only). `ReviewGenerator` hardcodes a live `openai.OpenAI` client with no
+injectable seam, so "mock LLM" will mean a test-side fake/monkeypatch of that client,
+not a new production mock-LLM class. Details and rationale are in `PLAN.md`'s
+Understand/Map/Risks sections.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,101 @@
+# PathReview — Module 3 Journal
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/38
+
+**Issue title:** Add an integration test that runs the full RAG pipeline against a mock LLM
+
+**Tier:** [ ] Tier 1  [x] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+PathReview builds a review by chaining several RAG stages together — retrieving the most
+relevant profile chunks, reranking them, sending them to an LLM to generate the review
+text, and parsing that text into structured feedback sections. Today each of those stages
+is only exercised by its own isolated unit tests, and there is no single test that runs the
+stages end-to-end. That gap means a regression at a *seam* between stages — for example a
+shape mismatch between what the retriever returns and what the generator expects — could
+pass every unit test while silently breaking the real flow. A successful fix adds an
+integration test at `tests/integration/test_rag_pipeline.py` that drives a representative
+query through the entire retrieval → rerank → generation → parsing path against the
+deterministic mock LLM provider and asserts a well-formed review comes out, giving CI a
+fast, offline regression guard for the whole pipeline.
+
+**Selection reasoning ("Is this right for me?" checklist):**
+- **Tier acknowledged / skill alignment:** This is a **Tier 2** issue (intermediate —
+  requires cross-module understanding). That matches my comfort level: I'm comfortable with
+  Python and `pytest` and can read across modules, so a test that spans the RAG package is a
+  deliberate, appropriate stretch rather than an overreach.
+- **Do I understand the issue?** Yes — it asks for one end-to-end test, using the existing
+  mock LLM provider so results are deterministic (no live API, no cost).
+- **Is the scope realistic?** Yes. The change surface is small and additive — a single new
+  test file, **no production-code changes required** — while still touching multiple modules
+  to read (`rag/` retriever/reranker/generator/parser, `core/config.py` for the mock
+  provider, `tests/` conventions). That "read broadly, write narrowly" shape is exactly the
+  Tier-2 intent and keeps risk low. The tracker's 4–6h estimate is realistic for one issue.
+- **Blockers / dependencies?** None external — the mock provider means no keys or network.
+  During setup I already located the pipeline stages and confirmed the pieces exist to wire
+  together, so there are no unknown dependencies.
+- **Why not Tier 1 / Tier 3?** Larger than a Tier-1 one-line fix (it requires understanding
+  the whole pipeline), but well short of a Tier-3 architectural change (no design decisions,
+  no schema/API changes).
+
+**Branch name:** `test/38-rag-pipeline-integration-test`
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger
+
+---
+
+### Setup evidence (Week 7)
+
+Environment stood up on Windows 11 following `docs/SETUP.md` (Docker services + Python venv
++ frontend). Captured 2026-07-21.
+
+**Backing services healthy (`docker compose ps`):**
+```
+SERVICE   STATUS                    PORTS
+db        Up (healthy)              0.0.0.0:5433->5432/tcp
+redis     Up (healthy)              0.0.0.0:6379->6379/tcp
+```
+(Postgres is mapped to host port **5433** on Windows per SETUP.md, matching `.env`'s
+`DATABASE_URL`.)
+
+**Database migrated + seeded:**
+```
+alembic upgrade head  ->  ran migrations 001, 002 successfully
+scripts/seed_db.py    ->  seeded 3 test accounts (user1..3@example.com)
+```
+
+**Frontend loads at http://localhost:5173 (the Week 7 requirement):**
+```
+$ curl -sI http://localhost:5173/
+HTTP/1.1 200 OK
+Content-Type: text/html
+
+$ curl -s http://localhost:5173/ | grep -o '<title>.*</title>'
+<title>PathReview - AI Portfolio Review Assistant</title>
+
+# Vite dev server:  VITE v5.4.21  ready
+```
+
+**Backend API responds at http://localhost:8000:**
+```
+$ curl -s http://localhost:8000/
+{"message":"PathReview API is running","version":"1.0.0"}   # HTTP 200
+
+$ curl -s -o /dev/null -w "%{http_code}" http://localhost:8000/docs
+200                                                          # Swagger UI
+```
+
+**Environment observations (pre-existing, not part of issue #38):**
+- `GET /health` returns 503 due to two pre-existing bugs in `api/routes/health.py`, *not*
+  actual outages (Postgres/Redis are up — migrations and seeding both succeeded against
+  them): (1) the Postgres check runs a raw `"SELECT 1"` string instead of
+  `sqlalchemy.text("SELECT 1")` (invalid under SQLAlchemy 2.0), and (2) the Redis check
+  reads `settings.redis_host`, an attribute that does not exist on the `Settings` model
+  (only `redis_url` is defined in `core/config.py`).
+- The `chromadb/chroma:0.4.22` container image crashes on boot (`AttributeError: np.float_
+  was removed in the NumPy 2.0 release`). Neither issue blocks the app from loading at
+  `localhost:5173`, and both are outside the scope of issue #38.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -274,3 +274,104 @@ have broken the test; also that `keyword_score > 0` relied on `rank_bm25`'s nega
 epsilon floor, that a `source_id` mis-attribution would have slipped through a
 `startswith("repo_")` check, and that context truncation past the first chunk was
 unasserted. All four were addressed in commit `d45627d` before the PR was opened.
+
+---
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes [x] No — still awaiting review
+
+**Summary of feedback:**
+No review arrived. As of August 4, 2026, PR
+[#881](https://github.com/ascherj/pathreview/pull/881) has zero reviews, zero inline review
+comments and zero conversation comments, and GitHub reports `reviewDecision:
+REVIEW_REQUIRED` — no maintainer has looked at it yet. CI has not run either: every workflow
+run on the branch sits at `action_required` with 0 jobs and 0s duration, which is GitHub's
+first-time-contributor gate — a maintainer with write access has to approve workflow runs
+before `lint`, `typecheck`, `test-unit`, `test-integration` or `frontend` will execute. So
+the PR shows no check results, which is a permissions gate rather than anything failing in
+the code. This matches the course guidance that reviewer feedback is not a feature of the
+Summer 2026 cohort.
+
+**How you responded:**
+Nothing to respond to, so no changes were made after submission. The PR is left open and
+marked ready for review, with the pre-existing `make check` / `make test-unit` failures and
+the four seam issues I found already documented in the PR description so a maintainer can
+pick it up without needing to ask. The four items raised on the draft before submission were
+already addressed in commit `d45627d`. If feedback does arrive after the course closes, the
+branch is still in a state where I can act on it.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The test itself was the easy part; the environment and the ground truth were not. `make`
+isn't installed on my Windows machine, and the venv's `.venv/Scripts/pytest.exe` shim exits
+1 with completely empty output — even for `--version` — so I lost real time to a "failing"
+test run that was actually a broken launcher, and ended up running every Makefile recipe as
+`python -m pytest` / `-m ruff` / `-m black` / `-m mypy` instead. The bigger surprise came
+when I baselined the repo before writing anything: `main` already had **53 failing unit
+tests and 182 ruff errors**, which meant the deliverable "make check passes" could not be
+taken literally and had to be reinterpreted as "introduces no new failures." That reframing
+is what made capturing a before/after baseline mandatory rather than a nice-to-have — without
+the diff of failing test names, I had no way to prove which failures were mine.
+
+**What did you learn about working in a large codebase?**
+That the seams between components can be broken even when every unit test passes, which is
+exactly the gap issue #38 exists to close. Three concrete examples I hit: `VectorStore.add_chunks`
+reads `chunk.id`, `chunk.source_id`, `chunk.chunk_index` and `chunk.section`, but `Chunk`
+in `ingestion/chunking/base.py` only defines `text` and `metadata` — so no object in the
+repo actually satisfies that method; `rag/retriever/hybrid.py:50` computes
+`_get_all_chunks()` and then throws the result away, so the BM25 half of the "hybrid"
+retriever is silently dead unless the caller indexes the searcher itself; and
+`_consolidate_feedback` de-duplicates sections by a name that comes from the LLM's own
+response, so a model answering every section under one key collapses a five-section review
+into one. I also found there was no orchestration to test through at all —
+`core/services/review_service.py::_run_rag_retrieval_generation` is a stub returning
+hardcoded data — so the test had to do the wiring itself. The discipline that was new to me
+was *not* fixing any of it: I kept the PR test-only and wrote all four findings up in Notes
+for Reviewers, because unrequested changes to someone else's production code make a PR
+harder to review and easier to reject.
+
+**How did AI tools help — and where did they fall short?**
+AI was strongest at mapping unfamiliar code quickly — pulling exact signatures and return
+shapes across `HybridRetriever`, `VectorStore`, `ReviewGenerator` and `parse_review_output`,
+and establishing that each was referenced only inside its own defining file, which is what
+confirmed the coverage gap was real. It was consistently weakest on what code actually
+*does* at runtime as opposed to what it looks like it does: it saw the `_get_all_chunks()`
+call at `hybrid.py:50` and assumed the result fed the keyword index, and it assumed the
+repo's `Chunk` would satisfy `add_chunks` — both plausible from reading, both wrong, and
+both only exposed by executing the code. The sharpest example was the mock: the obvious move
+is `MagicMock`, but a `MagicMock`'s `.choices[0].message.content` is itself a `Mock`, which
+`parse_review_output` quietly routes through its plaintext fallback — I would have gotten a
+green test that asserted essentially nothing. Hand-writing `FakeOpenAIClient` was the fix,
+and the general lesson was that AI accelerates locating and summarizing, but anything it
+claims about behaviour has to be run before I believe it.
+
+**What would you do differently if you started over?**
+Three things. First, baseline `make check` and `make test-unit` on day one instead of in
+Week 9 — I spent time unsure whether failures were mine, and one command up front would have
+answered it. Second, read `VectorStore.add_chunks` against `Chunk` *before* writing
+`PLAN.md`'s fixture plan; my plan's risk list confidently named the wrong seam, and I only
+caught it when the fixtures wouldn't work. Third, and most importantly, verify the issue text
+against the actual code before planning around it: issue #38 describes "retrieval →
+reranking → generation → parsing," but there is no reranker anywhere in `rag/` and zero
+matches for `rerank` in the repo, so a scope reduction I could have identified in Week 7 had
+to be carved out and explained later. I'd also weigh how contested an issue is — nine other
+students claimed #38, and PRs #429 and #586 target it, which I didn't consider when picking.
+
+**What are you most proud of from this module?**
+Not that the eight tests pass — that they demonstrably would have failed if the pipeline
+broke. I mutation-tested the suite by deliberately breaking eight production behaviours one
+at a time (renaming the returned `text` key, truncating `_format_context` to one chunk,
+removing citation appending, changing the blend weights from 0.7/0.3 to 0.5/0.5, removing
+the per-section `try/except`, writing a wrong `source_id`, disabling the `min_score` filter)
+and confirmed each one made a specific test fail before reverting it. That turned "8 passed"
+from a claim into evidence, and it's what I put in the PR so a reviewer could repeat it. The
+second thing is that when feedback came back on the draft I reworked the assertions instead
+of defending them — the exact-count assertion became a threshold test that holds whether or
+not `VectorStore.query`'s cosine-distance bug ever gets fixed, which is a better test than
+the one I was attached to.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -131,3 +131,146 @@ is never branched on anywhere, and the only existing mock is `MockEmbeddingProvi
 injectable seam, so "mock LLM" will mean a test-side fake/monkeypatch of that client,
 not a new production mock-LLM class. Details and rationale are in `PLAN.md`'s
 Understand/Map/Risks sections.
+
+---
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+All five sub-tasks from `PLAN.md`'s "Plan" section are complete, and
+`tests/integration/test_rag_pipeline.py` now exists as the first test in
+`tests/integration/`:
+
+- *Sub-task 1 (retrieval fixtures)* — a `retriever` fixture stands up `VectorStore`
+  against a pytest `tmp_path` and seeds it through `VectorStore.add_chunks(...)` with
+  embeddings from the existing `MockEmbeddingProvider`, then indexes a `KeywordSearcher`
+  over the same chunks. No Docker Chroma container needed.
+- *Sub-task 2 (fake LLM)* — a hand-written `FakeOpenAIClient` shaped like
+  `client.chat.completions.create(...)`, installed by patching
+  `rag.generator.review_generator.openai.OpenAI` (the name as imported in that module).
+  Hand-written rather than a `MagicMock` because a `MagicMock`'s
+  `.choices[0].message.content` is itself a `Mock`, which `parse_review_output` would
+  quietly route through its plaintext fallback and hide real breakage.
+- *Sub-task 3 (wiring)* — tests call `HybridRetriever.retrieve(...)` and feed the result
+  straight into `ReviewGenerator.generate_full_review(...)`, which is the seam nothing in
+  the codebase currently exercises (`core/services/review_service.py`'s
+  `_run_rag_retrieval_generation` is still a stub returning canned data).
+- *Sub-task 4 (assertions)* — covers the blended chunk contract, five parsed
+  `FeedbackSection`s, appended `Sources:` citations, context and profile data actually
+  reaching the prompt, zero-retrieval degradation, and a per-section LLM failure.
+- *Sub-task 5 (marker)* — the class is marked `@pytest.mark.integration`;
+  `pytest tests/integration -v -m integration` went from `no tests ran` (exit 5, 0
+  collected) to 8 collected and passing in ~3.5s.
+
+**Next steps:**
+Run an adversarial review pass over the test before opening the PR — specifically
+checking whether it would actually fail if a seam broke, rather than just passing — then
+fill in the PR template, document the pre-existing `make check` / `make test-unit`
+failures so it's clear this change doesn't add to them, and open the PR against
+`ascherj/pathreview`.
+
+**Blockers:**
+No hard blockers, but three things in the codebase shaped the implementation and are
+worth recording:
+
+1. `HybridRetriever.retrieve()` computes `all_chunks = self._get_all_chunks(...)` at
+   `rag/retriever/hybrid.py:50` and then never uses it — `keyword_searcher.index(...)` is
+   not called anywhere in the retriever, so the keyword arm returns `[]` and blended
+   scores cap at `vector_weight` unless the caller indexes the searcher itself. The test
+   fixture does this explicitly.
+2. `VectorStore.add_chunks(...)` reads `chunk.id`, `chunk.source_id`, `chunk.chunk_index`
+   and `chunk.section`, but `Chunk` (`ingestion/chunking/base.py`) only defines `text` and
+   `metadata` — no object in the repo satisfies the method. The test defines a minimal
+   `StoredChunk` record for the seam rather than changing production code.
+3. `generate_section` returns the *parser's* `section_name` and `_consolidate_feedback`
+   de-duplicates on it, so a fake LLM returning one canned payload for all five calls
+   collapses the review from five sections to one. The fake therefore answers under each
+   requested section's own key, matching on the distinct opening wording of each prompt
+   template.
+
+Tooling note: `make` is not installed on this Windows machine and the venv's
+`.venv/Scripts/pytest.exe` shim exits 1 with zero output even for `--version`, so the
+Makefile recipes are run directly via `.venv/Scripts/python.exe -m {pytest,ruff,black,mypy}`
+— the same commands `make test-unit`, `make test-integration` and `make check` invoke
+(`Makefile:39-59`).
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/881
+
+**Branch:** `test/38-rag-pipeline-integration-test`
+
+**What you built:**
+An integration test that drives one query through the real RAG pipeline —
+`HybridRetriever.retrieve()` → `ReviewGenerator.generate_full_review()` →
+`parse_review_output()` — against a deterministic mock LLM, closing the seam-level
+coverage gap in issue #38. Retrieval runs against a real Chroma `PersistentClient` on a
+pytest `tmp_path` seeded with `MockEmbeddingProvider` embeddings, and generation is
+isolated by patching `rag.generator.review_generator.openai.OpenAI` with a fake chat
+client that answers per requested section, so the whole test needs no Docker, no network
+and no API key.
+
+**Tests added or updated:**
+Added `tests/integration/test_rag_pipeline.py` (8 tests, the first content in
+`tests/integration/`). No existing test files were modified. What the tests cover:
+
+- `test_retrieval_blends_vector_and_keyword_scores` — retrieved chunks carry exactly the
+  keys `id/text/metadata/score/vector_score/keyword_score`, `score` equals
+  `0.7 * vector_score + 0.3 * keyword_score`, chunk metadata survives the Chroma
+  round-trip with its literal values intact, and results come back score-descending.
+- `test_min_score_threshold_filters_weak_matches` — the `min_score` cut-off is actually
+  applied to blended scores, asserted in a way that does not depend on how vector
+  similarity is derived from distance.
+- `test_pipeline_produces_all_sections_with_citations` — the generator is asked for all
+  five sections in template order, returns five distinct sections, and each one ends with
+  the `Sources: …` citation line built from the retrieved chunks' `source_id`s.
+- `test_json_response_parses_into_structured_section` — a fenced-JSON reply lands on the
+  parser's structured branch, giving `confidence == 0.9` and parsed `suggestions`, rather
+  than silently falling through to the plaintext branch.
+- `test_prompt_carries_retrieved_context_and_profile_data` — every retrieved chunk's text
+  and `Source:` line reaches the LLM prompt at the right position, along with
+  `github_username`, `project_count`, and the configured model/temperature/max_tokens.
+- `test_every_context_chunk_reaches_prompt_and_citations_cap_at_five` — `_format_context`
+  includes all supplied chunks in order and `_add_citations` cites at most five sources,
+  omitting the sixth.
+- `test_empty_retrieval_still_generates_uncited_sections` — the case where retrieval
+  returns no relevant chunks: the pipeline still produces all five sections and appends no
+  citations instead of raising.
+- `test_single_section_llm_failure_yields_placeholder` — when one section's LLM call
+  raises, only that section degrades to the `Error generating <section>` placeholder with
+  `confidence == 0.0`, and the other four are unaffected.
+
+Each of these was mutation-checked: production code was temporarily broken (renaming the
+`text` key, dropping chunk text from the prompt, removing citation appending, changing the
+blend weights, removing the per-section `try/except`, mis-attributing `source_id`,
+truncating context, disabling the `min_score` filter) and confirmed to make at least one
+test fail, then reverted.
+
+**Self-review confirmation:** [x] `make check` passes [x] `make test-unit` passes
+
+Read as the course guidance defines it for a codebase with documented pre-existing
+failures — my changes introduce no new failures. Measured before and after, with the
+Makefile's own commands:
+
+| Check | Before my change | After my change |
+| --- | --- | --- |
+| `ruff check .` | 182 errors | 182 errors (new file: clean) |
+| `black --check .` | 52 would reformat, 58 unchanged | 52 would reformat, 59 unchanged |
+| `mypy api/ core/ ingestion/ rag/ agent/ safety/` | 5 errors in 4 files, exit 2 | identical (`tests/` is not in scope) |
+| `pytest tests/unit -m unit` | 53 failed, 375 passed | 53 failed, 375 passed — identical set |
+| `pytest tests/integration -m integration` | no tests ran, exit 5 | 8 passed |
+
+The 53 failing unit tests and 182 lint errors are pre-existing on `main` and untouched by
+this branch; the failing-test names are byte-for-byte identical before and after.
+
+**Draft PR feedback received from:** Carlton Tam — flagged that the first draft asserted an
+exact retrieved-chunk count, which only passed because `VectorStore.query` converts cosine
+distance with the euclidean formula `1 / (1 + distance)`, meaning a fix to that bug would
+have broken the test; also that `keyword_score > 0` relied on `rank_bm25`'s negative-IDF
+epsilon floor, that a `source_id` mis-attribution would have slipped through a
+`startswith("repo_")` check, and that context truncation past the first chunk was
+unasserted. All four were addressed in commit `d45627d` before the PR was opened.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,131 @@
+## Solution plan
+
+**Issue:** Add an integration test that runs the full RAG pipeline against a mock LLM —
+https://github.com/ascherj/pathreview/issues/38
+
+### Understand
+The RAG pipeline is built from independently-tested stages: `HybridRetriever`
+(`rag/retriever/hybrid.py`, blending `VectorStore` + `KeywordSearcher` results),
+`ReviewGenerator` (`rag/generator/review_generator.py`, calls an LLM to produce feedback
+text per section), and `parse_review_output` (`rag/generator/output_parser.py`, turns raw
+LLM text into `FeedbackSection` objects). Each has unit tests in isolation
+(`tests/unit/test_keyword_search.py`, `tests/unit/test_output_parser.py`, etc.), but
+nothing runs them chained together. A repo-wide search confirms `HybridRetriever`,
+`ReviewGenerator`, and `parse_review_output` are each referenced only inside their own
+defining file — no orchestration point exists (`core/services/review_service.py`'s
+`_run_rag_retrieval_generation` is a stub that returns hardcoded data and never calls
+any of these classes). Root cause: a shape/contract mismatch at a seam between stages —
+e.g. the dict keys `HybridRetriever.retrieve()` returns (`text`, `metadata`, `score`)
+no longer matching what `ReviewGenerator._format_context()` expects — could pass every
+unit test while silently breaking the real end-to-end flow, because nothing asserts the
+seams line up. Expected behavior: a `tests/integration/` test drives a representative
+query through retrieval → generation → parsing against a deterministic mock and asserts
+a well-formed review comes out. Actual behavior: `tests/integration/` contains only
+`__init__.py` — confirmed by running
+`.venv/Scripts/python.exe -m pytest tests/integration -v -m integration`, which reports
+`no tests ran in 4.22s` (0 items collected).
+
+**Divergence from the issue text:** the issue says "retrieval → reranking → generation →
+parsing," but there is no reranking stage anywhere in `rag/` (no `rag/reranker/`
+directory, zero matches for `rerank` repo-wide). The test will cover the pipeline that
+actually exists — retrieval → generation → parsing — and this gap is called out rather
+than silently ignored.
+
+### Map
+- `rag/retriever/hybrid.py` — `HybridRetriever.__init__(vector_store, keyword_searcher,
+  vector_weight=0.7, keyword_weight=0.3)`, `.retrieve(query, profile_id, query_embedding,
+  max_chunks=10, min_score=0.3) -> list[dict]`. Blends vector + BM25 scores, filters by
+  `min_score`, returns top `max_chunks`.
+- `rag/retriever/vector_store.py` — `VectorStore(persist_dir)`, backed by a real Chroma
+  `PersistentClient`; `.get_collection(name)`, `.add_chunks(...)`, `.query(...)`.
+- `rag/retriever/keyword_search.py` — `KeywordSearcher`, in-memory BM25, `.index(chunks)`,
+  `.search(query, top_k)`.
+- `rag/generator/review_generator.py` — `ReviewConfig` dataclass (`api_key`, `base_url`,
+  `model`, `temperature`, `max_tokens`); `ReviewGenerator.__init__` builds
+  `self.client = openai.OpenAI(api_key=..., base_url=...)` directly (line 34, no
+  injectable client param); `.generate_full_review(profile_data, retrieved_chunks) ->
+  list[FeedbackSection]` loops 5 fixed section names, calls `.generate_section(...)` per
+  section, catches exceptions per-section, adds citations, consolidates.
+- `rag/generator/output_parser.py` — `FeedbackSection` dataclass (`section_name`,
+  `content`, `confidence`, `suggestions`); `parse_review_output(raw) -> list[FeedbackSection]`
+  tries JSON-in-fence, then raw JSON, then falls back to one plaintext section.
+- `ingestion/embeddings/provider.py` — `MockEmbeddingProvider.embed(texts) ->
+  list[list[float]]`, deterministic (SHA-256 hash → seeded RNG → normalized 1536-dim
+  vector); this is the existing "mock" building block for embeddings, reused to produce
+  query/document embeddings in the test.
+- New file: `tests/integration/test_rag_pipeline.py` (target of the issue). `tests/conftest.py`
+  currently only holds `sample_resume_text`/`sample_readme_text` fixtures — new
+  fixtures for this test will live either in the new file or a new
+  `tests/integration/conftest.py`.
+
+### Plan
+1. Add fixtures that stand up a `VectorStore` against a pytest `tmp_path` (Chroma
+   `PersistentClient` supports a plain local directory — no Docker/network needed) and
+   seed it with 2-3 known profile chunks, embedded via `MockEmbeddingProvider`, plus a
+   matching `KeywordSearcher.index(...)` call over the same chunks.
+2. Write a fake OpenAI client (a small class or `unittest.mock.MagicMock` shaped to
+   match) whose `chat.completions.create(...)` returns a canned response object with
+   `.choices[0].message.content` set to a JSON-fenced string that
+   `parse_review_output` will route through its first (JSON-in-fence) branch, and
+   monkeypatch `rag.generator.review_generator.openai.OpenAI` so `ReviewGenerator.__init__`
+   picks it up.
+3. Instantiate `HybridRetriever(vector_store, keyword_searcher)`, call `.retrieve(query,
+   profile_id, query_embedding=MockEmbeddingProvider().embed([query])[0])`, then feed the
+   resulting chunks into `ReviewGenerator(ReviewConfig(...)).generate_full_review(profile_data,
+   chunks)`.
+4. Assert on the full path: `.retrieve()` returns non-empty chunks with the expected dict
+   shape (`id`, `text`, `metadata`, `score`); `generate_full_review()` returns exactly 5
+   `FeedbackSection`s (one per fixed section name), each with non-empty `content` and a
+   `confidence` in `[0, 1]`; confirm citations get appended to `content` when chunks exist
+   (`Sources:` substring present).
+5. Mark the test class `@pytest.mark.integration` (per `pyproject.toml`'s registered
+   markers) and confirm `pytest tests/integration -v -m integration` now collects >0
+   items and passes with no Docker/network/live API key required, so `make
+   test-integration` picks it up in CI.
+
+### Inputs & outputs
+**Input:** a `profile_id`, a query string representative of a real review request (e.g.
+"How strong are this candidate's backend skills?"), and a small fixed corpus of
+profile-like text chunks (resume/README snippets) embedded via `MockEmbeddingProvider`.
+**Output:** a `list[FeedbackSection]` of length 5, with deterministic `content` and
+`confidence` values (deterministic because both the embeddings and the fake chat
+response are canned/seeded, not live).
+
+**Risks & unknowns:**
+- `ReviewGenerator.__init__` (`rag/generator/review_generator.py:34`) constructs
+  `openai.OpenAI` directly inside `__init__` rather than accepting an injected client —
+  the monkeypatch must target `rag.generator.review_generator.openai.OpenAI` (the name
+  as imported in that module), not `openai.OpenAI` globally, or the patch will silently
+  no-op and the test will attempt a real network call.
+- `VectorStore` (`rag/retriever/vector_store.py`) is backed by a real Chroma
+  `PersistentClient` — pointing it at a pytest `tmp_path` avoids needing the Docker
+  Chroma container, but Chroma's on-disk schema/version could change between the
+  installed `chromadb` version and what's pinned, so the test should confirm this
+  actually collects without Docker before assuming it's a good CI fit.
+- `parse_review_output` (`rag/generator/output_parser.py`) has three fallback branches
+  (JSON-fenced, raw JSON, plaintext) — the canned fake-LLM response's exact string
+  format determines which branch runs; the test must pin the response format
+  deliberately (JSON-in-fence) so it isn't accidentally testing the plaintext fallback
+  instead of the intended structured path.
+- `HybridRetriever._get_all_chunks()` (`rag/retriever/hybrid.py:106`) re-fetches all
+  chunks from the vector store's collection to build the keyword index's chunk-lookup —
+  the seeded chunks must be added through `VectorStore.add_chunks(...)` (not only
+  `KeywordSearcher.index(...)`) or this lookup will silently return an empty chunk map
+  for keyword-only hits.
+
+### Edge cases
+- **Empty/low-similarity corpus:** if `HybridRetriever.retrieve()`'s `min_score=0.3`
+  filter excludes every candidate (e.g. a query unrelated to the seeded corpus), the
+  retrieval step returns zero chunks; the test should assert `generate_full_review()`
+  still returns exactly 5 sections (via `ReviewGenerator`'s existing per-section
+  try/except in `generate_full_review`, `rag/generator/review_generator.py:126`) rather
+  than raising, confirming the pipeline degrades gracefully with no context.
+- **Malformed/unparseable LLM output for one section:** if the fake client's response
+  content isn't valid JSON-in-fence for one call (simulate by having the fake return a
+  broken payload for a single section), confirm the existing per-section
+  `except Exception` path (`review_generator.py:126-135`) still yields a placeholder
+  `FeedbackSection(content=f"Error generating {section_name}", confidence=0.0)` instead
+  of failing the whole `generate_full_review()` call.
+
+You'll update this file as your understanding evolves in Week 9. It's a living document,
+not a contract.

--- a/PLAN.md
+++ b/PLAN.md
@@ -127,5 +127,43 @@ response are canned/seeded, not live).
   `FeedbackSection(content=f"Error generating {section_name}", confidence=0.0)` instead
   of failing the whole `generate_full_review()` call.
 
-You'll update this file as your understanding evolves in Week 9. It's a living document,
-not a contract.
+### Week 9 update — what actually happened
+
+Implemented as `tests/integration/test_rag_pipeline.py` (8 tests, all passing). The five
+planned sub-tasks all landed, but building it surfaced four things the plan had wrong or
+did not know:
+
+1. **`HybridRetriever` never indexes the keyword searcher.** `hybrid.py:50` computes
+   `all_chunks = self._get_all_chunks(collection_name)` and then discards it —
+   `keyword_searcher.index(...)` is never called anywhere in the retriever. So the
+   keyword arm silently returns `[]` and blended scores cap at `vector_weight` unless
+   the *caller* indexes the searcher first. The test's `retriever` fixture does that
+   explicitly, with a comment. Risk 4 in the list above guessed at this seam but
+   assumed `_get_all_chunks` fed the index; it does not.
+2. **Nothing in the repo satisfies `VectorStore.add_chunks`.** It reads `chunk.id`,
+   `chunk.source_id`, `chunk.chunk_index` and `chunk.section`, but `Chunk`
+   (`ingestion/chunking/base.py`) only has `text` and `metadata`. The test defines a
+   minimal `StoredChunk` record for the seam; the mismatch itself is reported in the PR,
+   not fixed here.
+3. **A single canned LLM response would have collapsed the review to one section.**
+   `generate_section` returns the *parser's* `section_name` (taken from the JSON payload
+   key), and `_consolidate_feedback` de-duplicates on that name — so the same mock reply
+   for all five calls yields one section, not five. The fake client therefore identifies
+   which section is being requested by matching the distinct opening wording of each
+   prompt template and answers under that section's own key. As a corollary,
+   `first_impression` (whose template asks for prose, not JSON) comes back named
+   `general_feedback`; the test matches that section on its content rather than its
+   name, so the assertion holds whether or not that drift is later corrected.
+4. **The planned "empty corpus" edge case does not arise the way the plan assumed.**
+   Because both arms are max-normalised, the top hit always normalises to 1.0 and
+   `min_score=0.3` filters almost nothing — a query unrelated to the corpus still
+   returns chunks. Zero-retrieval is instead reached with a profile that has no indexed
+   chunks at all (empty collection *and* unindexed searcher), which is what the test
+   uses.
+
+A review pass then caught that the first draft asserted an exact retrieved-chunk count,
+which passed only because `VectorStore.query` converts cosine distance with the
+euclidean formula `1 / (1 + distance)`; fixing that bug would have broken the test. The
+count assertion was replaced with a threshold test that holds under either conversion.
+
+This file was a living document, not a contract — the divergences above are the point.

--- a/tests/integration/test_rag_pipeline.py
+++ b/tests/integration/test_rag_pipeline.py
@@ -24,11 +24,22 @@ SECTION_MARKERS = (
     ("first impression", "first_impression"),
 )
 
+JSON_SECTIONS = (
+    "skills_feedback",
+    "projects_feedback",
+    "presentation_feedback",
+    "gaps_feedback",
+)
+
+PROSE_RESPONSE = "A focused backend portfolio with room to grow."
+
 CHUNK_TEXTS = [
     "Python FastAPI backend service with pytest coverage and Docker deployment",
+    "Python Flask backend API with pytest fixtures and Docker packaging",
     "React TypeScript frontend dashboard built with Tailwind and Vite",
     "Machine learning pipeline in Python using scikit-learn and pandas",
     "Go microservice exposing gRPC endpoints with Kubernetes manifests",
+    "Terraform modules provisioning managed Postgres and Redis instances",
 ]
 
 FENCE = "```json"
@@ -121,7 +132,7 @@ class FakeOpenAIClient:
         # The first_impression template explicitly asks for prose, not JSON, so this
         # exercises the parser's plaintext fallback alongside the four JSON sections.
         if section_name == "first_impression":
-            return FakeResponse("A focused backend portfolio with room to grow.")
+            return FakeResponse(PROSE_RESPONSE)
 
         # Each section must answer under its own top-level key: generate_section() takes
         # the section name from the parsed payload, and _consolidate_feedback() then
@@ -139,6 +150,11 @@ class FakeOpenAIClient:
 class TestRagPipeline:
     """Test suite for the end-to-end RAG pipeline."""
 
+    @pytest.fixture(autouse=True)
+    def offline(self, monkeypatch):
+        """Keep Chroma from phoning home so the pipeline runs fully offline."""
+        monkeypatch.setenv("ANONYMIZED_TELEMETRY", "False")
+
     @pytest.fixture
     def embedder(self):
         """Return the deterministic mock embedding provider."""
@@ -146,9 +162,9 @@ class TestRagPipeline:
 
     @pytest.fixture
     def chunk_records(self):
-        """Return chunk records for the seeded profile."""
+        """Return chunk records for the seeded profile, one source each."""
         return [
-            StoredChunk(id=f"chunk_{i}", text=text, source_id=f"repo_{i % 2}", chunk_index=i)
+            StoredChunk(id=f"chunk_{i}", text=text, source_id=f"repo_{i}", chunk_index=i)
             for i, text in enumerate(CHUNK_TEXTS)
         ]
 
@@ -181,13 +197,26 @@ class TestRagPipeline:
     @pytest.fixture
     def empty_retriever(self, tmp_path):
         """Build a HybridRetriever with no vectors and no keyword index."""
-        store = VectorStore(persist_dir=str(tmp_path / "chroma_empty"))
+        store = VectorStore(persist_dir=str(tmp_path / "chroma_ghost"))
         return HybridRetriever(store, KeywordSearcher())
 
     @pytest.fixture
     def profile_data(self):
         """Return profile metadata passed to the generator."""
         return {"github_username": PROFILE_ID, "projects": [{"name": "a"}, {"name": "b"}]}
+
+    @staticmethod
+    def synthetic_chunks(count):
+        """Return retriever-shaped chunk dicts with one distinct source each."""
+        return [
+            {
+                "id": f"synthetic_{i}",
+                "text": f"Synthetic portfolio evidence number {i}",
+                "metadata": {"source_id": f"source_{i}", "chunk_index": i, "section": "readme"},
+                "score": 0.9 - i / 100,
+            }
+            for i in range(count)
+        ]
 
     @staticmethod
     def run_generation(fake_client, profile_data, chunks):
@@ -207,9 +236,13 @@ class TestRagPipeline:
     def test_retrieval_blends_vector_and_keyword_scores(self, retriever, embedder):
         """Test that retrieved chunks carry blended scores from both retrieval arms."""
         query = CHUNK_TEXTS[0]
-        results = retriever.retrieve(query, PROFILE_ID, embedder.embed([query])[0], max_chunks=5)
+        results = retriever.retrieve(
+            query, PROFILE_ID, embedder.embed([query])[0], max_chunks=len(CHUNK_TEXTS)
+        )
 
-        assert len(results) == len(CHUNK_TEXTS)
+        # Deliberately a range, not an exact count: how many chunks clear min_score
+        # depends on the vector score conversion, which is not what this test pins.
+        assert 1 <= len(results) <= len(CHUNK_TEXTS)
         for chunk in results:
             assert set(chunk) == {
                 "id",
@@ -219,22 +252,44 @@ class TestRagPipeline:
                 "vector_score",
                 "keyword_score",
             }
-            # Metadata survived the round-trip through Chroma.
-            assert chunk["metadata"]["source_id"].startswith("repo_")
             assert chunk["score"] == pytest.approx(
                 0.7 * chunk["vector_score"] + 0.3 * chunk["keyword_score"]
             )
             assert chunk["vector_score"] > 0
-            assert chunk["keyword_score"] > 0
+            # BM25 legitimately scores zero for a chunk sharing no query terms.
+            assert chunk["keyword_score"] >= 0
 
-        assert results[0]["id"] == "chunk_0"
-        assert results[0]["text"] == CHUNK_TEXTS[0]
+        top = results[0]
+        assert top["id"] == "chunk_0"
+        assert top["text"] == CHUNK_TEXTS[0]
+        # Metadata survived the round-trip through Chroma with its values intact.
+        assert top["metadata"] == {"source_id": "repo_0", "chunk_index": 0, "section": "readme"}
+        # The query is chunk 0's own text, so the keyword arm must have contributed.
+        assert top["keyword_score"] > 0
         scores = [chunk["score"] for chunk in results]
         assert scores == sorted(scores, reverse=True)
 
+    def test_min_score_threshold_filters_weak_matches(self, retriever, embedder):
+        """Test that min_score is applied to blended scores rather than ignored."""
+        query = CHUNK_TEXTS[0]
+        embedding = embedder.embed([query])[0]
+        lenient = retriever.retrieve(query, PROFILE_ID, embedding, max_chunks=len(CHUNK_TEXTS))
+        assert lenient
+
+        # Both arms are max-normalised, so no blended score can exceed 0.7 + 0.3; a
+        # threshold above that must filter everything however scores are computed.
+        assert retriever.retrieve(query, PROFILE_ID, embedding, min_score=1.01) == []
+
+        strict = retriever.retrieve(
+            query, PROFILE_ID, embedding, max_chunks=len(CHUNK_TEXTS), min_score=0.9
+        )
+        assert len(strict) <= len(lenient)
+        for chunk in strict:
+            assert chunk["score"] >= 0.9
+
     def test_pipeline_produces_all_sections_with_citations(self, retriever, embedder, profile_data):
         """Test that retrieval feeds generation and yields five distinct cited sections."""
-        query = "python backend testing"
+        query = "python backend pytest docker"
         chunks = retriever.retrieve(query, PROFILE_ID, embedder.embed([query])[0], max_chunks=3)
         assert chunks
 
@@ -248,19 +303,25 @@ class TestRagPipeline:
             "gaps_feedback",
             "first_impression",
         ]
-        # Asserting count and distinctness rather than the literal names: the generator
-        # currently takes each name from the parsed payload, so the plaintext section
-        # comes back named "general_feedback". This holds either way.
         assert len(sections) == 5
-        assert len({section.section_name for section in sections}) == 5
+        by_name = {section.section_name: section for section in sections}
+        assert set(JSON_SECTIONS) <= set(by_name)
+
+        # The prose section is matched on content, not name: generate_section() takes the
+        # name from the parsed payload, so the plaintext reply keeps the parser's own
+        # label. Asserting content holds whether or not that is later corrected.
+        prose = [section for section in sections if section.content.startswith(PROSE_RESPONSE)]
+        assert len(prose) == 1
+        assert prose[0].confidence == pytest.approx(0.7)
 
         expected = sorted({chunk["metadata"]["source_id"] for chunk in chunks[:5]})
+        assert len(expected) == len(chunks)
         for section in sections:
             assert section.content.endswith("Sources: " + ", ".join(expected))
 
     def test_json_response_parses_into_structured_section(self, retriever, embedder, profile_data):
         """Test that fenced JSON responses become high-confidence parsed sections."""
-        query = CHUNK_TEXTS[2]
+        query = CHUNK_TEXTS[3]
         chunks = retriever.retrieve(query, PROFILE_ID, embedder.embed([query])[0])
         sections = self.run_generation(FakeOpenAIClient(), profile_data, chunks)
         # Keyed by the payload's section name, which the fake echoes back deliberately.
@@ -283,13 +344,32 @@ class TestRagPipeline:
 
         first = client.calls[0]["kwargs"]
         prompt = first["messages"][1]["content"]
-        assert chunks[0]["text"] in prompt
-        assert "Source: " + chunks[0]["metadata"]["source_id"] in prompt
+        for position, chunk in enumerate(chunks, start=1):
+            assert chunk["text"] in prompt
+            assert "Source: " + chunk["metadata"]["source_id"] in prompt
+            assert f"[{position}] (relevance:" in prompt
         assert "GitHub Username: " + PROFILE_ID in prompt
         assert "Project Count: 2" in prompt
         assert first["model"] == "test-model"
         assert first["temperature"] == pytest.approx(0.2)
         assert first["max_tokens"] == 256
+
+    def test_every_context_chunk_reaches_prompt_and_citations_cap_at_five(self, profile_data):
+        """Test that all chunks reach the prompt while citations stop at five sources."""
+        chunks = self.synthetic_chunks(6)
+        client = FakeOpenAIClient()
+        sections = self.run_generation(client, profile_data, chunks)
+
+        prompt = client.calls[0]["kwargs"]["messages"][1]["content"]
+        for position, chunk in enumerate(chunks, start=1):
+            assert chunk["text"] in prompt
+            assert f"[{position}] (relevance:" in prompt
+
+        expected = sorted(chunk["metadata"]["source_id"] for chunk in chunks[:5])
+        assert len(expected) == 5
+        for section in sections:
+            assert section.content.endswith("Sources: " + ", ".join(expected))
+            assert chunks[5]["metadata"]["source_id"] not in section.content
 
     def test_empty_retrieval_still_generates_uncited_sections(
         self, empty_retriever, embedder, profile_data
@@ -309,7 +389,7 @@ class TestRagPipeline:
 
     def test_single_section_llm_failure_yields_placeholder(self, retriever, embedder, profile_data):
         """Test that one failing LLM call degrades only that section."""
-        query = CHUNK_TEXTS[1]
+        query = CHUNK_TEXTS[2]
         chunks = retriever.retrieve(query, PROFILE_ID, embedder.embed([query])[0])
         client = FakeOpenAIClient(fail_sections={"gaps_feedback"})
         sections = self.run_generation(client, profile_data, chunks)

--- a/tests/integration/test_rag_pipeline.py
+++ b/tests/integration/test_rag_pipeline.py
@@ -1,0 +1,326 @@
+"""Tests for the retrieval -> generation -> parsing RAG pipeline."""
+
+import json
+from dataclasses import dataclass
+from unittest.mock import patch
+
+import pytest
+
+from ingestion.embeddings.provider import MockEmbeddingProvider
+from rag.generator.review_generator import ReviewConfig, ReviewGenerator
+from rag.retriever.hybrid import HybridRetriever
+from rag.retriever.keyword_search import KeywordSearcher
+from rag.retriever.vector_store import VectorStore
+
+PROFILE_ID = "octocat"
+
+# Each prompt template opens with distinct wording, which lets the fake LLM tell which
+# section it is being asked for without the generator passing that name to the API.
+SECTION_MARKERS = (
+    ("skills demonstrated", "skills_feedback"),
+    ("quality and presentation of projects", "projects_feedback"),
+    ("overall presentation quality", "presentation_feedback"),
+    ("skill gaps relative to job market", "gaps_feedback"),
+    ("first impression", "first_impression"),
+)
+
+CHUNK_TEXTS = [
+    "Python FastAPI backend service with pytest coverage and Docker deployment",
+    "React TypeScript frontend dashboard built with Tailwind and Vite",
+    "Machine learning pipeline in Python using scikit-learn and pandas",
+    "Go microservice exposing gRPC endpoints with Kubernetes manifests",
+]
+
+FENCE = "```json"
+
+
+@dataclass
+class StoredChunk:
+    """Minimal chunk record satisfying VectorStore.add_chunks().
+
+    add_chunks() reads id, text, source_id, chunk_index and section off each chunk,
+    which the chunking layer's Chunk dataclass does not currently provide.
+    """
+
+    id: str
+    text: str
+    source_id: str
+    chunk_index: int
+    section: str = "readme"
+
+
+class FakeMessage:
+    """Stand-in for a chat completion message."""
+
+    def __init__(self, content):
+        self.content = content
+
+
+class FakeChoice:
+    """Stand-in for a chat completion choice."""
+
+    def __init__(self, content):
+        self.message = FakeMessage(content)
+
+
+class FakeResponse:
+    """Stand-in for a chat completion response."""
+
+    def __init__(self, content):
+        self.choices = [FakeChoice(content)]
+
+
+class FakeCompletions:
+    """Stand-in for client.chat.completions."""
+
+    def __init__(self, owner):
+        self._owner = owner
+
+    def create(self, **kwargs):
+        """Delegate to the owning client so the call is recorded."""
+        return self._owner.respond(kwargs)
+
+
+class FakeChat:
+    """Stand-in for client.chat."""
+
+    def __init__(self, owner):
+        self.completions = FakeCompletions(owner)
+
+
+class FakeOpenAIClient:
+    """Deterministic openai.OpenAI replacement answering per requested section.
+
+    Hand-rolled rather than a MagicMock because a MagicMock's
+    response.choices[0].message.content is itself a Mock, which the output parser
+    would silently route through its plaintext fallback instead of failing.
+    """
+
+    def __init__(self, fail_sections=None):
+        self.fail_sections = set(fail_sections or ())
+        self.calls = []
+        self.chat = FakeChat(self)
+
+    @staticmethod
+    def classify(prompt):
+        """Return the section name the prompt is asking about."""
+        for marker, section_name in SECTION_MARKERS:
+            if marker in prompt:
+                return section_name
+        return "unknown_section"
+
+    def respond(self, kwargs):
+        """Build a fake response for one chat.completions.create() call."""
+        prompt = kwargs["messages"][1]["content"]
+        section_name = self.classify(prompt)
+        self.calls.append({"section": section_name, "kwargs": kwargs})
+
+        if section_name in self.fail_sections:
+            raise RuntimeError("simulated LLM failure")
+
+        # The first_impression template explicitly asks for prose, not JSON, so this
+        # exercises the parser's plaintext fallback alongside the four JSON sections.
+        if section_name == "first_impression":
+            return FakeResponse("A focused backend portfolio with room to grow.")
+
+        # Each section must answer under its own top-level key: generate_section() takes
+        # the section name from the parsed payload, and _consolidate_feedback() then
+        # de-duplicates by that name, so a shared key would collapse five into one.
+        payload = {
+            section_name: {
+                "summary": "Assessment for " + section_name,
+                "suggestions": ["Improve " + section_name],
+            }
+        }
+        return FakeResponse(FENCE + "\n" + json.dumps(payload) + "\n```")
+
+
+@pytest.mark.integration
+class TestRagPipeline:
+    """Test suite for the end-to-end RAG pipeline."""
+
+    @pytest.fixture
+    def embedder(self):
+        """Return the deterministic mock embedding provider."""
+        return MockEmbeddingProvider()
+
+    @pytest.fixture
+    def chunk_records(self):
+        """Return chunk records for the seeded profile."""
+        return [
+            StoredChunk(id=f"chunk_{i}", text=text, source_id=f"repo_{i % 2}", chunk_index=i)
+            for i, text in enumerate(CHUNK_TEXTS)
+        ]
+
+    @pytest.fixture
+    def retriever(self, tmp_path, embedder, chunk_records):
+        """Build a HybridRetriever over a seeded on-disk Chroma collection."""
+        store = VectorStore(persist_dir=str(tmp_path / "chroma"))
+        embeddings = embedder.embed([record.text for record in chunk_records])
+        store.add_chunks(list(zip(chunk_records, embeddings, strict=True)), f"profile_{PROFILE_ID}")
+
+        # HybridRetriever.retrieve() never indexes the searcher itself, so the caller
+        # has to, or the keyword arm contributes nothing.
+        searcher = KeywordSearcher()
+        searcher.index(
+            [
+                {
+                    "id": record.id,
+                    "text": record.text,
+                    "metadata": {
+                        "source_id": record.source_id,
+                        "chunk_index": record.chunk_index,
+                        "section": record.section,
+                    },
+                }
+                for record in chunk_records
+            ]
+        )
+        return HybridRetriever(store, searcher)
+
+    @pytest.fixture
+    def empty_retriever(self, tmp_path):
+        """Build a HybridRetriever with no vectors and no keyword index."""
+        store = VectorStore(persist_dir=str(tmp_path / "chroma_empty"))
+        return HybridRetriever(store, KeywordSearcher())
+
+    @pytest.fixture
+    def profile_data(self):
+        """Return profile metadata passed to the generator."""
+        return {"github_username": PROFILE_ID, "projects": [{"name": "a"}, {"name": "b"}]}
+
+    @staticmethod
+    def run_generation(fake_client, profile_data, chunks):
+        """Run generate_full_review() against the fake OpenAI client."""
+        config = ReviewConfig(
+            api_key="test-key",
+            base_url="http://llm.invalid/v1",
+            model="test-model",
+            temperature=0.2,
+            max_tokens=256,
+        )
+        # Only construction needs patching; the client is then held on the instance.
+        with patch("rag.generator.review_generator.openai.OpenAI", return_value=fake_client):
+            generator = ReviewGenerator(config)
+        return generator.generate_full_review(profile_data, chunks)
+
+    def test_retrieval_blends_vector_and_keyword_scores(self, retriever, embedder):
+        """Test that retrieved chunks carry blended scores from both retrieval arms."""
+        query = CHUNK_TEXTS[0]
+        results = retriever.retrieve(query, PROFILE_ID, embedder.embed([query])[0], max_chunks=5)
+
+        assert len(results) == len(CHUNK_TEXTS)
+        for chunk in results:
+            assert set(chunk) == {
+                "id",
+                "text",
+                "metadata",
+                "score",
+                "vector_score",
+                "keyword_score",
+            }
+            # Metadata survived the round-trip through Chroma.
+            assert chunk["metadata"]["source_id"].startswith("repo_")
+            assert chunk["score"] == pytest.approx(
+                0.7 * chunk["vector_score"] + 0.3 * chunk["keyword_score"]
+            )
+            assert chunk["vector_score"] > 0
+            assert chunk["keyword_score"] > 0
+
+        assert results[0]["id"] == "chunk_0"
+        assert results[0]["text"] == CHUNK_TEXTS[0]
+        scores = [chunk["score"] for chunk in results]
+        assert scores == sorted(scores, reverse=True)
+
+    def test_pipeline_produces_all_sections_with_citations(self, retriever, embedder, profile_data):
+        """Test that retrieval feeds generation and yields five distinct cited sections."""
+        query = "python backend testing"
+        chunks = retriever.retrieve(query, PROFILE_ID, embedder.embed([query])[0], max_chunks=3)
+        assert chunks
+
+        client = FakeOpenAIClient()
+        sections = self.run_generation(client, profile_data, chunks)
+
+        assert [call["section"] for call in client.calls] == [
+            "skills_feedback",
+            "projects_feedback",
+            "presentation_feedback",
+            "gaps_feedback",
+            "first_impression",
+        ]
+        # Asserting count and distinctness rather than the literal names: the generator
+        # currently takes each name from the parsed payload, so the plaintext section
+        # comes back named "general_feedback". This holds either way.
+        assert len(sections) == 5
+        assert len({section.section_name for section in sections}) == 5
+
+        expected = sorted({chunk["metadata"]["source_id"] for chunk in chunks[:5]})
+        for section in sections:
+            assert section.content.endswith("Sources: " + ", ".join(expected))
+
+    def test_json_response_parses_into_structured_section(self, retriever, embedder, profile_data):
+        """Test that fenced JSON responses become high-confidence parsed sections."""
+        query = CHUNK_TEXTS[2]
+        chunks = retriever.retrieve(query, PROFILE_ID, embedder.embed([query])[0])
+        sections = self.run_generation(FakeOpenAIClient(), profile_data, chunks)
+        # Keyed by the payload's section name, which the fake echoes back deliberately.
+        by_name = {section.section_name: section for section in sections}
+
+        skills = by_name["skills_feedback"]
+        assert skills.confidence == pytest.approx(0.9)
+        assert skills.suggestions == ["Improve skills_feedback"]
+        payload = json.loads(skills.content.split("\nSources:")[0])
+        assert payload["summary"] == "Assessment for skills_feedback"
+
+    def test_prompt_carries_retrieved_context_and_profile_data(
+        self, retriever, embedder, profile_data
+    ):
+        """Test that retrieved chunk text and profile metadata reach the LLM prompt."""
+        query = CHUNK_TEXTS[0]
+        chunks = retriever.retrieve(query, PROFILE_ID, embedder.embed([query])[0], max_chunks=2)
+        client = FakeOpenAIClient()
+        self.run_generation(client, profile_data, chunks)
+
+        first = client.calls[0]["kwargs"]
+        prompt = first["messages"][1]["content"]
+        assert chunks[0]["text"] in prompt
+        assert "Source: " + chunks[0]["metadata"]["source_id"] in prompt
+        assert "GitHub Username: " + PROFILE_ID in prompt
+        assert "Project Count: 2" in prompt
+        assert first["model"] == "test-model"
+        assert first["temperature"] == pytest.approx(0.2)
+        assert first["max_tokens"] == 256
+
+    def test_empty_retrieval_still_generates_uncited_sections(
+        self, empty_retriever, embedder, profile_data
+    ):
+        """Test that a profile with no indexed chunks degrades to uncited feedback."""
+        query = "python backend testing"
+        chunks = empty_retriever.retrieve(query, "ghost-profile", embedder.embed([query])[0])
+        assert chunks == []
+
+        client = FakeOpenAIClient()
+        sections = self.run_generation(client, profile_data, chunks)
+
+        assert len(client.calls) == 5
+        assert len(sections) == 5
+        for section in sections:
+            assert "Sources:" not in section.content
+
+    def test_single_section_llm_failure_yields_placeholder(self, retriever, embedder, profile_data):
+        """Test that one failing LLM call degrades only that section."""
+        query = CHUNK_TEXTS[1]
+        chunks = retriever.retrieve(query, PROFILE_ID, embedder.embed([query])[0])
+        client = FakeOpenAIClient(fail_sections={"gaps_feedback"})
+        sections = self.run_generation(client, profile_data, chunks)
+
+        by_name = {section.section_name: section for section in sections}
+        placeholder = by_name["gaps_feedback"]
+        assert placeholder.content == "Error generating gaps_feedback"
+        assert placeholder.confidence == pytest.approx(0.0)
+        assert placeholder.suggestions == []
+        # The failure path skips citation appending, unlike the successful sections.
+        assert "Sources:" not in placeholder.content
+        assert len(client.calls) == 5
+        assert len(sections) == 5
+        assert by_name["skills_feedback"].confidence == pytest.approx(0.9)


### PR DESCRIPTION
## Summary

The RAG stages are each unit-tested in isolation, but nothing runs them chained together, so a mismatch at a seam between them can pass every unit test while breaking the real end-to-end flow. This PR adds `tests/integration/test_rag_pipeline.py`, the first test in `tests/integration/`, which drives one query through the actual pipeline — `HybridRetriever.retrieve()` → `ReviewGenerator.generate_full_review()` → `parse_review_output()` — and asserts a well-formed review comes out the far end.

Retrieval runs against a real Chroma `PersistentClient` pointed at a pytest `tmp_path` and seeded through `VectorStore.add_chunks(...)` with embeddings from the existing `MockEmbeddingProvider`, so vector search, BM25 keyword search and score blending all execute for real. Generation is isolated by patching `rag.generator.review_generator.openai.OpenAI` with a hand-written fake chat client. The result is a test that exercises the production wiring end to end while needing **no Docker container, no network access and no API key**.

This is a test-only, additive change. No production code is modified.

## Issue

Closes #38

## Changes

- Add `tests/integration/test_rag_pipeline.py` with 8 tests under a single `@pytest.mark.integration`-marked `TestRagPipeline` class, matching the layout of the existing files in `tests/unit/`.
- Seed retrieval from a `tmp_path`-backed `VectorStore` plus an indexed `KeywordSearcher`, using the existing deterministic `MockEmbeddingProvider` rather than a new fixture format.
- Add `FakeOpenAIClient`, a hand-written stand-in for `openai.OpenAI` that identifies which section is being generated from the distinct opening wording of each prompt template, answers under that section's own key, can be told to fail a specific section, and records every call for assertion. It is hand-written rather than a `MagicMock` because a `MagicMock`'s `response.choices[0].message.content` is itself a `Mock`, which `parse_review_output` silently routes through its plaintext fallback — hiding exactly the kind of breakage this test exists to catch.
- Add a small `StoredChunk` dataclass in the test as the record `VectorStore.add_chunks(...)` requires (see the first note for reviewers below).

Coverage, test by test:

| Test | What it pins |
| --- | --- |
| `test_retrieval_blends_vector_and_keyword_scores` | Chunk dict contract (`id/text/metadata/score/vector_score/keyword_score`), `score == 0.7*vector + 0.3*keyword`, metadata surviving the Chroma round-trip with literal values, score-descending order |
| `test_min_score_threshold_filters_weak_matches` | `min_score` is actually applied to blended scores |
| `test_pipeline_produces_all_sections_with_citations` | All five sections requested in template order, five distinct sections returned, `Sources: …` built from the retrieved chunks |
| `test_json_response_parses_into_structured_section` | Fenced JSON reaches the parser's structured branch (`confidence == 0.9`, parsed `suggestions`) rather than the plaintext fallback |
| `test_prompt_carries_retrieved_context_and_profile_data` | Retrieved chunk text, `Source:` lines and positions reach the prompt, along with `github_username`, `project_count` and the configured model/temperature/max_tokens |
| `test_every_context_chunk_reaches_prompt_and_citations_cap_at_five` | `_format_context` includes every chunk in order; `_add_citations` cites at most five sources |
| `test_empty_retrieval_still_generates_uncited_sections` | No relevant chunks retrieved → still five sections, no citations, no exception |
| `test_single_section_llm_failure_yields_placeholder` | One failing LLM call degrades only that section to the `Error generating <section>` placeholder |

## Testing

- [x] Unit tests pass (`make test-unit`)
- [x] Integration tests pass (`make test-integration`)
- [x] Linter passes (`make lint`)
- [x] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes

**Please read the pre-existing failures section below** — this repo has failing tests and lint errors on `main`, and the boxes above mean "no new failures introduced", measured before and after.

### How to verify manually

```bash
git fetch origin pull/<this-pr>/head:pr-38 && git checkout pr-38
python -m venv .venv && .venv/bin/pip install -e ".[dev]"   # .venv/Scripts/pip on Windows
make test-integration
```

Expect `8 passed`. Nothing else has to be running — no `docker compose up`, no `DATABASE_URL`, no `OPENAI_API_KEY`.

To see the gap this closes, run the same command on `main`:

```bash
git checkout main && make test-integration
```

Expect `no tests ran` with exit code 5 and 0 items collected, because `tests/integration/` contains only `__init__.py`.

To confirm the test actually fails when a seam breaks rather than merely passing, temporarily break one and re-run `make test-integration`:

| Temporary edit | Expected failure |
| --- | --- |
| In `rag/retriever/hybrid.py`, rename the returned `"text"` key to `"content"` | `test_retrieval_blends_vector_and_keyword_scores` (key-set assertion) and `test_prompt_carries_retrieved_context_and_profile_data` |
| In `rag/generator/review_generator.py`, change `chunks[:10]` to `chunks[:1]` in `_format_context` | `test_every_context_chunk_reaches_prompt_and_citations_cap_at_five` |
| In `_add_citations`, stop appending the `Sources:` line | `test_pipeline_produces_all_sections_with_citations` |
| In `HybridRetriever.__init__`, change the weights to `0.5 / 0.5` | `test_retrieval_blends_vector_and_keyword_scores` (blend formula) |
| In `generate_full_review`, remove the per-section `try/except` | `test_single_section_llm_failure_yields_placeholder` (the `RuntimeError` propagates) |
| In `VectorStore.add_chunks`, write a wrong `source_id` into the metadata | `test_retrieval_blends_vector_and_keyword_scores` (metadata assertion) |

Each of these was run and reverted while developing the test; all six fail as listed.

### Pre-existing failures on `main`

`make check` and `make test-unit` do not come back clean on `main`, independently of this branch. Measured with the Makefile's own commands, before and after this change:

| Check | Before | After |
| --- | --- | --- |
| `ruff check .` | 182 errors | 182 errors (the new file itself is clean) |
| `black --check .` | 52 would reformat, 58 unchanged | 52 would reformat, 59 unchanged |
| `mypy api/ core/ ingestion/ rag/ agent/ safety/` | 5 errors in 4 files, exit 2 | identical — `tests/` is not in mypy's scope |
| `pytest tests/unit -m unit` | 53 failed, 375 passed | 53 failed, 375 passed, byte-for-byte identical failure list |
| `pytest tests/integration -m integration` | no tests ran, exit 5 | **8 passed** |

**These changes do not affect any of the pre-existing failures.** The failing unit-test names are identical before and after, no existing file is touched, and the new file is `ruff`- and `black`-clean on its own. The `mypy` errors are unchanged because `make typecheck` does not cover `tests/`.

Worth noting for CI: the `test-integration` job in `.github/workflows/ci.yml` currently runs `pytest tests/integration` against an empty directory, so it exits 5 on every run. This PR gives that job real tests to execute.

## Screenshots / Demo

Not applicable — this is a test-only change with no user-facing surface. The `make test-integration` output described above is the observable result.

## Notes for Reviewers

Building this surfaced four pre-existing issues at the pipeline seams. **None are fixed here** — this PR is deliberately test-only, and each one deserves its own issue and its own discussion. Flagging them because they shaped the test's design, and because two of them mean the pipeline does not currently behave the way the code reads:

1. **`VectorStore.add_chunks` cannot consume the repo's `Chunk`.** It reads `chunk.id`, `chunk.source_id`, `chunk.chunk_index` and `chunk.section`, but `Chunk` (`ingestion/chunking/base.py`) defines only `text` and `metadata` — so no object in the codebase actually satisfies the method, and the ingestion path goes through `BatchEmbeddingProcessor` instead. The test defines a minimal `StoredChunk` record to bridge this; it would be better for `add_chunks` and `Chunk` to agree.
2. **`HybridRetriever` never indexes its keyword searcher.** `rag/retriever/hybrid.py:50` computes `all_chunks = self._get_all_chunks(collection_name)` and then discards the result; `keyword_searcher.index(...)` is called nowhere in the retriever. Unless the caller indexes the searcher first, `KeywordSearcher.search()` hits its empty-index guard, returns `[]`, and the keyword arm contributes nothing — blended scores silently cap at `vector_weight`. The test's fixture indexes it explicitly, with a comment saying why.
3. **`generate_full_review` can collapse five sections into one.** `generate_section` returns the *parser's* `section_name` (the JSON payload's top-level key, or `general_feedback` for a plaintext reply) rather than the section it asked for, and `_consolidate_feedback` then de-duplicates on that name. A real model that answers every section under the same key — or in prose — yields one section instead of five. This is why the fake client answers under each requested section's own key. As a visible consequence, `first_impression` (whose template explicitly asks for prose, not JSON) comes back named `general_feedback`; the test matches that section on its **content** rather than its name, so the assertion holds both now and after anyone corrects the naming.
4. **`VectorStore.query` converts cosine distance with a euclidean formula.** Collections are created with `metadata={"hnsw:space": "cosine"}`, but `query` computes `similarity = 1 / (1 + distance)` under a comment stating distances are euclidean. For cosine distances in `[0, 2]` that compresses similarity into `[0.33, 1.0]`, so with `min_score=0.3` essentially nothing is ever filtered out. An earlier draft of this test asserted an exact retrieved-chunk count and passed *only* because of this; it now asserts a range plus a threshold test that holds under either conversion, so fixing this bug will not break the test.

Two scope notes:

- **No reranking stage exists.** The issue describes "retrieval → reranking → generation → parsing", but there is no `rag/reranker/` and no match for `rerank` anywhere in the repo. This test covers the pipeline that exists — retrieval → generation → parsing. Happy to extend it if a reranker is planned.
- **No production mock-LLM provider was added.** `settings.llm_provider` is never branched on anywhere in the codebase, and the only existing mock is `MockEmbeddingProvider` (embeddings, not chat). Rather than introduce a production mock-LLM class, the test patches `rag.generator.review_generator.openai.OpenAI` — note the patch target is the name as imported in that module, not the global `openai.OpenAI`, since `ReviewGenerator.__init__` constructs its client directly with no injectable seam. If you would prefer `ReviewGenerator` to accept an injected client, that is a small change and would make this test simpler; say the word and I will open a follow-up.
