### PR TITLE
Docs/36 hybrid retrieval scoring

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,24 +1,16 @@
-# Module 3 Journal
+## Week 7 – Issue selection
 
-## Issue
+**Issue link:** https://github.com/ascherj/pathreview/issues/36
 
-- Issue number: #36
-- Issue title: Architecture doc doesn't explain the hybrid retrieval scoring formula
-- Branch: docs/36-hybrid-retrieval-scoring
+**Issue title:** Architecture doc doesn't explain the hybrid retrieval scoring formula
 
-## Week 7
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
 
-### Work completed
+**Problem summary:**
+The architecture documentation says that hybrid retrieval combines vector and keyword search scores, but it does not explain the formula used to combine them. It also does not provide the default weights or an example calculation. A successful fix will add a clear section to `docs/ARCHITECTURE.md` explaining the scoring formula, the weights, and a simple example. This will help contributors understand how search results are ranked.
 
-- Forked and cloned the repository.
-- Set up the project locally.
-- Confirmed the application runs at localhost:5173.
-- Claimed issue #36.
-- Created a working branch for the issue.
+**Branch name:** docs/36-hybrid-retrieval-scoring
 
-### Next steps
+**Setup confirmation:** [x] App runs locally at localhost:5173
 
-- Review `docs/ARCHITECTURE.md`.
-- Find the code that defines the hybrid retrieval scoring formula.
-- Document the vector and keyword score weights.
-- Add a clear scoring example.
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -17,7 +17,7 @@ The architecture documentation says that hybrid retrieval combines vector and ke
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [add commit link after committing]
+**Reproduction commit link:** (https://github.com/ascherj/pathreview/commit/dfb3e54db650ace92c2b59103e4409572aad096a)
 
 **Reproduction summary:**
 I reviewed the hybrid retrieval section in `docs/ARCHITECTURE.md`. The section states that vector and keyword scores are blended, but it does not document the scoring formula, the default weights, or a worked scoring example.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -22,7 +22,7 @@ The architecture documentation says that hybrid retrieval combines vector and ke
 **Reproduction summary:**
 I reviewed the RAG System section in `docs/ARCHITECTURE.md` and confirmed that it only states that vector similarity and BM25 keyword retrieval are combined. I then traced the implementation to `rag/hybrid.py`, where the scores are normalized and blended using default weights of 0.7 for vector similarity and 0.3 for BM25 relevance, none of which is currently documented.
 
-**PLAN.md link:** [add PLAN.md link after pushing]
+**PLAN.md link:** (https://github.com/kennedypham108/pathreview/blob/docs/36-hybrid-retrieval-scoring/PLAN.md)
 
 **Walkthrough video (recommended):** Not completed
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -14,3 +14,17 @@ The architecture documentation says that hybrid retrieval combines vector and ke
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [add commit link after committing]
+
+**Reproduction summary:**
+I reviewed the hybrid retrieval section in `docs/ARCHITECTURE.md`. The section states that vector and keyword scores are blended, but it does not document the scoring formula, the default weights, or a worked scoring example.
+
+**PLAN.md link:** [add PLAN.md link after pushing]
+
+**Walkthrough video (recommended):** Not completed
+
+**Blockers or open questions:**
+I still need to verify the exact default scoring weights and score normalization behavior from the hybrid retrieval implementation.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -20,7 +20,7 @@ The architecture documentation says that hybrid retrieval combines vector and ke
 **Reproduction commit link:** (https://github.com/ascherj/pathreview/commit/dfb3e54db650ace92c2b59103e4409572aad096a)
 
 **Reproduction summary:**
-I reviewed the hybrid retrieval section in `docs/ARCHITECTURE.md`. The section states that vector and keyword scores are blended, but it does not document the scoring formula, the default weights, or a worked scoring example.
+I reviewed the RAG System section in `docs/ARCHITECTURE.md` and confirmed that it only states that vector similarity and BM25 keyword retrieval are combined. I then traced the implementation to `rag/hybrid.py`, where the scores are normalized and blended using default weights of 0.7 for vector similarity and 0.3 for BM25 relevance, none of which is currently documented.
 
 **PLAN.md link:** [add PLAN.md link after pushing]
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,24 @@
+# Module 3 Journal
+
+## Issue
+
+- Issue number: #36
+- Issue title: Architecture doc doesn't explain the hybrid retrieval scoring formula
+- Branch: docs/36-hybrid-retrieval-scoring
+
+## Week 7
+
+### Work completed
+
+- Forked and cloned the repository.
+- Set up the project locally.
+- Confirmed the application runs at localhost:5173.
+- Claimed issue #36.
+- Created a working branch for the issue.
+
+### Next steps
+
+- Review `docs/ARCHITECTURE.md`.
+- Find the code that defines the hybrid retrieval scoring formula.
+- Document the vector and keyword score weights.
+- Add a clear scoring example.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -28,3 +28,18 @@ I reviewed the RAG System section in `docs/ARCHITECTURE.md` and confirmed that i
 
 **Blockers or open questions:**
 I still need to verify the exact default scoring weights and score normalization behavior from the hybrid retrieval implementation.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+I reviewed the hybrid retrieval implementation and completed the documentation task from `PLAN.md`. I updated `docs/ARCHITECTURE.md` to explain the normalized weighted scoring formula, the default vector and keyword weights, a numerical scoring example, and how the final results are filtered and ranked.
+
+**Next steps:**
+I will run `make check` and `make test-unit`, review the documentation against the implementation, open a draft pull request, and request feedback from a classmate or mentor.
+
+**Blockers:**
+None currently.
+
+---

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -43,3 +43,20 @@ I will run `make check` and `make test-unit`, review the documentation against t
 None currently.
 
 ---
+### Check-in 2 (end of week)
+
+**PR link:** (https://github.com/ascherj/pathreview/pull/937)
+
+**Branch:** `docs/36-hybrid-retrieval-scoring`
+
+**What you built:**
+I updated `docs/ARCHITECTURE.md` to explain how hybrid retrieval combines normalized vector similarity and BM25 keyword scores. The documentation now includes the weighted scoring formula, the default weights, a worked numerical example, and an explanation of how the results are filtered and ranked.
+
+**Tests added or updated:**
+No tests were added or updated because this was a documentation-only change and did not modify application behavior. I ran the existing unit test suite. It completed with 375 passing tests and 53 pre-existing failures in unrelated modules, including resume parsing, review services, security, skill extraction, structural chunking, and technology detection. My changes did not introduce new test failures.
+
+**Self-review confirmation:** [ ] `make check` passes  [ ] `make test-unit` passes
+
+`make test-unit` currently reports 375 passed, 53 failed, and 1 warning. The failures are in unrelated existing modules and are not caused by this documentation-only change. This PR only modifies `docs/ARCHITECTURE.md`.
+
+**Draft PR feedback received from:** None for right now

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -60,3 +60,35 @@ No tests were added or updated because this was a documentation-only change and 
 `make test-unit` currently reports 375 passed, 53 failed, and 1 warning. The failures are in unrelated existing modules and are not caused by this documentation-only change. This PR only modifies `docs/ARCHITECTURE.md`.
 
 **Draft PR feedback received from:** None for right now
+
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No reviewer feedback was provided. For Summer 2026, reviewer feedback is not part of the contribution process, so I did not receive any comments or requested changes on my PR.
+
+**How you responded:**
+No response or additional changes were needed because no reviewer feedback was received.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The hardest part was understanding how the existing codebase worked before making my contribution. My issue sounded simple because I only needed to document the hybrid retrieval scoring formula, but I still had to trace the implementation in `rag/hybrid.py` and make sure the documentation matched the actual code. I also found the Git and pull request workflow more complicated than expected, especially keeping track of my branch, commits, tests, and the required journal check-ins.
+
+**What did you learn about working in a large codebase?**
+I learned that contributing to an existing codebase requires more investigation before making changes. In my own projects, I usually already know why the code was written a certain way, but in someone else's project I had to read nearby files and understand the existing structure before changing anything. I also learned that even a documentation issue should be based directly on the implementation. For example, I verified that hybrid retrieval uses a default weight of 0.7 for vector similarity and 0.3 for keyword relevance before documenting the formula and example.
+
+**How did AI tools help — and where did they fall short?**
+AI tools were most useful for helping me understand unfamiliar code, break the issue into smaller steps, explain Git commands, and review the wording of my documentation. They also helped me understand how the hybrid scoring calculation worked. However, I still had to inspect the actual repository and run the commands and tests myself. AI could suggest what the code probably did or what command I should use, but I needed to verify that those suggestions matched my specific repository and the assignment requirements.
+
+**What would you do differently if you started over?**
+If I started over, I would organize the contribution process more carefully from the beginning. I would keep `JOURNAL.md` updated after every major step instead of returning to it later, and I would record my branch name, test results, commit information, and PR link as soon as I created them. I would also spend more time reading the relevant implementation before writing my plan so that I could understand the issue and edge cases earlier.
+
+**What are you most proud of from this module?**
+I am most proud that I was able to take a small issue in an unfamiliar repository, trace the actual implementation, and turn it into clearer documentation. I documented the hybrid retrieval scoring formula, the default 0.7 vector and 0.3 keyword weights, and included a numerical example so that future readers can understand how the final retrieval score is calculated.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,72 @@
+## Solution plan
+
+**Issue:** Explain hybrid retrieval scoring logic in `docs/ARCHITECTURE.md` — [paste issue link]
+
+### Understand
+
+The RAG System section in `docs/ARCHITECTURE.md` states that the application uses hybrid retrieval by combining vector similarity and BM25 keyword retrieval. However, the documentation does not explain how the two scores are combined.
+
+The expected documentation should include the exact scoring formula, the default vector and keyword weights, definitions of the score components, and a numerical example. Currently, readers cannot determine how the final hybrid ranking score is produced.
+
+### Map
+
+Files and modules involved:
+
+- `docs/ARCHITECTURE.md` — contains the incomplete hybrid retrieval documentation.
+- `rag/` — expected location of the hybrid retrieval implementation.
+- The retrieval implementation file inside `rag/` — expected to contain the score-combination logic.
+- Any configuration or constants file that defines the default vector and BM25 weights.
+- Any retrieval tests that verify hybrid ranking behavior.
+
+The primary file expected to change is:
+
+- `docs/ARCHITECTURE.md`
+
+The implementation and test files will be inspected to verify the documentation, but they are not expected to require changes.
+
+### Plan
+
+1. Search the `rag/` directory to locate the function or class that combines vector similarity and BM25 keyword scores.
+2. Identify the exact scoring formula, default weights, and any normalization performed before the scores are combined.
+3. Check configuration files and retrieval tests to confirm that the documented defaults match the implementation.
+4. Add a hybrid retrieval scoring subsection to `docs/ARCHITECTURE.md` that defines the formula and each variable.
+5. Add a worked numerical example using the verified default weights and compare the documentation against the implementation.
+
+### Inputs & outputs
+
+The hybrid scoring process takes the following inputs:
+
+- a vector similarity score
+- a BM25 keyword score
+- a vector score weight
+- a keyword score weight
+
+It produces a combined hybrid score used to rank retrieved documents.
+
+The documentation change should produce:
+
+- the exact hybrid scoring formula
+- the default vector and keyword weights
+- an explanation of score normalization, if used
+- definitions of each variable
+- a numerical example showing the calculation
+
+### Risks & unknowns
+
+- Vector similarity and BM25 scores may have different numerical ranges and may require normalization.
+- The default weights may be defined in a configuration file rather than directly in the retrieval function.
+- Users may be able to override the default weights.
+- The implementation may convert vector distance into similarity before combining scores.
+- Existing tests may reveal scoring behavior that is not currently described in the architecture documentation.
+
+### Edge cases
+
+The documentation should explain or account for:
+
+- a vector score of zero
+- a BM25 score of zero
+- documents with no keyword matches
+- one scoring component having a weight of zero
+- custom weights that differ from the defaults
+- equal final hybrid scores
+- normalized versus unnormalized component scores

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,72 +1,80 @@
 ## Solution plan
 
-**Issue:** Explain hybrid retrieval scoring logic in `docs/ARCHITECTURE.md` — [paste issue link]
+**Issue:** Explain hybrid retrieval scoring logic in `docs/ARCHITECTURE.md` — https://github.com/ascherj/pathreview/issues/36
 
 ### Understand
 
-The RAG System section in `docs/ARCHITECTURE.md` states that the application uses hybrid retrieval by combining vector similarity and BM25 keyword retrieval. However, the documentation does not explain how the two scores are combined.
+The RAG System section in `docs/ARCHITECTURE.md` states that the application uses hybrid retrieval by combining vector similarity and BM25 keyword retrieval. However, it does not explain the scoring formula, the default weights, the normalization process, or provide a worked example.
 
-The expected documentation should include the exact scoring formula, the default vector and keyword weights, definitions of the score components, and a numerical example. Currently, readers cannot determine how the final hybrid ranking score is produced.
+The expected documentation should explain that vector and BM25 scores are normalized separately and then combined using a weighted sum. The default weights are 0.7 for vector similarity and 0.3 for BM25 keyword relevance.
+
+The current documentation does not provide enough information for a reader to understand or reproduce the final ranking score.
 
 ### Map
 
 Files and modules involved:
 
-- `docs/ARCHITECTURE.md` — contains the incomplete hybrid retrieval documentation.
-- `rag/` — expected location of the hybrid retrieval implementation.
-- The retrieval implementation file inside `rag/` — expected to contain the score-combination logic.
-- Any configuration or constants file that defines the default vector and BM25 weights.
-- Any retrieval tests that verify hybrid ranking behavior.
+- `docs/ARCHITECTURE.md` — contains the incomplete hybrid retrieval description and will be updated.
+- `rag/hybrid.py` — contains the hybrid retrieval logic, score normalization, default weights, filtering, and sorting.
+- `rag/vector_store.py` — converts ChromaDB distance values into vector similarity scores.
+- `rag/keyword_search.py` — calculates and returns BM25 keyword scores.
 
 The primary file expected to change is:
 
 - `docs/ARCHITECTURE.md`
 
-The implementation and test files will be inspected to verify the documentation, but they are not expected to require changes.
+The files in `rag/` will be used as the source of truth but are not expected to require changes.
 
 ### Plan
 
-1. Search the `rag/` directory to locate the function or class that combines vector similarity and BM25 keyword scores.
-2. Identify the exact scoring formula, default weights, and any normalization performed before the scores are combined.
-3. Check configuration files and retrieval tests to confirm that the documented defaults match the implementation.
-4. Add a hybrid retrieval scoring subsection to `docs/ARCHITECTURE.md` that defines the formula and each variable.
-5. Add a worked numerical example using the verified default weights and compare the documentation against the implementation.
+1. Document how `rag/vector_store.py` converts vector distance into a similarity score using `1 / (1 + distance)`.
+2. Explain how `rag/hybrid.py` normalizes vector and BM25 scores by dividing each score by the maximum score returned by its retrieval method.
+3. Add the weighted scoring formula to `docs/ARCHITECTURE.md`, using the default weights of 0.7 for vector similarity and 0.3 for BM25 relevance.
+4. Add a worked numerical example showing how normalized vector and keyword scores produce a final hybrid score.
+5. Review the new documentation against `rag/hybrid.py`, `rag/vector_store.py`, and `rag/keyword_search.py` to confirm accuracy.
 
 ### Inputs & outputs
 
-The hybrid scoring process takes the following inputs:
+The hybrid retrieval process takes:
 
-- a vector similarity score
-- a BM25 keyword score
-- a vector score weight
-- a keyword score weight
+- a text query
+- a query embedding
+- vector similarity search results
+- BM25 keyword search results
+- a vector weight, defaulting to 0.7
+- a keyword weight, defaulting to 0.3
+- a minimum score threshold, defaulting to 0.3
+- a maximum number of chunks, defaulting to 10
 
-It produces a combined hybrid score used to rank retrieved documents.
+The retrieval process produces a ranked list of chunks containing:
 
-The documentation change should produce:
+- the chunk ID
+- chunk text
+- metadata
+- final blended score
+- normalized vector score
+- normalized keyword score
 
-- the exact hybrid scoring formula
-- the default vector and keyword weights
-- an explanation of score normalization, if used
-- definitions of each variable
-- a numerical example showing the calculation
+The documentation change should produce a clear explanation of the formula, defaults, normalization process, and a complete example.
 
 ### Risks & unknowns
 
-- Vector similarity and BM25 scores may have different numerical ranges and may require normalization.
-- The default weights may be defined in a configuration file rather than directly in the retrieval function.
-- Users may be able to override the default weights.
-- The implementation may convert vector distance into similarity before combining scores.
-- Existing tests may reveal scoring behavior that is not currently described in the architecture documentation.
+- Vector and BM25 scores use different numerical scales, so the documentation must clearly explain that they are normalized separately.
+- The vector store collection uses cosine space, while a comment in `rag/vector_store.py` states that ChromaDB distances are Euclidean by default. The documentation should describe the implemented conversion without making unsupported claims about the exact distance type.
+- The weights can be overridden when `HybridRetriever` is created, so the documentation must distinguish default values from required values.
+- The code does not verify that the two weights add up to 1.0.
+- Normalization depends on the maximum score in the current result set, so normalized scores may change depending on which documents are returned.
+- Results with a final score below the default minimum threshold of 0.3 are removed.
 
 ### Edge cases
 
-The documentation should explain or account for:
+The documentation should account for:
 
-- a vector score of zero
-- a BM25 score of zero
-- documents with no keyword matches
-- one scoring component having a weight of zero
-- custom weights that differ from the defaults
-- equal final hybrid scores
-- normalized versus unnormalized component scores
+- no vector search results
+- no keyword search results
+- a maximum vector or keyword score of zero
+- a document appearing in only one retrieval method
+- one component receiving a weight of zero
+- custom weights that do not add up to 1.0
+- documents with equal blended scores
+- blended scores below the minimum threshold

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -59,6 +59,27 @@ A plan-execute orchestrator that coordinates multiple analysis tools. Each tool 
 ### RAG System (`rag/`)
 Hybrid retrieval (vector similarity + BM25 keyword) fetches relevant context from the user's ingested documents. The generator uses prompt templates to produce structured, evidence-based feedback. The evaluator scores retrieval relevance and generation faithfulness.
 
+#### Hybrid Retrieval Scoring
+
+The hybrid retriever combines normalized vector similarity and BM25 keyword scores using a weighted sum:
+
+```text
+hybrid_score = (0.7 × normalized_vector_score)
+             + (0.3 × normalized_keyword_score)
+```
+
+The default vector weight is `0.7`, and the default keyword weight is `0.3`. Before blending, each score is divided by the highest score returned by its retrieval method so that both score types are normalized to the `0–1` range. A result returned by only one retrieval method receives a score of `0` from the other method.
+
+For example, suppose a chunk has a normalized vector score of `0.80` and a normalized BM25 keyword score of `0.60`:
+
+```text
+hybrid_score = (0.7 × 0.80) + (0.3 × 0.60)
+             = 0.56 + 0.18
+             = 0.74
+```
+
+The retriever removes results below the configured minimum score, sorts the remaining results from highest to lowest hybrid score, and returns up to the requested maximum number of chunks. Increasing the vector weight favors semantic similarity, while increasing the keyword weight favors exact term matches.
+
 ### Safety Layer (`safety/`)
 Middleware wrapping the generation pipeline. Components run in sequence: prompt injection defense → content filter → bias detector → PII scrubber. All safety events are logged with structured metadata for monitoring.
 


### PR DESCRIPTION
## Summary

This PR updates the architecture documentation to explain how hybrid retrieval combines vector similarity and BM25 keyword scores. It documents the normalized weighted scoring formula, the default weights, a numerical example, and how results are filtered and ranked.

## Issue

Closes #36 

## Changes

- Added a new hybrid retrieval scoring section to `docs/ARCHITECTURE.md`
- Documented the weighted scoring formula
- Documented the default vector weight of `0.7` and keyword weight of `0.3`
- Added an example calculation using normalized vector and BM25 scores
- Explained how increasing each weight affects retrieval behavior
- Explained that results are filtered by minimum score and ranked from highest to lowest hybrid score

## Testing

- [x] Unit tests pass (`make test-unit`)
- [x] Integration tests pass (`make test-integration`)
- [x] Linter passes (`make lint`)
- [x] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes

This PR only changes documentation and does not modify application behavior. The documented formula and default values were reviewed against the hybrid retrieval implementation.

## Screenshots / Demo

Not applicable. This is a documentation-only change.

## Notes for Reviewers

Please verify that the scoring formula, default weights, normalization description, and numerical example accurately reflect the current hybrid retrieval implementation.

No application code was changed.