### PR TITLE
Test/109 review service test coverage

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,28 @@
+# Module 3 Journal
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/109
+
+**Issue title:** Test coverage for `core/services/review_service.py` is below 40%
+
+**Tier:** [x] Tier 2  [ ] Tier 1  [ ] Tier 3
+
+**Problem summary:**
+`core/services/review_service.py` orchestrates the entire review workflow —
+creating a review, fetching it back while checking ownership, and listing a
+user's reviews — but most of its code paths currently have no test coverage.
+The existing test file only covers a handful of happy-path cases, so failure
+handling (a review that never finishes generating, a partially-completed
+review, a lookup for a review that doesn't belong to the requesting user) is
+unverified even though this is described as the most critical service in the
+application. A successful fix adds unit tests targeting the success,
+partial-failure, and full-failure paths through `create_review`, `get_review`,
+and `list_reviews`, using the existing mocked async DB session pattern already
+present in `tests/unit/test_review_service.py`.
+
+**Branch name:** test/109-review-service-test-coverage
+
+**Setup confirmation:** [ ] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -26,3 +26,17 @@ present in `tests/unit/test_review_service.py`.
 **Setup confirmation:** [ ] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/darylcarter2006/pathreview/commit/9c83385
+
+**Reproduction summary:**
+Ran `pytest tests/unit/test_review_service.py --cov=core.services.review_service --cov-report=term-missing` in a local venv (no Docker needed — the tests mock the DB session). Observed actual coverage of 22% (worse than the ~40% the issue implies), with `process_review`, `_run_ingestion_pipeline`, and `_run_safety_checks` — the functions covering the success/partial-failure/full-failure workflow — at 0% coverage. Also discovered 13 of the 19 existing tests in that file are already failing from an unrelated `AsyncMock` misconfiguration bug (tracked separately as issue #158), which affects how I need to write new tests.
+
+**PLAN.md link:** https://github.com/darylcarter2006/pathreview/blob/test/109-review-service-test-coverage/PLAN.md
+
+**Walkthrough video (recommended):** (not recorded)
+
+**Blockers or open questions:**
+Docker/Node aren't installed on my machine yet, so I've only run the backend unit tests directly in a venv, not the full `make setup && make run` app — that's fine for this test-only issue since `process_review` and friends don't need the frontend or a live DB, but I still need real Docker/Node installed before Week 9 if I want to sanity-check the app end-to-end. Also watching issue #158 (claimed by other students) since it touches the same test file and could conflict with my new tests if their fix lands first.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -40,3 +40,34 @@ Ran `pytest tests/unit/test_review_service.py --cov=core.services.review_service
 
 **Blockers or open questions:**
 Docker/Node aren't installed on my machine yet, so I've only run the backend unit tests directly in a venv, not the full `make setup && make run` app — that's fine for this test-only issue since `process_review` and friends don't need the frontend or a live DB, but I still need real Docker/Node installed before Week 9 if I want to sanity-check the app end-to-end. Also watching issue #158 (claimed by other students) since it touches the same test file and could conflict with my new tests if their fix lands first.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented all six sub-tasks from `PLAN.md`: added a `make_execute_result` helper that builds mocked `db.execute()` return values as plain `Mock()` objects (avoiding the `AsyncMock` auto-mocking trap behind issue #158), then added 17 new tests to `tests/unit/test_review_service.py` covering `process_review`'s success path, its two partial-failure branches (profile not found, safety checks failed), its full-failure branch (including the nested exception in the recovery block), `_run_ingestion_pipeline`'s per-source-type branches and error isolation, and `_run_safety_checks`'s four rejection conditions plus its own exception handler. Ran `pytest --cov=core.services.review_service --cov-report=term-missing`: coverage is now 95%, up from the 22% baseline. Also captured a `make check`/`make test-unit` baseline before touching any code and confirmed after my changes that the exact same 53 pre-existing test failures and the same categories of pre-existing lint/format/typecheck issues remain — my changes introduce no new failures (and net-fixed a few pre-existing lint issues in this file via `black`/`ruff --fix` while formatting my additions).
+
+**Next steps:**
+Open a draft PR against `ascherj/pathreview` for peer/mentor feedback, then address any feedback and mark it ready for review before the deadline.
+
+**Blockers:**
+None.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** _pending — will add once opened_
+
+**Branch:** test/109-review-service-test-coverage
+
+**What you built:**
+17 new unit tests for `core/services/review_service.py` covering `process_review`'s success/partial-failure/full-failure paths, `_run_ingestion_pipeline`'s per-source-type branches, and `_run_safety_checks`'s rejection branches — no production code changes, per the issue's scope.
+
+**Tests added or updated:**
+`tests/unit/test_review_service.py` — added a `make_execute_result` mock helper and 17 new test methods; raises module coverage from 22% to 95%. Did not modify the existing 19 tests (13 of which still fail due to the separately-tracked issue #158).
+
+**Self-review confirmation:** [x] make check passes (no new failures vs. documented pre-existing baseline)  [x] make test-unit passes (same 53 pre-existing failures as baseline; all 17 new tests pass)
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -71,3 +71,74 @@ None.
 **Self-review confirmation:** [x] make check passes (no new failures vs. documented pre-existing baseline)  [x] make test-unit passes (same 53 pre-existing failures as baseline; all 17 new tests pass)
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No feedback came in. Reviewer feedback isn't enabled for the Summer 2026
+cohort, so this is expected rather than a sign the PR was overlooked.
+
+**How you responded:**
+N/A — no feedback to respond to. PR #942 remains open against
+`ascherj/pathreview` for issue #109 in case it's picked up later.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Writing tests against `process_review` exposed a subtlety I hadn't
+anticipated: the shared `mock_db_session` fixture builds an `AsyncMock()`
+for the DB session, and since `result.scalars()` is called synchronously
+(not awaited) in the production code, mocking `result` itself as an
+`AsyncMock` silently returns an unawaited coroutine instead of the
+configured return value. That's the root cause of the 13 pre-existing
+failures tracked in issue #158. Once I understood it, writing new tests
+that used a plain `Mock()` for the execute-result object (while keeping
+`db.execute` itself as an `AsyncMock`) was straightforward, but diagnosing
+*why* the pattern in the existing tests was broken took longer than
+writing the actual test bodies.
+
+**What did you learn about working in a large codebase?**
+The biggest difference from my own projects (like AcademiqHQ) is that
+correctness here is bounded by scope, not just by "does it work." I found
+a second, undocumented bug while writing tests — `IngestedSource(...,
+raw_data=...)` always raises `TypeError` because the real model has no
+`raw_data` field, so every ingestion source silently fails in production
+today. Fixing it would have been a two-line change, but it was out of
+scope for a test-coverage issue, so I documented it in the PR instead of
+touching production code. In my own codebase I'd have just fixed it on
+the spot; here, staying inside the issue's stated boundary mattered more
+than being thorough.
+
+**How did AI tools help — and where did they fall short?**
+AI assistance was most useful for the mechanical parts: tracing the
+`AsyncMock`/`scalars()` interaction across the file, generating the
+repetitive mock-setup boilerplate for 17 test cases, and running
+`black`/`ruff --fix` loops to keep formatting clean as the file grew. It
+fell short on judgment calls that needed project context I had to supply
+myself — deciding the `IngestedSource` bug was out of scope rather than
+something to fix, and deciding how to represent per-branch error
+isolation in `_run_ingestion_pipeline` without leaning on a broken test
+premise (my first attempt at that test was actually wrong, and I had to
+identify why before rewriting it against a real code path).
+
+**What would you do differently if you started over?**
+I'd install Docker and Node earlier — I did all of this against the
+backend unit tests in a bare venv and never ran the full app end-to-end,
+which was fine for a test-only issue but would have been risky if the fix
+had touched anything user-facing. I'd also read `_run_ingestion_pipeline`
+line-by-line before Week 8 instead of during Week 9, since that's where
+the `raw_data` bug was hiding and I could have flagged it a week earlier.
+
+**What are you most proud of from this module?**
+Getting `core/services/review_service.py` from 22% to 95% coverage while
+leaving the exact same 53 pre-existing failures untouched — proving that
+with a before/after diff rather than eyeballing pass counts — feels like
+the real deliverable, more than the PR itself. It's the difference between
+"I added tests" and "I added tests without breaking anything or hiding
+whether I broke anything."

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -58,7 +58,7 @@ None.
 
 ### Check-in 2 (end of week)
 
-**PR link:** _pending — will add once opened_
+**PR link:** https://github.com/ascherj/pathreview/pull/942
 
 **Branch:** test/109-review-service-test-coverage
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,133 @@
+# Solution plan
+
+**Issue:** [Test coverage for `core/services/review_service.py` is below 40% (#109)](https://github.com/ascherj/pathreview/issues/109)
+
+### Understand
+
+The stated behavior is that `review_service.py` — described as the most
+critical service in the app — is under-tested. Reproduction showed the real
+number is worse than stated: **22% coverage**, not ~40%. The existing 19 tests
+in `tests/unit/test_review_service.py` only exercise `create_review`,
+`get_review`, and `list_reviews`, and only their happy paths (13 of those 19
+tests are additionally broken right now by an unrelated `AsyncMock`
+misconfiguration bug tracked as issue #158 — see Risks below).
+
+Expected behavior: the service's most important function, `process_review`
+(the background task that runs ingestion → agent orchestration → RAG →
+safety checks → sets the review's final status), should have its success
+path, its two early-exit "partial failure" paths (missing profile, failed
+safety check), and its outer exception handler ("full failure") all verified
+by tests. Actual behavior: none of `process_review` is covered at all (lines
+98-194 show 0% in the coverage report), nor is `_run_ingestion_pipeline`
+(202-279, three independent try/except branches per source type) or
+`_run_safety_checks` (369-390, three distinct rejection branches). This
+matches the issue's framing exactly: the code paths that matter most
+(success, partial failure, full failure) are the ones with zero coverage.
+
+### Map
+
+Files/functions this issue touches:
+
+- `core/services/review_service.py` — the module under test, not expected to
+  change (this is a test-only issue), specifically:
+  - `process_review` (lines 98-194): success path, missing-profile branch,
+    failed-safety-check branch, outer `except Exception` branch
+  - `_run_ingestion_pipeline` (202-279): github/portfolio/resume ingestion,
+    including each source type's individual `except Exception` branch
+  - `_run_safety_checks` (369-390): no-sections / incomplete-section /
+    invalid-confidence rejection branches, plus its own exception handler
+  - `list_reviews` (lines 68-79 tail): the paginated-results query, only
+    partially covered today
+- `tests/unit/test_review_service.py` — where all new tests are added
+- `core/models/review.py`, `core/models/profile.py`,
+  `core/models/ingested_source.py` — read-only, to know what attributes to
+  set on mock objects (`Review.status`, `Profile.github_username`, etc.)
+- `api/schemas/review.py` (`FeedbackSection`) — read-only, to build fixture
+  data matching the shape `process_review` expects from `rag_output`
+
+### Plan
+
+1. **Fix the mocking pattern before adding new tests.** The current
+   `mock_db_session` fixture builds `db.execute` as a plain `AsyncMock`,
+   which auto-mocks `.scalars()` on the return value as async too, breaking
+   any code that calls a sync method on the result (`test/109` inherits this
+   bug from #158). New tests will build the mocked `execute` return value
+   explicitly (`Mock` with `.scalars.return_value.first/.all` set to plain
+   values) instead of relying on `AsyncMock` autospec, so they don't fail the
+   same way.
+2. **Cover `process_review`'s success path** — mock `db.execute` to return a
+   review and profile, stub `_run_ingestion_pipeline` /
+   `_run_agent_orchestration` / `_run_rag_retrieval_generation` /
+   `_run_safety_checks` to return canned data, assert the review ends with
+   `status == "complete"`, `sections` populated, and `overall_score` set.
+3. **Cover `process_review`'s partial-failure branches** — (a) profile not
+   found → assert `status == "failed"` and early return; (b) safety checks
+   return `False` → assert `status == "failed"` and early return, without the
+   `sections`/`overall_score` fields being set.
+4. **Cover `process_review`'s full-failure branch** — force
+   `_run_agent_orchestration` (or another step) to raise, assert the outer
+   `except` sets `status == "failed"`, and separately test the nested
+   try/except (line 184-194) by making the recovery `db.execute` call itself
+   raise, asserting it's caught and logged rather than propagating.
+5. **Cover `_run_ingestion_pipeline` and `_run_safety_checks` directly** as
+   unit tests (not just indirectly through `process_review`): each
+   source-type branch (present/absent `github_username`, `portfolio_url`,
+   `resume_text`) and each of the three safety-check rejection conditions.
+6. **Re-run `pytest --cov` and confirm the module crosses well above 40%**
+   (targeting the previously-zero-coverage functions should land in the
+   70-85% range, since `_run_agent_orchestration`/`_run_rag_retrieval_generation`
+   are static placeholder data with little branching left to cover).
+
+### Inputs & outputs
+
+- **Input:** no production code changes — only new/adjusted test functions in
+  `tests/unit/test_review_service.py`, plus mocked `db`, `Profile`, and
+  `Review` objects constructed per test.
+- **Output:** a passing test suite for `review_service.py` with coverage
+  measurably above 40% (verified via `pytest --cov=core.services.review_service
+  --cov-report=term-missing`), and no test relying on the broken `AsyncMock`
+  autospec pattern.
+
+### Risks & unknowns
+
+- **Issue #158 overlap:** 13 of the 19 *existing* tests in this exact file are
+  already failing from the AsyncMock bug tracked in #158, which multiple
+  other students have claimed. I'm not fixing those existing tests as part of
+  #109 — only writing new tests that avoid the same trap — but if #158 lands
+  first and changes the shared `mock_db_session` fixture, my new tests may
+  need a rebase to stay consistent with whatever fixture pattern wins.
+- **`process_review` has no dependency injection** for
+  `_run_ingestion_pipeline` / `_run_agent_orchestration` /
+  `_run_rag_retrieval_generation` / `_run_safety_checks` — they're called as
+  module-level functions, not passed in. Testing `process_review` in
+  isolation means `unittest.mock.patch`-ing these at the module path
+  (`core.services.review_service._run_ingestion_pipeline`, etc.), which is
+  more brittle than dependency injection would be. If patch targets are
+  wrong (e.g. patching where it's defined instead of where it's imported)
+  tests will silently not mock anything — need to verify each patch actually
+  takes effect.
+- **`datetime.utcnow()`** is called directly inside `process_review`
+  (line 171, 190) rather than injected — tests asserting on `updated_at` will
+  need to tolerate a real timestamp or patch `datetime` at the module level.
+- Uncertain whether the course grader expects the coverage number to be
+  captured in a specific format (e.g. a committed coverage report) beyond a
+  passing `make test-unit` — will default to the `pytest --cov` invocation
+  documented in `tests/unit/REPRODUCTION-109.md` unless told otherwise.
+
+### Edge cases
+
+- `create_review` / `get_review` / `list_reviews`: review ID that doesn't
+  exist, review that exists but belongs to a different user's profile,
+  `list_reviews` with `page_size` larger than total results, `page` beyond
+  the last page (empty result, not an error).
+- `process_review`: review row missing entirely (early return before any
+  status change), profile row missing (sets `status="failed"` and returns),
+  an ingested source with all three of `github_username`/`portfolio_url`/
+  `resume_text` unset (should still complete without ingesting anything,
+  not raise), one ingestion sub-step raising while the others succeed
+  (should not abort the whole pipeline, per the existing per-branch
+  try/except).
+- `_run_safety_checks`: empty `sections` list, a section missing
+  `section_name` or `content`, `confidence` outside `[0, 1]` (negative and
+  `> 1`), and malformed input that raises inside the function itself
+  (should be caught and return `False`, not propagate).

--- a/tests/unit/REPRODUCTION-109.md
+++ b/tests/unit/REPRODUCTION-109.md
@@ -1,0 +1,60 @@
+# Reproduction: Issue #109 — review_service.py test coverage below 40%
+
+## How I reproduced it
+
+```bash
+python3 -m venv .venv
+.venv/bin/pip install -e ".[dev]"
+.venv/bin/pytest tests/unit/test_review_service.py -v -m unit \
+  --cov=core.services.review_service --cov-report=term-missing
+```
+
+No Docker/Postgres/Redis needed — `test_review_service.py` mocks the async DB
+session directly, so this runs against the venv alone.
+
+## What I observed
+
+```
+Name                              Stmts   Miss  Cover   Missing
+---------------------------------------------------------------
+core/services/review_service.py     135    105    22%   68-79, 98-194, 202-279, 288, 323, 369-390
+---------------------------------------------------------------
+TOTAL                               135    105    22%
+
+13 failed, 6 passed, 1 warning in 0.41s
+```
+
+Actual coverage is **22%**, worse than the 40% the issue title states.
+
+The uncovered ranges map to real functions with zero test coverage:
+- `68-79`: tail of `list_reviews` (the paginated-results query path)
+- `98-194`: all of `process_review` — the entire success / partial-failure /
+  full-failure workflow this issue asks to cover
+- `202-279`: all of `_run_ingestion_pipeline`, including its three independent
+  per-source-type try/except branches (github, portfolio, resume)
+- `369-390`: all of `_run_safety_checks`, including its three failure branches
+  (no sections, incomplete section, invalid confidence) and its own
+  exception handler
+
+**Unexpected finding:** 13 of the 19 existing tests in this file are already
+failing, independent of coverage. Example:
+
+```
+count_result = await db.execute(count_stmt)
+total = len(count_result.scalars().all())
+AttributeError: 'coroutine' object has no attribute 'all'
+```
+
+Root cause: the `mock_db_session` fixture builds `db.execute` as an
+`AsyncMock`. Any attribute accessed off the *return value* of an `AsyncMock`
+call is auto-specced as another `AsyncMock`, so `count_result.scalars()` —
+which is a synchronous SQLAlchemy call in real code — comes back as an
+unawaited coroutine instead of a `ScalarResult`, and `.all()` blows up.
+
+This is the exact bug tracked separately in
+[issue #158](https://github.com/ascherj/pathreview/issues/158) ("review_service
+unit tests misconfigure async mocks — 13 of 19 tests fail"), which several
+other students have already claimed. It lives in the same test file I'm
+adding coverage to, so my new tests need to use a mock pattern that doesn't
+have this problem (see `PLAN.md`) rather than copying the existing fixture
+as-is.

--- a/tests/unit/test_review_service.py
+++ b/tests/unit/test_review_service.py
@@ -1,15 +1,33 @@
 """Tests for review_service.py"""
 
-import pytest
-from uuid import uuid4
 from unittest.mock import AsyncMock, Mock, patch
-import asyncio
+from uuid import uuid4
+
+import pytest
 
 from core.services.review_service import (
+    _run_ingestion_pipeline,
+    _run_safety_checks,
     create_review,
     get_review,
     list_reviews,
+    process_review,
 )
+
+
+def make_execute_result(first=None, all=None):
+    """Build a plain (non-AsyncMock) result object for a mocked db.execute() call.
+
+    Production code calls `.scalars()` synchronously on the object returned by
+    `await db.execute(...)`. If that returned object is itself an AsyncMock,
+    `.scalars` is auto-specced as an AsyncMock too, so calling it returns an
+    unawaited coroutine instead of the configured Mock chain (this is the bug
+    tracked in issue #158). Using a plain Mock() here avoids that trap.
+    """
+    result = Mock()
+    result.scalars.return_value.first.return_value = first
+    result.scalars.return_value.all.return_value = all if all is not None else []
+    return result
 
 
 @pytest.mark.unit
@@ -45,7 +63,9 @@ class TestReviewService:
         return profile
 
     @pytest.mark.asyncio
-    async def test_create_review_returns_review_with_pending_status(self, mock_db_session, mock_review):
+    async def test_create_review_returns_review_with_pending_status(
+        self, mock_db_session, mock_review
+    ):
         """Test create_review returns Review with status='pending'."""
         profile_id = uuid4()
         user_id = uuid4()
@@ -55,7 +75,7 @@ class TestReviewService:
         mock_db_session.commit = AsyncMock()
         mock_db_session.refresh = AsyncMock()
 
-        with patch('core.services.review_service.Review') as MockReview:
+        with patch("core.services.review_service.Review") as MockReview:
             mock_instance = MockReview.return_value
             mock_instance.status = "pending"
             mock_instance.sections = None
@@ -66,7 +86,7 @@ class TestReviewService:
             # Check that Review was instantiated
             MockReview.assert_called()
             call_kwargs = MockReview.call_args[1]
-            assert call_kwargs['status'] == "pending"
+            assert call_kwargs["status"] == "pending"
 
     @pytest.mark.asyncio
     async def test_get_review_returns_review_for_correct_owner(self, mock_db_session):
@@ -133,9 +153,7 @@ class TestReviewService:
         mock_result.scalars.return_value.all.return_value = []
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
-        reviews, total = await list_reviews(
-            mock_db_session, user_id, page=2, page_size=page_size
-        )
+        reviews, total = await list_reviews(mock_db_session, user_id, page=2, page_size=page_size)
 
         # Second call should pass offset for page 2
         calls = mock_db_session.execute.call_args_list
@@ -165,7 +183,7 @@ class TestReviewService:
         profile_id = uuid4()
         user_id = uuid4()
 
-        with patch('core.services.review_service.Review'):
+        with patch("core.services.review_service.Review"):
             await create_review(mock_db_session, profile_id, user_id)
 
             mock_db_session.add.assert_called_once()
@@ -176,7 +194,7 @@ class TestReviewService:
         profile_id = uuid4()
         user_id = uuid4()
 
-        with patch('core.services.review_service.Review'):
+        with patch("core.services.review_service.Review"):
             await create_review(mock_db_session, profile_id, user_id)
 
             mock_db_session.commit.assert_called_once()
@@ -187,7 +205,7 @@ class TestReviewService:
         profile_id = uuid4()
         user_id = uuid4()
 
-        with patch('core.services.review_service.Review'):
+        with patch("core.services.review_service.Review"):
             await create_review(mock_db_session, profile_id, user_id)
 
             mock_db_session.refresh.assert_called_once()
@@ -244,13 +262,13 @@ class TestReviewService:
         profile_id = uuid4()
         user_id = uuid4()
 
-        with patch('core.services.review_service.Review') as MockReview:
+        with patch("core.services.review_service.Review") as MockReview:
             MockReview.return_value = Mock()
             await create_review(mock_db_session, profile_id, user_id)
 
             call_kwargs = MockReview.call_args[1]
-            assert 'profile_id' in call_kwargs
-            assert 'status' in call_kwargs
+            assert "profile_id" in call_kwargs
+            assert "status" in call_kwargs
 
     @pytest.mark.asyncio
     async def test_get_review_verifies_ownership(self, mock_db_session):
@@ -287,7 +305,7 @@ class TestReviewService:
         """Test list_reviews returns list of Review objects."""
         user_id = uuid4()
 
-        mock_reviews = [Mock(spec=['id', 'status']) for _ in range(3)]
+        mock_reviews = [Mock(spec=["id", "status"]) for _ in range(3)]
         mock_result = AsyncMock()
         mock_result.scalars.return_value.all.return_value = mock_reviews
         mock_db_session.execute = AsyncMock(return_value=mock_result)
@@ -302,13 +320,13 @@ class TestReviewService:
         profile_id = uuid4()
         user_id = uuid4()
 
-        with patch('core.services.review_service.Review') as MockReview:
+        with patch("core.services.review_service.Review") as MockReview:
             MockReview.return_value = Mock()
             await create_review(mock_db_session, profile_id, user_id)
 
             call_kwargs = MockReview.call_args[1]
-            assert call_kwargs['sections'] is None
-            assert call_kwargs['overall_score'] is None
+            assert call_kwargs["sections"] is None
+            assert call_kwargs["overall_score"] is None
 
     @pytest.mark.asyncio
     async def test_get_review_with_valid_uuid(self, mock_db_session):
@@ -338,3 +356,267 @@ class TestReviewService:
 
         # Should order by created_at descending
         mock_db_session.execute.assert_called_once()
+
+    # ---- process_review: success path ----
+
+    @pytest.mark.asyncio
+    async def test_process_review_success_path(self, mock_db_session, mock_review, mock_profile):
+        """Test process_review sets status='complete' and stores sections on success."""
+        review_result = make_execute_result(first=mock_review)
+        profile_result = make_execute_result(first=mock_profile)
+        mock_db_session.execute = AsyncMock(side_effect=[review_result, profile_result])
+
+        rag_output = {
+            "sections": [
+                {
+                    "section_name": "Technical Skills",
+                    "content": "Detailed feedback on technical skills",
+                    "confidence": 0.85,
+                    "suggestions": ["Add more detail"],
+                }
+            ],
+            "overall_score": 0.81,
+        }
+
+        with (
+            patch(
+                "core.services.review_service._run_ingestion_pipeline",
+                new=AsyncMock(return_value=[]),
+            ),
+            patch(
+                "core.services.review_service._run_agent_orchestration",
+                new=AsyncMock(return_value={"sections": [], "overall_score": 0.75}),
+            ),
+            patch(
+                "core.services.review_service._run_rag_retrieval_generation",
+                new=AsyncMock(return_value=rag_output),
+            ),
+            patch(
+                "core.services.review_service._run_safety_checks", new=AsyncMock(return_value=True)
+            ),
+        ):
+            await process_review(mock_db_session, mock_review.id, mock_profile.id)
+
+        assert mock_review.status == "complete"
+        assert mock_review.sections is not None
+        assert len(mock_review.sections) == 1
+        assert mock_review.overall_score == 0.81
+
+    # ---- process_review: partial-failure paths ----
+
+    @pytest.mark.asyncio
+    async def test_process_review_review_not_found_returns_early(self, mock_db_session):
+        """Test process_review returns early without committing when the review doesn't exist."""
+        review_result = make_execute_result(first=None)
+        mock_db_session.execute = AsyncMock(return_value=review_result)
+
+        await process_review(mock_db_session, uuid4(), uuid4())
+
+        mock_db_session.commit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_process_review_profile_not_found_sets_failed(self, mock_db_session, mock_review):
+        """Test process_review sets status='failed' when the profile lookup returns None."""
+        review_result = make_execute_result(first=mock_review)
+        profile_result = make_execute_result(first=None)
+        mock_db_session.execute = AsyncMock(side_effect=[review_result, profile_result])
+
+        with patch(
+            "core.services.review_service._run_ingestion_pipeline", new=AsyncMock()
+        ) as mock_ingest:
+            await process_review(mock_db_session, mock_review.id, uuid4())
+
+        assert mock_review.status == "failed"
+        mock_ingest.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_process_review_safety_check_failed_sets_failed(
+        self, mock_db_session, mock_review, mock_profile
+    ):
+        """Test process_review sets status='failed' when safety checks fail."""
+        review_result = make_execute_result(first=mock_review)
+        profile_result = make_execute_result(first=mock_profile)
+        mock_db_session.execute = AsyncMock(side_effect=[review_result, profile_result])
+
+        with (
+            patch(
+                "core.services.review_service._run_ingestion_pipeline",
+                new=AsyncMock(return_value=[]),
+            ),
+            patch(
+                "core.services.review_service._run_agent_orchestration",
+                new=AsyncMock(return_value={"sections": [], "overall_score": 0.5}),
+            ),
+            patch(
+                "core.services.review_service._run_rag_retrieval_generation",
+                new=AsyncMock(return_value={"sections": [], "overall_score": 0.5}),
+            ),
+            patch(
+                "core.services.review_service._run_safety_checks", new=AsyncMock(return_value=False)
+            ),
+        ):
+            await process_review(mock_db_session, mock_review.id, mock_profile.id)
+
+        assert mock_review.status == "failed"
+        assert mock_review.sections is None
+        assert mock_review.overall_score is None
+
+    # ---- process_review: full-failure paths ----
+
+    @pytest.mark.asyncio
+    async def test_process_review_exception_sets_failed(
+        self, mock_db_session, mock_review, mock_profile
+    ):
+        """Test the outer except sets status='failed' when a pipeline step raises."""
+        review_result = make_execute_result(first=mock_review)
+        profile_result = make_execute_result(first=mock_profile)
+        recovery_result = make_execute_result(first=mock_review)
+        mock_db_session.execute = AsyncMock(
+            side_effect=[review_result, profile_result, recovery_result]
+        )
+
+        with patch(
+            "core.services.review_service._run_ingestion_pipeline",
+            new=AsyncMock(side_effect=Exception("boom")),
+        ):
+            await process_review(mock_db_session, mock_review.id, mock_profile.id)
+
+        assert mock_review.status == "failed"
+
+    @pytest.mark.asyncio
+    async def test_process_review_recovery_exception_is_swallowed(
+        self, mock_db_session, mock_review, mock_profile
+    ):
+        """Test that a failure in the except-block's own recovery query doesn't propagate."""
+        review_result = make_execute_result(first=mock_review)
+        profile_result = make_execute_result(first=mock_profile)
+        mock_db_session.execute = AsyncMock(
+            side_effect=[review_result, profile_result, Exception("recovery db down")]
+        )
+
+        with patch(
+            "core.services.review_service._run_ingestion_pipeline",
+            new=AsyncMock(side_effect=Exception("boom")),
+        ):
+            # Should not raise even though the recovery block's db.execute also fails.
+            await process_review(mock_db_session, mock_review.id, mock_profile.id)
+
+    # ---- _run_ingestion_pipeline ----
+
+    @pytest.mark.asyncio
+    async def test_run_ingestion_pipeline_all_sources_present(self, mock_db_session):
+        """Test all three source types are ingested when present on the profile."""
+        profile = Mock()
+        profile.id = uuid4()
+        profile.github_username = "octocat"
+        profile.portfolio_url = "https://example.com/portfolio"
+        profile.resume_text = "resume contents"
+        profile.resume_filename = "resume.pdf"
+
+        sources = await _run_ingestion_pipeline(mock_db_session, profile)
+
+        assert len(sources) == 3
+        assert {s["source_type"] for s in sources} == {"github", "portfolio", "resume"}
+        # Note: db.add() is not currently reached for any source here because
+        # `IngestedSource(..., raw_data=...)` is called with a kwarg the real
+        # model doesn't define (pre-existing bug, out of scope for #109 —
+        # each branch's own except catches it and logs, per source_type).
+        mock_db_session.commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_run_ingestion_pipeline_no_sources(self, mock_db_session):
+        """Test no sources are ingested and no error occurs when none are present."""
+        profile = Mock()
+        profile.id = uuid4()
+        profile.github_username = None
+        profile.portfolio_url = None
+        profile.resume_text = None
+        profile.resume_filename = None
+
+        sources = await _run_ingestion_pipeline(mock_db_session, profile)
+
+        assert sources == []
+        mock_db_session.add.assert_not_called()
+        mock_db_session.commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_run_ingestion_pipeline_only_github(self, mock_db_session):
+        """Test only the github source is ingested when other sources are absent."""
+        profile = Mock()
+        profile.id = uuid4()
+        profile.github_username = "octocat"
+        profile.portfolio_url = None
+        profile.resume_text = None
+        profile.resume_filename = None
+
+        sources = await _run_ingestion_pipeline(mock_db_session, profile)
+
+        assert len(sources) == 1
+        assert sources[0]["source_type"] == "github"
+
+    @pytest.mark.asyncio
+    async def test_run_ingestion_pipeline_source_error_does_not_abort_others(self, mock_db_session):
+        """Test a failure in one source's ingestion doesn't prevent the others from completing."""
+        profile = Mock()
+        profile.id = uuid4()
+        profile.github_username = "octocat"
+        profile.portfolio_url = "https://example.com/portfolio"
+        profile.resume_text = "resume contents"
+        profile.resume_filename = "resume.pdf"
+
+        with patch(
+            "core.services.review_service.IngestedSource",
+            side_effect=[RuntimeError("github row boom"), Mock(), Mock()],
+        ):
+            sources = await _run_ingestion_pipeline(mock_db_session, profile)
+
+        assert len(sources) == 3
+        assert {s["source_type"] for s in sources} == {"github", "portfolio", "resume"}
+        assert mock_db_session.add.call_count == 2
+
+    # ---- _run_safety_checks ----
+
+    @pytest.mark.asyncio
+    async def test_run_safety_checks_passes_with_valid_sections(self):
+        """Test safety checks pass for well-formed sections with valid confidence."""
+        output = {
+            "sections": [
+                {"section_name": "Skills", "content": "Good content", "confidence": 0.8},
+            ]
+        }
+        assert await _run_safety_checks(output) is True
+
+    @pytest.mark.asyncio
+    async def test_run_safety_checks_fails_empty_sections(self):
+        """Test safety checks fail when there are no sections."""
+        assert await _run_safety_checks({"sections": []}) is False
+
+    @pytest.mark.asyncio
+    async def test_run_safety_checks_fails_missing_section_name(self):
+        """Test safety checks fail when a section is missing its name."""
+        output = {"sections": [{"section_name": "", "content": "text", "confidence": 0.5}]}
+        assert await _run_safety_checks(output) is False
+
+    @pytest.mark.asyncio
+    async def test_run_safety_checks_fails_missing_content(self):
+        """Test safety checks fail when a section is missing its content."""
+        output = {"sections": [{"section_name": "Skills", "content": "", "confidence": 0.5}]}
+        assert await _run_safety_checks(output) is False
+
+    @pytest.mark.asyncio
+    async def test_run_safety_checks_fails_negative_confidence(self):
+        """Test safety checks fail when confidence is below 0."""
+        output = {"sections": [{"section_name": "Skills", "content": "text", "confidence": -0.1}]}
+        assert await _run_safety_checks(output) is False
+
+    @pytest.mark.asyncio
+    async def test_run_safety_checks_fails_confidence_above_one(self):
+        """Test safety checks fail when confidence is above 1."""
+        output = {"sections": [{"section_name": "Skills", "content": "text", "confidence": 1.5}]}
+        assert await _run_safety_checks(output) is False
+
+    @pytest.mark.asyncio
+    async def test_run_safety_checks_catches_internal_exception(self):
+        """Test an internal error (e.g. a malformed section) is caught and returns False."""
+        output = {"sections": ["not-a-dict"]}
+        assert await _run_safety_checks(output) is False


### PR DESCRIPTION
## Summary
  Adds unit tests for `core/services/review_service.py`'s previously-untested code paths — `process_review`, `_run_ingestion_pipeline`, and `_run_safety_checks` — raising module coverage from 22% to 95%. This is a test-only fix per the issue; no production code changes.

  ## Issue
  Closes #109

  ## Changes
  - Added a `make_execute_result()` helper in `tests/unit/test_review_service.py` that builds mocked `db.execute()` results as plain `Mock()` objects instead of `AsyncMock`, avoiding the auto-specced-coroutine bug tracked in #158
  - Added tests for `process_review`'s success path, both partial-failure branches (profile not found, safety checks failed), and both full-failure branches (outer exception, and the nested exception in the failure-recovery block)
  - Added direct tests for `_run_ingestion_pipeline`'s per-source-type branches (github/portfolio/resume, present/absent) and its per-branch error isolation
  - Added direct tests for `_run_safety_checks`'s four rejection conditions (empty sections, missing name/content, confidence out of range) and its own exception handler

  ## Testing
  - [x] Unit tests pass (`make test-unit`)
  - [ ] Integration tests pass (`make test-integration`)
  - [x] Linter passes (`make lint`)
  - [x] Type checker passes (`make typecheck`)
  - [x] New/updated tests cover the changes

  Verified by running `make check` and `make test-unit` before and after my changes and diffing the output: the same 53 pre-existing test failures appear in both runs (13 of them are in this same file, tracked separately as #158), and lint/typecheck show no new errors — `make lint` actually went from 182 to 179 errors since formatting my additions with `black`/`ruff --fix` incidentally cleaned up a few pre-existing issues in this file. All 17 new tests pass. Coverage confirmed via `pytest --cov=core.services.review_service --cov-report=term-missing` (22% → 95%).

  ## Screenshots / Demo
  Not applicable — this is a backend test-only change with no UI impact.

  ## Notes for Reviewers
  - This file has 13 pre-existing failing tests unrelated to this PR, caused by an `AsyncMock` misconfiguration tracked separately in #158 (already claimed by another student). I intentionally left those alone — only made sure my new tests don't repeat the same mocking mistake.
  - While writing these tests I found that `_run_ingestion_pipeline`'s `IngestedSource(..., raw_data=...)` call always raises (the real model has no `raw_data` field), so no ingested source is ever actually persisted to the DB today — every branch silently fails and logs an error, though the in-memory `sources` list returned by the function is unaffected. Out of scope for this test-only issue, but worth a follow-up bug report.
  EOF)
## Summary
Adds unit tests for `core/services/review_service.py`'s previously-untested code paths — `process_review`, `_run_ingestion_pipeline`, and `_run_safety_checks` — raising module coverage from 22% to 95%. This is a test-only fix per the issue; no production code changes.

## Issue
Closes #109

## Changes
- Added a `make_execute_result()` helper in `tests/unit/test_review_service.py` that builds mocked `db.execute()` results as plain `Mock()` objects instead of `AsyncMock`, avoiding the auto-specced-coroutine bug tracked in #158
- Added tests for `process_review`'s success path, both partial-failure branches (profile not found, safety checks failed), and both full-failure branches (outer exception, and the nested exception in the failure-recovery block)
- Added direct tests for `_run_ingestion_pipeline`'s per-source-type branches (github/portfolio/resume, present/absent) and its per-branch error isolation
- Added direct tests for `_run_safety_checks`'s four rejection conditions (empty sections, missing name/content, confidence out of range) and its own exception handler

## Testing
- [x] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`)
- [x] Linter passes (`make lint`)
- [x] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes

Verified by running `make check` and `make test-unit` before and after my changes and diffing the output: the same 53 pre-existing test failures appear in both runs (13 of them are in this same file, tracked separately as #158), and lint/typecheck show no new errors — `make lint` actually went from 182 to 179 errors since formatting my additions with `black`/`ruff --fix` incidentally cleaned up a few pre-existing issues in this file. All 17 new tests pass. Coverage confirmed via `pytest --cov=core.services.review_service --cov-report=term-missing` (22% → 95%).

## Screenshots / Demo
Not applicable — this is a backend test-only change with no UI impact.

## Notes for Reviewers
- This file has 13 pre-existing failing tests unrelated to this PR, caused by an `AsyncMock` misconfiguration tracked separately in #158 (already claimed by another student). I intentionally left those alone — only made sure my new tests don't repeat the same mocking mistake.
- While writing these tests I found that `_run_ingestion_pipeline`'s `IngestedSource(..., raw_data=...)` call always raises (the real model has no `raw_data` field), so no ingested source is ever actually persisted to the DB today — every branch silently fails and logs an error, though the in-memory `sources` list returned by the function is unaffected. Out of scope for this test-only issue, but worth a follow-up bug report.