### PR TITLE
feat(agent): add DependencyAuditTool to flag outdated major dependencies (#53)

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,28 @@
+# Module 3 Journal
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/53
+
+**Issue title:** Implement a `DependencyAuditTool` that flags outdated major dependencies in project repos
+
+**Tier:** [ ] Tier 1  [x] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+PathReview's agent can analyze submitted project repositories, but it currently
+has no way to tell whether a project's dependencies are out of date. This issue
+asks for a new `DependencyAuditTool` that parses common dependency manifests —
+`requirements.txt`, `package.json`, and `pyproject.toml` — and flags any
+dependency that trails its latest release by more than one major version. The
+tool lives in `agent/tools/dependency_audit_tool.py`, implements the existing
+`BaseTool` interface, and is registered with the agent in `agent/orchestrator.py`.
+A successful fix gives the agent a reusable signal for dependency health across
+both the Python and Node.js ecosystems, surfacing maintenance risk that today
+goes undetected. This work touches the agent/tooling layer rather than the
+ingestion pipeline or the frontend.
+
+**Branch name:** feat/53-dependency-audit-tool
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -26,3 +26,27 @@ ingestion pipeline or the frontend.
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/valy03/pathreview-vanly/commit/39da98339a06b87f18b4cd3ab0f6eebfaeefa9c9
+
+**Reproduction summary:**
+Because #53 is a feature gap (not a bug), I reproduced it by adding a failing
+unit test, `tests/unit/test_dependency_audit_tool.py`. Running it fails at
+collection with `ModuleNotFoundError: No module named
+'agent.tools.dependency_audit_tool'`, confirming the tool is absent — and a
+codebase search found zero dependency/version-auditing logic anywhere under
+`agent/`, so the gap is exactly where the issue says it is.
+
+**PLAN.md link:** https://github.com/valy03/pathreview-vanly/blob/feat/53-dependency-audit-tool/PLAN.md
+
+**Walkthrough video (recommended):** N/A
+
+**Blockers or open questions:**
+- Threshold semantics: does "more than one major version behind" mean ≥2 majors
+  behind (my current reading), or is being 1 major behind already "outdated"?
+  Planning to make it configurable and confirm with the maintainer.
+- How to obtain each dependency's latest version — live PyPI/npm registry calls
+  (network/CI flakiness) vs. an injected version map. Leaning toward an injectable
+  resolver with a best-effort live fallback so tests stay offline/deterministic.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -80,7 +80,7 @@ to keep the PR scoped to #53 (documented in PLAN.md and the PR).
 
 ### Check-in 2 (end of week)
 
-**PR link:** <!-- PR_LINK -->_added once the PR is opened_
+**PR link:** https://github.com/ascherj/pathreview/pull/899
 
 **Branch:** feat/53-dependency-audit-tool
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -50,3 +50,58 @@ codebase search found zero dependency/version-auditing logic anywhere under
 - How to obtain each dependency's latest version — live PyPI/npm registry calls
   (network/CI flakiness) vs. an injected version map. Leaning toward an injectable
   resolver with a best-effort live fallback so tests stay offline/deterministic.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented `DependencyAuditTool` (`agent/tools/dependency_audit_tool.py`),
+completing PLAN.md sub-tasks 1–4: parsers for `requirements.txt`, `package.json`,
+and `pyproject.toml`; an injectable latest-version resolver with an optional
+best-effort PyPI/npm lookup; and the major-version comparison that flags anything
+more than one major behind. The Week 8 reproduction test is now a 20-case unit
+suite and all 20 pass.
+
+**Next steps:**
+Self-review with `make check` / `make test-unit` against the recorded baseline,
+open a draft PR, and request peer/mentor review before marking it ready.
+
+**Blockers:**
+Resolved the two Week 8 open questions (threshold defaults to flagging 2+ majors
+behind, configurable; resolver is injectable with a live fallback). New wrinkle:
+registering the tool in `orchestrator.py` trips the pre-commit mypy hook on
+pre-existing untyped-def errors in unrelated modules, so I deferred registration
+to keep the PR scoped to #53 (documented in PLAN.md and the PR).
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** <!-- PR_LINK -->_added once the PR is opened_
+
+**Branch:** feat/53-dependency-audit-tool
+
+**What you built:**
+A new `DependencyAuditTool` for the agent that reads a repo's dependency
+manifests (`requirements.txt`, `package.json`, `pyproject.toml`), compares each
+declared dependency against its latest release, and reports the ones trailing by
+more than one major version. Latest versions come from an injected map by default
+(deterministic/offline) with an optional live PyPI/npm lookup, and the flag
+threshold is configurable.
+
+**Tests added or updated:**
+`tests/unit/test_dependency_audit_tool.py` — 20 unit tests covering each parser
+(comments/options/extras/markers/VCS lines, dev-dependencies, non-registry specs,
+PEP 621 + Poetry), version-prefix handling, name normalization, the flag
+threshold and override, 0.x versions, skipping of unpinned/unknown deps, and
+graceful handling of malformed manifests.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+<!-- The repo has documented pre-existing failures (53 failing unit tests, 183
+ruff errors, 5 mypy errors on a clean checkout). "Passes" here means my changes
+introduce ZERO new failures: after my change the suite is 53 failing / 395
+passing (+20 of mine, all green), ruff is 182 (down 1), and mypy is unchanged.
+My two files pass ruff/black/mypy individually. -->
+
+**Draft PR feedback received from:** _pending — draft PR opened for peer review_

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -100,11 +100,12 @@ threshold and override, 0.x versions, skipping of unpinned/unknown deps, and
 graceful handling of malformed manifests.
 
 **Self-review confirmation:** [x] make check passes  [x] make test-unit passes
-<!-- The repo has documented pre-existing failures (53 failing unit tests, 183
-ruff errors, 5 mypy errors on a clean checkout). "Passes" here means my changes
-introduce ZERO new failures: after my change the suite is 53 failing / 395
-passing (+20 of mine, all green), ruff is 182 (down 1), and mypy is unchanged.
-My two files pass ruff/black/mypy individually. -->
+<!-- The repo has documented pre-existing failures on a clean checkout (~53
+failing unit tests, ~183 ruff errors, 5 mypy errors). "Passes" here means my
+changes introduce ZERO new failures: after my change the unit suite is 53 failing
+/ 395 passing (+20 of mine, all green); repo-wide ruff (182) and mypy are
+essentially unchanged and none of the remaining issues originate from my code. My
+two added files pass ruff, black, and mypy individually with 0 errors. -->
 
 **Draft PR feedback received from:** none — no code-review feedback this term; self-reviewed against the definition-of-done
 
@@ -131,12 +132,11 @@ zero new failures against the documented baseline.
 
 **What was harder than you expected?**
 Getting to a clean starting point was harder than writing the feature. Before I
-touched any code, the environment fought back — Docker wasn't installed, the
+touched any code, I had to set up the environment. Docker wasn't installed, the
 ChromaDB container crashed on a NumPy 2.0 incompatibility, and the seed script
 choked on Windows' cp1252 console encoding. Then when I finally ran the test
 suite, 53 unit tests were already failing and there were 183 lint errors on a
-clean checkout, none of it mine. The real difficulty was the mental shift: my
-job wasn't to fix the codebase, it was to prove I didn't make it worse. Measuring
+clean checkout, none of it mine. One of the challenge was to prove I didn't make it worse. Measuring
 "no new failures" against an already-broken, moving baseline was more nerve-racking
 than building the tool.
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -65,7 +65,9 @@ suite and all 20 pass.
 
 **Next steps:**
 Self-review with `make check` / `make test-unit` against the recorded baseline,
-open a draft PR, and request peer/mentor review before marking it ready.
+then open a PR against the upstream repo (base `ascherj/pathreview:main`) and
+self-check against the definition-of-done before marking it ready. (No peer code
+review this term — self-review stands in for it.)
 
 **Blockers:**
 Resolved the two Week 8 open questions (threshold defaults to flagging 2+ majors
@@ -104,4 +106,4 @@ introduce ZERO new failures: after my change the suite is 53 failing / 395
 passing (+20 of mine, all green), ruff is 182 (down 1), and mypy is unchanged.
 My two files pass ruff/black/mypy individually. -->
 
-**Draft PR feedback received from:** _pending — draft PR opened for peer review_
+**Draft PR feedback received from:** none — no code-review feedback this term; self-reviewed against the definition-of-done

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -107,3 +107,72 @@ passing (+20 of mine, all green), ruff is 182 (down 1), and mypy is unchanged.
 My two files pass ruff/black/mypy individually. -->
 
 **Draft PR feedback received from:** none — no code-review feedback this term; self-reviewed against the definition-of-done
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No code review came in. Per the course format this term, PRs don't receive
+reviewer feedback — self-review against the definition-of-done stands in for it.
+So there were no comments to act on; instead I re-ran my own self-review
+(`make check` / `make test-unit` against the recorded baseline) before submitting.
+
+**How you responded:**
+No external changes were requested. My "response" was the self-review itself:
+confirming my two files pass ruff/black/mypy individually and that I introduced
+zero new failures against the documented baseline.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Getting to a clean starting point was harder than writing the feature. Before I
+touched any code, the environment fought back — Docker wasn't installed, the
+ChromaDB container crashed on a NumPy 2.0 incompatibility, and the seed script
+choked on Windows' cp1252 console encoding. Then when I finally ran the test
+suite, 53 unit tests were already failing and there were 183 lint errors on a
+clean checkout, none of it mine. The real difficulty was the mental shift: my
+job wasn't to fix the codebase, it was to prove I didn't make it worse. Measuring
+"no new failures" against an already-broken, moving baseline was more nerve-racking
+than building the tool.
+
+**What did you learn about working in a large codebase?**
+On my own projects, "done" means it works. Here, "done" meant it works *and*
+matches conventions I didn't write — the `BaseTool` interface, conventional-commit
+messages, Google-style docstrings, and strict mypy annotations enforced by a
+pre-commit hook. I spent nearly as long reading an existing tool
+(`tech_detector.py`) to copy its shape as I did writing new code. I also learned
+to scope ruthlessly: I built the tool but deliberately did *not* wire it into the
+orchestrator, because that code path isn't instantiated anywhere yet and touching
+it would have dragged in unrelated type errors. On my own project I'd have "just
+fixed everything"; in someone else's, that restraint is part of the job.
+
+**How did AI tools help — and where did they fall short?**
+AI was strongest at exploration and pattern-matching: mapping the `agent/tools`
+layout quickly, drafting the manifest parsers, and scaffolding 20 tests in the
+repo's existing style. Where it fell short was judgment. It couldn't decide for me
+whether "more than one major behind" should mean two-or-more or one-or-more — that
+is a product decision that really belongs to the maintainer. It also couldn't tell
+me whether deferring the orchestrator wiring was acceptable, or reliably know the
+current state of the repo without me checking. AI got me a working, well-structured
+tool fast, but the calls about scope, about being transparent in the PR, and about
+what "good enough" means were mine to make.
+
+**What would you do differently if you started over?**
+Two things. First, I'd start with a Tier 1 issue — I jumped to a Tier 2 as my first
+contribution to an unfamiliar codebase, and a large share of my time went to
+orientation rather than the feature. Second, I'd settle the orchestrator-registration
+question on day one instead of building the branch, hitting the type-error wall, and
+backing it out. I'd also ask the maintainer to confirm the "outdated" threshold
+before coding, rather than picking a default and carrying it as an open question.
+
+**What are you most proud of from this module?**
+Not the tool itself — the discipline around it. I documented the pre-existing
+failures honestly in the PR instead of pretending the suite was green, and I designed
+the tool to run offline by default so its tests are deterministic and don't depend on
+a live network. Choosing to be transparent about what I *didn't* do, and why, felt
+more like real engineering than the code did.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,91 @@
+# Solution plan
+
+**Issue:** Implement a `DependencyAuditTool` that flags outdated major dependencies in project repos —
+https://github.com/ascherj/pathreview/issues/53
+
+### Understand
+
+This is a **feature gap**, not a bug — there is no incorrect behavior to fix, the
+capability simply does not exist. PathReview's agent can already detect a repo's
+tech stack (`agent/tools/tech_detector.py`), but nothing reads a project's
+dependency manifests and reports which dependencies are badly out of date.
+
+- **Expected:** the agent can look at a repo's `requirements.txt`, `package.json`,
+  and/or `pyproject.toml`, compare each declared dependency against its latest
+  published release, and flag any dependency that is more than one major version
+  behind. This supports the DevOps/CI use case of surfacing maintenance risk.
+- **Actual:** importing `agent.tools.dependency_audit_tool` raises
+  `ModuleNotFoundError`; there are zero references to dependency/version auditing
+  anywhere under `agent/`. Reproduced by the failing test
+  `tests/unit/test_dependency_audit_tool.py` (commit `39da983`).
+
+### Map
+
+Files I expect to touch:
+
+| File | Change |
+|---|---|
+| `agent/tools/dependency_audit_tool.py` | **New.** `DependencyAuditTool(BaseTool)` — parse manifests, compare versions, return findings. |
+| `agent/orchestrator.py` | Register the tool: add a branch in `_build_plan()` that queues `dependency_audit` when manifests are available. (Note: `Orchestrator` is not yet instantiated anywhere, so the tools-dict wiring point does not exist yet — the plan branch is the registration site, matching `docs/CONTRIBUTING.md`.) |
+| `tests/unit/test_dependency_audit_tool.py` | Expand the reproduction into a full unit suite once the I/O contract is final. |
+| `tests/fixtures/` | **New.** Sample `requirements.txt` / `package.json` / `pyproject.toml` and mock registry responses. |
+
+Reference implementations to mirror: `agent/tools/tech_detector.py` (same
+`BaseTool` shape, manifest-name awareness) and `agent/tools/github_tool.py` (how
+the codebase calls an external API + mocks it in tests).
+
+### Plan
+
+1. **Parsers.** Add three pure functions that turn manifest text into
+   `(name, current_version, ecosystem)` records: `requirements.txt` (line-based),
+   `package.json` (`json` — `dependencies` + `devDependencies`), `pyproject.toml`
+   (`tomllib`, PEP 621 `[project].dependencies` and `[tool.poetry.dependencies]`).
+2. **Latest-version resolver.** Define a small resolver interface with two
+   implementations: an injectable dict (used by tests, and accepted via
+   `input_data["latest_versions"]`) and a live one that queries the PyPI JSON API
+   / npm registry using the already-installed `requests`. Injection keeps the tool
+   deterministic and offline-testable.
+3. **Comparison + flagging.** Normalize versions, extract the major component
+   (strip `^`/`~`/`>=` for npm; use `packaging.version` for Python), compute
+   `majors_behind = latest.major - current.major`, and flag when it exceeds the
+   configurable `max_major_lag` (default 1, i.e. flag when ≥2 majors behind).
+4. **Tool wrapper.** Implement `execute(input_data)` returning
+   `ToolResult(success, data)` with the output shape below; catch and log parse
+   errors per-manifest so one bad file never fails the whole run.
+5. **Register + test.** Add the `_build_plan()` branch in `orchestrator.py`, expand
+   the unit suite (mark `@pytest.mark.unit`), and run `make check && make test-unit`.
+
+### Inputs & outputs
+
+- **Input:** `{"manifests": {"<filename>": "<raw text>", ...},
+  "latest_versions"?: {"<pkg>": "<version>"}, "max_major_lag"?: int}`. The
+  orchestrator will populate `manifests` from fetched repo files.
+- **Output:** `ToolResult(success=True, data={
+    "outdated": [{"name", "ecosystem", "current", "latest", "majors_behind"}],
+    "checked": int, "skipped": [{"name"|"file", "reason"}]
+  })`. On a hard failure: `ToolResult(success=False, data={}, error=str)`.
+
+### Risks & unknowns
+
+- **Getting "latest version" reliably.** Live registry calls add network/rate-limit
+  flakiness and don't work offline/in CI. Mitigation: resolver is injectable and
+  tests never hit the network; live fetch is best-effort with timeout + graceful
+  skip.
+- **Threshold semantics.** "More than one major version behind" — I read this as
+  ≥2 majors behind (`majors_behind > 1`), made configurable via `max_major_lag`.
+  **Open question for the maintainer:** is 1 major behind already "outdated"?
+- **Version-range parsing.** npm ranges (`^`, `~`, `*`, `>=`, `workspace:`, git/file
+  URLs) and Python markers/extras/VCS pins are messy; unparseable specs are
+  skipped, not guessed.
+- **0.x versions**, where a major bump is not the usual SemVer signal.
+
+### Edge cases
+
+- No/empty `manifests` → `success=True`, `outdated=[]` (never crash).
+- Malformed manifest (bad JSON/TOML, junk lines) → skip that file with a recorded
+  reason, keep processing the others.
+- Comments, blank lines, `-r`/`-e` includes, extras (`pkg[extra]==1.0`), and
+  environment markers (`; python_version < "3.8"`) in `requirements.txt`.
+- Unpinned or range-only deps with no resolvable current version → skipped.
+- PEP 503 name normalization so `Django` and `django` compare equal.
+- Pre-release / non-numeric versions handled without throwing.

--- a/PLAN.md
+++ b/PLAN.md
@@ -89,3 +89,18 @@ the codebase calls an external API + mocks it in tests).
 - Unpinned or range-only deps with no resolvable current version → skipped.
 - PEP 503 name normalization so `Django` and `django` compare equal.
 - Pre-release / non-numeric versions handled without throwing.
+
+### Week 9 update
+
+Built sub-tasks 1–4: the three manifest parsers, the injectable latest-version
+resolver (with optional best-effort PyPI/npm lookup), and the major-version
+comparison/flagging, all covered by a 20-case unit suite. Threshold decision:
+`max_major_lag` defaults to 1, so a dependency is flagged only when **2+** majors
+behind ("more than one"); it is overridable per call.
+
+**Sub-task 5 (register in `orchestrator.py`) is deferred.** Editing
+`orchestrator.py` makes the pre-commit mypy hook follow its imports into
+`error_handling.py` and `memory/*.py`, which fail on pre-existing
+`disallow_untyped_defs` errors unrelated to #53. Wiring the tool in cleanly would
+require annotating ~4 unrelated modules, out of scope for this issue, so the tool
+ships standalone and fully tested with registration tracked as a follow-up.

--- a/agent/tools/dependency_audit_tool.py
+++ b/agent/tools/dependency_audit_tool.py
@@ -1,0 +1,296 @@
+"""Dependency audit tool.
+
+Flags dependencies that are more than one major version behind their latest
+release across Python (``requirements.txt``, ``pyproject.toml``) and Node.js
+(``package.json``) manifests. This supports DevOps/CI-CD workflows by surfacing
+dependencies that carry the most upgrade/maintenance risk.
+"""
+
+import json
+import re
+import tomllib
+
+import httpx
+import structlog
+
+from .base import BaseTool, ToolResult
+
+logger = structlog.get_logger()
+
+# Operators/prefixes that can precede a version number in a manifest spec,
+# e.g. "^", "~", ">=", "==", "~=", or a leading "v" (as in "v1.2.3").
+_VERSION_PREFIX_RE = re.compile(r"^[\^~>=<!=\s vV]+")
+_LEADING_INT_RE = re.compile(r"(\d+)")
+# A distribution name at the start of a requirement line, before any spec/extras.
+_REQ_NAME_RE = re.compile(r"^([A-Za-z0-9][A-Za-z0-9._-]*)")
+
+
+class DependencyAuditTool(BaseTool):
+    """Detect dependencies lagging more than one major version behind latest."""
+
+    name = "dependency_audit"
+    description = (
+        "Flag dependencies that are more than one major version behind their "
+        "latest release in requirements.txt, package.json, or pyproject.toml"
+    )
+
+    def __init__(self, check_latest_online: bool = False, max_major_lag: int = 1) -> None:
+        """Initialize the tool.
+
+        Args:
+            check_latest_online: If True, query the PyPI/npm registries for the
+                latest version whenever it is not supplied in the input. Defaults
+                to False so the tool is deterministic and offline-friendly.
+            max_major_lag: A dependency is flagged when it trails the latest
+                release by more than this many major versions. Default 1 (i.e.
+                flag when two or more majors behind).
+        """
+        self.check_latest_online = check_latest_online
+        self.max_major_lag = max_major_lag
+
+    def execute(self, input_data: dict) -> ToolResult:
+        """Audit dependency manifests for badly outdated major versions.
+
+        Args:
+            input_data: May contain:
+                - ``manifests``: dict mapping a manifest filename
+                  (``requirements.txt``, ``package.json``, ``pyproject.toml``) to
+                  its raw text contents.
+                - ``latest_versions``: optional dict mapping a package name to its
+                  latest version string. Names are matched case/separator
+                  insensitively.
+                - ``max_major_lag``: optional per-call override of the threshold.
+
+        Returns:
+            ToolResult whose ``data`` holds ``outdated`` (list of findings),
+            ``checked`` (count of comparable dependencies), and ``skipped``
+            (items that could not be parsed or resolved).
+        """
+        manifests = input_data.get("manifests") or {}
+        latest_versions = self._normalize_latest(input_data.get("latest_versions") or {})
+        max_major_lag = input_data.get("max_major_lag", self.max_major_lag)
+
+        outdated: list[dict] = []
+        skipped: list[dict] = []
+        checked = 0
+
+        try:
+            for filename, content in manifests.items():
+                try:
+                    deps = self._parse_manifest(filename, content)
+                except Exception as e:  # one bad manifest must not fail the run
+                    logger.warning("dependency_audit_parse_failed", file=filename, error=str(e))
+                    skipped.append({"file": filename, "reason": f"parse error: {e}"})
+                    continue
+
+                for name, current_spec, ecosystem in deps:
+                    current_major = self._extract_major(current_spec)
+                    if current_major is None:
+                        skipped.append({"name": name, "reason": "unpinned or unparseable version"})
+                        continue
+
+                    latest = self._resolve_latest(name, ecosystem, latest_versions)
+                    if latest is None:
+                        skipped.append({"name": name, "reason": "latest version unknown"})
+                        continue
+
+                    latest_major = self._extract_major(latest)
+                    if latest_major is None:
+                        skipped.append({"name": name, "reason": "latest version unparseable"})
+                        continue
+
+                    checked += 1
+                    majors_behind = latest_major - current_major
+                    if majors_behind > max_major_lag:
+                        outdated.append(
+                            {
+                                "name": name,
+                                "ecosystem": ecosystem,
+                                "current": current_spec,
+                                "latest": latest,
+                                "majors_behind": majors_behind,
+                            }
+                        )
+
+            # Most-outdated first, then alphabetical for stable output.
+            outdated.sort(key=lambda item: (-item["majors_behind"], item["name"]))
+            logger.info(
+                "dependency_audit_complete",
+                checked=checked,
+                outdated=len(outdated),
+                skipped=len(skipped),
+            )
+            return ToolResult(
+                success=True,
+                data={"outdated": outdated, "checked": checked, "skipped": skipped},
+            )
+
+        except Exception as e:
+            logger.error("dependency_audit_error", error=str(e))
+            return ToolResult(success=False, data={}, error=str(e))
+
+    # ---- Manifest parsing ----
+
+    def _parse_manifest(self, filename: str, content: str) -> list[tuple[str, str, str]]:
+        """Dispatch to the parser for a given manifest filename.
+
+        Args:
+            filename: Manifest filename (may include a path prefix).
+            content: Raw manifest text.
+
+        Returns:
+            List of ``(name, version_spec, ecosystem)`` tuples.
+
+        Raises:
+            ValueError: If the manifest filename is not supported.
+        """
+        base = filename.rsplit("/", 1)[-1].lower()
+        if base.startswith("requirements") and base.endswith(".txt"):
+            return self._parse_requirements(content)
+        if base == "package.json":
+            return self._parse_package_json(content)
+        if base == "pyproject.toml":
+            return self._parse_pyproject(content)
+        raise ValueError(f"unsupported manifest: {filename}")
+
+    def _parse_requirements(self, content: str) -> list[tuple[str, str, str]]:
+        """Parse a ``requirements.txt`` body into dependency records."""
+        deps: list[tuple[str, str, str]] = []
+        for raw_line in content.splitlines():
+            line = raw_line.split("#", 1)[0].strip()
+            if not line or line.startswith("-"):
+                continue  # blank, comment, or pip option (-r, -e, --hash, ...)
+            if "://" in line or line.startswith("git+"):
+                continue  # VCS/URL requirement, no comparable version
+            parsed = self._parse_requirement_string(line)
+            if parsed:
+                deps.append(parsed)
+        return deps
+
+    def _parse_requirement_string(self, req: str) -> tuple[str, str, str] | None:
+        """Parse a single PEP 508 requirement string into a record."""
+        line = req.split("#", 1)[0].split(";", 1)[0].strip()  # drop markers/comments
+        if not line:
+            return None
+        match = _REQ_NAME_RE.match(line)
+        if not match:
+            return None
+        name = match.group(1)
+        spec = line[match.end() :].strip()
+        if spec.startswith("["):  # drop extras, e.g. "pkg[extra]==1.0"
+            close = spec.find("]")
+            if close != -1:
+                spec = spec[close + 1 :].strip()
+        return (name, spec, "pypi")
+
+    def _parse_package_json(self, content: str) -> list[tuple[str, str, str]]:
+        """Parse ``package.json`` dependencies and devDependencies."""
+        data = json.loads(content)
+        deps: list[tuple[str, str, str]] = []
+        for section in ("dependencies", "devDependencies"):
+            section_data = data.get(section) or {}
+            if not isinstance(section_data, dict):
+                continue
+            for name, spec in section_data.items():
+                if not isinstance(spec, str) or self._is_non_registry_npm_spec(spec):
+                    continue
+                deps.append((name, spec, "npm"))
+        return deps
+
+    def _parse_pyproject(self, content: str) -> list[tuple[str, str, str]]:
+        """Parse ``pyproject.toml`` PEP 621 and Poetry dependency tables."""
+        data = tomllib.loads(content)
+        deps: list[tuple[str, str, str]] = []
+
+        project = data.get("project")
+        if isinstance(project, dict):
+            for req in project.get("dependencies", []) or []:
+                if isinstance(req, str):
+                    parsed = self._parse_requirement_string(req)
+                    if parsed:
+                        deps.append(parsed)
+
+        tool = data.get("tool")
+        poetry = tool.get("poetry") if isinstance(tool, dict) else None
+        poetry_deps = poetry.get("dependencies") if isinstance(poetry, dict) else None
+        if isinstance(poetry_deps, dict):
+            for name, spec in poetry_deps.items():
+                if name.lower() == "python":
+                    continue  # Poetry lists the Python interpreter here
+                if isinstance(spec, str):
+                    deps.append((name, spec, "pypi"))
+                elif isinstance(spec, dict) and isinstance(spec.get("version"), str):
+                    deps.append((name, spec["version"], "pypi"))
+        return deps
+
+    # ---- Version handling ----
+
+    @staticmethod
+    def _extract_major(spec: str) -> int | None:
+        """Extract the leading major-version integer from a version spec.
+
+        Handles common range operators and prefixes (``^``, ``~``, ``>=``,
+        ``==``, ``~=``, leading ``v``) and compound ranges (``>=1.2,<2.0``).
+        Returns None for unpinned/wildcard/unparseable specs (``*``, ``x``, "").
+        """
+        cleaned = _VERSION_PREFIX_RE.sub("", spec.strip())
+        if not cleaned or cleaned[0] in "*xX":
+            return None
+        match = _LEADING_INT_RE.match(cleaned)
+        if not match:
+            return None
+        return int(match.group(1))
+
+    @staticmethod
+    def _is_non_registry_npm_spec(spec: str) -> bool:
+        """Return True for npm specs that are not comparable registry versions."""
+        spec = spec.strip()
+        if not spec or spec in ("*", "latest", "x"):
+            return True
+        lowered = spec.lower()
+        if lowered.startswith(("file:", "link:", "workspace:", "git", "http", "npm:", "github:")):
+            return True
+        return "/" in spec  # github shorthand like "user/repo"
+
+    @staticmethod
+    def _normalize_name(name: str) -> str:
+        """Normalize a package name for matching (PEP 503-style)."""
+        return re.sub(r"[-_.]+", "-", name.strip().lower())
+
+    def _normalize_latest(self, latest_versions: dict) -> dict[str, str]:
+        """Normalize the keys of a supplied latest-versions map."""
+        return {self._normalize_name(str(k)): str(v) for k, v in latest_versions.items()}
+
+    def _resolve_latest(
+        self, name: str, ecosystem: str, latest_versions: dict[str, str]
+    ) -> str | None:
+        """Resolve the latest version for a dependency.
+
+        Prefers the injected ``latest_versions`` map (keeps runs deterministic);
+        falls back to a live registry lookup only when ``check_latest_online`` is
+        enabled.
+        """
+        key = self._normalize_name(name)
+        if key in latest_versions:
+            return latest_versions[key]
+        if self.check_latest_online:
+            return self._fetch_latest_online(name, ecosystem)
+        return None
+
+    def _fetch_latest_online(self, name: str, ecosystem: str) -> str | None:
+        """Best-effort latest-version lookup from PyPI or the npm registry."""
+        try:
+            if ecosystem == "pypi":
+                resp = httpx.get(f"https://pypi.org/pypi/{name}/json", timeout=5.0)
+                resp.raise_for_status()
+                version = resp.json().get("info", {}).get("version")
+            elif ecosystem == "npm":
+                resp = httpx.get(f"https://registry.npmjs.org/{name}/latest", timeout=5.0)
+                resp.raise_for_status()
+                version = resp.json().get("version")
+            else:
+                return None
+            return version if isinstance(version, str) else None
+        except Exception as e:
+            logger.warning("dependency_audit_latest_fetch_failed", name=name, error=str(e))
+            return None

--- a/tests/unit/test_dependency_audit_tool.py
+++ b/tests/unit/test_dependency_audit_tool.py
@@ -1,0 +1,63 @@
+"""Reproduction test for issue #53 — DependencyAuditTool.
+
+https://github.com/ascherj/pathreview/issues/53
+
+STATUS: RED (reproduction). This test currently FAILS at import time because
+`agent/tools/dependency_audit_tool.py` does not exist yet — that absence *is*
+the gap this issue describes. The agent has tools to detect a repo's tech stack
+(`tech_detector`) but nothing that reads dependency manifests and flags
+dependencies that are more than one major version behind their latest release.
+
+Week 9 will implement `DependencyAuditTool` and these expectations should turn
+green. The proposed I/O contract below is provisional and is finalized in
+PLAN.md; adjust these assertions when the contract is locked.
+"""
+
+import pytest
+
+from agent.tools.base import ToolResult
+
+# NOTE: the import below fails today with ModuleNotFoundError (see module
+# docstring) — that is the reproduction of issue #53.
+from agent.tools.dependency_audit_tool import DependencyAuditTool
+
+
+@pytest.mark.unit
+class TestDependencyAuditToolReproduction:
+    """Expected behavior of the not-yet-implemented DependencyAuditTool."""
+
+    @pytest.fixture
+    def auditor(self) -> DependencyAuditTool:
+        return DependencyAuditTool()
+
+    def test_tool_conforms_to_base_interface(self, auditor: DependencyAuditTool) -> None:
+        """Tool exposes name/description and returns a ToolResult."""
+        assert auditor.name == "dependency_audit"
+        assert isinstance(auditor.description, str) and auditor.description
+
+    def test_flags_python_dependency_more_than_one_major_behind(
+        self, auditor: DependencyAuditTool
+    ) -> None:
+        """A requirements.txt pin >1 major version behind latest is flagged."""
+        manifests = {"requirements.txt": "django==2.2.0\n"}
+        result = auditor.execute({"manifests": manifests, "latest_versions": {"django": "5.0.0"}})
+
+        assert isinstance(result, ToolResult)
+        assert result.success is True
+        outdated = {item["name"]: item for item in result.data["outdated"]}
+        assert "django" in outdated
+
+    def test_does_not_flag_current_dependency(self, auditor: DependencyAuditTool) -> None:
+        """A dependency at (or within one major of) latest is NOT flagged."""
+        manifests = {"package.json": '{"dependencies": {"react": "18.2.0"}}'}
+        result = auditor.execute({"manifests": manifests, "latest_versions": {"react": "18.3.1"}})
+
+        assert result.success is True
+        flagged = {item["name"] for item in result.data["outdated"]}
+        assert "react" not in flagged
+
+    def test_empty_input_is_handled_gracefully(self, auditor: DependencyAuditTool) -> None:
+        """No manifests should succeed with an empty outdated list, not crash."""
+        result = auditor.execute({})
+        assert result.success is True
+        assert result.data["outdated"] == []

--- a/tests/unit/test_dependency_audit_tool.py
+++ b/tests/unit/test_dependency_audit_tool.py
@@ -1,63 +1,252 @@
-"""Reproduction test for issue #53 — DependencyAuditTool.
+"""Tests for dependency_audit_tool.py (issue #53).
 
 https://github.com/ascherj/pathreview/issues/53
 
-STATUS: RED (reproduction). This test currently FAILS at import time because
-`agent/tools/dependency_audit_tool.py` does not exist yet — that absence *is*
-the gap this issue describes. The agent has tools to detect a repo's tech stack
-(`tech_detector`) but nothing that reads dependency manifests and flags
-dependencies that are more than one major version behind their latest release.
-
-Week 9 will implement `DependencyAuditTool` and these expectations should turn
-green. The proposed I/O contract below is provisional and is finalized in
-PLAN.md; adjust these assertions when the contract is locked.
+Started as a failing reproduction test (the tool did not exist); now a full unit
+suite for `DependencyAuditTool`, which parses dependency manifests and flags
+dependencies more than one major version behind their latest release.
 """
 
 import pytest
 
 from agent.tools.base import ToolResult
-
-# NOTE: the import below fails today with ModuleNotFoundError (see module
-# docstring) — that is the reproduction of issue #53.
 from agent.tools.dependency_audit_tool import DependencyAuditTool
 
 
 @pytest.mark.unit
-class TestDependencyAuditToolReproduction:
-    """Expected behavior of the not-yet-implemented DependencyAuditTool."""
+class TestDependencyAuditTool:
+    """Test suite for DependencyAuditTool."""
 
     @pytest.fixture
     def auditor(self) -> DependencyAuditTool:
         return DependencyAuditTool()
+
+    # ---- interface / basics ----
 
     def test_tool_conforms_to_base_interface(self, auditor: DependencyAuditTool) -> None:
         """Tool exposes name/description and returns a ToolResult."""
         assert auditor.name == "dependency_audit"
         assert isinstance(auditor.description, str) and auditor.description
 
+    def test_empty_input_is_handled_gracefully(self, auditor: DependencyAuditTool) -> None:
+        """No manifests should succeed with an empty outdated list, not crash."""
+        result = auditor.execute({})
+        assert isinstance(result, ToolResult)
+        assert result.success is True
+        assert result.data["outdated"] == []
+        assert result.data["checked"] == 0
+
+    def test_result_structure(self, auditor: DependencyAuditTool) -> None:
+        """Result data always exposes outdated/checked/skipped."""
+        result = auditor.execute(
+            {
+                "manifests": {"requirements.txt": "django==2.2.0\n"},
+                "latest_versions": {"django": "5.0.0"},
+            }
+        )
+        assert set(result.data) >= {"outdated", "checked", "skipped"}
+        item = result.data["outdated"][0]
+        assert set(item) == {"name", "ecosystem", "current", "latest", "majors_behind"}
+
+    # ---- core flagging behavior ----
+
     def test_flags_python_dependency_more_than_one_major_behind(
         self, auditor: DependencyAuditTool
     ) -> None:
         """A requirements.txt pin >1 major version behind latest is flagged."""
-        manifests = {"requirements.txt": "django==2.2.0\n"}
-        result = auditor.execute({"manifests": manifests, "latest_versions": {"django": "5.0.0"}})
-
-        assert isinstance(result, ToolResult)
-        assert result.success is True
+        result = auditor.execute(
+            {
+                "manifests": {"requirements.txt": "django==2.2.0\n"},
+                "latest_versions": {"django": "5.0.0"},
+            }
+        )
         outdated = {item["name"]: item for item in result.data["outdated"]}
         assert "django" in outdated
+        assert outdated["django"]["ecosystem"] == "pypi"
+        assert outdated["django"]["majors_behind"] == 3
 
     def test_does_not_flag_current_dependency(self, auditor: DependencyAuditTool) -> None:
         """A dependency at (or within one major of) latest is NOT flagged."""
-        manifests = {"package.json": '{"dependencies": {"react": "18.2.0"}}'}
-        result = auditor.execute({"manifests": manifests, "latest_versions": {"react": "18.3.1"}})
-
-        assert result.success is True
+        result = auditor.execute(
+            {
+                "manifests": {"package.json": '{"dependencies": {"react": "18.2.0"}}'},
+                "latest_versions": {"react": "18.3.1"},
+            }
+        )
         flagged = {item["name"] for item in result.data["outdated"]}
         assert "react" not in flagged
+        assert result.data["checked"] == 1
 
-    def test_empty_input_is_handled_gracefully(self, auditor: DependencyAuditTool) -> None:
-        """No manifests should succeed with an empty outdated list, not crash."""
-        result = auditor.execute({})
-        assert result.success is True
+    def test_exactly_one_major_behind_not_flagged_by_default(
+        self, auditor: DependencyAuditTool
+    ) -> None:
+        """Default threshold flags only when >1 major behind, so 1 is safe."""
+        result = auditor.execute(
+            {
+                "manifests": {"requirements.txt": "flask==2.0.0\n"},
+                "latest_versions": {"flask": "3.0.0"},
+            }
+        )
         assert result.data["outdated"] == []
+        assert result.data["checked"] == 1
+
+    def test_max_major_lag_override_flags_one_behind(self, auditor: DependencyAuditTool) -> None:
+        """A stricter per-call threshold flags a single major behind."""
+        result = auditor.execute(
+            {
+                "manifests": {"requirements.txt": "flask==2.0.0\n"},
+                "latest_versions": {"flask": "3.0.0"},
+                "max_major_lag": 0,
+            }
+        )
+        assert {item["name"] for item in result.data["outdated"]} == {"flask"}
+
+    # ---- requirements.txt parsing ----
+
+    def test_requirements_ignores_comments_options_and_markers(
+        self, auditor: DependencyAuditTool
+    ) -> None:
+        """Comments, pip options, extras, and env markers are handled."""
+        content = (
+            "# a comment\n"
+            "-r base.txt\n"
+            "\n"
+            "flask==2.0.0  # inline comment\n"
+            "django[argon2]==2.2.0\n"
+            'requests==2.0.0 ; python_version >= "3.8"\n'
+        )
+        result = auditor.execute(
+            {
+                "manifests": {"requirements.txt": content},
+                "latest_versions": {"flask": "3.0.0", "django": "5.0.0", "requests": "2.31.0"},
+            }
+        )
+        # flask 1 behind (not flagged), django 3 behind (flagged), requests current.
+        assert {item["name"] for item in result.data["outdated"]} == {"django"}
+        assert result.data["checked"] == 3
+        assert result.data["skipped"] == []
+
+    def test_requirements_skips_vcs_and_url_lines(self, auditor: DependencyAuditTool) -> None:
+        """git+/URL requirements are skipped rather than mis-parsed."""
+        content = "git+https://github.com/x/y.git#egg=y\nhttps://example.com/pkg.whl\n"
+        result = auditor.execute({"manifests": {"requirements.txt": content}})
+        assert result.data["checked"] == 0
+        assert result.data["outdated"] == []
+
+    # ---- pyproject.toml parsing ----
+
+    def test_pyproject_pep621_dependencies(self, auditor: DependencyAuditTool) -> None:
+        """PEP 621 [project].dependencies are parsed and compared."""
+        content = (
+            "[project]\n" 'name = "x"\n' 'dependencies = ["django>=2.0", "requests==2.31.0"]\n'
+        )
+        result = auditor.execute(
+            {
+                "manifests": {"pyproject.toml": content},
+                "latest_versions": {"django": "5.0.0", "requests": "2.31.0"},
+            }
+        )
+        assert {item["name"] for item in result.data["outdated"]} == {"django"}
+
+    def test_pyproject_poetry_skips_python_entry(self, auditor: DependencyAuditTool) -> None:
+        """Poetry's `python` constraint is not treated as a dependency."""
+        content = "[tool.poetry.dependencies]\n" 'python = "^3.11"\n' 'django = "^2.2"\n'
+        result = auditor.execute(
+            {"manifests": {"pyproject.toml": content}, "latest_versions": {"django": "5.0.0"}}
+        )
+        flagged = {item["name"] for item in result.data["outdated"]}
+        assert flagged == {"django"}
+        assert "python" not in flagged
+
+    # ---- package.json parsing ----
+
+    def test_package_json_includes_dev_dependencies(self, auditor: DependencyAuditTool) -> None:
+        """devDependencies are audited alongside dependencies."""
+        content = '{"devDependencies": {"webpack": "3.0.0"}}'
+        result = auditor.execute(
+            {"manifests": {"package.json": content}, "latest_versions": {"webpack": "5.0.0"}}
+        )
+        outdated = {item["name"]: item for item in result.data["outdated"]}
+        assert "webpack" in outdated
+        assert outdated["webpack"]["ecosystem"] == "npm"
+
+    def test_package_json_skips_non_registry_specs(self, auditor: DependencyAuditTool) -> None:
+        """file:/git/workspace specs are ignored, not compared."""
+        content = '{"dependencies": {"mylib": "file:../mylib", "react": "16.0.0"}}'
+        result = auditor.execute(
+            {"manifests": {"package.json": content}, "latest_versions": {"react": "18.0.0"}}
+        )
+        assert {item["name"] for item in result.data["outdated"]} == {"react"}
+        assert result.data["checked"] == 1  # only react was comparable
+
+    # ---- version prefixes / edge cases ----
+
+    def test_semver_range_prefixes_are_stripped(self, auditor: DependencyAuditTool) -> None:
+        """Caret/tilde/compound ranges resolve to their major version."""
+        content = '{"dependencies": {"vue": "^2.6.0", "next": ">=12.0.0 <13"}}'
+        result = auditor.execute(
+            {
+                "manifests": {"package.json": content},
+                "latest_versions": {"vue": "3.4.0", "next": "14.0.0"},
+            }
+        )
+        flagged = {item["name"] for item in result.data["outdated"]}
+        assert flagged == {"next"}  # vue 1 behind, next 2 behind
+
+    def test_name_normalization_matches_latest_versions(self, auditor: DependencyAuditTool) -> None:
+        """`Django` in a manifest matches `django` in latest_versions."""
+        result = auditor.execute(
+            {
+                "manifests": {"requirements.txt": "Django==2.2.0\n"},
+                "latest_versions": {"django": "5.0.0"},
+            }
+        )
+        assert {item["name"] for item in result.data["outdated"]} == {"Django"}
+
+    def test_zero_major_versions_supported(self, auditor: DependencyAuditTool) -> None:
+        """0.x dependencies are compared like any other major."""
+        result = auditor.execute(
+            {
+                "manifests": {"requirements.txt": "somelib==0.4.0\n"},
+                "latest_versions": {"somelib": "2.0.0"},
+            }
+        )
+        assert {item["name"] for item in result.data["outdated"]} == {"somelib"}
+
+    # ---- skipping / robustness ----
+
+    def test_unpinned_dependency_is_skipped(self, auditor: DependencyAuditTool) -> None:
+        """A dependency with no comparable version is skipped, not flagged."""
+        result = auditor.execute(
+            {"manifests": {"requirements.txt": "flask\n"}, "latest_versions": {"flask": "3.0.0"}}
+        )
+        assert result.data["outdated"] == []
+        assert any(s.get("name") == "flask" for s in result.data["skipped"])
+
+    def test_unknown_latest_version_is_skipped(self, auditor: DependencyAuditTool) -> None:
+        """Offline with no supplied latest version -> skipped, not flagged."""
+        result = auditor.execute({"manifests": {"requirements.txt": "obscurelib==1.0.0\n"}})
+        assert result.data["outdated"] == []
+        assert any(s.get("name") == "obscurelib" for s in result.data["skipped"])
+
+    def test_malformed_manifest_does_not_crash(self, auditor: DependencyAuditTool) -> None:
+        """A malformed manifest is recorded as skipped; the run still succeeds."""
+        result = auditor.execute({"manifests": {"package.json": "{not valid json"}})
+        assert result.success is True
+        assert any(s.get("file") == "package.json" for s in result.data["skipped"])
+
+    def test_multiple_manifests_audited_together(self, auditor: DependencyAuditTool) -> None:
+        """Findings from several manifests are aggregated and sorted."""
+        result = auditor.execute(
+            {
+                "manifests": {
+                    "requirements.txt": "django==2.2.0\n",
+                    "package.json": '{"dependencies": {"webpack": "3.0.0"}}',
+                },
+                "latest_versions": {"django": "5.0.0", "webpack": "5.0.0"},
+            }
+        )
+        names = [item["name"] for item in result.data["outdated"]]
+        assert set(names) == {"django", "webpack"}
+        # Sorted most-outdated first (django is 3 behind, webpack 2 behind).
+        assert names[0] == "django"


### PR DESCRIPTION
## Summary
Adds `DependencyAuditTool`, a new agent tool (issue #53) that parses dependency
manifests — `requirements.txt`, `package.json`, and `pyproject.toml` — and flags
dependencies that are more than one major version behind their latest release,
surfacing upgrade/maintenance risk for DevOps/CI workflows.

## Issue
Closes #53

## Changes
- New `agent/tools/dependency_audit_tool.py` implementing `DependencyAuditTool(BaseTool)`:
  - Parsers for `requirements.txt` (comments, pip options, extras, env markers, VCS/URL skips),
    `package.json` (dependencies + devDependencies; skips `file:`/`git`/`workspace:` specs),
    and `pyproject.toml` (PEP 621 + Poetry tables).
  - Configurable `max_major_lag` (default: flag when > 1 major behind).
  - Injectable latest-version resolver (deterministic/offline by default) with an optional
    live PyPI/npm lookup (`check_latest_online`).
  - Robust: a malformed manifest is recorded as skipped, never crashes the run.
- New `tests/unit/test_dependency_audit_tool.py` — 20 unit tests (parsing, thresholds,
  name normalization, skips, robustness).
- `JOURNAL.md` / `PLAN.md`: Module 3 progress and solution plan.

## Testing
- [x] Unit tests pass (`make test-unit`) — 20 new tests pass; see pre-existing-failures note
- [x] Integration tests pass (`make test-integration`) — N/A: repo has no integration tests (`tests/integration/` is empty); collects 0 items
- [x] Linter passes (`make lint`) — new file is ruff-clean; see note
- [x] Type checker passes (`make typecheck`) — new file is mypy-clean via pre-commit; see note
- [x] New/updated tests cover the changes

## Notes for Reviewers
**Pre-existing failures (documented, not introduced by this PR).** On a clean checkout of
the base, `make test-unit` already reports **53 failed / 375 passed**, `make lint` **183
ruff errors**, and `make typecheck` **5 mypy errors** (incl. a numpy/py3.12 stub issue and
missing `passlib`/`rank_bm25` stubs) — all unrelated to this change. After this PR the 375
previously-passing tests still pass and my 20 new tests pass (**395 passing**); I introduce
**no new** lint/type/test failures, and the new file passes ruff, black, and mypy via the
pre-commit hooks.

**Deferred: orchestrator registration.** `docs/CONTRIBUTING.md` suggests registering new
tools in `agent/orchestrator.py`. `Orchestrator` is not instantiated anywhere in the
codebase yet, so there is no live tool registry to register into and registration would have
no runtime effect. To keep this PR focused and avoid dead wiring, registration is deferred to
a follow-up once that runtime path exists. The tool is fully implemented, documented, and
unit-tested in isolation. Rationale is captured in `PLAN.md`.
