### PR TITLE
test(rag): correct relevance scorer partial-overlap fixture

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -33,3 +33,29 @@ I reproduced issue #157 by running `pytest tests/unit/test_relevance_scorer.py -
 
 **Blockers or open questions:**
 None at this stage. The implementation fix will be completed in Week 9.
+
+## Week 9 — Check-in 1
+
+**Issue:** #157 — Relevance scorer “partial overlap” test fixture actually has full query overlap
+
+**Implementation summary:**
+I updated only the chunk text in `test_query_with_partial_overlap` so it matches two of the
+query's four keywords (`django` and `web`). This produces a genuine partial-overlap score of
+`0.5`. The assertion and production relevance-scoring logic remain unchanged.
+
+**Baseline results:**
+
+- The issue test failed with a score of `1.0` before the fixture update.
+- `make check` reported 182 pre-existing Ruff errors, including 86 marked fixable.
+- `make test-unit` reported 53 failed, 375 passed, and 1 warning.
+
+**Post-change validation:**
+
+- Individual issue test: 1 passed.
+- Full `tests/unit/test_relevance_scorer.py`: 19 passed.
+- `make check`: the same 182 pre-existing Ruff errors remained.
+- `make test-unit`: 52 failed, 376 passed, and 1 warning. The issue #157 test now passes; the
+  remaining failures are pre-existing and unrelated. No new failures were introduced.
+
+**Blockers or open questions:**
+None. The change is implemented and validated locally but remains uncommitted and unpushed.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -67,3 +67,34 @@ I updated `tests/unit/test_relevance_scorer.py`, specifically `test_query_with_p
 Both commands still contain documented pre-existing unrelated failures, but this contribution introduced no new failures. `make test-unit` improved from 53 failures to 52 because issue #157 now passes.
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No reviewer or maintainer feedback has been received on PR #901.
+
+**How you responded:**
+No code changes or reviewer responses were necessary.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Getting comfortable in a large and unfamiliar repository took more time than the actual fix. I had to figure out whether the scorer was broken or whether the test data was wrong, work around many unrelated test and Ruff failures without getting sidetracked, and learn the branch, fork, commit, and PR workflow along the way.
+
+**What did you learn about working in a large codebase?**
+Even a one-line change requires reading the surrounding code and tests first. I also learned not to fix unrelated problems just because I found them. Comparing results before and after the change made the impact clear and kept the PR focused and easy to review.
+
+**How did AI tools help — and where did they fall short?**
+AI helped me inspect files, understand the scoring behavior, and choose the right test commands. I still had to check its work for accuracy, scope, extra documentation, repository conventions, and claims that tests passed. Local setup and GitHub account issues also needed my own judgment.
+
+**What would you do differently if you started over?**
+I would read the contribution instructions earlier, record baseline failures before touching the code, and verify my Git author identity before committing. I would also open the draft PR earlier instead of waiting until close to the deadline.
+
+**What are you most proud of from this module?**
+I am proud that I recognized the production scorer was already working and fixed the real problem with one small fixture change instead of rewriting it. I also verified that the target test went from failing to passing without introducing any new failures. I am also proud to have further familiarized myself with open-source contributions.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -18,4 +18,4 @@ I selected this issue because it has a clearly defined failure, a focused reprod
 
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
-**Cohort ledger:** [ ] Issue added to cohort ledger
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -22,12 +22,12 @@ I selected this issue because it has a clearly defined failure, a focused reprod
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [add after reproduction commit is pushed]
+**Reproduction commit link:** https://github.com/VarnitB/pathreview/commit/e5f52b775d3283ebdb6c5b63d62afca69342f883
 
 **Reproduction summary:**
 I reproduced issue #157 by running `pytest tests/unit/test_relevance_scorer.py -q`. The `test_query_with_partial_overlap` test failed because the scorer returned `1.0`, while the fixture expects a partial-overlap score below `0.9`; the focused test run produced 1 failure and 18 passing tests.
 
-**PLAN.md link:** [add after PLAN.md is pushed]
+**PLAN.md link:** https://github.com/VarnitB/pathreview/blob/test/157-partial-overlap-fixture/PLAN.md
 
 **Walkthrough video (recommended):** Not recorded
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -49,3 +49,21 @@ Commit and push the validated change, open the pull request, and then add Check-
 
 **Blockers:**
 None. The remaining repository failures are pre-existing and unrelated to issue #157.
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/901
+
+**Branch:** `test/157-partial-overlap-fixture`
+
+**What you built:**
+I corrected the fixture in `test_query_with_partial_overlap` so it matches two of the query’s four keywords and represents genuine partial overlap with a score of `0.5`. The production relevance-scoring logic and existing assertion were left unchanged.
+
+**Tests added or updated:**
+I updated `tests/unit/test_relevance_scorer.py`, specifically `test_query_with_partial_overlap`. The focused test passes, and the full relevance scorer test file reports 19 passing tests.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+Both commands still contain documented pre-existing unrelated failures, but this contribution introduced no new failures. `make test-unit` improved from 53 failures to 52 because issue #157 now passes.
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,21 @@
+# PathReview Contribution Journal
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/157
+
+**Issue title:** Relevance scorer “partial overlap” test fixture actually has full query overlap
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The relevance scorer unit test intended to verify partial query overlap currently uses a chunk containing every meaningful term from the query. Because the fixture actually represents full overlap, the scorer correctly returns a score of 1.0 even though the test expects a value below 0.9. This affects the relevance scorer tests in `tests/unit/test_relevance_scorer.py`, rather than indicating a defect in the scorer itself. A successful fix will update the fixture so that it contains only some of the query terms and accurately tests partial overlap behavior.
+
+**Selection notes:**
+I selected this issue because it has a clearly defined failure, a focused reproduction command, and a narrow scope appropriate for a first contribution to a large codebase. The issue appears limited to correcting a unit-test fixture rather than changing production scoring behavior. The affected test file and expected outcome are identified, and the fix can be verified by running the focused relevance scorer test suite. I do not expect the issue to require database migrations, API changes, frontend changes, or broad architectural modifications.
+
+**Branch name:** test/157-partial-overlap-fixture
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -34,28 +34,18 @@ I reproduced issue #157 by running `pytest tests/unit/test_relevance_scorer.py -
 **Blockers or open questions:**
 None at this stage. The implementation fix will be completed in Week 9.
 
-## Week 9 — Check-in 1
+## Week 9 — Solution building & PR submission
 
-**Issue:** #157 — Relevance scorer “partial overlap” test fixture actually has full query overlap
+### Check-in 1 (mid-week)
 
-**Implementation summary:**
-I updated only the chunk text in `test_query_with_partial_overlap` so it matches two of the
-query's four keywords (`django` and `web`). This produces a genuine partial-overlap score of
-`0.5`. The assertion and production relevance-scoring logic remain unchanged.
+**Current progress:**
+I reproduced issue #157 and changed the fixture from full overlap to two-of-four token overlap.
+The focused test passes, and the full relevance scorer file has 19 passing tests. `make check`
+reported the same 182 pre-existing Ruff errors before and after the change. `make test-unit`
+improved from 53 failed / 375 passed to 52 failed / 376 passed, with no new failures introduced.
 
-**Baseline results:**
+**Next steps:**
+Commit and push the validated change, open the pull request, and then add Check-in 2.
 
-- The issue test failed with a score of `1.0` before the fixture update.
-- `make check` reported 182 pre-existing Ruff errors, including 86 marked fixable.
-- `make test-unit` reported 53 failed, 375 passed, and 1 warning.
-
-**Post-change validation:**
-
-- Individual issue test: 1 passed.
-- Full `tests/unit/test_relevance_scorer.py`: 19 passed.
-- `make check`: the same 182 pre-existing Ruff errors remained.
-- `make test-unit`: 52 failed, 376 passed, and 1 warning. The issue #157 test now passes; the
-  remaining failures are pre-existing and unrelated. No new failures were introduced.
-
-**Blockers or open questions:**
-None. The change is implemented and validated locally but remains uncommitted and unpushed.
+**Blockers:**
+None. The remaining repository failures are pre-existing and unrelated to issue #157.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -19,3 +19,17 @@ I selected this issue because it has a clearly defined failure, a focused reprod
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [add after reproduction commit is pushed]
+
+**Reproduction summary:**
+I reproduced issue #157 by running `pytest tests/unit/test_relevance_scorer.py -q`. The `test_query_with_partial_overlap` test failed because the scorer returned `1.0`, while the fixture expects a partial-overlap score below `0.9`; the focused test run produced 1 failure and 18 passing tests.
+
+**PLAN.md link:** [add after PLAN.md is pushed]
+
+**Walkthrough video (recommended):** Not recorded
+
+**Blockers or open questions:**
+None at this stage. The implementation fix will be completed in Week 9.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,69 @@
+## Solution plan
+
+**Issue:** [Relevance scorer “partial overlap” test fixture actually has full query overlap](https://github.com/ascherj/pathreview/issues/157)
+
+### Understand
+
+The failing test is intended to verify that partial keyword overlap produces a relevance score between a zero-overlap score and a full-match score.
+
+The test query is `Python Django web framework`, while the fixture chunk is `Django is a Python web framework for rapid development`. The chunk contains all four meaningful query terms: `python`, `django`, `web`, and `framework`.
+
+Because the fixture represents full query coverage rather than partial overlap, the relevance scorer correctly returns `1.0`. The actual issue is in the test fixture, not necessarily in the production scoring implementation.
+
+The expected behavior is for the fixture to contain only some of the query terms and produce a score satisfying the existing assertion:
+
+`0.3 < score < 0.9`
+
+### Map
+
+The main file expected to change is:
+
+- `tests/unit/test_relevance_scorer.py`
+  - `TestRelevanceScorer.test_query_with_partial_overlap`
+
+The production implementation should be reviewed to confirm the scoring behavior, but it is not expected to change:
+
+- `rag/evaluator/relevance_scorer.py`
+  - `RelevanceScorer.score`
+  - `RelevanceScorer._tokenize`
+
+No frontend, API, database, migration, or configuration files are expected to change.
+
+### Plan
+
+1. Review `RelevanceScorer.score` and `RelevanceScorer._tokenize` to confirm how query and chunk tokens are normalized and compared.
+2. Update the chunk text in `test_query_with_partial_overlap` so it contains only a subset of the meaningful query terms.
+3. Keep the existing assertion `0.3 < score < 0.9` so the test continues to verify a genuine middle-range partial-overlap score.
+4. Run the individual failing test to confirm the corrected fixture now passes.
+5. Run the full `tests/unit/test_relevance_scorer.py` file and relevant project checks to confirm no other relevance scorer tests regress.
+
+### Inputs & outputs
+
+The test input consists of:
+
+- A query string containing multiple meaningful keywords
+- A list containing a chunk dictionary with a `text` field
+
+The corrected fixture should contain some, but not all, query keywords.
+
+The expected output is a floating-point score between `0.0` and `1.0`. For the partial-overlap test specifically, the score should be greater than `0.3` and less than `0.9`.
+
+The final implementation should change only the test fixture and should not alter production scoring behavior unless further investigation reveals an actual implementation defect.
+
+### Risks & unknowns
+
+- A replacement chunk could accidentally still contain every query token.
+- A replacement chunk with too little overlap could produce a score of `0.3` or below.
+- Token normalization may treat punctuation or capitalization differently than expected.
+- Changing the assertion instead of the fixture could weaken the purpose of the test.
+- The focused test may pass while another relevance scorer test fails, so the full scorer test file must also be run.
+- The repository may contain unrelated failing tests; only failures connected to issue #157 should affect the scope of this fix.
+
+### Edge cases
+
+- The replacement fixture contains zero query terms rather than partial overlap.
+- The replacement fixture contains all query terms in a different order.
+- Capitalization differences affect matching unexpectedly.
+- Punctuation attached to keywords changes tokenization.
+- Repeating one matching keyword is mistaken for matching multiple distinct query terms.
+- The resulting score is exactly `0.3` or `0.9`, which would fail because the assertion uses strict inequalities.

--- a/tests/unit/test_relevance_scorer.py
+++ b/tests/unit/test_relevance_scorer.py
@@ -49,7 +49,7 @@ class TestRelevanceScorer:
         query = "Python Django web framework"
         chunks = [
             {
-                "text": "Django is a Python web framework for rapid development"
+                "text": "Django supports rapid web development"
             },
         ]
 


### PR DESCRIPTION
## Summary

Correct the relevance scorer's partial-overlap test fixture so it exercises a true middle-range
keyword overlap, and include the related contribution planning and validation notes.

## Root cause

The query contains `python`, `django`, `web`, and `framework`, while the original chunk contained
all four tokens. The scorer therefore correctly returned `1.0`, conflicting with the test's
partial-overlap assertion.

## Changes made

- Changed the fixture chunk to `Django supports rapid web development`, which matches two of the
  four query tokens and produces a score of `0.5`.
- Documented the issue reproduction, solution plan, implementation, and validation results in
  `PLAN.md` and `JOURNAL.md`.

## Validation

- Focused test: 1 passed.
- Full `tests/unit/test_relevance_scorer.py`: 19 passed.
- `make check` baseline: 182 pre-existing Ruff errors, including 86 marked fixable.
- `make check` post-change: the same 182 Ruff errors.
- `make test-unit` baseline: 53 failed, 375 passed, 1 warning.
- `make test-unit` post-change: 52 failed, 376 passed, 1 warning.

The issue #157 test is the only test that changed from failing to passing. All remaining failures
are pre-existing and unrelated, and no new failures were introduced.

## Scope

Production relevance-scoring logic was not changed. The functional change is limited to the test
fixture.

Closes #157
