### PR TITLE
fix(safety): redact parenthesized and space-separated US phone numbers

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,38 @@
+# Module 3 Journal — Abhilash Gorle
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/146
+
+**Issue title:** PII scrubber fails to redact parenthesized US phone numbers
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+PathReview's safety module is supposed to strip personal information out of
+user-submitted text before it goes anywhere else, but the phone-number regex
+in `safety/pii_scrubber.py` only matches dashed numbers like `555-123-4567`.
+The parenthesized format `(555) 123-4567` — one of the most common ways US
+numbers are written on resumes — passes through `scrub()` unredacted, and
+`detect()` doesn't flag it as PII at all. I reproduced this locally in two
+lines of Python. A successful fix widens the pattern to cover parenthesized
+(and ideally other common) formats so that the four currently-failing tests
+in `tests/unit/test_pii_scrubber.py` pass without breaking the rest of the
+suite.
+
+**"Is this right for me?" notes:**
+- Reproducible in under a minute: two-line Python snippet from the issue
+  confirms the bug on my machine.
+- Objectively verifiable: the issue names four failing unit tests that
+  define "done" (`test_us_phone_number_redaction`, `test_us_phone_formats`,
+  `test_detect_phone_pii`, `test_phone_at_start_of_text`).
+- Self-contained scope: one regex in one file in the `safety/` module — no
+  dependency on the RAG pipeline, agent, or vector DB.
+- Not trivial: phone-format regexes have real edge cases (spacing variants,
+  country codes), so there is genuine design thinking to document.
+
+**Branch name:** fix/146-pii-scrubber-parenthesized-phones
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -39,3 +39,37 @@ other tests breaking.
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** _(added in follow-up commit — see below)_
+
+**Reproduction summary:**
+Ran `.venv/bin/python -m pytest tests/unit/test_pii_scrubber.py -v` on this
+branch: the four tests named in issue #146 all fail because `scrub()` returns
+`(555) 123-4567` untouched and `detect()` finds no phone match — the
+`phone_us` regex's separator class `[-.]?` has no way to match the space after
+the closing paren. I also observed an unexpected fifth failure
+(`test_mixed_pii_and_text`), caused by a pre-existing `street_address`
+false positive unrelated to phones — documented in PLAN.md.
+
+```
+5 failed, 20 passed in 1.13s
+FAILED test_us_phone_number_redaction
+FAILED test_us_phone_formats
+FAILED test_detect_phone_pii
+FAILED test_phone_at_start_of_text
+FAILED test_mixed_pii_and_text  (pre-existing street_address bug, see PLAN.md)
+```
+
+**PLAN.md link:** _(added in follow-up commit — see below)_
+
+**Walkthrough video (recommended):** _Not recorded yet (optional)._
+
+**Blockers or open questions:**
+- Is the `test_mixed_pii_and_text` failure (the `street_address` pattern's
+  `Pl` abbreviation redacting part of "applications") in scope for #146, or
+  should it be filed separately? Planning to ask maintainers before the PR.
+- If `phone_us` learns to match `+1 555 123 4567`, `detect()` may report the
+  same number under both `phone_us` and `phone_intl` — need to pin expected
+  behavior with a test.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -38,4 +38,4 @@ other tests breaking.
 
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
-**Cohort ledger:** [ ] Issue added to cohort ledger
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -9,16 +9,19 @@
 **Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
 
 **Problem summary:**
-PathReview's safety module is supposed to strip personal information out of
-user-submitted text before it goes anywhere else, but the phone-number regex
-in `safety/pii_scrubber.py` only matches dashed numbers like `555-123-4567`.
-The parenthesized format `(555) 123-4567` — one of the most common ways US
-numbers are written on resumes — passes through `scrub()` unredacted, and
-`detect()` doesn't flag it as PII at all. I reproduced this locally in two
-lines of Python. A successful fix widens the pattern to cover parenthesized
-(and ideally other common) formats so that the four currently-failing tests
-in `tests/unit/test_pii_scrubber.py` pass without breaking the rest of the
-suite.
+PathReview runs every piece of user-submitted text through a PII scrubber in
+the `safety/` module before storing or processing it, so personal details
+like phone numbers are supposed to get replaced with `[REDACTED]`. The bug is
+that the regex in `safety/pii_scrubber.py` only recognizes dashed phone
+numbers like `555-123-4567` — if the same number is written as
+`(555) 123-4567`, which is probably the most common way people format numbers
+on resumes, both `scrub()` and `detect()` miss it completely. I confirmed
+this on my machine with the two-line snippet from the issue: the
+parenthesized number came back untouched and `detect()` returned an empty
+list. A successful fix means widening the pattern to handle parenthesized
+(and other common US) formats, verified by the four tests in
+`tests/unit/test_pii_scrubber.py` that currently fail going green, with no
+other tests breaking.
 
 **"Is this right for me?" notes:**
 - Reproducible in under a minute: two-line Python snippet from the issue

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -42,7 +42,7 @@ other tests breaking.
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** _(added in follow-up commit — see below)_
+**Reproduction commit link:** https://github.com/GORLEABHILASH/pathreview/commit/c9bfaf19e139d727fe7aeafb1c46351583902d4a
 
 **Reproduction summary:**
 Ran `.venv/bin/python -m pytest tests/unit/test_pii_scrubber.py -v` on this
@@ -62,7 +62,7 @@ FAILED test_phone_at_start_of_text
 FAILED test_mixed_pii_and_text  (pre-existing street_address bug, see PLAN.md)
 ```
 
-**PLAN.md link:** _(added in follow-up commit — see below)_
+**PLAN.md link:** https://github.com/GORLEABHILASH/pathreview/blob/fix/146-pii-scrubber-parenthesized-phones/PLAN.md
 
 **Walkthrough video (recommended):** _Not recorded yet (optional)._
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -73,3 +73,137 @@ FAILED test_mixed_pii_and_text  (pre-existing street_address bug, see PLAN.md)
 - If `phone_us` learns to match `+1 555 123 4567`, `detect()` may report the
   same number under both `phone_us` and `phone_intl` — need to pin expected
   behavior with a test.
+
+## Week 9 — Implementation & PR
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Steps 1–3 of PLAN.md are done. I wrote down the target format list first
+(the four formats from `test_us_phone_formats`, plus `+1 (555) 123-4567`
+and the must-not-match strings — version numbers and SSNs), then widened
+the `phone_us` separator class from `[-.]?` to `[-.\s]?` in
+`safety/pii_scrubber.py`. That alone wasn't enough: the pattern's leading
+`\b` can never sit between a space and an opening paren, so matches
+started *after* the paren and `scrub()` produced `([REDACTED]`. Replacing
+`\b` with a `(?<!\w)` lookbehind fixed it. All four tests named in issue
+#146 now pass.
+
+**Next steps:**
+- Run the full unit suite and diff failures against a clean checkout to
+  confirm zero regressions (PLAN.md step 4).
+- Resolve the `test_mixed_pii_and_text` / `street_address` scope question
+  (PLAN.md step 5).
+- Add tests for the `+1 (555) 123-4567` combined format and full-paren
+  redaction, then open the PR.
+
+**Blockers:**
+Whether the pre-existing `street_address` false positive (the `Pl`
+abbreviation matching inside "applications") is in scope for #146 — it
+blocks a green run of the test module either way.
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/920
+
+**Branch:** fix/146-pii-scrubber-parenthesized-phones
+
+**What was built:**
+Fixed the `phone_us` regex in `safety/pii_scrubber.py` so parenthesized
+and space-separated US phone numbers — `(555) 123-4567`,
+`+1 555 123 4567` — are redacted by `scrub()` and reported by `detect()`.
+Also anchored the `street_address` pattern with a trailing `\b` to fix a
+pre-existing false positive that was the real cause of the fifth failing
+test in the module (called out for reviewers as a scope question in the
+PR).
+
+**Tests:**
+Modified `tests/unit/test_pii_scrubber.py`: added a case for the
+`+1 (555) 123-4567` combined format, an assertion that the opening paren
+is included in the redaction (no leftover `([REDACTED]`), and a
+regression test that words containing street-type abbreviations (e.g.
+"applications") are not partially redacted by the `street_address`
+pattern. All 28 tests in the module pass, including the 4 named in issue
+#146.
+
+**Self-review:**
+- [x] `make check` passes — clean on both touched files
+  (`safety/pii_scrubber.py`, `tests/unit/test_pii_scrubber.py`),
+  including the stricter pre-commit mypy hook; repo-wide lint errors in
+  unrelated files pre-date this branch and are untouched.
+- [x] `make test-unit` passes — all 28 tests in the touched module pass;
+  the repo-wide failures in unrelated files (review service, skill
+  extractor, etc.) exist identically before and after this change,
+  verified by diffing the failure lists with the change stashed vs.
+  applied.
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No reviewer comments have come in on PR #920 as of the end of Week 10
+(reviewer feedback is not provided in the Summer 2026 cohort). The PR
+remains open with the scope question about the `street_address` fix
+flagged in the "Notes for Reviewers" section so a maintainer can ask for
+it to be split out if they prefer.
+
+**How you responded:**
+N/A — no feedback received.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Debugging a one-line regex took far longer than writing it. I went in
+expecting to "add parentheses support," but PLAN.md's root-cause step
+showed the parens were already allowed — the real bug was the separator
+class `[-.]?` having no way to match the space after the closing paren.
+Then the fix surfaced a second subtlety: the pattern's leading `\b` can
+never match between a space and `(` (both non-word characters), so the
+paren was silently excluded and `scrub()` emitted `([REDACTED]`. Getting
+from "tests fail" to *why* a word boundary fails next to punctuation was
+the hardest hour of the module.
+
+**What did you learn about working in a large codebase?**
+The verification burden is completely different from my own projects. The
+repo's unit suite had ~48 pre-existing failures in unrelated files, so
+"run the tests and see green" was not an available signal — I had to
+establish a baseline first, then diff the failure lists with my change
+stashed vs. applied to prove I introduced zero regressions. I also
+learned to verify blast radius instead of assuming it: a grep showed
+`PIIScrubber` had no runtime call sites outside the unit tests, which is
+what made a regex change to a safety module safe to ship confidently.
+
+**How did AI tools help — and where did they fall short?**
+AI was most useful at enumerating edge cases I would not have listed
+myself — the SSN pattern owning `123-45-6789`, version strings like
+`1.2.3`, scrub idempotency, and the `phone_us`/`phone_intl` double-report
+risk all went into PLAN.md before I touched the regex. It fell short in
+two places: regex explanations sound confident whether or not they are
+right, so every claim (like the `\b`-next-to-paren behavior) had to be
+verified empirically in a REPL before I trusted it; and it could not make
+the scope call on the `street_address` fix — that took reading
+CONTRIBUTING.md's requirement that the touched module's suite pass and
+making a judgment I then had to defend in the PR description.
+
+**What would you do differently if you started over?**
+Run the full test suite on day one, before committing to the issue. The
+fifth failing test (`test_mixed_pii_and_text`) and the repo-wide
+pre-existing failures were both mid-module surprises that reshaped my
+plan; a baseline run in Week 7 would have surfaced them when they were
+free to absorb. I would also ask the maintainers the scope question in
+the issue thread early in Week 8 instead of deciding unilaterally at PR
+time and offering to split it after the fact.
+
+**What are you most proud of from this module?**
+The verification story in the PR, more than the fix itself. The diff is
+about two characters of regex, but the PR proves it is safe: before/after
+failure-list diffs showing zero regressions, an explicit check that
+`+1`-prefixed numbers are not double-reported by both phone patterns, and
+a regression test pinning the false-positive fix. A reviewer who has
+never seen the code can verify every claim in it — that is the standard I
+want my future PRs held to.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,129 @@
+# Solution plan
+
+**Issue:** [#146 — PII scrubber fails to redact parenthesized US phone numbers](https://github.com/ascherj/pathreview/issues/146)
+
+## Understand
+
+**Expected behavior:** Any common US phone number format in user-submitted text —
+`555-123-4567`, `(555) 123-4567`, `555.123.4567`, `+1 555 123 4567` — should be
+replaced with `[REDACTED]` by `PIIScrubber.scrub()` and reported by
+`PIIScrubber.detect()`.
+
+**Actual behavior:** Only dash- and dot-separated numbers are caught.
+`(555) 123-4567` and `+1 555 123 4567` pass through untouched: `scrub()` returns
+the text unchanged and `detect()` returns an empty list.
+
+**Root cause:** The `phone_us` pattern in `safety/pii_scrubber.py` (line 15)
+*does* allow optional parentheses (`\(?` and `\)?`), so the parens themselves are
+not the problem. The problem is the separator character class `[-.]?`, which only
+permits a dash or a dot between number groups. In `(555) 123-4567` there is a
+**space** after the closing paren, and the space has nowhere to match, so the
+whole match fails. The same missing-space handling is why `+1 555 123 4567`
+fails. So the precise fix is widening the separator handling, not "adding
+parentheses support."
+
+**Reproduction (confirmed locally, 2026-07-28):**
+
+```
+$ .venv/bin/python -m pytest tests/unit/test_pii_scrubber.py -v
+...
+5 failed, 20 passed
+```
+
+The four failures named in the issue all reproduce:
+`test_us_phone_number_redaction`, `test_us_phone_formats`,
+`test_detect_phone_pii`, `test_phone_at_start_of_text`.
+
+**Unexpected fifth failure:** `test_mixed_pii_and_text` also fails, but for an
+unrelated reason — the `street_address` pattern (line 18) contains the
+abbreviation `Pl` and runs with `re.IGNORECASE`, so it false-positive-matches
+"5 years developing Python appl" (a digit + words ending in "pl") and redacts
+part of the word "applications". Fixing the phone regex will **not** make this
+test pass. *(Decision needed: treat as out of scope for #146 and file/report it
+separately, or include it in this fix — see Risks.)*
+
+## Map
+
+- `safety/pii_scrubber.py` — the only file whose behavior changes. Specifically
+  the `phone_us` entry in `PII_PATTERNS` (line 15). `scrub()` and `detect()`
+  both iterate over the same pattern dict, so one regex change fixes both.
+- `tests/unit/test_pii_scrubber.py` — the four failing tests define "done";
+  the other 20 passing tests (especially `test_detect_no_false_positives`,
+  `test_scrub_idempotent`, `test_international_phone_redaction`) are the
+  regression guardrail. May add extra format cases here.
+- **Not involved (verified by grep):** `PIIScrubber` is not imported anywhere in
+  `api/`, `agent/`, `rag/`, or `ingestion/` — the scrubber currently runs only
+  via the unit tests. The fix is therefore fully self-contained; there are no
+  runtime call sites that could regress.
+
+## Plan
+
+1. **Write down the target format list before touching the regex.** Enumerate
+   the formats the pattern must catch (the four in `test_us_phone_formats`,
+   plus `+1 (555) 123-4567` and bare `5551234567`) and the strings it must NOT
+   catch (version numbers like `1.2.3` from `test_detect_no_false_positives`,
+   SSNs like `123-45-6789` which belong to the `ssn` pattern).
+2. **Modify the `phone_us` regex** in `safety/pii_scrubber.py:15` to accept a
+   space as a separator alongside dash/dot (e.g. widen `[-.]?` to something like
+   `[-.\s]?`), and re-check the word-boundary anchors still behave with the
+   parenthesized form (the leading `\b` cannot sit before `(`, since both are
+   non-word characters).
+3. **Run the four target tests** and iterate on the pattern until they pass:
+   `.venv/bin/python -m pytest tests/unit/test_pii_scrubber.py -v`.
+4. **Run the full test suite** (`.venv/bin/python -m pytest`) to confirm no
+   regressions — in particular that the widened pattern doesn't start eating
+   dates, version numbers, or the SSN pattern's matches, and that
+   `test_scrub_idempotent` still holds.
+5. **Resolve the `test_mixed_pii_and_text` question** (see Risks): either
+   document it in the PR as a separate pre-existing bug, or fix the
+   `street_address` `Pl` false positive in the same PR if maintainers agree
+   it's in scope.
+
+## Inputs & outputs
+
+- **Input:** free-form user text (resume/review content) passed to
+  `PIIScrubber.scrub(text: str)` and `PIIScrubber.detect(text: str)`.
+- **Output of `scrub()`:** the same text with every US-format phone number —
+  now including parenthesized and space-separated forms — replaced by the
+  literal `[REDACTED]`.
+- **Output of `detect()`:** a `list[dict]` with `type`/`value`/`start`/`end`
+  entries that now includes `phone_us` hits for the previously missed formats,
+  with `start`/`end` spanning the full formatted number (including the parens).
+- **No signature changes:** only the value of `PII_PATTERNS["phone_us"]`
+  changes; both public methods keep their current interfaces.
+
+## Risks & unknowns
+
+- **Overlap with `phone_intl` (line 16):** if `phone_us` learns to match
+  `+1 555 123 4567`, both patterns may match the same substring. `scrub()` is
+  safe (text already replaced by `[REDACTED]` can't re-match), but `detect()`
+  iterates patterns independently and could report the same number twice.
+  Need to check whether duplicate detections matter to any consumer, or add a
+  test pinning the expected behavior.
+- **False-positive creep:** allowing spaces as separators makes the pattern
+  looser — e.g. could `123 456 7890`-shaped text inside addresses, IDs, or
+  tables get redacted? `test_detect_no_false_positives` covers version numbers
+  and URLs but not space-separated digit runs; may need a new negative test.
+- **Scope of `test_mixed_pii_and_text`:** it fails on the pre-existing
+  `street_address` `Pl` false positive, not on phones. Unknown whether the
+  maintainers want that fixed here or filed separately — will ask in the issue
+  thread / Slack before the PR. Either way the PR description must explain why
+  this fifth test was failing at the start.
+- **Regex readability:** the one-line pattern is already hard to review; if the
+  fix makes it much longer, consider `re.VERBOSE` with comments — but that's a
+  style call to keep minimal unless it stays clearly readable.
+
+## Edge cases
+
+- `(555) 123-4567` — paren + space (the headline case from the issue).
+- `+1 (555) 123-4567` — country code combined with parens.
+- `555 123 4567` / `+1 555 123 4567` — space-only separators.
+- `(555)123-4567` — parens with **no** space after, which the current pattern
+  handles; must not break.
+- Phone number at the very start or end of the text (no leading/trailing
+  context for `\b` — covered by `test_phone_at_start_of_text` and
+  `test_phone_at_end_of_text`).
+- Must **not** match: version strings (`1.2.3`), SSNs (`123-45-6789` — the
+  `ssn` pattern owns those), 7-digit fragments inside longer digit runs, and
+  already-scrubbed text (`[REDACTED]` must survive a second `scrub()` pass
+  unchanged).

--- a/PLAN.md
+++ b/PLAN.md
@@ -109,6 +109,11 @@ separately, or include it in this fix — see Risks.)*
   maintainers want that fixed here or filed separately — will ask in the issue
   thread / Slack before the PR. Either way the PR description must explain why
   this fifth test was failing at the start.
+  - **Resolved (Week 9):** included the fix in this PR — a trailing `\b` on
+    the `street_address` pattern — because CONTRIBUTING.md requires the unit
+    suite for touched code to pass before opening a PR, and this failure sits
+    in the same file/test module. Called out explicitly in the PR description
+    so reviewers can ask for it to be split out if they prefer.
 - **Regex readability:** the one-line pattern is already hard to review; if the
   fix makes it much longer, consider `re.VERBOSE` with comments — but that's a
   style call to keep minimal unless it stays clearly readable.

--- a/safety/pii_scrubber.py
+++ b/safety/pii_scrubber.py
@@ -1,6 +1,7 @@
 """PII detection and scrubbing."""
 
 import re
+
 import structlog
 
 logger = structlog.get_logger()
@@ -12,10 +13,22 @@ class PIIScrubber:
     # Regex patterns for common PII
     PII_PATTERNS = {
         "email": r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b",
-        "phone_us": r"\b(?:\+?1[-.]?)?\(?([0-9]{3})\)?[-.]?([0-9]{3})[-.]?([0-9]{4})\b",
+        # Lookbehind instead of \b so a match can start at "(" — a word
+        # boundary can never sit between a space and a paren, which left
+        # the paren unredacted. \s in the separator class covers
+        # "(555) 123-4567" and "+1 555 123 4567".
+        "phone_us": (
+            r"(?<!\w)(?:\+?1[-.\s]?)?" r"\(?([0-9]{3})\)?[-.\s]?([0-9]{3})[-.\s]?([0-9]{4})\b"
+        ),
         "phone_intl": r"\+[0-9]{1,3}[-.]?[0-9]{1,14}",
         "ssn": r"\b(?!000|666)[0-9]{3}-(?!00)[0-9]{2}-(?!0000)[0-9]{4}\b",
-        "street_address": r"\b\d+\s+[A-Za-z\s]+(?:Street|St|Avenue|Ave|Road|Rd|Boulevard|Blvd|Drive|Dr|Lane|Ln|Court|Ct|Circle|Cir|Park|Pl|Plaza|Place|Drive|Dr|Way|Parkway|Pkwy|Point|Pt|Pike|Run|Summit|Summit|Terrace|Ter|Trail|Trl|Tunnel|Turnpike|View|Vista|Vlg|Village|Vly|Valley)",
+        "street_address": (
+            r"\b\d+\s+[A-Za-z\s]+"
+            r"(?:Street|St|Avenue|Ave|Road|Rd|Boulevard|Blvd|Drive|Dr|Lane|Ln|"
+            r"Court|Ct|Circle|Cir|Park|Pl|Plaza|Place|Drive|Dr|Way|Parkway|Pkwy|"
+            r"Point|Pt|Pike|Run|Summit|Summit|Terrace|Ter|Trail|Trl|Tunnel|"
+            r"Turnpike|View|Vista|Vlg|Village|Vly|Valley)\b"
+        ),
     }
 
     def scrub(self, text: str) -> str:
@@ -29,7 +42,7 @@ class PIIScrubber:
         """
         scrubbed = text
 
-        for pii_type, pattern in self.PII_PATTERNS.items():
+        for pattern in self.PII_PATTERNS.values():
             scrubbed = re.sub(pattern, "[REDACTED]", scrubbed, flags=re.IGNORECASE)
 
         return scrubbed
@@ -47,13 +60,15 @@ class PIIScrubber:
 
         for pii_type, pattern in self.PII_PATTERNS.items():
             for match in re.finditer(pattern, text, flags=re.IGNORECASE):
-                detected.append({
-                    "type": pii_type,
-                    "value": match.group(),
-                    "start": match.start(),
-                    "end": match.end()
-                })
+                detected.append(
+                    {
+                        "type": pii_type,
+                        "value": match.group(),
+                        "start": match.start(),
+                        "end": match.end(),
+                    }
+                )
 
-        logger.info("pii_detected", count=len(detected), types=len(set(d["type"] for d in detected)))
+        logger.info("pii_detected", count=len(detected), types=len({d["type"] for d in detected}))
 
         return detected

--- a/tests/unit/test_pii_scrubber.py
+++ b/tests/unit/test_pii_scrubber.py
@@ -10,11 +10,11 @@ class TestPIIScrubber:
     """Test suite for PIIScrubber."""
 
     @pytest.fixture
-    def scrubber(self):
+    def scrubber(self) -> PIIScrubber:
         """Create a PIIScrubber instance."""
         return PIIScrubber()
 
-    def test_email_redaction(self, scrubber):
+    def test_email_redaction(self, scrubber: PIIScrubber) -> None:
         """Test email address is redacted."""
         text = "Contact me at john.doe@example.com for more info."
         scrubbed = scrubber.scrub(text)
@@ -22,7 +22,7 @@ class TestPIIScrubber:
         assert "[REDACTED]" in scrubbed
         assert "john.doe@example.com" not in scrubbed
 
-    def test_multiple_emails_redacted(self, scrubber):
+    def test_multiple_emails_redacted(self, scrubber: PIIScrubber) -> None:
         """Test multiple email addresses are redacted."""
         text = "Email alice@example.com or bob@company.org"
         scrubbed = scrubber.scrub(text)
@@ -31,7 +31,7 @@ class TestPIIScrubber:
         assert "alice@example.com" not in scrubbed
         assert "bob@company.org" not in scrubbed
 
-    def test_us_phone_number_redaction(self, scrubber):
+    def test_us_phone_number_redaction(self, scrubber: PIIScrubber) -> None:
         """Test US phone number is redacted."""
         text = "Call me at (555) 123-4567"
         scrubbed = scrubber.scrub(text)
@@ -39,7 +39,7 @@ class TestPIIScrubber:
         assert "[REDACTED]" in scrubbed
         assert "555" not in scrubbed or "1234567" not in scrubbed
 
-    def test_us_phone_formats(self, scrubber):
+    def test_us_phone_formats(self, scrubber: PIIScrubber) -> None:
         """Test various US phone number formats."""
         formats = [
             "555-123-4567",
@@ -53,14 +53,14 @@ class TestPIIScrubber:
             scrubbed = scrubber.scrub(text)
             assert "[REDACTED]" in scrubbed
 
-    def test_international_phone_redaction(self, scrubber):
+    def test_international_phone_redaction(self, scrubber: PIIScrubber) -> None:
         """Test international phone number is redacted."""
         text = "Reach me at +44 20 7946 0958"
         scrubbed = scrubber.scrub(text)
 
         assert "[REDACTED]" in scrubbed or "20" not in scrubbed
 
-    def test_ssn_redaction(self, scrubber):
+    def test_ssn_redaction(self, scrubber: PIIScrubber) -> None:
         """Test SSN is redacted."""
         text = "SSN: 123-45-6789"
         scrubbed = scrubber.scrub(text)
@@ -68,7 +68,7 @@ class TestPIIScrubber:
         assert "[REDACTED]" in scrubbed
         assert "123-45-6789" not in scrubbed
 
-    def test_ssn_variations(self, scrubber):
+    def test_ssn_variations(self, scrubber: PIIScrubber) -> None:
         """Test various SSN formats are handled."""
         ssns = [
             "123-45-6789",
@@ -81,14 +81,14 @@ class TestPIIScrubber:
             # Should be redacted or modified
             assert ssn not in scrubbed
 
-    def test_street_address_redaction(self, scrubber):
+    def test_street_address_redaction(self, scrubber: PIIScrubber) -> None:
         """Test street address is redacted."""
         text = "Address: 123 Main Street, Apt 4"
         scrubbed = scrubber.scrub(text)
 
         assert "[REDACTED]" in scrubbed or "123" not in scrubbed
 
-    def test_text_with_no_pii(self, scrubber):
+    def test_text_with_no_pii(self, scrubber: PIIScrubber) -> None:
         """Test text with no PII is returned unchanged."""
         text = "This is a normal paragraph with no personally identifiable information."
         scrubbed = scrubber.scrub(text)
@@ -96,7 +96,7 @@ class TestPIIScrubber:
         assert scrubbed == text
         assert "[REDACTED]" not in scrubbed
 
-    def test_detect_returns_list_of_pii(self, scrubber):
+    def test_detect_returns_list_of_pii(self, scrubber: PIIScrubber) -> None:
         """Test detect() returns list with type, value, start, end."""
         text = "Email: john@example.com and call 555-123-4567"
         detected = scrubber.detect(text)
@@ -109,7 +109,7 @@ class TestPIIScrubber:
             assert "start" in item
             assert "end" in item
 
-    def test_detect_email_pii(self, scrubber):
+    def test_detect_email_pii(self, scrubber: PIIScrubber) -> None:
         """Test detect() finds email PII."""
         text = "Contact: alice@example.com"
         detected = scrubber.detect(text)
@@ -119,7 +119,7 @@ class TestPIIScrubber:
         assert len(email_detections) > 0
         assert "alice@example.com" in email_detections[0]["value"]
 
-    def test_detect_phone_pii(self, scrubber):
+    def test_detect_phone_pii(self, scrubber: PIIScrubber) -> None:
         """Test detect() finds phone number PII."""
         text = "Phone: (555) 123-4567"
         detected = scrubber.detect(text)
@@ -127,7 +127,7 @@ class TestPIIScrubber:
         phone_detections = [d for d in detected if "phone" in d["type"]]
         assert len(phone_detections) > 0
 
-    def test_detect_ssn_pii(self, scrubber):
+    def test_detect_ssn_pii(self, scrubber: PIIScrubber) -> None:
         """Test detect() finds SSN PII."""
         text = "SSN: 123-45-6789"
         detected = scrubber.detect(text)
@@ -135,7 +135,7 @@ class TestPIIScrubber:
         ssn_detections = [d for d in detected if d["type"] == "ssn"]
         assert len(ssn_detections) > 0
 
-    def test_detect_positions_accurate(self, scrubber):
+    def test_detect_positions_accurate(self, scrubber: PIIScrubber) -> None:
         """Test that detected positions are accurate."""
         text = "Email is john@example.com here."
         detected = scrubber.detect(text)
@@ -147,7 +147,7 @@ class TestPIIScrubber:
                 extracted = text[start:end]
                 assert "john@example.com" in extracted
 
-    def test_detect_multiple_pii_items(self, scrubber):
+    def test_detect_multiple_pii_items(self, scrubber: PIIScrubber) -> None:
         """Test detecting multiple PII items."""
         text = "John: 555-123-4567, jane@example.com, SSN: 987-65-4321"
         detected = scrubber.detect(text)
@@ -155,7 +155,7 @@ class TestPIIScrubber:
         # Should find multiple items
         assert len(detected) >= 2
 
-    def test_case_insensitive_email_matching(self, scrubber):
+    def test_case_insensitive_email_matching(self, scrubber: PIIScrubber) -> None:
         """Test email matching is case insensitive."""
         text = "Contact John.Doe@Example.COM"
         scrubbed = scrubber.scrub(text)
@@ -163,7 +163,7 @@ class TestPIIScrubber:
         # Email should be redacted despite case differences
         assert "[REDACTED]" in scrubbed
 
-    def test_complex_email_addresses(self, scrubber):
+    def test_complex_email_addresses(self, scrubber: PIIScrubber) -> None:
         """Test complex email address formats."""
         emails = [
             "user+tag@example.com",
@@ -176,21 +176,37 @@ class TestPIIScrubber:
             scrubbed = scrubber.scrub(text)
             assert email not in scrubbed or "[REDACTED]" in scrubbed
 
-    def test_phone_at_start_of_text(self, scrubber):
+    def test_phone_at_start_of_text(self, scrubber: PIIScrubber) -> None:
         """Test phone number at start of text."""
         text = "(555) 123-4567 is my phone number."
         scrubbed = scrubber.scrub(text)
 
         assert "[REDACTED]" in scrubbed
 
-    def test_phone_at_end_of_text(self, scrubber):
+    def test_phone_with_country_code_and_parens(self, scrubber: PIIScrubber) -> None:
+        """Test phone number with country code and parentheses."""
+        text = "Call +1 (555) 123-4567 anytime."
+        scrubbed = scrubber.scrub(text)
+
+        assert "[REDACTED]" in scrubbed
+        assert "123-4567" not in scrubbed
+
+    def test_parenthesized_phone_fully_redacted(self, scrubber: PIIScrubber) -> None:
+        """Test the parentheses are redacted along with the number."""
+        text = "Call me at (555) 123-4567"
+        scrubbed = scrubber.scrub(text)
+
+        assert "(555" not in scrubbed
+        assert "(" not in scrubbed.replace("[REDACTED]", "")
+
+    def test_phone_at_end_of_text(self, scrubber: PIIScrubber) -> None:
         """Test phone number at end of text."""
         text = "My phone is 555-123-4567"
         scrubbed = scrubber.scrub(text)
 
         assert "[REDACTED]" in scrubbed
 
-    def test_address_variations(self, scrubber):
+    def test_address_variations(self, scrubber: PIIScrubber) -> None:
         """Test various street address formats."""
         addresses = [
             "123 Main Street",
@@ -200,10 +216,17 @@ class TestPIIScrubber:
 
         for addr in addresses:
             text = f"Address: {addr}"
-            scrubbed = scrubber.scrub(text)
+            scrubber.scrub(text)
             # Should attempt to redact addresses
 
-    def test_empty_text(self, scrubber):
+    def test_address_no_false_positive_inside_words(self, scrubber: PIIScrubber) -> None:
+        """Regression: address abbreviations must not match inside words."""
+        text = "I spent 5 years developing Python applications"
+        scrubbed = scrubber.scrub(text)
+
+        assert scrubbed == text
+
+    def test_empty_text(self, scrubber: PIIScrubber) -> None:
         """Test with empty text."""
         text = ""
         scrubbed = scrubber.scrub(text)
@@ -212,13 +235,13 @@ class TestPIIScrubber:
         detected = scrubber.detect(text)
         assert detected == []
 
-    def test_whitespace_only(self, scrubber):
+    def test_whitespace_only(self, scrubber: PIIScrubber) -> None:
         """Test with whitespace only."""
         text = "   \n\t  "
         scrubbed = scrubber.scrub(text)
         assert scrubbed == text
 
-    def test_mixed_pii_and_text(self, scrubber):
+    def test_mixed_pii_and_text(self, scrubber: PIIScrubber) -> None:
         """Test text with mix of PII and regular content."""
         text = """
         Professional Background:
@@ -237,7 +260,7 @@ class TestPIIScrubber:
         assert "john.smith@company.com" not in scrubbed
         assert "555-123-4567" not in scrubbed
 
-    def test_scrub_idempotent(self, scrubber):
+    def test_scrub_idempotent(self, scrubber: PIIScrubber) -> None:
         """Test that scrubbing twice produces same result."""
         text = "Email: test@example.com"
         scrubbed_once = scrubber.scrub(text)
@@ -245,10 +268,10 @@ class TestPIIScrubber:
 
         assert scrubbed_once == scrubbed_twice
 
-    def test_detect_no_false_positives(self, scrubber):
+    def test_detect_no_false_positives(self, scrubber: PIIScrubber) -> None:
         """Test that detect doesn't flag legitimate text as PII."""
         text = "The project uses version 1.2.3. It's available at https://example.com"
-        detected = scrubber.detect(text)
+        scrubber.detect(text)
 
         # Should be minimal or no detections
         # (version number shouldn't be flagged as SSN)


### PR DESCRIPTION
## Summary
The PII scrubber missed US phone numbers written with parentheses — `(555) 123-4567`, the most common format on resumes — as well as space-separated forms like `+1 555 123 4567`. Both `scrub()` and `detect()` returned the text untouched. The root cause was not the parentheses (the pattern already allowed them) but the separator class `[-.]?`, which had no way to match the space after the closing paren. This PR widens the separator class to `[-.\s]?` and replaces the pattern's leading `\b` with `(?<!\w)` so the opening paren is included in the match (a word boundary can never sit between a space and a paren, which previously left the paren behind as `([REDACTED]`).

## Issue
Closes #146

## Changes
- Widened the `phone_us` separator class from `[-.]?` to `[-.\s]?` in `safety/pii_scrubber.py` so spaces between number groups match
- Replaced the pattern's leading `\b` with `(?<!\w)` so the opening parenthesis is redacted along with the number (and matches can't start mid-word/mid-number)
- Anchored the `street_address` pattern with a trailing `\b` — short abbreviations like `Pl` were matching inside ordinary words (e.g. "developing Python a**ppl**ications") under `re.IGNORECASE`; this pre-existing false positive was the actual cause of the fifth failing test in this module, `test_mixed_pii_and_text`
- Added tests: `+1 (555) 123-4567` format, full paren redaction, and a regression test for the address false positive
- Lint, formatting, and type-annotation cleanup on both touched files, required by the pre-commit hooks

## Testing
- [x] Unit tests pass (`make test-unit`) — all 28 tests in `tests/unit/test_pii_scrubber.py` pass, including the 4 named in the issue. 43 unrelated tests elsewhere in the suite were failing before this change and fail identically after (verified by diffing failure lists with the change stashed vs. applied — zero regressions introduced)
- [ ] Integration tests pass (`make test-integration`) — not run; this change is confined to a regex constant with no service dependencies
- [x] Linter passes (`make lint`) — clean on both touched files; repo-wide pre-existing errors in other files are untouched
- [x] Type checker passes (`make typecheck`) — clean, including the stricter pre-commit mypy hook on the test file
- [x] New/updated tests cover the changes

## Screenshots / Demo
Before → after on the snippet from the issue:
```
>>> PIIScrubber().scrub("Call me at (555) 123-4567")
'Call me at (555) 123-4567'   # before
'Call me at [REDACTED]'       # after
```

## Notes for Reviewers
- **Scope question:** the trailing-`\b` fix to `street_address` is technically a second bug, but it blocks a green run of this test module (`test_mixed_pii_and_text`), so I included it here and kept it to one character. Happy to split it into a separate PR if you'd prefer.
- The `(?<!\w)` lookbehind is the one non-obvious regex choice — rationale is in the code comment and Summary above.
- I verified `detect()` does not double-report `+1`-prefixed numbers under both `phone_us` and `phone_intl`: the intl pattern's separator class has no `\s`, so it can't match past the space in `+1 555…`.
