### PR TITLE
Fix/159 stucture output capturing

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -19,14 +19,14 @@ The issue is that the app's logging (via structlog) isn't wired up to feed into 
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [link to commit documenting the reproduced issue]
+**Reproduction commit link:** https://github.com/harshi-puli/pathreview/tree/fix/159-stucture-output-capturing
 
 **Reproduction summary:**
 I ran `.venv/bin/python -m pytest tests/unit/test_batch_processor.py::TestBatchEmbeddingProcessor::test_empty_chunks_list_returns_empty -q` and confirmed the failure. The captured stdout showed the expected warning log line was actually emitted, but `caplog.text` and `caplog.records` were empty, proving structlog's output never routes through Python's stdlib logging module that `caplog` reads from.
 
-**PLAN.md link:** [link to PLAN.md in your fork]
+**PLAN.md link:** https://github.com/harshi-puli/pathreview/blob/fix/159-stucture-output-capturing/PLAN.md
 
 **Walkthrough video (recommended):** no video.
 
 **Blockers or open questions:**
-[Anything you're still uncertain about going into Week 9, or leave blank]
+Nothing so far.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,20 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/pull/249
+
+**Issue title:** Add an end-to-end agent test using a fully stubbed tool suite
+
+**Tier:** [ ] Tier 1  [ ] Tier 2  [*] Tier 3
+
+**Problem summary:**
+Currently there is no test that completely undergoes the full agent process from planning, execution, and synthesizing without reinstalling live dependencies. This issue description basically wants us to add an integration test that is able to test the agent using a "stub implementation" of the tools while also utilizing a mock LLM.
+
+Currently no file exists within tests/integration/ that allows for testing the agents. The description specifically calls for the existence of the file "test_agent_orchestrator.py."
+
+A successful fix will be able to test the full agent life cycle without needing the live dependencies and only needing stub implementations.
+
+**Branch name:** test/59-Add-an-end-to-end-agent-test
+
+**Setup confirmation:** [*] App runs locally at localhost:5173
+
+**Cohort ledger:** [*] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -16,3 +16,17 @@ The issue is that the app's logging (via structlog) isn't wired up to feed into 
 **Cohort ledger:** [*] Issue added to cohort ledger
 
 **Selection Notes:** The issue checked all the boxes under the is this right for me checklist
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [link to commit documenting the reproduced issue]
+
+**Reproduction summary:**
+I ran `.venv/bin/python -m pytest tests/unit/test_batch_processor.py::TestBatchEmbeddingProcessor::test_empty_chunks_list_returns_empty -q` and confirmed the failure. The captured stdout showed the expected warning log line was actually emitted, but `caplog.text` and `caplog.records` were empty, proving structlog's output never routes through Python's stdlib logging module that `caplog` reads from.
+
+**PLAN.md link:** [link to PLAN.md in your fork]
+
+**Walkthrough video (recommended):** no video.
+
+**Blockers or open questions:**
+[Anything you're still uncertain about going into Week 9, or leave blank]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,20 +1,18 @@
 ## Week 7 — Issue selection
 
-**Issue link:** https://github.com/ascherj/pathreview/pull/249
+**Issue link:** https://github.com/ascherj/pathreview/issues/159
 
-**Issue title:** Add an end-to-end agent test using a fully stubbed tool suite
+**Issue title:** structlog output is not captured by pytest caplog — log assertions fail suite-wide
 
-**Tier:** [ ] Tier 1  [ ] Tier 2  [*] Tier 3
+**Tier:** [*] Tier 1  [ ] Tier 2  [ ] Tier 3
 
 **Problem summary:**
-Currently there is no test that completely undergoes the full agent process from planning, execution, and synthesizing without reinstalling live dependencies. This issue description basically wants us to add an integration test that is able to test the agent using a "stub implementation" of the tools while also utilizing a mock LLM.
+The issue is that the app's logging (via structlog) isn't wired up to feed into Python's standard logging module during test runs. Because of that gap, any test using caplog to check for expected log messages fails, even though the code is correctly producing those log events (you can see them printed to stderr, just not captured by caplog) — test_empty_chunks_list_returns_empty in tests/unit/test_batch_processor.py is one example. The fix involves updating tests/conftest.py to properly configure structlog (using something like structlog.stdlib processors or capture_logs) so its output routes through stdlib logging. Once fixed, caplog-based assertions across the test suite should work correctly and reflect the log events actually emitted by the batch processor and other modules.
 
-Currently no file exists within tests/integration/ that allows for testing the agents. The description specifically calls for the existence of the file "test_agent_orchestrator.py."
-
-A successful fix will be able to test the full agent life cycle without needing the live dependencies and only needing stub implementations.
-
-**Branch name:** test/59-Add-an-end-to-end-agent-test
+**Branch name:** fix/159-stucture-output-capturing
 
 **Setup confirmation:** [*] App runs locally at localhost:5173
 
 **Cohort ledger:** [*] Issue added to cohort ledger
+
+**Selection Notes:** The issue checked all the boxes under the is this right for me checklist

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -30,3 +30,40 @@ I ran `.venv/bin/python -m pytest tests/unit/test_batch_processor.py::TestBatchE
 
 **Blockers or open questions:**
 Nothing so far.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the fix from PLAN.md step 1: added an autouse `configure_structlog_for_tests` fixture to tests/conftest.py that configures structlog with `structlog.stdlib.LoggerFactory()` and `structlog.stdlib.BoundLogger`, ending the processor chain in `ProcessorFormatter.wrap_for_formatter`. Verified `test_empty_chunks_list_returns_empty` now passes, and diffed the full suite's failures before/after the change to confirm no regressions.
+
+**Next steps:**
+Open the PR and address review feedback. Still need to reconcile the self-review checklist, since the repo has pre-existing, unrelated lint errors and unit test failures that make `make check` / `make test-unit` fail suite-wide regardless of this fix.
+
+**Blockers:**
+None specific to this fix. The repo already has ~52 failing unit tests and ~182 lint errors unrelated to structlog/caplog (confirmed present on the branch before my change too), so `make check` / `make test-unit` can't be checked as fully green for the whole suite.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** (https://github.com/ascherj/pathreview/pull/932)
+
+**Branch:** fix/159-stucture-output-capturing
+
+**What you built:**
+An autouse pytest fixture in tests/conftest.py that configures structlog to route through stdlib logging (`LoggerFactory` + `BoundLogger` + `ProcessorFormatter.wrap_for_formatter`) instead of structlog's default `PrintLogger`, which printed straight to stdout and bypassed the `logging` module entirely. This lets `caplog`-based assertions see structlog-emitted log events.
+
+**Tests added or updated:**
+No test files were changed — only tests/conftest.py. The existing repro case, `tests/unit/test_batch_processor.py::test_empty_chunks_list_returns_empty`, now passes unmodified with the new fixture in place.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes — "passes" here means no new failures introduced, per the documented pre-existing baseline below.
+
+**Pre-existing failures (documented):**
+Ran `make check` and `make test-unit` on `main` before making any changes, then again after, and diffed the results:
+- `make test-unit` — before: 53 failed, 375 passed. After: 52 failed, 376 passed. Diffing the failing test names shows exactly one line removed (`test_batch_processor.py::TestBatchEmbeddingProcessor::test_empty_chunks_list_returns_empty`, the issue's repro case) and zero other changes in either direction.
+- `make check` — before: 182 lint errors (fails at the `lint` step, same set of pre-existing ruff findings unrelated to structlog/logging). After: 182 lint errors, byte-identical rule-code lines (confirmed via diff — 161 matching lines, 0 differences).
+- Conclusion: this change fixes the target test and introduces zero new lint or test failures; the pre-existing 52 test failures and 182 lint errors are unrelated to structlog/caplog and out of scope for this issue.
+
+**Draft PR feedback received from:** TF

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -67,3 +67,34 @@ Ran `make check` and `make test-unit` on `main` before making any changes, then 
 - Conclusion: this change fixes the target test and introduces zero new lint or test failures; the pre-existing 52 test failures and 182 lint errors are unrelated to structlog/caplog and out of scope for this issue.
 
 **Draft PR feedback received from:** TF
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No review or comments on PR #932 yet (confirmed via `gh pr view 932` — reviews and comments are both empty as of this writing). TF gave informal feedback pre-PR, but hadn't left anything on the PR itself by the time I checked.
+
+**How you responded:**
+N/A yet — nothing to respond to. Will update this section once a review comes in.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Confirming the fix was actually correct took more work than writing it. The repo already had 52 failing unit tests and 182 lint errors unrelated to this issue, so a naive "did the suite pass?" check would've been meaningless either way. I had to stash my change, capture a clean before/after run of `make test-unit` and `make check`, and diff the exact failure lists to prove my fix changed exactly one thing and nothing else. That habit — always get a before/after diff, not just a pass/fail — was the biggest process lesson.
+
+**What did you learn about working in a large codebase?**
+In your own project, a green test suite is a reasonable bar. In someone else's production codebase, "no new failures" is the actual bar, and you have to go prove that explicitly — you can't just point at `make check` failing and assume it's your fault, but you also can't wave it away without evidence. I also learned to trace a bug to its root cause before touching anything: the real issue wasn't in the test file at all, it was that `configure_logging()` in `core/logging.py` was never being called during tests, so structlog silently fell back to a default that bypassed `logging` entirely.
+
+**How did AI tools help — and where did they fall short?**
+AI was most useful for the mechanical-but-tedious parts: reproducing the failure, tracing why `caplog` came up empty while stdout clearly showed the log line, and running the before/after diffs across two commands instead of eyeballing long test output. It also caught something I would've missed — the `mypy` pre-commit hook failing on a missing return type annotation on the fixture — and fixed it in one pass. Where it fell short was anything requiring my own judgment or memory: it couldn't tell me what TF's actual feedback was, or make the call about whether "82 pre-existing lint errors" was an acceptable baseline to build on top of — that's a decision I had to own.
+
+**What would you do differently if you started over?**
+I'd run the before/after `make check` / `make test-unit` baseline *before* writing any fix, not after — I ended up doing it retroactively to document pre-existing failures, but capturing it up front would have saved a step and given me a cleaner paper trail from the start.
+
+**What are you most proud of from this module?**
+Not the fix itself (it's a small, four-line fixture) — I'm proud of the rigor around it: diffing exact failure sets instead of trusting a pass/fail count, and being able to say with evidence, not just confidence, that the change doesn't make anything worse.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,38 @@
+## Solution plan
+
+**Issue:** [#159 - structlog output is not captured by pytest caplog — log assertions fail suite-wide](https://github.com/ascherj/pathreview/issues/159)
+
+### Understand
+- **Expected:** `caplog`-based assertions (e.g. `assert "Empty chunks list" in caplog.text`) should see log events emitted via `structlog.get_logger()` calls in application code.
+- **Actual:** They fail suite-wide, even though the log line is visibly printed (confirmed by reproducing `test_empty_chunks_list_returns_empty` — `caplog.text` is `''` while stdout shows `2026-07-28 ... [warning] Empty chunks list provided to BatchEmbeddingProcessor`).
+- **Root cause:** [core/logging.py](core/logging.py) defines `configure_logging()`, which wires structlog into the stdlib `logging` module (`logger_factory=structlog.stdlib.LoggerFactory()` + `logging.basicConfig(...)`). But `configure_logging()` is only ever called from [scripts/seed_db.py](scripts/seed_db.py) — it's never invoked during the test session. Without it, structlog falls back to its own default global config: `PrintLoggerFactory` + plain `BoundLogger`, which renders and **prints directly to stdout**, completely bypassing the stdlib `logging` module. Since pytest's `caplog` fixture only captures records that pass through stdlib `logging` handlers, it never sees anything.
+
+### Map
+- [tests/conftest.py](tests/conftest.py) — add an autouse fixture to configure structlog for the test session (currently only has unrelated data fixtures).
+- [core/logging.py](core/logging.py) — reference for the processor chain shape (`configure_logging`); test config should mirror it but route through `ProcessorFormatter` instead of a renderer, and use `structlog.stdlib.BoundLogger` as the wrapper class so log calls reach real `logging.Logger` records.
+- [tests/unit/test_batch_processor.py](tests/unit/test_batch_processor.py) — existing failing test used to verify the fix (`test_empty_chunks_list_returns_empty`); no changes expected here if the fix is done correctly.
+- Any other test file asserting on `caplog` against structlog-emitted logs (grep for `caplog` under `tests/`) should be checked once the fixture is in place.
+
+### Plan
+1. In `tests/conftest.py`, add an autouse, session- or function-scoped fixture (e.g. `configure_structlog_for_tests`) that calls `structlog.configure(...)` with:
+   - `processors=[..., structlog.stdlib.ProcessorFormatter.wrap_for_formatter]` (same pre-processing chain as `core/logging.py`, but ending in `wrap_for_formatter` instead of `ConsoleRenderer`/`JSONRenderer`), so the final message reaches a real stdlib `LogRecord`.
+   - `logger_factory=structlog.stdlib.LoggerFactory()` and `wrapper_class=structlog.stdlib.BoundLogger`, so `structlog.get_logger()` calls proxy into real `logging.Logger` instances.
+   - `cache_logger_on_first_use=False` (or call this fixture with `autouse=True` before any logger is cached) to avoid stale loggers from a prior configuration leaking across tests.
+2. Make sure the fixture doesn't require formatting output to be readable — caplog only needs records to exist on the root/propagated logger; a bare `ProcessorFormatter.wrap_for_formatter` is sufficient without attaching a formatter/handler ourselves, since pytest's own `LogCaptureHandler` is already attached to the root logger.
+3. Restore/reset structlog's configuration after each test (or scope the fixture appropriately) so test-only config doesn't bleed into other test modules or leave global state mutated between runs — use `structlog.reset_defaults()` in fixture teardown, or configure once per session if isolation isn't required.
+4. Run `pytest tests/unit/test_batch_processor.py::TestBatchEmbeddingProcessor::test_empty_chunks_list_returns_empty -q` to confirm it now passes.
+5. Run the full suite (`pytest -q`) to confirm no regressions and that other `caplog`-dependent tests (if any) also pass.
+
+### Inputs & outputs
+- **Input:** structlog log calls made via `structlog.get_logger()` throughout application code under test (e.g. `logger.warning(...)`, `logger.info(...)`).
+- **Output:** Those events become real stdlib `logging.LogRecord`s visible to pytest's `caplog` fixture (`caplog.text`, `caplog.records`), without changing any production logging behavior in `core/logging.py` or requiring test files to switch to `structlog.testing.capture_logs()`.
+
+### Risks & unknowns
+- `cache_logger_on_first_use=True` (used in production config) can cause a logger fetched by one test to keep a stale processor chain if another module configures structlog differently later — need to confirm no other place in the codebase calls `structlog.configure()` during test collection that could race with the conftest fixture.
+- Default caplog capture level is `WARNING` in some pytest versions/configs — need to verify INFO/DEBUG-level structlog calls in other tests (if any) require `caplog.set_level(...)`; this is a pytest-level concern separate from the structlog wiring itself, but worth checking after the fix so the fixture doesn't need a `level=logging.DEBUG` default that's overly broad.
+- Since `configure_logging()` (prod) and the new test fixture both call `structlog.configure(...)` globally, order-of-import between conftest and any code path that might call `configure_logging()` during tests (currently none do) should be double-checked so tests don't accidentally trigger production JSON/console rendering.
+
+### Edge cases
+- Tests that don't use `caplog` at all should be unaffected (no behavior change when the fixture is present but the test doesn't inspect logs).
+- Tests running in parallel (if `pytest-xdist` is used) — structlog global configuration is process-global; confirm this doesn't cause cross-test interference within a worker (should be fine since each worker is a separate process).
+- Log calls using structlog's keyword-argument style (`logger.warning("msg", key=value)`) should still produce a `record.message`/`caplog.text` that contains the original event string, not just the structured kwargs — verify via the existing test's dual assertion (`"Empty chunks list" in caplog.text or any(... in record.message ...)`).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,3 +56,4 @@ services:
 volumes:
   pgdata:
   chromadata:
+  

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,34 @@
 """Shared test fixtures for PathReview."""
 
+from collections.abc import Iterator
+
 import pytest
+import structlog
+
+
+@pytest.fixture(autouse=True)
+def configure_structlog_for_tests() -> Iterator[None]:
+    """Route structlog output through stdlib logging so caplog can see it.
+
+    Without this, structlog uses its own default PrintLogger and never
+    touches the `logging` module that pytest's `caplog` fixture reads from.
+    """
+    structlog.configure(
+        processors=[
+            structlog.stdlib.add_log_level,
+            structlog.stdlib.PositionalArgumentsFormatter(),
+            structlog.processors.TimeStamper(fmt="iso"),
+            structlog.processors.StackInfoRenderer(),
+            structlog.processors.format_exc_info,
+            structlog.processors.UnicodeDecoder(),
+            structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
+        ],
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        wrapper_class=structlog.stdlib.BoundLogger,
+        cache_logger_on_first_use=False,
+    )
+    yield
+    structlog.reset_defaults()
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
structlog was never wired into Python's stdlib logging module during test runs, so pytest's caplog fixture couldn't see any log events emitted through structlog.get_logger() — even though the messages were visibly printed to stdout. This caused caplog-based assertions to fail suite-wide (e.g. test_empty_chunks_list_returns_empty in tests/unit/test_batch_processor.py). This PR adds an autouse pytest fixture that configures structlog to route through stdlib logging for the duration of the test session, so caplog correctly captures structlog-emitted events without changing any production logging behavior.

## Issue
Closes #159 

## Changes
<!-- Bullet list of the specific changes made -->

- Added an autouse configure_structlog_for_tests fixture to tests/conftest.py that configures structlog with structlog.stdlib.LoggerFactory() and structlog.stdlib.BoundLogger, ending the processor chain in structlog.stdlib.ProcessorFormatter.wrap_for_formatter instead of a renderer — so log calls become real logging.LogRecords that pytest's caplog handler already listens for.
- Fixture resets structlog's configuration on teardown (structlog.reset_defaults()) so the test-only config doesn't leak into other contexts.
- No changes to production logging config in core/logging.py.

## Testing
 
- [ ] Unit tests pass (make test-unit) — test_empty_chunks_list_returns_empty now passes; verified via a before/after diff of the full suite's failures that this change fixes exactly that one test and introduces zero new failures (52 pre-existing, unrelated failures are present identically before and after this change)

 

- [ ] Integration tests pass (make test-integration) — not run (no Docker services available in this environment; change is test-config-only and doesn't touch integration paths)

 

- [ ] Linter passes (make lint) — tests/conftest.py is ruff-clean; repo-wide make lint still reports pre-existing, unrelated errors

 

- [ ] Type checker passes (make typecheck) — no new mypy errors introduced by this change

- [ ]  New/updated tests cover the changes — no new tests needed; the existing repro case now passes unmodified, which is the direct verification for this fix

## Screenshots / Demo
NA

## Notes for Reviewers
Nona
