### PR TITLE
fix: wrap health check SQL in text() for SQLAlchemy 2.x (#154)

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -37,3 +37,16 @@ This is why it maps to Tier 1 rather than a larger tier.
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/sr-daniels/pathreview/commit/ff3d092aa82a4a02d189834f80c94d4f1f1338db
+
+**Reproduction summary:**
+Added a unit test that exercises the health check's Postgres probe with a mocked async session; confirmed db.execute("SELECT 1") raises sqlalchemy.exc.ArgumentError under SQLAlchemy 2.x, which the route's try/except catches and misreports as "postgres": "unhealthy".
+
+**PLAN.md link:** https://github.com/sr-daniels/pathreview/blob/fix/154-health-check-textual-sql/PLAN.md
+
+**Walkthrough video (recommended):**
+
+**Blockers or open questions:**

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,22 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/154
+
+**Issue title:** Health check DB probe passes a raw SQL string, which fails under SQLAlchemy 2.x
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The `/health` endpoint in `api/routes/health.py` checks Postgres connectivity by calling
+`db.execute("SELECT 1")` with a plain Python string. SQLAlchemy 2.x no longer accepts raw
+strings for textual SQL — they must be wrapped in `sqlalchemy.text()` — so the call raises
+an `ArgumentError` instead of running the query. Because that exception is caught by the
+surrounding `try/except`, the health check reports Postgres (and the overall service) as
+unhealthy even when the database is up and reachable. A correct fix wraps the query string
+in `text("SELECT 1")` so the probe actually executes and reflects the real DB status.
+
+**Branch name:** fix/154-health-check-textual-sql
+
+**Setup confirmation:** [ ] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -15,8 +15,25 @@ surrounding `try/except`, the health check reports Postgres (and the overall ser
 unhealthy even when the database is up and reachable. A correct fix wraps the query string
 in `text("SELECT 1")` so the probe actually executes and reflects the real DB status.
 
+**Scope reasoning ("Is this right for me?"):**
+Worked through the issue-selection checklist and confirmed this is a well-sized Tier 1 pick:
+
+- **Appropriately scoped / bounded blast radius:** The fix is a single line in a single file
+  (`api/routes/health.py:31`) — wrapping the existing `"SELECT 1"` string in `text(...)`. No
+  schema changes, no migrations, no API-contract changes, and no new dependencies (`text` already
+  ships with the SQLAlchemy version in use).
+- **Well-understood root cause:** The failure mode is a known SQLAlchemy 2.x behavior change
+  (raw strings are no longer accepted for textual SQL), so there is no open-ended investigation.
+- **Clear, deterministic acceptance criteria:** With the DB up, `/health` should report Postgres
+  (and overall status) as healthy instead of catching an `ArgumentError`. This is directly
+  observable and testable via the existing `/health` endpoint.
+- **Fits my skill level and available time:** Self-contained, isolated to the health probe's
+  `try/except`, with no cross-subsystem coordination — completable within the Week 7 window.
+
+This is why it maps to Tier 1 rather than a larger tier.
+
 **Branch name:** fix/154-health-check-textual-sql
 
-**Setup confirmation:** [ ] App runs locally at localhost:5173
+**Setup confirmation:** [x] App runs locally at localhost:5173
 
-**Cohort ledger:** [ ] Issue added to cohort ledger
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -68,3 +68,19 @@ Open a draft PR and request peer/mentor review. The live-DB smoke test (confirmi
 **Blockers:**
 - **Live-DB check blocked — Docker will not run locally.** Docker Desktop is installed but its daemon does not become ready when launched, and the `docker` / `docker compose` command-line tools are not operational in this environment (commands hang / the CLI is unavailable). Because docker compose can't bring up Postgres, the live GET /health smoke test could not be performed. It remains pending until Docker is working (or the check is run on another machine). This does not affect the code fix, which is covered by the unit tests above.
 - Out-of-scope discovery: the /health redis probe reads settings.redis_host / settings.redis_port, which aren't defined on Settings, so redis always reports unhealthy independent of #154 — noted in PLAN.md as a follow-up.
+
+### Check-in 2 (end of week)
+
+**PR link:** _<paste the PR URL here after opening it — e.g. https://github.com/ascherj/pathreview/pull/NNN>_
+
+**Branch:** fix/154-health-check-textual-sql
+
+**What was built:**
+Fixed the /health endpoint's Postgres probe, which passed a raw SQL string to db.execute() and raised sqlalchemy.exc.ArgumentError under SQLAlchemy 2.x — causing Postgres to be misreported as "unhealthy" even when the database was up. The fix wraps the query in sqlalchemy.text("SELECT 1") in api/routes/health.py, so the probe runs and reflects real connectivity.
+
+**Tests:**
+Updated `tests/unit/test_health.py` with two tests: `test_health_check_reports_postgres_healthy_when_query_succeeds` — asserts the probe reports `dependencies.postgres == "healthy"` once the query succeeds, and guards against regression by asserting the executed statement is a SQLAlchemy `text()` clause rather than a raw `str`; and `test_health_check_reports_postgres_unhealthy_on_real_db_error` — asserts a genuine DB connection error is still reported as "unhealthy" (HTTP 503), so the fix doesn't mask real outages.
+
+**Self-review:**
+- [x] `make test-unit` — this change introduces **no new failures**: identical `53 failed / 377 passed` before and after (the 53 are pre-existing and unrelated to /health; baseline captured before any change), and the two updated test_health.py tests pass.
+- [x] `make check` — this change introduces **no new lint/type errors**: both changed files are clean under `black`, add zero new `ruff` errors (repo total actually dropped 183 → 182), and `mypy` output is byte-for-byte identical to baseline. (The repo has pre-existing ruff/mypy debt unrelated to #154, left untouched to keep the diff minimal.)

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -59,7 +59,12 @@ Added a unit test that exercises the health check's Postgres probe with a mocked
 Implemented the fix in api/routes/health.py (wrapped the raw SQL string in sqlalchemy.text()) and updated tests/unit/test_health.py to assert the health check now reports postgres as healthy. All sub-tasks from PLAN.md's core fix are done; ran make check and make test-unit with no new failures introduced versus baseline.
 
 **Next steps:**
-Open a draft PR, request peer/mentor review, and confirm the app reports a healthy postgres status when run against a live database (docker-compose up) before marking the PR ready for review.
+Open a draft PR and request peer/mentor review. The live-DB smoke test (confirming GET /health reports postgres "healthy" against a running database via docker compose up) is still **pending** — see Blockers.
+
+**Verification status:**
+- Fix verified at the unit level: tests/unit/test_health.py confirms the postgres probe now reports "healthy" (and that the query is a text() clause, not a raw string), plus a regression that a genuine DB error still reports "unhealthy". make test-unit shows no new failures vs. baseline.
+- Live-DB manual smoke test: **pending / not yet run** (blocked, see below).
 
 **Blockers:**
-None on the fix itself. One out-of-scope discovery: the /health redis probe reads settings.redis_host / settings.redis_port, which aren't defined on Settings, so redis always reports unhealthy independent of #154 — noted in PLAN.md as a follow-up.
+- **Live-DB check blocked — Docker will not run locally.** Docker Desktop is installed but its daemon does not become ready when launched, and the `docker` / `docker compose` command-line tools are not operational in this environment (commands hang / the CLI is unavailable). Because docker compose can't bring up Postgres, the live GET /health smoke test could not be performed. It remains pending until Docker is working (or the check is run on another machine). This does not affect the code fix, which is covered by the unit tests above.
+- Out-of-scope discovery: the /health redis probe reads settings.redis_host / settings.redis_port, which aren't defined on Settings, so redis always reports unhealthy independent of #154 — noted in PLAN.md as a follow-up.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -50,3 +50,16 @@ Added a unit test that exercises the health check's Postgres probe with a mocked
 **Walkthrough video (recommended):**
 
 **Blockers or open questions:**
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the fix in api/routes/health.py (wrapped the raw SQL string in sqlalchemy.text()) and updated tests/unit/test_health.py to assert the health check now reports postgres as healthy. All sub-tasks from PLAN.md's core fix are done; ran make check and make test-unit with no new failures introduced versus baseline.
+
+**Next steps:**
+Open a draft PR, request peer/mentor review, and confirm the app reports a healthy postgres status when run against a live database (docker-compose up) before marking the PR ready for review.
+
+**Blockers:**
+None on the fix itself. One out-of-scope discovery: the /health redis probe reads settings.redis_host / settings.redis_port, which aren't defined on Settings, so redis always reports unhealthy independent of #154 — noted in PLAN.md as a follow-up.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -84,3 +84,34 @@ Updated `tests/unit/test_health.py` with two tests: `test_health_check_reports_p
 **Self-review:**
 - [x] `make test-unit` passes — *note: 53 pre-existing failures unrelated to #154; this change adds none (identical before/after).*
 - [x] `make check` passes — *note: repo has pre-existing ruff/mypy debt; this change adds none.*
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No review came in. Per the Summer 2026 note, reviewer feedback is not provided this term, so PR #894 was submitted but did not receive peer/mentor comments.
+
+**How you responded:**
+N/A — no feedback to respond to. If review does arrive, the plan is to address the postgres-probe change directly and file the redis-probe defect (see below) as its own issue rather than expanding this PR's scope.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The actual fix was two lines — `import text` and wrapping `text("SELECT 1")`. Almost everything *around* it was harder than the fix itself. Three things stood out. (1) Just getting the app to run: the repo's own `node` was v14 and Vite 5 needs 18+, so I had to install a second Node (`node@20`) side-by-side just to confirm the frontend booted at localhost:5173. (2) Writing a reproduction test that actually *proves* the bug instead of assuming it. The issue said "raises ArgumentError," but I didn't want to just hard-code that assumption — I ran SQLAlchemy 2.x directly and confirmed the exact exception (`ArgumentError`, with the "declare it as text()" message) and, importantly, that it's raised during statement coercion *before* any DB connection, which is why the test needs no live database. (3) Establishing a trustworthy baseline. `make test-unit` and `make check` were already red before I touched anything (53 failing tests, ~180 lint errors), so the hard part wasn't making them pass — it was proving my change added *zero* new failures by capturing a before/after diff of the exact failing set.
+
+**What did you learn about working in a large codebase?**
+In my own projects I assume the repo is green and the environment "just works." Neither held here. The test suite was already failing, dependency versions drifted from what was pinned, and I found a completely separate latent bug while testing — the redis probe reads `settings.redis_host`/`settings.redis_port`, which don't exist on `Settings`, so `/health` returns 503 no matter what my fix does. The big shift was discipline: keep the diff minimal (I deliberately left pre-existing lint nits in the file I edited so the change stayed focused), scope strictly to the one issue instead of "fixing everything I notice," resist fixing the redis bug in the same PR and note it as a follow-up instead, and read the surrounding code to match existing conventions (I copied the async-mock and `@pytest.mark.unit` patterns from the existing tests rather than inventing my own). Contributing to someone else's code is much more about *evidence and restraint* than about writing clever code.
+
+**How did AI tools help — and where did they fall short?**
+AI was most useful for speed in an unfamiliar codebase: finding the call site, learning the test conventions, drafting PLAN.md/the PR description, and flagging a subtlety I'd have missed — that SQLAlchemy might raise `ObjectNotExecutableError` rather than `ArgumentError` (it turned out `ArgumentError` was right, but only because we actually ran it to check). Where it fell short was anything requiring the real environment or a judgment call: it couldn't make Docker run, so the live-DB smoke test stayed unverified no matter how much we wanted the checkbox; and it couldn't decide *for me* whether it was honest to tick "make check passes" on a repo that isn't green. That was mine to own — the right answer was to check the box but annotate it as "no new failures introduced," not to claim a clean suite I never saw pass. AI accelerates the mechanical work; it can't take responsibility for what you attest to.
+
+**What would you do differently if you started over?**
+I'd set up the *full* environment first — Docker, `make setup`, a real Postgres — before selecting the issue, so the end-to-end verification wouldn't be blocked right at the finish line. Picking a health-check issue and then being unable to run the service against a live DB was avoidable. I'd also capture the baseline (`make check`/`make test-unit`) in Week 7, not Week 9, so I had a clean "before" snapshot from day one instead of reconstructing it later. And I'd file the redis-probe bug as its own issue the moment I found it, instead of just leaving a note.
+
+**What are you most proud of?**
+Not the fix — the honesty of the record. It would have been easy to check every box and claim a green suite and a verified live check. Instead the journal says exactly what I proved (unit-level: postgres now reports healthy, with a regression test so real outages still surface), exactly what I couldn't (the live smoke test, because Docker wouldn't run), and exactly what's out of scope (the redis bug). A reviewer can trust every claim in it, and that felt more valuable than a clean-looking checklist.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -71,7 +71,7 @@ Open a draft PR and request peer/mentor review. The live-DB smoke test (confirmi
 
 ### Check-in 2 (end of week)
 
-**PR link:** _<paste the PR URL here after opening it — e.g. https://github.com/ascherj/pathreview/pull/NNN>_
+**PR link:** https://github.com/ascherj/pathreview/pull/894
 
 **Branch:** fix/154-health-check-textual-sql
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -82,5 +82,5 @@ Fixed the /health endpoint's Postgres probe, which passed a raw SQL string to db
 Updated `tests/unit/test_health.py` with two tests: `test_health_check_reports_postgres_healthy_when_query_succeeds` — asserts the probe reports `dependencies.postgres == "healthy"` once the query succeeds, and guards against regression by asserting the executed statement is a SQLAlchemy `text()` clause rather than a raw `str`; and `test_health_check_reports_postgres_unhealthy_on_real_db_error` — asserts a genuine DB connection error is still reported as "unhealthy" (HTTP 503), so the fix doesn't mask real outages.
 
 **Self-review:**
-- [x] `make test-unit` — this change introduces **no new failures**: identical `53 failed / 377 passed` before and after (the 53 are pre-existing and unrelated to /health; baseline captured before any change), and the two updated test_health.py tests pass.
-- [x] `make check` — this change introduces **no new lint/type errors**: both changed files are clean under `black`, add zero new `ruff` errors (repo total actually dropped 183 → 182), and `mypy` output is byte-for-byte identical to baseline. (The repo has pre-existing ruff/mypy debt unrelated to #154, left untouched to keep the diff minimal.)
+- [x] `make test-unit` passes — *note: 53 pre-existing failures unrelated to #154; this change adds none (identical before/after).*
+- [x] `make check` passes — *note: repo has pre-existing ruff/mypy debt; this change adds none.*

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,81 @@
+## Solution plan
+
+**Issue:** Health check DB probe passes a raw SQL string, which fails under SQLAlchemy 2.x — https://github.com/ascherj/pathreview/issues/154
+
+### Understand
+`health_check()` in `api/routes/health.py` probes Postgres connectivity with
+`await db.execute("SELECT 1")` (line 31), passing a bare Python string. Under
+SQLAlchemy 2.x, `AsyncSession.execute()` no longer accepts raw strings as
+executable statements — textual SQL must be wrapped in `sqlalchemy.text()`.
+
+- **Expected behavior:** the Postgres probe runs `SELECT 1` and, when the database
+  is reachable, sets `dependencies.postgres = "healthy"` and returns HTTP 200.
+- **Actual behavior:** `execute()` raises `sqlalchemy.exc.ArgumentError`
+  ("Textual SQL expression 'SELECT 1' should be explicitly declared as
+  text('SELECT 1')") during statement coercion — *before any DB round-trip*. The
+  surrounding `try/except Exception` on lines 34–37 catches it, sets
+  `dependencies.postgres = "unhealthy"` and `status = "unhealthy"`, and the
+  endpoint returns HTTP 503 (lines 83–87) even though Postgres is up and
+  reachable. The failure is an API misuse being misreported as an outage.
+
+### Map
+- **`api/routes/health.py`** — the one line to change (`await db.execute("SELECT 1")`
+  at line 31). This is the only raw-string `execute()` call in the codebase
+  (verified by grep; every other `execute()` in `api/`, `core/services/`, and
+  `scripts/` passes a `select(...)` / prepared `stmt` construct, which is already
+  2.x-correct).
+- **`core/database.py`** — context only, no change. Defines the async `engine`,
+  `AsyncSessionLocal` (`async_sessionmaker`), and the `get_db()` dependency that
+  yields the `AsyncSession` injected into `health_check`. Confirms the session is a
+  genuine SQLAlchemy 2.x `AsyncSession`, so `text()` is the correct fix.
+- **`tests/unit/test_health.py`** — new reproduction test (committed this week). It
+  currently asserts the *broken* behavior (`ArgumentError` raised; postgres
+  reported "unhealthy"); its assertions get flipped to expect "healthy" once the
+  fix lands.
+
+### Plan
+1. Import `text`: add `from sqlalchemy import text` at the top of
+   `api/routes/health.py`.
+2. Wrap the probe: change line 31 to `await db.execute(text("SELECT 1"))`.
+3. Update `tests/unit/test_health.py`: the `ArgumentError` assertion no longer
+   holds after the fix, so replace it with a test that the probe reports Postgres
+   `"healthy"` when `execute()` succeeds (mock/stub `execute` to return normally),
+   and keep a regression test that a *real* connection error still reports
+   `"unhealthy"`.
+4. Manually verify against a running Postgres: `docker compose up -d`, `make run`,
+   then `curl localhost:8000/health` and confirm `dependencies.postgres` is
+   `"healthy"` and the endpoint returns HTTP 200.
+5. Confirm no other call sites need the same fix (grep already shows only
+   `health.py`); document that check in the PR.
+
+### Inputs & outputs
+- **Input:** a live async DB session provided by the `get_db` dependency
+  (`AsyncSession` from `core.database`).
+- **Output:** the `health_status` dict returned by `health_check`, specifically
+  `dependencies.postgres`, correctly reflecting real connectivity ("healthy" when
+  the DB responds to `SELECT 1`, "unhealthy" only on a genuine connection error) —
+  and the overall `status` / HTTP code (200 vs 503) derived from it — instead of
+  flipping to "unhealthy" because of a SQLAlchemy API mismatch.
+
+### Risks & unknowns
+- **Other raw-string call sites:** mitigated — a repo-wide grep confirms
+  `health.py:31` is the only `execute()` passed a raw string; all others use
+  `select()`/`stmt`. Will re-confirm in the PR.
+- **Behavior when Postgres is genuinely down:** the fix must not mask real
+  outages. With `text("SELECT 1")`, an unreachable DB should raise a connection
+  error (e.g. `OperationalError`), still caught and reported as "unhealthy" — this
+  needs an explicit regression assertion so we don't trade one bug for another.
+- **Test approach masking the fix:** the current reproduction relies on the
+  ArgumentError being raised pre-connection; the post-fix test must exercise the
+  success path without a real DB (stub `execute` to return normally) so it
+  actually validates the `text()` wrapping rather than connectivity.
+
+### Edge cases
+- **DB genuinely unreachable:** should still report `postgres: "unhealthy"`, now
+  via a real connection/operational error rather than an `ArgumentError`.
+- **DB reachable but slow / query times out:** probe should surface a timeout as
+  "unhealthy"; confirm no indefinite hang holds the endpoint open.
+- **`get_db` fails before the `try` block:** if the dependency itself can't yield a
+  session, the exception escapes `health_check` entirely (it happens during
+  dependency resolution, outside the route's `try/except`) — worth noting as
+  distinct from the in-probe failure this issue addresses.

--- a/PLAN.md
+++ b/PLAN.md
@@ -2,6 +2,20 @@
 
 **Issue:** Health check DB probe passes a raw SQL string, which fails under SQLAlchemy 2.x — https://github.com/ascherj/pathreview/issues/154
 
+### Status — ✅ Implemented as planned
+
+The core fix is done on branch `fix/154-health-check-textual-sql`:
+
+- `api/routes/health.py` now imports `text` and calls `await db.execute(text("SELECT 1"))` (commit `bee7833`).
+- `tests/unit/test_health.py` was updated to assert the Postgres probe reports "healthy" when the query succeeds, plus a regression test that a genuine DB error still reports "unhealthy" (commit `410f6ae`).
+- Baseline vs. after `make test-unit`: identical **53 failed / 377 passed** — all 53 failures are pre-existing and unrelated to #154; **no new failures introduced**. `ruff`/`black`/`mypy` output is unchanged versus baseline (ruff count actually dropped by 1 after tidying the test's imports).
+
+**What changed from the original plan once the code was written:**
+
+- The plan assumed the fixed endpoint would return a clean 200 "healthy". In practice the `/health` endpoint still returns **503** in the unit tests because of a **separate, pre-existing bug**: the redis probe reads `settings.redis_host` / `settings.redis_port`, which are **not defined** on `Settings` (only `redis_url` is), so redis always reports "unhealthy". This is out of scope for #154, so the tests assert on `dependencies["postgres"]` specifically rather than the overall status/HTTP code. (Worth filing as a follow-up issue.)
+- Plan step 5 (grep for other raw-string `execute()` call sites) is confirmed: `api/routes/health.py` was the **only** one — every other `execute()` in the codebase already passes a `select()` / prepared statement.
+- Still outstanding (next check-in): manual verification against a live Postgres (`docker compose up`) that `GET /health` reports `postgres: "healthy"`.
+
 ### Understand
 `health_check()` in `api/routes/health.py` probes Postgres connectivity with
 `await db.execute("SELECT 1")` (line 31), passing a bare Python string. Under

--- a/PLAN.md
+++ b/PLAN.md
@@ -14,7 +14,7 @@ The core fix is done on branch `fix/154-health-check-textual-sql`:
 
 - The plan assumed the fixed endpoint would return a clean 200 "healthy". In practice the `/health` endpoint still returns **503** in the unit tests because of a **separate, pre-existing bug**: the redis probe reads `settings.redis_host` / `settings.redis_port`, which are **not defined** on `Settings` (only `redis_url` is), so redis always reports "unhealthy". This is out of scope for #154, so the tests assert on `dependencies["postgres"]` specifically rather than the overall status/HTTP code. (Worth filing as a follow-up issue.)
 - Plan step 5 (grep for other raw-string `execute()` call sites) is confirmed: `api/routes/health.py` was the **only** one — every other `execute()` in the codebase already passes a `select()` / prepared statement.
-- Still outstanding (next check-in): manual verification against a live Postgres (`docker compose up`) that `GET /health` reports `postgres: "healthy"`.
+- Still outstanding: manual verification against a live Postgres (`docker compose up`) that `GET /health` reports `postgres: "healthy"`. **Currently blocked / pending** — Docker will not run in the local environment (Docker Desktop's daemon does not become ready and the `docker` / `docker compose` CLI is not operational), so the stack can't be brought up for the smoke test. The fix is covered by the unit tests regardless; the live check will be completed once Docker is available (or run on another machine).
 
 ### Understand
 `health_check()` in `api/routes/health.py` probes Postgres connectivity with

--- a/api/routes/health.py
+++ b/api/routes/health.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, HTTPException, status, Depends
 import structlog
 from datetime import datetime, timedelta
+from sqlalchemy import text
 
 from core.database import get_db
 
@@ -28,7 +29,7 @@ async def health_check(db=Depends(get_db)):
 
     try:
         # Check PostgreSQL
-        await db.execute("SELECT 1")
+        await db.execute(text("SELECT 1"))
         health_status["dependencies"]["postgres"] = "healthy"
         log.debug("postgres_health_check_passed")
     except Exception as exc:

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -1,0 +1,77 @@
+"""Tests for the /health route DB probe (api/routes/health.py).
+
+Reproduction test for issue #154:
+https://github.com/ascherj/pathreview/issues/154
+
+The health check probes Postgres with ``await db.execute("SELECT 1")`` — a bare
+Python string. Under SQLAlchemy 2.x a raw string is no longer an executable
+object; it must be wrapped in ``sqlalchemy.text()``. Passing the raw string
+raises ``sqlalchemy.exc.ArgumentError`` during statement coercion (before any DB
+round-trip), and the route's ``try/except`` swallows it and misreports Postgres
+as "unhealthy" even when the database is up.
+
+These tests document today's *broken* behavior. They pass on the current code and
+will need their assertions flipped (expecting "healthy") once the fix wraps the
+query in ``text("SELECT 1")`` — see PLAN.md.
+"""
+
+import pytest
+from sqlalchemy import exc as sa_exc
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from fastapi import HTTPException
+
+from api.routes.health import health_check
+
+
+@pytest.mark.unit
+class TestHealthCheckRawSQLBug:
+    """Reproduce the SQLAlchemy 2.x raw-SQL failure in the health check (#154)."""
+
+    @pytest.fixture
+    def async_session_factory(self):
+        """A real async session factory built like core.database's.
+
+        The engine points at an unreachable host on purpose. The bug we are
+        reproducing surfaces during SQLAlchemy's statement coercion, which
+        happens *before* any connection is attempted, so no live database is
+        required and the test stays a fast, dependency-free unit test.
+        """
+        engine = create_async_engine(
+            "postgresql+asyncpg://healthcheck:healthcheck@127.0.0.1:1/pathreview_repro",
+        )
+        return async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    @pytest.mark.asyncio
+    async def test_raw_string_execute_raises_argument_error(self, async_session_factory):
+        """`db.execute("SELECT 1")` raises ArgumentError under SQLAlchemy 2.x (#154).
+
+        Proves the failure comes purely from passing a raw string to execute(),
+        not from database connectivity — the error is raised before we connect.
+        """
+        async with async_session_factory() as session:
+            with pytest.raises(sa_exc.ArgumentError) as exc_info:
+                await session.execute("SELECT 1")
+
+        # SQLAlchemy 2.x tells us exactly how to fix it: wrap in text().
+        assert "text(" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_health_check_reports_db_unhealthy_due_to_raw_sql_string(
+        self, async_session_factory
+    ):
+        """The route swallows the ArgumentError and misreports Postgres (#154).
+
+        Confirms the bug's user-visible impact: even though the ArgumentError is
+        an API misuse (not a real connectivity problem), the surrounding
+        try/except catches it and marks Postgres — and the overall service — as
+        "unhealthy", returning HTTP 503.
+        """
+        async with async_session_factory() as session:
+            with pytest.raises(HTTPException) as exc_info:
+                await health_check(db=session)
+
+        detail = exc_info.value.detail
+        assert exc_info.value.status_code == 503
+        assert detail["dependencies"]["postgres"] == "unhealthy"
+        assert detail["status"] == "unhealthy"

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -1,75 +1,75 @@
 """Tests for the /health route DB probe (api/routes/health.py).
 
-Reproduction test for issue #154:
+Regression tests for issue #154:
 https://github.com/ascherj/pathreview/issues/154
 
-The health check probes Postgres with ``await db.execute("SELECT 1")`` — a bare
-Python string. Under SQLAlchemy 2.x a raw string is no longer an executable
-object; it must be wrapped in ``sqlalchemy.text()``. Passing the raw string
-raises ``sqlalchemy.exc.ArgumentError`` during statement coercion (before any DB
-round-trip), and the route's ``try/except`` swallows it and misreports Postgres
-as "unhealthy" even when the database is up.
+Background: the health check probed Postgres with ``await db.execute("SELECT 1")``,
+passing a bare Python string. Under SQLAlchemy 2.x a raw string is no longer an
+executable object — it must be wrapped in ``sqlalchemy.text()`` — so the call
+raised ``sqlalchemy.exc.ArgumentError``. The route's ``try/except`` swallowed that
+error and misreported Postgres as "unhealthy" even when the database was up.
 
-These tests document today's *broken* behavior. They pass on the current code and
-will need their assertions flipped (expecting "healthy") once the fix wraps the
-query in ``text("SELECT 1")`` — see PLAN.md.
+The fix wraps the query in ``text("SELECT 1")``. These tests confirm the fix by
+asserting on the ``postgres`` dependency specifically: it now reports "healthy"
+when the probe query succeeds, and still reports "unhealthy" on a genuine DB
+error (the fix does not mask real outages).
+
+Scope note: these tests intentionally assert on ``dependencies["postgres"]`` only.
+The endpoint may still return HTTP 503 because of an unrelated, pre-existing issue
+in the redis probe (it reads ``settings.redis_host`` / ``settings.redis_port``,
+which are not defined on ``Settings``). That is out of scope for issue #154.
 """
 
-import pytest
-from sqlalchemy import exc as sa_exc
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from unittest.mock import AsyncMock
 
+import pytest
 from fastapi import HTTPException
 
 from api.routes.health import health_check
 
 
 @pytest.mark.unit
-class TestHealthCheckRawSQLBug:
-    """Reproduce the SQLAlchemy 2.x raw-SQL failure in the health check (#154)."""
-
-    @pytest.fixture
-    def async_session_factory(self):
-        """A real async session factory built like core.database's.
-
-        The engine points at an unreachable host on purpose. The bug we are
-        reproducing surfaces during SQLAlchemy's statement coercion, which
-        happens *before* any connection is attempted, so no live database is
-        required and the test stays a fast, dependency-free unit test.
-        """
-        engine = create_async_engine(
-            "postgresql+asyncpg://healthcheck:healthcheck@127.0.0.1:1/pathreview_repro",
-        )
-        return async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+class TestHealthCheckPostgresProbe:
+    """Verify the health check's Postgres probe after the #154 fix."""
 
     @pytest.mark.asyncio
-    async def test_raw_string_execute_raises_argument_error(self, async_session_factory):
-        """`db.execute("SELECT 1")` raises ArgumentError under SQLAlchemy 2.x (#154).
+    async def test_health_check_reports_postgres_healthy_when_query_succeeds(self):
+        """Confirms the #154 fix: Postgres reports "healthy" when the probe runs.
 
-        Proves the failure comes purely from passing a raw string to execute(),
-        not from database connectivity — the error is raised before we connect.
+        With the query wrapped in ``text("SELECT 1")``, ``db.execute`` succeeds and
+        the Postgres probe reports "healthy" — where the raw string previously
+        raised ``ArgumentError`` and got misreported as "unhealthy".
         """
-        async with async_session_factory() as session:
-            with pytest.raises(sa_exc.ArgumentError) as exc_info:
-                await session.execute("SELECT 1")
+        db = AsyncMock()
+        db.execute = AsyncMock()
 
-        # SQLAlchemy 2.x tells us exactly how to fix it: wrap in text().
-        assert "text(" in str(exc_info.value)
+        # The endpoint raises 503 due to the unrelated redis probe issue (see the
+        # module docstring); we assert on the postgres dependency value only.
+        with pytest.raises(HTTPException) as exc_info:
+            await health_check(db=db)
+
+        detail = exc_info.value.detail
+        assert detail["dependencies"]["postgres"] == "healthy"
+
+        # Guard against a regression to a raw SQL string: the statement passed to
+        # execute() must be a SQLAlchemy text() clause, not a plain str (#154).
+        executed_stmt = db.execute.call_args[0][0]
+        assert not isinstance(executed_stmt, str)
+        assert str(executed_stmt) == "SELECT 1"
 
     @pytest.mark.asyncio
-    async def test_health_check_reports_db_unhealthy_due_to_raw_sql_string(
-        self, async_session_factory
-    ):
-        """The route swallows the ArgumentError and misreports Postgres (#154).
+    async def test_health_check_reports_postgres_unhealthy_on_real_db_error(self):
+        """The fix must not mask genuine outages (#154).
 
-        Confirms the bug's user-visible impact: even though the ArgumentError is
-        an API misuse (not a real connectivity problem), the surrounding
-        try/except catches it and marks Postgres — and the overall service — as
-        "unhealthy", returning HTTP 503.
+        When ``db.execute`` fails with a real connectivity error (not an API
+        misuse), the probe should still report Postgres "unhealthy" and the
+        endpoint should return HTTP 503.
         """
-        async with async_session_factory() as session:
-            with pytest.raises(HTTPException) as exc_info:
-                await health_check(db=session)
+        db = AsyncMock()
+        db.execute = AsyncMock(side_effect=ConnectionError("could not connect to postgres"))
+
+        with pytest.raises(HTTPException) as exc_info:
+            await health_check(db=db)
 
         detail = exc_info.value.detail
         assert exc_info.value.status_code == 503


### PR DESCRIPTION
## Summary
The `/health` Postgres check called `db.execute("SELECT 1")` with a raw string. Under
SQLAlchemy 2.x that raises `ArgumentError`, which got swallowed and misreported Postgres
as "unhealthy" even when the DB was up. Wrapped the query in `sqlalchemy.text()` so the
probe runs and reflects real connectivity.

## Issue
Closes #154

## Changes
- `api/routes/health.py`: `await db.execute(text("SELECT 1"))` (+ import `text`)
- `tests/unit/test_health.py`: assert Postgres reports "healthy" on success (and that the
  statement is a `text()` clause, not a raw `str`), and still "unhealthy" on a real DB error

## Testing
- [x] Unit tests for this change pass (`pytest tests/unit/test_health.py` → 2 passed)
- [x] No new failures vs. baseline in `make test-unit` / ruff / mypy (see Notes)
- [ ] Live-DB smoke test — pending (Docker won't run in my env)

## Notes for Reviewers
Baseline was captured before any change (this repo is not green at HEAD): `make test-unit`
is `53 failed / 377 passed` both before and after, identical failing set, **0 new**; all 53
are pre-existing and unrelated to `/health`. `black`/`ruff`/`mypy` on the two changed files add
nothing new.