### PR TITLE
fix(api): populate safety_events_last_hour in /health from SafetyMonitor

### DIFF
--- a/api/routes/health.py
+++ b/api/routes/health.py
@@ -1,6 +1,7 @@
-from fastapi import APIRouter, HTTPException, status, Depends
+from datetime import datetime
+
 import structlog
-from datetime import datetime, timedelta
+from fastapi import APIRouter, Depends, HTTPException, status
 
 from core.database import get_db
 
@@ -39,6 +40,7 @@ async def health_check(db=Depends(get_db)):
     try:
         # Check Redis (if available)
         import redis
+
         from core.config import settings
 
         r = redis.Redis(
@@ -72,12 +74,24 @@ async def health_check(db=Depends(get_db)):
         health_status["dependencies"]["vector_db"] = "unhealthy"
         health_status["status"] = "unhealthy"
 
-    # Count safety events in last hour (placeholder)
+    # Count safety events via SafetyMonitor. A failure here must not take down the
+    # whole health check, so it degrades to 0 and logs rather than raising.
     try:
-        # This would be populated by actual safety event logging
-        health_status["safety_events_last_hour"] = 0
+        import redis
+
+        from core.config import settings
+        from safety.monitoring import SafetyMonitor
+
+        safety_redis = redis.Redis.from_url(
+            settings.redis_url,
+            decode_responses=True,
+        )
+        monitor = SafetyMonitor(safety_redis)
+        health_status["safety_events_last_hour"] = monitor.get_total_event_count()
+        log.debug("safety_events_check_passed")
     except Exception as exc:
         log.error("safety_events_check_failed", error=str(exc))
+        health_status["safety_events_last_hour"] = 0
 
     # Return 503 if any critical dependency is down
     if health_status["status"] == "unhealthy":

--- a/safety/monitoring.py
+++ b/safety/monitoring.py
@@ -1,8 +1,9 @@
 """Safety event monitoring."""
 
+from datetime import datetime
+
 import redis
 import structlog
-from datetime import datetime, timedelta
 
 logger = structlog.get_logger()
 
@@ -16,7 +17,7 @@ class SafetyMonitor:
         "injection_attempt",
         "content_filtered",
         "bias_detected",
-        "rate_limited"
+        "rate_limited",
     }
 
     def __init__(self, redis_client: redis.Redis):
@@ -72,3 +73,27 @@ class SafetyMonitor:
         except Exception as e:
             logger.error("event_count_error", event_type=event_type, error=str(e))
             return 0
+
+    def get_total_event_count(self, window_hours: int = 1) -> int:
+        """Get the total count of safety events across all event types.
+
+        Sums the per-type counts for every value in ``VALID_EVENT_TYPES``. This
+        backs the ``safety_events_last_hour`` field on the ``/health`` endpoint so
+        operators can see aggregate safety activity in one number.
+
+        Note: the per-type counters are rolling counters with a 24-hour Redis TTL,
+        so ``window_hours`` is not strictly enforced here (same limitation already
+        documented on ``get_event_count``).
+
+        Args:
+            window_hours: Time window in hours (passed through for reference).
+
+        Returns:
+            Total number of safety events across all valid event types. Individual
+            per-type read failures are already handled by ``get_event_count`` (which
+            returns 0), so this method never raises on a Redis error.
+        """
+        return sum(
+            self.get_event_count(event_type, window_hours=window_hours)
+            for event_type in self.VALID_EVENT_TYPES
+        )

--- a/tests/unit/test_health_safety_events_reproduction.py
+++ b/tests/unit/test_health_safety_events_reproduction.py
@@ -104,3 +104,32 @@ def test_health_endpoint_reports_recorded_safety_events() -> None:
 
     # The endpoint now surfaces the recorded events instead of a hardcoded 0.
     assert health["safety_events_last_hour"] == recorded
+
+
+@pytest.mark.unit
+def test_health_degrades_gracefully_when_safety_redis_unavailable() -> None:
+    """Failure-path integration test: if Redis is down during the safety-event
+    read, the endpoint degrades gracefully.
+
+    The safety-event read must not propagate its error out of the endpoint; instead
+    ``safety_events_last_hour`` falls back to 0. (The payload is returned via the
+    503 detail here only because of a pre-existing, unrelated bug in the Redis
+    *dependency* check; the point of this test is that the safety metric degrades to
+    0 rather than crashing the handler.)
+    """
+    from fastapi import HTTPException
+
+    async def run() -> dict:
+        # Simulate Redis being unavailable when the endpoint builds its client.
+        with patch("redis.Redis.from_url", side_effect=ConnectionError("redis down")):
+            try:
+                return await health_mod.health_check(db=FakeDB())
+            except HTTPException as exc:
+                return exc.detail
+
+    health = asyncio.run(run())
+
+    # Reaching this line at all proves the ConnectionError did not propagate out of
+    # the endpoint (it would have surfaced as an unhandled error, not an
+    # HTTPException). The metric degrades to 0.
+    assert health["safety_events_last_hour"] == 0

--- a/tests/unit/test_health_safety_events_reproduction.py
+++ b/tests/unit/test_health_safety_events_reproduction.py
@@ -1,0 +1,106 @@
+"""Regression tests for issue #68 — safety event count on the health check endpoint.
+
+Issue: https://github.com/ascherj/pathreview/issues/68
+
+Background
+----------
+The ``/health`` endpoint used to hardcode ``safety_events_last_hour`` to ``0`` and
+never consult ``SafetyMonitor`` (the class that records safety events in Redis), so
+the field never reflected real activity. This file started as the reproduction for
+that bug; the fix wires the endpoint to ``SafetyMonitor.get_total_event_count()``,
+and these tests now guard against a regression:
+
+    * ``test_safety_monitor_actually_counts_events`` -- SafetyMonitor records events
+      and can count them back.
+    * ``test_health_endpoint_reports_recorded_safety_events`` -- the endpoint reports
+      the recorded count instead of a hardcoded 0.
+"""
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+
+from api.routes import health as health_mod
+from safety.monitoring import SafetyMonitor
+
+
+class FakeRedis:
+    """Minimal in-memory stand-in for Redis (counters + ping)."""
+
+    def __init__(self) -> None:
+        self.store: dict[str, int] = {}
+
+    def incr(self, key: str) -> int:
+        self.store[key] = self.store.get(key, 0) + 1
+        return self.store[key]
+
+    def expire(self, key: str, seconds: int) -> None:
+        pass
+
+    def get(self, key: str):
+        return self.store.get(key)
+
+    def ping(self) -> bool:
+        return True
+
+
+class FakeDB:
+    """Async DB stub so the endpoint's ``await db.execute(...)`` succeeds."""
+
+    async def execute(self, query):
+        return None
+
+
+def _call_health(shared_redis: FakeRedis) -> dict:
+    """Invoke the real health endpoint and return its status dict.
+
+    Dependency health is irrelevant to this bug, so if the endpoint raises a 503
+    we still return the payload (it is attached to the HTTPException's ``detail``).
+    ``redis.Redis.from_url`` is patched to return ``shared_redis`` so the endpoint
+    reads the same counters the test recorded events into.
+    """
+    from fastapi import HTTPException
+
+    async def run() -> dict:
+        with patch("redis.Redis.from_url", return_value=shared_redis):
+            try:
+                return await health_mod.health_check(db=FakeDB())
+            except HTTPException as exc:
+                return exc.detail  # payload still contains safety_events_last_hour
+
+    return asyncio.run(run())
+
+
+@pytest.mark.unit
+def test_safety_monitor_actually_counts_events() -> None:
+    """The data exists: SafetyMonitor records safety events and counts them back."""
+    redis = FakeRedis()
+    monitor = SafetyMonitor(redis)
+
+    monitor.log_event("pii_detected", {"field": "email"})
+    monitor.log_event("injection_attempt", {"pattern": "ignore previous"})
+    monitor.log_event("pii_detected", {"field": "phone"})
+
+    total = sum(monitor.get_event_count(t) for t in SafetyMonitor.VALID_EVENT_TYPES)
+    assert total == 3
+
+
+@pytest.mark.unit
+def test_health_endpoint_reports_recorded_safety_events() -> None:
+    """After safety events are recorded, /health reports them (not 0).
+
+    Was the reproduction for issue #68 (previously xfail); now a regression test
+    that passes because the endpoint reads the count from SafetyMonitor.
+    """
+    shared_redis = FakeRedis()
+    monitor = SafetyMonitor(shared_redis)
+    monitor.log_event("pii_detected", {"field": "email"})
+    monitor.log_event("injection_attempt", {"pattern": "ignore previous"})
+    recorded = sum(monitor.get_event_count(t) for t in SafetyMonitor.VALID_EVENT_TYPES)
+    assert recorded == 2  # precondition: two real safety events exist
+
+    health = _call_health(shared_redis)
+
+    # The endpoint now surfaces the recorded events instead of a hardcoded 0.
+    assert health["safety_events_last_hour"] == recorded

--- a/tests/unit/test_monitoring.py
+++ b/tests/unit/test_monitoring.py
@@ -1,0 +1,75 @@
+"""Tests for safety/monitoring.py (SafetyMonitor)."""
+
+from unittest.mock import Mock
+
+import pytest
+
+from safety.monitoring import SafetyMonitor
+
+
+class FakeRedis:
+    """Minimal in-memory Redis stand-in supporting the counter operations used."""
+
+    def __init__(self) -> None:
+        self.store: dict[str, int] = {}
+
+    def incr(self, key: str) -> int:
+        self.store[key] = self.store.get(key, 0) + 1
+        return self.store[key]
+
+    def expire(self, key: str, seconds: int) -> None:
+        pass
+
+    def get(self, key: str):
+        return self.store.get(key)
+
+
+@pytest.mark.unit
+class TestSafetyMonitor:
+    """Test suite for SafetyMonitor, focused on get_total_event_count."""
+
+    @pytest.fixture
+    def redis(self) -> FakeRedis:
+        return FakeRedis()
+
+    @pytest.fixture
+    def monitor(self, redis: FakeRedis) -> SafetyMonitor:
+        return SafetyMonitor(redis)
+
+    def test_total_is_zero_when_no_events(self, monitor: SafetyMonitor) -> None:
+        """With no events recorded, the total is 0 (not an error)."""
+        assert monitor.get_total_event_count() == 0
+
+    def test_total_sums_across_event_types(self, monitor: SafetyMonitor) -> None:
+        """The total sums counts across all event types, not just one."""
+        monitor.log_event("pii_detected", {"field": "email"})
+        monitor.log_event("pii_detected", {"field": "phone"})
+        monitor.log_event("injection_attempt", {"pattern": "ignore previous"})
+        monitor.log_event("rate_limited", {"ip": "1.2.3.4"})
+
+        # 2 pii_detected + 1 injection_attempt + 1 rate_limited = 4
+        assert monitor.get_total_event_count() == 4
+
+    def test_total_ignores_unknown_event_types(self, monitor: SafetyMonitor) -> None:
+        """Events with unknown types are dropped by log_event and not counted."""
+        monitor.log_event("pii_detected", {"field": "email"})
+        monitor.log_event("not_a_real_event", {"foo": "bar"})  # rejected
+
+        assert monitor.get_total_event_count() == 1
+
+    def test_total_defaults_to_zero_on_redis_error(self) -> None:
+        """A Redis read failure degrades to 0 rather than raising."""
+        broken_redis = Mock()
+        broken_redis.get = Mock(side_effect=ConnectionError("redis down"))
+        monitor = SafetyMonitor(broken_redis)
+
+        # get_event_count swallows the error per key and returns 0, so the sum is 0.
+        assert monitor.get_total_event_count() == 0
+
+    def test_single_type_count(self, monitor: SafetyMonitor) -> None:
+        """get_event_count returns the count for one event type."""
+        monitor.log_event("bias_detected", {"score": 0.9})
+        monitor.log_event("bias_detected", {"score": 0.8})
+
+        assert monitor.get_event_count("bias_detected") == 2
+        assert monitor.get_event_count("pii_detected") == 0


### PR DESCRIPTION
## Summary
The `/health` endpoint exposed a `safety_events_last_hour` field, but it was hardcoded to `0` and never consulted `SafetyMonitor` (the class that records safety events in Redis). This PR wires the endpoint to real data so operators can see aggregate safety activity directly from the health check.

## Issue
Closes #68

## Changes
- Added `SafetyMonitor.get_total_event_count(window_hours=1)` in `safety/monitoring.py`, which sums the per-type counters across all `VALID_EVENT_TYPES`.
- Updated `api/routes/health.py` to compute `safety_events_last_hour` from `SafetyMonitor.get_total_event_count()` instead of a hardcoded `0`. The read is wrapped in a `try/except` so a Redis failure degrades to `0` and logs, rather than failing the whole health check.
- Added `tests/unit/test_monitoring.py` covering the new method (no events, summed across types, unknown types ignored, Redis error → 0, single-type count).
- Converted the issue-#68 reproduction (`tests/unit/test_health_safety_events_reproduction.py`) from an `xfail` into a passing regression test.

## Testing
- [x] Unit tests pass (`make test-unit`) — see note on pre-existing failures below
- [ ] Integration tests pass (`make test-integration`) — not run (require Docker services)
- [x] Linter passes (`make lint`) — my changed files are ruff-clean; repo has pre-existing lint errors (see note)
- [ ] Type checker passes (`make typecheck`) — `mypy` cannot run in this environment (numpy stubs require a newer Python); pre-existing, unrelated to this change
- [x] New/updated tests cover the changes

## Screenshots / Demo
N/A (API/monitoring change). The regression test demonstrates the behavior: after recording safety events, `/health` reports the count instead of `0`.

## Notes for Reviewers
**Pre-existing failures (this change does not affect them):** Before any changes, `make test-unit` reported **53 failed / 376 passed** across 16 unrelated test files, and `make lint` reported **183 errors**. After this change, `make test-unit` reports **53 failed / 382 passed** — the same 53 pre-existing failures, plus 6 new passing tests from this PR. There are **no new failures**, and no failures in the files I touched (`health`, `monitoring`).

**Scope note:** While wiring this up I noticed the *existing* Redis dependency check in `health.py` references `settings.redis_host` / `settings.redis_port`, which don't exist (the config defines `redis_url`). That's a separate pre-existing bug; I used `redis.Redis.from_url(settings.redis_url, ...)` in my new code but left the existing check alone to keep this PR scoped to #68.

**Design note ("last hour"):** The issue names the field `safety_events_last_hour`, but the underlying counters are rolling counters with a 24-hour TTL (`window_hours` was already documented as "not enforced"). For this Tier-1 scope I summed the existing counters and documented the limitation in the docstring rather than re-architecting event storage. Happy to follow up with true one-hour windowing (e.g. Redis sorted sets) if reviewers prefer.
