### PR TITLE
Fix Issue #88: Add regression coverage for profiles without ingested documents

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -70,3 +70,19 @@ After this contribution, the test suite will include coverage for profiles that 
 Notes
 
 This issue focuses on strengthening the project’s automated test suite rather than adding new application functionality. Improving test coverage for edge cases increases confidence in the API’s behavior and helps maintain long-term reliability.
+
+## Week 8 — Reproduction & Solution Planning
+
+### Reproduction commit link
+https://github.com/rupesh-vk/pathreview/commit/2a1bd55 
+
+### Reproduction summary
+
+I investigated Issue #88 by locating the current review-related tests in the repository. Although the issue references `tests/unit/test_review_routes.py`, that file is no longer present in the current codebase. I found that review tests now exist in `tests/unit/test_review_service.py` and confirmed that there is no test covering the scenario where a valid profile exists but has no ingested documents. This reproduces the missing test coverage described in the issue.
+
+### Reproduction Notes
+
+- Verified that `tests/unit/test_review_routes.py` does not exist.
+- Located the current review test file: `tests/unit/test_review_service.py`.
+- Reviewed all existing review tests.
+- Confirmed there is no test for the "profile exists but has no ingested documents" scenario.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,72 @@
+JOURNAL.md
+
+Week 7 – Issue Selection & Planning
+
+Selected Issue
+
+Title: POST /reviews endpoint has no test for when the profile has no ingested documents
+
+GitHub Issue: https://github.com/ascherj/pathreview/issues/88
+
+⸻
+
+Problem Summary
+
+The current test suite does not verify how the POST /reviews endpoint behaves when a profile exists but has no ingested documents associated with it. Because this edge case is not covered, the endpoint could return an unexpected error or even crash without being detected during testing. The goal of this issue is to add a unit test that exercises this scenario and verifies that the endpoint responds with the appropriate error instead of failing unexpectedly. Successfully addressing this issue will improve the reliability of the API and increase the project’s test coverage.
+
+⸻
+
+Why I Selected This Issue
+
+I selected this issue because it is well-scoped for a first contribution and focuses on improving the project’s automated tests. It allows me to become familiar with the API layer and the existing testing framework without requiring major architectural changes. Since the estimated effort is only a few hours, it is an appropriate issue for learning the contribution workflow while making a meaningful improvement to the project.
+
+⸻
+
+“Is This Right for Me?” Checklist
+
+Is the issue appropriately scoped?
+
+Yes. The issue is estimated to take approximately 2–3 hours and involves adding a single missing test case rather than implementing new functionality. The scope is limited and clearly defined.
+
+Do I understand the problem?
+
+Yes. The issue description explains that there is currently no test covering the case where a profile exists but has no ingested documents. My task is to verify that the endpoint returns an appropriate error response instead of crashing.
+
+Can I identify the relevant files?
+
+Yes. The primary file involved is:
+
+* tests/unit/test_review_routes.py
+
+I may also review related test fixtures or helper functions if necessary, but most of the work should remain within the existing test suite.
+
+Am I likely to modify production code?
+
+Probably not. The issue specifically requests adding a missing unit test. If the new test exposes a bug in the implementation, I may need to make a small production code change, but the primary objective is to improve test coverage.
+
+Why is this issue a good fit?
+
+This issue is a good fit because it is focused, easy to understand, and allows me to practice navigating an unfamiliar codebase while learning the project’s testing patterns. It also contributes to improving software quality by covering an important edge case.
+
+⸻
+
+High-Level Solution Plan
+
+1. Read the existing tests in tests/unit/test_review_routes.py to understand the current testing structure.
+2. Review how profile fixtures and review requests are created.
+3. Create a test scenario where a valid profile exists but has no ingested documents.
+4. Send a request to the POST /reviews endpoint using that profile.
+5. Verify that the endpoint returns the expected error response instead of crashing.
+6. Run the test suite to ensure the new test passes and does not affect existing tests.
+
+⸻
+
+Expected Outcome
+
+After this contribution, the test suite will include coverage for profiles that have no ingested documents. This will help ensure that the POST /reviews endpoint handles this edge case gracefully and continues returning the correct error response even as the application evolves. The additional test will also reduce the likelihood of regressions in future development.
+
+⸻
+
+Notes
+
+This issue focuses on strengthening the project’s automated test suite rather than adding new application functionality. Improving test coverage for edge cases increases confidence in the API’s behavior and helps maintain long-term reliability.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -86,3 +86,41 @@ I investigated Issue #88 by locating the current review-related tests in the rep
 - Located the current review test file: `tests/unit/test_review_service.py`.
 - Reviewed all existing review tests.
 - Confirmed there is no test for the "profile exists but has no ingested documents" scenario.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented handling for profiles with no ingested documents during review processing. Added a regression unit test covering this edge case.
+
+**Next steps:**
+Run the project tests, create the pull request, and submit the final branch URL.
+
+**Blockers:**
+None.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:**
+<https://github.com/ascherj/pathreview/pull/914>
+
+**Branch:**
+feature/issue-88-review-test
+
+**What you built:**
+Added handling for the case where a profile has no ingested documents during review processing. If no documents are available, the review is marked as failed and an error message is stored. Also added a regression unit test covering this scenario.
+
+**Tests added or updated:**
+Updated `tests/unit/test_review_service.py` with a regression test for profiles without ingested documents.
+
+**Self-review confirmation:**
+[x] make check run
+[x] make test-unit run
+
+Note: The repository contains pre-existing unrelated test failures. My changes do not introduce additional failures.
+
+**Draft PR feedback received from:**
+None

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -99,7 +99,6 @@ Run the project tests, create the pull request, and submit the final branch URL.
 
 **Blockers:**
 None.
-
 ---
 
 ### Check-in 2 (end of week)
@@ -124,3 +123,34 @@ Note: The repository contains pre-existing unrelated test failures. My changes d
 
 **Draft PR feedback received from:**
 None
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**  
+I did not receive reviewer feedback on my pull request. For the Summer 2026 cohort, formal reviewer feedback was not part of the project process, so there were no requested changes or maintainer comments for me to address.
+
+**How you responded:**  
+No response or additional changes were necessary because I did not receive reviewer feedback.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**  
+The hardest part was navigating an issue whose original instructions no longer completely matched the current codebase. Issue #88 referenced `tests/unit/test_review_routes.py`, but that file was no longer present in the repository. I had to investigate the current project structure and determine that the relevant review tests were now in `tests/unit/test_review_service.py`. I also had to trace the review flow into `process_review()` and understand how ingestion results were handled before deciding where the missing-document case should be addressed. Debugging the local test environment was another unexpected challenge because `pytest-asyncio` initially was not being recognized.
+
+**What did you learn about working in a large codebase?**  
+I learned that working in an existing codebase requires much more investigation before making changes than building a project from scratch. An issue description may become outdated as the repository evolves, so I could not rely only on the file paths listed in the issue. I used searches through the repository to locate review-related files, traced functions across the API, service, model, and schema layers, and looked at existing tests before implementing anything. I also learned the importance of limiting a contribution to the scope of the issue instead of trying to fix unrelated problems in the repository.
+
+**How did AI tools help — and where did they fall short?**  
+AI tools were especially useful for helping me navigate unfamiliar code, understand the relationship between `api/routes/reviews.py`, `core/services/review_service.py`, and the existing unit tests, and interpret terminal and pytest errors. They also helped me reason through how to mock the database interactions needed for the regression test. However, AI could not simply assume that the issue description still represented the current repository. I had to verify suggestions by searching the actual codebase, examining `process_review()`, checking existing test patterns, and running the tests myself. This showed me that AI is useful for accelerating investigation, but its suggestions still need to be validated against the current code.
+
+**What would you do differently if you started over?**  
+I would investigate the repository structure and run the relevant test suite earlier, before writing a detailed implementation plan. Because the issue referenced a test file that no longer existed, identifying that mismatch immediately would have saved time later. I would also verify the development environment and project dependencies at the beginning so issues such as the missing `pytest-asyncio` plugin do not interrupt testing after the implementation is already written. Finally, I would open the draft pull request earlier so that the contribution workflow is visible throughout implementation instead of waiting until most of the work is complete.
+
+**What are you most proud of from this module?**  
+I am most proud that I was able to take an issue from selection through investigation, implementation, testing, and pull request submission even though the repository had changed since the issue was written. Instead of assuming the missing test file meant I could not complete the issue, I traced the current implementation, found the appropriate location for the regression test, added handling for profiles with no ingested documents, verified the new test passed, and submitted the contribution as PR #914. The experience gave me a much better understanding of what contributing to an existing open-source codebase actually involves.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,62 @@
+# Solution Plan
+
+## Issue
+
+POST /reviews endpoint has no test for when the profile has no ingested documents
+
+https://github.com/ascherj/pathreview/issues/88
+
+---
+
+## Understand
+
+Issue #88 identifies a missing unit test for the review creation flow when a valid profile exists but has no ingested documents. The issue description references `tests/unit/test_review_routes.py`, but that file is no longer present in the current repository. After investigating the current codebase, I found that review-related tests now exist in `tests/unit/test_review_service.py`. The expected behavior is that attempting to create a review for a profile without ingested documents should return an appropriate error instead of failing unexpectedly.
+
+---
+
+## Map
+
+Files involved:
+
+- tests/unit/test_review_service.py
+- core/services/review_service.py
+- api/routes/reviews.py
+
+---
+
+## Plan
+
+1. Review the existing review creation tests in `tests/unit/test_review_service.py`.
+2. Determine how the review service handles profiles without ingested documents.
+3. Add a new unit test covering this missing scenario.
+4. Verify the expected error response or exception.
+5. Run the test suite to ensure the new test passes and existing tests continue to pass.
+
+---
+
+## Inputs & Outputs
+
+Input:
+- Valid profile ID
+- Profile without ingested documents
+
+Output:
+- Appropriate error response
+- New unit test validating the behavior
+
+---
+
+## Risks & Unknowns
+
+- The expected error type or HTTP status code may need to be confirmed.
+- The repository structure has changed since the issue was opened, so the original file path is no longer valid.
+- Additional fixtures may be required to create a profile with no ingested documents.
+
+---
+
+## Edge Cases
+
+- Profile exists but has no ingested documents.
+- Invalid profile ID.
+- Missing user permissions.
+- Empty ingestion results.

--- a/core/services/review_service.py
+++ b/core/services/review_service.py
@@ -131,6 +131,21 @@ async def process_review(
             review_id=str(review_id),
             sources_count=len(ingestion_results),
         )
+        # Handle profiles with no ingested content
+        if not ingestion_results:
+            log.warning(
+                "no_ingested_documents",
+                review_id=str(review_id),
+                profile_id=str(profile_id),
+        )
+
+            review.status = "failed"
+            review.error_message = "Profile has no ingested documents."
+            review.updated_at = datetime.utcnow()
+
+            db.add(review)
+            await db.commit()
+            return
 
         # Step 3: Run agent orchestration
         agent_output = await _run_agent_orchestration(profile, ingestion_results)

--- a/tests/unit/test_review_service.py
+++ b/tests/unit/test_review_service.py
@@ -9,6 +9,7 @@ from core.services.review_service import (
     create_review,
     get_review,
     list_reviews,
+    process_review,
 )
 
 
@@ -338,3 +339,37 @@ class TestReviewService:
 
         # Should order by created_at descending
         mock_db_session.execute.assert_called_once()
+
+@pytest.mark.unit
+class TestProcessReviewNoIngestedDocuments:
+    """Regression test for Issue #88."""
+
+    @pytest.mark.asyncio
+    async def test_process_review_fails_when_profile_has_no_documents(self):
+        review = Mock()
+        review.id = uuid4()
+        review.status = "pending"
+        review.error_message = None
+
+        profile = Mock()
+        profile.id = uuid4()
+        profile.github_username = None
+        profile.portfolio_url = None
+        profile.resume_text = None
+
+        db = AsyncMock()
+        db.add = Mock()
+        db.commit = AsyncMock()
+
+        review_result = Mock()
+        review_result.scalars.return_value.first.return_value = review
+
+        profile_result = Mock()
+        profile_result.scalars.return_value.first.return_value = profile
+
+        db.execute = AsyncMock(side_effect=[review_result, profile_result])
+
+        await process_review(db, review.id, profile.id)
+
+        assert review.status == "failed"
+        assert review.error_message == "Profile has no ingested documents."


### PR DESCRIPTION
## Summary

Adds regression coverage for the case where a profile exists but has no ingested documents.

## Changes
- Added handling for profiles with no ingested documents during review processing.
- Added a regression unit test covering this edge case.

## Testing
- Verified the new regression test passes locally.
- Ran the project's test suite.

Note:
The repository currently contains unrelated pre-existing failing tests. My changes do not introduce additional failures beyond those already present.