### PR TITLE
feat(agent): add has_tests to GitHub repository metadata

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,67 +1,42 @@
-\# PathReview Contribution Journal
+# PathReview Contribution Journal
 
+## Week 7 — Issue Selection
 
+**Name:** Muhammad Raza
 
-\## Week 7 — Issue Selection
+**GitHub Username:** Muhammad8640
 
+**Issue Link:** https://github.com/ascherj/pathreview/issues/50
 
+**Issue Title:** Add a `has_tests` boolean to the repo analysis output
 
-\*\*Name:\*\* Muhammad Raza
+**Tier:** ☑ Tier 1 ☐ Tier 2 ☐ Tier 3
 
+### Problem Summary
 
+The repository analysis currently does not indicate whether a GitHub repository contains automated tests. This issue requires adding a new boolean field called `has_tests` to the analysis output. The value should be `true` when the repository contains common testing indicators such as a `tests/` or `test/` directory, a `pytest.ini` file, or Python test files matching the `test_*.py` naming convention. A successful implementation will allow users to quickly determine whether a repository includes automated tests.
 
-\*\*GitHub Username:\*\* Muhammad8640
-
-
-
-\*\*Issue Link:\*\* https://github.com/ascherj/pathreview/issues/50
-
-
-
-\*\*Issue Title:\*\* Add a `has\_tests` boolean to the repo analysis output
-
-
-
-\*\*Tier:\*\* ☑ Tier 1 ☐ Tier 2 ☐ Tier 3
-
-
-
-\### Problem Summary
-
-
-
-The repository analysis currently does not indicate whether a GitHub repository contains automated tests. This issue requires adding a new boolean field called `has\_tests` to the analysis output. The value should be `true` when the repository contains common testing indicators such as a `tests/` or `test/` directory, a `pytest.ini` file, or Python test files matching the `test\_\*.py` naming convention. A successful implementation will allow users to quickly determine whether a repository includes automated tests.
-
-
-
-\### "Is this the right issue for me?" Reasoning
-
-
+### "Is this the right issue for me?" Reasoning
 
 I selected this issue because it is labeled as a Tier 1 issue and a good first issue. The scope is well defined, the expected behavior is clearly described, and the issue identifies the primary files that will likely need modification. It appears to be a manageable feature to implement while helping me become familiar with the PathReview codebase.
 
-
-
-\*\*Branch Name:\*\* `feat/50-add-has-tests`
-
-
+**Branch Name:** `feat/50-add-has-tests`
 
 **Setup Confirmation:** ☑ App runs locally at `http://localhost:5173`
 
-
 **Cohort Ledger:** ☑ Issue added to the cohort issue ledger
 
-
+---
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link: https://github.com/Muhammad8640/pathreview/commit/ca18d9c**
+**Reproduction commit link:** https://github.com/Muhammad8640/pathreview/commit/ca18d9c
 
 **Reproduction summary:**
 
 Inspected the current implementation of `agent/tools/github_tool.py` and `ingestion/parsers/repo_analyzer.py`. Confirmed that `RepoAnalyzer` already supports detecting whether a repository contains tests and includes a `has_tests` field, but `GitHubTool` does not expose this field or gather the repository file structure needed to determine it. This reproduces the missing functionality described in Issue #50.
 
-**PLAN.md link:https://github.com/Muhammad8640/pathreview/blob/feat/50-add-has-tests/PLAN.md**
+**PLAN.md link:** https://github.com/Muhammad8640/pathreview/blob/feat/50-add-has-tests/PLAN.md
 
 **Walkthrough video (recommended):**
 
@@ -70,3 +45,55 @@ Not recorded.
 **Blockers or open questions:**
 
 Need to determine the best way for `GitHubTool` to retrieve the repository file structure so `has_tests` can be detected without negatively affecting performance.
+
+---
+
+# Week 9 — Solution building & PR submission
+
+## Check-in 1 (mid-week)
+
+**Current progress:**
+
+Implemented support for detecting whether a GitHub repository contains automated tests within `GitHubTool`. The tool now retrieves the repository's recursive Git tree and checks for common testing indicators including `tests/`, `test/`, `pytest.ini`, and Python test files matching the `test_*.py` naming convention. Added a new `has_tests` field to the returned metadata and created unit tests covering repositories both with and without tests.
+
+**Next steps:**
+
+Run the complete project validation commands, open a draft pull request, request peer feedback, update documentation, and submit the completed pull request.
+
+**Blockers:**
+
+The repository currently contains unrelated pre-existing lint and unit test failures that are outside the scope of Issue #50. My implementation has been verified independently and does not introduce additional failures.
+
+---
+
+## Check-in 2 (end of week)
+
+**PR link:** *(Add your pull request URL here after opening it.)*
+
+**Branch:** `feat/50-add-has-tests`
+
+**What you built:**
+
+Implemented support for a new `has_tests` metadata field in `GitHubTool`. The tool now retrieves the repository's recursive file tree from the GitHub API and detects common testing indicators including `tests/`, `test/`, `pytest.ini`, and Python test files named `test_*.py`, returning the result as part of the repository metadata.
+
+**Tests added or updated:**
+
+Added `tests/unit/test_github_tool.py` with unit tests covering:
+- repositories containing a `tests/` directory,
+- repositories containing a `test/` directory,
+- repositories containing `pytest.ini`,
+- repositories containing `test_*.py` files,
+- repositories without tests,
+- failed GitHub tree requests.
+
+The new unit tests pass successfully.
+
+**Self-review confirmation:**
+
+- [ ] `make check` passes*
+- [ ] `make test-unit` passes*
+
+\*The repository currently contains pre-existing lint (`make check`) and unit test (`make test-unit`) failures unrelated to Issue #50. My implementation introduces no additional failures. The new `GitHubTool` unit tests pass successfully.
+
+**Draft PR feedback received from:none**
+

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -55,13 +55,13 @@ I selected this issue because it is labeled as a Tier 1 issue and a good first i
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** *(add after pushing the commit)*
+**Reproduction commit link: https://github.com/Muhammad8640/pathreview/commit/ca18d9c**
 
 **Reproduction summary:**
 
 Inspected the current implementation of `agent/tools/github_tool.py` and `ingestion/parsers/repo_analyzer.py`. Confirmed that `RepoAnalyzer` already supports detecting whether a repository contains tests and includes a `has_tests` field, but `GitHubTool` does not expose this field or gather the repository file structure needed to determine it. This reproduces the missing functionality described in Issue #50.
 
-**PLAN.md link:** *(add after creating PLAN.md)*
+**PLAN.md link:https://github.com/Muhammad8640/pathreview/blob/feat/50-add-has-tests/PLAN.md**
 
 **Walkthrough video (recommended):**
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -50,3 +50,23 @@ I selected this issue because it is labeled as a Tier 1 issue and a good first i
 
 
 **Cohort Ledger:** ☑ Issue added to the cohort issue ledger
+
+
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** *(add after pushing the commit)*
+
+**Reproduction summary:**
+
+Inspected the current implementation of `agent/tools/github_tool.py` and `ingestion/parsers/repo_analyzer.py`. Confirmed that `RepoAnalyzer` already supports detecting whether a repository contains tests and includes a `has_tests` field, but `GitHubTool` does not expose this field or gather the repository file structure needed to determine it. This reproduces the missing functionality described in Issue #50.
+
+**PLAN.md link:** *(add after creating PLAN.md)*
+
+**Walkthrough video (recommended):**
+
+Not recorded.
+
+**Blockers or open questions:**
+
+Need to determine the best way for `GitHubTool` to retrieve the repository file structure so `has_tests` can be detected without negatively affecting performance.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,54 @@
+\# PathReview Contribution Journal
+
+
+
+\## Week 7 — Issue Selection
+
+
+
+\*\*Name:\*\* Muhammad Raza
+
+
+
+\*\*GitHub Username:\*\* Muhammad8640
+
+
+
+\*\*Issue Link:\*\* https://github.com/ascherj/pathreview/issues/50
+
+
+
+\*\*Issue Title:\*\* Add a `has\_tests` boolean to the repo analysis output
+
+
+
+\*\*Tier:\*\* ☑ Tier 1 ☐ Tier 2 ☐ Tier 3
+
+
+
+\### Problem Summary
+
+
+
+The repository analysis currently does not indicate whether a GitHub repository contains automated tests. This issue requires adding a new boolean field called `has\_tests` to the analysis output. The value should be `true` when the repository contains common testing indicators such as a `tests/` or `test/` directory, a `pytest.ini` file, or Python test files matching the `test\_\*.py` naming convention. A successful implementation will allow users to quickly determine whether a repository includes automated tests.
+
+
+
+\### "Is this the right issue for me?" Reasoning
+
+
+
+I selected this issue because it is labeled as a Tier 1 issue and a good first issue. The scope is well defined, the expected behavior is clearly described, and the issue identifies the primary files that will likely need modification. It appears to be a manageable feature to implement while helping me become familiar with the PathReview codebase.
+
+
+
+\*\*Branch Name:\*\* `feat/50-add-has-tests`
+
+
+
+\*\*Setup Confirmation:\*\* ☐ App runs locally at `http://localhost:5173`
+
+
+
+\*\*Cohort Ledger:\*\* ☐ Issue added to the cohort issue ledger
+

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -68,7 +68,7 @@ The repository currently contains unrelated pre-existing lint and unit test fail
 
 ## Check-in 2 (end of week)
 
-**PR link:** *(Add your pull request URL here after opening it.)*
+**PR link:** *https://github.com/ascherj/pathreview/pull/891*
 
 **Branch:** `feat/50-add-has-tests`
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -46,9 +46,7 @@ I selected this issue because it is labeled as a Tier 1 issue and a good first i
 
 
 
-\*\*Setup Confirmation:\*\* ☐ App runs locally at `http://localhost:5173`
+**Setup Confirmation:** ☑ App runs locally at `http://localhost:5173`
 
 
-
-\*\*Cohort Ledger:\*\* ☐ Issue added to the cohort issue ledger
-
+**Cohort Ledger:** ☑ Issue added to the cohort issue ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -97,3 +97,33 @@ The new unit tests pass successfully.
 
 **Draft PR feedback received from:none**
 
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No reviewer feedback was provided for my pull request. This matches the Summer 2026 course note that reviewer feedback is not part of the PathReview process this term.
+
+**How you responded:**
+N/A — there was no reviewer feedback to respond to.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The hardest part was understanding where the change actually belonged in a codebase I did not build. At first, the issue sounded like a simple task of adding a boolean field, but after tracing the existing implementation I found that `RepoAnalyzer` already had logic for detecting tests while `GitHubTool` did not collect the repository file structure needed to expose that information. I had to understand how those parts of the project related to each other before deciding what to change. It was also challenging to separate failures caused by my work from pre-existing lint and unit test failures in the repository. That made validation more important because I needed to show that the tests for my new functionality passed even though the full project checks were not completely clean.
+
+**What did you learn about working in a large codebase?**
+I learned that contributing to an existing codebase requires much more investigation before writing code than building a small project from scratch. I could not assume that the issue description showed the entire implementation path. I had to inspect multiple files, understand existing patterns, and avoid duplicating functionality that was already present elsewhere in the project. I also learned the importance of keeping a contribution focused on the issue instead of trying to fix unrelated problems that I discovered while testing. Working in someone else's codebase means respecting the existing architecture, writing tests that fit the project, and making the smallest change that solves the requested problem.
+
+**How did AI tools help — and where did they fall short?**
+AI tools were most helpful for understanding unfamiliar code, thinking through possible implementation approaches, explaining Git and GitHub workflow steps, and helping me organize tests for the different `has_tests` cases. They also helped me reason about how to use the GitHub API recursive tree endpoint and what edge cases I should test. However, AI could not replace actually inspecting the PathReview codebase or running the project. I still had to verify which classes already contained related logic, determine what the current code really returned, run the tests, and distinguish pre-existing failures from problems caused by my implementation. I learned that AI is useful for guidance and acceleration, but its suggestions still need to be checked against the real repository.
+
+**What would you do differently if you started over?**
+If I started over, I would spend more time mapping the relevant parts of the codebase before thinking about the implementation. I would inspect the existing analyzer, GitHub tool, related tests, and contribution guidelines together at the beginning instead of discovering some of those details while working. I would also run the full validation commands earlier and record the existing failures immediately so that I had an even clearer baseline before changing anything. That would make it easier to separate repository problems from my own changes and would make the implementation process more organized.
+
+**What are you most proud of from this module?**
+I am most proud that I was able to take a real open-source issue from investigation through implementation, testing, and pull request submission. The feature itself was relatively small, but completing it required me to navigate an unfamiliar codebase, understand existing behavior, make a focused change, add unit tests for several cases, and document the work across multiple weeks. Submitting PR #891 made the process feel much closer to real collaborative software development than working only on an isolated class project.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,104 @@
+# Solution Plan
+
+**Issue:** Add a `has_tests` boolean to the repo analysis output
+
+Issue Link: https://github.com/ascherj/pathreview/issues/50
+
+---
+
+## Understand
+
+The goal of this issue is to expose a `has_tests` boolean in the repository analysis output.
+
+After inspecting the codebase, I found that `ingestion/parsers/repo_analyzer.py` already contains a `_detect_tests()` method that can detect test-related files and directories and already adds `has_tests` to its metadata.
+
+However, `agent/tools/github_tool.py`, which retrieves repository metadata from the GitHub API, does not currently collect the repository file structure or return a `has_tests` field. Because of this, users of `GitHubTool` cannot determine whether a repository contains tests.
+
+The expected behavior is for the repository analysis output to include a `has_tests` boolean that is `true` whenever the repository contains:
+
+- `tests/`
+- `test/`
+- `pytest.ini`
+- Python test files matching `test_*.py`
+
+Otherwise, it should return `false`.
+
+---
+
+## Map
+
+Files investigated:
+
+- `agent/tools/github_tool.py`
+- `ingestion/parsers/repo_analyzer.py`
+
+Expected files to modify:
+
+- `agent/tools/github_tool.py`
+
+Potential supporting files:
+
+- Existing GitHub API helper methods
+- Any repository analysis or integration tests if available
+
+---
+
+## Plan
+
+1. Determine how `GitHubTool` should retrieve the repository file structure from the GitHub API.
+2. Reuse the existing test detection logic where possible instead of duplicating functionality.
+3. Add logic to determine whether the repository contains supported test indicators.
+4. Include a `has_tests` boolean in the metadata returned by `GitHubTool`.
+5. Verify that repositories with and without test files return the correct value.
+
+---
+
+## Inputs & Outputs
+
+### Input
+
+- GitHub repository owner
+- Repository name
+- Repository contents retrieved through the GitHub API
+
+### Output
+
+Repository metadata containing a new field:
+
+```json
+{
+  "has_tests": true
+}
+```
+
+or
+
+```json
+{
+  "has_tests": false
+}
+```
+
+depending on whether test-related files or directories are detected.
+
+---
+
+## Risks & Unknowns
+
+- `GitHubTool` currently does not retrieve the repository file structure, so additional GitHub API requests may be required.
+- The existing `_detect_tests()` implementation is located in `RepoAnalyzer`; I need to determine whether it should be reused directly or whether the logic should be moved into a shared utility.
+- Additional API requests could impact performance or GitHub rate limits.
+
+---
+
+## Edge Cases
+
+The implementation should correctly handle:
+
+- Repositories containing only a `tests/` directory.
+- Repositories containing only a `test/` directory.
+- Repositories containing only `pytest.ini`.
+- Repositories containing only `test_*.py` files.
+- Empty repositories.
+- Repositories with no test-related files.
+- Large repositories where only part of the file tree may initially be retrieved.

--- a/agent/tools/github_tool.py
+++ b/agent/tools/github_tool.py
@@ -2,6 +2,7 @@
 
 import httpx
 import structlog
+
 from .base import BaseTool, ToolResult
 
 logger = structlog.get_logger()
@@ -35,44 +36,30 @@ class GitHubTool(BaseTool):
         repo_name = input_data.get("repo_name")
 
         if not username or not repo_name:
-            return ToolResult(
-                success=False,
-                data={},
-                error="Missing github_username or repo_name"
-            )
+            return ToolResult(success=False, data={}, error="Missing github_username or repo_name")
 
         try:
             repo_data = self._fetch_repo_metadata(username, repo_name)
             return ToolResult(success=True, data=repo_data)
 
         except httpx.HTTPStatusError as e:
-            logger.error("github_request_failed", status=e.response.status_code,
-                        username=username, repo=repo_name)
+            logger.error(
+                "github_request_failed",
+                status=e.response.status_code,
+                username=username,
+                repo=repo_name,
+            )
             if e.response.status_code == 404:
-                return ToolResult(
-                    success=False,
-                    data={},
-                    error="Repository not found"
-                )
+                return ToolResult(success=False, data={}, error="Repository not found")
             elif e.response.status_code == 403:
-                return ToolResult(
-                    success=False,
-                    data={},
-                    error="Rate limited or access denied"
-                )
+                return ToolResult(success=False, data={}, error="Rate limited or access denied")
             return ToolResult(
-                success=False,
-                data={},
-                error=f"GitHub API error: {e.response.status_code}"
+                success=False, data={}, error=f"GitHub API error: {e.response.status_code}"
             )
 
         except Exception as e:
             logger.error("github_tool_error", error=str(e))
-            return ToolResult(
-                success=False,
-                data={},
-                error=str(e)
-            )
+            return ToolResult(success=False, data={}, error=str(e))
 
     def _fetch_repo_metadata(self, username: str, repo_name: str) -> dict:
         """Fetch repository metadata from GitHub API.
@@ -95,6 +82,8 @@ class GitHubTool(BaseTool):
 
         repo_json = response.json()
 
+        default_branch = repo_json.get("default_branch", "main")
+
         # Extract metadata, handling null values
         metadata = {
             "name": repo_json.get("name", ""),
@@ -105,12 +94,22 @@ class GitHubTool(BaseTool):
             "open_issues_count": repo_json.get("open_issues_count", 0),
             "last_commit_date": repo_json.get("pushed_at", ""),
             "has_readme": self._has_readme(username, repo_name),
+            "has_tests": self._has_tests(
+                username,
+                repo_name,
+                default_branch,
+            ),
             "topics": repo_json.get("topics", []),
             "homepage": repo_json.get("homepage") or "",
         }
 
-        logger.info("github_repo_fetched", username=username, repo=repo_name,
-                   language=metadata["primary_language"], stars=metadata["star_count"])
+        logger.info(
+            "github_repo_fetched",
+            username=username,
+            repo=repo_name,
+            language=metadata["primary_language"],
+            stars=metadata["star_count"],
+        )
 
         return metadata
 
@@ -132,6 +131,58 @@ class GitHubTool(BaseTool):
 
         try:
             response = httpx.head(url, headers=headers, timeout=5.0)
-            return response.status_code == 200
+            return bool(response.status_code == 200)
+        except Exception:
+            return False
+
+    def _has_tests(
+        self,
+        username: str,
+        repo_name: str,
+        default_branch: str,
+    ) -> bool:
+        """Check if repository contains recognized test files or directories.
+
+        Args:
+            username: GitHub username
+            repo_name: Repository name
+            default_branch: Repository default branch
+
+        Returns:
+            True if tests are detected
+        """
+        url = (
+            f"{self.base_url}/repos/{username}/{repo_name}"
+            f"/git/trees/{default_branch}?recursive=1"
+        )
+
+        headers = {}
+        if self.api_token:
+            headers["Authorization"] = f"token {self.api_token}"
+
+        try:
+            response = httpx.get(url, headers=headers, timeout=10.0)
+            response.raise_for_status()
+
+            tree = response.json().get("tree", [])
+
+            for item in tree:
+                path = item.get("path", "").lower()
+                filename = path.rsplit("/", maxsplit=1)[-1]
+
+                if path == "tests" or path.startswith("tests/"):
+                    return True
+
+                if path == "test" or path.startswith("test/"):
+                    return True
+
+                if filename == "pytest.ini":
+                    return True
+
+                if filename.startswith("test_") and filename.endswith(".py"):
+                    return True
+
+            return False
+
         except Exception:
             return False

--- a/tests/unit/test_github_tool.py
+++ b/tests/unit/test_github_tool.py
@@ -1,0 +1,184 @@
+"""Unit tests for GitHubTool."""
+
+from unittest.mock import Mock, patch
+
+import httpx
+import pytest
+
+from agent.tools.github_tool import GitHubTool
+
+
+@pytest.fixture
+def github_tool() -> GitHubTool:
+    """Return a GitHubTool instance for testing."""
+    return GitHubTool()
+
+
+@pytest.mark.parametrize(
+    "test_path",
+    [
+        "tests/test_example.py",
+        "test/test_example.py",
+        "pytest.ini",
+        "src/test_service.py",
+    ],
+)
+def test_execute_detects_repository_tests(
+    github_tool: GitHubTool,
+    test_path: str,
+) -> None:
+    """Test recognized test paths set has_tests to True."""
+    repo_response = Mock()
+    repo_response.raise_for_status.return_value = None
+    repo_response.json.return_value = {
+        "name": "example-repo",
+        "description": "Example repository",
+        "language": "Python",
+        "stargazers_count": 1,
+        "forks_count": 2,
+        "open_issues_count": 3,
+        "pushed_at": "2026-08-04T00:00:00Z",
+        "default_branch": "main",
+        "topics": [],
+        "homepage": None,
+    }
+
+    tree_response = Mock()
+    tree_response.raise_for_status.return_value = None
+    tree_response.json.return_value = {
+        "tree": [
+            {"path": "README.md", "type": "blob"},
+            {"path": test_path, "type": "blob"},
+        ]
+    }
+
+    readme_response = Mock()
+    readme_response.status_code = 200
+
+    with (
+        patch(
+            "agent.tools.github_tool.httpx.get",
+            side_effect=[repo_response, tree_response],
+        ),
+        patch(
+            "agent.tools.github_tool.httpx.head",
+            return_value=readme_response,
+        ),
+    ):
+        result = github_tool.execute(
+            {
+                "github_username": "example-user",
+                "repo_name": "example-repo",
+            }
+        )
+
+    assert result.success is True
+    assert result.error is None
+    assert result.data["has_tests"] is True
+
+
+def test_execute_returns_false_when_repository_has_no_tests(
+    github_tool: GitHubTool,
+) -> None:
+    """Test repositories without test indicators return False."""
+    repo_response = Mock()
+    repo_response.raise_for_status.return_value = None
+    repo_response.json.return_value = {
+        "name": "example-repo",
+        "description": "Example repository",
+        "language": "Python",
+        "stargazers_count": 1,
+        "forks_count": 2,
+        "open_issues_count": 3,
+        "pushed_at": "2026-08-04T00:00:00Z",
+        "default_branch": "main",
+        "topics": [],
+        "homepage": None,
+    }
+
+    tree_response = Mock()
+    tree_response.raise_for_status.return_value = None
+    tree_response.json.return_value = {
+        "tree": [
+            {"path": "README.md", "type": "blob"},
+            {"path": "src/main.py", "type": "blob"},
+            {"path": "requirements.txt", "type": "blob"},
+        ]
+    }
+
+    readme_response = Mock()
+    readme_response.status_code = 200
+
+    with (
+        patch(
+            "agent.tools.github_tool.httpx.get",
+            side_effect=[repo_response, tree_response],
+        ),
+        patch(
+            "agent.tools.github_tool.httpx.head",
+            return_value=readme_response,
+        ),
+    ):
+        result = github_tool.execute(
+            {
+                "github_username": "example-user",
+                "repo_name": "example-repo",
+            }
+        )
+
+    assert result.success is True
+    assert result.data["has_tests"] is False
+
+
+def test_execute_returns_false_when_tree_request_fails(
+    github_tool: GitHubTool,
+) -> None:
+    """Test failed tree requests safely return has_tests False."""
+    repo_response = Mock()
+    repo_response.raise_for_status.return_value = None
+    repo_response.json.return_value = {
+        "name": "example-repo",
+        "description": "Example repository",
+        "language": "Python",
+        "stargazers_count": 1,
+        "forks_count": 2,
+        "open_issues_count": 3,
+        "pushed_at": "2026-08-04T00:00:00Z",
+        "default_branch": "main",
+        "topics": [],
+        "homepage": None,
+    }
+
+    request = httpx.Request(
+        "GET",
+        "https://api.github.com/repos/example-user/example-repo/git/trees/main",
+    )
+    failed_response = httpx.Response(404, request=request)
+    tree_error = httpx.HTTPStatusError(
+        "Tree request failed",
+        request=request,
+        response=failed_response,
+    )
+
+    readme_response = Mock()
+    readme_response.status_code = 200
+
+    with (
+        patch(
+            "agent.tools.github_tool.httpx.get",
+            side_effect=[repo_response, tree_error],
+        ),
+        patch(
+            "agent.tools.github_tool.httpx.head",
+            return_value=readme_response,
+        ),
+    ):
+        result = github_tool.execute(
+            {
+                "github_username": "example-user",
+                "repo_name": "example-repo",
+            }
+        )
+
+    assert result.success is True
+    assert result.data["has_tests"] is False


### PR DESCRIPTION
## Summary

This PR adds a `has_tests` boolean to the metadata returned by `GitHubTool`.

The implementation retrieves the repository's recursive Git tree using the GitHub API and checks for common testing indicators, including:

- `tests/`
- `test/`
- `pytest.ini`
- Python files matching `test_*.py`

The detected value is returned as part of the repository metadata.

Closes #50

## Testing

Added unit tests covering:

- repositories containing `tests/`
- repositories containing `test/`
- repositories containing `pytest.ini`
- repositories containing `test_*.py`
- repositories without tests
- failed GitHub tree requests

The new GitHubTool unit tests pass successfully.

## Validation

The repository currently contains pre-existing `make check` lint failures and `make test-unit` failures unrelated to this issue. I recorded these before implementation and confirmed that my changes do not introduce additional failures.