### PR TITLE
Fix #68: Add safety_events_last_hour metric to /health endpoint

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -7,3 +7,11 @@ The /health API endpoint returns the basic service status but not surface safety
 **Branch name:** fix/68-health-endpoint-safety-count
 **Setup confirmation:** [x] App runs locally at localhost:5173
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+**Reproduction commit link:** (https://github.com/ascherj/pathreview/commit/2578ff266e9aabf44706292441ea468c8d028520)
+**Reproduction summary:**
+Requested the `/health` endpoint locally and verified the response omits the `safety_events_last_hour` metric entirely.
+**PLAN.md link:** (https://github.com/10-49/pathreview/blob/fix 68-health-endpoint-safety-count/PLAN.md)
+**Walkthrough video (recommended):** 
+**Blockers or open questions:**

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,9 @@
+## Week 7 — Issue selection
+**Issue link:** https://github.com/ascherj/pathreview/issues/68
+**Issue title:** Add a safety event count to the health check endpoint
+**Tier:** Tier 1
+**Problem summary:**
+The /health API endpoint returns the basic service status but not surface safety metrics. Operators currently have to use the monitoring dashboard manually to track system activity. Implementing a safety_events_last_hour field in the health check response will expose this metric directly, requiring data flow modifications between safety/monitoring.py and api/routes/health.py.
+**Branch name:** fix/68-health-endpoint-safety-count
+**Setup confirmation:** [x] App runs locally at localhost:5173
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -15,3 +15,28 @@ Requested the `/health` endpoint locally and verified the response omits the `sa
 **PLAN.md link:** (https://github.com/10-49/pathreview/blob/fix 68-health-endpoint-safety-count/PLAN.md)
 **Walkthrough video (recommended):** 
 **Blockers or open questions:**
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Took notes on current environment status pre-working on the issue and began implementing the fix. Updated `api/routes/health.py` to call `get_safety_events_last_hour()` and return the `safety_events_last_hour` key in the JSON, outputting to `null` if the monitoring fails.
+
+**Next steps:**
+Add a comprehensive unit test for the new monitoring logic and health route responses. confirm `make check` and `make test-unit` pass, and finalize PR.
+
+**Blockers:**
+My workstation moved so trying to setup the repository on two different machines was a large hassle, and syncing work between them properly. Version mismatches on imported tools causing issues, docker/setup issues plagued the beginning of the working process. 
+
+**PR link:** 
+
+**Branch:** `fix/68-health-endpoint-safety-count`
+
+**What you built:**
+Added a `safety_events_last_hour` metric to the `/health` endpoint response. Implemented a timestamped event logging using sets sorted by Redis in `safety/monitoring.py` (calcuating rolling-window style event totals for safety health events). Updated the `api/routes/health.py` file to execute the query and output `null` if the monitoring service fails, keeping the standard health check status.
+
+**Tests added or updated:**
+Added `tests/unit/test_monitoring.py` and `tests/unit/test_health.py` to cover rolling-window, edge boundaries, failure, and response formatting.
+
+**Self-review confirmation:** Make check and make unit-test passes. Verified that pre-existing failures observed count as 176 in make check and 53 in make test-unit. New implementation and unit tests introduced no new failures. 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -40,3 +40,33 @@ Added a `safety_events_last_hour` metric to the `/health` endpoint response. Imp
 Added `tests/unit/test_monitoring.py` and `tests/unit/test_health.py` to cover rolling-window, edge boundaries, failure, and response formatting.
 
 **Self-review confirmation:** Make check and make unit-test passes. Verified that pre-existing failures observed count as 176 in make check and 53 in make test-unit. New implementation and unit tests introduced no new failures. 
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** No
+
+**Summary of feedback:**
+
+**How you responded:**
+
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Setting up the project to work in my local environment was a lot more tedious than I had expected it to be. Setup took as much if not more time than it took to actually implement the feature/bugfix into the codebase. 
+
+**What did you learn about working in a large codebase?**
+There is a lot more to the process of working in a large codebase than just writing and uploading code, I had to refactor and re-evaluate my implementation to make sure it met contribution guidelines, as well as passing the linter and other evaluations to greenlight the push to the branch before I could even make a pull request. 
+
+**How did AI tools help — and where did they fall short?**
+AI tools helped a lot during the implementation of the bugfix for both understanding overarching concepts of how the repository functioned, understanding the functions I was interacting with to implement the fix, and understanding errors in my code that were being caught in the linter. 
+
+**What would you do differently if you started over?**
+I would take more time to learn about the specific linting and evaluation metrics for git so that my implementation doesn't get interrrupted by me spending a lot of time trying to rewrite code to pass evaluation when I could have written the code while being more aware of how the linter would evaluate it from the start.
+
+**What are you most proud of from this module?**
+I am the most proud of experiencing something new and learning about the processes of git, as well as the nature of open source contributions. 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -29,7 +29,7 @@ Add a comprehensive unit test for the new monitoring logic and health route resp
 **Blockers:**
 My workstation moved so trying to setup the repository on two different machines was a large hassle, and syncing work between them properly. Version mismatches on imported tools causing issues, docker/setup issues plagued the beginning of the working process. 
 
-**PR link:** 
+**PR link:**: https://github.com/ascherj/pathreview/pull/923 
 
 **Branch:** `fix/68-health-endpoint-safety-count`
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,28 @@
+## Solution plan
+
+
+**Issue:** [Add a safety event count to the health check endpoint #68 https://github.com/ascherj/pathreview/issues/68]
+
+### Understand
+The `/health` API endpoint currently returns service status and does not surface safety metrics. The expected behavior  for the endpoint is to include a `safety_events_last_hour` field, so that operators can monitor safety system activity without having to additionally query the monitoring dashboard directly for the metrics.
+
+### Map
+*   `api/routes/health.py`
+*   `safety/monitoring.py`
+
+### Plan
+1.  Inspect `safety/monitoring.py` to identify / implement a function that retrieves the count of safety events from the last hour.
+2.  Update `api/routes/health.py` to import the created monitoring function.
+3.  Modify the JSON response in `api/routes/health.py` to execute the function and assign its return value to the `safety_events_last_hour` key.
+4.  Finally update the relevant unit tests in the `tests/` directory to verify the health endpoint properly returns the new field.
+
+### Inputs & outputs
+*   **Input**: A GET request to the `/health` endpoint. (standard)
+*   **Output**: A JSON response containing the standard health status alongside `"safety_events_last_hour": <integer>`.
+
+### Risks & unknowns
+*   Performance degradation is possible if the safety event query in `safety/monitoring.py` is unreasonably computationally heavy or database-intensive on a high-frequency occuring health check endpoint.
+*   Uncertainty on whether `safety/monitoring.py` currently tracks event timestamps well enough to filter by the last hour.
+
+### Edge cases
+*   If the safety monitoring system is temporarily unreachable or fails to calculate the count, the `/health` endpoint must handle the exception (e.g., returning `null` or `0` for the field) as opposed to failing the entire health check.

--- a/api/routes/health.py
+++ b/api/routes/health.py
@@ -1,12 +1,17 @@
-from fastapi import APIRouter, HTTPException, status, Depends
+from datetime import datetime
+
 import structlog
-from datetime import datetime, timedelta
+from fastapi import APIRouter, Depends, HTTPException, status
 
 from core.database import get_db
 
 log = structlog.get_logger()
 
 router = APIRouter(prefix="/health", tags=["health"])
+
+# TODO (Issue #68): The current response omits any safety metrics
+# it has to be updated to include the 'safety_events_last_hour' field by integrating event
+# tracking from safety/monitoring.py.
 
 
 @router.get("")
@@ -39,6 +44,7 @@ async def health_check(db=Depends(get_db)):
     try:
         # Check Redis (if available)
         import redis
+
         from core.config import settings
 
         r = redis.Redis(

--- a/api/routes/health.py
+++ b/api/routes/health.py
@@ -1,26 +1,26 @@
 from datetime import datetime
+from typing import Annotated, Any
 
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from core.database import get_db
+from safety.monitoring import get_safety_events_last_hour
 
 log = structlog.get_logger()
 
 router = APIRouter(prefix="/health", tags=["health"])
 
-# TODO (Issue #68): The current response omits any safety metrics
-# it has to be updated to include the 'safety_events_last_hour' field by integrating event
-# tracking from safety/monitoring.py.
-
 
 @router.get("")
-async def health_check(db=Depends(get_db)):
+async def health_check(db: Annotated[AsyncSession, Depends(get_db)]) -> dict[str, Any]:
     """
     Check health of PostgreSQL, Redis, and Vector DB.
     Returns 200 if all healthy, 503 if any dependency is down.
     """
-    health_status = {
+    health_status: dict[str, Any] = {
         "status": "healthy",
         "dependencies": {
             "postgres": "unknown",
@@ -33,7 +33,7 @@ async def health_check(db=Depends(get_db)):
 
     try:
         # Check PostgreSQL
-        await db.execute("SELECT 1")
+        await db.execute(text("SELECT 1"))
         health_status["dependencies"]["postgres"] = "healthy"
         log.debug("postgres_health_check_passed")
     except Exception as exc:
@@ -47,12 +47,7 @@ async def health_check(db=Depends(get_db)):
 
         from core.config import settings
 
-        r = redis.Redis(
-            host=settings.redis_host,
-            port=settings.redis_port,
-            db=0,
-            decode_responses=True,
-        )
+        r = redis.Redis.from_url(settings.redis_url, decode_responses=True)
         r.ping()
         health_status["dependencies"]["redis"] = "healthy"
         log.debug("redis_health_check_passed")
@@ -78,12 +73,13 @@ async def health_check(db=Depends(get_db)):
         health_status["dependencies"]["vector_db"] = "unhealthy"
         health_status["status"] = "unhealthy"
 
-    # Count safety events in last hour (placeholder)
+    # Count safety events in last hour. A monitoring failure must not fail the
+    # health check, so the count degrades to null and the status is unchanged.
     try:
-        # This would be populated by actual safety event logging
-        health_status["safety_events_last_hour"] = 0
+        health_status["safety_events_last_hour"] = get_safety_events_last_hour()
     except Exception as exc:
         log.error("safety_events_check_failed", error=str(exc))
+        health_status["safety_events_last_hour"] = None
 
     # Return 503 if any critical dependency is down
     if health_status["status"] == "unhealthy":

--- a/safety/monitoring.py
+++ b/safety/monitoring.py
@@ -1,10 +1,13 @@
 """Safety event monitoring."""
 
+from datetime import datetime
+
 import redis
 import structlog
-from datetime import datetime, timedelta
 
 logger = structlog.get_logger()
+
+##Issue 68 temp marking
 
 
 class SafetyMonitor:
@@ -16,7 +19,7 @@ class SafetyMonitor:
         "injection_attempt",
         "content_filtered",
         "bias_detected",
-        "rate_limited"
+        "rate_limited",
     }
 
     def __init__(self, redis_client: redis.Redis):

--- a/safety/monitoring.py
+++ b/safety/monitoring.py
@@ -1,13 +1,23 @@
 """Safety event monitoring."""
 
+import time
 from datetime import datetime
+from uuid import uuid4
 
 import redis
 import structlog
 
 logger = structlog.get_logger()
 
-##Issue 68 temp marking
+# Sorted set of individual event timestamps, one key per event type. Scored by
+# epoch seconds so counts can be taken over an arbitrary rolling window.
+RECENT_EVENTS_KEY_PREFIX = "safety:events:recent"
+
+# How long individual events are kept for windowed counts.
+EVENT_RETENTION_SECONDS = 86400
+
+# Default rolling window used by get_safety_events_last_hour().
+DEFAULT_WINDOW_SECONDS = 3600
 
 
 class SafetyMonitor:
@@ -53,6 +63,16 @@ class SafetyMonitor:
             # Set expiry to 24 hours
             self.redis.expire(key, 86400)
 
+            # Record the individual event so it can be counted over a rolling
+            # window. The member must be unique or ZADD would overwrite a
+            # same-timestamp event instead of adding one.
+            now = time.time()
+            recent_key = f"{RECENT_EVENTS_KEY_PREFIX}:{event_type}"
+            self.redis.zadd(recent_key, {f"{timestamp}:{uuid4().hex[:8]}": now})
+            # Drop events that have aged out of the retention period
+            self.redis.zremrangebyscore(recent_key, 0, now - EVENT_RETENTION_SECONDS)
+            self.redis.expire(recent_key, EVENT_RETENTION_SECONDS + 60)
+
         except Exception as e:
             logger.error("safety_monitor_error", error=str(e))
 
@@ -75,3 +95,65 @@ class SafetyMonitor:
         except Exception as e:
             logger.error("event_count_error", event_type=event_type, error=str(e))
             return 0
+
+    def get_events_in_window(self, window_seconds: int = DEFAULT_WINDOW_SECONDS) -> int:
+        """Count safety events of every type within a rolling window.
+
+        Only events whose timestamp falls strictly after ``now - window_seconds``
+        are counted, so an event exactly on the boundary is treated as expired.
+
+        Args:
+            window_seconds: Size of the rolling window, in seconds
+
+        Returns:
+            Total number of events across all event types in the window
+
+        Raises:
+            redis.RedisError: If Redis is unreachable. Callers that must not
+                fail (the health endpoint) are expected to catch this.
+        """
+        window_start = time.time() - window_seconds
+
+        # One round trip for all event types
+        pipe = self.redis.pipeline()
+        for event_type in sorted(self.VALID_EVENT_TYPES):
+            # The "(" prefix makes the lower bound exclusive
+            pipe.zcount(f"{RECENT_EVENTS_KEY_PREFIX}:{event_type}", f"({window_start}", "+inf")
+
+        return sum(pipe.execute())
+
+
+_redis_client: redis.Redis | None = None
+
+
+def _get_redis_client() -> redis.Redis:
+    """Return a lazily created, process-wide Redis client.
+
+    Imported locally so that this module stays importable without application
+    config, and so callers can keep injecting their own client.
+    """
+    global _redis_client
+
+    if _redis_client is None:
+        from core.config import settings
+
+        _redis_client = redis.Redis.from_url(settings.redis_url, decode_responses=True)
+
+    return _redis_client
+
+
+def get_safety_events_last_hour(redis_client: redis.Redis | None = None) -> int:
+    """Total number of safety events logged in the last hour.
+
+    Args:
+        redis_client: Redis client to use. Defaults to a shared client built
+            from ``settings.redis_url``.
+
+    Returns:
+        Count of events strictly within the last hour
+
+    Raises:
+        redis.RedisError: If Redis is unreachable or the count fails.
+    """
+    monitor = SafetyMonitor(redis_client or _get_redis_client())
+    return monitor.get_events_in_window(DEFAULT_WINDOW_SECONDS)

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -1,0 +1,168 @@
+"""Tests for the health endpoint (Issue #68: safety_events_last_hour)"""
+
+from collections.abc import AsyncGenerator, Generator
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.routes import health as health_route
+from core.database import get_db
+
+# Stand-in for core.config.settings. The endpoint resolves settings at call
+# time (`from core.config import settings` inside the function body), so
+# patching the module attribute is enough and no real services are contacted.
+FAKE_SETTINGS = SimpleNamespace(
+    redis_host="localhost",
+    redis_port=6379,
+    redis_url="redis://localhost:6379/0",
+    vector_db_url="http://localhost:8001",
+)
+
+
+class StubSession:
+    """Minimal async DB session that satisfies the postgres liveness probe."""
+
+    async def execute(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+
+async def override_get_db() -> AsyncGenerator[StubSession, None]:
+    """Dependency override that avoids a live PostgreSQL connection."""
+    yield StubSession()
+
+
+@pytest.mark.unit
+class TestHealthSafetyEventCount:
+    """Test suite for the safety_events_last_hour field on GET /health."""
+
+    @pytest.fixture
+    def app(self) -> FastAPI:
+        """Build a minimal app with only the health router mounted."""
+        app = FastAPI()
+        app.include_router(health_route.router)
+        app.dependency_overrides[get_db] = override_get_db
+        return app
+
+    @pytest.fixture
+    def client(self, app: FastAPI) -> TestClient:
+        """Create a TestClient for the isolated app."""
+        return TestClient(app)
+
+    @pytest.fixture(autouse=True)
+    def healthy_dependencies(self) -> Generator[None, None, None]:
+        """Make postgres/redis/vector_db report healthy without live services."""
+        with patch("core.config.settings", FAKE_SETTINGS), patch("redis.Redis", MagicMock()):
+            yield
+
+    def test_success_state_reports_event_count(self, client: TestClient) -> None:
+        """Test a successful count is surfaced in the response payload."""
+        with patch.object(health_route, "get_safety_events_last_hour", return_value=3) as counter:
+            response = client.get("/health")
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["safety_events_last_hour"] == 3
+        counter.assert_called_once_with()
+
+    def test_zero_events_reported_as_zero(self, client: TestClient) -> None:
+        """Test a quiet hour reports 0 rather than null."""
+        with patch.object(health_route, "get_safety_events_last_hour", return_value=0):
+            response = client.get("/health")
+
+        assert response.status_code == 200
+        assert response.json()["safety_events_last_hour"] == 0
+
+    def test_fault_tolerance_degrades_to_null(self, client: TestClient) -> None:
+        """Test a monitoring failure yields null instead of failing the check."""
+        with patch.object(
+            health_route,
+            "get_safety_events_last_hour",
+            side_effect=Exception("monitoring unreachable"),
+        ):
+            response = client.get("/health")
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["safety_events_last_hour"] is None
+        assert "safety_events_last_hour" in payload
+
+    def test_monitoring_failure_does_not_change_overall_status(self, client: TestClient) -> None:
+        """Test the endpoint stays healthy when only monitoring is broken."""
+        with patch.object(
+            health_route,
+            "get_safety_events_last_hour",
+            side_effect=Exception("monitoring unreachable"),
+        ):
+            response = client.get("/health")
+
+        payload = response.json()
+        assert payload["status"] == "healthy"
+        assert payload["dependencies"]["postgres"] == "healthy"
+        assert payload["dependencies"]["redis"] == "healthy"
+
+    def test_redis_connection_error_degrades_to_null(self, client: TestClient) -> None:
+        """Test the realistic failure mode: Redis is unreachable."""
+        import redis
+
+        with patch.object(
+            health_route,
+            "get_safety_events_last_hour",
+            side_effect=redis.ConnectionError("Error 111 connecting to localhost:6379"),
+        ):
+            response = client.get("/health")
+
+        assert response.status_code == 200
+        assert response.json()["safety_events_last_hour"] is None
+
+    def test_monitoring_failure_is_logged(self, client: TestClient) -> None:
+        """Test the swallowed exception is still recorded for operators."""
+        with (
+            patch.object(
+                health_route,
+                "get_safety_events_last_hour",
+                side_effect=Exception("monitoring unreachable"),
+            ),
+            patch.object(health_route, "log") as mock_log,
+        ):
+            client.get("/health")
+
+        logged_events = [call[0][0] for call in mock_log.error.call_args_list]
+        assert "safety_events_check_failed" in logged_events
+
+    def test_field_present_when_a_dependency_is_down(
+        self, app: FastAPI, client: TestClient
+    ) -> None:
+        """Test the count still appears in the 503 detail payload."""
+
+        class BrokenSession:
+            async def execute(self, *args: Any, **kwargs: Any) -> None:
+                raise Exception("postgres down")
+
+        async def broken_get_db() -> AsyncGenerator[BrokenSession, None]:
+            yield BrokenSession()
+
+        app.dependency_overrides[get_db] = broken_get_db
+
+        with patch.object(health_route, "get_safety_events_last_hour", return_value=7):
+            response = client.get("/health")
+
+        assert response.status_code == 503
+        detail = response.json()["detail"]
+        assert detail["status"] == "unhealthy"
+        assert detail["safety_events_last_hour"] == 7
+
+    def test_no_live_redis_connection_is_opened(self, client: TestClient) -> None:
+        """Test the count comes from the mocked function, not a real client."""
+        with (
+            patch.object(health_route, "get_safety_events_last_hour", return_value=5) as counter,
+            patch("safety.monitoring._get_redis_client") as real_client,
+        ):
+            response = client.get("/health")
+
+        assert response.json()["safety_events_last_hour"] == 5
+        counter.assert_called_once_with()
+        real_client.assert_not_called()

--- a/tests/unit/test_monitoring.py
+++ b/tests/unit/test_monitoring.py
@@ -1,0 +1,295 @@
+"""Tests for monitoring.py (Issue #68: safety_events_last_hour)"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import redis
+
+from safety.monitoring import (
+    DEFAULT_WINDOW_SECONDS,
+    EVENT_RETENTION_SECONDS,
+    RECENT_EVENTS_KEY_PREFIX,
+    SafetyMonitor,
+    get_safety_events_last_hour,
+)
+
+# Fixed clock so window_start is exactly predictable
+FROZEN_NOW = 1_700_000_000.0
+
+
+@pytest.mark.unit
+class TestGetEventsInWindow:
+    """Test suite for SafetyMonitor.get_events_in_window."""
+
+    @pytest.fixture
+    def mock_pipeline(self) -> MagicMock:
+        """Create a mock Redis pipeline that records zcount calls."""
+        pipe = MagicMock()
+        # One result per event type, summing to 6
+        pipe.execute = MagicMock(return_value=[1, 1, 1, 1, 2])
+        return pipe
+
+    @pytest.fixture
+    def mock_redis(self, mock_pipeline: MagicMock) -> MagicMock:
+        """Create a mock Redis client that hands out the mock pipeline."""
+        client = MagicMock(spec=redis.Redis)
+        client.pipeline = MagicMock(return_value=mock_pipeline)
+        return client
+
+    @pytest.fixture
+    def monitor(self, mock_redis: MagicMock) -> SafetyMonitor:
+        """Create a SafetyMonitor instance with mocked Redis."""
+        return SafetyMonitor(mock_redis)
+
+    def test_initializes_redis_pipeline(
+        self, monitor: SafetyMonitor, mock_redis: MagicMock, mock_pipeline: MagicMock
+    ) -> None:
+        """Test a pipeline is opened and executed once (single round trip)."""
+        monitor.get_events_in_window(window_seconds=3600)
+
+        mock_redis.pipeline.assert_called_once_with()
+        mock_pipeline.execute.assert_called_once_with()
+
+    def test_zcount_called_once_per_valid_event_type(
+        self, monitor: SafetyMonitor, mock_pipeline: MagicMock
+    ) -> None:
+        """Test the method loops over every entry in VALID_EVENT_TYPES."""
+        monitor.get_events_in_window(window_seconds=3600)
+
+        assert mock_pipeline.zcount.call_count == len(SafetyMonitor.VALID_EVENT_TYPES)
+
+        queried_keys = {call[0][0] for call in mock_pipeline.zcount.call_args_list}
+        expected_keys = {
+            f"{RECENT_EVENTS_KEY_PREFIX}:{event_type}"
+            for event_type in SafetyMonitor.VALID_EVENT_TYPES
+        }
+        assert queried_keys == expected_keys
+
+    def test_zcount_uses_recent_events_key_prefix(
+        self, monitor: SafetyMonitor, mock_pipeline: MagicMock
+    ) -> None:
+        """Test every queried key carries the rolling-window key prefix."""
+        monitor.get_events_in_window(window_seconds=3600)
+
+        for call in mock_pipeline.zcount.call_args_list:
+            key = call[0][0]
+            assert key.startswith(f"{RECENT_EVENTS_KEY_PREFIX}:")
+            # The suffix must be a real event type, not a stringified set/None
+            assert key.rsplit(":", 1)[1] in SafetyMonitor.VALID_EVENT_TYPES
+
+    def test_zcount_window_start_calculated_from_window_seconds(
+        self, monitor: SafetyMonitor, mock_pipeline: MagicMock
+    ) -> None:
+        """Test window_start is now - window_seconds, with +inf upper bound."""
+        window_seconds = 900
+
+        with patch("safety.monitoring.time.time", return_value=FROZEN_NOW):
+            monitor.get_events_in_window(window_seconds=window_seconds)
+
+        expected_min = f"({FROZEN_NOW - window_seconds}"  # "(1699999100.0"
+        for call in mock_pipeline.zcount.call_args_list:
+            _key, min_score, max_score = call[0]
+            assert min_score == expected_min
+            assert max_score == "+inf"
+
+    def test_window_start_lower_bound_is_exclusive(
+        self, monitor: SafetyMonitor, mock_pipeline: MagicMock
+    ) -> None:
+        """Test the lower bound is exclusive so counts are strictly in-window."""
+        with patch("safety.monitoring.time.time", return_value=FROZEN_NOW):
+            monitor.get_events_in_window(window_seconds=3600)
+
+        for call in mock_pipeline.zcount.call_args_list:
+            min_score = call[0][1]
+            # Redis treats a leading "(" as an exclusive range bound
+            assert min_score.startswith("(")
+            assert float(min_score[1:]) == FROZEN_NOW - 3600
+
+    def test_returns_summed_integer_from_pipeline_execute(
+        self, monitor: SafetyMonitor, mock_pipeline: MagicMock
+    ) -> None:
+        """Test the return value is the sum of the pipeline results."""
+        mock_pipeline.execute = MagicMock(return_value=[3, 0, 7, 1, 4])
+
+        result = monitor.get_events_in_window(window_seconds=3600)
+
+        assert result == 15
+        assert isinstance(result, int)
+
+    def test_returns_zero_when_no_events_in_window(
+        self, monitor: SafetyMonitor, mock_pipeline: MagicMock
+    ) -> None:
+        """Test an empty window counts as zero, not None."""
+        mock_pipeline.execute = MagicMock(return_value=[0] * len(SafetyMonitor.VALID_EVENT_TYPES))
+
+        assert monitor.get_events_in_window(window_seconds=3600) == 0
+
+    def test_default_window_is_one_hour(
+        self, monitor: SafetyMonitor, mock_pipeline: MagicMock
+    ) -> None:
+        """Test the default window is 3600 seconds."""
+        assert DEFAULT_WINDOW_SECONDS == 3600
+
+        with patch("safety.monitoring.time.time", return_value=FROZEN_NOW):
+            monitor.get_events_in_window()
+
+        min_score = mock_pipeline.zcount.call_args_list[0][0][1]
+        assert float(min_score[1:]) == FROZEN_NOW - 3600
+
+    def test_larger_window_reaches_further_back(
+        self, monitor: SafetyMonitor, mock_pipeline: MagicMock
+    ) -> None:
+        """Test a wider window produces an earlier window_start."""
+        with patch("safety.monitoring.time.time", return_value=FROZEN_NOW):
+            monitor.get_events_in_window(window_seconds=60)
+            narrow = float(mock_pipeline.zcount.call_args_list[0][0][1][1:])
+
+            mock_pipeline.reset_mock()
+            monitor.get_events_in_window(window_seconds=7200)
+            wide = float(mock_pipeline.zcount.call_args_list[0][0][1][1:])
+
+        assert wide < narrow
+
+    def test_redis_error_propagates_to_caller(
+        self, monitor: SafetyMonitor, mock_redis: MagicMock
+    ) -> None:
+        """Test Redis failures propagate so the health endpoint can degrade."""
+        mock_redis.pipeline = MagicMock(side_effect=redis.RedisError("connection refused"))
+
+        with pytest.raises(redis.RedisError):
+            monitor.get_events_in_window(window_seconds=3600)
+
+    def test_execute_error_propagates_to_caller(
+        self, monitor: SafetyMonitor, mock_pipeline: MagicMock
+    ) -> None:
+        """Test a failure during execute() also propagates."""
+        mock_pipeline.execute = MagicMock(side_effect=redis.ConnectionError("redis down"))
+
+        with pytest.raises(redis.ConnectionError):
+            monitor.get_events_in_window(window_seconds=3600)
+
+
+@pytest.mark.unit
+class TestLogEventWindowTracking:
+    """Test suite for the rolling-window writes added to log_event."""
+
+    @pytest.fixture
+    def mock_redis(self) -> MagicMock:
+        """Create a mock Redis client."""
+        return MagicMock(spec=redis.Redis)
+
+    @pytest.fixture
+    def monitor(self, mock_redis: MagicMock) -> SafetyMonitor:
+        """Create a SafetyMonitor instance with mocked Redis."""
+        return SafetyMonitor(mock_redis)
+
+    def test_event_added_to_rolling_window_sorted_set(
+        self, monitor: SafetyMonitor, mock_redis: MagicMock
+    ) -> None:
+        """Test the event is scored by epoch seconds in the per-type sorted set."""
+        with patch("safety.monitoring.time.time", return_value=FROZEN_NOW):
+            monitor.log_event("pii_detected", {"field": "email"})
+
+        mock_redis.zadd.assert_called_once()
+        key, mapping = mock_redis.zadd.call_args[0]
+
+        assert key == f"{RECENT_EVENTS_KEY_PREFIX}:pii_detected"
+        assert list(mapping.values()) == [FROZEN_NOW]
+
+    def test_repeated_events_use_unique_members(
+        self, monitor: SafetyMonitor, mock_redis: MagicMock
+    ) -> None:
+        """Test identical events do not overwrite each other in the sorted set."""
+        with patch("safety.monitoring.time.time", return_value=FROZEN_NOW):
+            monitor.log_event("rate_limited", {"ip": "1.1.1.1"})
+            monitor.log_event("rate_limited", {"ip": "1.1.1.1"})
+
+        members = [member for call in mock_redis.zadd.call_args_list for member in call[0][1]]
+        assert len(members) == 2
+        assert len(set(members)) == 2, "ZADD members collided; one event would be lost"
+
+    def test_aged_out_events_are_pruned(
+        self, monitor: SafetyMonitor, mock_redis: MagicMock
+    ) -> None:
+        """Test events older than the retention period are removed."""
+        with patch("safety.monitoring.time.time", return_value=FROZEN_NOW):
+            monitor.log_event("injection_attempt", {"pattern": "ignore previous"})
+
+        mock_redis.zremrangebyscore.assert_called_once()
+        key, low, high = mock_redis.zremrangebyscore.call_args[0]
+
+        assert key == f"{RECENT_EVENTS_KEY_PREFIX}:injection_attempt"
+        assert low == 0
+        assert high == FROZEN_NOW - EVENT_RETENTION_SECONDS
+
+    def test_rolling_window_key_has_ttl(
+        self, monitor: SafetyMonitor, mock_redis: MagicMock
+    ) -> None:
+        """Test the sorted set expires if events stop arriving."""
+        monitor.log_event("bias_detected", {"term": "example"})
+
+        ttls = [call[0][1] for call in mock_redis.expire.call_args_list]
+        assert EVENT_RETENTION_SECONDS + 60 in ttls
+
+    def test_invalid_event_type_is_not_recorded(
+        self, monitor: SafetyMonitor, mock_redis: MagicMock
+    ) -> None:
+        """Test unknown event types never reach the sorted set."""
+        monitor.log_event("not_a_real_type", {})
+
+        mock_redis.zadd.assert_not_called()
+        mock_redis.incr.assert_not_called()
+
+    def test_redis_failure_during_log_is_swallowed(
+        self, monitor: SafetyMonitor, mock_redis: MagicMock
+    ) -> None:
+        """Test logging an event never raises (logging must not break callers)."""
+        mock_redis.zadd = MagicMock(side_effect=redis.RedisError("redis down"))
+
+        with patch("safety.monitoring.logger"):
+            monitor.log_event("content_filtered", {"reason": "toxicity"})
+
+
+@pytest.mark.unit
+class TestGetSafetyEventsLastHour:
+    """Test suite for the module-level function the health endpoint imports."""
+
+    @pytest.fixture
+    def mock_redis(self) -> MagicMock:
+        """Create a mock Redis client with a configurable pipeline."""
+        client = MagicMock(spec=redis.Redis)
+        client.pipeline.return_value.execute = MagicMock(return_value=[2, 0, 1, 0, 0])
+        return client
+
+    def test_uses_injected_client_without_touching_settings(self, mock_redis: MagicMock) -> None:
+        """Test an injected client is used, so no live Redis is needed."""
+        with patch("safety.monitoring._get_redis_client") as fallback:
+            result = get_safety_events_last_hour(mock_redis)
+
+        assert result == 3
+        fallback.assert_not_called()
+
+    def test_falls_back_to_shared_client(self, mock_redis: MagicMock) -> None:
+        """Test the shared client is used when none is injected."""
+        with patch("safety.monitoring._get_redis_client", return_value=mock_redis) as fallback:
+            result = get_safety_events_last_hour()
+
+        assert result == 3
+        fallback.assert_called_once_with()
+
+    def test_queries_the_one_hour_window(self, mock_redis: MagicMock) -> None:
+        """Test the function counts over a one-hour window."""
+        with patch("safety.monitoring.time.time", return_value=FROZEN_NOW):
+            get_safety_events_last_hour(mock_redis)
+
+        min_score = mock_redis.pipeline.return_value.zcount.call_args_list[0][0][1]
+        assert float(min_score[1:]) == FROZEN_NOW - 3600
+
+    def test_redis_error_propagates(self, mock_redis: MagicMock) -> None:
+        """Test errors reach the caller; the health endpoint is what catches them."""
+        mock_redis.pipeline.return_value.execute = MagicMock(
+            side_effect=redis.ConnectionError("redis down")
+        )
+
+        with pytest.raises(redis.ConnectionError):
+            get_safety_events_last_hour(mock_redis)


### PR DESCRIPTION
## Summary
Adds a `safety_events_last_hour` count to the `/health` endpoint so operators can monitor recent safety system activity directly without having to check external dashboards. It uses Redis sorted sets to track event totals over trailing 60 minutes and includes fallback handling so monitoring issues don't break the main health check.

## Issue
Closes #68  

## Changes
-Updated `safety/monitoring.py` to record individual event timestamps in Redis sorted sets and added `get_events_in_window()` to count events over a rolling timeframe
- Updated `api/routes/health.py` to call `get_safety_events_last_hour()` and include the metric in the JSON response
- Added `try/except` error handling around the safety check in `api/routes/health.py` so it outputs to `null` if Redis/monitoring is down without throwing a 503
- Added comprehensive unit test suites in `tests/unit/test_monitoring.py` and `tests/unit/test_health.py`

## Testing
<!-- How did you verify your changes? -->
- [✅] Unit tests pass (`make test-unit`)
- [✅] Linter passes (`make lint`)
- [✅] Type checker passes (`make typecheck`)
- [✅] New/updated tests cover the changes