### PR TITLE
fix: handle null text in faithfulness context chunks

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,19 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/153
+
+**Issue title:** Faithfulness checker crashes when a context chunk has text: None
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The faithfulness checker combines the text from retrieved context chunks before evaluating an AI-generated statement. When a chunk contains a `text` key whose value is `None`, the current use of `dict.get()` returns `None` instead of the empty-string default. Passing that value to `" ".join()` raises a `TypeError`, causing the evaluation to stop. A successful fix will handle null text safely, preserve valid context text, and pass the related unit test.
+
+**Selection notes:**
+The issue has a small and clearly defined scope within the faithfulness checker. It includes a direct reproduction example and an existing related unit test, so I can verify the behavior locally. It does not require a paid API or an architectural change, and success is clearly defined as handling `None` without crashing.
+
+**Branch name:** fix/153-faithfulness-none-context
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -17,3 +17,37 @@ The issue has a small and clearly defined scope within the faithfulness checker.
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+
+## Week 8 — Issue reproduction and solution planning
+
+**Reproduction status:** [x] Issue reproduced locally
+
+**Reproduction command:**
+
+```bash
+.venv/bin/pytest tests/unit/test_faithfulness_checker.py::TestFaithfulnessChecker::test_none_context_chunk_text -v
+```
+
+**Observed result:**
+The test failed with `TypeError: sequence item 0: expected str instance, NoneType found` in `rag/evaluator/faithfulness_checker.py`.
+
+**Expected result:**
+The checker should handle a context chunk containing `{"text": None}` without crashing and return a valid float score.
+
+**Root cause:**
+`chunk.get("text", "")` returns the empty-string default when the key is missing, but it returns `None` when the key exists with a null value. The resulting list is passed to `" ".join()`, which only accepts strings. This causes the checker to crash before calculating its score.
+
+**Files investigated:**
+
+- `rag/evaluator/faithfulness_checker.py`
+- `tests/unit/test_faithfulness_checker.py`
+- `rag/evaluator/eval_suite.py`
+- `rag/evaluator/relevance_scorer.py`
+
+**Solution plan:** [PLAN.md](./PLAN.md)
+
+**Planned scope:**
+Normalize missing or null context text inside `FaithfulnessChecker.check()` while preserving valid text and leaving the scoring algorithm unchanged. The similar behavior in `RelevanceScorer` is outside the scope of issue #153.
+
+**Walkthrough video:** [ ] Optional video completed

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -51,3 +51,27 @@ The checker should handle a context chunk containing `{"text": None}` without cr
 Normalize missing or null context text inside `FaithfulnessChecker.check()` while preserving valid text and leaving the scoring algorithm unchanged. The similar behavior in `RelevanceScorer` is outside the scope of issue #153.
 
 **Walkthrough video:** [ ] Optional video completed
+
+## Week 9 — Build and pull request
+
+### Check-in 1 — Implementation and draft PR
+
+**Progress:**
+I implemented the fix for issue #153 by normalizing missing or null context text to an empty string before joining the chunks. I strengthened the existing regression test and added a test confirming that a null chunk does not discard text from another valid chunk.
+
+**Verification:**
+
+- Focused regression tests: 2 passed
+- Full faithfulness test file: 20 passed, 3 pre-existing scoring failures
+- `make check`: 182 pre-existing errors before and after the change
+- `make test-unit` before: 53 failed, 375 passed
+- `make test-unit` after: 52 failed, 377 passed
+- No new test failures were introduced
+
+**Draft pull request:** https://github.com/ascherj/pathreview/pull/919
+
+**Current blockers:**
+The repository still has pre-existing lint, typing, and unrelated unit-test failures. They do not block the issue-specific correction.
+
+**Next step:**
+Request peer feedback, respond to the review, run the final checks, and mark the pull request ready for review.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -75,3 +75,34 @@ The repository still has pre-existing lint, typing, and unrelated unit-test fail
 
 **Next step:**
 Request peer feedback, respond to the review, run the final checks, and mark the pull request ready for review.
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+*Feedback received:* [ ] Yes  [x] No — still awaiting review
+
+*Summary of feedback:*
+No reviewer or maintainer feedback has been received yet. The pull request is open and ready for review, but its workflows and merge remain pending maintainer approval.
+
+*How you responded:*
+
+
+---
+
+### Reflection
+
+*What was harder than you expected?*
+The hardest part was separating problems caused by my change from problems that already existed in the repository. The baseline had 182 lint errors and 53 failing unit tests before implementation. When I attempted to commit, Ruff and Black modified the staged Python files, while mypy reported 26 existing annotation errors in the test file. I had to understand Git staging, restore only the hook-generated working-tree changes, preserve my intended diff, and document the baseline failures instead of expanding the issue into a repository-wide cleanup.
+
+*What did you learn about working in a large codebase?*
+I learned that contributing to someone else's codebase requires controlling scope and collecting evidence before changing anything. I first reproduced the exact ⁠ TypeError ⁠, identified how ⁠ dict.get("text", "") ⁠ still returns ⁠ None ⁠ when the key exists, and recorded the test and lint baseline. I kept the fix limited to ⁠ FaithfulnessChecker ⁠ even though I noticed similar behavior in ⁠ RelevanceScorer ⁠, because that was outside issue #153. Unlike building my own project, I could not treat every problem I encountered as part of my task. I had to follow the repository's Git workflow, tests, formatting tools, and review process.
+
+*How did AI tools help — and where did they fall short?*
+AI assistance helped me understand the unfamiliar codebase, trace the failure to Python's ⁠ dict.get() ⁠ behavior, compare possible fixes, and design regression coverage for both an all-null context and a mixture of null and valid chunks. It also helped me interpret test output and prepare the pull request documentation. However, AI-generated changes did not initially account for the repository's full pre-commit behavior: Ruff and Black reformatted the files, and mypy exposed many existing errors. I still needed to inspect the staged and unstaged diffs, verify which failures were pre-existing, make the scope decision myself, and ensure the final PR contained only intentional changes.
+
+*What would you do differently if you started over?*
+I would run the repository's pre-commit hooks and focused tests on the target files immediately after reproducing the issue, before implementation. That would reveal formatting, lint, and typing problems earlier. I would also record the baseline results in one place from the beginning and open the draft PR as soon as the first tested commit was available. I would still choose this issue because its scope and success criteria were clear, but I would plan the validation and commit workflow earlier.
+
+*What are you most proud of from this module?*
+I am most proud that I completed the full contribution cycle instead of stopping after writing a one-line fix. I reproduced the bug, explained its root cause, added regression coverage, compared the complete test suite before and after the change, documented the repository's existing failures honestly, and submitted PR #919 without introducing any new test failures.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,159 @@
+# Solution Plan — Issue #153
+
+## Issue
+
+**Title:** Faithfulness checker crashes when a context chunk has `text: None`
+**Link:** https://github.com/ascherj/pathreview/issues/153
+**Branch:** `fix/153-faithfulness-none-context`
+
+## Problem
+
+`FaithfulnessChecker.check()` combines retrieved context text using `" ".join()`. It currently reads each value with `chunk.get("text", "")`. The default empty string handles a missing key, but it does not handle a key that exists with the value `None`. As a result, `" ".join()` receives a `None` value and raises a `TypeError` instead of returning a faithfulness score.
+
+## Local reproduction
+
+### Environment
+
+- macOS on Apple Silicon
+- Python 3.11.15
+- pytest 9.1.1
+- Working branch: `fix/153-faithfulness-none-context`
+
+### Reproduction command
+
+```bash
+.venv/bin/pytest tests/unit/test_faithfulness_checker.py::TestFaithfulnessChecker::test_none_context_chunk_text -v
+```
+
+### Test input
+
+The failing test calls the checker with:
+
+```python
+feedback = "Has Python skills"
+context_chunks = [{"text": None}]
+```
+
+### Observed behavior
+
+The test fails in `rag/evaluator/faithfulness_checker.py` with:
+
+```text
+TypeError: sequence item 0: expected str instance, NoneType found
+```
+
+The failure occurs on this context-building operation:
+
+```python
+context_text = " ".join([
+    chunk.get("text", "") for chunk in context_chunks
+])
+```
+
+### Expected behavior
+
+The checker should treat a missing or null text value as empty context. It should complete the evaluation without crashing and return a float between `0.0` and `1.0`.
+
+## Root cause
+
+`dict.get("text", "")` uses the empty-string default only when the `"text"` key is missing. If the key exists with the value `None`, `dict.get()` returns `None`.
+
+The `" ".join()` operation accepts only strings. When it receives `None`, it raises a `TypeError`.
+
+## Code-path analysis
+
+1. `test_none_context_chunk_text` creates a context chunk containing `{"text": None}`.
+2. The test calls `FaithfulnessChecker.check()`.
+3. `check()` extracts claims from the supplied feedback.
+4. It reads the `"text"` value from each context chunk.
+5. The current expression returns `None` for the null text value.
+6. `" ".join()` attempts to combine the values into one context string.
+7. The join operation raises a `TypeError`.
+8. The checker never calculates or returns the faithfulness score.
+
+`EvalSuite.run()` also calls `FaithfulnessChecker.check()`. Therefore, an exception in the checker can prevent the full evaluation suite from calculating its overall result.
+
+## Files involved
+
+### File to modify
+
+- `rag/evaluator/faithfulness_checker.py`
+  - Normalize missing or `None` chunk text to an empty string before joining the context.
+  - Preserve valid string values.
+  - Keep the existing claim extraction and scoring behavior unchanged.
+
+### Test file used for validation
+
+- `tests/unit/test_faithfulness_checker.py`
+  - Use the existing `test_none_context_chunk_text` as regression coverage.
+  - Verify that `test_missing_text_key_in_chunk` continues passing.
+  - Run the complete test file to detect regressions.
+
+## Proposed solution
+
+Update the context concatenation in `FaithfulnessChecker.check()` so that both a missing `"text"` key and a `"text"` value of `None` are normalized to an empty string.
+
+The implementation should:
+
+- Pass only strings to `" ".join()`.
+- Treat `None` as empty context rather than converting it to the literal string `"None"`.
+- Preserve all valid context strings.
+- Avoid changing the existing scoring algorithm.
+
+## Implementation steps
+
+1. Modify the context-building expression in `FaithfulnessChecker.check()`.
+2. Normalize missing and null text values to an empty string.
+3. Run the targeted regression test.
+4. Run the full faithfulness checker test file.
+5. Review the diff to ensure the change remains narrowly scoped.
+6. Run the project’s linting, formatting, and type checks.
+7. Run the complete unit-test suite.
+8. Commit the implementation using the project’s commit convention.
+
+## Edge cases
+
+- A chunk has no `"text"` key.
+- A chunk has `"text": None`.
+- All chunks contain missing or null text.
+- Valid and null chunks appear together.
+- `context_chunks` is empty.
+- Valid string chunks continue producing the same results.
+
+## Risks and scope
+
+- The fix must not convert `None` into the string `"None"`, because that would introduce false context.
+- The change must not modify claim extraction, keyword matching, or scoring thresholds.
+- Valid text from other chunks must not be discarded when one chunk contains `None`.
+- `RelevanceScorer` has a similar assumption about chunk text, but it is outside the scope of issue #153.
+- Unexpected truthy non-string values are not part of the reported issue and should not cause unnecessary scope expansion.
+
+## Validation commands
+
+Run the targeted regression test:
+
+```bash
+.venv/bin/pytest tests/unit/test_faithfulness_checker.py::TestFaithfulnessChecker::test_none_context_chunk_text -v
+```
+
+Run all faithfulness checker tests:
+
+```bash
+.venv/bin/pytest tests/unit/test_faithfulness_checker.py -v
+```
+
+Run the required project checks:
+
+```bash
+make check
+make test-unit
+```
+
+## Definition of done
+
+- The reported `None` input no longer raises a `TypeError`.
+- `test_none_context_chunk_text` passes.
+- The missing-key test continues passing.
+- All faithfulness checker tests pass.
+- Project linting, formatting, type checking, and unit tests pass.
+- The implementation remains limited to issue #153.

--- a/rag/evaluator/faithfulness_checker.py
+++ b/rag/evaluator/faithfulness_checker.py
@@ -32,7 +32,7 @@ class FaithfulnessChecker:
 
         # Concatenate context text
         context_text = " ".join([
-            chunk.get("text", "") for chunk in context_chunks
+            chunk.get("text") or "" for chunk in context_chunks
         ])
 
         # Check each claim for support

--- a/tests/unit/test_faithfulness_checker.py
+++ b/tests/unit/test_faithfulness_checker.py
@@ -237,9 +237,19 @@ class TestFaithfulnessChecker:
 
         score = checker.check(feedback, context_chunks)
 
-        # Should handle gracefully
-        assert isinstance(score, float)
-        assert 0.0 <= score <= 1.0
+        assert score == 0.0
+
+    def test_none_context_chunk_preserves_valid_chunk_text(self, checker):
+        """Test None text does not discard text from another context chunk."""
+        feedback = "Has Python skills"
+        context_chunks = [
+            {"text": None},
+            {"text": "Python skills"},
+        ]
+
+        score = checker.check(feedback, context_chunks)
+
+        assert score == 1.0
 
     def test_missing_text_key_in_chunk(self, checker):
         """Test handling of missing 'text' key in context chunk."""


### PR DESCRIPTION
## Summary

- Treat missing or null context chunk text as an empty string
- Prevent `FaithfulnessChecker.check()` from raising a `TypeError`
- Strengthen the existing null-context regression test
- Add coverage ensuring null chunks do not discard other valid context text

Fixes #153

## Testing

- Focused regression tests: 2 passed
- Full faithfulness test file: 20 passed, 3 pre-existing scoring failures
- `make check`: 182 pre-existing errors before and after the change
- `make test-unit` before: 53 failed, 375 passed
- `make test-unit` after: 52 failed, 377 passed

No new test failures were introduced.