### PR TITLE
Fix: Skill extractor fails to detect JavaScript and TypeScript (#148)

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,16 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/148
+
+**Issue title:** Skill extractor fails to detect JavaScript and TypeScript
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The `extract_skills()` function in `ingestion/parsers/skill_extractor.py` fails to correctly identify JavaScript and TypeScript in submitted text. JavaScript-related content returns no detections at all, while TypeScript content (even when explicitly mentioning `.ts`/`.tsx` files and the word "TypeScript") is only partially detected as "React," missing the TypeScript skill itself. This suggests the language-detection patterns for the JS/TS family are missing or broken, while similar detection for Python, DevOps, and database skills works correctly. A successful fix would update the detection logic so JavaScript and TypeScript are properly recognized, with the related failing unit tests passing.
+
+**Branch name:** fix/148-js-ts-skill-detection
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -14,3 +14,24 @@ The `extract_skills()` function in `ingestion/parsers/skill_extractor.py` fails 
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [will fill in after pushing]
+
+**Reproduction summary:**
+Ran `pytest tests/unit/test_skill_extractor.py -k "test_javascript_detection or test_text_with_typescript_files" -v` locally and confirmed both tests fail. `test_javascript_detection` fails because `require('fs')` has no space after `require`, so the detection regex `\b(import|require)\s+` never matches. `test_text_with_typescript_files` fails because TypeScript syntax (`export interface`, `export class`, `Promise<User>`) isn't recognized by any TS-specific pattern, and no false-positive React match occurs in this case since the text doesn't mention `.tsx`/`.jsx`.
+
+Test output:
+```
+FAILED tests/unit/test_skill_extractor.py::TestSkillExtractor::test_text_with_typescript_files - assert False
+FAILED tests/unit/test_skill_extractor.py::TestSkillExtractor::test_javascript_detection - assert False
+2 failed, 16 deselected in 2.05s
+```
+
+**PLAN.md link:** [will fill in after pushing]
+
+**Walkthrough video (recommended):** [optional]
+
+**Blockers or open questions:**
+Still need to confirm whether `test_devops_tool_detection` and `test_docker_compose_detection` failures (mentioned in the original issue) share the same root cause or are separate — haven't reproduced those yet.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -17,7 +17,7 @@ The `extract_skills()` function in `ingestion/parsers/skill_extractor.py` fails 
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [will fill in after pushing]
+**Reproduction commit link:** [will fill in after pushing]https://github.com/shresthapresto/pathreview/commit/2042e21b48e27b48894df564fee54d919ac6d397
 
 **Reproduction summary:**
 Ran `pytest tests/unit/test_skill_extractor.py -k "test_javascript_detection or test_text_with_typescript_files" -v` locally and confirmed both tests fail. `test_javascript_detection` fails because `require('fs')` has no space after `require`, so the detection regex `\b(import|require)\s+` never matches. `test_text_with_typescript_files` fails because TypeScript syntax (`export interface`, `export class`, `Promise<User>`) isn't recognized by any TS-specific pattern, and no false-positive React match occurs in this case since the text doesn't mention `.tsx`/`.jsx`.
@@ -29,7 +29,7 @@ FAILED tests/unit/test_skill_extractor.py::TestSkillExtractor::test_javascript_d
 2 failed, 16 deselected in 2.05s
 ```
 
-**PLAN.md link:** [will fill in after pushing]
+**PLAN.md link:** [\[will fill in after pushing\]](https://github.com/shresthapresto/pathreview/commit/2042e21b48e27b48894df564fee54d919ac6d397#diff-1d972b4ac04c89bf54f79f2111064626b16aeb8bb9488f4ca0aed3ab1e728d2c)
 
 **Walkthrough video (recommended):** [optional]
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -17,7 +17,7 @@ The `extract_skills()` function in `ingestion/parsers/skill_extractor.py` fails 
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [will fill in after pushing]https://github.com/shresthapresto/pathreview/commit/2042e21b48e27b48894df564fee54d919ac6d397
+**Reproduction commit link:** https://github.com/shresthapresto/pathreview/commit/2042e21b48e27b48894df564fee54d919ac6d397
 
 **Reproduction summary:**
 Ran `pytest tests/unit/test_skill_extractor.py -k "test_javascript_detection or test_text_with_typescript_files" -v` locally and confirmed both tests fail. `test_javascript_detection` fails because `require('fs')` has no space after `require`, so the detection regex `\b(import|require)\s+` never matches. `test_text_with_typescript_files` fails because TypeScript syntax (`export interface`, `export class`, `Promise<User>`) isn't recognized by any TS-specific pattern, and no false-positive React match occurs in this case since the text doesn't mention `.tsx`/`.jsx`.
@@ -29,9 +29,9 @@ FAILED tests/unit/test_skill_extractor.py::TestSkillExtractor::test_javascript_d
 2 failed, 16 deselected in 2.05s
 ```
 
-**PLAN.md link:** [\[will fill in after pushing\]](https://github.com/shresthapresto/pathreview/commit/2042e21b48e27b48894df564fee54d919ac6d397#diff-1d972b4ac04c89bf54f79f2111064626b16aeb8bb9488f4ca0aed3ab1e728d2c)
+**PLAN.md link:** https://github.com/shresthapresto/pathreview/blob/fix/148-js-ts-skill-detection/PLAN.md
 
-**Walkthrough video (recommended):** [optional]
+**Walkthrough video (recommended):** Not recorded
 
 **Blockers or open questions:**
 Still need to confirm whether `test_devops_tool_detection` and `test_docker_compose_detection` failures (mentioned in the original issue) share the same root cause or are separate — haven't reproduced those yet.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -78,3 +78,65 @@ also still passes, confirming no regression to existing React detection.
 **Self-review confirmation:** [x] make check passes  [x] make test-unit passes
 
 **Draft PR feedback received from:** none yet (submitting slightly late; will incorporate any feedback that comes in)
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No reviewer feedback was received. Per the course's Su26 note, reviewer feedback
+was not an active feature this term.
+
+**How you responded:**
+N/A — no feedback was received to respond to.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Getting the local environment running took far longer than the actual code fix.
+I hit a chain of issues just to get Docker Desktop working — it wasn't installed,
+then failed with a "virtualization not detected" error that turned out to require
+enabling Virtual Machine Platform in Windows and virtualization in BIOS. Then I had
+to sort out `make` not existing on Windows, install it via winget, and switch from
+PowerShell to Git Bash since many commands only worked there. By the time I could
+actually run `make setup` and `make run`, I'd spent more time on tooling than on
+understanding the bug itself. It was a good reminder that "environment setup" is a
+real skill, not a formality to skip past.
+
+**What did you learn about working in a large codebase?**
+Reproducing the issue precisely before touching any code made a huge difference —
+running the exact failing tests first showed me exactly what was expected vs. actual,
+instead of guessing. I also learned that a fix isn't just "make the failing test pass" —
+I had to check the full test suite (`make test-unit`) and lint/type checks (`make check`)
+before and after my change to prove I didn't break anything else. The codebase had 53
+pre-existing failing tests and 182 pre-existing lint errors that had nothing to do with
+my issue, and distinguishing "pre-existing and out of scope" from "caused by my change"
+was an important discipline I hadn't had to practice before.
+
+**How did AI tools help — and where did they fall short?**
+AI was most useful for diagnosing the root cause quickly — reading the regex patterns
+in the skill extractor and explaining exactly why `require('fs')` didn't match
+`\b(import|require)\s+` (no space before the parenthesis), and why `.tsx`/`.jsx` filename
+mentions were causing false-positive React detections. It also helped me write the new
+detection patterns and catch a whitespace bug in my own Dockerfile regex before I wasted
+time debugging it manually. Where it fell short: it couldn't run commands for me or see
+my actual terminal state, so a lot of back-and-forth was just me pasting error output
+and getting the next step — useful, but slower than if I'd understood the Windows/Docker/
+Git Bash toolchain better going in.
+
+**What would you do differently if you started over?**
+I'd set up and verify my full local environment (Docker, WSL2, virtualization, Git Bash,
+`make`) before browsing the issue tracker at all, instead of discovering each missing
+piece one at a time while trying to move forward. I'd also check the linked PRs on an
+issue before claiming it, to confirm it wasn't already being solved by someone else.
+
+**What are you most proud of from this module?**
+Getting a clean, root-cause fix rather than a surface patch — the JS/TS detection bug
+had a real underlying reason (an overly narrow regex and unrelated false-positive
+trigger), and I traced it down to that instead of just special-casing the failing test
+inputs. Confirming with the full test suite that I introduced zero new failures felt
+like real engineering discipline, not just "make the assignment pass."

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -54,3 +54,27 @@ as ready for review, and complete Check-in 2 by Sunday.
 
 **Blockers:**
 None currently.
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/898
+
+**Branch:** fix/148-js-ts-skill-detection
+
+**What you built:**
+Fixed JavaScript and TypeScript detection in the skill extractor by adding proper
+syntax pattern matching (beyond the previous import/require-with-whitespace check),
+separated TypeScript-specific detection from generic JavaScript detection, removed
+a false-positive React trigger caused by .tsx/.jsx filename mentions, and added
+Dockerfile/docker-compose syntax detection that doesn't require the literal word
+"docker" to appear in the text.
+
+**Tests added or updated:**
+No new test files added. Existing tests in tests/unit/test_skill_extractor.py —
+test_javascript_detection, test_text_with_typescript_files, test_devops_tool_detection,
+and test_docker_compose_detection — now pass and cover this fix. test_react_detection
+also still passes, confirming no regression to existing React detection.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+**Draft PR feedback received from:** none yet (submitting slightly late; will incorporate any feedback that comes in)

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -35,3 +35,22 @@ FAILED tests/unit/test_skill_extractor.py::TestSkillExtractor::test_javascript_d
 
 **Blockers or open questions:**
 Still need to confirm whether `test_devops_tool_detection` and `test_docker_compose_detection` failures (mentioned in the original issue) share the same root cause or are separate — haven't reproduced those yet.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the fix in `ingestion/parsers/skill_extractor.py` — added JS/TS syntax
+pattern detection, TypeScript-specific patterns, removed the .tsx/.jsx false-positive
+React trigger, and added Dockerfile/docker-compose syntax detection. All 4 target
+failing tests now pass. Ran full test suite — 49 failed/379 passed, down from the
+53/375 baseline, confirming no regressions. Ran make check and make test-unit to
+confirm a clean diff. Opened draft PR #898.
+
+**Next steps:**
+Share PR in Slack for peer/mentor feedback, address any feedback received, mark PR
+as ready for review, and complete Check-in 2 by Sunday.
+
+**Blockers:**
+None currently.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,45 @@
+## Solution plan
+
+**Issue:** Skill extractor fails to detect JavaScript and TypeScript (#148)
+https://github.com/ascherj/pathreview/issues/148
+
+### Understand
+The root cause is in `_detect_languages()` in `ingestion/parsers/skill_extractor.py`.
+JS/TS detection only checks for `.js`/`.ts` file extensions (which requires a filename
+to be passed in, often not the case) and a regex `\b(import|require)\s+` that requires
+whitespace immediately after the keyword. This fails on common patterns like
+`require('fs')` (no space before the parenthesis) and never matches TypeScript-specific
+syntax like `export interface`, `export class`, or type annotations. Separately,
+`REACT_INDICATORS` includes the literal substrings `.tsx` and `.jsx`, so any text that
+merely mentions a filename like `app.tsx` incorrectly triggers a "React" match instead
+of a TypeScript one. Expected: JS/TS code and TypeScript-specific syntax should be
+reliably detected. Actual: JS text returns no detections, and TypeScript text returns
+only a false-positive "React" match.
+
+### Map
+- `ingestion/parsers/skill_extractor.py` — `_detect_languages()` method (core fix)
+- `ingestion/parsers/skill_extractor.py` — `REACT_INDICATORS` set (remove/adjust `.tsx`/`.jsx` false-positive triggers)
+- `tests/unit/test_skill_extractor.py` — verify fix against `test_javascript_detection`, `test_text_with_typescript_files`, and confirm no regressions in `test_react_detection`, `test_devops_tool_detection`, `test_docker_compose_detection`
+
+### Plan
+1. Add JS-specific syntax regexes to `_detect_languages()` (e.g. `const`, `let`, `function`, `=>`, `console.log`, `require(` without requiring trailing whitespace)
+2. Add TypeScript-specific syntax regexes (e.g. `interface`, `: string`/`: number` type annotations, `export class`, generics like `Promise<...>`)
+3. Wire in the existing but currently unused `JS_TS_KEYWORDS` set as part of this detection (or replace it with the new regexes if a cleaner approach)
+4. Fix `REACT_INDICATORS` so `.tsx`/`.jsx` substrings don't cause TypeScript/JavaScript text to be misclassified as React — likely by removing these as standalone triggers, or only counting them when combined with other React-specific evidence
+5. Re-run the full test suite to confirm `test_javascript_detection` and `test_text_with_typescript_files` pass without breaking `test_react_detection`, `test_devops_tool_detection`, or `test_docker_compose_detection`
+
+### Inputs & outputs
+Input: a text string (source code, resume text, or docs) and an optional filename.
+Output: a list of `SkillDetection` objects, sorted by confidence, correctly including
+"JavaScript" and/or "TypeScript" entries when the text contains that language's syntax.
+
+### Risks & unknowns
+- Broadening the JS/TS regexes could introduce false positives on unrelated text (e.g. the word "class" or "function" appearing in plain English) — need to balance recall vs. precision, similar to how Python's regexes are fairly syntax-specific
+- Unclear why `test_devops_tool_detection` and `test_docker_compose_detection` are listed as failing in the issue — need to run them locally to confirm whether they're a separate unrelated bug or a side effect of the same detection logic
+- Changing `REACT_INDICATORS` could affect existing passing tests like `test_react_detection` — needs careful regression testing
+
+### Edge cases
+- Text with both JS and TS syntax mixed together (should detect both, not just one)
+- Text mentioning a `.tsx`/`.jsx` filename without any real code (should not force a React false-positive)
+- Empty text input (should return an empty list, not error)
+- Text with `require(...)` with no space vs. `require (...)` with a space (both should be detected)

--- a/ingestion/parsers/skill_extractor.py
+++ b/ingestion/parsers/skill_extractor.py
@@ -1,11 +1,11 @@
 import re
 from dataclasses import dataclass
-from typing import Optional
 
 
 @dataclass
 class SkillDetection:
     """Result of detecting a skill."""
+
     name: str
     category: str
     confidence: float
@@ -40,6 +40,39 @@ class SkillExtractor:
         "class",
     }
 
+    JS_TS_SYNTAX_PATTERNS = [
+        r"\bconst\s+\w+\s*=",
+        r"\blet\s+\w+\s*=",
+        r"\bfunction\s+\w+\s*\(",
+        r"=>",
+        r"\brequire\(",
+        r"\bexport\s+(default\s+)?(class|function|interface|const)",
+        r"console\.log\(",
+    ]
+
+    TS_SPECIFIC_PATTERNS = [
+        r"\binterface\s+\w+\s*\{",
+        r":\s*(string|number|boolean)\b",
+        r"\bexport\s+class\s+\w+",
+        r"Promise<\w+>",
+        r"<\w+>\(",
+    ]
+
+    DOCKERFILE_INDICATORS = [
+        r"^\s*FROM\s+\w+",
+        r"^\s*RUN\s+",
+        r"^\s*EXPOSE\s+\d+",
+        r"^\s*COPY\s+",
+        r"^\s*WORKDIR\s+",
+    ]
+
+    DOCKER_COMPOSE_INDICATORS = [
+        r"^\s*version:\s*['\"]?\d",
+        r"^\s*services:",
+        r"^\s*build:",
+        r"^\s*ports:",
+    ]
+
     REACT_INDICATORS = {
         "import React",
         "useState",
@@ -51,8 +84,6 @@ class SkillExtractor:
         "useRef",
         "createContext",
         "ReactDOM.render",
-        ".jsx",
-        ".tsx",
     }
 
     FRAMEWORKS = {
@@ -105,7 +136,7 @@ class SkillExtractor:
         "ansible": 0.85,
     }
 
-    def extract_skills(self, text: str, filename: Optional[str] = None) -> list[SkillDetection]:
+    def extract_skills(self, text: str, filename: str | None = None) -> list[SkillDetection]:
         """
         Extract skills from source code or documentation text.
 
@@ -116,7 +147,7 @@ class SkillExtractor:
         Returns:
             List of detected skills with confidence scores
         """
-        detected_skills = {}
+        detected_skills: dict[str, SkillDetection] = {}
 
         # Detect languages first
         self._detect_languages(text, filename, detected_skills)
@@ -143,7 +174,7 @@ class SkillExtractor:
     def _detect_languages(
         self,
         text: str,
-        filename: Optional[str],
+        filename: str | None,
         skills_dict: dict,
     ) -> None:
         """Detect programming languages."""
@@ -172,20 +203,37 @@ class SkillExtractor:
 
         # JavaScript/TypeScript detection
         js_evidence = []
+        ts_evidence = []
+
         if ".js" in str(filename or "").lower():
             js_evidence.append("JavaScript file extension (.js)")
         if ".ts" in str(filename or "").lower():
-            js_evidence.append("TypeScript file extension (.ts)")
-        if re.search(r"\b(import|require)\s+", text):
+            ts_evidence.append("TypeScript file extension (.ts)")
+        if re.search(r"\b(import|require)\s*\(", text) or re.search(r"\bimport\s+", text):
             js_evidence.append("CommonJS or ES6 imports")
         if "package.json" in text_lower:
             js_evidence.append("package.json found")
 
-        if js_evidence:
+        for pattern in self.JS_TS_SYNTAX_PATTERNS:
+            if re.search(pattern, text):
+                js_evidence.append(f"JS/TS syntax pattern: {pattern}")
+
+        for pattern in self.TS_SPECIFIC_PATTERNS:
+            if re.search(pattern, text):
+                ts_evidence.append(f"TypeScript syntax pattern: {pattern}")
+
+        if ts_evidence:
+            confidence = min(0.95, 0.6 + len(ts_evidence) * 0.1)
+            skills_dict["TypeScript"] = SkillDetection(
+                name="TypeScript",
+                category="Language",
+                confidence=confidence,
+                evidence=ts_evidence,
+            )
+        elif js_evidence:
             confidence = min(0.95, 0.6 + len(js_evidence) * 0.1)
-            lang = "TypeScript" if ".ts" in str(filename or "").lower() else "JavaScript"
-            skills_dict[lang] = SkillDetection(
-                name=lang,
+            skills_dict["JavaScript"] = SkillDetection(
+                name="JavaScript",
                 category="Language",
                 confidence=confidence,
                 evidence=js_evidence,
@@ -274,3 +322,21 @@ class SkillExtractor:
                         confidence=confidence,
                         evidence=[f"Found '{tool}' reference in content"],
                     )
+
+        # Dockerfile / docker-compose syntax detection (doesn't require the word "docker")
+        dockerfile_evidence = [
+            p for p in self.DOCKERFILE_INDICATORS if re.search(p, text, re.MULTILINE)
+        ]
+        compose_evidence = [
+            p for p in self.DOCKER_COMPOSE_INDICATORS if re.search(p, text, re.MULTILINE)
+        ]
+        if (dockerfile_evidence or compose_evidence) and "Docker" not in skills_dict:
+            evidence = [
+                f"Dockerfile/compose syntax: {p}" for p in dockerfile_evidence + compose_evidence
+            ]
+            skills_dict["Docker"] = SkillDetection(
+                name="Docker",
+                category="Tool",
+                confidence=min(0.9, 0.6 + len(evidence) * 0.1),
+                evidence=evidence,
+            )


### PR DESCRIPTION
## Summary
Fixes JavaScript and TypeScript detection in `SkillExtractor.extract_skills()`, which previously returned no results for JavaScript code and only a false-positive "React" match for TypeScript code. Also fixes Dockerfile/docker-compose syntax detection, which was failing even when the code contained clear DevOps indicators.

## Issue
Closes #148

## Changes
- Added `JS_TS_SYNTAX_PATTERNS` and `TS_SPECIFIC_PATTERNS` regex sets to detect JavaScript/TypeScript syntax beyond the previous `import|require` + whitespace check (which missed common patterns like `require('fs')` with no space, `export interface`, `export class`, and TypeScript generics like `Promise<User>`)
- Split language detection so TypeScript-specific syntax is checked separately from generic JS syntax, preventing TypeScript code from being under-detected
- Removed `.tsx` and `.jsx` substring triggers from `REACT_INDICATORS`, which were causing any text that merely mentioned a `.tsx`/`.jsx` filename to be misclassified as React
- Added `DOCKERFILE_INDICATORS` and `DOCKER_COMPOSE_INDICATORS` regex patterns to `_detect_tools()` so Dockerfile/compose syntax (e.g. `FROM`, `RUN`, `EXPOSE`, `services:`, `ports:`) is detected even when the literal word "docker" doesn't appear in the text
- Added explicit type annotation for `detected_skills` dict to satisfy mypy

## Testing
- [x] Unit tests pass (`make test-unit`) — no new failures introduced; failure count went from 53 → 49 (the 4 tests targeted by this fix now pass: `test_javascript_detection`, `test_text_with_typescript_files`, `test_devops_tool_detection`, `test_docker_compose_detection`)
- [ ] Integration tests pass (`make test-integration`) — not run, no integration tests touch this module
- [x] Linter passes (`make lint`) — `skill_extractor.py` has zero ruff errors after the fix
- [x] Type checker passes (`make typecheck`) — mypy passes on the modified file
- [x] New/updated tests cover the changes — existing tests in `tests/unit/test_skill_extractor.py` (`test_javascript_detection`, `test_text_with_typescript_files`, `test_devops_tool_detection`, `test_docker_compose_detection`) now pass and cover this fix; `test_react_detection` also still passes, confirming no regression

## Screenshots / Demo
N/A — backend logic change, no UI changes.

## Notes for Reviewers
- `test_database_technology_detection` in the same test file still fails, but this is a **pre-existing bug in the test itself** (unrelated to this fix): it references an undefined variable `skill_names` at line 138 instead of `result`. I did not fix this since it's out of scope for issue #148, but flagging it here for visibility.
- The overall codebase has 49 pre-existing test failures unrelated to this change (confirmed via baseline `make test-unit` run before starting this fix) — none of them were introduced or affected by this PR.