### PR TITLE
Pr/36 hybrid retrieval scoring

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -59,6 +59,48 @@ A plan-execute orchestrator that coordinates multiple analysis tools. Each tool 
 ### RAG System (`rag/`)
 Hybrid retrieval (vector similarity + BM25 keyword) fetches relevant context from the user's ingested documents. The generator uses prompt templates to produce structured, evidence-based feedback. The evaluator scores retrieval relevance and generation faithfulness.
 
+#### Hybrid Retrieval Scoring
+
+`HybridRetriever` (`rag/retriever/hybrid.py`) blends two signals because neither alone is sufficient: vector similarity catches paraphrases and related concepts but misses exact tokens, while BM25 catches literal terms (framework names, acronyms) but misses semantic matches. Each query runs both searches, requesting `max_chunks * 2` candidates from each side, and the two candidate sets are merged by chunk ID.
+
+The two raw scores are not comparable — vector scores come back as `1 / (1 + distance)` and land in `(0, 1]`, while BM25 scores are unbounded and depend on corpus statistics. So each side is **max-normalized** against its own result set before blending: every raw score is divided by the largest raw score in that set, which puts both signals on a 0–1 scale and makes the top hit on each side exactly `1.0`. If a side returns no results (or an all-zero maximum), its normalized contribution is `0` rather than a division by zero.
+
+The normalized scores are then combined linearly:
+
+```
+score = vector_weight * normalized_vector_score + keyword_weight * normalized_keyword_score
+
+where  normalized_vector_score  = raw_vector_score  / max(raw_vector_scores)
+       normalized_keyword_score = raw_bm25_score    / max(raw_bm25_scores)
+```
+
+A chunk that appears in only one candidate set still gets a blended score — the missing side contributes `0`. Chunks scoring below `min_score` are dropped, the rest are sorted by blended score descending, and the top `max_chunks` are returned. Each returned chunk carries its `vector_score` and `keyword_score` components alongside the blended `score`, which is useful when debugging why a chunk ranked where it did.
+
+| Parameter | Default | Set in | Meaning |
+|---|---|---|---|
+| `vector_weight` | `0.7` | `HybridRetriever.__init__` | Weight applied to the normalized vector score |
+| `keyword_weight` | `0.3` | `HybridRetriever.__init__` | Weight applied to the normalized BM25 score |
+| `max_chunks` | `10` | `retrieve()` | Chunks returned; each side is queried for `2x` this many candidates |
+| `min_score` | `0.3` | `retrieve()` | Chunks with a blended score below this are dropped |
+
+The defaults favor semantic similarity over keyword matching roughly 2:1, on the assumption that a reviewer's query ("what testing experience does this candidate have?") rarely uses the same wording as the source document.
+
+**Worked example.** A query returns three chunks from vector search and three from BM25 (`C1` and `C2` appear on both sides). The raw maxima are `0.60` for vector and `8.0` for BM25:
+
+| Chunk | Raw vector | Raw BM25 | Normalized vector | Normalized keyword | Blended score |
+|---|---|---|---|---|---|
+| `C1` | 0.60 | 2.0 | 0.60 / 0.60 = **1.00** | 2.0 / 8.0 = **0.25** | 0.7(1.00) + 0.3(0.25) = **0.775** |
+| `C2` | 0.42 | 8.0 | 0.42 / 0.60 = **0.70** | 8.0 / 8.0 = **1.00** | 0.7(0.70) + 0.3(1.00) = **0.790** |
+| `C3` | 0.30 | — | 0.30 / 0.60 = **0.50** | absent → **0** | 0.7(0.50) + 0.3(0) = **0.350** |
+| `C4` | — | 4.0 | absent → **0** | 4.0 / 8.0 = **0.50** | 0.7(0) + 0.3(0.50) = **0.150** |
+
+`C4` scores `0.150`, below the `0.3` cutoff, so it is dropped. The final ranking is `C2` (0.790), `C1` (0.775), `C3` (0.350). Note that `C2` outranks `C1` even though `C1` was the single best vector hit — a strong keyword match is enough to overcome a moderate vector deficit, which is the whole point of blending.
+
+Two consequences worth knowing when tuning:
+
+- **Normalization is relative to the current result set**, not global. A chunk's score describes how it compares to the other candidates for *this* query, so blended scores are not comparable across queries, and `min_score` behaves as a relative threshold rather than an absolute confidence level.
+- **The cutoff is inclusive.** The filter is `score >= min_score`, so a chunk scoring exactly `0.3` is kept.
+
 ### Safety Layer (`safety/`)
 Middleware wrapping the generation pipeline. Components run in sequence: prompt injection defense → content filter → bias detector → PII scrubber. All safety events are logged with structured metadata for monitoring.
 

--- a/tests/unit/test_architecture_docs.py
+++ b/tests/unit/test_architecture_docs.py
@@ -1,0 +1,41 @@
+"""Reproduction test for issue #36: ARCHITECTURE.md doesn't explain the
+hybrid retrieval scoring formula.
+
+This test documents the doc gap by asserting that docs/ARCHITECTURE.md
+contains a "Hybrid Retrieval Scoring" subsection describing the blending
+formula, default weights, normalization step, and a worked example. It
+currently fails, which reproduces the issue; it should pass once the
+architecture doc is updated.
+"""
+
+from pathlib import Path
+
+import pytest
+
+ARCHITECTURE_DOC = Path(__file__).resolve().parents[2] / "docs" / "ARCHITECTURE.md"
+
+
+@pytest.mark.unit
+class TestArchitectureDocHybridScoring:
+    """Test suite reproducing issue #36 (missing hybrid scoring docs)."""
+
+    @pytest.fixture
+    def doc_text(self):
+        return ARCHITECTURE_DOC.read_text(encoding="utf-8")
+
+    def test_has_hybrid_retrieval_scoring_subsection(self, doc_text):
+        """The doc should have a dedicated subsection on hybrid scoring."""
+        assert "Hybrid Retrieval Scoring" in doc_text
+
+    def test_documents_default_weights(self, doc_text):
+        """The doc should state the default vector/keyword weights (0.7/0.3)."""
+        assert "0.7" in doc_text
+        assert "0.3" in doc_text
+
+    def test_documents_normalization_step(self, doc_text):
+        """The doc should explain the max-normalization step."""
+        assert "normaliz" in doc_text.lower()
+
+    def test_documents_min_score_cutoff(self, doc_text):
+        """The doc should mention the min_score cutoff behavior."""
+        assert "min_score" in doc_text

--- a/tests/unit/test_architecture_docs.py
+++ b/tests/unit/test_architecture_docs.py
@@ -1,16 +1,21 @@
-"""Reproduction test for issue #36: ARCHITECTURE.md doesn't explain the
-hybrid retrieval scoring formula.
+"""Tests for the "Hybrid Retrieval Scoring" section of docs/ARCHITECTURE.md (issue #36).
 
-This test documents the doc gap by asserting that docs/ARCHITECTURE.md
-contains a "Hybrid Retrieval Scoring" subsection describing the blending
-formula, default weights, normalization step, and a worked example. It
-currently fails, which reproduces the issue; it should pass once the
-architecture doc is updated.
+TestArchitectureDocHybridScoring asserts the subsection exists and mentions the
+blending formula, default weights, normalization step, and min_score cutoff.
+These reproduced issue #36 by failing against the pre-fix doc.
+
+TestArchitectureDocMatchesCode goes further and checks that what the doc claims
+is actually true of HybridRetriever, so the prose can't drift away from
+rag/retriever/hybrid.py without a test failing.
 """
 
+import inspect
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
+
+from rag.retriever.hybrid import HybridRetriever
 
 ARCHITECTURE_DOC = Path(__file__).resolve().parents[2] / "docs" / "ARCHITECTURE.md"
 
@@ -39,3 +44,114 @@ class TestArchitectureDocHybridScoring:
     def test_documents_min_score_cutoff(self, doc_text):
         """The doc should mention the min_score cutoff behavior."""
         assert "min_score" in doc_text
+
+
+@pytest.mark.unit
+class TestArchitectureDocMatchesCode:
+    """Guard against the documented scoring behavior drifting from hybrid.py.
+
+    The four assertions above only check that the doc *mentions* the formula.
+    These check that what it says is actually true of HybridRetriever, so the
+    subsection can't silently go stale when defaults or blending change.
+    """
+
+    @pytest.fixture
+    def doc_text(self):
+        return ARCHITECTURE_DOC.read_text(encoding="utf-8")
+
+    @pytest.fixture
+    def retriever(self):
+        """Build a HybridRetriever over mocked vector and keyword backends.
+
+        The scores match the worked example in the architecture doc: C1 and C2
+        are found by both searches, C3 only by vector, C4 only by BM25.
+        """
+        vector_store = MagicMock()
+        vector_store.query.return_value = [
+            {"id": "C1", "text": "c1", "metadata": {}, "score": 0.60},
+            {"id": "C2", "text": "c2", "metadata": {}, "score": 0.42},
+            {"id": "C3", "text": "c3", "metadata": {}, "score": 0.30},
+        ]
+        # _get_all_chunks() reads the collection directly; nothing to return.
+        vector_store.get_collection.return_value.get.return_value = {
+            "ids": [],
+            "documents": [],
+            "metadatas": [],
+        }
+
+        keyword_searcher = MagicMock()
+        keyword_searcher.search.return_value = [
+            {"id": "C2", "text": "c2", "bm25_score": 8.0},
+            {"id": "C4", "text": "c4", "bm25_score": 4.0},
+            {"id": "C1", "text": "c1", "bm25_score": 2.0},
+        ]
+
+        return HybridRetriever(vector_store, keyword_searcher)
+
+    @staticmethod
+    def _doc_line_for(doc_text: str, parameter: str) -> str:
+        """Return the doc's parameter-table row mentioning the given parameter."""
+        matches = [
+            line for line in doc_text.splitlines() if f"`{parameter}`" in line and "|" in line
+        ]
+        assert matches, f"no parameter-table row documenting `{parameter}`"
+        return matches[0]
+
+    @pytest.mark.parametrize(
+        ("parameter", "method"),
+        [
+            ("vector_weight", HybridRetriever.__init__),
+            ("keyword_weight", HybridRetriever.__init__),
+            ("max_chunks", HybridRetriever.retrieve),
+            ("min_score", HybridRetriever.retrieve),
+        ],
+    )
+    def test_documented_defaults_match_signature(self, doc_text, parameter, method):
+        """Each default in the doc's parameter table matches the actual signature."""
+        actual_default = inspect.signature(method).parameters[parameter].default
+
+        assert str(actual_default) in self._doc_line_for(
+            doc_text, parameter
+        ), f"doc row for `{parameter}` does not state its real default {actual_default!r}"
+
+    def test_worked_example_scores_match_real_blending(self, retriever):
+        """Running the doc's worked example through HybridRetriever reproduces its numbers."""
+        results = retriever.retrieve("testing experience", "p1", [0.1, 0.2, 0.3])
+
+        scores = {r["id"]: r["score"] for r in results}
+        assert scores == pytest.approx({"C2": 0.790, "C1": 0.775, "C3": 0.350})
+
+    def test_worked_example_ranking_matches_doc(self, retriever):
+        """The doc claims the ranking is C2, C1, C3 — a keyword win over the top vector hit."""
+        results = retriever.retrieve("testing experience", "p1", [0.1, 0.2, 0.3])
+
+        assert [r["id"] for r in results] == ["C2", "C1", "C3"]
+
+    def test_worked_example_drops_chunk_below_min_score(self, retriever):
+        """The doc claims C4 (0.150) is dropped by the default min_score of 0.3."""
+        results = retriever.retrieve("testing experience", "p1", [0.1, 0.2, 0.3])
+
+        assert "C4" not in [r["id"] for r in results]
+
+    def test_top_hit_on_each_side_normalizes_to_one(self, retriever):
+        """The doc claims max-normalization makes each side's best raw score exactly 1.0."""
+        results = retriever.retrieve("testing experience", "p1", [0.1, 0.2, 0.3])
+        by_id = {r["id"]: r for r in results}
+
+        # C1 had the highest raw vector score, C2 the highest raw BM25 score.
+        assert by_id["C1"]["vector_score"] == pytest.approx(1.0)
+        assert by_id["C2"]["keyword_score"] == pytest.approx(1.0)
+
+    def test_chunk_missing_from_one_side_scores_zero_there(self, retriever):
+        """The doc claims a chunk absent from one candidate set contributes 0 on that side."""
+        results = retriever.retrieve("testing experience", "p1", [0.1, 0.2, 0.3])
+        by_id = {r["id"]: r for r in results}
+
+        # C3 was never returned by BM25.
+        assert by_id["C3"]["keyword_score"] == 0.0
+
+    def test_min_score_cutoff_is_inclusive(self, retriever):
+        """The doc claims the filter is `>=`, so a chunk scoring exactly min_score is kept."""
+        results = retriever.retrieve("testing experience", "p1", [0.1, 0.2, 0.3], min_score=0.350)
+
+        assert "C3" in [r["id"] for r in results]


### PR DESCRIPTION
## Summary

`docs/ARCHITECTURE.md` described the RAG system as using "hybrid retrieval (vector similarity + BM25 keyword)" but never explained how the two signals are actually combined. A reader could not tell how two differently-scaled scores are reconciled, what the blend formula is, or what the default weights and cutoff are the only way to find out was to read `rag/retriever/hybrid.py`. This PR adds a "Hybrid Retrieval Scoring" subsection documenting the max-normalization step, the linear blend formula, the default parameters, and a worked numeric example, and adds tests that keep the documented numbers pinned to the code so they can't silently drift.

## Issue

Closes #36

## Changes

- **`docs/ARCHITECTURE.md`**,new `#### Hybrid Retrieval Scoring` subsection under "RAG System" covering:
  - why two signals are blended, and that each side contributes `max_chunks * 2` candidates
  - why the raw scores aren't comparable (vector is `1 / (1 + distance)` in `(0, 1]`; BM25 is unbounded) and how **max-normalization** puts both on a 0‚Äì1 scale, including the guard that avoids dividing by a zero maximum
  - the blend formula: `score = vector_weight * normalized_vector_score + keyword_weight * normalized_keyword_score`
  - a parameter table with the real defaults,`vector_weight=0.7`, `keyword_weight=0.3`, `max_chunks=10`, `min_score=0.3`
  - a worked four-chunk example showing a keyword-strong chunk (`C2`, 0.790) outranking the best vector hit (`C1`, 0.775), a chunk absent from BM25 still scoring (`C3`, 0.350), and a low scorer dropped by the cutoff (`C4`, 0.150)
  - two tuning caveats: normalization is relative to the current result set (so scores aren't comparable across queries), and the `min_score` filter is inclusive (`>=`)
- **`tests/unit/test_architecture_docs.py`**,`TestArchitectureDocHybridScoring` (4 tests) asserts the subsection exists and mentions the formula, weights, normalization, and `min_score`. These failed against the pre-fix doc and reproduce the issue. `TestArchitectureDocMatchesCode` (10 tests) verifies the doc is *correct*, not just present.

No application code was changed ‚`rag/retriever/hybrid.py` was read-only for this work.

## Testing

- [x] Unit tests pass (`make test-unit`), see pre-existing failures note below
- [x] Integration tests pass (`make test-integration`), `tests/integration/` currently contains no tests, so this collects and exits cleanly
- [x] Linter passes (`make lint`), see pre-existing failures note below
- [x] Type checker passes (`make typecheck`), see pre-existing failures note below
- [x] New/updated tests cover the changes

**How the tests verify the doc rather than just its wording.** It would be easy to write a doc test that keeps passing while the prose goes stale, so `TestArchitectureDocMatchesCode` ties the doc to the code two ways:

1. It reads the defaults straight out of `inspect.signature(HybridRetriever.__init__)` and `inspect.signature(HybridRetriever.retrieve)` and asserts the doc's parameter table states those same values. Changing a default in `hybrid.py` without updating the table fails the test.
2. It feeds the worked example's exact raw scores through the real `HybridRetriever` over mocked backends and asserts the documented outputs: the blended scores (0.790 / 0.775 / 0.350), the `C2, C1, C3` ranking, `C4` being dropped by `min_score`, each side's top hit normalizing to `1.0`, a missing side contributing `0`, and the cutoff being inclusive.

**Pre-existing failures.** This repo has failures on `main` that are unrelated to this issue. I recorded them before starting and confirmed my changes introduce no new ones:

| Check | Before | After |
|---|---|---|
| `make lint` (ruff) | 182 errors | 182 errors |
| `make format` (black) | 52 files would be reformatted | 52 files would be reformatted |
| `make typecheck` (mypy) | 103 errors in 26 files | 103 errors in 26 files |
| `make test-unit` | 57 failed, 375 passed | 53 failed, 389 passed |

The four tests that went from failing to passing are exactly the issue #36 reproduction assertions in `tests/unit/test_architecture_docs.py`; the other 10 newly-passing tests are the drift guards added here. Diffing the failure lists before and after shows **zero newly-failing tests**. Both files I touched are ruff-clean and black-clean on their own, so this PR does not add to the lint/format backlog.

## Screenshots / Demo

Not applicable, documentation and test-only change. The new subsection renders as prose, a parameter table, and a worked-example table in `docs/ARCHITECTURE.md`.

## Notes for Reviewers

- **Please sanity-check the worked example's framing.** The arithmetic is verified by `test_worked_example_scores_match_real_blending`, but the *choice* of example is a judgment call: I picked numbers where a strong keyword match beats the top vector hit, because that's the behavior most likely to surprise someone reading only the 0.7/0.3 weights.
- **Heading level.** I used `####` so the subsection nests under "RAG System" rather than reading as a sixth entry in the "Subsystem Details" list. Happy to promote it to `###` or move it into an ADR if you'd prefer.
- **Scope.** I deliberately left `keyword_search.py`'s BM25 internals and `_get_all_chunks` undocumented‚ the issue is scoped to the scoring formula. Two things I noticed while reading `hybrid.py` but did **not** change, since they're out of scope for a docs issue and would each deserve their own issue:
  - `all_chunks = self._get_all_chunks(collection_name)` (line 50) is assigned but never used, so every `retrieve()` call fetches the whole collection and discards it.
  - The comment on `vector_store.py:102` says distances are Euclidean, but collections are created with `{"hnsw:space": "cosine"}`. I described the score as `1 / (1 + distance)` without naming the metric, to avoid documenting something contradictory.
