### PR TITLE
Fix/163 review creation profile ownership error

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -24,3 +24,33 @@ The `POST /reviews` endpoint lets any logged-in user create a review for a profi
 - **Codebase readiness:** I've read the three service functions and confirmed the bug: `create_review()` takes `user_id` but never filters by it. The test file `tests/unit/test_review_service.py` exists, so I have existing tests to model my regression test on.
 
 - **Scope & time:** Small, well-bounded change plus one test — realistic within the Week 8–9 window alongside other commitments. No blockers or dependencies listed on the issue.
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** <!-- TODO: paste the GitHub link to this Week 8 commit after pushing, e.g. https://github.com/EMP-Kritazya/pathreview/commit/<sha> -->
+
+**Reproduction summary:**
+I reproduced issue #163 by driving `create_review()` (in `core/services/review_service.py`)
+directly with a mismatched pair — an attacker `user_id` and a victim `profile_id` the
+attacker does not own — while tracking whether the service performs any ownership lookup.
+Observed: `create_review()` never issued an ownership query (`db.execute` was never called),
+called `db.add`, and returned a persisted `pending` review anyway. This confirms the IDOR:
+any authenticated user can create a review against another user's profile just by knowing
+its UUID, because `create_review()` accepts `user_id` but ignores it. The read paths
+(`get_review`, `list_reviews`) already scope by `Profile.user_id`, so only the create path
+is unprotected.
+
+**Reproduction steps:**
+1. From the fork root (`pathreview/`), with the app's virtualenv, call `create_review(db, profile_id, user_id)` with `profile_id` and `user_id` that do not correspond to the same profile (mocked DB session, patched `Review`).
+2. Assert whether any ownership `SELECT` is issued before the write.
+3. Observed result: no ownership check, `db.add` called, a review returned — i.e. the review is created for a profile the caller does not own.
+
+**PLAN.md link:** [PLAN.md](./PLAN.md) <!-- on GitHub: https://github.com/EMP-Kritazya/pathreview/blob/fix/163-review-creation-profile-ownership-error/PLAN.md -->
+
+**Walkthrough video (recommended):** [link to your Loom video, ≤2 min — recommended, not graded]
+
+**Blockers or open questions:**
+Deciding between `404` (matches `get_review`/`get_profile`, avoids leaking profile existence)
+and `403` for the rejected case — leaning `404` for consistency. Also whether to fix the
+pre-existing `AsyncMock().scalars()` failures in `tests/unit/test_review_service.py` as part
+of this PR or keep them out of scope (leaning out of scope).

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -41,6 +41,7 @@ its UUID, because `create_review()` accepts `user_id` but ignores it. The read p
 is unprotected.
 
 **Reproduction steps:**
+
 1. From the fork root (`pathreview/`), with the app's virtualenv, call `create_review(db, profile_id, user_id)` with `profile_id` and `user_id` that do not correspond to the same profile (mocked DB session, patched `Review`).
 2. Assert whether any ownership `SELECT` is issued before the write.
 3. Observed result: no ownership check, `db.add` called, a review returned — i.e. the review is created for a profile the caller does not own.
@@ -54,3 +55,69 @@ Deciding between `404` (matches `get_review`/`get_profile`, avoids leaking profi
 and `403` for the rejected case — leaning `404` for consistency. Also whether to fix the
 pre-existing `AsyncMock().scalars()` failures in `tests/unit/test_review_service.py` as part
 of this PR or keep them out of scope (leaning out of scope).
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week, 2026-08-04)
+
+**Current progress:**
+All 5 steps of PLAN.md are implemented and locally verified:
+
+1. `create_review()` in `core/services/review_service.py` now calls
+   `profile_service.get_profile(db, profile_id, user_id)` before constructing a
+   `Review`, and returns `None` when the profile is missing or not owned.
+2. `create_review_endpoint()` in `api/routes/reviews.py` checks for that `None`
+   and raises `HTTPException(404, "Profile not found")` before queuing the
+   `process_review` background task — matching the `404` decision noted as an
+   open question in the Week 8 entry.
+3. Added the regression test `test_create_review_returns_none_for_unauthorized_profile`
+   in `tests/unit/test_review_service.py`, plus updated the other `create_review`
+   tests to mock `get_profile` (they now patch it to return an owned profile so the
+   happy path still exercises `Review` construction). Also replaced the `AsyncMock().scalars()`
+   pattern with plain `Mock()` for `.scalars()` across the file, which resolves the
+   pre-existing mock-quirk failures flagged in Week 8 — so that "leaning out of scope"
+   call ended up moot, since it was needed to make the new/adjacent tests reliable.
+4. Verified the happy path manually against the running API (docker-compose postgres
+   + uvicorn): registered two users, created a profile for each, confirmed
+   `POST /reviews` with another user's `profile_id` returns `404` and creates nothing,
+   and `POST /reviews` with the caller's own `profile_id` returns `200` and the
+   background task completes the review end-to-end.
+5. `make test-unit`: 20/20 tests pass in `tests/unit/test_review_service.py`; full
+   suite is 389 passed / 40 failed, and I confirmed those 40 failures are pre-existing
+   and unrelated (bias_detector, pii_scrubber, tech_detector, etc. — none touch
+   review/profile code) by running the same suite before my changes (53 failed / 375
+   passed at baseline — my change actually *fixes* 13 of those, the ones caused by the
+   mock-quirk in `test_review_service.py`). `make check` passes with no new lint/type
+   errors introduced; two pre-existing mypy/type gaps in files I touched
+   (`User.id`/`Review.id` stored as `str` vs. the `UUID` params services expect, and
+   `Review.sections` typed as `dict | None` while `process_review` stores a list) were
+   fixed or explicitly annotated as pre-existing so the pre-commit hook's mypy check
+   passes without silently masking unrelated bugs.
+
+**Next steps:**
+Push the branch, open the PR against `ascherj/pathreview`, and fill in the PR
+template (including the pre-existing-failures note above). Also want to re-read
+`docs/CONTRIBUTING.md` once more for docstring conventions before opening the PR.
+
+**Blockers:**
+None — the only snag was the local pre-commit hook (ruff/mypy) failing on
+pre-existing issues in the files I touched; resolved with minimal, behavior-preserving
+type annotations rather than skipping the hook.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [link to your submitted pull request]
+
+**Branch:** [the branch name you worked on, e.g. `fix/123-short-description`]
+
+**What you built:**
+[1–3 sentences summarizing what your fix does and how it works]
+
+**Tests added or updated:**
+[Which test files did you touch? What do they cover?]
+
+**Self-review confirmation:** [ ] make check passes [ ] make test-unit passes
+
+**Draft PR feedback received from:** [name or Slack handle, or "none"]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,26 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/163
+
+**Issue title:** Review creation does not verify profile ownership
+
+**Tier:** [ ] Tier 1 [X] Tier 2 [ ] Tier 3
+
+**Problem summary:**
+The `POST /reviews` endpoint lets any logged-in user create a review for a profile just by passing its ID, without checking that the profile actually belongs to them. The bug lives in `create_review()` in `core/services/review_service.py`, which trusts the supplied `profile_id` even though the read functions (`get_review()`, `list_reviews()`) in the same file already filter by `Profile.user_id`. This is a broken-access-control (IDOR) vulnerability: knowing another user's profile UUID is enough to create reviews on their data. A successful fix adds an ownership check so that requests for a profile the user doesn't own are rejected (e.g. 403/404), and a regression test confirms the attack is blocked.
+
+**Branch name:** fix/163-review-creation-profile-ownership-error
+
+**Setup confirmation:** [X] App runs locally at localhost:5173
+
+**Cohort ledger:** [X] Issue added to cohort ledger
+
+**Is this right for me? checklist reasoning:**
+
+- **Understanding:** I can explain it in my own words and I know the "done" state — before: a user can create a review on someone else's profile by passing its ID; after: that request is rejected (403/404) and only the owner can create a review. Before/after is concrete and testable.
+
+- **Tier fit:** Tier 2 is a stretch for a first contribution, but the scope is narrow — the fix is confined to `create_review()` in `core/services review_service.py`, and the exact pattern I need (`Profile.user_id == user_id`) already exists in `get_review()` and `list_reviews()` in the same file. So it reads like a Tier 1-sized change with Tier 2 cross-module context (auth → profile → review). Comfortable, not over my head.
+
+- **Codebase readiness:** I've read the three service functions and confirmed the bug: `create_review()` takes `user_id` but never filters by it. The test file `tests/unit/test_review_service.py` exists, so I have existing tests to model my regression test on.
+
+- **Scope & time:** Small, well-bounded change plus one test — realistic within the Week 8–9 window alongside other commitments. No blockers or dependencies listed on the issue.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -137,3 +137,82 @@ against a pre-change baseline of 53 failed/375 passed; this branch is 40 failed/
 passed, so no new failures and 13 fewer than baseline)
 
 **Draft PR feedback received from:** none yet
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes [X] No — Su26 note: reviewer feedback is not a
+feature this term, so no review is expected on PR #912.
+
+**Summary of feedback:**
+No feedback came in — reviewer feedback is not enabled for Summer 2026, per
+the course note for this week. PR #912 remains open with no comments.
+
+**How you responded:**
+N/A — nothing to respond to. In its absence, I did my own second pass on the
+diff before finalizing Week 9's Check-in 2 (re-reading `create_review()`,
+`create_review_endpoint()`, and the new/updated tests end to end) to catch
+anything a reviewer likely would have flagged.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Telling apart "my change broke this" from "this was already broken" was
+harder than I expected. When `make test-unit` came back 40 failed / 389
+passed after my change, my first instinct was that I'd introduced 40
+regressions. It took running the full suite against the unmodified branch
+(53 failed / 375 passed) to see that my change actually netted 13 _fewer_
+failures, because replacing `AsyncMock().scalars()` with `Mock()` in
+`test_review_service.py` incidentally fixed a mock-quirk that was failing
+unrelated tests. Without that baseline comparison I would have either
+panicked or, worse, tried to "fix" failures that had nothing to do with
+issue #163. The 403-vs-404 decision was a smaller version of the same
+problem: it wasn't obvious until I checked that `get_review()` already used
+404 for the equivalent case, so consistency with the existing pattern
+settled it rather than my own judgment.
+
+**What did you learn about working in a large codebase?**
+The biggest lesson was that the fix was already half-written elsewhere in
+the file. `get_review()` and `list_reviews()` in `review_service.py` already
+filtered by `Profile.user_id` — the bug was that `create_review()` never
+called the equivalent `profile_service.get_profile(db, profile_id,
+user_id)` check. In my own projects I'd probably have written a fresh
+ownership check inline; here, reusing the existing helper kept the fix
+small and consistent with the codebase's conventions instead of adding a
+second way of doing the same thing. I also learned to draw a hard line
+around scope — I was tempted to fix all 40 pre-existing failures
+(bias_detector, pii_scrubber, tech_detector) since I was already in the
+test suite, but they were unrelated to #163 and touching them would have
+bloated the PR and made it harder to review, so I documented them instead
+of fixing them.
+
+**How did AI tools help — and where did they fall short?**
+AI assistance was most useful for the mechanical parts: scaffolding the
+reproduction script that called `create_review()` directly with a
+mismatched `user_id`/`profile_id` pair, and drafting the regression test
+`test_create_review_returns_none_for_unauthorized_profile` to match the
+existing test file's mocking conventions. It fell short on the judgment
+calls — deciding 404 vs. 403, deciding whether the pre-existing
+`AsyncMock().scalars()` failures were in scope to fix, and reasoning
+through the `User.id`/`Review.id` `str`-vs-`UUID` mypy gaps so the fix was
+correct rather than just quiet. Those needed me to actually read the
+surrounding code and the codebase's own precedent, not just generate
+something plausible.
+
+**What would you do differently if you started over?**
+I'd establish the pre-existing-failures baseline (`make test-unit` on the
+unmodified branch) in Week 8 during reproduction, not in Week 9 right
+before the PR. I ended up doing it reactively once I saw 40 failures and
+got worried, but doing it up front would have saved the mid-week scramble
+and let me state "N pre-existing failures, none touching review/profile
+code" with confidence from the start instead of backfilling the evidence.
+
+**What are you most proud of from this module?**
+Catching that my fix incidentally repaired 13 unrelated test failures, and
+resisting the urge to expand the PR to "clean up" the other 40 — instead
+documenting both clearly in the PR description. That distinction between
+what's honestly in scope and what's just nearby felt like the most
+professional judgment call of the whole four weeks.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -78,15 +78,15 @@ All 5 steps of PLAN.md are implemented and locally verified:
    pre-existing mock-quirk failures flagged in Week 8 — so that "leaning out of scope"
    call ended up moot, since it was needed to make the new/adjacent tests reliable.
 4. Verified the happy path manually against the running API (docker-compose postgres
-   + uvicorn): registered two users, created a profile for each, confirmed
-   `POST /reviews` with another user's `profile_id` returns `404` and creates nothing,
-   and `POST /reviews` with the caller's own `profile_id` returns `200` and the
-   background task completes the review end-to-end.
+   - uvicorn): registered two users, created a profile for each, confirmed
+     `POST /reviews` with another user's `profile_id` returns `404` and creates nothing,
+     and `POST /reviews` with the caller's own `profile_id` returns `200` and the
+     background task completes the review end-to-end.
 5. `make test-unit`: 20/20 tests pass in `tests/unit/test_review_service.py`; full
    suite is 389 passed / 40 failed, and I confirmed those 40 failures are pre-existing
-   and unrelated (bias_detector, pii_scrubber, tech_detector, etc. — none touch
+   and unrelated (bias*detector, pii_scrubber, tech_detector, etc. — none touch
    review/profile code) by running the same suite before my changes (53 failed / 375
-   passed at baseline — my change actually *fixes* 13 of those, the ones caused by the
+   passed at baseline — my change actually \_fixes* 13 of those, the ones caused by the
    mock-quirk in `test_review_service.py`). `make check` passes with no new lint/type
    errors introduced; two pre-existing mypy/type gaps in files I touched
    (`User.id`/`Review.id` stored as `str` vs. the `UUID` params services expect, and
@@ -108,16 +108,32 @@ type annotations rather than skipping the hook.
 
 ### Check-in 2 (end of week)
 
-**PR link:** [link to your submitted pull request]
+**PR link:** https://github.com/ascherj/pathreview/pull/912
 
-**Branch:** [the branch name you worked on, e.g. `fix/123-short-description`]
+**Branch:** `fix/163-review-creation-profile-ownership-error`
 
 **What you built:**
-[1–3 sentences summarizing what your fix does and how it works]
+`create_review()` in `core/services/review_service.py` now checks profile ownership
+before creating a review, by reusing the existing `profile_service.get_profile(db,
+profile_id, user_id)` lookup that already scopes by `Profile.user_id`. If the
+profile doesn't exist or isn't owned by the caller, `create_review()` returns
+`None` and `create_review_endpoint()` in `api/routes/reviews.py` responds `404`
+before any background processing is queued — closing the IDOR in issue #163
+without touching the read paths, which were already safe.
 
 **Tests added or updated:**
-[Which test files did you touch? What do they cover?]
+`tests/unit/test_review_service.py` — added
+`test_create_review_returns_none_for_unauthorized_profile` (asserts `create_review`
+returns `None` and never calls `db.add`/`commit`/`refresh` for a profile the caller
+doesn't own). Updated the other `create_review` tests to mock `get_profile` so the
+happy path still exercises `Review` construction, and replaced the
+`AsyncMock().scalars()` pattern with plain `Mock()` for `.scalars()` throughout the
+file, fixing several pre-existing mock-quirk failures unrelated to #163 along the
+way.
 
-**Self-review confirmation:** [ ] make check passes [ ] make test-unit passes
+**Self-review confirmation:** [x] make check passes [x] make test-unit passes
+(40 pre-existing, unrelated failures documented in the PR description — confirmed
+against a pre-change baseline of 53 failed/375 passed; this branch is 40 failed/389
+passed, so no new failures and 13 fewer than baseline)
 
-**Draft PR feedback received from:** [name or Slack handle, or "none"]
+**Draft PR feedback received from:** none yet

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,112 @@
+# Solution plan
+
+**Issue:** Review creation does not verify profile ownership — https://github.com/ascherj/pathreview/issues/163
+
+## Understand
+
+**Root cause.** `create_review()` in `core/services/review_service.py` accepts a
+`user_id` argument but never uses it. It builds a `Review` directly from the
+caller-supplied `profile_id` and persists it, without ever checking that the
+profile belongs to `user_id`. There is no `db.execute` / ownership query in the
+function at all (confirmed at runtime — see reproduction).
+
+This is a broken-access-control / IDOR (Insecure Direct Object Reference) bug.
+It is also _inconsistent_ with the rest of the module: `get_review()` and
+`list_reviews()` in the same file already scope every read through
+`Profile.user_id == user_id`, and `profile_service.get_profile()` does the same
+for profiles. Only the create path skips the check.
+
+**Expected vs. actual behavior**
+
+- **Actual:** An authenticated user sends `POST /reviews {"profile_id": "<another
+user's profile id>"}` and receives `200 OK` with a new `pending` review created
+  against a profile they do not own. A background `process_review` task is then
+  queued against that profile.
+- **Expected:** A request for a profile the caller does not own is rejected with
+  `404 Not Found` (consistent with `get_review` / `get_profile`, which return 404
+  for non-owned resources and avoid leaking whether the profile exists). No review
+  is created and no background task is queued.
+
+## Map
+
+Files/functions I expect to touch or rely on:
+
+| File                                              | Symbol                                               | Role in the fix                                                                                                                                                                                     |
+| ------------------------------------------------- | ---------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `core/services/review_service.py`                 | `create_review()` (lines 15–32)                      | **Primary change.** Add an ownership check before creating the `Review`.                                                                                                                            |
+| `core/services/profile_service.py`                | `get_profile(db, profile_id, user_id)` (lines 36–48) | **Reuse.** Returns `None` when the profile is missing or not owned — exactly the check I need. Import and call it.                                                                                  |
+| `api/routes/reviews.py`                           | `create_review_endpoint()` (lines 22–62)             | Handle the rejected case: when the service signals "not owned", raise `HTTPException(404)` (mirroring `get_review_endpoint`) instead of proceeding to `model_validate` / queueing `process_review`. |
+| `tests/unit/test_review_service.py`               | new regression test                                  | Add a test asserting `create_review` does **not** persist / return a review for a profile the caller does not own.                                                                                  |
+| `core/models/profile.py`, `core/models/review.py` | (read-only)                                          | Confirm `Profile.user_id` and `Review.profile_id` field names used in the check.                                                                                                                    |
+
+## Plan
+
+1. **Reuse the ownership check in the service.** In `create_review()`, before
+   constructing the `Review`, call `get_profile(db, profile_id, user_id)`. If it
+   returns `None`, do not create anything — return `None` (matching the
+   `X | None` return contract already used by `get_review`). Import `get_profile`
+   from `core.services.profile_service`.
+2. **Reject cleanly at the route.** In `create_review_endpoint()`, check the
+   service result; if it's `None`, raise `HTTPException(status_code=404,
+detail="Profile not found")` and log a `warning` — the same shape as
+   `get_review_endpoint`. Because this is raised before `background_tasks.add_task`,
+   no `process_review` job is queued for a non-owned profile.
+3. **Add a regression test.** In `tests/unit/test_review_service.py`, add
+   `test_create_review_rejects_profile_not_owned_by_user`: an attacker `user_id`
+   with a victim `profile_id`, assert `db.add` is not called and no review is
+   returned. Also keep/adjust a happy-path test proving an owned profile still
+   creates a review.
+4. **Verify the happy path is untouched.** Manually confirm via the running API
+   (register user → create profile → `POST /reviews` with own profile) that a
+   normal review still returns `200` and processes.
+5. **Run the suite and linters.** `make test-unit`, then `make check`
+   (ruff + black + mypy) before opening the PR.
+
+## Inputs & outputs
+
+- **Input:** `create_review(db, profile_id: UUID, user_id: UUID)` — the
+  authenticated user's id (from `get_current_user`) and the requested profile id
+  (from the `ReviewCreate` body).
+- **Output (owned profile):** unchanged — a persisted `Review` with
+  `status="pending"`, returned and serialized as `ReviewResponse` (`200`); a
+  `process_review` background task queued.
+- **Output (not owned / missing profile):** no `Review` created, no background
+  task queued; the endpoint responds `404 Not Found`.
+- **Side effects changed:** one added ownership `SELECT` on `Profile` per create;
+  `db.add`/`commit`/`refresh` only run when ownership passes.
+
+## Risks & unknowns
+
+- **404 vs 403.** I plan `404` to match `get_review`/`get_profile` (don't leak
+  existence). A `403` would arguably be more semantically precise; I'll follow the
+  repo's existing convention and can revisit if a maintainer prefers 403.
+- **Where the check lives.** Doing it in the service (`create_review`) vs. the
+  route. I chose the service so the ownership guarantee holds for any future
+  caller, consistent with how reads are scoped. Risk: the route's broad
+  `except Exception -> 500` in `create_review_endpoint` would swallow a `None`
+  into a 500 if I forget the explicit `if not review` check — step 2 addresses
+  this directly.
+- **Extra DB round-trip.** Reusing `get_profile` adds one `SELECT`. Negligible for
+  a create endpoint, and it mirrors `update_profile`/`delete_profile`, which
+  already do this.
+- **Pre-existing test noise.** `tests/unit/test_review_service.py` currently has
+  failing tests due to an `AsyncMock().scalars()` returning a coroutine under the
+  installed pytest/mock versions — unrelated to #163. My new test must use a plain
+  `Mock` result (not `AsyncMock`) so its pass/fail reflects the bug, not the mock
+  quirk. Unknown: whether to fix those pre-existing failures here or leave them out
+  of scope (leaning out of scope to keep the PR focused).
+- **`process_review` also trusts `profile_id`.** It fetches the profile without a
+  `user_id` scope. Once creation is guarded, an unowned profile can no longer reach
+  it, so I'll leave `process_review` unchanged but note it in the PR.
+
+## Edge cases
+
+- **Profile belongs to another user** — the core exploit → `404`, nothing created.
+- **`profile_id` does not exist at all** — `get_profile` returns `None` → `404`
+  (same path, no separate branch needed).
+- **Profile belongs to the caller** — happy path unchanged → `200`, review created.
+- **Well-formed UUID that simply isn't theirs** — passes Pydantic `UUID`
+  validation but fails ownership → `404` (validation ≠ authorization).
+- **Malformed / missing `profile_id`** — rejected earlier by `ReviewCreate`
+  schema validation → `422`; my change doesn't affect this.
+- **Unauthenticated request** — already `401` via `get_current_user`; unchanged.

--- a/api/routes/reviews.py
+++ b/api/routes/reviews.py
@@ -1,12 +1,14 @@
-from fastapi import APIRouter, Depends, HTTPException, status, BackgroundTasks
+from typing import cast
 from uuid import UUID
-import structlog
 
-from api.schemas.review import ReviewCreate, ReviewResponse, ReviewListResponse
+import structlog
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from api.middleware.auth import get_current_user
-from core.models.user import User
-from core.models.review import Review
+from api.schemas.review import ReviewCreate, ReviewListResponse, ReviewResponse
 from core.database import get_db
+from core.models.user import User
 from core.services.review_service import (
     create_review,
     get_review,
@@ -18,38 +20,55 @@ log = structlog.get_logger()
 
 router = APIRouter(prefix="/reviews", tags=["reviews"])
 
+# Module-level dependency singletons (ruff B008: avoid calling Depends() in defaults)
+_current_user_dep = Depends(get_current_user)
+_db_dep = Depends(get_db)
+
 
 @router.post("", response_model=ReviewResponse)
 async def create_review_endpoint(
     data: ReviewCreate,
     background_tasks: BackgroundTasks,
-    current_user: User = Depends(get_current_user),
-    db=Depends(get_db),
-):
+    current_user: User = _current_user_dep,
+    db: AsyncSession = _db_dep,
+) -> ReviewResponse:
     """
     Create a new review for a profile.
     Triggers ingestion pipeline and agent orchestration asynchronously.
     Returns review with status="pending" immediately.
     """
     try:
+        user_id = UUID(current_user.id)
+
         # Create review with status="pending"
         review = await create_review(
             db=db,
             profile_id=data.profile_id,
-            user_id=current_user.id,
+            user_id=user_id,
         )
 
+        if not review:
+            log.warning(
+                "review_create_profile_not_found",
+                profile_id=str(data.profile_id),
+                user_id=str(user_id),
+            )
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Profile not found",
+            )
+
         # Add background task for processing
-        background_tasks.add_task(process_review, db, review.id, data.profile_id)
+        background_tasks.add_task(process_review, db, UUID(review.id), data.profile_id)
 
         log.info(
             "review_created",
             review_id=str(review.id),
             profile_id=str(data.profile_id),
-            user_id=str(current_user.id),
+            user_id=str(user_id),
         )
 
-        return ReviewResponse.model_validate(review)
+        return cast("ReviewResponse", ReviewResponse.model_validate(review))
 
     except HTTPException:
         raise
@@ -59,34 +78,35 @@ async def create_review_endpoint(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to create review",
-        )
+        ) from exc
 
 
 @router.get("/{review_id}", response_model=ReviewResponse)
 async def get_review_endpoint(
     review_id: UUID,
-    current_user: User = Depends(get_current_user),
-    db=Depends(get_db),
-):
+    current_user: User = _current_user_dep,
+    db: AsyncSession = _db_dep,
+) -> ReviewResponse:
     """
     Get a review by ID.
     Returns 404 if not found or not owned by current user.
     """
     try:
-        review = await get_review(db=db, review_id=review_id, user_id=current_user.id)
+        user_id = UUID(current_user.id)
+        review = await get_review(db=db, review_id=review_id, user_id=user_id)
 
         if not review:
             log.warning(
                 "review_not_found",
                 review_id=str(review_id),
-                user_id=str(current_user.id),
+                user_id=str(user_id),
             )
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail="Review not found",
             )
 
-        return ReviewResponse.model_validate(review)
+        return cast("ReviewResponse", ReviewResponse.model_validate(review))
 
     except HTTPException:
         raise
@@ -95,16 +115,16 @@ async def get_review_endpoint(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to retrieve review",
-        )
+        ) from exc
 
 
 @router.get("", response_model=ReviewListResponse)
 async def list_reviews_endpoint(
     page: int = 1,
     page_size: int = 20,
-    current_user: User = Depends(get_current_user),
-    db=Depends(get_db),
-):
+    current_user: User = _current_user_dep,
+    db: AsyncSession = _db_dep,
+) -> ReviewListResponse:
     """
     List reviews for current user with pagination.
     """
@@ -116,7 +136,7 @@ async def list_reviews_endpoint(
 
         reviews, total = await list_reviews(
             db=db,
-            user_id=current_user.id,
+            user_id=UUID(current_user.id),
             page=page,
             page_size=page_size,
         )
@@ -133,27 +153,28 @@ async def list_reviews_endpoint(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to list reviews",
-        )
+        ) from exc
 
 
 @router.get("/{review_id}/status")
 async def get_review_status(
     review_id: UUID,
-    current_user: User = Depends(get_current_user),
-    db=Depends(get_db),
-):
+    current_user: User = _current_user_dep,
+    db: AsyncSession = _db_dep,
+) -> dict[str, object]:
     """
     Get review status and progress.
     Returns {review_id, status, progress_pct}
     """
     try:
-        review = await get_review(db=db, review_id=review_id, user_id=current_user.id)
+        user_id = UUID(current_user.id)
+        review = await get_review(db=db, review_id=review_id, user_id=user_id)
 
         if not review:
             log.warning(
                 "review_not_found",
                 review_id=str(review_id),
-                user_id=str(current_user.id),
+                user_id=str(user_id),
             )
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
@@ -173,4 +194,4 @@ async def get_review_status(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to retrieve review status",
-        )
+        ) from exc

--- a/core/services/profile_service.py
+++ b/core/services/profile_service.py
@@ -1,21 +1,24 @@
+from typing import cast
 from uuid import UUID
+
 import structlog
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
+from api.schemas.profile import ProfileCreate, ProfileUpdate
+from core.models.ingested_source import IngestedSource
 from core.models.profile import Profile
 from core.models.review import Review
-from core.models.ingested_source import IngestedSource
-from api.schemas.profile import ProfileCreate, ProfileUpdate
 
 log = structlog.get_logger()
 
 
 async def create_profile(
-    db,
+    db: AsyncSession,
     user_id: UUID,
     data: ProfileCreate,
-    resume_filename: str = None,
-    resume_text: str = None,
+    resume_filename: str | None = None,
+    resume_text: str | None = None,
 ) -> Profile:
     """
     Create a new profile for a user.
@@ -34,22 +37,20 @@ async def create_profile(
 
 
 async def get_profile(
-    db,
+    db: AsyncSession,
     profile_id: UUID,
     user_id: UUID,
 ) -> Profile | None:
     """
     Get a profile by ID, checking ownership.
     """
-    stmt = select(Profile).where(
-        (Profile.id == profile_id) & (Profile.user_id == user_id)
-    )
+    stmt = select(Profile).where((Profile.id == profile_id) & (Profile.user_id == user_id))
     result = await db.execute(stmt)
-    return result.scalars().first()
+    return cast("Profile | None", result.scalars().first())
 
 
 async def update_profile(
-    db,
+    db: AsyncSession,
     profile_id: UUID,
     user_id: UUID,
     data: ProfileUpdate,
@@ -73,7 +74,7 @@ async def update_profile(
 
 
 async def delete_profile(
-    db,
+    db: AsyncSession,
     profile_id: UUID,
     user_id: UUID,
 ) -> bool:

--- a/core/services/review_service.py
+++ b/core/services/review_service.py
@@ -1,25 +1,34 @@
-from uuid import UUID
-import structlog
 import json
 from datetime import datetime
-from sqlalchemy import select, and_
+from typing import Any, cast
+from uuid import UUID
 
-from core.models.review import Review
-from core.models.profile import Profile
-from core.models.ingested_source import IngestedSource
+import structlog
+from sqlalchemy import and_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from api.schemas.review import FeedbackSection
+from core.models.ingested_source import IngestedSource
+from core.models.profile import Profile
+from core.models.review import Review
+from core.services.profile_service import get_profile
 
 log = structlog.get_logger()
 
 
 async def create_review(
-    db,
+    db: AsyncSession,
     profile_id: UUID,
     user_id: UUID,
-) -> Review:
+) -> Review | None:
     """
     Create a new review with status="pending".
+    Returns None if the profile does not exist or is not owned by user_id.
     """
+    profile = await get_profile(db, profile_id, user_id)
+    if not profile:
+        return None
+
     review = Review(
         profile_id=profile_id,
         status="pending",
@@ -33,22 +42,22 @@ async def create_review(
 
 
 async def get_review(
-    db,
+    db: AsyncSession,
     review_id: UUID,
     user_id: UUID,
 ) -> Review | None:
     """
     Get a review by ID, checking that it belongs to the user's profile.
     """
-    stmt = select(Review).join(Profile).where(
-        and_(Review.id == review_id, Profile.user_id == user_id)
+    stmt = (
+        select(Review).join(Profile).where(and_(Review.id == review_id, Profile.user_id == user_id))
     )
     result = await db.execute(stmt)
-    return result.scalars().first()
+    return cast("Review | None", result.scalars().first())
 
 
 async def list_reviews(
-    db,
+    db: AsyncSession,
     user_id: UUID,
     page: int = 1,
     page_size: int = 20,
@@ -74,13 +83,13 @@ async def list_reviews(
         .limit(page_size)
     )
     result = await db.execute(stmt)
-    reviews = result.scalars().all()
+    reviews = list(result.scalars().all())
 
     return reviews, total
 
 
 async def process_review(
-    db,
+    db: AsyncSession,
     review_id: UUID,
     profile_id: UUID,
 ) -> None:
@@ -166,7 +175,9 @@ async def process_review(
         ]
 
         review.status = "complete"
-        review.sections = [s.model_dump() for s in sections]
+        # Review.sections is typed as dict | None; pre-existing mismatch with the
+        # list of section dicts stored here, unrelated to #163.
+        review.sections = [s.model_dump() for s in sections]  # type: ignore[assignment]
         review.overall_score = rag_output.get("overall_score", None)
         review.updated_at = datetime.utcnow()
 
@@ -194,12 +205,12 @@ async def process_review(
             log.error("review_status_update_failed", review_id=str(review_id), error=str(e))
 
 
-async def _run_ingestion_pipeline(db, profile: Profile) -> list[dict]:
+async def _run_ingestion_pipeline(db: AsyncSession, profile: Profile) -> list[dict]:
     """
     Run ingestion pipeline to extract data from profile sources.
     Returns list of ingested source data.
     """
-    sources = []
+    sources: list[dict[str, Any]] = []
 
     # Ingest from GitHub if available
     if profile.github_username:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -99,7 +99,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -449,7 +448,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -473,7 +471,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1561,7 +1558,6 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1579,7 +1575,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1972,7 +1967,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3507,7 +3501,6 @@
       "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^2.0.1",
         "cssstyle": "^4.0.1",
@@ -4094,7 +4087,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4107,7 +4099,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4771,7 +4762,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/tests/unit/test_review_service.py
+++ b/tests/unit/test_review_service.py
@@ -1,9 +1,9 @@
 """Tests for review_service.py"""
 
-import pytest
-from uuid import uuid4
 from unittest.mock import AsyncMock, Mock, patch
-import asyncio
+from uuid import uuid4
+
+import pytest
 
 from core.services.review_service import (
     create_review,
@@ -17,7 +17,7 @@ class TestReviewService:
     """Test suite for review_service module."""
 
     @pytest.fixture
-    def mock_db_session(self):
+    def mock_db_session(self) -> AsyncMock:
         """Create a mock async database session."""
         session = AsyncMock()
         session.add = Mock()
@@ -27,7 +27,7 @@ class TestReviewService:
         return session
 
     @pytest.fixture
-    def mock_review(self):
+    def mock_review(self) -> Mock:
         """Create a mock Review object."""
         review = Mock()
         review.id = uuid4()
@@ -37,7 +37,7 @@ class TestReviewService:
         return review
 
     @pytest.fixture
-    def mock_profile(self):
+    def mock_profile(self) -> Mock:
         """Create a mock Profile object."""
         profile = Mock()
         profile.id = uuid4()
@@ -45,7 +45,9 @@ class TestReviewService:
         return profile
 
     @pytest.mark.asyncio
-    async def test_create_review_returns_review_with_pending_status(self, mock_db_session, mock_review):
+    async def test_create_review_returns_review_with_pending_status(
+        self, mock_db_session: AsyncMock, mock_review: Mock
+    ) -> None:
         """Test create_review returns Review with status='pending'."""
         profile_id = uuid4()
         user_id = uuid4()
@@ -55,21 +57,29 @@ class TestReviewService:
         mock_db_session.commit = AsyncMock()
         mock_db_session.refresh = AsyncMock()
 
-        with patch('core.services.review_service.Review') as MockReview:
-            mock_instance = MockReview.return_value
+        with (
+            patch(
+                "core.services.review_service.get_profile",
+                new=AsyncMock(return_value=Mock()),
+            ),
+            patch("core.services.review_service.Review") as mock_review_ctor,
+        ):
+            mock_instance = mock_review_ctor.return_value
             mock_instance.status = "pending"
             mock_instance.sections = None
             mock_instance.overall_score = None
 
             result = await create_review(mock_db_session, profile_id, user_id)
 
-            # Check that Review was instantiated
-            MockReview.assert_called()
-            call_kwargs = MockReview.call_args[1]
-            assert call_kwargs['status'] == "pending"
+        mock_review_ctor.assert_called()
+        call_kwargs = mock_review_ctor.call_args[1]
+        assert call_kwargs["status"] == "pending"
+        assert result is not None
 
     @pytest.mark.asyncio
-    async def test_get_review_returns_review_for_correct_owner(self, mock_db_session):
+    async def test_get_review_returns_review_for_correct_owner(
+        self, mock_db_session: AsyncMock
+    ) -> None:
         """Test get_review returns review when user_id matches."""
         review_id = uuid4()
         user_id = uuid4()
@@ -79,7 +89,9 @@ class TestReviewService:
 
         # Setup mock execute to return review
         mock_result = AsyncMock()
-        mock_result.scalars.return_value.first.return_value = mock_review
+        mock_scalars = Mock()
+        mock_scalars.first.return_value = mock_review
+        mock_result.scalars = Mock(return_value=mock_scalars)
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
         result = await get_review(mock_db_session, review_id, user_id)
@@ -88,15 +100,16 @@ class TestReviewService:
         mock_db_session.execute.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_get_review_returns_none_for_wrong_user(self, mock_db_session):
+    async def test_get_review_returns_none_for_wrong_user(self, mock_db_session: AsyncMock) -> None:
         """Test get_review returns None when user_id doesn't match."""
         review_id = uuid4()
-        user_id = uuid4()
         wrong_user_id = uuid4()
 
         # Setup mock to return None
         mock_result = AsyncMock()
-        mock_result.scalars.return_value.first.return_value = None
+        mock_scalars = Mock()
+        mock_scalars.first.return_value = None
+        mock_result.scalars = Mock(return_value=mock_scalars)
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
         result = await get_review(mock_db_session, review_id, wrong_user_id)
@@ -104,7 +117,7 @@ class TestReviewService:
         assert result is None
 
     @pytest.mark.asyncio
-    async def test_list_reviews_returns_paginated_results(self, mock_db_session):
+    async def test_list_reviews_returns_paginated_results(self, mock_db_session: AsyncMock) -> None:
         """Test list_reviews returns paginated results."""
         user_id = uuid4()
 
@@ -113,7 +126,9 @@ class TestReviewService:
 
         # Setup execute mock to return reviews
         mock_result = AsyncMock()
-        mock_result.scalars.return_value.all.return_value = mock_reviews
+        mock_scalars = Mock()
+        mock_scalars.all.return_value = mock_reviews
+        mock_result.scalars = Mock(return_value=mock_scalars)
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
         reviews, total = await list_reviews(mock_db_session, user_id, page=1, page_size=20)
@@ -123,19 +138,21 @@ class TestReviewService:
         assert total >= 0
 
     @pytest.mark.asyncio
-    async def test_list_reviews_page_2_returns_correct_offset(self, mock_db_session):
+    async def test_list_reviews_page_2_returns_correct_offset(
+        self, mock_db_session: AsyncMock
+    ) -> None:
         """Test list_reviews page 2 returns correct offset."""
         user_id = uuid4()
         page_size = 20
 
         # Setup mock
         mock_result = AsyncMock()
-        mock_result.scalars.return_value.all.return_value = []
+        mock_scalars = Mock()
+        mock_scalars.all.return_value = []
+        mock_result.scalars = Mock(return_value=mock_scalars)
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
-        reviews, total = await list_reviews(
-            mock_db_session, user_id, page=2, page_size=page_size
-        )
+        reviews, total = await list_reviews(mock_db_session, user_id, page=2, page_size=page_size)
 
         # Second call should pass offset for page 2
         calls = mock_db_session.execute.call_args_list
@@ -143,12 +160,14 @@ class TestReviewService:
         assert len(calls) > 0
 
     @pytest.mark.asyncio
-    async def test_list_reviews_returns_tuple(self, mock_db_session):
+    async def test_list_reviews_returns_tuple(self, mock_db_session: AsyncMock) -> None:
         """Test list_reviews returns (reviews, total) tuple."""
         user_id = uuid4()
 
         mock_result = AsyncMock()
-        mock_result.scalars.return_value.all.return_value = []
+        mock_scalars = Mock()
+        mock_scalars.all.return_value = []
+        mock_result.scalars = Mock(return_value=mock_scalars)
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
         result = await list_reviews(mock_db_session, user_id)
@@ -160,46 +179,68 @@ class TestReviewService:
         assert isinstance(total, int)
 
     @pytest.mark.asyncio
-    async def test_create_review_calls_db_add(self, mock_db_session):
+    async def test_create_review_calls_db_add(self, mock_db_session: AsyncMock) -> None:
         """Test create_review calls db.add()."""
         profile_id = uuid4()
         user_id = uuid4()
 
-        with patch('core.services.review_service.Review'):
+        with (
+            patch(
+                "core.services.review_service.get_profile",
+                new=AsyncMock(return_value=Mock()),
+            ),
+            patch("core.services.review_service.Review"),
+        ):
             await create_review(mock_db_session, profile_id, user_id)
 
-            mock_db_session.add.assert_called_once()
+        mock_db_session.add.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_create_review_calls_db_commit(self, mock_db_session):
+    async def test_create_review_calls_db_commit(self, mock_db_session: AsyncMock) -> None:
         """Test create_review calls db.commit()."""
         profile_id = uuid4()
         user_id = uuid4()
 
-        with patch('core.services.review_service.Review'):
+        with (
+            patch(
+                "core.services.review_service.get_profile",
+                new=AsyncMock(return_value=Mock()),
+            ),
+            patch("core.services.review_service.Review"),
+        ):
             await create_review(mock_db_session, profile_id, user_id)
 
-            mock_db_session.commit.assert_called_once()
+        mock_db_session.commit.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_create_review_calls_db_refresh(self, mock_db_session):
+    async def test_create_review_calls_db_refresh(self, mock_db_session: AsyncMock) -> None:
         """Test create_review calls db.refresh()."""
         profile_id = uuid4()
         user_id = uuid4()
 
-        with patch('core.services.review_service.Review'):
+        with (
+            patch(
+                "core.services.review_service.get_profile",
+                new=AsyncMock(return_value=Mock()),
+            ),
+            patch("core.services.review_service.Review"),
+        ):
             await create_review(mock_db_session, profile_id, user_id)
 
-            mock_db_session.refresh.assert_called_once()
+        mock_db_session.refresh.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_get_review_uses_select_and_join(self, mock_db_session):
+    async def test_get_review_uses_select_and_join(self, mock_db_session: AsyncMock) -> None:
         """Test get_review constructs proper SQL with join."""
         review_id = uuid4()
         user_id = uuid4()
 
         mock_result = AsyncMock()
-        mock_result.scalars.return_value.first.return_value = None
+        mock_scalars = Mock()
+        result_review = Mock()
+        result_review.id = review_id
+        mock_scalars.first.return_value = result_review
+        mock_result.scalars = Mock(return_value=mock_scalars)
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
         await get_review(mock_db_session, review_id, user_id)
@@ -208,12 +249,14 @@ class TestReviewService:
         mock_db_session.execute.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_list_reviews_default_pagination(self, mock_db_session):
+    async def test_list_reviews_default_pagination(self, mock_db_session: AsyncMock) -> None:
         """Test list_reviews uses default pagination."""
         user_id = uuid4()
 
         mock_result = AsyncMock()
-        mock_result.scalars.return_value.all.return_value = []
+        mock_scalars = Mock()
+        mock_scalars.all.return_value = []
+        mock_result.scalars = Mock(return_value=mock_scalars)
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
         reviews, total = await list_reviews(mock_db_session, user_id)
@@ -223,13 +266,15 @@ class TestReviewService:
         assert isinstance(total, int)
 
     @pytest.mark.asyncio
-    async def test_list_reviews_custom_page_size(self, mock_db_session):
+    async def test_list_reviews_custom_page_size(self, mock_db_session: AsyncMock) -> None:
         """Test list_reviews with custom page size."""
         user_id = uuid4()
         custom_page_size = 50
 
         mock_result = AsyncMock()
-        mock_result.scalars.return_value.all.return_value = []
+        mock_scalars = Mock()
+        mock_scalars.all.return_value = []
+        mock_result.scalars = Mock(return_value=mock_scalars)
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
         reviews, total = await list_reviews(
@@ -239,27 +284,54 @@ class TestReviewService:
         assert isinstance(reviews, list)
 
     @pytest.mark.asyncio
-    async def test_create_review_with_uuid_ids(self, mock_db_session):
+    async def test_create_review_with_uuid_ids(self, mock_db_session: AsyncMock) -> None:
         """Test create_review handles UUID objects correctly."""
         profile_id = uuid4()
         user_id = uuid4()
 
-        with patch('core.services.review_service.Review') as MockReview:
-            MockReview.return_value = Mock()
+        with (
+            patch(
+                "core.services.review_service.get_profile",
+                new=AsyncMock(return_value=Mock()),
+            ),
+            patch("core.services.review_service.Review") as mock_review_ctor,
+        ):
+            mock_review_ctor.return_value = Mock()
             await create_review(mock_db_session, profile_id, user_id)
 
-            call_kwargs = MockReview.call_args[1]
-            assert 'profile_id' in call_kwargs
-            assert 'status' in call_kwargs
+        call_kwargs = mock_review_ctor.call_args[1]
+        assert "profile_id" in call_kwargs
+        assert "status" in call_kwargs
 
     @pytest.mark.asyncio
-    async def test_get_review_verifies_ownership(self, mock_db_session):
+    async def test_create_review_returns_none_for_unauthorized_profile(
+        self, mock_db_session: AsyncMock
+    ) -> None:
+        """Test create_review returns None when the profile is not owned."""
+        profile_id = uuid4()
+        user_id = uuid4()
+
+        with patch(
+            "core.services.review_service.get_profile",
+            new=AsyncMock(return_value=None),
+        ):
+            result = await create_review(mock_db_session, profile_id, user_id)
+
+        assert result is None
+        mock_db_session.add.assert_not_called()
+        mock_db_session.commit.assert_not_called()
+        mock_db_session.refresh.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_get_review_verifies_ownership(self, mock_db_session: AsyncMock) -> None:
         """Test get_review checks Profile.user_id matches."""
         review_id = uuid4()
         user_id = uuid4()
 
         mock_result = AsyncMock()
-        mock_result.scalars.return_value.first.return_value = None
+        mock_scalars = Mock()
+        mock_scalars.first.return_value = None
+        mock_result.scalars = Mock(return_value=mock_scalars)
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
         await get_review(mock_db_session, review_id, user_id)
@@ -268,13 +340,15 @@ class TestReviewService:
         mock_db_session.execute.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_list_reviews_counts_total(self, mock_db_session):
+    async def test_list_reviews_counts_total(self, mock_db_session: AsyncMock) -> None:
         """Test list_reviews calculates total count."""
         user_id = uuid4()
 
         mock_reviews = [Mock() for _ in range(5)]
         mock_result = AsyncMock()
-        mock_result.scalars.return_value.all.return_value = mock_reviews
+        mock_scalars = Mock()
+        mock_scalars.all.return_value = mock_reviews
+        mock_result.scalars = Mock(return_value=mock_scalars)
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
         reviews, total = await list_reviews(mock_db_session, user_id)
@@ -283,13 +357,15 @@ class TestReviewService:
         assert isinstance(total, int)
 
     @pytest.mark.asyncio
-    async def test_list_reviews_returns_reviews_list(self, mock_db_session):
+    async def test_list_reviews_returns_reviews_list(self, mock_db_session: AsyncMock) -> None:
         """Test list_reviews returns list of Review objects."""
         user_id = uuid4()
 
-        mock_reviews = [Mock(spec=['id', 'status']) for _ in range(3)]
+        mock_reviews = [Mock(spec=["id", "status"]) for _ in range(3)]
         mock_result = AsyncMock()
-        mock_result.scalars.return_value.all.return_value = mock_reviews
+        mock_scalars = Mock()
+        mock_scalars.all.return_value = mock_reviews
+        mock_result.scalars = Mock(return_value=mock_scalars)
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
         reviews, total = await list_reviews(mock_db_session, user_id)
@@ -297,44 +373,56 @@ class TestReviewService:
         assert isinstance(reviews, list)
 
     @pytest.mark.asyncio
-    async def test_review_sections_and_score_initially_none(self, mock_db_session):
+    async def test_review_sections_and_score_initially_none(
+        self, mock_db_session: AsyncMock
+    ) -> None:
         """Test review has None for sections and overall_score initially."""
         profile_id = uuid4()
         user_id = uuid4()
 
-        with patch('core.services.review_service.Review') as MockReview:
-            MockReview.return_value = Mock()
+        with (
+            patch(
+                "core.services.review_service.get_profile",
+                new=AsyncMock(return_value=Mock()),
+            ),
+            patch("core.services.review_service.Review") as mock_review_ctor,
+        ):
+            mock_review_ctor.return_value = Mock()
             await create_review(mock_db_session, profile_id, user_id)
 
-            call_kwargs = MockReview.call_args[1]
-            assert call_kwargs['sections'] is None
-            assert call_kwargs['overall_score'] is None
+        call_kwargs = mock_review_ctor.call_args[1]
+        assert call_kwargs["sections"] is None
+        assert call_kwargs["overall_score"] is None
 
     @pytest.mark.asyncio
-    async def test_get_review_with_valid_uuid(self, mock_db_session):
+    async def test_get_review_with_valid_uuid(self, mock_db_session: AsyncMock) -> None:
         """Test get_review handles valid UUID parameters."""
         review_id = uuid4()
         user_id = uuid4()
 
         mock_result = AsyncMock()
-        mock_result.scalars.return_value.first.return_value = None
+        mock_scalars = Mock()
+        mock_scalars.first.return_value = None
+        mock_result.scalars = Mock(return_value=mock_scalars)
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
         # Should not raise
-        result = await get_review(mock_db_session, review_id, user_id)
+        _ = await get_review(mock_db_session, review_id, user_id)
 
-        assert result is None or result is not None  # Just verify no exception
+        assert True
 
     @pytest.mark.asyncio
-    async def test_list_reviews_ordered_by_created_at(self, mock_db_session):
+    async def test_list_reviews_ordered_by_created_at(self, mock_db_session: AsyncMock) -> None:
         """Test list_reviews returns results ordered by created_at desc."""
         user_id = uuid4()
 
         mock_result = AsyncMock()
-        mock_result.scalars.return_value.all.return_value = []
+        mock_scalars = Mock()
+        mock_scalars.all.return_value = []
+        mock_result.scalars = Mock(return_value=mock_scalars)
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
-        reviews, total = await list_reviews(mock_db_session, user_id)
+        await list_reviews(mock_db_session, user_id)
 
-        # Should order by created_at descending
-        mock_db_session.execute.assert_called_once()
+        # Should run both count and paginated queries
+        assert mock_db_session.execute.call_count == 2


### PR DESCRIPTION
## Summary
POST /reviews` created a review for any `profile_id` supplied in the request body without checking that the profile belonged to the authenticated user — a broken-access-control (IDOR) vulnerability that let any logged-in user create reviews against another user's profile. This PR closes the gap by reusing the same ownership check the read paths (`get_review`, `list_reviews`) already rely on, and rejects unowned/nonexistent profiles with `404` before any work is queued.

## Issue
Closes 163

## Changes
- `core/services/review_service.py`: `create_review()` now calls `profile_service.get_profile(db, profile_id, user_id)` before constructing a `Review`, and returns `None` if the profile is missing or not owned by the caller. Added type annotations (`AsyncSession`, explicit return types) to the functions in this file and fixed the pre-existing `sources: list[dict]` inference issue in `_run_ingestion_pipeline`.
- `api/routes/reviews.py`: `create_review_endpoint()` checks for that `None` and raises `HTTPException(404, "Profile not found")` before `background_tasks.add_task(process_review, ...)` is called, so no background processing happens for a non-owned profile. Also added return-type annotations, module-level `Depends()` singletons, `raise ... from exc`, and `UUID(current_user.id)` conversions across all four route handlers (`User.id`/`Review.id` are stored as `str`; the service layer expects `UUID`) — needed to satisfy the repo's mypy/ruff pre-commit hook, which type-checks whole files rather than diffs.
- `core/services/profile_service.py`: added type annotations (`AsyncSession`, `str | None` defaults) so it type-checks cleanly as an import of `review_service.py`. No behavior change.
- `tests/unit/test_review_service.py`: added `test_create_review_returns_none_for_unauthorized_profile` (asserts `create_review` returns `None` and never calls `db.add`/`commit`/`refresh` for an unowned profile). Updated the other `create_review` tests to mock `get_profile`, and replaced the `AsyncMock().scalars()` pattern with plain `Mock()` for `.scalars()` throughout the file, which also fixes several pre-existing mock-quirk test failures unrelated to this bug.


## Testing
<!-- How did you verify your changes? -->
- [x] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`) — no integration test suite exercises this route; verified manually instead (see below)
- [x] Linter passes (`make lint`)
- [x] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes

## Screenshots / Demo
<!-- If applicable, add screenshots or a link to a demo video -->
**Manual verification:** ran the app locally (docker-compose postgres + uvicorn), registered two users, created a profile for each, then:
- `POST /reviews` as user A targeting user B's `profile_id` → `404 {"detail":"Profile not found"}`, no review created.
- `POST /reviews` as user A targeting their own `profile_id` → `200`, review created with `status="pending"`, and the background task completed it to `status="complete"`.

<img width="3258" height="798" alt="image" src="https://github.com/user-attachments/assets/64cf73a5-019d-4f18-9600-56df80aa7ad7" />


## Notes for Reviewers
<!-- Anything the reviewer should pay particular attention to -->
- I chose `404` over `403` for the rejected case to match the existing convention in `get_review`/`get_profile` (avoids leaking whether the profile exists).
- The `AsyncSession`/`UUID` type-annotation changes across all four route handlers (not just `create_review_endpoint`) are larger than the security fix alone requires — they were necessary to get the repo's mypy pre-commit hook to pass, since it type-checks entire files. Two spots use a narrow, commented `type: ignore`/`cast` for pre-existing type mismatches unrelated to #163 (`Review.sections` typed `dict | None` but storing a list in `process_review`; `Any`-typed `.scalars().first()` results) rather than silently fixing or masking unrelated behavior.
- `process_review()` still fetches its profile without a `user_id` scope, but it's no longer reachable for a non-owned profile since `create_review()` now blocks that path upstream — left unchanged as noted in PLAN.md.