### PR TITLE
feat: add GitHub Actions workflow parser to detect CI/CD skills

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,34 @@
+# Journal
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/14
+
+**Issue title:** Add support for parsing GitHub Actions workflow files to detect CI/CD skills
+
+**Tier:** [ ] Tier 1 [ ] Tier 2 [x] Tier 3
+
+**Problem summary:**
+The ingestion pipeline currently infers a developer's skills from things like
+import statements and README text, but it has no parser for `.github/workflows/*.yml`
+files. That means CI/CD practices — setting up GitHub Actions, building Docker
+images, running test suites in CI, deploying on merge — go completely
+undetected, even though maintaining these workflows is a real signal of DevOps
+skill. A successful fix adds a new `workflow_parser.py` under
+`ingestion/parsers/` that implements the existing `BaseParser` interface,
+reads workflow YAML files, and extracts skills like `GitHub Actions`, `Docker`,
+`pytest`, and `deployment` (likely via `ingestion/parsers/skill_extractor.py`),
+then registers the new parser in the ingestion pipeline.
+
+**Branch name:** feat/14-github-workflow-parser
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger
+
+Selection Reasoning:
+
+- **Part 1**: I completely understand the issue and have contributed to similar features in my job
+- **Part 2**: I already contributed to open source and have expansive experience in large codebases
+- **Part 3**: I read the `parsers/` flow and have sufficient understanding and confidence to implement the new feature
+- **Part 4**: I have alot of time, the scope is realistic to me, and there are no blockers on the issue

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -32,3 +32,25 @@ Selection Reasoning:
 - **Part 2**: I already contributed to open source and have expansive experience in large codebases
 - **Part 3**: I read the `parsers/` flow and have sufficient understanding and confidence to implement the new feature
 - **Part 4**: I have alot of time, the scope is realistic to me, and there are no blockers on the issue
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/Y4dd/pathreview/commit/6d607cefb3de1dfc4f852c64fce077f6a7feb762
+
+**Reproduction summary:**
+Added `tests/unit/test_workflow_parser.py`, which imports the not-yet-existent
+`ingestion.parsers.workflow_parser`. Running `pytest tests/unit/test_workflow_parser.py -v`
+fails at collection with `ModuleNotFoundError: No module named 'ingestion.parsers.workflow_parser'`,
+confirming the pipeline has no parser for `.github/workflows/*.yml` and therefore cannot detect
+CI/CD skills.
+
+**PLAN.md link:** https://github.com/Y4dd/pathreview/blob/feat/14-github-workflow-parser/PLAN.md
+
+**Walkthrough video (recommended):**
+
+**Blockers or open questions:**
+ChromaDB requires scalar metadata values (str/int/float/bool), so the extracted `skills` cannot be
+stored as a raw list — still deciding between a comma-joined string and boolean flags
+(`has_docker`, `runs_pytest`, `has_deployment`). Also weighing whether to rely on `SkillExtractor`'s
+substring matching (which over-matches, e.g. `git` inside `github`) versus inspecting structured
+`uses:`/`run:` values directly in the parser.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -86,8 +86,7 @@ tests, ~103 mypy errors — all pre-existing); this change introduces no new fai
 
 ### Check-in 2 (end of week)
 
-**PR link:** https://github.com/ascherj/pathreview/pull/887 (draft; to be marked ready for review
-after peer feedback)
+**PR link:** https://github.com/ascherj/pathreview/pull/887 (open, marked ready for review)
 
 **Branch:** `feat/14-github-workflow-parser`
 
@@ -107,4 +106,6 @@ matrix builds, reusable job-level `uses:`, ChromaDB-scalar metadata, and `SkillE
 documented pre-existing failures in this repo; this change adds none, and the new/edited files are
 ruff-, black-, and mypy-clean. Details in the PR's Notes for Reviewers.)
 
-**Draft PR feedback received from:** none yet (draft opened for peer review)
+**Draft PR feedback received from:** None — the PR did not receive a formal peer/mentor review this
+cycle. The approach was discussed at team standups (where I shared the PLAN.md), but no PR-level
+review was obtained.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -101,7 +101,7 @@ pipeline as a new `workflow` source type with structural chunking.
 skills, bytes/invalid input, empty/whitespace, non-workflow and malformed YAML, the `on:`-key gotcha,
 matrix builds, reusable job-level `uses:`, ChromaDB-scalar metadata, and `SkillExtractor` reuse.
 
-**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+**Self-review confirmation:** [x] make check passes [x] make test-unit passes
 (Per the Week 9 pre-existing-failures rule, "passes" = introduces no new failures. Both commands have
 documented pre-existing failures in this repo; this change adds none, and the new/edited files are
 ruff-, black-, and mypy-clean. Details in the PR's Notes for Reviewers.)
@@ -109,3 +109,53 @@ ruff-, black-, and mypy-clean. Details in the PR's Notes for Reviewers.)
 **Draft PR feedback received from:** None — the PR did not receive a formal peer/mentor review this
 cycle. The approach was discussed at team standups (where I shared the PLAN.md), but no PR-level
 review was obtained.
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes [x] No — still awaiting review
+
+**Summary of feedback:**
+[What did reviewers comment on? Or note that no review came in.]
+No feedback was provided.
+
+**How you responded:**
+[What changes did you make, or what did you reply? If no feedback,
+leave blank.]
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+[Be specific — what part of the process, codebase, or workflow
+surprised you?]
+Making sure the plan for a specific task is completely accurate to stop AI from being too passionate
+Other that that, I didn't encounter any issues as I'm familiar with navigating large codebases.
+
+**What did you learn about working in a large codebase?**
+[What's different about contributing to someone else's production code
+vs. building your own project?]
+The autonomy is the biggest factor. when I do my projects I own every feature,
+standard and idea, and I love that freedom. Whereas in other people's codebases
+such as open source or corporation, you do not have that freedom of execution or thought.
+
+**How did AI tools help — and where did they fall short?**
+[Where was AI assistance most useful this module? Where did you need
+to go beyond what AI could give you?]
+AI Tools helped immensly in helping understand the codebase which directed my decision making,
+then ofcourse implementation was seemless and robust with multiple unit tests, which took miniscule amount of effort
+compared to doing it by hand.
+
+A short-comming i noticed early on from using AI is you should never delegate decision making to it.
+It can sometimes fail royally and select a sub-optimal solution for complicate things.
+
+**What would you do differently if you started over?**
+[Issue selection, planning, implementation, or process — anything
+you'd change?]
+No, I'm quite satisfied with what I did in this task.
+
+**What are you most proud of from this module?**
+[One thing — it doesn't have to be the PR itself.]
+I'm proud about delivering a Tier 3 issue.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -50,7 +50,61 @@ CI/CD skills.
 
 **Blockers or open questions:**
 ChromaDB requires scalar metadata values (str/int/float/bool), so the extracted `skills` cannot be
-stored as a raw list — still deciding between a comma-joined string and boolean flags
+stored as a raw list, still deciding between a comma-joined string and boolean flags
 (`has_docker`, `runs_pytest`, `has_deployment`). Also weighing whether to rely on `SkillExtractor`'s
 substring matching (which over-matches, e.g. `git` inside `github`) versus inspecting structured
 `uses:`/`run:` values directly in the parser.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+All implementation sub-tasks from PLAN.md are complete. Added `ingestion/parsers/workflow_parser.py`
+(`WorkflowParser`), which parses workflow YAML and detects GitHub Actions, Docker, pytest, and
+deployment structurally from the workflow's triggers/jobs/steps; wired it into
+`IngestionPipeline.ingest_workflow()` and routed `"workflow"` sources to the structural chunker;
+declared `pyyaml` / `types-pyyaml`; and extended `tests/unit/test_workflow_parser.py` from the 4
+reproduction tests to 15 (edge cases: empty/whitespace input, non-workflow YAML, malformed YAML, the
+`on:`-key YAML 1.1 gotcha, matrix builds, reusable job-level `uses:`, ChromaDB-scalar metadata, and
+`SkillExtractor` reuse). All 15 pass.
+
+Resolved both Week 8 open questions: skills are serialized to a comma-joined string plus boolean
+flags (ChromaDB-safe), and the parser does its own structural detection rather than relying on
+`SkillExtractor`'s substring matching — `SkillExtractor` is still called for supplementary signal
+(`extracted_skills`), honoring the issue's "reuse it" note without depending on it.
+
+**Next steps:**
+Gather peer/mentor feedback on the draft PR, address it, and mark the PR ready for review by the end
+of the week.
+
+**Blockers:**
+None. The repo has documented pre-existing `make check` / `make test-unit` failures (53 failing unit
+tests, ~103 mypy errors — all pre-existing); this change introduces no new failures.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/887 (draft; to be marked ready for review
+after peer feedback)
+
+**Branch:** `feat/14-github-workflow-parser`
+
+**What you built:**
+A `WorkflowParser` for `.github/workflows/*.yml` that detects CI/CD and DevOps skills (GitHub
+Actions, Docker, pytest, deployment) structurally from the workflow's triggers, jobs, and steps, and
+reuses the existing `SkillExtractor` for supplementary signal. It is wired into the ingestion
+pipeline as a new `workflow` source type with structural chunking.
+
+**Tests added or updated:**
+`tests/unit/test_workflow_parser.py` — 15 unit tests covering the `ParseResult` shape, the four #14
+skills, bytes/invalid input, empty/whitespace, non-workflow and malformed YAML, the `on:`-key gotcha,
+matrix builds, reusable job-level `uses:`, ChromaDB-scalar metadata, and `SkillExtractor` reuse.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+(Per the Week 9 pre-existing-failures rule, "passes" = introduces no new failures. Both commands have
+documented pre-existing failures in this repo; this change adds none, and the new/edited files are
+ruff-, black-, and mypy-clean. Details in the PR's Notes for Reviewers.)
+
+**Draft PR feedback received from:** none yet (draft opened for peer review)

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,96 @@
+## Solution plan
+
+**Issue:** [#14 — Add support for parsing GitHub Actions workflow files to detect CI/CD skills](https://github.com/ascherj/pathreview/issues/14)
+
+### Understand
+
+**Root cause.** The ingestion pipeline infers a developer's skills from imports, README text, and
+repository metadata, but it has **no parser for `.github/workflows/*.yml`**. The pipeline only wires
+three parsers — `ResumeParser`, `ReadmeParser`, `RepoAnalyzer` (`ingestion/pipeline.py:10-12` and
+`:51-53`). As a result, maintaining CI/CD workflows — a genuine DevOps signal (GitHub Actions,
+Docker builds, running `pytest` in CI, deploying on merge) — goes completely undetected.
+
+**Secondary gap.** The existing `SkillExtractor` (`ingestion/parsers/skill_extractor.py`) that the
+issue points us at is missing the very skills this feature must surface:
+- `pytest` and `deployment` are **not defined anywhere** (`FRAMEWORKS` has only `jest`/`mocha`).
+- There is no `GitHub Actions` entry — only a generic `TOOLS["github"] = 0.90`, which renders with
+  the wrong casing `"Github"` (via `.title()` at `skill_extractor.py:269`).
+- `SkillExtractor` is **not currently called by any parser or by the pipeline** — only by its own
+  unit test. So "reuse it" also means wiring its output into `ParseResult.metadata`.
+
+**Expected vs. actual.** Expected: feeding a workflow YAML through the pipeline yields inferred
+skills such as `GitHub Actions`, `Docker`, `pytest`, and `deployment`. Actual: there is no code path
+that reads workflow files at all, so nothing is produced.
+
+### Map
+
+Files the fix will touch (feature work — a later week):
+
+- **NEW** `ingestion/parsers/workflow_parser.py` — `WorkflowParser(BaseParser)` returning a
+  `ParseResult`. Closest template to copy is `ingestion/parsers/readme_parser.py` (simple
+  `str | bytes` parser); prior art for CI detection is `RepoAnalyzer._detect_ci`
+  (`ingestion/parsers/repo_analyzer.py:111-119`, already keys off `.github/workflows`).
+- `ingestion/parsers/skill_extractor.py` — add CI/CD entries to `TOOLS`/`FRAMEWORKS` and fix display
+  casing (see Plan step 1).
+- `ingestion/pipeline.py` — import + instantiate `WorkflowParser`, and add an `ingest_workflow(...)`
+  method mirroring `ingest_readme` (`:126-199`), stamping `source_type="workflow"` and a
+  `workflow_` source-id prefix.
+- `ingestion/chunking/strategy_selector.py` — add a `"workflow"` branch (`select_chunker`,
+  `:14-32`); today `"workflow"` falls through to the semantic default. Structural chunking suits
+  YAML better.
+- **NEW** `tests/unit/test_workflow_parser.py`; optionally add a `sample_workflow_yaml` fixture to
+  `tests/conftest.py`.
+- `pyproject.toml` — declare `pyyaml` in `dependencies` (installed only transitively today) and
+  `types-pyyaml` in the `dev` extra (CI runs `mypy` with `disallow_untyped_defs = true`).
+- **Reuse:** `ingestion/parsers/base.py` (`BaseParser`, `ParseResult`).
+
+### Plan
+
+1. **Extend `SkillExtractor`.** Add `"github actions": 0.9` and `"deployment": 0.8` to `TOOLS`; add
+   `"pytest": ("Python", 0.85)` to `FRAMEWORKS`; extend the display-name special-cases
+   (`skill_extractor.py:269`) so `github actions` → `"GitHub Actions"` (a bare `.title()` gives the
+   wrong `"Github Actions"`).
+2. **Implement `WorkflowParser.parse(content: str | bytes) -> ParseResult`.** Decode bytes → str;
+   `yaml.safe_load`; raise `ValueError` on unsupported types / invalid YAML. Build a human-readable
+   `text` summary (triggers from `on:`, job names, `runs-on`, each step's `uses:` / `run:`), then
+   call `SkillExtractor().extract_skills(text, filename)` and thread the results into `metadata`.
+3. **Wire into the pipeline.** Import + instantiate in `IngestionPipeline.__init__`; add
+   `ingest_workflow(...)`; add the `"workflow"` branch to `StrategySelector.select_chunker`.
+4. **Declare `pyyaml`** (and `types-pyyaml` in `dev`) in `pyproject.toml`.
+5. **Tests.** Add `tests/unit/test_workflow_parser.py` following `test_readme_parser.py`: `parser`
+   fixture, `ParseResult` assertions, bytes + UTF-8 input, empty input, invalid-type `ValueError`,
+   and skill-extraction assertions (`GitHub Actions`, `Docker`, `pytest`, `deployment`).
+
+### Inputs & outputs
+
+- **Input:** the contents of a GitHub Actions workflow file as `str | bytes` (plus an optional
+  `filename`).
+- **Output:** a `ParseResult` with `source_type="workflow"`, `text` = a readable summary suitable for
+  embedding, and `metadata` including `triggers`, `job_count`/job names, `actions_used`, boolean
+  flags (`has_docker`, `runs_pytest`, `has_deployment`), and the extracted `skills` (see Risks for
+  the serialization constraint). Downstream, `ingest_workflow` chunks + embeds this like other
+  sources.
+
+### Risks & unknowns
+
+- **ChromaDB metadata must be scalar** (str/int/float/bool). Putting a raw `skills` **list** into
+  `metadata` would break `BatchEmbeddingProcessor` storage — serialize to a comma-joined string
+  and/or boolean flags. **This is the main open question going into implementation.**
+- `SkillExtractor` matching is case-insensitive **substring** matching → false positives (`git`
+  inside `github`, `go` inside `go.mod`). Prefer inspecting structured `uses:` / `run:` values in the
+  parser rather than dumping raw YAML at the extractor.
+- `pyyaml` is only a transitive dependency today; relying on `import yaml` without declaring it is
+  fragile and could break in a clean environment.
+- Shared-file merge surface: `ingestion/pipeline.py` and `ingestion/parsers/skill_extractor.py` are
+  common edit targets for other issues.
+
+### Edge cases
+
+- Empty file; whitespace-only file.
+- Valid YAML that is **not** a workflow (no `on:` / `jobs:`).
+- `.yaml` vs `.yml` extension.
+- Matrix builds (`strategy.matrix`), reusable/composite workflows (`uses:` at the job level).
+- Multi-document YAML; anchored/aliased YAML.
+- Invalid / malformed YAML → raise `ValueError` (consistent with other parsers).
+- `bytes` input with UTF-8 characters.
+- A workflow with `on:` triggers but zero jobs.

--- a/PLAN.md
+++ b/PLAN.md
@@ -18,6 +18,14 @@ issue points us at is missing the very skills this feature must surface:
 - `SkillExtractor` is **not currently called by any parser or by the pipeline** — only by its own
   unit test. So "reuse it" also means wiring its output into `ParseResult.metadata`.
 
+**Decision (Week 9, informed by the step-0 baseline).** `SkillExtractor` detection is literal
+substring matching and already carries 5 failing tests; `"github actions"` isn't even a literal
+substring of a real workflow file. Rather than harden a flaky shared module as a load-bearing
+dependency, `WorkflowParser` does its own structural detection (authoritative) and merely *calls*
+`extract_skills` for supplementary signal (issue #14 says "reuse", which we satisfy by calling — not
+by editing). The `TOOLS`/`FRAMEWORKS`/casing improvements are deferred to a follow-up so this PR stays
+single-purpose. See Plan step 1.
+
 **Expected vs. actual.** Expected: feeding a workflow YAML through the pipeline yields inferred
 skills such as `GitHub Actions`, `Docker`, `pytest`, and `deployment`. Actual: there is no code path
 that reads workflow files at all, so nothing is produced.
@@ -30,36 +38,83 @@ Files the fix will touch (feature work — a later week):
   `ParseResult`. Closest template to copy is `ingestion/parsers/readme_parser.py` (simple
   `str | bytes` parser); prior art for CI detection is `RepoAnalyzer._detect_ci`
   (`ingestion/parsers/repo_analyzer.py:111-119`, already keys off `.github/workflows`).
-- `ingestion/parsers/skill_extractor.py` — add CI/CD entries to `TOOLS`/`FRAMEWORKS` and fix display
-  casing (see Plan step 1).
+- `ingestion/parsers/skill_extractor.py` — **reused, not modified** (see Plan step 1). `WorkflowParser`
+  calls `extract_skills(...)` for supplementary signal only; no edits here this PR. **NB:** this is the
+  ingestion `SkillExtractor`; there is a separate, unrelated `SkillExtractor(BaseTool)` at
+  `agent/tools/skill_extractor.py:10` — do not touch or wire that one.
 - `ingestion/pipeline.py` — import + instantiate `WorkflowParser`, and add an `ingest_workflow(...)`
   method mirroring `ingest_readme` (`:126-199`), stamping `source_type="workflow"` and a
   `workflow_` source-id prefix.
 - `ingestion/chunking/strategy_selector.py` — add a `"workflow"` branch (`select_chunker`,
   `:14-32`); today `"workflow"` falls through to the semantic default. Structural chunking suits
   YAML better.
-- **NEW** `tests/unit/test_workflow_parser.py`; optionally add a `sample_workflow_yaml` fixture to
-  `tests/conftest.py`.
+- `tests/unit/test_workflow_parser.py` — **already exists** as a failing reproduction (commit
+  `6d607ce`); it imports the not-yet-created `WorkflowParser`, so collection fails with
+  `ModuleNotFoundError`. Week 9 makes its four tests pass and adds the edge-case tests below. A
+  `sample_workflow_yaml` fixture in `tests/conftest.py` is optional — the repro inlines
+  `SAMPLE_WORKFLOW_YAML`.
 - `pyproject.toml` — declare `pyyaml` in `dependencies` (installed only transitively today) and
   `types-pyyaml` in the `dev` extra (CI runs `mypy` with `disallow_untyped_defs = true`).
-- **Reuse:** `ingestion/parsers/base.py` (`BaseParser`, `ParseResult`).
+- **Reuse:** `ingestion/parsers/base.py` (`BaseParser`, `ParseResult`). `ParseResult` is a dataclass
+  with positional fields `(text, metadata, source_type)` (`base.py:4-9`) — construct with keyword args
+  so a positional call can't swap `metadata`/`source_type`. `BaseParser` is not a formal ABC; `parse`
+  just `raise NotImplementedError` (`base.py:29`), so the subclass simply overrides it.
 
 ### Plan
 
-1. **Extend `SkillExtractor`.** Add `"github actions": 0.9` and `"deployment": 0.8` to `TOOLS`; add
-   `"pytest": ("Python", 0.85)` to `FRAMEWORKS`; extend the display-name special-cases
-   (`skill_extractor.py:269`) so `github actions` → `"GitHub Actions"` (a bare `.title()` gives the
-   wrong `"Github Actions"`).
+Ordered for Week 9 execution. Commit after each numbered step so progress stays visible
+(conventional commits, `ingestion` scope — see "Week 9 execution & submission" below).
+
+0. **Capture a baseline (before any change).** Run `make check` and `make test-unit` and record
+   which failures already exist. The only expected failure on this branch is the `test_workflow_parser.py`
+   collection error (the repro). Any *other* pre-existing `make check`/test failure must be noted now
+   so it can go in the PR's **Notes for Reviewers** — Week 9's bar is "no new failures," not "fix the
+   whole codebase."
+1. **Skill detection — parser-authoritative, extractor reused (not extended).** Baseline capture
+   (step 0) showed `SkillExtractor` does literal case-insensitive substring matching and already ships
+   5 failing tests; and `"github actions"` is *not* a literal substring of a real workflow YAML (it
+   carries `actions/checkout`, `runs-on`). So `WorkflowParser` **structurally** detects the skills —
+   GitHub Actions from the `on:`/`jobs:` structure, Docker/pytest/deployment from `uses:` / `run:` /
+   job names — and writes those authoritative labels into `text` and `metadata["skills"]`. It **also
+   calls** `SkillExtractor().extract_skills(summary_text)` and stores that result under a separate
+   `metadata["extracted_skills"]`, honoring issue #14's "reuse it" directive without making the
+   feature depend on it. **Do not edit `skill_extractor.py`** — its detection gaps (substring matching;
+   the 5 pre-existing failures, incl. the `test_database_technology_detection` self-referential typo)
+   are pre-existing and out of scope; document them in the PR's Notes for Reviewers and, if desired,
+   file a follow-up issue. The originally-planned `TOOLS`/`FRAMEWORKS`/casing edits move to that
+   follow-up. Google-style docstrings on anything new (CONTRIBUTING.md).
 2. **Implement `WorkflowParser.parse(content: str | bytes) -> ParseResult`.** Decode bytes → str;
    `yaml.safe_load`; raise `ValueError` on unsupported types / invalid YAML. Build a human-readable
    `text` summary (triggers from `on:`, job names, `runs-on`, each step's `uses:` / `run:`), then
-   call `SkillExtractor().extract_skills(text, filename)` and thread the results into `metadata`.
+   call `SkillExtractor().extract_skills(text, filename)`. This returns `list[SkillDetection]`
+   (dataclass: `name`, `category`, `confidence`, `evidence: list[str]` — `skill_extractor.py:6-12`),
+   **not** strings — pull `.name` off each and comma-join into a scalar string
+   (`", ".join(d.name for d in detections)`) for `metadata["skills"]`; never put the objects or the
+   `evidence` list into `metadata` (ChromaDB rejects non-scalars — see Risks). Build `ParseResult`
+   with keyword args and set `metadata["source_type"] = "workflow"`. Full type annotations — `mypy`
+   runs over `ingestion/` with `disallow_untyped_defs = true`, so an untyped def fails `make typecheck`.
 3. **Wire into the pipeline.** Import + instantiate in `IngestionPipeline.__init__`; add
-   `ingest_workflow(...)`; add the `"workflow"` branch to `StrategySelector.select_chunker`.
-4. **Declare `pyyaml`** (and `types-pyyaml` in `dev`) in `pyproject.toml`.
-5. **Tests.** Add `tests/unit/test_workflow_parser.py` following `test_readme_parser.py`: `parser`
-   fixture, `ParseResult` assertions, bytes + UTF-8 input, empty input, invalid-type `ValueError`,
-   and skill-extraction assertions (`GitHub Actions`, `Docker`, `pytest`, `deployment`).
+   `ingest_workflow(...)`; add the `"workflow"` branch to `StrategySelector.select_chunker`. Note the
+   selector receives its key via `chunk()` → `metadata.get("source_type", "unknown")`
+   (`strategy_selector.py:45`), so the new branch fires only because step 2 stamps
+   `metadata["source_type"] = "workflow"` — keep the two in sync.
+4. **Declare `pyyaml`** (and `types-pyyaml` in `dev`) in `pyproject.toml`, then re-`pip install -e ".[dev]"`
+   so `types-pyyaml` is present when `make typecheck` runs.
+5. **Tests — make the repro green, then extend.** The four tests already in
+   `tests/unit/test_workflow_parser.py` (returns `ParseResult`, detects CI/CD skills, bytes input,
+   invalid-type `ValueError`) must pass. Add edge-case tests from the Edge cases list — empty /
+   whitespace-only, valid-YAML-but-not-a-workflow, `.yaml` vs `.yml`, matrix builds, malformed YAML →
+   `ValueError`. **Any new test class or function must carry `@pytest.mark.unit`** (class-level, as
+   `TestWorkflowParser` already does) — `make test-unit` runs `-m unit` and silently skips anything
+   unmarked. Verify in isolation with `pytest tests/unit/test_workflow_parser.py -v`, then run the
+   full `make test-unit`.
+6. **Self-review & verify.** Run `make check` (ruff + black + mypy) and `make test-unit` until clean;
+   walk `docs/CHECKLIST.md`; read the full diff (`git diff origin/main..HEAD`) and strip any debug
+   prints / stray TODOs. Confirm the baseline failures from step 0 are unchanged.
+7. **Draft PR → peer review → ready.** Push the branch, open a **draft** PR early, fill every section
+   of `.github/PULL_REQUEST_TEMPLATE.md` (`Closes #14` goes in **Issue**, not the title; **Notes for
+   Reviewers** lists the step-0 baseline). Request peer/mentor feedback in Slack, address it, then mark
+   Ready for Review. Log both JOURNAL check-ins (Wed / Sun).
 
 ### Inputs & outputs
 
@@ -67,30 +122,73 @@ Files the fix will touch (feature work — a later week):
   `filename`).
 - **Output:** a `ParseResult` with `source_type="workflow"`, `text` = a readable summary suitable for
   embedding, and `metadata` including `triggers`, `job_count`/job names, `actions_used`, boolean
-  flags (`has_docker`, `runs_pytest`, `has_deployment`), and the extracted `skills` (see Risks for
-  the serialization constraint). Downstream, `ingest_workflow` chunks + embeds this like other
-  sources.
+  flags (`has_docker`, `runs_pytest`, `has_deployment`), the authoritative structural `skills`
+  (comma-joined string) and, separately, `extracted_skills` from the reused `SkillExtractor` (see
+  Risks for the serialization constraint). Downstream, `ingest_workflow` chunks + embeds this like
+  other sources.
 
 ### Risks & unknowns
 
-- **ChromaDB metadata must be scalar** (str/int/float/bool). Putting a raw `skills` **list** into
-  `metadata` would break `BatchEmbeddingProcessor` storage — serialize to a comma-joined string
-  and/or boolean flags. **This is the main open question going into implementation.**
-- `SkillExtractor` matching is case-insensitive **substring** matching → false positives (`git`
-  inside `github`, `go` inside `go.mod`). Prefer inspecting structured `uses:` / `run:` values in the
-  parser rather than dumping raw YAML at the extractor.
-- `pyyaml` is only a transitive dependency today; relying on `import yaml` without declaring it is
-  fragile and could break in a clean environment.
+- **ChromaDB metadata must be scalar** (str/int/float/bool). `extract_skills` hands back
+  `list[SkillDetection]` objects (each carrying an `evidence: list[str]`), so dumping the list — or any
+  `SkillDetection` / its `evidence` — straight into `metadata` breaks `BatchEmbeddingProcessor`
+  storage. Serialize `.name` values to a comma-joined string and/or boolean flags. The existing repro
+  test resolves *how* skills must surface: it asserts on
+  `(result.text + " " + str(result.metadata)).lower()`, so a comma-joined string satisfies both the
+  scalar constraint and the test. Because the assert is lowercased-substring, the parser writing the
+  literal label `GitHub Actions` into its summary text is what makes `"github actions" in haystack`
+  pass — the (deferred) extractor casing fix is irrelevant to the test.
+- **`make test-unit` filters on `-m unit`.** Additional tests without `@pytest.mark.unit` are collected
+  by a bare `pytest` run but silently skipped by `make test-unit` — an easy way to think tests pass
+  when they never ran.
+- **`make typecheck` covers `ingestion/`** with `disallow_untyped_defs = true`; the new parser and any
+  new test helpers need full annotations or `make check` fails.
+- **Baseline (step 0, captured):** unit suite is **53 failed / 375 passed** on a clean branch before
+  our change (the repro module was excluded to get past its collection error). All 53 are pre-existing
+  and mostly in unrelated modules (`rag`/`agent`/`safety`/services); 5 are in `test_skill_extractor.py`.
+  Record this in the PR's Notes for Reviewers; our bar is *no new* failures.
+- `SkillExtractor` matching is case-insensitive **substring** matching (confirmed by the baseline:
+  it can't infer Docker from a Dockerfile or JS from `require('fs')`) → also false positives (`git`
+  inside `github`). This is why the parser does its own structural detection (Plan step 1) rather than
+  routing raw YAML through the extractor.
+- **YAML 1.1 `on:` boolean-key gotcha.** `yaml.safe_load("on: push")` returns `{True: 'push'}` — PyYAML
+  resolves the unquoted `on` key to boolean `True`. The parser must read triggers from *both* the
+  `"on"` and `True` keys, or triggers silently vanish on real workflow files.
+- `pyyaml` is only a transitive dependency today (pyyaml 6.0.3 present); relying on `import yaml`
+  without declaring it is fragile. Also `types-pyyaml` is **not** installed — mypy fails with "Library
+  stubs not installed for yaml" until step 4 adds it and re-installs the `dev` extra.
 - Shared-file merge surface: `ingestion/pipeline.py` and `ingestion/parsers/skill_extractor.py` are
   common edit targets for other issues.
 
 ### Edge cases
 
 - Empty file; whitespace-only file.
-- Valid YAML that is **not** a workflow (no `on:` / `jobs:`).
+- Valid YAML that is **not** a workflow (no `on:` / `jobs:`) → return a `ParseResult` (do not raise);
+  emit no skills / empty flags.
+- The `on:` → `{True: ...}` boolean-key gotcha above (look up both `"on"` and `True`).
 - `.yaml` vs `.yml` extension.
 - Matrix builds (`strategy.matrix`), reusable/composite workflows (`uses:` at the job level).
 - Multi-document YAML; anchored/aliased YAML.
 - Invalid / malformed YAML → raise `ValueError` (consistent with other parsers).
 - `bytes` input with UTF-8 characters.
 - A workflow with `on:` triggers but zero jobs.
+
+### Week 9 execution & submission
+
+The code above is the deliverable, but the grade also depends on process (per WEEK9.md). Conventions
+are already validated against `docs/`:
+
+- **Branch:** `feat/14-github-workflow-parser` — matches CONTRIBUTING.md `<type>/<issue>-<desc>`. Keep
+  it rebased on `main` (no merge commits; CHECKLIST §1).
+- **Commits:** `<type>(ingestion): <imperative description>` — e.g. `feat(ingestion): add WorkflowParser
+  for GitHub Actions files`, `test(ingestion): cover workflow parser edge cases`. One logical change
+  per commit; no `wip`/`fix fix`.
+- **PR is the primary graded artifact.** Title in conventional-commit form (`feat: …`); fill every
+  `.github/PULL_REQUEST_TEMPLATE.md` section substantively (a deleted heading fails, "N/A — reason"
+  passes). Model the **Changes** section on the root-cause framing in *Understand* above; **Screenshots
+  / Demo** is `N/A` (backend-only) with one line pointing at `test_workflow_parser.py`.
+- **Gate before Ready-for-Review:** `make check` and `make test-unit` both pass (Plan step 6), draft PR
+  reviewed by a peer/mentor.
+- **JOURNAL.md:** Check-in 1 (Wed) with progress vs. these Plan steps; Check-in 2 (Sun) with the PR
+  link, tests touched, and self-review boxes. Submit the `/tree/feat/14-github-workflow-parser` branch
+  URL via the portal — not a bare repo link.

--- a/ingestion/chunking/strategy_selector.py
+++ b/ingestion/chunking/strategy_selector.py
@@ -16,7 +16,7 @@ class StrategySelector:
         Select appropriate chunker based on document type.
 
         Args:
-            source_type: One of "resume", "readme", "repo", or default
+            source_type: One of "resume", "readme", "repo", "workflow", or default
 
         Returns:
             Appropriate BaseChunker instance
@@ -27,6 +27,9 @@ class StrategySelector:
             return self.structural_chunker
         elif source_type == "repo":
             return self.semantic_chunker
+        elif source_type == "workflow":
+            # Workflow YAML is highly structured; chunk by structure.
+            return self.structural_chunker
         else:
             # Default to semantic chunking
             return self.semantic_chunker

--- a/ingestion/parsers/workflow_parser.py
+++ b/ingestion/parsers/workflow_parser.py
@@ -1,0 +1,190 @@
+import yaml
+
+from .base import BaseParser, ParseResult
+from .skill_extractor import SkillExtractor
+
+
+class WorkflowParser(BaseParser):
+    """Parser for GitHub Actions workflow files (``.github/workflows/*.yml``).
+
+    Detects CI/CD and DevOps skills structurally from the workflow's triggers,
+    jobs, and steps (GitHub Actions, Docker, pytest, deployment) and threads them
+    into the result as authoritative labels. It also reuses the existing
+    :class:`SkillExtractor` on the generated summary for supplementary signal,
+    stored separately under ``metadata["extracted_skills"]``.
+    """
+
+    def parse(self, content: str | bytes) -> ParseResult:
+        """Parse a GitHub Actions workflow file.
+
+        Args:
+            content: Workflow YAML as a string or UTF-8 bytes.
+
+        Returns:
+            A :class:`ParseResult` with ``source_type="workflow"``, a
+            human-readable ``text`` summary suitable for embedding, and
+            ``metadata`` carrying triggers, job info, actions used, boolean skill
+            flags, and the detected skills.
+
+        Raises:
+            ValueError: If ``content`` is not ``str``/``bytes``, or is not valid
+                (single-document) YAML.
+        """
+        if isinstance(content, bytes):
+            content = content.decode("utf-8", errors="replace")
+        elif not isinstance(content, str):
+            raise ValueError("Content must be a string or bytes")
+
+        try:
+            data = yaml.safe_load(content)
+        except yaml.YAMLError as exc:
+            raise ValueError(f"Invalid workflow YAML: {exc}") from exc
+
+        # Valid YAML that is not a mapping (empty file, bare scalar, top-level
+        # list) is not a workflow; treat it as an empty document rather than raise.
+        if not isinstance(data, dict):
+            data = {}
+
+        workflow_name = self._as_str(data.get("name")) or "unnamed"
+        triggers = self._extract_triggers(data)
+        jobs = self._extract_jobs(data)
+        actions_used = self._collect_uses(jobs)
+        run_commands = self._collect_runs(jobs)
+
+        # Structural skill detection (authoritative). A file with triggers or jobs
+        # is by definition a GitHub Actions workflow.
+        haystack = " ".join(actions_used + run_commands + list(jobs.keys())).lower()
+        has_docker = "docker" in haystack
+        runs_pytest = "pytest" in haystack
+        has_deployment = "deploy" in haystack or "deployment" in triggers
+
+        skills: list[str] = []
+        if triggers or jobs:
+            skills.append("GitHub Actions")
+        if has_docker:
+            skills.append("Docker")
+        if runs_pytest:
+            skills.append("pytest")
+        if has_deployment:
+            skills.append("deployment")
+
+        text = self._build_summary(
+            workflow_name, triggers, jobs, actions_used, run_commands, skills
+        )
+
+        # Reuse SkillExtractor for supplementary signal (issue #14). This is not
+        # load-bearing: the structural labels above are authoritative.
+        extracted = [d.name for d in SkillExtractor().extract_skills(text)]
+
+        metadata = {
+            "source_type": "workflow",
+            "workflow_name": workflow_name,
+            "triggers": ", ".join(triggers),
+            "job_count": len(jobs),
+            "job_names": ", ".join(jobs.keys()),
+            "actions_used": ", ".join(actions_used),
+            "has_docker": has_docker,
+            "runs_pytest": runs_pytest,
+            "has_deployment": has_deployment,
+            "skills": ", ".join(skills),
+            "extracted_skills": ", ".join(extracted),
+        }
+
+        return ParseResult(
+            text=text,
+            metadata=metadata,
+            source_type="workflow",
+        )
+
+    def _extract_triggers(self, data: dict) -> list[str]:
+        """Extract trigger event names from the ``on:`` key.
+
+        PyYAML resolves an unquoted ``on`` key to the boolean ``True`` (YAML 1.1),
+        so we look under both ``"on"`` and ``True``.
+        """
+        on_value = data.get("on")
+        if on_value is None:
+            on_value = data.get(True)
+
+        if isinstance(on_value, str):
+            return [on_value]
+        if isinstance(on_value, list):
+            return [s for s in (self._as_str(v) for v in on_value) if s]
+        if isinstance(on_value, dict):
+            return [s for s in (self._as_str(k) for k in on_value) if s]
+        return []
+
+    def _extract_jobs(self, data: dict) -> dict[str, dict]:
+        """Return a mapping of job name to its (dict) configuration."""
+        jobs_value = data.get("jobs")
+        if not isinstance(jobs_value, dict):
+            return {}
+        return {
+            self._as_str(name): (config if isinstance(config, dict) else {})
+            for name, config in jobs_value.items()
+        }
+
+    def _collect_uses(self, jobs: dict[str, dict]) -> list[str]:
+        """Collect every ``uses:`` value (step-level and reusable job-level)."""
+        uses: list[str] = []
+        for config in jobs.values():
+            job_uses = config.get("uses")
+            if isinstance(job_uses, str):
+                uses.append(job_uses)
+            for step in self._steps(config):
+                step_uses = step.get("uses")
+                if isinstance(step_uses, str):
+                    uses.append(step_uses)
+        return uses
+
+    def _collect_runs(self, jobs: dict[str, dict]) -> list[str]:
+        """Collect every ``run:`` command across all job steps."""
+        runs: list[str] = []
+        for config in jobs.values():
+            for step in self._steps(config):
+                step_run = step.get("run")
+                if isinstance(step_run, str):
+                    runs.append(step_run)
+        return runs
+
+    def _steps(self, config: dict) -> list[dict]:
+        """Return the list of step mappings for a job config."""
+        steps = config.get("steps")
+        if not isinstance(steps, list):
+            return []
+        return [s for s in steps if isinstance(s, dict)]
+
+    def _build_summary(
+        self,
+        name: str,
+        triggers: list[str],
+        jobs: dict[str, dict],
+        actions_used: list[str],
+        run_commands: list[str],
+        skills: list[str],
+    ) -> str:
+        """Build a human-readable, embeddable summary of the workflow."""
+        lines = [f"Workflow file: {name}"]
+        if skills:
+            lines.append(f"Detected skills: {', '.join(skills)}")
+        if triggers:
+            lines.append(f"Triggers: {', '.join(triggers)}")
+        if jobs:
+            lines.append(f"Jobs ({len(jobs)}): {', '.join(jobs.keys())}")
+            for job_name, config in jobs.items():
+                runs_on = self._as_str(config.get("runs-on"))
+                if runs_on:
+                    lines.append(f"  Job '{job_name}' runs on {runs_on}")
+        if actions_used:
+            lines.append(f"Actions used: {', '.join(actions_used)}")
+        if run_commands:
+            lines.append("Commands:")
+            lines.extend(f"  run: {cmd}" for cmd in run_commands)
+        return "\n".join(lines)
+
+    @staticmethod
+    def _as_str(value: object) -> str:
+        """Coerce a YAML scalar/key to a string ("" for ``None``)."""
+        if value is None:
+            return ""
+        return str(value)

--- a/ingestion/pipeline.py
+++ b/ingestion/pipeline.py
@@ -10,6 +10,7 @@ from .embeddings.provider import EmbeddingProvider
 from .parsers.readme_parser import ReadmeParser
 from .parsers.repo_analyzer import RepoAnalyzer
 from .parsers.resume_parser import ResumeParser
+from .parsers.workflow_parser import WorkflowParser
 
 
 logger = structlog.get_logger()
@@ -51,6 +52,7 @@ class IngestionPipeline:
         self.resume_parser = ResumeParser()
         self.readme_parser = ReadmeParser()
         self.repo_analyzer = RepoAnalyzer()
+        self.workflow_parser = WorkflowParser()
 
     def ingest_resume(
         self,
@@ -192,6 +194,83 @@ class IngestionPipeline:
         except Exception as e:
             logger.error(
                 "README ingestion failed",
+                profile_id=profile_id,
+                repo_name=repo_name,
+                error=str(e),
+            )
+            raise
+
+    def ingest_workflow(
+        self,
+        profile_id: str,
+        repo_name: str,
+        content: str | bytes,
+    ) -> IngestResult:
+        """
+        Ingest a GitHub Actions workflow file.
+
+        Args:
+            profile_id: ID of the profile owner
+            repo_name: Name of the repository the workflow belongs to
+            content: Workflow YAML content (string or bytes)
+
+        Returns:
+            IngestResult with ingestion status
+        """
+        source_id = f"workflow_{profile_id}_{repo_name}_{self._hash_content(content)}"
+
+        logger.info(
+            "Starting workflow ingestion",
+            profile_id=profile_id,
+            repo_name=repo_name,
+            source_id=source_id,
+        )
+
+        # Check if already ingested
+        skip_result = self._check_skip(source_id, "workflow")
+        if skip_result:
+            return skip_result
+
+        try:
+            # Parse workflow
+            parse_result = self.workflow_parser.parse(content)
+            logger.info(
+                "Workflow parsed successfully",
+                job_count=parse_result.metadata.get("job_count"),
+                skills=parse_result.metadata.get("skills"),
+            )
+
+            # Prepare metadata
+            metadata = parse_result.metadata.copy()
+            metadata.update(
+                {
+                    "source_id": source_id,
+                    "profile_id": profile_id,
+                    "repo_name": repo_name,
+                    "source_type": "workflow",
+                }
+            )
+
+            # Chunk the content
+            chunks = self.strategy_selector.chunk(parse_result.text, metadata)
+            logger.info("Workflow chunked successfully", chunk_count=len(chunks))
+
+            # Generate embeddings and store
+            self.batch_processor.process(chunks)
+            logger.info("Workflow embeddings stored", chunk_count=len(chunks))
+
+            # Record in database
+            self._record_ingested_source(source_id, "workflow", profile_id, len(chunks))
+
+            return IngestResult(
+                source_id=source_id,
+                chunk_count=len(chunks),
+                skipped=False,
+            )
+
+        except Exception as e:
+            logger.error(
+                "Workflow ingestion failed",
                 profile_id=profile_id,
                 repo_name=repo_name,
                 error=str(e),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "structlog>=24.1.0",
     "rank-bm25>=0.2.2",
     "numpy>=1.26.0",
+    "pyyaml>=6.0",
 ]
 
 [project.optional-dependencies]
@@ -50,6 +51,7 @@ dev = [
     "pre-commit>=3.6.0",
     "mutmut>=2.4.4",
     "types-redis>=4.6.0",
+    "types-pyyaml>=6.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/tests/unit/test_workflow_parser.py
+++ b/tests/unit/test_workflow_parser.py
@@ -1,0 +1,89 @@
+"""Tests for workflow_parser.py
+
+REPRODUCTION (Issue #14): As of this commit, ``ingestion/parsers/workflow_parser.py``
+does not exist, so the import below fails at collection time with a
+``ModuleNotFoundError``. That failure is the concrete proof that the ingestion
+pipeline has no parser for ``.github/workflows/*.yml`` files and therefore cannot
+detect CI/CD / DevOps skills. These tests are written to PASS once ``WorkflowParser``
+is implemented per PLAN.md.
+
+Run:  pytest tests/unit/test_workflow_parser.py -v
+"""
+
+import pytest
+
+from ingestion.parsers.base import ParseResult
+from ingestion.parsers.workflow_parser import WorkflowParser
+
+SAMPLE_WORKFLOW_YAML = """
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+      - name: Run tests
+        run: pytest tests/ -v
+      - name: Build image
+        run: docker build -t app:latest .
+
+  deploy:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to production
+        run: ./scripts/deploy.sh
+"""
+
+
+@pytest.mark.unit
+class TestWorkflowParser:
+    """Test suite for WorkflowParser."""
+
+    @pytest.fixture
+    def parser(self) -> WorkflowParser:
+        """Create a WorkflowParser instance."""
+        return WorkflowParser()
+
+    def test_parse_returns_parse_result(self, parser: WorkflowParser) -> None:
+        """Parsing a workflow returns a ParseResult tagged as 'workflow'."""
+        result = parser.parse(SAMPLE_WORKFLOW_YAML)
+
+        assert isinstance(result, ParseResult)
+        assert result.source_type == "workflow"
+        assert result.metadata["source_type"] == "workflow"
+
+    def test_detects_cicd_skills(self, parser: WorkflowParser) -> None:
+        """The parser surfaces the CI/CD skills named in issue #14."""
+        result = parser.parse(SAMPLE_WORKFLOW_YAML)
+
+        # skills are threaded into metadata (exact container shape is an
+        # implementation detail; assert on the human-readable text + metadata blob)
+        haystack = (result.text + " " + str(result.metadata)).lower()
+        assert "github actions" in haystack
+        assert "docker" in haystack
+        assert "pytest" in haystack
+        assert "deploy" in haystack
+
+    def test_parse_bytes_input(self, parser: WorkflowParser) -> None:
+        """Workflow YAML provided as UTF-8 bytes is accepted."""
+        result = parser.parse(SAMPLE_WORKFLOW_YAML.encode("utf-8"))
+
+        assert isinstance(result, ParseResult)
+        assert result.source_type == "workflow"
+
+    def test_parse_invalid_content_type(self, parser: WorkflowParser) -> None:
+        """Non-str/bytes content raises ValueError."""
+        with pytest.raises(ValueError):
+            parser.parse(12345)

--- a/tests/unit/test_workflow_parser.py
+++ b/tests/unit/test_workflow_parser.py
@@ -87,3 +87,107 @@ class TestWorkflowParser:
         """Non-str/bytes content raises ValueError."""
         with pytest.raises(ValueError):
             parser.parse(12345)
+
+    def test_empty_content_returns_result_with_no_skills(self, parser: WorkflowParser) -> None:
+        """An empty file parses to a ParseResult with no detected skills."""
+        result = parser.parse("")
+
+        assert isinstance(result, ParseResult)
+        assert result.source_type == "workflow"
+        assert result.metadata["skills"] == ""
+        assert result.metadata["job_count"] == 0
+
+    def test_whitespace_only_content(self, parser: WorkflowParser) -> None:
+        """Whitespace-only content is handled like an empty document."""
+        result = parser.parse("   \n   \n")
+
+        assert isinstance(result, ParseResult)
+        assert result.metadata["skills"] == ""
+
+    def test_valid_yaml_but_not_a_workflow(self, parser: WorkflowParser) -> None:
+        """Valid YAML without on:/jobs: is not flagged as a GitHub Actions workflow."""
+        result = parser.parse("name: not-a-workflow\nfoo:\n  bar: baz\n")
+
+        assert "GitHub Actions" not in result.metadata["skills"]
+        assert result.metadata["job_count"] == 0
+
+    def test_malformed_yaml_raises_value_error(self, parser: WorkflowParser) -> None:
+        """Malformed YAML raises ValueError, consistent with the other parsers."""
+        with pytest.raises(ValueError):
+            parser.parse("on: [push, pull_request\njobs: :::")
+
+    def test_on_key_boolean_gotcha(self, parser: WorkflowParser) -> None:
+        """Triggers are read even though PyYAML resolves the `on:` key to True."""
+        yaml_text = (
+            "on:\n"
+            "  push:\n"
+            "  pull_request:\n"
+            "jobs:\n"
+            "  a:\n"
+            "    runs-on: ubuntu-latest\n"
+        )
+        result = parser.parse(yaml_text)
+
+        assert "push" in result.metadata["triggers"]
+        assert "pull_request" in result.metadata["triggers"]
+        assert "GitHub Actions" in result.metadata["skills"]
+
+    def test_triggers_but_zero_jobs(self, parser: WorkflowParser) -> None:
+        """A workflow with triggers but no jobs is still GitHub Actions, 0 jobs."""
+        result = parser.parse("on: [push]\n")
+
+        assert result.metadata["job_count"] == 0
+        assert "GitHub Actions" in result.metadata["skills"]
+
+    def test_matrix_build_parses(self, parser: WorkflowParser) -> None:
+        """Matrix builds (strategy.matrix) parse and the job/steps are detected."""
+        yaml_text = (
+            "on: [push]\n"
+            "jobs:\n"
+            "  test:\n"
+            "    runs-on: ubuntu-latest\n"
+            "    strategy:\n"
+            "      matrix:\n"
+            "        python: ['3.10', '3.11']\n"
+            "    steps:\n"
+            "      - run: pytest\n"
+        )
+        result = parser.parse(yaml_text)
+
+        assert result.metadata["job_count"] == 1
+        assert result.metadata["runs_pytest"] is True
+
+    def test_reusable_workflow_uses_at_job_level(self, parser: WorkflowParser) -> None:
+        """A job-level `uses:` (reusable workflow) is captured in actions_used."""
+        yaml_text = (
+            "on: [push]\n"
+            "jobs:\n"
+            "  call:\n"
+            "    uses: owner/repo/.github/workflows/reusable.yml@main\n"
+        )
+        result = parser.parse(yaml_text)
+
+        assert "owner/repo/.github/workflows/reusable.yml@main" in result.metadata["actions_used"]
+
+    def test_metadata_values_are_chromadb_scalars(self, parser: WorkflowParser) -> None:
+        """Every metadata value must be scalar (str/int/float/bool) for ChromaDB."""
+        result = parser.parse(SAMPLE_WORKFLOW_YAML)
+
+        scalar_types = (str, int, float, bool)
+        for key, value in result.metadata.items():
+            assert isinstance(value, scalar_types), f"{key} is not scalar"
+
+    def test_reuses_skill_extractor(self, parser: WorkflowParser) -> None:
+        """The parser threads SkillExtractor output into extracted_skills."""
+        result = parser.parse(SAMPLE_WORKFLOW_YAML)
+
+        assert "extracted_skills" in result.metadata
+        assert isinstance(result.metadata["extracted_skills"], str)
+
+    def test_skill_flags_reflect_sample(self, parser: WorkflowParser) -> None:
+        """has_docker / runs_pytest / has_deployment reflect the sample workflow."""
+        result = parser.parse(SAMPLE_WORKFLOW_YAML)
+
+        assert result.metadata["has_docker"] is True
+        assert result.metadata["runs_pytest"] is True
+        assert result.metadata["has_deployment"] is True


### PR DESCRIPTION
## Summary

The ingestion pipeline inferred developer skills from resumes, READMEs, and repo metadata but had **no parser for `.github/workflows/*.yml`**, so CI/CD and DevOps signals — GitHub Actions, Docker builds, running pytest in CI, deploy-on-merge — went completely undetected. This PR adds a `WorkflowParser` that reads workflow YAML, detects those skills structurally, and wires it into the ingestion pipeline as a new `workflow` source type.

## Issue

Closes #14

## Changes

**Root cause:** `IngestionPipeline` only instantiated `ResumeParser`, `ReadmeParser`, and `RepoAnalyzer` — there was no code path that read workflow files at all, so no CI/CD skill could ever be produced.

- **`ingestion/parsers/workflow_parser.py` (new)** — `WorkflowParser(BaseParser)` parses workflow YAML (`str`/`bytes`), builds an embeddable text summary, and detects skills **structurally** from the workflow's triggers/jobs/steps: GitHub Actions (any file with `on:`/`jobs:`), and Docker / pytest / deployment from `uses:` / `run:` / job names. Skills are stored as ChromaDB-safe scalars (comma-joined strings plus boolean flags `has_docker` / `runs_pytest` / `has_deployment`). Raises `ValueError` on non-`str`/`bytes` input or invalid YAML, and handles the YAML 1.1 gotcha where an unquoted `on:` key is parsed as the boolean `True`.
- **Reuses the existing `SkillExtractor`** (as the issue suggests) by calling `extract_skills()` on the summary and storing its output under a separate `extracted_skills` field — supplementary only. I deliberately did **not** modify `skill_extractor.py`: its matching is literal substring-based and it already carries pre-existing test failures (see Notes), so making the feature depend on it would be fragile. The parser's structural detection is authoritative.
- **`ingestion/pipeline.py`** — instantiate `WorkflowParser`; add `ingest_workflow()` mirroring `ingest_readme` (a `workflow_` source-id prefix and `source_type="workflow"`).
- **`ingestion/chunking/strategy_selector.py`** — route `"workflow"` sources to the structural chunker, which suits highly structured YAML better than the semantic default.
- **`pyproject.toml`** — declare `pyyaml` as a runtime dependency (previously only transitive) and `types-pyyaml` in the `dev` extra for mypy.
- **`tests/unit/test_workflow_parser.py`** — makes the #14 reproduction pass and adds 11 edge-case tests.

## Testing

- [x] Unit tests pass (`make test-unit`) — no new failures introduced (see Notes for the pre-existing baseline)
- [ ] Integration tests pass (`make test-integration`) — not run; this change is unit-scoped
- [x] Linter passes (`make lint`) — no new findings from the changed files
- [x] Type checker passes (`make typecheck`) — the new/edited files are mypy-clean (see Notes)
- [x] New/updated tests cover the changes

The 15 tests in `tests/unit/test_workflow_parser.py` cover: the `ParseResult` shape, the four CI/CD skills from #14, bytes input, invalid-type `ValueError`, empty/whitespace input, valid-but-non-workflow YAML, malformed YAML, the `on:`-key boolean gotcha, matrix builds, reusable job-level `uses:`, ChromaDB-scalar metadata, and `SkillExtractor` reuse.

**Manual verification:**

```python
from ingestion.parsers.workflow_parser import WorkflowParser

result = WorkflowParser().parse(open(".github/workflows/ci.yml").read())
print(result.metadata["skills"])
# e.g. "GitHub Actions, Docker, pytest, deployment"
```

## Screenshots / Demo

N/A — backend-only change. The observable behavior lives in `WorkflowParser.parse()` and the new `IngestionPipeline.ingest_workflow()`, both exercised by `tests/unit/test_workflow_parser.py`.

## Notes for Reviewers

**Pre-existing failures — not introduced by this PR.** I captured a baseline on a clean branch before making any change:

- **`make test-unit`:** 53 failed / 375 passed *before* this change; 53 failed / **390** passed *after* (the +15 are this PR's new tests). No previously-passing test regressed.
- **`make check`** does not pass on this repo independently of this change: ~103 mypy errors across 26 files (concentrated in `api/`, `rag/`, `agent/`, `safety/`, with a few pre-existing in `ingestion/`), and ~53 files are not black-compliant. The files this PR adds or edits are ruff-, black-, and mypy-clean. The two mypy errors that fall in files I edited (`pipeline.py:30`, `strategy_selector.py:9`) are on pre-existing untyped `__init__` signatures that this PR does not touch.
- Five of the pre-existing failures are in `tests/unit/test_skill_extractor.py` (including a self-referential `skill_names` typo in `test_database_technology_detection`). These are the reason `WorkflowParser` performs its own structural detection rather than relying on `SkillExtractor`.

Happy to split out any of the above into a follow-up issue if useful.
