### PR TITLE
fix(safety): redact parenthesized US phone numbers

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -18,5 +18,5 @@ scaffold notes, replace with my own 3-5 sentences before submitting:
 [REPLACE THIS LINE WITH MY OWN WORDS]
 
 **Branch name:** fix/146-pii-scrubber-parenthesized-phone
-**Setup confirmation:** [ ] App runs locally at localhost:5173
+**Setup confirmation:** [x] App runs locally at localhost:5173
 **Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -21,7 +21,7 @@ tests already named in the issue.
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** https://github.com/spicyneutrino/pathreview/commit/<hash>
+**Reproduction commit link:** https://github.com/spicyneutrino/pathreview/commit/3977650c99490509cc8089cbb3f3d32611ad019a
 
 **Reproduction summary:**
 Ran the scrub() and detect() methods locally against a string containing

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -5,17 +5,15 @@
 **Tier:** [x] Tier 1
 
 **Problem summary:**
-<!--
-scaffold notes, replace with my own 3-5 sentences before submitting:
-- broken: phone regex anchors on \b (word boundary), ( isn't a word char,
-  so it never matches when a number opens with a parenthesized area code
-  like (555) 123-4567. Dashed format 555-123-4567 still matches fine.
-- effect: scrub() leaves those numbers in plaintext, detect() reports zero
-  PII found even though a phone number is right there
-- fix: broaden the regex to also match when the number opens with (,
-  verified by 4 named failing tests in tests/unit/test_pii_scrubber.py
--->
-[REPLACE THIS LINE WITH MY OWN WORDS]
+The phone-number regex in pii_scrubber.py uses a \b word-boundary anchor,
+but ( is not a word character, so the pattern never matches when a number
+opens with a parenthesized area code like (555) 123-4567. Dashed formats
+like 555-123-4567 still match correctly. Because of this, scrub() leaves
+parenthesized numbers in plaintext instead of redacting them, and detect()
+returns an empty list even when a phone number is clearly present, which is
+a real gap in a safety layer meant to catch PII. The fix is to broaden the
+regex to also accept a leading parenthesis, verified by the four failing
+tests already named in the issue.
 
 **Branch name:** fix/146-pii-scrubber-parenthesized-phone
 **Setup confirmation:** [x] App runs locally at localhost:5173

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,22 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/146
+**Issue title:** PII scrubber fails to redact parenthesized US phone numbers
+**Tier:** [x] Tier 1
+
+**Problem summary:**
+<!--
+scaffold notes, replace with my own 3-5 sentences before submitting:
+- broken: phone regex anchors on \b (word boundary), ( isn't a word char,
+  so it never matches when a number opens with a parenthesized area code
+  like (555) 123-4567. Dashed format 555-123-4567 still matches fine.
+- effect: scrub() leaves those numbers in plaintext, detect() reports zero
+  PII found even though a phone number is right there
+- fix: broaden the regex to also match when the number opens with (,
+  verified by 4 named failing tests in tests/unit/test_pii_scrubber.py
+-->
+[REPLACE THIS LINE WITH MY OWN WORDS]
+
+**Branch name:** fix/146-pii-scrubber-parenthesized-phone
+**Setup confirmation:** [ ] App runs locally at localhost:5173
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -18,3 +18,22 @@ tests already named in the issue.
 **Branch name:** fix/146-pii-scrubber-parenthesized-phone
 **Setup confirmation:** [x] App runs locally at localhost:5173
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/spicyneutrino/pathreview/commit/<hash>
+
+**Reproduction summary:**
+Ran the scrub() and detect() methods locally against a string containing
+both a dashed and parenthesized phone number. Confirmed the parenthesized
+format passes through unredacted and detect() returns an empty list,
+matching the issue description. Also ran the four named failing tests in
+test_pii_scrubber.py and confirmed they fail as expected.
+
+**PLAN.md link:** https://github.com/spicyneutrino/pathreview/blob/fix/146-pii-scrubber-parenthesized-phone/PLAN.md
+
+**Walkthrough video (recommended):** 
+
+**Blockers or open questions:**
+Need to confirm whether the phone_us pattern is a single regex or several
+patterns, before finalizing the exact fix approach in Week 9.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -37,3 +37,88 @@ test_pii_scrubber.py and confirmed they fail as expected.
 **Blockers or open questions:**
 Need to confirm whether the phone_us pattern is a single regex or several
 patterns, before finalizing the exact fix approach in Week 9.
+
+## Week 9 — Fix implementation & verification
+
+**Check-in 1**
+
+**Progress:**
+Confirmed the open question from Week 8: phone_us is a single regex, one
+entry in the PII_PATTERNS dict (safety/pii_scrubber.py), used identically
+by both scrub() and detect(). Root-caused the bug more precisely than the
+original issue description: \b does find a valid boundary right after the
+leading "(", but the pattern only accepted "-" or "." between digit groups,
+not a literal space, so "555)" never bridged to " 123". Fixed with a
+one-line regex change: separators now accept a literal space in addition
+to "-"/"." , and the leading \b was swapped for a (?<!\w) lookbehind so the
+match can start at the "(" or "+" itself (full clean redaction span, no
+leftover punctuation) while keeping the exact same protection against
+false positives on digits glued to a preceding letter (e.g.
+"invoice5551234567" still correctly doesn't match).
+
+Ran pytest tests/unit/test_pii_scrubber.py -v: 24 passed, 1 failed
+(test_mixed_pii_and_text). That failure is pre-existing and unrelated to
+this fix — it's a bug in the separate street_address pattern (a bare "Pl"
+alternative for "Place" that, case-insensitively, matches the "pl" inside
+ordinary words like "applications"). Confirmed via git log that the
+street_address line hasn't changed since the initial commit, and via
+isolated regex testing that it fails the same way with zero involvement
+from phone_us. Left it untouched — out of scope for issue #146.
+
+Ran make check: fails at the lint stage on pre-existing ruff issues spread
+across unrelated files (agent/error_handling.py, agent/memory/*, etc. —
+import ordering, Optional vs X | None). Isolated ruff/mypy to just
+safety/pii_scrubber.py: mypy is clean, and the only ruff hits on that file
+are pre-existing (unsorted imports, the already-too-long street_address
+line, an unused loop variable, a too-long logger line) — none on the line
+I changed.
+
+Ran make test-unit (428 tests, whole repo): 49 failed, 379 passed. All 49
+are pre-existing and unrelated (bias_detector, resume_parser,
+review_service, skill_extractor, tech_detector, etc.) — within
+test_pii_scrubber.py specifically, only the one expected street_address
+failure shows up. The phone fix introduced zero regressions.
+
+Manually verified extra edge cases beyond the test suite: parens with no
+space ("(555)123-4567"), trailing punctuation after the number, and
+multiple phone numbers in mixed formats in one string — all redact
+correctly with accurate detect() spans.
+
+**Next steps:**
+Self-review the diff, then open the PR against ascherj/pathreview.
+
+**Blockers:**
+None remaining.
+
+**Check-in 2**
+
+**PR link:** [to be added once PR is opened]
+
+**Branch:** fix/146-pii-scrubber-parenthesized-phone
+
+**What I built:**
+One-line fix to the phone_us regex in safety/pii_scrubber.py: separators widened from
+[-.]? to [-. ]? (3 places) so a literal space bridges "555)" to " 123", and the leading
+\b anchor was swapped for (?<!\w) so the match can start at the "(" or "+" itself
+(clean full-span redaction, matching detect()'s start/end contract) while keeping the
+exact same protection against false positives on digits glued to a preceding letter.
+Committed together with 4 small, pre-existing lint/format fixes in the same file that
+pre-commit's ruff/black hooks required before any commit to this file would go through:
+wrapped the overlong street_address regex literal (byte-identical content, split across
+concatenated raw strings), wrapped an overlong logger.info call, renamed an unused loop
+variable (pii_type -> _pii_type) in scrub(), and added the import-group blank line ruff's
+I001 rule requires. None of these four change behavior.
+
+**Tests touched:**
+tests/unit/test_pii_scrubber.py — no new tests added, the existing 25 already specify
+the bug (the 4 named failing tests plus the 2 already-passing edge cases from Week 8).
+
+**Self-review confirmation:**
+ruff check safety/pii_scrubber.py and mypy safety/ both pass clean with zero issues on
+this file. make check's repo-wide failure (178 errors, none in this file) and make
+test-unit's 49 failures are both fully pre-existing and unaffected by this change —
+verified the failure lists are identical, line for line, before and after this commit,
+and confirmed via git log/git diff main...HEAD that this branch's prior commits only
+ever touched JOURNAL.md/PLAN.md/repro.txt, so none of it could have caused them.
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -122,3 +122,61 @@ and confirmed via git log/git diff main...HEAD that this branch's prior commits 
 ever touched JOURNAL.md/PLAN.md/repro.txt, so none of it could have caused them.
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No feedback was received. Per the Su26 course note, reviewer feedback
+is not enabled for this term's PathReview simulation.
+
+**How you responded:**
+N/A — no feedback arrived to respond to.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Keeping the fix scoped to only the actual bug was harder than I
+expected. AI coding tools will often overwrite or rewrite more logic
+than necessary if you let them, so I had to actively push back and
+constrain changes to the exact regex issue in `pii_scrubber.py` rather
+than accepting broader edits. Adhering to the project's contribution
+rules (branch naming, commit message format, PR template) also took
+more deliberate attention than I expected, since it's easy to fall
+back on habits from personal projects.
+
+**What did you learn about working in a large codebase?**
+I had to pay much closer attention to existing coding conventions and
+patterns instead of just writing what felt natural to me. I was also
+unfamiliar with some of the technologies already in use, which raised
+the stakes: something that looks wrong or redundant in someone else's
+codebase might be intentional, so changing it carelessly is riskier
+than in a project I own end to end. This made me slower and more
+careful, especially before touching anything outside the direct scope
+of the issue.
+
+**How did AI tools help — and where did they fall short?**
+AI tools were most useful for implementation, spotting errors, and
+brainstorming approaches to the fix. Where they fell short was scope
+control: left unchecked, the AI would sometimes change or rewrite more
+of the file than the issue actually required, so I had to review every
+suggested change and explicitly restrict it to the bug at hand rather
+than trusting the first version it produced.
+
+**What would you do differently if you started over?**
+I would read more of the repository's documentation upfront, before
+starting implementation, rather than picking it up as issues came up
+along the way. Understanding the project's conventions and structure
+earlier would have made the scoping and review process faster.
+
+**What are you most proud of from this module?**
+Going through the full cycle for the first time: claiming an issue
+publicly, understanding and reproducing it, writing an actual plan
+before touching code, documenting my process in JOURNAL.md, and
+pushing a real PR that follows a project's contribution standards.
+That end-to-end process was new to me, not just the code fix itself.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -92,7 +92,7 @@ None remaining.
 
 **Check-in 2**
 
-**PR link:** [to be added once PR is opened]
+**PR link:** https://github.com/ascherj/pathreview/pull/911
 
 **Branch:** fix/146-pii-scrubber-parenthesized-phone
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,90 @@
+Create PLAN.md at the repo root with this content, exactly as written, no edits:
+
+## Solution plan
+
+**Issue:** PII scrubber fails to redact parenthesized US phone numbers
+https://github.com/ascherj/pathreview/issues/146
+
+### Understand
+The phone-number regex in `safety/pii_scrubber.py` is anchored with `\b`
+(word boundary). `\b` only matches between a word character and a
+non-word character. `(` is a non-word character, so when a phone number
+starts with a parenthesized area code like `(555) 123-4567`, there's no
+word-boundary transition at the point the pattern expects one, and the
+match never triggers. Dashed formats like `555-123-4567` start with a
+digit (a word character), so the boundary check passes fine there.
+Confirmed locally: `test_us_phone_number_redaction`, `test_us_phone_formats`,
+`test_detect_phone_pii`, and `test_phone_at_start_of_text` all fail with
+the exact behavior described in the issue, while `test_international_phone_redaction`
+and `test_phone_at_end_of_text` pass, confirming the bug is specific to a
+phone number opening with `(`, not the regex as a whole.
+
+### Map
+- `safety/pii_scrubber.py` — contains the `phone_us` regex pattern and the
+  `PIIScrubber` class with `scrub()` and `detect()` methods. This is the
+  only file I expect to change.
+- `tests/unit/test_pii_scrubber.py` — contains the four failing tests
+  confirmed above. I expect to make these pass without adding new tests,
+  unless I find a gap they don't cover.
+
+### Plan
+1. Read the current `phone_us` regex pattern and confirm exactly how it's
+   anchored and why `(` breaks it.
+2. Update the pattern to accept an optional leading `(area code)` group
+   alongside the existing dashed/dotted formats, without loosening the
+   pattern enough to start matching non-phone-number digit sequences.
+3. Run the four confirmed failing tests and verify they pass.
+4. Run the full `test_pii_scrubber.py` suite to confirm the two currently
+   passing tests (international, end-of-text) still pass, and nothing
+   else in the suite regresses.
+5. Manually re-run the reproduction snippet from Week 8 to confirm both
+   phone formats are now redacted and detected.
+
+### Inputs & outputs
+Input: raw text strings passed to `scrub()` and `detect()`, potentially
+containing phone numbers in various US formats.
+Output: `scrub()` should return the text with all recognized phone
+number formats replaced by `[REDACTED]`. `detect()` should return a
+non-empty list of matches when any recognized format is present.
+
+### Risks & unknowns
+- Broadening the regex could cause false positives, matching
+  non-phone-number parenthesized digit groups that happen to look
+  similar. Need to check existing test fixtures for anything like this.
+- Unsure yet whether `phone_us` is one regex or several patterns tried
+  in sequence, need to read the actual file before finalizing the fix.
+- `test_phone_at_start_of_text` failing alongside the others confirms
+  the leading-parenthesis case needs to work both mid-sentence and at
+  the very start of a string, so the fix has to handle both positions.
+
+### Edge cases
+- Phone number at the very start of a string (confirmed failing above).
+- Phone number followed immediately by punctuation, e.g.
+  `"(555) 123-4567."`
+- Multiple phone numbers in one string, mixed formats.
+- Parenthesized area code with no space before the local number, e.g.
+  `(555)123-4567`.
+
+Then append this Week 8 section to the end of JOURNAL.md, below the
+existing Week 7 section. Do not touch or remove the Week 7 content:
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [link to be added after commit]
+
+**Reproduction summary:**
+Ran scrub() and detect() locally against a string containing both a dashed
+and a parenthesized phone number. Confirmed the parenthesized format
+passes through unredacted and detect() returns an empty list. Ran the
+four named tests in test_pii_scrubber.py and confirmed all four fail
+exactly as the issue describes, while two related phone tests
+(international format, end-of-text position) pass, isolating the bug to
+phone numbers that open with a parenthesis.
+
+**PLAN.md link:** https://github.com/spicyneutrino/pathreview/blob/fix/146-pii-scrubber-parenthesized-phone/PLAN.md
+
+**Walkthrough video (recommended):**
+
+**Blockers or open questions:**
+Need to confirm whether phone_us is a single regex or multiple patterns
+before finalizing the exact fix approach in Week 9.

--- a/repro.txt
+++ b/repro.txt
@@ -1,0 +1,92 @@
+============================= test session starts ==============================
+platform linux -- Python 3.14.6, pytest-9.1.1, pluggy-1.6.0 -- /var/home/oak/Codes/courses/codepath/AI201/week7/pathreview/.venv/bin/python
+cachedir: .pytest_cache
+hypothesis profile 'default'
+benchmark: 5.2.3 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
+rootdir: /var/home/oak/Codes/courses/codepath/AI201/week7/pathreview
+configfile: pyproject.toml
+plugins: hypothesis-6.158.1, anyio-4.14.2, pytest_httpserver-1.1.5, cov-7.1.0, benchmark-5.2.3, asyncio-1.4.0
+asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
+collecting ... collected 25 items / 19 deselected / 6 selected
+
+tests/unit/test_pii_scrubber.py::TestPIIScrubber::test_us_phone_number_redaction FAILED [ 16%]
+tests/unit/test_pii_scrubber.py::TestPIIScrubber::test_us_phone_formats FAILED [ 33%]
+tests/unit/test_pii_scrubber.py::TestPIIScrubber::test_international_phone_redaction PASSED [ 50%]
+tests/unit/test_pii_scrubber.py::TestPIIScrubber::test_detect_phone_pii FAILED [ 66%]
+tests/unit/test_pii_scrubber.py::TestPIIScrubber::test_phone_at_start_of_text FAILED [ 83%]
+tests/unit/test_pii_scrubber.py::TestPIIScrubber::test_phone_at_end_of_text PASSED [100%]
+
+=================================== FAILURES ===================================
+________________ TestPIIScrubber.test_us_phone_number_redaction ________________
+
+self = <tests.unit.test_pii_scrubber.TestPIIScrubber object at 0x7f3c37b63bb0>
+scrubber = <safety.pii_scrubber.PIIScrubber object at 0x7f3c3787c440>
+
+    def test_us_phone_number_redaction(self, scrubber):
+        """Test US phone number is redacted."""
+        text = "Call me at (555) 123-4567"
+        scrubbed = scrubber.scrub(text)
+    
+>       assert "[REDACTED]" in scrubbed
+E       AssertionError: assert '[REDACTED]' in 'Call me at (555) 123-4567'
+
+tests/unit/test_pii_scrubber.py:39: AssertionError
+____________________ TestPIIScrubber.test_us_phone_formats _____________________
+
+self = <tests.unit.test_pii_scrubber.TestPIIScrubber object at 0x7f3c378b8180>
+scrubber = <safety.pii_scrubber.PIIScrubber object at 0x7f3c37833250>
+
+    def test_us_phone_formats(self, scrubber):
+        """Test various US phone number formats."""
+        formats = [
+            "555-123-4567",
+            "(555) 123-4567",
+            "555.123.4567",
+            "+1 555 123 4567",
+        ]
+    
+        for phone in formats:
+            text = f"Contact: {phone}"
+            scrubbed = scrubber.scrub(text)
+>           assert "[REDACTED]" in scrubbed
+E           AssertionError: assert '[REDACTED]' in 'Contact: (555) 123-4567'
+
+tests/unit/test_pii_scrubber.py:54: AssertionError
+____________________ TestPIIScrubber.test_detect_phone_pii _____________________
+
+self = <tests.unit.test_pii_scrubber.TestPIIScrubber object at 0x7f3c37866970>
+scrubber = <safety.pii_scrubber.PIIScrubber object at 0x7f3c378b88a0>
+
+    def test_detect_phone_pii(self, scrubber):
+        """Test detect() finds phone number PII."""
+        text = "Phone: (555) 123-4567"
+        detected = scrubber.detect(text)
+    
+        phone_detections = [d for d in detected if "phone" in d["type"]]
+>       assert len(phone_detections) > 0
+E       assert 0 > 0
+E        +  where 0 = len([])
+
+tests/unit/test_pii_scrubber.py:128: AssertionError
+----------------------------- Captured stdout call -----------------------------
+2026-07-29 00:43:26 [info     ] pii_detected                   count=0 types=0
+_________________ TestPIIScrubber.test_phone_at_start_of_text __________________
+
+self = <tests.unit.test_pii_scrubber.TestPIIScrubber object at 0x7f3c378a75f0>
+scrubber = <safety.pii_scrubber.PIIScrubber object at 0x7f3c378b8fc0>
+
+    def test_phone_at_start_of_text(self, scrubber):
+        """Test phone number at start of text."""
+        text = "(555) 123-4567 is my phone number."
+        scrubbed = scrubber.scrub(text)
+    
+>       assert "[REDACTED]" in scrubbed
+E       AssertionError: assert '[REDACTED]' in '(555) 123-4567 is my phone number.'
+
+tests/unit/test_pii_scrubber.py:184: AssertionError
+=========================== short test summary info ============================
+FAILED tests/unit/test_pii_scrubber.py::TestPIIScrubber::test_us_phone_number_redaction
+FAILED tests/unit/test_pii_scrubber.py::TestPIIScrubber::test_us_phone_formats
+FAILED tests/unit/test_pii_scrubber.py::TestPIIScrubber::test_detect_phone_pii
+FAILED tests/unit/test_pii_scrubber.py::TestPIIScrubber::test_phone_at_start_of_text
+================== 4 failed, 2 passed, 19 deselected in 0.18s ==================

--- a/safety/pii_scrubber.py
+++ b/safety/pii_scrubber.py
@@ -1,6 +1,7 @@
 """PII detection and scrubbing."""
 
 import re
+
 import structlog
 
 logger = structlog.get_logger()
@@ -12,10 +13,14 @@ class PIIScrubber:
     # Regex patterns for common PII
     PII_PATTERNS = {
         "email": r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b",
-        "phone_us": r"\b(?:\+?1[-.]?)?\(?([0-9]{3})\)?[-.]?([0-9]{3})[-.]?([0-9]{4})\b",
+        "phone_us": r"(?<!\w)(?:\+?1[-. ]?)?\(?([0-9]{3})\)?[-. ]?([0-9]{3})[-. ]?([0-9]{4})\b",
         "phone_intl": r"\+[0-9]{1,3}[-.]?[0-9]{1,14}",
         "ssn": r"\b(?!000|666)[0-9]{3}-(?!00)[0-9]{2}-(?!0000)[0-9]{4}\b",
-        "street_address": r"\b\d+\s+[A-Za-z\s]+(?:Street|St|Avenue|Ave|Road|Rd|Boulevard|Blvd|Drive|Dr|Lane|Ln|Court|Ct|Circle|Cir|Park|Pl|Plaza|Place|Drive|Dr|Way|Parkway|Pkwy|Point|Pt|Pike|Run|Summit|Summit|Terrace|Ter|Trail|Trl|Tunnel|Turnpike|View|Vista|Vlg|Village|Vly|Valley)",
+        "street_address": (
+            r"\b\d+\s+[A-Za-z\s]+(?:Street|St|Avenue|Ave|Road|Rd|Boulevard|Blvd|Drive|Dr|Lane|Ln|"
+            r"Court|Ct|Circle|Cir|Park|Pl|Plaza|Place|Drive|Dr|Way|Parkway|Pkwy|Point|Pt|Pike|Run|"
+            r"Summit|Summit|Terrace|Ter|Trail|Trl|Tunnel|Turnpike|View|Vista|Vlg|Village|Vly|Valley)"
+        ),
     }
 
     def scrub(self, text: str) -> str:
@@ -29,7 +34,7 @@ class PIIScrubber:
         """
         scrubbed = text
 
-        for pii_type, pattern in self.PII_PATTERNS.items():
+        for _pii_type, pattern in self.PII_PATTERNS.items():
             scrubbed = re.sub(pattern, "[REDACTED]", scrubbed, flags=re.IGNORECASE)
 
         return scrubbed
@@ -47,13 +52,17 @@ class PIIScrubber:
 
         for pii_type, pattern in self.PII_PATTERNS.items():
             for match in re.finditer(pattern, text, flags=re.IGNORECASE):
-                detected.append({
-                    "type": pii_type,
-                    "value": match.group(),
-                    "start": match.start(),
-                    "end": match.end()
-                })
+                detected.append(
+                    {
+                        "type": pii_type,
+                        "value": match.group(),
+                        "start": match.start(),
+                        "end": match.end(),
+                    }
+                )
 
-        logger.info("pii_detected", count=len(detected), types=len(set(d["type"] for d in detected)))
+        logger.info(
+            "pii_detected", count=len(detected), types=len(set(d["type"] for d in detected))
+        )
 
         return detected


### PR DESCRIPTION
## Summary
- Fixes #146: `PIIScrubber.scrub()`/`detect()` failed to redact/detect parenthesized US
  phone numbers (e.g. `(555) 123-4567`) because the `phone_us` regex only accepted `-`/`.`
  as separators between digit groups, not a literal space, and its leading `\b` anchor
  couldn't include a leading `(` in the match.
- One-line regex fix, plus 4 small, unrelated pre-existing lint/format issues in the same
  file that pre-commit's hooks required be resolved before *any* change to this file could
  be committed (called out separately below, not part of the bug fix itself).

## Issue
Closes #146

## Changes
- `safety/pii_scrubber.py`: `phone_us` pattern's separators widened from `[-.]?` to
  `[-. ]?` (3 occurrences), and the leading `\b` swapped for `(?<!\w)`, so parenthesized
  and `+1`-prefixed formats with space separators now match cleanly — full span including
  the parens/plus sign, consistent with `detect()`'s start/end span contract. Trailing `\b`
  unchanged; still correctly rejects digits glued to a preceding letter (e.g.
  `invoice5551234567`).
- Also fixed 4 pre-existing, unrelated issues in the same file that blocked pre-commit from
  accepting any change to it: wrapped an overlong `street_address` regex literal
  (byte-identical content, just split across concatenated raw strings), wrapped an overlong
  `logger.info` call, renamed an unused loop variable (`pii_type` → `_pii_type`) in
  `scrub()`, and added the import-group blank line ruff's `I001` rule requires. None change
  behavior.

## Testing
- [x] Unit tests pass: `pytest tests/unit/test_pii_scrubber.py -v` — 24/25 pass. The 1
      failure (`test_mixed_pii_and_text`) is pre-existing and unrelated to this fix — caused
      by the separate `street_address` pattern's bare `Pl` alternative matching the "pl"
      inside ordinary words like "applications". Confirmed via `git log` that line hasn't
      changed since the repo's initial commit, and confirmed in isolation that the regex
      fails the same way with zero involvement from `phone_us`. Left untouched, out of scope
      for this issue.
- [ ] Integration tests: n/a
- [x] Linter: `ruff check safety/pii_scrubber.py` — 0 issues. (Repo-wide `make check` still
      fails on 178 pre-existing errors in unrelated files; confirmed this file has zero
      hits.)
- [x] Typechecker: `mypy safety/` — 0 issues
- [ ] New or updated tests: none added — existing suite already specifies the bug

## Screenshots / Demo
N/A — backend regex fix, no UI change. Manual verification:
```
>>> scrubber.scrub("Call (555) 123-4567")
'Call [REDACTED]'
>>> scrubber.detect("Call (555) 123-4567")
[{'type': 'phone_us', 'value': '(555) 123-4567', 'start': 5, 'end': 19}]
```

## Notes for Reviewers
- Root cause is more precise than the original issue text: `\b` *does* find a valid
  boundary right after the `(` — the actual gap was that only `-`/`.` were accepted as
  separators, not a literal space, so `) 123` never bridged.
- `make test-unit` (428 tests, whole repo) shows 49 pre-existing failures unrelated to this
  change (`test_bias_detector`, `test_resume_parser`, `test_review_service`,
  `test_skill_extractor`, `test_tech_detector`, etc.). Verified via `git log`/`git diff
  main...HEAD` that this branch's prior commits only touched `JOURNAL.md`/`PLAN.md`/
  `repro.txt`, so these failures already exist on `main` too.
- Happy to split the 4 incidental lint/format fixes into a separate commit/PR if you'd
  prefer a purer diff — they're bundled here only because pre-commit blocked committing the
  regex fix at all until they were resolved.