### PR TITLE
Fix/159 structlog caplog capture

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -26,7 +26,7 @@ assertions pass without changing the application code.
 
 **Branch name:** `fix/159-structlog-caplog-capture`
 
-**Setup confirmation:** [ ] App runs locally at localhost:5173
+**Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [ ] Issue added to cohort ledger
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -28,7 +28,7 @@ assertions pass without changing the application code.
 
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
-**Cohort ledger:** [ ] Issue added to cohort ledger
+**Cohort ledger:** [x] Issue added to cohort ledger
 
 ---
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,47 @@
+# Module 3 Journal
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/159
+
+**Issue title:** structlog output is not captured by pytest caplog — log assertions fail suite-wide
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The app does its logging through `structlog`, but the test suite checks log output
+using pytest's built-in `caplog` fixture. Those two don't talk to each other by
+default: `structlog.get_logger()` doesn't route its events into Python's standard
+`logging` system, so `caplog.text` and `caplog.records` come up empty even when the
+code clearly emits the log (the message is visibly printed to stderr). Because of
+this, any test that asserts on a log — like `test_empty_chunks_list_returns_empty`
+in `tests/unit/test_batch_processor.py` — fails even though the behavior under test
+is correct. A successful fix configures `structlog` inside `tests/conftest.py` so its
+output propagates into the stdlib logging that `caplog` reads, making the log-based
+assertions pass without changing the application code.
+
+**Affected area:** `tests/conftest.py` (test setup), verified against
+`tests/unit/test_batch_processor.py`. The application logging in
+`ingestion/embeddings/batch_processor.py` is already correct.
+
+**Branch name:** `fix/159-structlog-caplog-capture`
+
+**Setup confirmation:** [ ] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger
+
+---
+
+### "Is this right for me?" — scope reasoning
+
+- **Tier:** Tier 1, labeled `bug` + `tests`. Scoped to a single config file
+  (`tests/conftest.py`), which matches a good first contribution.
+- **Do I understand the problem?** Yes. I reproduced the mismatch: the code logs via
+  `structlog`, the test reads via `caplog` (stdlib logging), and the two aren't bridged.
+- **Is the blast radius small?** Yes. The fix lives in test configuration only — no
+  application code changes — so the risk of breaking runtime behavior is low.
+- **Can I verify it?** Yes. There's a concrete failing test to run before and after
+  (`tests/unit/test_batch_processor.py::TestBatchEmbeddingProcessor::test_empty_chunks_list_returns_empty`),
+  plus the broader suite to confirm nothing else regresses.
+- **Note:** Two other students (`amanadhav`, `oherna25`) also claimed #159. Claims
+  aren't exclusive per the module rules, so I'm proceeding with my own approach.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -50,7 +50,7 @@ assertions pass without changing the application code.
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** _(this commit — permalink added in the follow-up entry below)_
+**Reproduction commit link:** [`669ba55` — docs: reproduce #159 — structlog bypasses stdlib logging](https://github.com/ShawarmaOnGit/pathreview/commit/669ba5577b602043a8ce1125a7fb11b2ee6793fb)
 
 **Reproduction summary:**
 I ran the single failing test in a clean local environment and confirmed the failure is
@@ -58,9 +58,13 @@ real: `caplog.text` comes back as the empty string, while pytest's own stdout ca
 shows the warning was definitely emitted. So the log fires, but `caplog` never sees it —
 the two logging systems aren't connected.
 
-**PLAN.md link:** _(added in Week 8 planning commit)_
+**PLAN.md link:** [PLAN.md](https://github.com/ShawarmaOnGit/pathreview/blob/fix/159-structlog-caplog-capture/PLAN.md)
+(added in [`8f96737`](https://github.com/ShawarmaOnGit/pathreview/commit/8f96737ab2ae727fda700654837461183edf2ff1))
 
-**Walkthrough video (recommended):** _(not recorded)_
+**Walkthrough video (recommended):** _Not recorded — optional and not graded._
+
+**Branch URL (portal submission):**
+https://github.com/ShawarmaOnGit/pathreview/tree/fix/159-structlog-caplog-capture
 
 **Blockers or open questions:**
 None blocking. One open design question I'll settle in Week 9: whether to reuse the

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -45,3 +45,103 @@ assertions pass without changing the application code.
   plus the broader suite to confirm nothing else regresses.
 - **Note:** Two other students (`amanadhav`, `oherna25`) also claimed #159. Claims
   aren't exclusive per the module rules, so I'm proceeding with my own approach.
+
+---
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** _(this commit — permalink added in the follow-up entry below)_
+
+**Reproduction summary:**
+I ran the single failing test in a clean local environment and confirmed the failure is
+real: `caplog.text` comes back as the empty string, while pytest's own stdout capture
+shows the warning was definitely emitted. So the log fires, but `caplog` never sees it —
+the two logging systems aren't connected.
+
+**PLAN.md link:** _(added in Week 8 planning commit)_
+
+**Walkthrough video (recommended):** _(not recorded)_
+
+**Blockers or open questions:**
+None blocking. One open design question I'll settle in Week 9: whether to reuse the
+app's existing `configure_logging()` from `core/logging.py` or write a purpose-built
+test configuration in `conftest.py`. I'm currently leaning toward the latter — see
+PLAN.md for the reasoning.
+
+---
+
+### Reproduction steps
+
+Reproduced on `structlog 26.1.0` / `pytest 9.1.1`.
+
+```bash
+python -m pytest "tests/unit/test_batch_processor.py::TestBatchEmbeddingProcessor::test_empty_chunks_list_returns_empty" -v
+```
+
+**Observed output:**
+
+```
+FAILED tests/unit/test_batch_processor.py::...::test_empty_chunks_list_returns_empty
+
+>       assert "Empty chunks list" in caplog.text or any(
+            "empty" in record.message.lower() for record in caplog.records
+        )
+E       AssertionError: assert ('Empty chunks list' in '' or False)
+E        +  where '' = <_pytest.logging.LogCaptureFixture object at 0x107927e00>.text
+E        +  and   False = any(<generator object ...>)
+
+tests/unit/test_batch_processor.py:42: AssertionError
+----------------------------- Captured stdout call -----------------------------
+2026-07-29 02:07:26 [warning  ] Empty chunks list provided to BatchEmbeddingProcessor
+=========================== short test summary info ============================
+1 failed in 1.91s
+```
+
+The two highlighted lines are the whole issue side by side: `caplog.text` is `''`, yet
+the warning text appears under **Captured stdout**. The application code at
+`ingestion/embeddings/batch_processor.py:40` is doing its job correctly.
+
+### Root cause (confirmed, not inferred)
+
+I checked structlog's active configuration directly rather than assuming:
+
+```bash
+python -c "import structlog; print(structlog.get_config()['logger_factory'])"
+# <structlog._output.PrintLoggerFactory object at 0x101a59010>
+```
+
+Because nothing configures structlog during the test run, it falls back to its default
+`PrintLoggerFactory`, which writes **straight to stdout** and never touches Python's
+standard `logging` module. `caplog` is implemented as a stdlib logging handler, so a
+record that never enters stdlib logging can never reach it. That is why the message is
+visible in captured stdout but absent from `caplog.text`.
+
+The correct bridge already exists in this repo — `core/logging.py:43` sets
+`logger_factory=structlog.stdlib.LoggerFactory()`, which *does* route events into stdlib
+logging. It simply is never invoked from the test suite: the only caller of
+`configure_logging()` is `scripts/seed_db.py:20`.
+
+### Scope correction to my Week 7 entry
+
+Two details from Week 7 I got wrong and want on the record:
+
+1. The issue title says log assertions fail **suite-wide**. In practice, exactly **one**
+   test in the entire suite currently uses `caplog` (`tests/unit/test_batch_processor.py:36`).
+   The fix is still worth making — it unblocks every future log assertion — but the
+   present blast radius is one test, not many.
+2. I wrote that the message prints to **stderr**. It is actually **stdout**; structlog's
+   default `PrintLoggerFactory` writes to stdout.
+
+### Regression baseline
+
+Recorded before changing anything, so I can prove Week 9 introduces no new failures:
+
+```
+python -m pytest tests/unit -q      →  53 failed, 375 passed
+python -m pytest tests/unit/test_batch_processor.py -q  →  1 failed, 10 passed
+```
+
+The 53 failures are pre-existing and unrelated to #159 (this fork is seeded with ~130
+intentional issues). Of the 11 tests in `test_batch_processor.py`, the single failure is
+the `caplog` one. My success criterion is therefore **52 failed / 376 passed**, not a
+green suite.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -149,3 +149,56 @@ The 53 failures are pre-existing and unrelated to #159 (this fork is seeded with
 intentional issues). Of the 11 tests in `test_batch_processor.py`, the single failure is
 the `caplog` one. My success criterion is therefore **52 failed / 376 passed**, not a
 green suite.
+
+---
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Most of the PLAN.md sub-tasks are done. I wrote the failing tests first and confirmed they
+were red, then added the autouse fixture in `tests/conftest.py` that routes structlog through
+stdlib logging (Plan steps 1-3). The target test `test_empty_chunks_list_returns_empty` now
+passes, and I ran the full unit suite to confirm no regressions (Plan steps 4-5). I also
+settled the open design question from Week 8: I went with a purpose-built test config instead
+of reusing the app's `configure_logging()`, because that function calls `basicConfig` and
+fights pytest's own log capture.
+
+**Next steps:**
+Add type annotations the pre-commit mypy hook wants on the new test file, commit, push, and
+open the PR. Then write Check-in 2 and submit the branch URL through the portal.
+
+**Blockers:**
+None. One minor snag: `make typecheck` skips `tests/`, so it did not catch that my test
+methods needed return annotations, but the pre-commit hook did. Fixed in a couple minutes.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/917
+
+**Branch:** `fix/159-structlog-caplog-capture`
+
+**What you built:**
+An autouse pytest fixture in `tests/conftest.py` that reconfigures structlog to emit through
+Python's standard `logging` module during tests, so pytest's `caplog` fixture can actually
+capture log events. It resets structlog to its defaults after each test so the global config
+does not leak. No application code changed.
+
+**Tests added or updated:**
+Added `tests/unit/test_logging_capture.py` with 5 tests. They cover that a structlog warning
+becomes one captured record with level `WARNING`, that the record's name matches the logger,
+that bound key/value data renders into the captured text, that INFO logs are dropped until a
+test opts in with `caplog.at_level(INFO)`, and that a test which logs nothing sees zero
+records (the fixture adds no noise). The existing `test_empty_chunks_list_returns_empty` in
+`tests/unit/test_batch_processor.py` also flips from failing to passing.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+(This fork has documented pre-existing failures, so "passes" means my changes add no new ones.
+Baselines recorded in my PR description: unit tests went 53 failed / 375 passed to 52 failed /
+381 passed, exactly one pre-existing failure flipped, and lint/format/typecheck counts are
+unchanged.)
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -202,3 +202,66 @@ Baselines recorded in my PR description: unit tests went 53 failed / 375 passed 
 unchanged.)
 
 **Draft PR feedback received from:** none
+
+---
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No review arrived
+
+**How you responded:**
+No changes were required, so the branch stands as submitted in Week 9.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Picking the issue. I wanted something small enough that I could actually finish it, but two
+other students had already claimed #159 before me, so I had to decide whether to go ahead
+anyway. The part I really didn't see coming was the baseline. This fork ships with around 130
+intentional bugs, so 53 unit tests were already failing before I touched anything. That meant a
+green test suite was never going to be my finish line. I had to define success as 53 failures
+going down to 52, and then prove that the one that flipped was mine.
+
+**What did you learn about working in a large codebase?**
+The biggest thing is that the fix already existed. `core/logging.py:43` already sets up the exact
+structlog to stdlib bridge I needed. Nothing in the test suite ever calls it though. The only
+caller in the whole repo is a database seed script. In my own projects, when something doesn't
+work it's usually because I haven't written it yet. Here it was code that was written correctly
+and just never got reached, which is a very different thing to go looking for. I also had to get
+used to working in a suite that's red on purpose, and check failing tests by name instead of
+trusting the counts.
+
+**How did AI tools help and where did they fall short?**
+Claude Code was most useful for speed of understanding. It explained how structlog's processor
+chain and logger factory fit together in plain language, which would have taken me a lot longer
+to piece together from the docs. Where it fell short was anything specific to this repo. The
+standard structlog setup you find everywhere includes `filter_by_level`, and if I had just pasted
+that in, INFO logs would still have been dropped and `caplog` would still have come back empty.
+Same bug, new cause. I had to work that out myself and leave it out on purpose. It was the same
+with the root cause. I only really believed it after running
+`python -c "import structlog; print(structlog.get_config()['logger_factory'])"` and seeing
+`PrintLoggerFactory` with my own eyes.
+
+**What would you do differently if you started over?**
+Read the code before writing my problem summary. In Week 7 I repeated the issue title's claim
+that log assertions fail suite wide, and I wrote that the output goes to stderr. When I actually
+checked in Week 8, it turned out exactly one test in the entire repo uses `caplog`, and the
+output goes to stdout. Both of those were about twenty minutes of reading away and I wrote them
+down as facts instead. I'd also record the regression baseline in the first week instead of the
+second, because every claim I made later depended on it.
+
+**What are you most proud of from this module?**
+Not the PR itself. It's the before and after table in my PR description, where I compared the
+failing test names before and after my change instead of just the counts, so a reviewer can
+confirm that nothing quietly swapped places. A close second is writing down why I didn't reuse
+the app's own `configure_logging()`. It calls `basicConfig`, caches loggers, and reads the log
+level from settings, so a maintainer can disagree with that decision instead of guessing at my
+reasoning. And I'm glad I put my two Week 7 mistakes in the journal instead of quietly editing
+them out.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,218 @@
+# Solution plan
+
+**Issue:** [#159 — structlog output is not captured by pytest caplog — log assertions fail suite-wide](https://github.com/ascherj/pathreview/issues/159)
+
+---
+
+## Understand
+
+**What's broken.** The application logs through `structlog`, but the test suite asserts
+on log output using pytest's built-in `caplog` fixture. Nothing configures `structlog`
+during a test run, so it falls back to its shipped default `logger_factory` —
+`PrintLoggerFactory`, which writes rendered events **straight to stdout** and never hands
+them to Python's standard `logging` module.
+
+`caplog` is implemented as a stdlib logging handler attached to the root logger. A log
+event that never enters stdlib logging can never reach that handler. So the message is
+plainly visible in pytest's captured stdout while `caplog.text` stays empty.
+
+I confirmed the active factory rather than assuming it:
+
+```bash
+python -c "import structlog; print(structlog.get_config()['logger_factory'])"
+# <structlog._output.PrintLoggerFactory object at 0x101a59010>
+```
+
+**Expected vs. actual**, using `test_empty_chunks_list_returns_empty`:
+
+| | |
+|---|---|
+| **Expected** | `logger.warning("Empty chunks list…")` produces a `LogRecord`, so `caplog.text` contains the message and `caplog.records` holds one WARNING record. |
+| **Actual** | `caplog.text == ''` and `caplog.records == []`. The message appears only under pytest's *Captured stdout* section. |
+
+**The fix is test-side only.** The application logging call at
+`ingestion/embeddings/batch_processor.py:40` is already correct — it emits a WARNING with
+a sensible message. Nothing in `ingestion/` needs to change.
+
+Notably, **the correct bridge already exists in this repo.** `core/logging.py:43` sets
+`logger_factory=structlog.stdlib.LoggerFactory()`, which *does* route structlog events
+into stdlib logging. It is simply never invoked from the test suite — the only caller of
+`configure_logging()` anywhere in the codebase is `scripts/seed_db.py:20`. The fix is
+therefore about making the test suite establish an equivalent configuration, not about
+inventing a new mechanism.
+
+**Scope note.** The issue title says log assertions fail *suite-wide*. In practice exactly
+one test currently uses `caplog` (`tests/unit/test_batch_processor.py:36`). The fix is
+still worth making — it unblocks every future log assertion in the project — but I want the
+real blast radius on record rather than overstating it.
+
+---
+
+## Map
+
+Files I expect to **touch**:
+
+| File | Change |
+|---|---|
+| `tests/conftest.py` | The entire fix. Add an autouse fixture that configures `structlog` to emit through stdlib logging, and resets it afterward. Currently holds only `sample_resume_text` and `sample_readme_text` fixtures and imports nothing but `pytest`. |
+
+Files I expect to **read or verify against, but not modify**:
+
+| File | Role |
+|---|---|
+| `tests/unit/test_batch_processor.py:36` | `test_empty_chunks_list_returns_empty` — the one concrete failing test; my pass/fail signal. Asserts on both `caplog.text` (line 42) and `record.message` (line 43). |
+| `ingestion/embeddings/batch_processor.py:40` | The `logger.warning("Empty chunks list provided to BatchEmbeddingProcessor")` emit site. Correct as written; do not change. |
+| `core/logging.py:40-45` | The app's existing `structlog.configure()` block. My reference for what a correct configuration looks like, and the source of the `cache_logger_on_first_use=True` hazard noted under Risks. |
+| `scripts/seed_db.py:20` | The sole caller of `configure_logging()` — evidence that the app never configures structlog during tests. |
+| `pyproject.toml:83-90` | `[tool.pytest.ini_options]`. Defines markers but sets **no** `log_cli` or `log_level`, which is why the root logger sits at its WARNING default. |
+
+Modules that log via `structlog` and would also become assertable once this lands (context,
+not targets): `ingestion/pipeline.py`, `agent/orchestrator.py`, `agent/error_handling.py`,
+`agent/tools/tech_detector.py`, `agent/tools/market_analyzer.py`,
+`core/services/profile_service.py`.
+
+---
+
+## Plan
+
+1. **Add an autouse fixture to `tests/conftest.py`** that calls `structlog.configure()`
+   with `logger_factory=structlog.stdlib.LoggerFactory()` and
+   `wrapper_class=structlog.stdlib.BoundLogger`. This is the actual bridge: it makes
+   structlog emit through `logging.getLogger(name)` instead of printing to stdout.
+
+2. **Set `cache_logger_on_first_use=False`** in that configuration, and build a minimal
+   processor chain (`add_log_level`, `StackInfoRenderer`, `format_exc_info`, and a
+   `ConsoleRenderer(colors=False)`). Deliberately **omit** `structlog.stdlib.filter_by_level`
+   — see Edge cases for why it would silently re-break capture.
+
+3. **Restore global state on teardown** by calling `structlog.reset_defaults()` after each
+   test, so the fixture cannot leak configuration into unrelated tests. `structlog.configure()`
+   mutates process-global state, so this isolation step is not optional.
+
+4. **Verify the target test flips to passing** by running
+   `pytest "tests/unit/test_batch_processor.py::TestBatchEmbeddingProcessor::test_empty_chunks_list_returns_empty" -v`,
+   and confirm `caplog.records` now holds one record with `levelname == "WARNING"` — not just
+   that the string match succeeds.
+
+5. **Check for regressions against the recorded baseline.** Before any change,
+   `pytest tests/unit -q` gives **53 failed / 375 passed**, and
+   `pytest tests/unit/test_batch_processor.py -q` gives **1 failed / 10 passed**. Success is
+   **52 failed / 376 passed** — exactly one test flipping. The other 52 failures are
+   pre-existing and belong to unrelated seeded issues in this fork; a green suite is *not*
+   the target and claiming one would be wrong.
+
+---
+
+## Inputs & outputs
+
+**Input.** Structured log events emitted by application code through module-level
+`structlog.get_logger()` calls — for example
+`logger.warning("Empty chunks list provided to BatchEmbeddingProcessor")` at
+`ingestion/embeddings/batch_processor.py:40`, including any bound key/value pairs such as
+`chunk_count=total_chunks`.
+
+**Output.** Standard-library `logging.LogRecord` objects delivered to pytest's
+`LogCaptureHandler`, so that within a test:
+
+- `caplog.text` contains the rendered event text,
+- `caplog.records` is non-empty and each record carries a correct `levelname`
+  (`"WARNING"` for the target test) and a `name` matching the emitting module
+  (`ingestion.embeddings.batch_processor`).
+
+**What changes.** Only test-time configuration. Concretely:
+
+- `tests/conftest.py` gains one autouse fixture and imports of `structlog` (and `logging`).
+- No function signature changes anywhere.
+- No application code changes — `ingestion/`, `agent/`, `core/`, and `api/` are untouched.
+- No runtime behavior change: production logging still flows through
+  `core/logging.py::configure_logging()` exactly as it does today.
+
+**What is explicitly out of scope.** Rewriting `core/logging.py`, changing the assertion
+style in `test_batch_processor.py`, or fixing any of the other 52 failing tests.
+
+---
+
+## Risks & unknowns
+
+1. **`structlog.configure()` mutates process-global state.** It is not scoped to a test or
+   module. If the fixture configures without restoring, ordering-dependent failures could
+   appear in tests that run afterward — the classic symptom being a suite that passes
+   file-by-file but fails when run whole. *Mitigation:* `structlog.reset_defaults()` on
+   fixture teardown, plus a full-suite run (step 5) rather than trusting a single-file run.
+
+2. **Reusing `configure_logging()` from `core/logging.py` looks tempting but is the wrong
+   call.** Three concrete reasons, each tied to a line: it sets
+   `cache_logger_on_first_use=True` (`core/logging.py:44`), which freezes a bound logger's
+   underlying factory on first use and can pin a logger to a stale configuration; it calls
+   `logging.basicConfig(stream=sys.stdout)` (`core/logging.py:48-52`), which installs a root
+   handler that fights pytest's own capture; and it reads `settings.app_env` and
+   `settings.log_level` from `core.config` (`core/logging.py:8, 13, 51`), coupling test
+   logging to environment configuration. I'm planning a purpose-built test config instead —
+   but this is the main design decision I'd want a reviewer's opinion on, since "reuse the
+   app's own function" is the more obvious-looking choice.
+
+3. **The renderer choice leaks into `record.message`.** With `ConsoleRenderer`, the rendered
+   string becomes the stdlib message, so `record.message` reads
+   `'[warning  ] Empty chunks list provided to BatchEmbeddingProcessor'` — the level is baked
+   into the text *and* available as `record.levelname`. Line 43 of the test does
+   `record.message.lower()`, so it passes either way, but a future test asserting exact
+   message equality would be surprised. *Open question:* whether to use
+   `structlog.stdlib.ProcessorFormatter` for a cleaner separation between rendered output and
+   the raw event. I judged that more machinery than this fix needs, but it is the more
+   idiomatic long-term setup.
+
+4. **Unknown: interaction with tests that configure logging themselves.** I grepped and found
+   no test calling `configure_logging()`, `basicConfig()`, or `structlog.configure()`, so
+   today there is no conflict. That could change, and an autouse fixture would silently win
+   over a test's own setup. *Investigation path:* re-run
+   `grep -rn "configure_logging\|basicConfig\|structlog.configure" tests/` before finalizing.
+
+5. **Unknown: integration and non-unit test paths.** My baseline covers `tests/unit` only.
+   `tests/integration` requires Docker services per the `integration` marker in
+   `pyproject.toml:87` and I have not run it. An autouse fixture in the root `conftest.py`
+   applies to *every* test, including those. *Investigation path:* attempt an integration run,
+   or scope the fixture more narrowly if it proves disruptive.
+
+---
+
+## Edge cases
+
+1. **INFO-level logs are dropped unless the test opts in.** pytest's root logger sits at
+   WARNING by default and `pyproject.toml` sets no `log_level`, so
+   `logger.info("Starting batch embedding processing", ...)` at
+   `ingestion/embeddings/batch_processor.py:46` produces **no** captured record unless the test
+   calls `caplog.set_level(logging.INFO)`. I verified both halves of this behavior directly.
+   The fix must not paper over it by force-lowering the global level; that would change what
+   every other test sees. It should be documented in the fixture docstring instead.
+
+2. **`structlog.stdlib.filter_by_level` in the processor chain would silently re-break
+   capture.** It consults the stdlib logger's effective level *before* the record is emitted,
+   so with the root logger at WARNING it discards INFO and DEBUG events even when a test has
+   called `caplog.set_level(logging.INFO)` — reproducing the original "log fires but caplog is
+   empty" symptom for a different reason. It appears in the app chain at `core/logging.py:16`
+   and `core/logging.py:29`; it must be omitted from the test chain.
+
+3. **Structured key/value pairs must survive into the captured text.** Calls like
+   `logger.info("Starting batch embedding processing", chunk_count=total_chunks)` bind extra
+   context. A test asserting on `chunk_count` needs those rendered into the message rather than
+   dropped, so the processor chain must end in a renderer that serializes bound values.
+
+4. **Loggers are created at import time.** Every module does `logger = structlog.get_logger()`
+   at module scope (e.g. `ingestion/embeddings/batch_processor.py:7`), which runs during pytest
+   *collection* — before any fixture executes. This is safe only because `get_logger()` returns
+   a lazy proxy that resolves configuration on first *use*, and because
+   `cache_logger_on_first_use=False` keeps it from freezing. If either assumption breaks, the
+   fixture would configure too late to matter.
+
+5. **Exception context is carried as a bound value, not as `exc_info`.** Logging inside
+   `except` blocks — `agent/error_handling.py:43-44` (`logger.error("retry_exhausted", …,
+   error=str(e))`) — passes the exception as a plain `error=` key. I grepped the codebase and
+   **no** call site uses `logger.exception()` or `exc_info=`, so `format_exc_info` is currently
+   a no-op here. Two consequences: a test asserting on exception detail must look for the
+   `error=` value in the rendered text, not `record.exc_info`, which will be `None`; and
+   `format_exc_info` should still stay in the chain so that any future `logger.exception()`
+   call is captured correctly rather than silently losing its traceback.
+
+6. **An empty log run must stay empty.** A test that triggers no logging should still see
+   `caplog.records == []`. The fixture must not inject startup or configuration noise of its
+   own, or it would break negative assertions like "this path logs nothing."

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,55 @@
 """Shared test fixtures for PathReview."""
 
+from collections.abc import Iterator
+
 import pytest
+import structlog
+
+
+@pytest.fixture(autouse=True)
+def configure_structlog_for_tests() -> Iterator[None]:
+    """Route structlog events through stdlib logging so ``caplog`` can capture them.
+
+    structlog's shipped default ``PrintLoggerFactory`` writes rendered events
+    straight to stdout and never creates a ``logging.LogRecord``. pytest's
+    ``caplog`` fixture is a stdlib logging handler, so it never sees those
+    events. Binding ``structlog.stdlib.LoggerFactory`` makes structlog emit
+    through ``logging.getLogger(name)`` instead, which is what ``caplog`` reads.
+
+    Two deliberate choices:
+
+    * ``structlog.stdlib.filter_by_level`` is omitted from the chain. It checks
+      the stdlib logger's effective level *before* the record is emitted, which
+      would discard INFO and DEBUG events even after a test called
+      ``caplog.set_level(logging.INFO)`` — reproducing the original "log fires
+      but caplog is empty" symptom for a different reason.
+    * ``cache_logger_on_first_use`` is ``False`` so that module-level loggers,
+      which are created at import time during collection, resolve this
+      configuration on use rather than freezing an earlier one.
+
+    The root logger keeps its default WARNING level: a test asserting on INFO or
+    DEBUG output must opt in with ``caplog.set_level`` or ``caplog.at_level``.
+
+    Yields:
+        None. Configuration is reset after each test so that this
+        process-global setup cannot leak into unrelated tests.
+    """
+    structlog.configure(
+        processors=[
+            structlog.stdlib.add_log_level,
+            structlog.processors.StackInfoRenderer(),
+            structlog.processors.format_exc_info,
+            structlog.dev.ConsoleRenderer(colors=False),
+        ],
+        context_class=dict,
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        wrapper_class=structlog.stdlib.BoundLogger,
+        cache_logger_on_first_use=False,
+    )
+
+    yield
+
+    structlog.reset_defaults()
 
 
 @pytest.fixture

--- a/tests/unit/test_logging_capture.py
+++ b/tests/unit/test_logging_capture.py
@@ -1,0 +1,65 @@
+"""Tests for structlog events reaching pytest's caplog fixture.
+
+These tests exercise the autouse fixture in ``tests/conftest.py`` that bridges
+structlog into the standard library ``logging`` module. Without that bridge,
+structlog uses its default ``PrintLoggerFactory``, which writes rendered events
+straight to stdout and never creates a ``LogRecord`` — so ``caplog``, which is
+implemented as a stdlib logging handler, captures nothing.
+
+The probe logger here is deliberately independent of application code: the unit
+under test is the test-environment configuration, not any particular module that
+happens to log.
+"""
+
+import logging
+
+import pytest
+import structlog
+
+LOGGER_NAME = "tests.logging_probe"
+
+
+@pytest.mark.unit
+class TestStructlogCaplogCapture:
+    """Test suite for structlog-to-caplog capture in the test environment."""
+
+    def test_warning_creates_a_captured_log_record(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A structlog warning becomes a stdlib LogRecord that caplog captures."""
+        structlog.get_logger(LOGGER_NAME).warning("probe warning event")
+
+        assert len(caplog.records) == 1
+        assert caplog.records[0].levelname == "WARNING"
+
+    def test_record_name_matches_the_emitting_logger(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The captured record carries the name passed to get_logger()."""
+        structlog.get_logger(LOGGER_NAME).warning("named probe event")
+
+        assert caplog.records[0].name == LOGGER_NAME
+
+    def test_bound_context_renders_into_captured_text(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Structured key/value pairs survive into the captured message text."""
+        structlog.get_logger(LOGGER_NAME).warning("probe with context", chunk_count=3)
+
+        assert "chunk_count" in caplog.text
+        assert "3" in caplog.text
+
+    def test_info_is_dropped_until_the_test_lowers_the_level(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """INFO events need an explicit level opt-in; the fixture must not force it."""
+        structlog.get_logger(LOGGER_NAME).info("info below the default level")
+
+        assert caplog.records == []
+
+        with caplog.at_level(logging.INFO):
+            structlog.get_logger(LOGGER_NAME).info("info above the lowered level")
+
+        assert [record.levelname for record in caplog.records] == ["INFO"]
+
+    def test_a_silent_test_captures_nothing(self, caplog: pytest.LogCaptureFixture) -> None:
+        """The fixture itself must not emit configuration or startup noise."""
+        assert caplog.records == []


### PR DESCRIPTION
## Summary
Log assertions couldn't pass because structlog events never reached pytest's caplog. structlog's default `PrintLoggerFactory` renders events straight to stdout and never creates a `logging.LogRecord`; `caplog` is a stdlib logging handler, so with no record created it captures nothing. This added a fixture in `tests/conftest.py` that configures the structlog to go thry the standard library `logging` module for the duration of each test. And then it resets the global config on teardown. There are no application code changes.

## Issue
Closes #159 

## Changes
- **`tests/conftest.py`**: added an autouse fixture called `configure_structlog_for_tests`. It points structlog at `structlog.stdlib.LoggerFactory` so log events become standard `logging` records that `caplog` can capture, and it calls `structlog.reset_defaults()` afterward so this setup does not leak into other tests. Two choices worth calling out, both explained in the fixture's docstring:
  - I left `structlog.stdlib.filter_by_level` out of the chain on purpose. It checks the log level before the record is sent, so it would throw away INFO and DEBUG logs even after a test lowered the level with `caplog.set_level()`. That would bring back the same "log fires but caplog is empty" bug for a different reason.
  - I set `cache_logger_on_first_use=False`. Loggers get created when modules are first imported, which happens before the fixture runs, so caching would freeze an old config. Turning it off means they pick up the right config when they are actually used.
- **`tests/unit/test_logging_capture.py`**: new test file with 5 tests that check the fixture works (details below).

## Testing
**New tests in `tests/unit/test_logging_capture.py`:**
- a structlog warning shows up as exactly one captured record with level `WARNING`
- the captured record's name matches the name passed to `get_logger()`
- extra key/value data like `chunk_count=3` shows up in the captured text
- INFO logs are ignored by default and only captured after a test opts in with `caplog.at_level(INFO)`, so the fixture does not force the level for everyone
- a test that logs nothing still sees zero records, so the fixture does not add its own noise

How to check it yourself:
```bash
# 1. The test from the issue that used to fail now passes:
.venv/bin/pytest "tests/unit/test_batch_processor.py::TestBatchEmbeddingProcessor::test_empty_chunks_list_returns_empty" -v

# 2. The new tests pass:
.venv/bin/pytest tests/unit/test_logging_capture.py -v

# 3. To see the original bug, git stash the conftest change and run step 1 again.
#    It fails with caplog.text == '' while the warning still shows under "Captured stdout".
```

- [x] Unit tests pass (`make test-unit`), see the pre-existing failures note below
- [ ] Integration tests pass (`make test-integration`), not run because they need Docker services. `pytest tests/integration --collect-only` reports no tests collected, so this fixture does not touch them.
- [x] Linter passes (`make lint`), no new problems (see note)
- [x] Type checker passes (`make typecheck`), no new errors (see note)
- [x] New tests cover the changes


## Notes for Reviewers
This fork is seeded with intentional broken tests, so the suite is not green to start with. I recorded the numbers on `main` before my change so you can confirm I did not make anything worse:

| Command | Before | After |
|---|---|---|
| `make test-unit` | 53 failed / 375 passed | **52 failed / 381 passed** |
| `make lint` (`ruff check .`) | 182 errors | 182 errors |
| `black --check .` | 52 files | 52 files |
| `make typecheck` | 5 errors / 4 files | 5 errors / 4 files |

Exactly one failing test flips to passing (`test_empty_chunks_list_returns_empty`, the one from the issue). I compared the failing test names before and after, not just the counts, to make sure nothing else moved. The passed count goes from 375 to 381 because that one test flipped plus 5 new tests. Everything else that fails was already failing and has nothing to do with #159.

**Why I did not reuse the app's own `configure_logging()`.** The app already has a function in `core/logging.py` that bridges structlog into standard logging, so reusing it looks tempting. I did not, for three reasons: it calls `logging.basicConfig(stream=sys.stdout)`, which adds a root handler that fights with pytest's own log capture; it sets `cache_logger_on_first_use=True`, which breaks per-test isolation; and it reads `settings.log_level` from the environment, which ties test logging to config. A small purpose-built setup avoids all of that. Happy to switch to reuse if you would rather.