### PR TITLE
fix(agent): log and preserve tool call failures in orchestrator

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,26 @@
+# Journal
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/44
+
+**Issue title:** Orchestrator catches all exceptions from tool calls and continues without logging the failure
+
+**Tier:** [ ] Tier 1  [x] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The agent orchestrator's plan-execute loop wraps every tool call in a broad
+`except Exception` block that silently swallows failures and moves on to the
+next step. When a tool call fails partway through generating a review, the
+orchestrator has no way to record that anything went wrong, so it produces a
+review with missing sections and gives the user no indication of the
+failure. A successful fix adds proper error logging in `agent/orchestrator.py`
+and `agent/error_handling.py` so tool failures are captured and surfaced
+instead of disappearing silently, without changing the orchestrator's overall
+control flow.
+
+**Branch name:** fix/44-log-tool-call-failures
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -24,3 +24,33 @@ control flow.
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/ericitem/pathreview/commit/5f573fb
+
+**Reproduction summary:**
+Added `tests/unit/test_orchestrator.py`, which runs a fake tool that fails
+the same way every real tool in `agent/tools/` fails (returns
+`ToolResult(success=False, ...)` internally instead of raising) through the
+actual `Orchestrator.run()`. The test confirms the orchestrator never checks
+`result.success`: it stores the failed tool's output as an indistinguishable
+empty dict and logs `tool_executed ... success=True` with no error/warning
+log anywhere, matching the issue's reported symptom exactly.
+
+**PLAN.md link:** https://github.com/ericitem/pathreview/blob/fix/44-log-tool-call-failures/PLAN.md
+
+**Walkthrough video (recommended):** Not recorded.
+
+**Blockers or open questions:**
+- Whether failed tool results should be cached by `ContextManager` the same
+  way successful ones are (currently they are, unconditionally) needs a
+  decision before implementation.
+- Whether to wrap successful `tool_results` values in the same envelope as
+  the fixed failure shape, or keep the two shapes different, is an open
+  design question -- see PLAN.md Risks & unknowns.
+- The mypy pre-commit hook is currently broken in this dev environment
+  (pre-existing untyped functions in the touched modules, plus a
+  numpy/mypy stub incompatibility under Python 3.14) independent of this
+  issue; unconfirmed whether CI hits the same problem. Needs checking before
+  the Week 9 PR.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -121,6 +121,8 @@ before it reaches any changed file, and 53 pre-existing unrelated
 before and after for every check, see the PR description for exact numbers
 and commands.
 
-**Draft PR feedback received from:** none yet -- PR was just opened as a
-draft; peer/mentor review through the course Slack workflow is still
-outstanding, and the PR will stay in draft until that feedback is addressed.
+**Draft PR feedback received from:** none. A peer/mentor review request was
+prepared for the course Slack workflow, but review was not obtained before
+the submission deadline. With the deadline close, I made the call to submit
+without it rather than hold the PR in draft indefinitely -- noting this
+openly here rather than marking the review step as complete.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -54,3 +54,73 @@ log anywhere, matching the issue's reported symptom exactly.
   numpy/mypy stub incompatibility under Python 3.14) independent of this
   issue; unconfirmed whether CI hits the same problem. Needs checking before
   the Week 9 PR.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the fix from `PLAN.md`: `Orchestrator.run()` (`agent/orchestrator.py`)
+now branches on `result.success` instead of unconditionally logging
+`success=True` and storing `result.data`; a failing tool now logs
+`tool_execution_failed` at error level and stores `{"error": ..., "success":
+False}`. `_execute_tool()` no longer caches failed results (resolves the
+caching risk from `PLAN.md`). `retry_with_backoff(max_retries=0)` in
+`agent/error_handling.py` now raises `ValueError` instead of silently
+returning `None`. All 5 `PLAN.md` sub-tasks are done. Test coverage expanded
+from 1 to 7 cases in `tests/unit/test_orchestrator.py`, plus 4 new cases in
+`tests/unit/test_error_handling.py` -- 11 total, all passing. Baseline
+established before touching anything (`make check` / `make test-unit`); full
+suite after the change is 53 failed / 386 passed, matching the documented
+pre-existing 53-failure baseline exactly, with zero new failures.
+
+**Next steps:**
+Open the draft PR, request peer/mentor review through the course Slack
+workflow, and address any feedback before marking it ready for review.
+
+**Blockers:**
+None.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/903
+
+**Branch:** `fix/44-log-tool-call-failures`
+
+**What you built:**
+`Orchestrator.run()` no longer trusts a tool call to have succeeded just
+because it didn't raise. Every tool in `agent/tools/` catches its own
+exceptions and returns `ToolResult(success=False, error=...)` instead of
+raising, so the orchestrator now checks `result.success` explicitly: on
+failure it logs an error with the real error message and stores a
+distinguishable failure shape instead of an empty dict tagged as a success.
+Also fixed a related bug where failed results were being cached and replayed
+as false "cache hits," and a latent `max_retries=0` bug in the retry
+decorator that silently returned `None`.
+
+**Tests added or updated:**
+`tests/unit/test_orchestrator.py` (expanded 1 -> 7 cases: the original
+reproduction now passing, a success-path regression check, a tool that
+raises directly, the pre-existing unknown-tool path, independent multi-tool
+outcomes, and both directions of the caching fix) and new
+`tests/unit/test_error_handling.py` (4 cases: the `max_retries=0` guard plus
+baseline retry/success/exhaustion behavior that had zero prior coverage).
+
+**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+
+Neither box is checked as a blanket pass -- both commands fail
+**repo-wide** due to a large pre-existing baseline unrelated to this issue
+(documented in the PR's "Notes for Reviewers" and in Week 7/8 entries above):
+182 pre-existing `ruff` errors, 52 files needing `black` reformatting, `mypy`
+crashing on a numpy/Python-3.14 stub incompatibility in this local venv
+before it reaches any changed file, and 53 pre-existing unrelated
+`test-unit` failures. What's verified instead: this contribution introduces
+**zero new failures** against that baseline -- confirmed failure counts
+before and after for every check, see the PR description for exact numbers
+and commands.
+
+**Draft PR feedback received from:** none yet -- PR was just opened as a
+draft; peer/mentor review through the course Slack workflow is still
+outstanding, and the PR will stay in draft until that feedback is addressed.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -126,3 +126,125 @@ prepared for the course Slack workflow, but review was not obtained before
 the submission deadline. With the deadline close, I made the call to submit
 without it rather than hold the PR in draft indefinitely -- noting this
 openly here rather than marking the review step as complete.
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No reviewer or maintainer feedback came in. PR #903 has been open since the
+Week 9 submission with zero comments and zero reviews (confirmed directly
+against the PR: `comments: []`, `reviews: []`, `state: OPEN`). As documented
+in the Week 9 entry above, a peer/mentor review request was prepared through
+the course Slack workflow, but it wasn't picked up before the Week 9
+deadline, and reviewer feedback is not a graded feature of this module for
+Summer 2026. Nothing here has been invented -- this section reflects the PR
+exactly as it stands.
+
+**How you responded:**
+N/A -- there's nothing to respond to yet. If review comments come in after
+this journal entry is submitted, I'll address them on the branch, but as of
+Week 10 the PR is unreviewed.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Distinguishing what was actually broken from what only *looked* broken took
+longer than fixing the real bug. The issue text pointed at
+`agent/error_handling.py` as well as `agent/orchestrator.py`, and my first
+instinct in Week 8 was to assume the swallowed-exception bug lived in
+`retry_with_backoff`. Reading all five tools in `agent/tools/` end to end
+showed the opposite: every tool already caught its own exceptions and
+returned a `ToolResult(success=False, ...)` instead of raising, which meant
+`retry_with_backoff` and the orchestrator's own `except Exception` blocks
+were essentially dead code for the failure mode the issue described -- the
+real bug was one missing `if result.success` check in `run()`. I only
+became confident of that because `PLAN.md`'s "Map" section forced me to
+write down, file by file, what each piece of code actually did instead of
+what I assumed it did. The other place that ate more time than expected was
+telling apart real problems from environment noise: this dev environment's
+`mypy` fails immediately on a numpy/Python-3.14 stub incompatibility before
+it even reaches the files I changed, and the repo has 182 pre-existing
+`ruff` errors and 53 pre-existing failing tests unrelated to issue #44. I
+had to run `mypy agent/orchestrator.py agent/error_handling.py
+--ignore-missing-imports` in isolation, both before and after my change, and
+capture exact pytest pass/fail counts (54 failed/375 passed before, 53
+failed/386 passed after) to be able to say with confidence that my change
+introduced zero new failures -- a claim I couldn't have made by just running
+`make check` once and eyeballing the output.
+
+**What did you learn about working in a large codebase?**
+The biggest adjustment was realizing that a fix's correctness has to be
+argued from the code as it exists, not from what the issue description
+implies. The issue said the orchestrator "catches all exceptions... and
+continues without logging," which reads like an exception-handling bug, but
+the actual defect was a missing success check on a value the orchestrator
+already had in hand. I also learned to check whether a fix even reaches
+production before treating it as high-risk: `PLAN.md`'s "Risks & unknowns"
+section notes that `core/services/review_service.py`'s
+`_run_agent_orchestration()` is a hardcoded placeholder that never calls
+`Orchestrator` at all, which I only found by grepping for `Orchestrator`
+usage repo-wide. That one search changed how carefully I needed to reason
+about the `tool_results` shape change, since nothing downstream currently
+consumes it. And unlike a solo project, I couldn't just fix the things I
+found broken along the way -- the caching-of-failed-results bug and the
+`retry_with_backoff(max_retries=0)` silent-`None` bug were both real, but I
+had to explicitly separate "in scope for issue #44" from "worth flagging for
+someone else," like the unenforced tool timeout I noted in `PLAN.md` but
+left untouched.
+
+**How did AI tools help — and where did they fall short?**
+Claude was most useful in Weeks 7 and 8 for structuring the investigation
+before any code was written -- `PLAN.md`'s Understand/Map/Plan/Risks/Edge
+cases format kept me from jumping straight to a fix, and having to fill in
+"Map" with an explicit file-by-file list is what surfaced that
+`error_handling.py` wasn't actually the bug's location, which I would
+likely have assumed otherwise given how the issue is worded. It was also
+useful for drafting the wording of PR descriptions and journal entries in a
+way that stayed precise about what was and wasn't verified, rather than
+rounding up to "tests pass."
+
+Where it fell short was anything that required actually running something.
+The exact baseline failure counts (54 failed/375 passed before, 53
+failed/386 passed after; 182 pre-existing ruff errors; 13 pre-existing mypy
+errors in the two touched files, unchanged by this fix) all came from
+executing `pytest`, `ruff`, and `mypy` myself and reading the real output --
+no amount of reasoning about the code could have told me those numbers or
+confirmed they didn't shift. Same with the numpy/mypy stub failure under
+Python 3.14: that's a runtime environment fact, discoverable only by running
+`mypy` and reading the traceback, not something inferable from the source.
+And the decision in `PLAN.md` Plan step 3 -- whether to wrap successful
+results in the same `{"success": ..., "data": ...}` envelope as the new
+failure shape, or leave successes as bare `result.data` for backward
+compatibility -- was a real design fork with downstream consequences that I
+had to resolve myself and document as a deliberate choice, not something
+that had a single obviously-correct answer to generate.
+
+**What would you do differently if you started over?**
+I'd try to get a peer or mentor review request out earlier than the Week 9
+deadline instead of preparing it and hoping it would be picked up in time --
+the JOURNAL.md Week 9 entry already documents making that call under time
+pressure rather than holding the PR in draft indefinitely, and in hindsight
+the request should have gone out as soon as the fix was implementation-complete
+rather than bundled with the final PR submission. I'd also front-load the
+tooling investigation -- I didn't discover the mypy/numpy incompatibility
+until Week 8, close to when I needed a clean `make check` run, and confirming
+it was a pre-existing, environment-specific issue (rather than something my
+change caused) took time I could have spent earlier if I'd run the full
+check suite against a clean `main` checkout in Week 7.
+
+**What are you most proud of from this module?**
+The `--no-verify` commit message on `8eebc32` is the thing I'd point to --
+not the workaround itself, but that it documents exactly why: 13
+pre-existing mypy errors in the touched files, unchanged before and after,
+verified in isolation, plus the same numpy stub issue documented earlier in
+this journal. It would have been easy to either force the hook through
+silently or avoid touching the files that trip it. Instead the PR makes it
+possible for a reviewer to check my claim against the repo themselves rather
+than trusting my word for it, which is the same standard I held the actual
+bug fix to -- store an error a caller can act on instead of a result that
+merely looks successful.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,198 @@
+## Solution plan
+
+**Issue:** [Orchestrator catches all exceptions from tool calls and continues without logging the failure](https://github.com/ascherj/pathreview/issues/44)
+
+### Understand
+
+**Confirmed root cause.** `Orchestrator.run()` (`agent/orchestrator.py`, lines
+51-62) calls `self._execute_tool(tool_name, tool_input)`, gets back a
+`ToolResult` object, and does:
+
+```python
+result = self._execute_tool(tool_name, tool_input)
+results[tool_name] = result.data if hasattr(result, 'data') else result
+logger.info("tool_executed", tool=tool_name, success=True)
+```
+
+It never inspects `result.success` or `result.error`. Every tool in
+`agent/tools/` (`github_tool.py`, `tech_detector.py`, `readme_scorer.py`,
+`skill_extractor.py`, `market_analyzer.py`) already catches its own
+exceptions internally inside `execute()` and always returns a `ToolResult`
+(`success=True` or `success=False`) instead of letting an exception escape
+(confirmed by reading all five `execute()` implementations). This means the
+orchestrator's own `except Exception` blocks (lines 60-62 in `run()`, 171-173
+in `_execute_tool()`) are effectively unreachable for real tool failures --
+the only exception that reliably reaches them today is the explicit
+`raise ValueError(f"Unknown tool: {tool_name}")` in `_execute_tool()` for an
+unregistered tool name, which is a different, already-correctly-logged
+scenario.
+
+**Expected behavior:** when a tool reports failure (`ToolResult.success is
+False`), the orchestrator should log the failure at error level with the
+tool name and error message, and store something in `results[tool_name]`
+that is distinguishable from a successful-but-empty result.
+
+**Actual behavior:** the failure is stored as `result.data` (frequently
+`{}`), and the orchestrator logs `tool_executed ... success=True` -- a false
+positive -- with no error or warning log anywhere.
+
+**Evidence:** `tests/unit/test_orchestrator.py::test_run_logs_and_preserves_failed_tool_result`
+(commit `5f573fb`) constructs a fake tool that fails the same way every real
+tool fails (returns `ToolResult(success=False, ...)` without raising), runs
+it through the actual `Orchestrator.run()`, and shows: no error/warning log
+is emitted, `output["tool_results"]["tech_detector"] == {}`, and the captured
+log explicitly contains `('info', 'tool_executed', {'tool': 'tech_detector',
+'success': True})`.
+
+### Map
+
+- **`agent/orchestrator.py` -- `Orchestrator.run()` (lines 51-62):** primary
+  fix location. Must branch on `result.success` before deciding what to log
+  and what to store in `results[tool_name]`.
+- **`agent/orchestrator.py` -- `Orchestrator._execute_tool()` (lines 136-173):**
+  currently catches `TimeoutError`/`Exception` and re-raises after logging --
+  this part already works correctly for genuinely raised exceptions and
+  should be left alone, but its interaction with the new `result.success`
+  check in `run()` needs to stay consistent (one failure shape regardless of
+  whether the tool raised or returned `success=False`).
+- **`agent/tools/base.py` -- `ToolResult` dataclass (`success: bool, data:
+  dict, error: str | None`):** defines the contract the orchestrator must
+  start honoring. Not expected to change.
+- **`agent/tools/github_tool.py`, `tech_detector.py`, `readme_scorer.py`,
+  `skill_extractor.py`, `market_analyzer.py`:** read-only reference -- each
+  confirms the `ToolResult(success=False, error=...)` contract on failure.
+  Not expected to change.
+- **`agent/error_handling.py` -- `retry_with_backoff`, `RetryContext`:**
+  listed as relevant in the issue, but investigation shows it already
+  re-raises `last_exception` correctly and logs at warning/error level on
+  each retry attempt. It is not the source of the silent-swallowing bug for
+  any of the current tools, since none of them let exceptions reach it in
+  the failure case. Kept in scope for Week 9 only to confirm no related edge
+  case (e.g. `max_retries=0` never entering the loop and returning `None`
+  silently) needs a fix alongside the main change.
+- **`agent/memory/context_manager.py` -- `store_tool_result` /
+  `get_tool_result`:** currently caches whatever `_execute_tool` returns,
+  including a failed `ToolResult`, unconditionally. Relevant because a fix
+  that changes what gets returned/cached from `_execute_tool` also changes
+  what gets memoized as a "cache hit" on a later call.
+- **`tests/unit/test_orchestrator.py`:** existing reproduction test (added
+  this week); expected to grow additional cases during the actual fix.
+
+**Files expected to be modified during implementation (Week 9):**
+- `agent/orchestrator.py`
+- `tests/unit/test_orchestrator.py`
+- Possibly `agent/error_handling.py`, only if the `max_retries=0` edge case
+  (see Risks) is judged in-scope.
+
+### Plan
+
+1. In `Orchestrator.run()`, replace the unconditional
+   `results[tool_name] = result.data` / `logger.info(..., success=True)` with
+   a branch on `result.success`: on failure, call
+   `logger.error("tool_execution_failed", tool=tool_name, error=result.error)`
+   and store a failure-shaped value in `results[tool_name]` (e.g.
+   `{"success": False, "error": result.error}`), matching the shape already
+   used by the existing `except Exception` branch at lines 60-62 so callers
+   see one consistent failure format regardless of path.
+2. Only log `logger.info("tool_executed", tool=tool_name, success=True)` in
+   the branch where `result.success` is actually `True`.
+3. Decide (and document the decision inline) whether *successful* results
+   should also be wrapped in a consistent envelope (e.g.
+   `{"success": True, "data": ...}`) or left as bare `result.data` for
+   backward compatibility -- this is a real design fork with downstream
+   consequences (see Risks) and should be resolved before writing the fix,
+   not discovered while writing it.
+4. Extend `tests/unit/test_orchestrator.py` to cover: a tool that raises
+   directly (confirm the pre-existing exception path still logs/returns
+   consistently with the new `ToolResult`-based path), the existing
+   "unknown tool" `ValueError` path (no regression), and a genuine success
+   case (no regression in the happy path).
+5. Re-run the full unit suite (`.venv/bin/pytest tests/unit -v -m unit`) and
+   confirm the failure count only decreases by the tests this issue touches
+   -- there are 53 pre-existing unrelated failures in this repo that are out
+   of scope and must not be conflated with this fix.
+
+### Inputs & outputs
+
+**Inputs:**
+- `profile_id: str` and `profile_data: dict` passed into `Orchestrator.run()`.
+- The `(tool_name, tool_input)` pairs produced by `_build_plan()` (unchanged
+  by this fix).
+- The `ToolResult(success, data, error)` object returned by each tool's
+  `execute()`.
+
+**Outputs:**
+- The dict returned by `run()`: `{"profile_id", "tool_results",
+  "cached_results"}`. After the fix, `tool_results[tool_name]` must have a
+  shape that lets a caller distinguish "tool succeeded with this data" from
+  "tool failed with this error" for every tool, not just the ones that
+  happened to raise an unregistered-tool `ValueError`.
+- Structlog output: exactly one error-level log entry per failed tool call,
+  and no misleading `success=True` info log for a tool that failed.
+
+### Risks & unknowns
+
+- **Breaking change to `tool_results` shape:** wrapping failure results
+  (and possibly success results, per Plan step 3) changes what downstream
+  code receives from `results[tool_name]`. Today nothing in the app actually
+  consumes this shape in production -- `core/services/review_service.py`'s
+  `_run_agent_orchestration()` is a hardcoded placeholder and does not call
+  `Orchestrator` at all (confirmed by reading the file and grepping for
+  `Orchestrator` usage repo-wide: it's only referenced inside
+  `agent/orchestrator.py` itself). This lowers the immediate blast radius,
+  but should be verified again in Week 9 in case that wiring changes before
+  this fix lands.
+- **Caching of failed results:** `_execute_tool` caches whatever it gets
+  back from `_execute_with_timeout` via `context_manager.store_tool_result`,
+  including a failed `ToolResult`, unconditionally. Need to verify whether a
+  failed result should be cached at all -- as written today, a failure is
+  memoized and would be replayed as a "cache hit" on a later call within the
+  same session, silently skipping any retry.
+- **`retry_with_backoff(max_retries=0)`:** if `max_retries` were ever `0`,
+  the `while attempt < max_retries` loop never executes, `last_exception`
+  stays `None`, and the wrapper falls through returning `None` with nothing
+  raised -- a separate latent bug in `agent/error_handling.py`. Current
+  orchestrator usage always passes `max_retries=2`, so this is not reachable
+  today, but should be double-checked before Week 9 sign-off.
+- **Timeout is measured, not enforced:** `_execute_with_timeout` computes
+  `elapsed` and only logs a `tool_slow` warning if it exceeds `timeout` --
+  there is no actual timeout mechanism (no thread/async cancellation), so a
+  hanging tool call blocks indefinitely regardless of `tool_timeout`. Related
+  to this issue's theme (failures not surfaced) but a distinct bug; flagging
+  it here so it isn't silently folded into this fix without a deliberate
+  decision.
+- **Zero pre-existing test coverage:** there was no test file for
+  `agent/orchestrator.py` or `agent/error_handling.py` before this week, so
+  the fix's regression risk is higher than for a well-tested module --
+  mitigated by Plan step 4's expanded test cases.
+- **mypy/pre-commit tooling is currently broken in this dev environment,**
+  independent of this issue: this Python 3.14 venv's `mypy` (pinned to
+  `v1.8.0` in `.pre-commit-config.yaml`) fails on a numpy type-stub syntax
+  error before it can check anything, and `agent/orchestrator.py`,
+  `error_handling.py`, `context_manager.py`, and `session_store.py` already
+  fail `disallow_untyped_defs=true` independent of any change here (verified
+  by running `mypy agent/orchestrator.py --ignore-missing-imports` in
+  isolation). Unknown whether CI runs a different Python version where this
+  resolves itself -- needs checking (e.g. `.github/workflows/`) before the
+  Week 9 PR, since the final fix will need to pass mypy cleanly on whatever
+  functions it touches at minimum.
+
+### Edge cases
+
+- A tool returns `ToolResult(success=False, data={}, error=None)` (failed,
+  but with no error message) -- the fix must not crash while trying to log a
+  `None` error message.
+- A tool raises an exception directly instead of returning
+  `ToolResult(success=False, ...)` (e.g. a bug in a future tool that doesn't
+  follow the existing convention) -- the pre-existing `except Exception`
+  path in `run()` must produce the same failure shape as the new
+  `result.success is False` path, not two different formats.
+- The existing "unknown tool" case (`tool_name not in self.tools`, raises
+  `ValueError`) must continue to log and return exactly as it does today --
+  this already works correctly and is a regression risk if touched carelessly.
+- Two or more tools fail within the same `run()` call -- `results` must
+  reflect each tool's own outcome independently, not just the last one
+  processed in the loop.
+- A tool fails on its first attempt but succeeds after a retry inside
+  `retry_with_backoff` -- the final logged outcome must reflect the
+  eventual success, not the earlier retry warning.

--- a/agent/error_handling.py
+++ b/agent/error_handling.py
@@ -1,14 +1,16 @@
 """Retry logic with exponential backoff."""
 
-import time
 import functools
+import time
+
 import structlog
 
 logger = structlog.get_logger()
 
 
-def retry_with_backoff(max_retries: int = 3, backoff_factor: float = 2.0,
-                       exceptions: tuple = (Exception,)):
+def retry_with_backoff(
+    max_retries: int = 3, backoff_factor: float = 2.0, exceptions: tuple = (Exception,)
+):
     """Decorator for retry logic with exponential backoff.
 
     Args:
@@ -18,7 +20,14 @@ def retry_with_backoff(max_retries: int = 3, backoff_factor: float = 2.0,
 
     Returns:
         Decorated function
+
+    Raises:
+        ValueError: If max_retries is less than 1 (zero attempts would
+            silently return None instead of ever calling func or raising).
     """
+    if max_retries < 1:
+        raise ValueError("max_retries must be at least 1")
+
     def decorator(func):
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
@@ -36,26 +45,37 @@ def retry_with_backoff(max_retries: int = 3, backoff_factor: float = 2.0,
 
                     if attempt < max_retries:
                         wait_time = backoff_factor ** (attempt - 1)
-                        logger.warning("retry_attempt", func=func.__name__,
-                                     attempt=attempt, max_retries=max_retries,
-                                     wait_seconds=wait_time, error=str(e))
+                        logger.warning(
+                            "retry_attempt",
+                            func=func.__name__,
+                            attempt=attempt,
+                            max_retries=max_retries,
+                            wait_seconds=wait_time,
+                            error=str(e),
+                        )
                         time.sleep(wait_time)
                     else:
-                        logger.error("retry_exhausted", func=func.__name__,
-                                   max_retries=max_retries, error=str(e))
+                        logger.error(
+                            "retry_exhausted",
+                            func=func.__name__,
+                            max_retries=max_retries,
+                            error=str(e),
+                        )
 
             if last_exception:
                 raise last_exception
 
         return wrapper
+
     return decorator
 
 
 class RetryContext:
     """Context manager for retry logic with exponential backoff."""
 
-    def __init__(self, max_retries: int = 3, backoff_factor: float = 2.0,
-                 exceptions: tuple = (Exception,)):
+    def __init__(
+        self, max_retries: int = 3, backoff_factor: float = 2.0, exceptions: tuple = (Exception,)
+    ):
         """Initialize retry context.
 
         Args:
@@ -86,12 +106,20 @@ class RetryContext:
 
         if self.attempt < self.max_retries:
             wait_time = self.backoff_factor ** (self.attempt - 1)
-            logger.warning("retry_context_attempt", attempt=self.attempt,
-                         max_retries=self.max_retries, wait_seconds=wait_time,
-                         error=str(exc_val))
+            logger.warning(
+                "retry_context_attempt",
+                attempt=self.attempt,
+                max_retries=self.max_retries,
+                wait_seconds=wait_time,
+                error=str(exc_val),
+            )
             time.sleep(wait_time)
             return True  # Suppress exception and retry
 
-        logger.error("retry_context_exhausted", attempt=self.attempt,
-                   max_retries=self.max_retries, error=str(exc_val))
+        logger.error(
+            "retry_context_exhausted",
+            attempt=self.attempt,
+            max_retries=self.max_retries,
+            error=str(exc_val),
+        )
         return False  # Re-raise exception

--- a/agent/orchestrator.py
+++ b/agent/orchestrator.py
@@ -1,12 +1,12 @@
 """Plan-execute orchestrator for agent tools."""
 
 import time
-import structlog
-from typing import Optional
 
-from .memory.session_store import SessionStore
-from .memory.context_manager import ContextManager
+import structlog
+
 from .error_handling import retry_with_backoff
+from .memory.context_manager import ContextManager
+from .memory.session_store import SessionStore
 
 logger = structlog.get_logger()
 
@@ -14,8 +14,9 @@ logger = structlog.get_logger()
 class Orchestrator:
     """Orchestrate tool execution with planning and memoization."""
 
-    def __init__(self, tools: dict, session_store: Optional[SessionStore] = None,
-                 tool_timeout: float = 30.0):
+    def __init__(
+        self, tools: dict, session_store: SessionStore | None = None, tool_timeout: float = 30.0
+    ):
         """Initialize orchestrator.
 
         Args:
@@ -53,9 +54,14 @@ class Orchestrator:
         for tool_name, tool_input in plan:
             try:
                 result = self._execute_tool(tool_name, tool_input)
-                results[tool_name] = result.data if hasattr(result, 'data') else result
 
-                logger.info("tool_executed", tool=tool_name, success=True)
+                if getattr(result, "success", True):
+                    results[tool_name] = result.data if hasattr(result, "data") else result
+                    logger.info("tool_executed", tool=tool_name, success=True)
+                else:
+                    error_message = getattr(result, "error", None)
+                    logger.error("tool_execution_failed", tool=tool_name, error=error_message)
+                    results[tool_name] = {"error": error_message, "success": False}
 
             except Exception as e:
                 logger.error("tool_execution_failed", tool=tool_name, error=str(e))
@@ -66,13 +72,12 @@ class Orchestrator:
             session_state.update(results)
             self.session_store.set(profile_id, session_state)
 
-        logger.info("orchestrator_complete", profile_id=profile_id,
-                   tools_executed=len(results))
+        logger.info("orchestrator_complete", profile_id=profile_id, tools_executed=len(results))
 
         return {
             "profile_id": profile_id,
             "tool_results": results,
-            "cached_results": self.context_manager.get_all_results()
+            "cached_results": self.context_manager.get_all_results(),
         }
 
     def _build_plan(self, profile_data: dict) -> list[tuple[str, dict]]:
@@ -90,45 +95,42 @@ class Orchestrator:
         if profile_data.get("github_username"):
             for project in profile_data.get("projects", []):
                 if project.get("github_repo"):
-                    plan.append((
-                        "github_tool",
-                        {
-                            "github_username": profile_data["github_username"],
-                            "repo_name": project["github_repo"]
-                        }
-                    ))
+                    plan.append(
+                        (
+                            "github_tool",
+                            {
+                                "github_username": profile_data["github_username"],
+                                "repo_name": project["github_repo"],
+                            },
+                        )
+                    )
                     break  # Only process first repo for now
 
         # Tech detector (if files available)
         if profile_data.get("files"):
-            plan.append((
-                "tech_detector",
-                {"files": profile_data["files"]}
-            ))
+            plan.append(("tech_detector", {"files": profile_data["files"]}))
 
         # README scorer
         if profile_data.get("readme_content"):
-            plan.append((
-                "readme_scorer",
-                {"readme_content": profile_data["readme_content"]}
-            ))
+            plan.append(("readme_scorer", {"readme_content": profile_data["readme_content"]}))
 
         # Skill extractor
         if profile_data.get("resume_text"):
-            plan.append((
-                "skill_extractor",
-                {
-                    "resume_text": profile_data["resume_text"],
-                    "repo_metadata": profile_data.get("repo_metadata", {})
-                }
-            ))
+            plan.append(
+                (
+                    "skill_extractor",
+                    {
+                        "resume_text": profile_data["resume_text"],
+                        "repo_metadata": profile_data.get("repo_metadata", {}),
+                    },
+                )
+            )
 
         # Market analyzer (if skills detected)
         if plan:  # Only if other tools executed
-            plan.append((
-                "market_analyzer",
-                {"detected_skills": {}}  # Will be populated by context
-            ))
+            plan.append(
+                ("market_analyzer", {"detected_skills": {}})  # Will be populated by context
+            )
 
         logger.info("plan_built", plan_size=len(plan))
         return plan
@@ -160,8 +162,11 @@ class Orchestrator:
         try:
             result = self._execute_with_timeout(tool, tool_input)
 
-            # Cache result
-            self.context_manager.store_tool_result(tool_name, input_hash, result)
+            # Only cache successful results -- caching a failure would replay
+            # it as a "cache hit" on a later call within the same session,
+            # silently skipping any retry.
+            if getattr(result, "success", True):
+                self.context_manager.store_tool_result(tool_name, input_hash, result)
 
             return result
 
@@ -172,7 +177,7 @@ class Orchestrator:
             logger.error("tool_execution_error", tool=tool_name, error=str(e))
             raise
 
-    def _execute_with_timeout(self, tool, tool_input: dict, timeout: Optional[float] = None):
+    def _execute_with_timeout(self, tool, tool_input: dict, timeout: float | None = None):
         """Execute tool with timeout.
 
         Args:

--- a/tests/unit/test_error_handling.py
+++ b/tests/unit/test_error_handling.py
@@ -1,0 +1,58 @@
+"""Tests for error_handling.py
+
+Covers a latent bug found while investigating issue #44: with
+max_retries=0, the `while attempt < max_retries` loop in
+retry_with_backoff() never executes, `last_exception` stays None, and the
+wrapper falls through returning None -- silently, with no exception raised
+and nothing logged. Not reachable via the current Orchestrator (which
+always passes max_retries=2), but a real defect in a function this issue
+lists as relevant.
+"""
+
+import pytest
+
+from agent.error_handling import retry_with_backoff
+
+
+@pytest.mark.unit
+class TestRetryWithBackoff:
+    def test_max_retries_zero_raises_value_error(self):
+        """max_retries=0 must raise immediately rather than silently
+        returning None without ever calling the wrapped function."""
+        with pytest.raises(ValueError, match="max_retries"):
+
+            @retry_with_backoff(max_retries=0)
+            def _never_called():
+                raise AssertionError("should not be called")
+
+    def test_succeeds_on_first_attempt(self):
+        calls = []
+
+        @retry_with_backoff(max_retries=3, backoff_factor=0.0)
+        def _succeeds():
+            calls.append(1)
+            return "ok"
+
+        assert _succeeds() == "ok"
+        assert len(calls) == 1
+
+    def test_succeeds_after_transient_failure(self):
+        attempts = {"count": 0}
+
+        @retry_with_backoff(max_retries=3, backoff_factor=0.0)
+        def _fails_once_then_succeeds():
+            attempts["count"] += 1
+            if attempts["count"] < 2:
+                raise ValueError("transient")
+            return "ok"
+
+        assert _fails_once_then_succeeds() == "ok"
+        assert attempts["count"] == 2
+
+    def test_raises_last_exception_after_exhausting_retries(self):
+        @retry_with_backoff(max_retries=2, backoff_factor=0.0)
+        def _always_fails():
+            raise ValueError("persistent failure")
+
+        with pytest.raises(ValueError, match="persistent failure"):
+            _always_fails()

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -1,0 +1,92 @@
+"""Tests for orchestrator.py
+
+Reproduction for issue #44: "Orchestrator catches all exceptions from tool
+calls and continues without logging the failure."
+
+Every tool in agent/tools/ (github_tool.py, tech_detector.py,
+readme_scorer.py, skill_extractor.py, market_analyzer.py) catches its own
+exceptions internally inside execute() and always returns a ToolResult --
+success=True or success=False -- rather than letting an exception propagate.
+Orchestrator.run() (agent/orchestrator.py) never inspects `result.success` or
+`result.error`; it unconditionally does `results[tool_name] = result.data`
+and logs `tool_executed ... success=True`, regardless of what the tool
+actually reported.
+
+The test below encodes the expected, correct behavior: when a tool reports
+failure, the orchestrator should log that failure and the failure should be
+visible in the returned results, not silently collapsed into an empty dict
+tagged as a success. It fails against the current implementation.
+"""
+
+import pytest
+
+from agent.orchestrator import Orchestrator
+from agent.tools.base import BaseTool, ToolResult
+
+
+class FailingTool(BaseTool):
+    """A tool that fails the way every real tool in this repo fails: by
+    catching its own exception internally and returning
+    ToolResult(success=False, ...) rather than raising."""
+
+    name = "tech_detector"
+    description = "Simulates a tool that fails internally without raising"
+
+    def execute(self, input_data: dict) -> ToolResult:
+        return ToolResult(success=False, data={}, error="simulated tool failure")
+
+
+class SpyLogger:
+    """Records structlog-style calls so we can assert on what was logged."""
+
+    def __init__(self):
+        self.calls = []
+
+    def info(self, event, **kwargs):
+        self.calls.append(("info", event, kwargs))
+
+    def warning(self, event, **kwargs):
+        self.calls.append(("warning", event, kwargs))
+
+    def error(self, event, **kwargs):
+        self.calls.append(("error", event, kwargs))
+
+    def calls_at_level(self, level):
+        return [c for c in self.calls if c[0] == level]
+
+
+@pytest.mark.unit
+class TestOrchestratorToolFailureLogging:
+    """Reproduction test for issue #44."""
+
+    def test_run_logs_and_preserves_failed_tool_result(self, monkeypatch):
+        """When a tool reports failure, run() should log it at error level
+        and preserve the failure in the returned tool_results, instead of
+        silently storing an empty dict and logging a false success.
+        """
+        spy = SpyLogger()
+        monkeypatch.setattr("agent.orchestrator.logger", spy)
+
+        orchestrator = Orchestrator(tools={"tech_detector": FailingTool()})
+        # Bypass _build_plan (its own logic is unrelated to this issue) so
+        # the test isolates exactly the result-handling defect in run().
+        monkeypatch.setattr(
+            orchestrator,
+            "_build_plan",
+            lambda profile_data: [("tech_detector", {"files": ["main.py"]})],
+        )
+
+        output = orchestrator.run("profile-1", {"files": ["main.py"]})
+
+        assert spy.calls_at_level("error"), (
+            "expected an error-level log when a tool reports failure, "
+            f"but only these calls were logged: {spy.calls}"
+        )
+
+        tech_result = output["tool_results"]["tech_detector"]
+        assert isinstance(tech_result, dict)
+        assert tech_result.get("success") is False, (
+            "expected the failure to be visible in tool_results, but got "
+            f"{tech_result!r} -- indistinguishable from an empty success"
+        )
+        assert "error" in tech_result

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -1,21 +1,15 @@
 """Tests for orchestrator.py
 
-Reproduction for issue #44: "Orchestrator catches all exceptions from tool
-calls and continues without logging the failure."
+Covers issue #44: "Orchestrator catches all exceptions from tool calls and
+continues without logging the failure."
 
 Every tool in agent/tools/ (github_tool.py, tech_detector.py,
 readme_scorer.py, skill_extractor.py, market_analyzer.py) catches its own
 exceptions internally inside execute() and always returns a ToolResult --
 success=True or success=False -- rather than letting an exception propagate.
-Orchestrator.run() (agent/orchestrator.py) never inspects `result.success` or
-`result.error`; it unconditionally does `results[tool_name] = result.data`
-and logs `tool_executed ... success=True`, regardless of what the tool
-actually reported.
-
-The test below encodes the expected, correct behavior: when a tool reports
-failure, the orchestrator should log that failure and the failure should be
-visible in the returned results, not silently collapsed into an empty dict
-tagged as a success. It fails against the current implementation.
+Orchestrator.run() and Orchestrator._execute_tool() now inspect
+`result.success` before deciding what to log, what to store in
+`tool_results`, and what to cache -- see agent/orchestrator.py.
 """
 
 import pytest
@@ -34,6 +28,49 @@ class FailingTool(BaseTool):
 
     def execute(self, input_data: dict) -> ToolResult:
         return ToolResult(success=False, data={}, error="simulated tool failure")
+
+
+class CountingFailingTool(BaseTool):
+    """Like FailingTool, but tracks how many times execute() was called, so
+    tests can assert on whether a failure was cached."""
+
+    name = "tech_detector"
+    description = "Simulates a tool that fails internally, counting calls"
+
+    def __init__(self):
+        self.call_count = 0
+
+    def execute(self, input_data: dict) -> ToolResult:
+        self.call_count += 1
+        return ToolResult(success=False, data={}, error="simulated tool failure")
+
+
+class CountingSucceedingTool(BaseTool):
+    """A tool that succeeds and tracks how many times execute() was called,
+    so tests can assert that successful results are still cached."""
+
+    name = "tech_detector"
+    description = "Simulates a tool that succeeds, counting calls"
+
+    def __init__(self):
+        self.call_count = 0
+
+    def execute(self, input_data: dict) -> ToolResult:
+        self.call_count += 1
+        return ToolResult(success=True, data={"primary_language": "Python"})
+
+
+class RaisingTool(BaseTool):
+    """A tool that raises directly instead of returning
+    ToolResult(success=False). Not how any current tool behaves, but the
+    orchestrator must handle it consistently with the ToolResult-based
+    failure path."""
+
+    name = "tech_detector"
+    description = "Simulates a tool that raises instead of returning a result"
+
+    def execute(self, input_data: dict) -> ToolResult:
+        raise RuntimeError("boom")
 
 
 class SpyLogger:
@@ -55,28 +92,34 @@ class SpyLogger:
         return [c for c in self.calls if c[0] == level]
 
 
+def _run_single_tool(monkeypatch, tool, tool_name="tech_detector"):
+    """Run Orchestrator.run() with a single tool in the plan, bypassing
+    _build_plan (its own logic is unrelated to this issue) so each test
+    isolates exactly the result-handling behavior in run()."""
+    spy = SpyLogger()
+    monkeypatch.setattr("agent.orchestrator.logger", spy)
+
+    orchestrator = Orchestrator(tools={tool_name: tool})
+    monkeypatch.setattr(
+        orchestrator,
+        "_build_plan",
+        lambda profile_data: [(tool_name, {"files": ["main.py"]})],
+    )
+
+    output = orchestrator.run("profile-1", {"files": ["main.py"]})
+    return output, spy
+
+
 @pytest.mark.unit
 class TestOrchestratorToolFailureLogging:
-    """Reproduction test for issue #44."""
+    """Reproduction and regression tests for issue #44."""
 
     def test_run_logs_and_preserves_failed_tool_result(self, monkeypatch):
-        """When a tool reports failure, run() should log it at error level
-        and preserve the failure in the returned tool_results, instead of
-        silently storing an empty dict and logging a false success.
-        """
-        spy = SpyLogger()
-        monkeypatch.setattr("agent.orchestrator.logger", spy)
-
-        orchestrator = Orchestrator(tools={"tech_detector": FailingTool()})
-        # Bypass _build_plan (its own logic is unrelated to this issue) so
-        # the test isolates exactly the result-handling defect in run().
-        monkeypatch.setattr(
-            orchestrator,
-            "_build_plan",
-            lambda profile_data: [("tech_detector", {"files": ["main.py"]})],
-        )
-
-        output = orchestrator.run("profile-1", {"files": ["main.py"]})
+        """When a tool reports failure via ToolResult(success=False), run()
+        must log it at error level and preserve the failure in the returned
+        tool_results, instead of silently storing an empty dict and logging
+        a false success."""
+        output, spy = _run_single_tool(monkeypatch, FailingTool())
 
         assert spy.calls_at_level("error"), (
             "expected an error-level log when a tool reports failure, "
@@ -85,8 +128,121 @@ class TestOrchestratorToolFailureLogging:
 
         tech_result = output["tool_results"]["tech_detector"]
         assert isinstance(tech_result, dict)
-        assert tech_result.get("success") is False, (
-            "expected the failure to be visible in tool_results, but got "
-            f"{tech_result!r} -- indistinguishable from an empty success"
+        assert tech_result.get("success") is False
+        assert tech_result.get("error") == "simulated tool failure"
+
+        # No misleading success log for the failed tool.
+        false_success = [
+            c
+            for c in spy.calls_at_level("info")
+            if c[1] == "tool_executed" and c[2].get("success") is True
+        ]
+        assert not false_success
+
+    def test_run_success_path_is_unchanged(self, monkeypatch):
+        """A successful tool call must still log success=True and store the
+        tool's bare data dict in tool_results (no regression)."""
+        output, spy = _run_single_tool(monkeypatch, CountingSucceedingTool())
+
+        assert output["tool_results"]["tech_detector"] == {"primary_language": "Python"}
+
+        success_logs = [
+            c
+            for c in spy.calls_at_level("info")
+            if c[1] == "tool_executed" and c[2].get("success") is True
+        ]
+        assert success_logs
+        assert not spy.calls_at_level("error")
+
+    def test_run_handles_raised_exception_consistently_with_failed_result(self, monkeypatch):
+        """A tool that raises directly (instead of returning
+        ToolResult(success=False)) must produce the same failure shape as
+        the ToolResult-based failure path, not a different format."""
+        output, spy = _run_single_tool(monkeypatch, RaisingTool())
+
+        assert spy.calls_at_level("error")
+
+        tech_result = output["tool_results"]["tech_detector"]
+        assert tech_result == {"error": "boom", "success": False}
+
+    def test_run_logs_error_for_unknown_tool(self, monkeypatch):
+        """Pre-existing correct behavior: a plan step referencing a tool name
+        that isn't registered must still log an error and record the
+        failure, unchanged by this fix."""
+        spy = SpyLogger()
+        monkeypatch.setattr("agent.orchestrator.logger", spy)
+
+        orchestrator = Orchestrator(tools={})
+        monkeypatch.setattr(
+            orchestrator,
+            "_build_plan",
+            lambda profile_data: [("nonexistent_tool", {})],
         )
-        assert "error" in tech_result
+
+        output = orchestrator.run("profile-1", {})
+
+        assert spy.calls_at_level("error")
+        result = output["tool_results"]["nonexistent_tool"]
+        assert result["success"] is False
+        assert "Unknown tool" in result["error"]
+
+    def test_run_reflects_each_tool_outcome_independently(self, monkeypatch):
+        """When multiple tools run in the same plan, a failure in one must
+        not affect another tool's own recorded outcome."""
+        spy = SpyLogger()
+        monkeypatch.setattr("agent.orchestrator.logger", spy)
+
+        orchestrator = Orchestrator(
+            tools={
+                "tech_detector": FailingTool(),
+                "readme_scorer": CountingSucceedingTool(),
+            }
+        )
+        monkeypatch.setattr(
+            orchestrator,
+            "_build_plan",
+            lambda profile_data: [
+                ("tech_detector", {}),
+                ("readme_scorer", {}),
+            ],
+        )
+
+        output = orchestrator.run("profile-1", {})
+
+        assert output["tool_results"]["tech_detector"] == {
+            "error": "simulated tool failure",
+            "success": False,
+        }
+        assert output["tool_results"]["readme_scorer"] == {"primary_language": "Python"}
+
+
+@pytest.mark.unit
+class TestOrchestratorFailureCaching:
+    """A failed tool result must not be cached -- caching it would replay the
+    same failure as a "cache hit" on a later call within the same session,
+    silently skipping any retry."""
+
+    def test_failed_result_is_not_cached(self):
+        tool = CountingFailingTool()
+        orchestrator = Orchestrator(tools={"tech_detector": tool})
+
+        first = orchestrator._execute_tool("tech_detector", {"files": ["main.py"]})
+        second = orchestrator._execute_tool("tech_detector", {"files": ["main.py"]})
+
+        assert first.success is False
+        assert second.success is False
+        assert tool.call_count == 2, (
+            "expected the tool to be re-executed on the second call, but "
+            "the failed result appears to have been served from cache"
+        )
+
+    def test_successful_result_is_still_cached(self):
+        """Regression check: the caching fix must not disable memoization
+        for successful results."""
+        tool = CountingSucceedingTool()
+        orchestrator = Orchestrator(tools={"tech_detector": tool})
+
+        orchestrator._execute_tool("tech_detector", {"files": ["main.py"]})
+        orchestrator._execute_tool("tech_detector", {"files": ["main.py"]})
+
+        assert tool.call_count == 1, "expected the second call to be served from cache"


### PR DESCRIPTION
## Summary
Fixes issue #44: `Orchestrator.run()` in `agent/orchestrator.py` never inspected `ToolResult.success`/`.error` before logging and storing a tool's output. Because every tool in `agent/tools/` catches its own exceptions internally and always returns a `ToolResult` object instead of raising, a failed tool's result was silently stored as an empty, success-shaped dict and logged as `tool_executed ... success=True` -- with no error surfaced anywhere. This PR makes the orchestrator branch on `result.success`, fixes a related caching bug that would have replayed failures as cache hits, and closes a latent `retry_with_backoff(max_retries=0)` silent-`None`-return bug in the other file the issue names as relevant.

## Issue
Closes #44

## Changes
- `agent/orchestrator.py`: `run()` now logs `tool_execution_failed` at error level and stores `{"error": ..., "success": False}` when a tool reports failure via `ToolResult.success is False`, instead of unconditionally logging `success=True` and storing the tool's (often empty) `data`.
- `agent/orchestrator.py`: `_execute_tool()` no longer caches a failed `ToolResult`, so a failure isn't replayed as a "cache hit" on a later call within the same session.
- `agent/error_handling.py`: `retry_with_backoff(max_retries=0)` now raises `ValueError` immediately instead of silently falling through and returning `None` with nothing raised or logged.
- `tests/unit/test_orchestrator.py`: expanded from 1 to 7 test cases covering the original reproduction, the success path (no regression), a tool that raises directly (consistent failure shape), the pre-existing "unknown tool" path (no regression), independent multi-tool outcomes, and both directions of the caching fix.
- `tests/unit/test_error_handling.py` (new): 4 test cases covering the `max_retries=0` guard plus baseline retry/success/exhaustion behavior that had zero prior coverage.

## Testing
- [ ] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`)
- [ ] Linter passes (`make lint`)
- [ ] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes

## Screenshots / Demo
N/A -- backend logic change with no UI surface.

## Notes for Reviewers
This repo currently has a large pre-existing baseline of unrelated failures across `make test-unit`, `make lint`, and `make typecheck` (documented in `JOURNAL.md` on this branch). The four unchecked boxes above are unchecked because those commands don't exit cleanly **repo-wide** for reasons unrelated to this change, not because this PR regresses anything:

- **`make test-unit`**: baseline was 54 failed / 375 passed before this PR (53 pre-existing unrelated failures + 1 failing test, which *was* this issue's reproduction test). After this PR: 53 failed / 386 passed -- the same 53 pre-existing failures, unchanged, plus 11 new/fixed passing tests for this issue. Verified via `.venv/bin/pytest tests/unit -m unit`.
- **`make lint`**: 182 pre-existing `ruff` errors repo-wide before this PR, none in files this PR touches except 4 that the pre-commit hook auto-fixed as a side effect of committing. The new/changed test files are ruff-clean. Verified via `.venv/bin/ruff check <touched files>`.
- **`make typecheck`**: `mypy` cannot get past a `numpy` type-stub syntax error in this Python 3.14 local dev venv before it reaches any of the changed files (CI pins Python 3.11 per `.github/workflows/ci.yml`, so this may be local-environment-specific -- unconfirmed against real CI since fork-PR workflow runs require maintainer approval). Scoped in isolation to just the two touched source files, there were 13 pre-existing `no-untyped-def` errors before this change and 13 after (same functions, unchanged count) -- this PR adds no new mypy errors to the files it touches, but doesn't fix the pre-existing ones either.

Two related-but-out-of-scope findings from investigating this issue, intentionally left untouched (see `PLAN.md` on this branch for full reasoning):
- `_execute_with_timeout` measures elapsed time but never actually enforces a timeout (no cancellation mechanism).
- `core/services/review_service.py`'s `_run_agent_orchestration()` is a hardcoded placeholder and doesn't call `Orchestrator` at all yet, so this fix isn't yet visible in the live review pipeline.

Open to splitting the caching fix and the `error_handling.py` guard into separate commits if reviewers would prefer a narrower diff.
