### PR TITLE
Fix/149 structural chunker no headings

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,82 @@
+# PathReview Contribution Journal
+
+A running record of my Module 3 work on PathReview.
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/149
+
+**Issue title:** Structural chunker silently drops documents that contain no headings
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The issue is in PathReview's StructuralChunker, which only creates sections from content that appears under Markdown headings. If a document contains no headings, _extract_sections never records any text, causing chunk() to return an empty list. As a result, heading-less documents are silently excluded from the RAG indexing pipeline and cannot be retrieved during searches. A successful fix would ensure that any non-empty document without headings is still chunked—either as a single chunk or by using the semantic chunker fallback—so every valid document contributes at least one chunk to the index and the existing test_document_with_no_headings passes.
+
+**Branch name:** fix/149-structural-chunker-no-headings
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger
+
+Issue Selection & Readiness
+"Is this right for me?" — Scope reasoning (selection notes)
+Single, well-defined location. The bug lives in one file, ingestion/chunking/structural_chunker.py (specifically the content-collection guard in _extract_sections). No cross-subsystem changes are required.
+Clear, reproducible failure. Running StructuralChunker().chunk("plain text ...", {}) returns []. This is easy to reproduce and verify once fixed.
+Existing test defines "done". There is already a failing unit test, test_document_with_no_headings in tests/unit/test_structural_chunker.py. The goal is to make that test pass without breaking the existing heading-based tests.
+Right size for a first contribution. The issue is tagged Tier 1 and good first issue, making it a small, localized fix rather than a large refactor.
+I understand the surrounding code. I traced the issue to the if heading_stack or current_section_lines guard in _extract_sections, which prevents content from being collected when a document has no headings.
+Conclusion. This issue is within my current skill level and is an appropriate first open-source contribution.
+Setup Notes
+Forked the repository and cloned it locally.
+Configured remotes:
+origin → samanth1111-1111/pathreview
+upstream → ascherj/pathreview
+Created a .env file from .env.example using LLM_PROVIDER=mock.
+Installed frontend dependencies with npm install.
+Verified the Vite development server runs at http://localhost:5173.
+Outstanding: Install Docker Desktop and make, then run make setup and make run to start PostgreSQL, Redis, and the backend services.
+Part 1 — Understanding the Issue
+Can I explain what this issue is asking for in my own words?
+
+The issue occurs because the structural chunker only collects text after encountering a Markdown heading. If a document has no headings, it produces no chunks. The fix should ensure that plain-text documents are still chunked instead of being silently dropped.
+
+✅ I can explain the problem and the expected behavior in 2–3 sentences without rereading the issue.
+Do I understand which part of the app is affected?
+
+The issue affects the ingestion pipeline, specifically the structural chunking logic in ingestion/chunking/structural_chunker.py.
+
+✅ I've located the relevant files and confirmed they exist in the codebase.
+Do I understand what "done" looks like?
+
+Before the fix, documents without Markdown headings produce no chunks. After the fix, they should still produce at least one chunk while preserving the existing behavior for documents that do contain headings.
+
+✅ I can describe a concrete before-and-after.
+Part 2 — Tier Fit
+Is the tier a realistic match for where I am right now?
+
+ Picking a Tier 1 issue is appropriate. The change is localized, has clear acceptance criteria, and does not require understanding the entire system.
+
+Part 3 — Codebase Readiness
+Can I find the relevant code?
+✅ I've found and read the specific code the issue references.
+Do I understand the surrounding code well enough to change it safely?
+
+I understand how _extract_sections processes documents and where the bug occurs, so I can outline the change before editing the code.
+
+✅ I've read enough surrounding context that I can write a rough plan for the fix.
+Have I read the relevant test file?
+✅ I've found the test file (tests/unit/test_structural_chunker.py) and reviewed the existing tests.
+Part 4 — Scope and Time
+How many others are already working on this issue?
+19
+Is the scope realistic for Weeks 8–9?
+
+This Tier 1 issue is expected to take approximately 3–6 hours. Based on its scope, I am confident I can complete it before the Week 9 deadline.
+
+✅ I've estimated the time required and believe it is realistic.
+Are there any blockers or dependencies?
+
+I still need to install Docker Desktop and make to run the full backend. However, this does not block this issue because the fix is in ingestion/chunking/structural_chunker.py and can be tested using the existing unit test with pytest.
+
+✅ I have identified the remaining setup steps, and they do not block this fix.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -94,3 +94,78 @@ I created a local venv, installed the two dependencies needed (`tiktoken`, `pyte
 
 **Blockers or open questions:**
 Need to confirm what the downstream ingestion/indexer expects in `Chunk.metadata` for a heading-less chunk (empty `heading_path` string vs. omitting the key). Also deciding whether to also capture pre-first-heading "preamble" content as part of this fix or defer it to keep the change tight.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Resolved the Week 8 open question first: the only downstream consumer of chunk
+metadata (`ingestion/embeddings/batch_processor.py`) reads `source_id` and
+`chunk_index` via `.get()` with defaults and never requires `heading_path` to be
+non-empty, so an empty `heading_path` string / `heading_level = 0` on the
+heading-less path is safe. Implemented the fix in
+`ingestion/chunking/structural_chunker.py` (PLAN sub-tasks 1 & 2): rather than a
+separate fallback branch in `chunk()`, I fixed the root cause in
+`_extract_sections()` so accumulated content is always emitted as a level-0
+section (empty heading path) whenever content exists — even with no headings, or
+before the first heading. `chunk()`'s existing logic then handles it: short text
+→ one chunk, long text (> 800 tokens) → semantic sub-chunking, reusing the
+already-tested token-budget path. The acceptance test
+`test_document_with_no_headings` now passes, and I added 4 more tests
+(single short chunk, long-doc sub-chunking, source-metadata preservation,
+preamble-not-dropped).
+
+**Next steps:**
+Open a draft PR and request peer feedback in Slack; fill in the PR template;
+mark ready for review after addressing feedback; then complete Check-in 2 with
+the PR link.
+
+**Blockers:**
+None. (The repo has substantial pre-existing `make check` / `make test-unit`
+failures unrelated to this issue — see Check-in 2 — but they do not block this
+change.)
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** _(to be added when the PR is opened)_
+
+**Branch:** `fix/149-structural-chunker-no-headings`
+
+**What you built:**
+Fixed `StructuralChunker._extract_sections()` so content in a document with no
+Markdown headings (or content appearing before the first heading) is emitted as
+a level-0 section instead of being silently discarded. `chunk()` then chunks it
+normally — one chunk for short text, semantic sub-chunking for text over the
+800-token limit — with `heading_path=""` and `heading_level=0`. Heading-based
+documents are unaffected. Guarantee: any document with non-empty `text.strip()`
+now yields at least one chunk.
+
+**Tests added or updated:**
+`tests/unit/test_structural_chunker.py` — the existing acceptance test
+`test_document_with_no_headings` now passes; added `test_short_no_heading_doc_
+produces_single_level0_chunk`, `test_long_no_heading_doc_sub_chunked`,
+`test_no_heading_doc_preserves_source_metadata`, and
+`test_preamble_before_first_heading_not_dropped`.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+> "Passes" here means *no new failures introduced*, per the Week 9 pre-existing-
+> failure guidance. Documented baselines (measured on this branch with dev
+> extras installed, Python 3.13):
+> - `make test-unit`: **53 failed / 375 passed** before my change →
+>   **52 failed / 380 passed** after. My change flips the acceptance test
+>   fail→pass and adds 4 passing tests; it introduces **zero** new failures.
+>   All 52 remaining failures are pre-existing in unrelated modules
+>   (`test_tech_detector`, `test_skill_extractor`, etc.).
+> - `make check`: `ruff` reports 3 pre-existing `F841` unused-variable errors in
+>   test methods I did not touch; `black --check` would reformat 52 files
+>   repo-wide (a committed black-version drift), including
+>   `structural_chunker.py` *before* my change — so I matched the file's existing
+>   committed style rather than reformat unrelated code; `mypy` fails inside a
+>   numpy stub (`Type statement is only supported in Python 3.12+`) before
+>   reaching my file. None of these are caused by or affected by my change.
+
+**Draft PR feedback received from:** _(to be added)_

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -80,3 +80,17 @@ Are there any blockers or dependencies?
 I still need to install Docker Desktop and make to run the full backend. However, this does not block this issue because the fix is in ingestion/chunking/structural_chunker.py and can be tested using the existing unit test with pytest.
 
 ✅ I have identified the remaining setup steps, and they do not block this fix.
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/samanth1111-1111/pathreview/commit/2f3cdd1b44ae6536a094612a7aa9f49af6e7d17c
+
+**Reproduction summary:**
+I created a local venv, installed the two dependencies needed (`tiktoken`, `pytest`), and ran the existing unit test `tests/unit/test_structural_chunker.py::test_document_with_no_headings`, which fails with `assert 0 >= 1`. I also confirmed it directly: `StructuralChunker().chunk("plain text ..." * 20, {})` returns `[]`. I traced the cause to two guards in `_extract_sections` that only collect/emit content when `heading_stack` is non-empty, so a heading-less document produces zero sections and is silently dropped from the RAG index; I marked both lines with inline `BUG (#149)` comments in the reproduction commit.
+
+**PLAN.md link:** https://github.com/samanth1111-1111/pathreview/blob/fix/149-structural-chunker-no-headings/PLAN.md
+
+**Walkthrough video (recommended):** _(not recorded)_
+
+**Blockers or open questions:**
+Need to confirm what the downstream ingestion/indexer expects in `Chunk.metadata` for a heading-less chunk (empty `heading_path` string vs. omitting the key). Also deciding whether to also capture pre-first-heading "preamble" content as part of this fix or defer it to keep the change tight.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -168,4 +168,85 @@ produces_single_level0_chunk`, `test_long_no_heading_doc_sub_chunked`,
 >   numpy stub (`Type statement is only supported in Python 3.12+`) before
 >   reaching my file. None of these are caused by or affected by my change.
 
-**Draft PR feedback received from:** _(to be added)_
+**Draft PR feedback received from:** No peer feedback came in on the draft PR
+before I marked it ready for review. Per the Summer 2026 course note that
+maintainer review is not a guaranteed feature, I did not block on it — see the
+Week 10 "Reviewer feedback" section below.
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No maintainer or reviewer comments came in on
+[PR #907](https://github.com/ascherj/pathreview/pull/907) by the end of the
+week. This matches the course note that reviewer feedback is not a feature in
+Summer 2026, so I did not expect a review and none arrived. The PR remains open
+against `ascherj/pathreview` with the fix and five tests.
+
+**How you responded:**
+No changes were warranted since no feedback arrived. I re-read my own diff one
+more time to confirm the fix still reads cleanly and that the `flush_section()`
+comments explain *why* the level-0 emission exists (the `#149` rationale), so a
+future reviewer can understand the change without needing the issue open beside
+them.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The fix itself was small — the hard part was working out what "done" and "passing"
+even meant against a repo that was already red. When I first ran `make test-unit`
+I got **53 failed / 375 passed**, and `make check` flagged `black` wanting to
+reformat 52 files plus a `mypy` crash inside a numpy stub. None of it was mine.
+Figuring out that the honest bar was "introduce zero *new* failures" — and then
+proving it by capturing a before/after baseline (53→52 failing, my acceptance
+test flipping fail→pass) — took longer than writing the actual code. Resisting
+the urge to "helpfully" run `black` across the whole repo, which would have
+buried a one-file fix under 52 unrelated files, was also harder than expected;
+the disciplined move was to match the file's existing committed style instead.
+
+**What did you learn about working in a large codebase?**
+That you can't safely change a line until you know who reads its output. The real
+work wasn't in `_extract_sections` — it was tracing *downstream* to
+`ingestion/embeddings/batch_processor.py` to confirm that emitting a chunk with
+`heading_path=""` and `heading_level=0` wouldn't break the indexer (it reads
+`source_id`/`chunk_index` via `.get()` with defaults and never requires a
+non-empty heading path). In my own projects I hold the whole system in my head;
+here the existing tests and the consumer code *were* the spec, and I had to read
+them to learn the contract rather than invent one. I also learned to fix the root
+cause (the collection guard in `_extract_sections`) rather than bolt a special
+fallback branch onto `chunk()` — the smaller, more surgical change is the one a
+maintainer can actually trust.
+
+**How did AI tools help — and where did they fall short?**
+AI was most useful for orientation and tracing: quickly locating the guards in
+`_extract_sections`, following the chunk metadata to its only real consumer, and
+sanity-checking that an empty `heading_path` was safe downstream. That collapsed
+hours of code-reading into minutes. Where it fell short was judgment against a
+*messy* real-world baseline — an assistant will happily suggest "just make the
+tests pass" or "run the formatter," and neither is right when 52 failures and a
+formatter-version drift are pre-existing. Deciding scope (emit preamble content
+now vs. defer it), deciding what to *not* touch, and deciding how to
+truthfully document a partially-broken baseline were calls I had to make myself.
+
+**What would you do differently if you started over?**
+I'd finish environment setup before committing to the issue. I picked the issue
+in Week 7 but was still missing Docker/`make`, which meant I couldn't run the
+full stack and had to lean entirely on the unit test to define "done." It worked
+out because the fix was genuinely isolated, but I got lucky — a slightly wider
+bug would have blocked me. I'd also capture the failing baseline on day one
+rather than reconstructing it at PR time, so "did I break anything?" is a diff I
+can check continuously instead of a claim I assemble at the end.
+
+**What are you most proud of?**
+Not the code — the honesty of the write-up. It would have been easy to write
+"`make check` passes" and move on. Instead I measured and documented the exact
+baseline (53→52 failures, which tests, and *why* each remaining failure is
+unrelated), and matched the file's existing style rather than reformatting the
+world. Contributing to someone else's codebase is as much about being a
+trustworthy, low-noise collaborator as it is about the fix, and I think this PR
+reads that way.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -130,7 +130,7 @@ change.)
 
 ### Check-in 2 (end of week)
 
-**PR link:** _(to be added when the PR is opened)_
+**PR link:** https://github.com/ascherj/pathreview/pull/907
 
 **Branch:** `fix/149-structural-chunker-no-headings`
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,104 @@
+# Solution plan
+
+**Issue:** Structural chunker silently drops documents that contain no headings — https://github.com/ascherj/pathreview/issues/149
+
+### Understand
+
+**Root cause.** `StructuralChunker._extract_sections()` only records content
+*after* a Markdown heading has been seen. Two guards enforce this:
+
+- The content-collection guard (`if heading_stack or current_section_lines:`)
+  never fires for a heading-less document, because `heading_stack` stays empty
+  and `current_section_lines` therefore never receives its first line.
+- The final-section guard (`if current_section_lines and heading_stack:`)
+  additionally requires `heading_stack` to be non-empty before emitting the
+  trailing section.
+
+So a non-empty document with no `#` headings produces **zero** sections, and
+`chunk()` returns `[]`.
+
+**Expected vs. actual.**
+
+| Input | Expected | Actual |
+| --- | --- | --- |
+| `"plain text ..." * 20` (no headings) | ≥ 1 `Chunk` | `[]` |
+| Document with headings | unchanged | unchanged (works today) |
+
+**Impact.** Heading-less documents (plain-text notes, pasted resumes, PDFs
+with no Markdown structure) are silently excluded from the RAG index and can
+never be retrieved. Failure is silent — no error, just missing data.
+
+Reproduced in Week 8: `chunk("...", {})` returns `[]`, and
+`tests/unit/test_structural_chunker.py::test_document_with_no_headings` fails
+with `assert 0 >= 1`.
+
+### Map
+
+Files/functions involved:
+
+- `ingestion/chunking/structural_chunker.py`
+  - `StructuralChunker.chunk()` — where the empty `sections` list currently
+    yields `[]`; best place to add the fallback.
+  - `StructuralChunker._extract_sections()` — the two guards that are the root
+    cause.
+- `ingestion/chunking/semantic_chunker.py` — existing, tested chunker to reuse
+  as the fallback (handles token limits + overlap for long plain text).
+- `tests/unit/test_structural_chunker.py` — `test_document_with_no_headings`
+  is the acceptance test; add a few more cases.
+
+**Files I expect to touch:** `ingestion/chunking/structural_chunker.py` and
+`tests/unit/test_structural_chunker.py`.
+
+### Plan
+
+1. In `chunk()`, after `sections = self._extract_sections(text)`, detect the
+   "no sections extracted but text is non-empty" case and fall back to the
+   semantic chunker: `self.semantic_chunker.chunk(text, metadata)` with a
+   `heading_path=""` / `heading_level=0` in metadata. This produces ≥ 1 chunk
+   and correctly sub-chunks long documents by token budget.
+2. (Optional, related) Also capture content that appears *before* the first
+   heading (preamble) so it isn't dropped — likely by relaxing the collection
+   guard and emitting a level-0 section. Keep this small and behind the same
+   fix; do not regress heading behavior.
+3. Add unit tests: short no-heading doc → exactly 1 chunk; long no-heading doc
+   (> 800 tokens) → multiple chunks; whitespace-only → still `[]`; source
+   metadata preserved on the fallback path.
+4. Run the full structural + semantic chunker test suites and `ruff` to
+   confirm no regressions.
+5. Update `JOURNAL.md` (Week 9) with the fix summary and open the PR.
+
+### Inputs & outputs
+
+- **Input:** `text: str` (arbitrary document, may contain zero headings) and
+  `metadata: dict`.
+- **Output:** `list[Chunk]`. New guarantee: for any `text` where
+  `text.strip()` is non-empty, `len(result) >= 1`. Each fallback `Chunk`
+  carries the original metadata plus `chunk_index`, `char_start`, `char_end`
+  (from the semantic chunker) and `heading_path=""`.
+- **Unchanged:** empty/whitespace input still returns `[]`; documents with
+  headings produce the same chunks as today.
+
+### Risks & unknowns
+
+- **Metadata shape.** Downstream indexing may assume `heading_path` /
+  `heading_level` keys exist. Need to confirm what the indexer expects for a
+  headingless chunk (empty string vs. missing key). Will check the ingestion
+  pipeline that consumes `Chunk.metadata`.
+- **Double-counting `chunk_index`.** The semantic chunker sets its own
+  `chunk_index` starting at 0; make sure mixing fallback and heading paths
+  never happens in one call (it can't — fallback only fires when `sections`
+  is empty), so indices stay consistent.
+- **Preamble change (step 2)** could subtly alter output for docs that have
+  both a preamble and headings; must be covered by a test before shipping, or
+  deferred to keep scope tight.
+
+### Edge cases
+
+- Whitespace-only / empty input → `[]` (must stay).
+- Single short line, no heading → exactly 1 chunk.
+- Very long plain text (> `SECTION_TOKEN_LIMIT` 800 tokens) → sub-chunked into
+  multiple chunks via the semantic chunker.
+- Text that looks like a heading but isn't (`#nohash`, `#### ` with no text) →
+  treated as content, still chunked.
+- Document with content before the first real heading (preamble) → not dropped.
+- Non-ASCII / emoji content → chunked without error (tiktoken handles it).

--- a/ingestion/chunking/structural_chunker.py
+++ b/ingestion/chunking/structural_chunker.py
@@ -79,21 +79,30 @@ class StructuralChunker(BaseChunker):
         sections = []
         heading_stack = []  # Stack of (level, heading_text)
         current_section_lines = []
-        current_level = 0
+
+        def flush_section():
+            """Emit the accumulated lines as a section, if any content exists.
+
+            Content collected before the first heading (or in a document with no
+            headings at all) is emitted as a level-0 section with an empty path,
+            so heading-less documents are chunked rather than silently dropped
+            (#149).
+            """
+            content = "\n".join(current_section_lines).strip()
+            if content:
+                sections.append({
+                    "content": content,
+                    "path": [h[1] for h in heading_stack],
+                    "level": heading_stack[-1][0] if heading_stack else 0,
+                })
 
         for line in lines:
             heading_match = re.match(r"^(#{1,6})\s+(.+)$", line)
 
             if heading_match:
-                # Save previous section if exists
-                if current_section_lines:
-                    if heading_stack:
-                        sections.append({
-                            "content": "\n".join(current_section_lines).strip(),
-                            "path": [h[1] for h in heading_stack],
-                            "level": heading_stack[-1][0] if heading_stack else 0,
-                        })
-                    current_section_lines = []
+                # Save previous section (preamble or prior heading's content).
+                flush_section()
+                current_section_lines = []
 
                 # Process new heading
                 heading_level = len(heading_match.group(1))
@@ -104,28 +113,14 @@ class StructuralChunker(BaseChunker):
                     heading_stack.pop()
 
                 heading_stack.append((heading_level, heading_text))
-                current_level = heading_level
 
             else:
-                # Regular content line
-                # BUG (#149): content is only collected once a heading has been
-                # seen (heading_stack is non-empty). For a document with NO
-                # headings, this branch never appends anything, so
-                # current_section_lines stays empty and no section is produced.
-                if heading_stack or current_section_lines:  # Only collect if we have a heading
-                    current_section_lines.append(line)
+                # Regular content line. Collect unconditionally so that content
+                # in a heading-less document (or before the first heading) is
+                # retained instead of being discarded (#149).
+                current_section_lines.append(line)
 
-        # Save final section
-        # BUG (#149): the final-section guard also requires heading_stack to be
-        # non-empty, so even accumulated content is discarded when the document
-        # has no headings -> chunk() returns [] and the document is dropped from
-        # the RAG index. Reproduced by tests/unit/test_structural_chunker.py::
-        # test_document_with_no_headings.
-        if current_section_lines and heading_stack:
-            sections.append({
-                "content": "\n".join(current_section_lines).strip(),
-                "path": [h[1] for h in heading_stack],
-                "level": heading_stack[-1][0] if heading_stack else 0,
-            })
+        # Save final section.
+        flush_section()
 
         return sections

--- a/ingestion/chunking/structural_chunker.py
+++ b/ingestion/chunking/structural_chunker.py
@@ -108,10 +108,19 @@ class StructuralChunker(BaseChunker):
 
             else:
                 # Regular content line
+                # BUG (#149): content is only collected once a heading has been
+                # seen (heading_stack is non-empty). For a document with NO
+                # headings, this branch never appends anything, so
+                # current_section_lines stays empty and no section is produced.
                 if heading_stack or current_section_lines:  # Only collect if we have a heading
                     current_section_lines.append(line)
 
         # Save final section
+        # BUG (#149): the final-section guard also requires heading_stack to be
+        # non-empty, so even accumulated content is discarded when the document
+        # has no headings -> chunk() returns [] and the document is dropped from
+        # the RAG index. Reproduced by tests/unit/test_structural_chunker.py::
+        # test_document_with_no_headings.
         if current_section_lines and heading_stack:
             sections.append({
                 "content": "\n".join(current_section_lines).strip(),

--- a/tests/unit/test_structural_chunker.py
+++ b/tests/unit/test_structural_chunker.py
@@ -34,6 +34,54 @@ class TestStructuralChunker:
         assert isinstance(result[0], Chunk)
         assert all(isinstance(c, Chunk) for c in result)
 
+    def test_short_no_heading_doc_produces_single_level0_chunk(self, chunker):
+        """Short heading-less text yields exactly one level-0 chunk (#149)."""
+        text = "This is a single short line of plain text without headings."
+        result = chunker.chunk(text, {})
+
+        assert len(result) == 1
+        chunk = result[0]
+        assert chunk.text.strip()
+        # Heading-less content is emitted with an empty path at level 0.
+        assert chunk.metadata["heading_path"] == ""
+        assert chunk.metadata["heading_level"] == 0
+
+    def test_long_no_heading_doc_sub_chunked(self, chunker):
+        """Long heading-less text (> 800 tokens) is sub-chunked (#149)."""
+        # ~14 tokens per repetition * 100 (~1300 tokens) > 800 token limit.
+        text = "This is a paragraph with a fair amount of content in it. " * 100
+        result = chunker.chunk(text, {})
+
+        assert len(result) > 1
+        assert all(isinstance(c, Chunk) for c in result)
+        assert all(c.text.strip() for c in result)
+
+    def test_no_heading_doc_preserves_source_metadata(self, chunker):
+        """Source metadata is preserved on the heading-less path (#149)."""
+        text = "Plain text without any markdown headings. " * 20
+        result = chunker.chunk(text, {"source": "notes", "version": 2})
+
+        assert len(result) >= 1
+        for chunk in result:
+            assert chunk.metadata["source"] == "notes"
+            assert chunk.metadata["version"] == 2
+
+    def test_preamble_before_first_heading_not_dropped(self, chunker):
+        """Content before the first heading is retained, not dropped (#149)."""
+        text = """Preamble text that appears before any heading.
+
+# First Heading
+Content under the first heading.
+"""
+        result = chunker.chunk(text, {})
+
+        assert len(result) >= 2
+        # A level-0 (empty heading_path) section carries the preamble.
+        assert any(c.metadata["heading_path"] == "" for c in result)
+        assert any("Preamble" in c.text for c in result)
+        # The heading section is still present and unchanged.
+        assert any(c.metadata.get("heading_path") == "First Heading" for c in result)
+
     def test_document_with_nested_headings(self, chunker):
         """Test document with nested headings preserves heading_path."""
         text = """# Main Title


### PR DESCRIPTION
## Summary
StructuralChunker silently dropped any document with no Markdown headings — `_extract_sections` only emitted content while a heading was active, so heading-less documents produced zero chunks and never entered the RAG index. This fixes the root cause so every non-empty document yields at least one chunk.

## Issue
Closes #149

## Changes
- Removed the unused `current_level` variable. It was assigned in two places (`current_level = 0` and `current_level = heading_level`) but never read anywhere. It tracked the current heading depth but went unused — the heading level is already tracked in `heading_stack`.
- Replaced the two heading-gated save blocks with a single `flush_section()` helper that gates on content instead of on `heading_stack`. The old save blocks required `current_section_lines` and `heading_stack`; the helper only requires that there's content. `heading_stack` still drives `path`/`heading_level`, but is no longer required to emit a section — so heading-less content becomes a level-0 section rather than being dropped.

## Testing
- [x] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`)
- [ ] Linter passes (`make lint`)
- [ ] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes

## Screenshots / Demo
N/A

## Notes for Reviewers
The existing acceptance test `test_document_with_no_headings` now passes; added 4 tests (short single-chunk, long-doc sub-chunking, source-metadata preservation, preamble-not-dropped).
