### PR TITLE
fix: detect resume section headers with leading whitespace (#147)

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,70 @@
+\# JOURNAL
+
+
+
+\## Week 7 — Issue selection
+
+
+
+\*\*Issue link:\*\* https://github.com/ascherj/pathreview/issues/147
+
+
+
+\*\*Issue title:\*\* Resume section detection fails on text with leading whitespace
+
+
+
+\*\*Tier:\*\* \[x] Tier 1  \[ ] Tier 2  \[ ] Tier 3
+
+
+
+\*\*Problem summary:\*\*
+
+The `\_detect\_sections()` method in `ingestion/parsers/resume\_parser.py` uses
+
+regex patterns anchored to the very start of each line (e.g. `^Experience`),
+
+but text extracted from PDFs often keeps its original indentation, so headers
+
+like "Education:" appear with leading spaces. Because the anchored patterns
+
+never match indented headers, `detected\_sections` comes back completely empty
+
+for that input, and the resume content is never split into structured
+
+sections. This also causes three unit tests in
+
+`tests/unit/test\_resume\_parser.py` to fail. A successful fix would make the
+
+matching tolerant of leading whitespace — for example by stripping/normalizing
+
+lines before matching or allowing optional whitespace in the patterns — so
+
+that sections are detected regardless of indentation and the failing tests
+
+pass.
+
+
+
+\*\*Is this right for me? — reasoning:\*\*
+
+The problem is isolated to one method in one file, comes with a minimal
+
+reproduction snippet, and already has failing unit tests that define exactly
+
+what "fixed" looks like. No database, API, or frontend changes are involved,
+
+so the scope is well contained and fits Tier 1.
+
+
+
+\*\*Branch name:\*\* fix/147-resume-leading-whitespace
+
+
+
+\*\*Setup confirmation:\*\* \[x] App runs locally at localhost:5173
+
+
+
+\*\*Cohort ledger:\*\* \[x] Issue added to cohort ledger
+

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,70 +1,79 @@
-\# JOURNAL
+# JOURNAL
 
+## Week 7 — Issue selection
 
+**Issue link:** https://github.com/ascherj/pathreview/issues/147
 
-\## Week 7 — Issue selection
+**Issue title:** Resume section detection fails on text with leading whitespace
 
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
 
-
-\*\*Issue link:\*\* https://github.com/ascherj/pathreview/issues/147
-
-
-
-\*\*Issue title:\*\* Resume section detection fails on text with leading whitespace
-
-
-
-\*\*Tier:\*\* \[x] Tier 1  \[ ] Tier 2  \[ ] Tier 3
-
-
-
-\*\*Problem summary:\*\*
-
-The `\_detect\_sections()` method in `ingestion/parsers/resume\_parser.py` uses
-
+**Problem summary:**
+The `_detect_sections()` method in `ingestion/parsers/resume_parser.py` uses
 regex patterns anchored to the very start of each line (e.g. `^Experience`),
-
 but text extracted from PDFs often keeps its original indentation, so headers
-
 like "Education:" appear with leading spaces. Because the anchored patterns
-
-never match indented headers, `detected\_sections` comes back completely empty
-
+never match indented headers, `detected_sections` comes back completely empty
 for that input, and the resume content is never split into structured
-
 sections. This also causes three unit tests in
-
-`tests/unit/test\_resume\_parser.py` to fail. A successful fix would make the
-
+`tests/unit/test_resume_parser.py` to fail. A successful fix would make the
 matching tolerant of leading whitespace — for example by stripping/normalizing
-
 lines before matching or allowing optional whitespace in the patterns — so
-
 that sections are detected regardless of indentation and the failing tests
-
 pass.
 
-
-
-\*\*Is this right for me? — reasoning:\*\*
-
+**Is this right for me? — reasoning:**
 The problem is isolated to one method in one file, comes with a minimal
-
 reproduction snippet, and already has failing unit tests that define exactly
-
 what "fixed" looks like. No database, API, or frontend changes are involved,
-
 so the scope is well contained and fits Tier 1.
 
+**Branch name:** fix/147-resume-leading-whitespace
 
+**Setup confirmation:** [x] App runs locally at localhost:5173
 
-\*\*Branch name:\*\* fix/147-resume-leading-whitespace
+**Cohort ledger:** [x] Issue added to cohort ledger
 
+## Week 9 — Solution building & PR submission
 
+### Check-in 1 (mid-week)
 
-\*\*Setup confirmation:\*\* \[x] App runs locally at localhost:5173
+**Current progress:**
+Implemented the fix for issue #147. Updated the four regex patterns in
+`_detect_sections()` (`ingestion/parsers/resume_parser.py`) to allow optional
+leading whitespace before section headers, and applied the same fix to the
+markdown header-stripping regex in `_strip_markdown()`, which had the same
+root cause and was blocking section detection for indented markdown resumes.
+Added `test_detect_sections_with_leading_whitespace`; all 11 tests in
+`tests/unit/test_resume_parser.py` now pass, including two that were failing
+on `main` (`test_parse_markdown_resume`, `test_strip_markdown_syntax`).
+Verified the remaining 48 suite failures are pre-existing on `main` in
+unrelated modules — the suite went from 54 failures to 48 with this change
+and no new failures were introduced. Committed and pushed (`cc95774`);
+draft PR opened and shared in Slack for peer review.
 
+**Next steps:**
+Address peer feedback on the draft PR, run final `make check` /
+`make test-unit` verification, mark the PR ready for review, and complete
+Check-in 2 with the PR link by Sunday.
 
+**Blockers:**
+None currently.
 
-\*\*Cohort ledger:\*\* \[x] Issue added to cohort ledger
+---
 
+### Check-in 2 (end of week)
+
+**PR link:** [add your PR link here on Sunday]
+
+**Branch:** `fix/147-resume-leading-whitespace`
+
+**What you built:**
+[fill in on Sunday]
+
+**Tests added or updated:**
+[fill in on Sunday]
+
+**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+
+**Draft PR feedback received from:** [name or Slack handle, fill in on Sunday]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -55,7 +55,7 @@ draft PR opened and shared in Slack for peer review.
 **Next steps:**
 Address peer feedback on the draft PR, run final `make check` /
 `make test-unit` verification, mark the PR ready for review, and complete
-Check-in 2 with the PR link by Sunday.
+Check-in 2 with the PR link.
 
 **Blockers:**
 None currently.
@@ -64,16 +64,101 @@ None currently.
 
 ### Check-in 2 (end of week)
 
-**PR link:** [add your PR link here on Sunday]
+**PR link:** https://github.com/ascherj/pathreview/pull/902
 
 **Branch:** `fix/147-resume-leading-whitespace`
 
 **What you built:**
-[fill in on Sunday]
+Fixed resume section detection failing on text with leading whitespace
+(issue #147). Added optional leading whitespace to the header-matching
+regexes in `_detect_sections()` and to the markdown header-stripping regex
+in `_strip_markdown()` — the same root cause existed in both places — so
+indented headers from PDF-extracted and markdown resumes are now detected,
+while column-0 headers continue to work with no regression.
 
 **Tests added or updated:**
-[fill in on Sunday]
+Modified `tests/unit/test_resume_parser.py`: added
+`test_detect_sections_with_leading_whitespace`, which verifies that section
+headers preceded by spaces (e.g. indented "Education:" and "Skills:") are
+detected. Also added type annotations to the existing tests (required by the
+mypy pre-commit hook). Two previously failing tests in this file now pass:
+`test_parse_markdown_resume` and `test_strip_markdown_syntax` (indented
+markdown headers are now stripped and detected). Full file: 11/11 passing.
 
-**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+*(no new failures introduced beyond the failures pre-existing on `main` —
+48 test failures and 178 lint errors in unrelated modules, documented in the
+PR description; both changed files pass ruff, black, and mypy)*
 
-**Draft PR feedback received from:** [name or Slack handle, fill in on Sunday]
+**Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No reviewer feedback came in on PR #902 before the end of the module
+(reviewer feedback is not a feature this term).
+
+**How you responded:**
+
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The gap between "I have the fix" and "the fix is actually in my repo."
+At one point I was sure the code change was done — I had the corrected
+file open and had even shared it — but when I ran `grep` on the actual
+file on disk, the old buggy regex was still there. My branch only had
+documentation commits. Nothing was wrong with my understanding of the
+fix; the problem was that I never verified what was actually saved and
+committed. Debugging that taught me more than writing the fix did.
+
+**What did you learn about working in a large codebase?**
+That my change doesn't exist in isolation. When I ran the test suite
+and saw 54 failures, my first instinct was panic — but most of those
+failures existed on `main` before I touched anything. I had to run the
+suite on both branches and diff the results to prove my change
+introduced zero new failures (and actually fixed two pre-existing
+ones). I also learned that one bug can live in more than one place:
+the leading-whitespace problem from issue #147 existed in
+`_detect_sections()` AND in `_strip_markdown()`, and fixing only the
+reported one would have left markdown resumes still broken. The
+pre-commit hooks (ruff, black, mypy) blocked my commits repeatedly
+until my files met the project's standards — in a shared codebase, the
+tooling enforces conventions whether you like it or not. I also
+accidentally overwrote `readme_parser.py` with a bad paste and broke
+test collection for the whole suite; `git status` and `git restore`
+saved me, which showed me how much blast radius a careless edit has in
+someone else's code.
+
+**How did AI tools help — and where did they fall short?**
+AI helped me debug, check my code, and understand the structure of the
+codebase and the contribution workflow — things like why pre-commit
+hooks abort a commit after auto-fixing, and how to classify
+pre-existing test failures. Where it fell short: the AI can only see
+what I show it. It "verified" a fixed version of my file that turned
+out to never exist in my repo — the real state of my code was only
+visible through `git status`, `git diff`, and `grep` on my own
+machine. The lesson is that AI output isn't done until I've verified
+it against the actual filesystem and test runner myself.
+
+**What would you do differently if you started over?**
+Give myself more time and finish early instead of compressing
+everything near the deadline — most of my mistakes came from rushing.
+And I'd build one small habit: after every edit, run `git status` and
+`git diff` to confirm the work actually exists on disk before assuming
+it's done, and after every submission, open my own submitted link in
+an incognito browser to confirm a grader could find everything from
+that URL alone.
+
+**What are you most proud of?**
+Completing the full contribution cycle end to end — reproducing a real
+issue, planning the fix, getting it through the project's linting and
+type-checking standards, proving it against `main`, and submitting PR
+#902 with a clean trail — and actually learning every concept along
+the way instead of just getting it done.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,193 @@
+# Week 8 — Issue Reproduction & Solution Planning
+
+## Issue
+
+**Issue:** #147 – Resume section detection fails on text with leading whitespace
+
+**Issue Link:** https://github.com/ascherj/pathreview/issues/147
+
+---
+
+# 1. Issue Reproduction
+
+## Description
+
+The resume parser fails to detect common resume section headers when the extracted text contains leading whitespace before the section names. This commonly occurs when text is extracted from PDF resumes, where indentation is preserved.
+
+The `_detect_sections()` function currently expects section headers such as `Education`, `Skills`, and `Experience` to begin immediately at the start of a line. When spaces precede these headers, no match is found and the parser returns an empty list of detected sections.
+
+---
+
+## Steps to Reproduce
+
+```python
+from ingestion.parsers.resume_parser import ResumeParser
+
+r = ResumeParser()
+
+res = r.parse("""
+    John Smith
+    john@example.com
+
+    Education:
+    - B.S. Computer Science
+
+    Skills: Python
+""")
+
+print(res.metadata["detected_sections"])
+```
+
+### Observed Result
+
+```python
+[]
+```
+
+### Expected Result
+
+```python
+["Education", "Skills"]
+```
+
+---
+
+# 2. Current Code Investigation
+
+Relevant file:
+
+```
+ingestion/parsers/resume_parser.py
+```
+
+Relevant function:
+
+```
+_detect_sections()
+```
+
+The function iterates through predefined section names stored in `SECTION_HEADERS` and searches for each using regular expressions.
+
+Current patterns:
+
+```python
+rf"^{re.escape(section)}\s*$"
+rf"^{re.escape(section)}\s*[:|-]"
+rf"\n{re.escape(section)}\s*$"
+rf"\n{re.escape(section)}\s*[:|-]"
+```
+
+These expressions require the section header to begin immediately after the beginning of the line or immediately after a newline.
+
+---
+
+# 3. Root Cause Analysis
+
+The parser assumes every section header begins at column 0.
+
+However, PDF extraction frequently preserves indentation, producing text such as:
+
+```
+    Education:
+```
+
+instead of
+
+```
+Education:
+```
+
+Because the regular expressions do not allow optional leading whitespace, the parser fails to recognize these section headers.
+
+As a result:
+
+- no section headers are matched
+- `detected_sections` becomes an empty list
+- downstream processing loses useful resume structure
+
+---
+
+# 4. Planned Solution
+
+The implementation will update the regular expression patterns used by `_detect_sections()` so they accept optional leading whitespace before each section header.
+
+The modification should preserve the current matching behavior for resumes that already work while extending support for indented text extracted from PDF documents.
+
+---
+
+# 5. Files Expected to Change
+
+Primary file:
+
+```
+ingestion/parsers/resume_parser.py
+```
+
+Possible additional files:
+
+- parser unit tests
+- resume parser test fixtures (if present)
+
+---
+
+# 6. Implementation Tasks
+
+1. Reproduce the issue using the provided example.
+2. Inspect `_detect_sections()` and existing regex patterns.
+3. Modify the regex patterns to support optional leading whitespace.
+4. Verify existing behavior for non-indented resumes.
+5. Test resumes containing leading spaces before section headers.
+6. Run the project's test suite.
+7. Commit changes and prepare a pull request.
+
+---
+
+# 7. Risks
+
+- Making the regular expressions too permissive could detect text that is not actually a section header.
+- Changes must preserve detection for existing resumes.
+- All current parser behavior should remain unchanged except for supporting leading whitespace.
+
+---
+
+# 8. Edge Cases
+
+The updated solution should correctly handle:
+
+- multiple spaces before section headers
+- tab indentation
+- blank lines before headers
+- headers ending with a colon
+- headers without punctuation
+- mixed uppercase and lowercase headers
+- multiple occurrences of the same section
+- resumes that contain no recognizable sections
+
+---
+
+# 9. Testing Plan
+
+Manual testing:
+
+- Resume without indentation
+- Resume with four leading spaces
+- Resume using tabs
+- Resume containing multiple section headers
+- Resume with no section headers
+
+Expected outcome:
+
+- Previously supported resumes continue to work.
+- Indented section headers are correctly detected.
+- `detected_sections` contains the expected section names.
+
+---
+
+# 10. Success Criteria
+
+The issue will be considered resolved when:
+
+- resumes containing indented section headers are correctly parsed
+- `detected_sections` includes headers such as Education and Skills
+- existing functionality remains unchanged
+- all relevant tests pass successfully

--- a/ingestion/parsers/resume_parser.py
+++ b/ingestion/parsers/resume_parser.py
@@ -5,7 +5,6 @@ from pypdf import PdfReader
 
 from .base import BaseParser, ParseResult
 
-
 SECTION_HEADERS = {
     "experience",
     "education",
@@ -75,7 +74,7 @@ class ResumeParser(BaseParser):
                 source_type="resume",
             )
         except Exception as e:
-            raise ValueError(f"Failed to parse PDF: {str(e)}")
+            raise ValueError(f"Failed to parse PDF: {str(e)}") from e
 
     def _parse_markdown(self, content: str) -> ParseResult:
         """Extract text from markdown resume, stripping markdown syntax."""
@@ -98,8 +97,8 @@ class ResumeParser(BaseParser):
 
     def _strip_markdown(self, content: str) -> str:
         """Remove markdown syntax from content."""
-        # Remove markdown headers
-        text = re.sub(r"^#+\s+", "", content, flags=re.MULTILINE)
+        # Remove markdown headers (allowing leading whitespace before the #)
+        text = re.sub(r"^[ \t]*#+\s+", "", content, flags=re.MULTILINE)
 
         # Remove markdown links [text](url)
         text = re.sub(r"\[([^\]]+)\]\(([^\)]+)\)", r"\1", text)
@@ -130,12 +129,12 @@ class ResumeParser(BaseParser):
         text_lower = text.lower()
 
         for section in SECTION_HEADERS:
-            # Look for section header patterns
+            # Look for section header patterns (allowing leading whitespace)
             patterns = [
-                rf"^{re.escape(section)}\s*$",
-                rf"^{re.escape(section)}\s*[:|-]",
-                rf"\n{re.escape(section)}\s*$",
-                rf"\n{re.escape(section)}\s*[:|-]",
+                rf"^\s*{re.escape(section)}\s*$",
+                rf"^\s*{re.escape(section)}\s*[:|-]",
+                rf"\n\s*{re.escape(section)}\s*$",
+                rf"\n\s*{re.escape(section)}\s*[:|-]",
             ]
 
             for pattern in patterns:

--- a/tests/unit/test_resume_parser.py
+++ b/tests/unit/test_resume_parser.py
@@ -1,11 +1,11 @@
 """Tests for resume_parser.py"""
 
-import pytest
-from unittest.mock import Mock, patch, MagicMock
-from io import BytesIO
+from unittest.mock import Mock, patch
 
-from ingestion.parsers.resume_parser import ResumeParser
+import pytest
+
 from ingestion.parsers.base import ParseResult
+from ingestion.parsers.resume_parser import ResumeParser
 
 
 @pytest.mark.unit
@@ -13,11 +13,13 @@ class TestResumeParser:
     """Test suite for ResumeParser."""
 
     @pytest.fixture
-    def parser(self):
+    def parser(self) -> ResumeParser:
         """Create a ResumeParser instance."""
         return ResumeParser()
 
-    def test_parse_single_column_resume_text(self, parser, sample_resume_text):
+    def test_parse_single_column_resume_text(
+        self, parser: ResumeParser, sample_resume_text: str
+    ) -> None:
         """Test parsing a standard single-column resume text."""
         result = parser.parse(sample_resume_text)
 
@@ -33,7 +35,7 @@ class TestResumeParser:
             "skills" in s for s in detected_lower
         )
 
-    def test_parse_resume_no_work_experience(self, parser):
+    def test_parse_resume_no_work_experience(self, parser: ResumeParser) -> None:
         """Test parsing a resume with no work experience section - handles gracefully."""
         resume_no_work = """
         John Smith
@@ -54,7 +56,7 @@ class TestResumeParser:
         detected_lower = [s.lower() for s in result.metadata["detected_sections"]]
         assert any("education" in s for s in detected_lower)
 
-    def test_parse_multipage_pdf(self, parser):
+    def test_parse_multipage_pdf(self, parser: ResumeParser) -> None:
         """Test parsing a multi-page PDF resume."""
         # Create a mock PDF with multiple pages
         with patch("ingestion.parsers.resume_parser.PdfReader") as mock_pdf_reader:
@@ -81,7 +83,7 @@ class TestResumeParser:
             assert "Page 2 Content" in result.text
             assert "Page 3 Content" in result.text
 
-    def test_parse_markdown_resume(self, parser):
+    def test_parse_markdown_resume(self, parser: ResumeParser) -> None:
         """Test parsing a Markdown resume."""
         markdown_resume = """
         # Jane Doe
@@ -105,25 +107,25 @@ class TestResumeParser:
         assert "#" not in result.text or result.text.count("#") < markdown_resume.count("#")
         assert "Jane Doe" in result.text
 
-    def test_parse_invalid_content_type(self, parser):
+    def test_parse_invalid_content_type(self, parser: ResumeParser) -> None:
         """Test that invalid content type raises ValueError with clear message."""
         with pytest.raises(ValueError) as exc_info:
-            parser.parse(12345)  # Invalid: integer
+            parser.parse(12345)  # type: ignore[arg-type]  # Invalid: integer
 
         assert "Content must be bytes" in str(exc_info.value) or "Content must be" in str(
             exc_info.value
         )
 
-    def test_parse_invalid_list_content(self, parser):
+    def test_parse_invalid_list_content(self, parser: ResumeParser) -> None:
         """Test that list content raises ValueError."""
         with pytest.raises(ValueError) as exc_info:
-            parser.parse(["not", "valid"])
+            parser.parse(["not", "valid"])  # type: ignore[arg-type]
 
         assert "Content must be bytes" in str(exc_info.value) or "Content must be" in str(
             exc_info.value
         )
 
-    def test_detect_sections(self, parser):
+    def test_detect_sections(self, parser: ResumeParser) -> None:
         """Test section detection in resume text."""
         text = """
         Experience:
@@ -143,15 +145,34 @@ class TestResumeParser:
         assert any("education" in s for s in sections_lower)
         assert any("skills" in s for s in sections_lower)
 
-    def test_strip_markdown_syntax(self, parser):
+    def test_detect_sections_with_leading_whitespace(self, parser: ResumeParser) -> None:
+        """Test that section headers with leading whitespace are detected."""
+        text = """
+            John Smith
+            john@example.com
+
+            Education:
+            BS Computer Science
+
+            Skills: Python
+        """
+
+        sections = parser._detect_sections(text)
+
+        sections_lower = [s.lower() for s in sections]
+
+        assert "education" in sections_lower
+        assert "skills" in sections_lower
+
+    def test_strip_markdown_syntax(self, parser: ResumeParser) -> None:
         """Test markdown syntax stripping."""
         markdown_text = """
         # Header
         **Bold text** and _italic text_
         [Link](https://example.com)
-        ```python
+```python
         print("code")
-        ```
+```
         `inline code`
         """
         stripped = parser._strip_markdown(markdown_text)
@@ -163,7 +184,7 @@ class TestResumeParser:
         # But actual text content should remain
         assert "Header" in stripped or "Bold text" in stripped
 
-    def test_pdf_parsing_error_handling(self, parser):
+    def test_pdf_parsing_error_handling(self, parser: ResumeParser) -> None:
         """Test graceful error handling for invalid PDF."""
         with patch("ingestion.parsers.resume_parser.PdfReader") as mock_pdf_reader:
             mock_pdf_reader.side_effect = Exception("Invalid PDF format")
@@ -173,7 +194,7 @@ class TestResumeParser:
 
             assert "Failed to parse PDF" in str(exc_info.value)
 
-    def test_parse_preserves_text_content(self, parser):
+    def test_parse_preserves_text_content(self, parser: ResumeParser) -> None:
         """Test that parsing preserves actual content text."""
         original_text = "John Doe\nSoftware Engineer\nPython, JavaScript, React"
         result = parser.parse(original_text)


### PR DESCRIPTION
## Summary

Resume section detection returned an empty `detected_sections` list whenever
extracted text had leading whitespace before section headers — common in
PDF-extracted resumes, where indentation is preserved. The regex patterns
anchored headers to column 0, so indented headers like `    Education:` never
matched. This PR makes the matching tolerant of leading whitespace in both
places it occurs.

## Issue

Closes #147 — Resume section detection fails on text with leading whitespace.

## Changes

- `_detect_sections()` in `ingestion/parsers/resume_parser.py`: added
  optional leading whitespace (`\s*`) after the line-start anchors in all
  four header patterns. Indented headers are now detected; column-0 headers
  still match (no regression).
- `_strip_markdown()` in the same file: applied the same fix to the
  header-stripping regex (`^[ \t]*#+\s+`) — same root cause in a second
  location. Without it, indented markdown resumes never had `#` headers
  stripped, so section detection failed for markdown input too. Used `[ \t]*`
  rather than `\s*` so the pattern cannot consume blank lines.
- Minor cleanups required by pre-commit hooks on the touched files:
  `raise ... from e` (ruff B904) and type annotations on existing test
  functions (mypy no-untyped-def).

## Testing

Automated:
- Added `test_detect_sections_with_leading_whitespace` in
  `tests/unit/test_resume_parser.py`, covering indented section headers.
- `pytest tests/unit/test_resume_parser.py` → 11 passed. Two tests that were
  failing on `main` now pass: `test_parse_markdown_resume` and
  `test_strip_markdown_syntax`.

Manual verification steps:
1. Check out this branch and open a Python shell in the repo root.
2. Run the reproduction from issue #147:
```python
   from ingestion.parsers.resume_parser import ResumeParser
   r = ResumeParser()
   res = r.parse("""
       John Smith
       john@example.com

       Education:
       - B.S. Computer Science

       Skills: Python
   """)
   print(res.metadata["detected_sections"])
```
3. Expected output: `['Education', 'Skills']` (order may vary). On `main`
   this prints `[]`.
4. Regression check — repeat with the same text unindented (headers at
   column 0): sections are still detected.

## Notes for Reviewers

- Pre-existing failures: `make test-unit` has 48 failures on `main` in
  modules unrelated to this change (review_service, bias_detector,
  pii_scrubber, skill_extractor, tech_detector, and others). I ran the suite
  on both `main` and this branch: this PR introduces no new failures and
  fixes 2 pre-existing ones (54 → 48). `make check` likewise reports 178
  pre-existing ruff errors across `agent/`, `api/`, `alembic/`, and `core/`
  — none in files touched here; both changed files pass ruff, black, and
  mypy via the pre-commit hooks.
- Design note: in `_detect_sections` I used `\s*` (matching the existing
  pattern style); in `_strip_markdown` I used `[ \t]*` because `\s` matches
  newlines and could otherwise consume blank lines during header stripping.