### PR TITLE
Fix/156 readme test fixture too short

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,16 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/156
+
+**Issue title:** README scorer test fixture is too short for its own word-count assertion
+
+**Tier:** [X] Tier 1 [ ] Tier 2 [ ] Tier 3
+
+**Problem summary:**
+The issue is in the README scoring unit test, where the test data is inconsistent with the expectations it sets. The fixture used by the README scorer test is too short to satisfy the assertion that the scored README should be considered “comprehensive,” so the test fails even though the scorer may be behaving correctly. A successful fix would make the fixture or the assertion match the intended test behavior, so the unit test accurately validates the README scorer’s output.
+
+**Branch name:** fix/156-README-test-fixture-too-short
+
+**Setup confirmation:** [X] App runs locally at localhost:5173
+
+**Cohort ledger:** [X] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -14,3 +14,20 @@ The issue is in the README scoring unit test, where the test data is inconsisten
 **Setup confirmation:** [X] App runs locally at localhost:5173
 
 **Cohort ledger:** [X] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** (https://github.com/bluecrushangel/pathreview/commit/98ab411949763b24dacf4d1cab1c2c8f21775276)
+
+**Reproduction summary:**
+I reproduced the issue by running the testscript:
+pytest tests/unit/test_readme_scorer.py -q 
+
+I checked the error logs and verified the issue exists.
+
+**PLAN.md link:** [link to PLAN.md in your fork]
+
+**Walkthrough video (recommended):** N/A 
+
+**Blockers or open questions:**
+N/A

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -30,3 +30,34 @@ I checked the error logs and verified the issue exists.
 
 **Blockers or open questions:**
 N/A
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the fix by expanding the `test_readme_scorer.py` fixture so the sample README now exceeds the comprehensive word-count threshold and validates the intended category.
+
+**Next steps:**
+Finalize the PR description, verify the test passes, and prepare the branch for submission.
+
+**Blockers:**
+None.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** (https://github.com/ascherj/pathreview/pull/893)
+
+**Branch:** (https://github.com/bluecrushangel/pathreview/tree/fix/156-README-test-fixture-too-short)
+
+**What you built:**
+The readme_scorer unit test fixture was too short to meet its own comprehensive word-count assertion. I expanded the sample README in test_readme_scorer.py so it now exceeds the scorer’s > 500 word threshold and validates the intended "comprehensive" category.
+
+**Tests added or updated:**
+Updated test_readme_scorer.py to expand the fixture and validate that the README sample now exceeds the comprehensive word-count threshold and returns word_count_category == "comprehensive".
+
+**Self-review confirmation:** [X] make check passes  [X] make test-unit passes
+
+**Draft PR feedback received from:** "none"

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -25,8 +25,7 @@ pytest tests/unit/test_readme_scorer.py -q
 
 I checked the error logs and verified the issue exists.
 
-**PLAN.md link:** [link to PLAN.md in your fork]
-
+**PLAN.md link:** (https://github.com/bluecrushangel/pathreview/blob/fix/156-README-test-fixture-too-short/PLAN.md)
 **Walkthrough video (recommended):** N/A 
 
 **Blockers or open questions:**

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -61,3 +61,42 @@ Updated test_readme_scorer.py to expand the fixture and validate that the README
 **Self-review confirmation:** [X] make check passes  [X] make test-unit passes
 
 **Draft PR feedback received from:** "none"
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [X] No — still awaiting review
+
+**Summary of feedback:**
+No review.
+
+**How you responded:**
+n/a
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Understanding the codebase and specifically the tests  were harder than expected. There were just a large
+amount of scripts.
+
+**What did you learn about working in a large codebase?**
+Working in a large codebase taught me the the importance of code formatting/code standardization,
+so that all the written code is standardized and easily understanable when scanning
+large code bases.
+
+**How did AI tools help — and where did they fall short?**
+AI tools greatly helped me helping me understand the codebase and tests. It feel short on
+decision making when writing specific tests. Such as what to focus on, as well as the proper threshold values for the tests.
+
+**What would you do differently if you started over?**
+I would choose a harder issue. I definetly underestimated myself a little bit and understand
+the process of contribution alot more, so a harder issue would definetly have helped
+me learn alot more.
+
+**What are you most proud of from this module?**
+I'm really proud of my organizational and formatting skills. Specifically, how quickly
+I was able to grasp the concept of pull requests, and writing good pull requests, as well
+as writing good commit titles. 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,29 @@
+## Solution plan
+
+**Issue:** [issue title and link]
+
+### Understand
+The root cause is that the README scorer test fixture does not match the scorer’s word-count categorization. Expected behavior: comprehensive fixture should be >500 words and satisfy the scorer’s signals.
+
+### Map
+Files: `tests/unit/test_readme_scorer.py`, `agent/tools/readme_scorer.py`
+Functions: `ReadmeScorer._score_readme`, `TestReadmeScorer.test_readme_with_all_quality_signals`
+
+### Plan
+1. Verify current scorer threshold logic.
+2. Update fixture to meet “comprehensive” criteria or adjust assertions to match intent.
+3. Run pre-commit / mypy and confirm test passes.
+
+### Inputs & outputs
+Input: README test fixture text and scorer output.
+Output: consistent test expectations with scorer behavior and passing unit test.
+
+### Risks & unknowns
+Risk: changing fixture may mask broader score logic issues.
+Unknown: whether “comprehensive” category should be based on >500 words or more structural signals.
+
+### Edge cases
+- Empty README
+- Minimal README with title only
+- Adequate README between 100-500 words
+- README with sections but low word count

--- a/tests/unit/test_readme_scorer.py
+++ b/tests/unit/test_readme_scorer.py
@@ -113,7 +113,9 @@ class TestReadmeScorer:
         result = scorer.execute({"readme_content": readme})
 
         data = result.data
-        assert data["word_count"] > 500
+        assert (
+            data["word_count"] > 500
+        )  # Probably shouldn't use it as the main proxy for cohesiveness.
         assert data["word_count_category"] == "comprehensive"
 
     def test_installation_section_detection(self, scorer):
@@ -157,9 +159,10 @@ class TestReadmeScorer:
 
         result = scorer.execute({"readme_content": readme})
         # "Getting Started" matches the pattern
-        assert result.data["has_installation_section"] is True or result.data[
-            "has_usage_section"
-        ] is True
+        assert (
+            result.data["has_installation_section"] is True
+            or result.data["has_usage_section"] is True
+        )
 
     def test_quickstart_counts_as_usage(self, scorer):
         """Test that 'quickstart' counts as usage."""
@@ -218,7 +221,8 @@ class TestReadmeScorer:
 
     def test_overall_score_calculation(self, scorer):
         """Test that overall score aggregates components."""
-        readme = """
+        readme = (
+            """
         # Good README
 
         ## Installation
@@ -233,7 +237,9 @@ class TestReadmeScorer:
         ![Build](https://example.com/build.svg)
 
         This readme has lots of content here.
-        """ * 3  # Make it comprehensive
+        """
+            * 3
+        )  # Make it comprehensive
 
         result = scorer.execute({"readme_content": readme})
 

--- a/tests/unit/test_readme_scorer.py
+++ b/tests/unit/test_readme_scorer.py
@@ -18,12 +18,42 @@ class TestReadmeScorer:
         """Test README with all quality signals returns high score."""
         readme = """
         # Project Name
-        A comprehensive project description.
+        A comprehensive project description that explains the problem solved,
+        the target audience, and how the product can be used in real-world
+        scenarios.
+
+        ## Overview
+        This README provides a detailed overview of the project architecture,
+        deployment strategy, and the expected user experience. It is meant to
+        serve as a reference for contributors, maintainers, and end users who
+        need a clear and concise summary of what the project does.
+
+        This project uses a modular design with separate components for API
+        handling, data ingestion, and machine learning evaluation. Each
+        component is designed to be independently deployable and easily
+        testable. The documentation includes instructions for local development,
+        environment setup, and how to run the full test suite.
+
+        The architecture section also includes performance expectations,
+        scalability goals, and the manner in which the system separates
+        concerns between storage, business logic, and presentation layers.
 
         ## Installation
         ```bash
         pip install package
         ```
+
+        To install the package from source, clone the repository, create a Python
+        virtual environment, and install the required dependencies. The
+        requirements file contains all of the packages needed for development,
+        testing, and production usage.
+
+        For reproducible development environments, the repository also includes
+        a Docker Compose configuration to start the local services, including
+        the database, cache, and worker processes. Installation notes cover
+        Python version compatibility, virtual environment activation,
+        dependency pinning, and the recommended upgrade path for third-party
+        libraries.
 
         ## Usage
         ```python
@@ -31,21 +61,122 @@ class TestReadmeScorer:
         package.run()
         ```
 
+        The usage section includes sample commands and code snippets. Users can
+        execute the main entry point, configure the application through
+        environment variables, and run one-off tasks using the command line
+        interface.
+
+        Additional usage examples demonstrate how to run the HTTP API locally,
+        how to invoke background jobs, and how to use the package in a larger
+        orchestration pipeline. Each usage example includes expected output,
+        optional debug flags, and troubleshooting tips for common environment
+        issues.
+
         ## Features
-        - Feature 1
-        - Feature 2
-        - Feature 3
+        - Feature 1: Structured data ingestion with automatic normalization and
+          validation.
+        - Feature 2: Configurable pipeline processing using clear chunking and
+          embedding strategies.
+        - Feature 3: Real-time scoring and feedback for README quality, badge
+          detection, and demo link validation.
+        - Feature 4: Comprehensive error handling and retry logic for external
+          API calls.
+        - Feature 5: Modular architecture supporting both REST and event-driven
+          patterns.
+        - Feature 6: Pluggable provider adapters for third-party services and
+          custom storage backends.
+        - Feature 7: Built-in logging, metrics, and health-check endpoints for
+          service observability.
 
         ## Tech Stack
         - Python 3.9
         - FastAPI
         - PostgreSQL
+        - SQLAlchemy
+        - Redis
+        - Docker
+        - TypeScript for frontend utilities
+        - GitHub Actions for continuous integration
+
+        This section further explains how each technology is used in the
+        project. Python is the primary implementation language for backend
+        services, FastAPI provides a lightweight web framework, PostgreSQL
+        stores persistent state, and Redis is used for caching and messaging.
+
+        The frontend and developer tooling are built with modern libraries that
+        support incremental builds, type-safe configuration, and automated
+        linting. Docker ensures consistent environments across local development
+        and continuous integration.
+
+        The repository also documents how to use GitHub Actions for test
+        execution, linting, release packaging, and deployment previews. It
+        explains the relationship between local developer workflows and CI
+        pipelines, including how feature branches are validated before merge.
+
+        ## Configuration
+        Configuration is managed through environment variables, a configuration
+        file, and optional secret management. The README details the available
+        options, default values, and examples for local and cloud deployments.
+
+        Example configuration includes database connection settings, Redis
+        cache TTL values, service endpoint URLs, and feature flag definitions.
+        There are instructions for managing credentials securely in
+        development, staging, and production environments.
+
+        The configuration section also includes a sample `.env.example` file,
+        descriptions of each setting, and guidance on which options are required
+        versus optional. It highlights best practices for keeping sensitive
+        values out of version control and for validating configuration on
+        application startup.
+
+        ## Contribution
+        Contributions are welcome. The repository includes guidelines for
+        submitting issues, pull requests, and code reviews. The project uses a
+        standard branching strategy and includes instructions for running the
+        test suite before opening a PR.
+
+        Contributors can follow the contribution guide to understand how to
+        format commit messages, write descriptive change summaries, and assign
+        reviewers. The README also documents the code style conventions, the
+        preferred issue labeling scheme, and the process for proposing
+        architecture changes.
+
+        ## Testing
+        Automated tests cover unit, integration, and end-to-end scenarios. The
+        README outlines how to execute tests, run linting checks, and generate
+        coverage reports.
+
+        The project includes a dedicated test directory with fixture data, mock
+        services, and scripts for running the test matrix locally. There are
+        instructions for running `pytest` with coverage output, checking style
+        with the linter, and validating documentation builds.
+
+        The README also details how to interpret common failures, how to re-run
+        flaky tests, and how to add new test cases when changing existing
+        functionality.
+
+        ## Troubleshooting
+        Common troubleshooting topics are covered here, including how to handle
+        dependency conflicts, database migrations, and environment drift between
+        local and staging systems.
+
+        The troubleshooting section provides pointers for resolving
+        authentication issues, restoring service connectivity, and debugging
+        unexpected failures during startup. It also includes links to external
+        resources for the tooling and services used by the project.
 
         ![Build Status](https://example.com/badge.svg)
         ![Coverage](https://example.com/coverage.svg)
+        ![License](https://example.com/license.svg)
 
         ## Live Demo
         [Try it here](https://demo.example.com)
+
+        ## Additional Resources
+        For additional details, see the API documentation, architecture decision
+        records, and setup guides included in the repository. This README is
+        intentionally verbose to support newcomers and longtime maintainers
+        alike.
         """
 
         result = scorer.execute({"readme_content": readme})


### PR DESCRIPTION
## Summary
The readme_scorer unit test fixture was too short to meet its own `comprehensive` word-count assertion. This PR expands the sample README in `test_readme_scorer.py` so it now exceeds the scorer’s `> 500` word threshold and validates the intended `"comprehensive"` category.

## Issue
Closes #156

## Changes
- Root cause: `test_readme_with_all_quality_signals` used a README fixture that was only adequate in length, so the scorer correctly returned `word_count_category == "adequate"` while the test still expected `"comprehensive"`.
- `test_readme_scorer.py` — lengthened the README fixture with additional overview, installation, usage, feature, tech stack, configuration, contribution, testing, and troubleshooting prose so the fixture now exceeds the comprehensive word-count threshold and exercises the intended category assertion.

## Testing
- [x] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`)
- [ ] Linter passes (`make lint`)
- [ ] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes

## Screenshots / Demo
N/A — test-only fix. The verification is the passing unit test result for `test_readme_scorer.py`.

## Notes for Reviewers
- This PR does not alter scoring logic; it only fixes the test fixture to match the existing `ReadmeScorer` thresholds.
- The failure was due to a mismatch between the sample README size and the asserted category, not a scorer bug.
- No additional files were added beyond the existing unit test file.