### PR TITLE
fix: normalize None text in faithfulness checker context chunks

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,23 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/153
+
+**Issue title:** Faithfulness checker crashes when a context chunk has `text: None`
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The faithfulness checker's `check()` method builds its context string using
+`chunk.get("text", "")`, which only substitutes an empty string when the
+`text` key is missing — not when it's present but set to `None`. When a
+context chunk has `text: None`, `.get()` returns `None`, and the subsequent
+`" ".join()` call raises a `TypeError`, crashing the safety-layer's
+faithfulness check entirely. A successful fix normalizes `None` values to
+empty strings at this boundary, since the checker sits in the RAG
+evaluation layer and shouldn't assume its inputs are always well-formed.
+
+**Branch name:** fix/153-faithfulness-checker-none-text
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -21,3 +21,24 @@ evaluation layer and shouldn't assume its inputs are always well-formed.
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [ ] Issue added to cohort ledger
+
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/batyrkhan9/pathreview/commit/59e4cba6e746810a266a572801d1c517a01d370e
+
+**Reproduction summary:**
+The bug was reproduced by inspecting the original implementation before my
+Week 7 fix: `chunk.get("text", "")` only supplies the default when the key
+is missing, so a chunk with `text: None` caused `" ".join()` to raise
+`TypeError: sequence item 0: expected str instance, NoneType found`. This is
+documented in the diff of commit 59e4cba, which shows the original buggy
+line and the corrected version.
+
+**PLAN.md link:** https://github.com/batyrkhan9/pathreview/blob/fix/153-faithfulness-checker-none-text/PLAN.md
+
+**Walkthrough video (recommended):** (skipped — not graded)
+
+**Blockers or open questions:**
+Not yet sure why some chunks end up with `text: None` upstream — treating
+it as an unknown for now and guarding at the checker boundary.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -75,13 +75,13 @@ introduced. No new failures from this change.
 PR description before deadline.
 
 **Blockers:**
-Three tests in `test_faithfulness_checker.py`
+None blocking. Three tests in `test_faithfulness_checker.py`
 (`test_partial_support_returns_middle_score`, `test_multiple_context_chunks`,
 `test_multiple_claims_varying_support`) fail at baseline, but for an unrelated
-reason: `_is_supported` splits on whitespace without stripping punctuation, so
-a context token like `projects.` never matches the claim token `projects`, and
-the 2-token overlap threshold is not met. Out of scope for #153 — flagging as a
-possible follow-up issue rather than fixing it here.
+reason: `_is_supported` requires a 2-token non-stopword overlap, which short
+claims can never meet. I checked the tracker and this is already filed as
+issue #152, which names those exact three tests. Out of scope for #153, so I
+left them untouched rather than overlapping with that issue.
 
 ---
 
@@ -103,14 +103,33 @@ Added `test_mixed_none_and_valid_context_chunk_text` to
 `tests/unit/test_faithfulness_checker.py`, covering a mixed
 `{"text": None}` + valid-text chunk list.
 
-**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+**Self-review confirmation:** [x] make check run and reviewed — no new errors
+  [x] make test-unit run and reviewed — no new failures
 
-  Both boxes are intentionally left unchecked because neither command passes on
-  this repo — and neither passes on `main` either. `make check` fails on 182
-  pre-existing ruff errors and `make test-unit` fails 52 pre-existing tests,
-  none of which are caused by or related to this change. What I did verify is
-  that my change introduces **no new failures**: the failing-test set after my
-  change is identical to the baseline captured before it, and the ruff error
-  count is unchanged at 182.
+  Both commands were run and their output compared against a baseline captured
+  before any of my changes. Neither passes cleanly on this repo, and neither
+  passes on `main` either — `make check` fails on 182 pre-existing ruff errors
+  and `make test-unit` reports 52 pre-existing failures. That is expected: the
+  repo has 67 open issues, and those failures *are* those issues. For example,
+  #158 ("review_service unit tests misconfigure async mocks — 13 of 19 tests
+  fail") accounts for the review_service failures, #151 the bias detector ones,
+  #146 the PII scrubber ones, and #157/#156 the scorer fixtures. A fully green
+  suite would mean every open issue was already fixed.
+
+  What I verified is that my change is clean with respect to that baseline:
+
+  | Command | Before | After |
+  |---|---|---|
+  | `make test-unit` | 52 failed, 376 passed | 52 failed, **377** passed |
+  | `make lint` (ruff) | 182 errors | 182 errors |
+  | `make typecheck` (mypy) | 103 errors / 26 files | 103 errors / 26 files |
+
+  The failing-test set after my change is identical to the baseline set; the
+  only delta is the passing count rising by one, from the test I added.
+
+  Note also that the three faithfulness-checker failures are already tracked as
+  issue #152, which names those exact three tests. They are a separate defect
+  (the `_is_supported` two-token overlap threshold) from the `None` handling
+  fixed here, so I left them for whoever picks up #152.
 
 **Draft PR feedback received from:** [PLACEHOLDER]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -86,8 +86,7 @@ possible follow-up issue rather than fixing it here.
 ---
 
 ### Check-in 2 (end of week)
-**PR link:** [PLACEHOLDER — I will fill this in after opening the PR
-manually on GitHub, since PR creation needs to happen in the browser]
+**PR link:** https://github.com/ascherj/pathreview/pull/908 (draft)
 
 **Branch:** fix/153-faithfulness-checker-none-text
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -86,7 +86,7 @@ left them untouched rather than overlapping with that issue.
 ---
 
 ### Check-in 2 (end of week)
-**PR link:** https://github.com/ascherj/pathreview/pull/908 (draft)
+**PR link:** https://github.com/ascherj/pathreview/pull/908 (open, ready for review)
 
 **Branch:** fix/153-faithfulness-checker-none-text
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -133,3 +133,59 @@ Added `test_mixed_none_and_valid_context_chunk_text` to
   fixed here, so I left them for whoever picks up #152.
 
 **Draft PR feedback received from:** [PLACEHOLDER]
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No reviewer feedback — Summer 2026 cohort does not include this feature per instructor note.
+
+**How you responded:**
+N/A
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Locating and confirming the actual bug was harder than expected. Without AI
+assistance, I'd have had to manually trace through the codebase file by
+file to find where `check()` built its context string and understand why
+a `None` value slipped past `chunk.get()`. Even with AI help, there was a
+confusing moment where I ran the test expecting it to fail and it passed —
+I had to stop and figure out whether the bug was already fixed, the test
+was wrong, or I was looking at the wrong thing, before moving forward.
+
+**What did you learn about working in a large codebase?**
+The biggest difference from my own projects (like Provenance Guard or
+TakeMeter) is that I don't have the codebase's structure memorized. When I
+build something myself, I know exactly where everything lives because I put
+it there. In `pathreview`, I had to actively search for where a class was
+defined, what fixtures a test file used, and how test classes were nested,
+instead of just knowing.
+
+**How did AI tools help — and where did they fall short?**
+AI was useful for almost every step — identifying the bug, explaining why
+`.get()` behaved the way it did, drafting the fix, and writing PLAN.md and
+JOURNAL.md content. But it fell short anywhere that required seeing my
+actual environment: it couldn't know my test was nested inside a class, or
+that `structlog` wasn't installed in my active conda environment, or that
+I'd already committed the fix from a previous week. Those things only
+became clear once I ran commands myself and reported back real output —
+AI could reason about the code, but I had to be the one debugging against
+reality.
+
+**What would you do differently if you started over?**
+I'd try to lean less on AI for the actual investigation and do more of the
+manual tracing myself first, even if slower, so I build the instinct for
+navigating an unfamiliar codebase without needing to ask for the answer.
+This module I leaned on AI heavily just to keep pace with the deadlines.
+
+**What are you most proud of from this module?**
+Successfully working through someone else's production codebase for the
+first time — end to end, from picking an issue to a fix that actually
+passes the existing tests. It's a different skill than building my own
+projects from scratch, and this was my first real experience with it.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -42,3 +42,76 @@ line and the corrected version.
 **Blockers or open questions:**
 Not yet sure why some chunks end up with `text: None` upstream — treating
 it as an unknown for now and guarding at the checker boundary.
+
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+**Current progress:**
+Set up a local Python 3.11 virtualenv (the project requires >=3.11; the
+system default `python3` is 3.9) and captured a full baseline of `make check`
+and `make test-unit` before making any changes. Baseline on this branch:
+`make check` fails at the lint step with 182 pre-existing ruff errors (so
+black and mypy never run; separately, black would reformat 52 files and mypy
+reports 103 errors), and `make test-unit` reports 52 failed / 376 passed.
+All of these are pre-existing on `main` and unrelated to issue #153.
+
+Added one new test, `test_mixed_none_and_valid_context_chunk_text`, to
+`tests/unit/test_faithfulness_checker.py`. It covers the realistic mixed
+case the existing tests miss: a `context_chunks` list containing both a
+`{"text": None}` chunk and a valid-text chunk. Beyond asserting no crash, it
+asserts `score > 0.5` to prove the valid chunk's text still contributes
+rather than being silently dropped. Verified the test genuinely guards the
+regression — the pre-fix expression `chunk.get("text", "")` raises
+`TypeError: sequence item 0: expected str instance, NoneType found` on this
+input.
+
+Re-ran both commands after the change: the set of failing tests is byte-for-byte
+identical to the baseline (52 failed), with passed rising 376 → 377 from the new
+test. Ruff still reports exactly 182 errors, so no new lint issues were
+introduced. No new failures from this change.
+
+**Next steps:** Open a draft PR, request peer review in Slack, finalize
+PR description before deadline.
+
+**Blockers:**
+Three tests in `test_faithfulness_checker.py`
+(`test_partial_support_returns_middle_score`, `test_multiple_context_chunks`,
+`test_multiple_claims_varying_support`) fail at baseline, but for an unrelated
+reason: `_is_supported` splits on whitespace without stripping punctuation, so
+a context token like `projects.` never matches the claim token `projects`, and
+the 2-token overlap threshold is not met. Out of scope for #153 — flagging as a
+possible follow-up issue rather than fixing it here.
+
+---
+
+### Check-in 2 (end of week)
+**PR link:** [PLACEHOLDER — I will fill this in after opening the PR
+manually on GitHub, since PR creation needs to happen in the browser]
+
+**Branch:** fix/153-faithfulness-checker-none-text
+
+**What you built:**
+Fixed a `TypeError` crash in the RAG faithfulness checker that occurred when a
+retrieved context chunk had `text: None`. The context-building expression used
+`chunk.get("text", "")`, which only applies its default when the key is
+missing — not when the key is present but `None` — so `" ".join()` received a
+`None` and raised. Changed it to `chunk.get("text") or ""` so both the missing
+key and the explicit `None` normalize to an empty string.
+
+**Tests added or updated:**
+Added `test_mixed_none_and_valid_context_chunk_text` to
+`tests/unit/test_faithfulness_checker.py`, covering a mixed
+`{"text": None}` + valid-text chunk list.
+
+**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+
+  Both boxes are intentionally left unchecked because neither command passes on
+  this repo — and neither passes on `main` either. `make check` fails on 182
+  pre-existing ruff errors and `make test-unit` fails 52 pre-existing tests,
+  none of which are caused by or related to this change. What I did verify is
+  that my change introduces **no new failures**: the failing-test set after my
+  change is identical to the baseline captured before it, and the ruff error
+  count is unchanged at 182.
+
+**Draft PR feedback received from:** [PLACEHOLDER]

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,48 @@
+## Solution plan
+
+**Issue:** Faithfulness checker crashes when a context chunk has `text: None` — https://github.com/ascherj/pathreview/issues/153
+
+### Understand
+The root cause is `chunk.get("text", "")` in `check()`, which only substitutes
+the default `""` when the `text` key is missing entirely. When a chunk is
+`{"text": None}`, the key is present, so `.get()` returns `None` instead of
+the default. Expected behavior: a chunk with no usable text should contribute
+an empty string to the joined context. Actual behavior: `" ".join(...)`
+raises `TypeError` because it can't join a `None` value with strings.
+
+### Map
+- `rag/evaluator/faithfulness_checker.py` — `FaithfulnessChecker.check()`,
+  where the context string is built from chunk dicts.
+- `tests/unit/test_faithfulness_checker.py` — contains
+  `test_none_context_chunk_text`, the test that currently fails and defines
+  expected behavior.
+
+### Plan
+1. Reproduce the crash locally and confirm `test_none_context_chunk_text` fails.
+2. Change `chunk.get("text", "")` to `chunk.get("text") or ""` so both a
+   missing key and an explicit `None` value normalize to an empty string.
+3. Re-run the failing test and confirm it passes.
+4. Run the full `test_faithfulness_checker.py` suite to confirm no regressions
+   in the "missing key" case or normal text handling.
+5. Commit the fix with a message referencing issue #153.
+
+### Inputs & outputs
+Input: a list of context chunk dicts passed to `check()`, where each chunk
+may have a `text` key that is a string, missing, or `None`. Output: a single
+joined context string used for the faithfulness comparison; the fix ensures
+this join never raises regardless of which of those three states a chunk is in.
+
+### Risks & unknowns
+- Unsure why chunks with `text: None` are produced upstream in the first
+  place (ingestion bug vs. expected null state) — this fix treats the
+  symptom at the checker boundary rather than the unknown upstream cause.
+- `or ""` also treats an empty string `""` and `None` identically, which is
+  fine here but worth confirming no downstream logic distinguishes between
+  "empty text" and "missing text."
+
+### Edge cases
+- `text` key missing entirely (the original `.get()` default case).
+- `text` present but an empty string `""`.
+- `chunk` itself is an empty dict `{}`.
+- Non-string `text` value (e.g. a number or list) — out of scope for this
+  fix, but worth flagging as a possible follow-up issue.

--- a/rag/evaluator/faithfulness_checker.py
+++ b/rag/evaluator/faithfulness_checker.py
@@ -31,9 +31,7 @@ class FaithfulnessChecker:
             return 0.5  # Default to neutral if no extractable claims
 
         # Concatenate context text
-        context_text = " ".join([
-            chunk.get("text", "") for chunk in context_chunks
-        ])
+        context_text = " ".join(chunk.get("text") or "" for chunk in context_chunks)
 
         # Check each claim for support
         supported = 0

--- a/tests/unit/test_faithfulness_checker.py
+++ b/tests/unit/test_faithfulness_checker.py
@@ -254,6 +254,23 @@ class TestFaithfulnessChecker:
         assert isinstance(score, float)
         assert 0.0 <= score <= 1.0
 
+    def test_mixed_none_and_valid_context_chunk_text(self, checker):
+        """Test handling of a None text chunk alongside a valid text chunk."""
+        feedback = "The developer has strong Python skills and experience with Django."
+        context_chunks = [
+            {"text": None},
+            {
+                "text": "The portfolio shows Python expertise and Django framework experience."
+            },
+        ]
+
+        score = checker.check(feedback, context_chunks)
+
+        # Should handle gracefully and still use the valid chunk's text
+        assert isinstance(score, float)
+        assert 0.0 <= score <= 1.0
+        assert score > 0.5
+
     def test_score_consistency(self, checker):
         """Test that same input produces same score."""
         feedback = "The developer has strong Python skills."


### PR DESCRIPTION
## Summary

The faithfulness checker crashes with a `TypeError` whenever a retrieved context chunk has `text: None`. The context string is built with `chunk.get("text", "")`, but `dict.get`'s default only applies when the key is **missing** — when the key is present and explicitly set to `None`, `.get()` returns `None`, and the surrounding `" ".join(...)` then raises `TypeError: sequence item 0: expected str instance, NoneType found`. Because `FaithfulnessChecker.check()` sits in the RAG safety/evaluation layer, a single malformed chunk takes down the entire faithfulness check rather than degrading gracefully. This PR normalizes `None` to an empty string at that boundary.

## Issue

Fixes #153

## Changes

- `rag/evaluator/faithfulness_checker.py`: changed `chunk.get("text", "")` to `chunk.get("text") or ""`, so that a missing `text` key **and** an explicit `text: None` both normalize to an empty string before the join.
- `tests/unit/test_faithfulness_checker.py`: added `test_mixed_none_and_valid_context_chunk_text`, covering a `context_chunks` list that contains both a `{"text": None}` chunk and a valid-text chunk.

Guarding at the checker boundary is deliberate. The checker consumes retrieval output and shouldn't assume its inputs are well-formed — a null chunk should contribute nothing to the context, not crash the safety layer. `or ""` collapses `None` and `""` to the same result, which is correct here because downstream logic only tokenizes the joined string and draws no distinction between "empty text" and "missing text".

## Testing

The repo already had `test_none_context_chunk_text` and `test_missing_text_key_in_chunk`, but both use a single-chunk list. The new test covers the realistic mixed case: one null chunk alongside one valid chunk. It asserts more than "doesn't crash" — it asserts `score > 0.5`, proving the valid chunk's text still reaches the comparison rather than being silently dropped along with the null one.

I verified the test genuinely guards the regression: against the pre-fix `chunk.get("text", "")` expression, this input raises `TypeError: sequence item 0: expected str instance, NoneType found`.

- [x] New/updated tests cover the changes
- [x] Unit tests pass (`make test-unit`) — no new failures vs. baseline; see table below
- [x] Linter passes (`make lint`) — no new errors vs. baseline; see table below
- [x] Type checker passes (`make typecheck`) — no new errors vs. baseline; see table below
- [ ] Integration tests pass (`make test-integration`) — not run; requires database/service setup

I captured a full baseline on a clean checkout **before** making any changes, then re-ran everything after:

| Command | Baseline (before) | After my change |
|---|---|---|
| `make test-unit` | 52 failed, 376 passed | 52 failed, **377** passed |
| `make lint` (ruff) | 182 errors | 182 errors |
| `black --check` | 52 files would reformat | 52 files |
| `make typecheck` (mypy) | 103 errors in 26 files | 103 errors in 26 files |

The set of failing tests after my change is **identical** to the baseline set, and the ruff and mypy counts are unchanged. The only delta is the passing count going 376 → 377, from the test added here. Those pre-existing failures correspond to other open issues in this tracker (e.g. #158 covers the `review_service` failures, #151 the bias detector, #146 the PII scrubber, #157 and #156 the scorer fixtures), so I deliberately left them alone to keep this PR scoped to #153.

## Screenshots / Demo

Not applicable — this is a backend-only fix to the RAG evaluation layer with no user-facing surface. The behavior change is covered by the unit test described above.

## Notes for Reviewers

**The three failing tests in the file I touched are already tracked as #152.** `test_partial_support_returns_middle_score`, `test_multiple_context_chunks`, and `test_multiple_claims_varying_support` fail both before and after this change. That's the `_is_supported` two-token overlap threshold described in #152, which names those same three tests — a separate defect from the `None` handling fixed here. I've left them untouched so this PR doesn't overlap with whoever picks up #152.

**A note on `make check`.** The `check` target is `lint format typecheck`, and `lint` currently fails on pre-existing errors, so make aborts before the rest run — I ran `black` and `mypy` separately to get the baseline numbers above. Worth flagging that the `format` target runs `black .` rather than `black --check .`, so once those lint errors are resolved, `make check` will silently rewrite 52 files as a side effect of a command that reads as read-only. Happy to open a separate issue for that if it's useful.

**Formatting.** I matched the surrounding test file's existing conventions (multi-line dict literals) rather than black's preferred style, since the file is not currently black-clean and reformatting it would have added unrelated noise to this diff.

**`JOURNAL.md` and `PLAN.md`** on this branch are CodePath coursework artifacts (a progress journal and a solution plan) rather than changes to the project itself. They're here because the assignment tracks work through them. If you'd rather not carry them, I can strip them out and force-push, or you can drop them at merge — the actual fix is confined to `rag/evaluator/faithfulness_checker.py` and `tests/unit/test_faithfulness_checker.py`.
