### PR TITLE
feat(ingestion): add GitHub Actions workflow parser for CI/CD skill detection

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,16 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/14
+
+**Issue title:** Add support for parsing GitHub Actions workflow files to detect CI/CD skills
+
+**Tier:** [ ] Tier 1  [ ] Tier 2  [x] Tier 3
+
+**Problem summary:**
+Right now the ingestion pipeline only infers skills from import statements and README text, so contributors who set up and maintain CI/CD pipelines get no credit for that work — their DevOps experience is invisible to the skill extractor. This issue asks for a new parser that reads `.github/workflows/*.yml` files in a repo and infers skills like GitHub Actions, Docker, pytest, and deployment from the workflow configuration (jobs, steps, actions used, etc.). The fix touches the ingestion pipeline: a new `ingestion/parsers/workflow_parser.py` module plus changes to `ingestion/parsers/skill_extractor.py` to wire the new parser's output into the overall skill extraction results. Estimated effort is 6–10 hours, and it's labeled tier-3 since it involves adding a new architectural piece to the ingestion/skill-detection system rather than a small isolated fix.
+
+**Branch name:** feat/14-github-action-parser-for-skills
+
+**Setup confirmation:** [x] (https://github.com/ascherj/pathreview/issues/14) App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -14,3 +14,18 @@ Right now the ingestion pipeline only infers skills from import statements and R
 **Setup confirmation:** [x] (https://github.com/ascherj/pathreview/issues/14) App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/somabadri/pathreview/commit/88d643cb55fc0bbcd14698cc04e13e33d2635e00
+
+**Reproduction summary:**
+This is a new feature rather than a bug, so there's no failing behavior to reproduce — instead I confirmed the gap by tracing the ingestion pipeline and confirming no code path reads `.github/workflows/*.yml`. The commit above locates the placeholder `ingestion/parsers/workflow_parser.py` where the new parser will be added.
+
+**PLAN.md link:** https://github.com/somabadri/pathreview/blob/feat/14-github-action-parser-for-skills/PLAN.md
+
+**Walkthrough video (recommended):** N/A — no walkthrough video since this is a new feature with no existing behavior to demo.
+
+**Blockers or open questions:**
+How to structure the implicit skill mappings for workflow-derived skills (actions used, run commands → GitHub Actions/Docker/pytest/deployment). Still deciding between hardcoding a keyword map similar to `skill_extractor.py`'s existing `FRAMEWORKS`/`TOOLS` dicts, or a different approach.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -61,3 +61,35 @@ A `WorkflowParser` that reads `.github/workflows/*.yml` content into text + meta
 **Self-review confirmation:** [x] make check passes  [x] make test-unit passes
 
 **Draft PR feedback received from:** none yet
+
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No review or comments have come in on PR #948 as of this check-in. Per the Su26 course note, reviewer feedback isn't a standard feature this term, so this is expected rather than a signal about the PR itself.
+
+**How you responded:**
+N/A — no feedback to respond to. Left the PR open and ready for review; no further changes made this week beyond re-verifying `make check`/`make test-unit` still pass against the current baseline.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Designing the skill-mapping approach for `CI_CD_INDICATORS` took longer than expected. The blocker I flagged back in Week 8 — hardcoded keyword map (matching the existing `FRAMEWORKS`/`TOOLS` pattern in `skill_extractor.py`) vs. something more structured — didn't have an obviously correct answer, and going back and forth on it ate more time than the actual parsing logic did. In hindsight the existing codebase already had a strong convention (the keyword-map dicts), and I should have trusted that convention sooner instead of treating it as an open design question.
+
+**What did you learn about working in a large codebase?**
+The real cost wasn't writing new code, it was proving the new code didn't break anything that was already broken. `pathreview` has a pre-existing baseline of failures (183 ruff, 103 mypy, 53 test failures) that have nothing to do with my change, and I had to `git stash` my diff and re-run the checks to confirm those numbers were unchanged before I could trust my own results. In a solo project there's no such thing as a "pre-existing failure" to control for — everything failing is yours. Contributing to someone else's production code means the bar isn't "my code works," it's "my code doesn't move any number that isn't already mine to move."
+
+**How did AI tools help — and where did they fall short?**
+AI was most useful for drafting the mechanical parts fast — the YAML parsing scaffolding, the initial pass at `WorkflowParser.parse()`, and generating the bulk of the 21 unit tests once I'd decided what needed covering. Where it fell short was exactly the baseline-verification step above: an assistant can't tell you which of 53 failing tests are pre-existing versus newly introduced by your change — that required me to actually stash my diff, re-run the suite against a clean tree, and diff the two failure counts myself. It's a check that only works if you distrust your own change enough to isolate it, which isn't something you can delegate.
+
+**What would you do differently if you started over?**
+Not much — issue selection, planning, and the build itself went the way I expected them to, given the PLAN.md I wrote in Week 8. If anything, I'd resolve the skill-mapping design question faster by defaulting to the codebase's existing convention instead of treating it as open-ended, per the note above.
+
+**What are you most proud of from this module?**
+Catching the PyYAML `on:` gotcha — where PyYAML silently parses the bare YAML key `on:` as the boolean `True` rather than the string `"on"` — before it caused a subtly wrong trigger detection in `WorkflowParser`. It's the kind of bug that wouldn't show up in a quick manual test, only in test cases that specifically exercise real GitHub Actions workflow files, and catching it during implementation rather than after review felt like the moment I was actually thinking like a maintainer of this codebase rather than just a contributor bolting on a feature.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -29,3 +29,35 @@ This is a new feature rather than a bug, so there's no failing behavior to repro
 
 **Blockers or open questions:**
 How to structure the implicit skill mappings for workflow-derived skills (actions used, run commands → GitHub Actions/Docker/pytest/deployment). Still deciding between hardcoding a keyword map similar to `skill_extractor.py`'s existing `FRAMEWORKS`/`TOOLS` dicts, or a different approach.
+
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented all of PLAN.md's sub-tasks: added the `PyYAML` dependency, built `WorkflowParser.parse()` (triggers, job names, `uses:` actions, `run:` commands, including the PyYAML `on:` → `True` boolean gotcha and `ValueError` handling for malformed/non-mapping YAML), extended `SkillExtractor` with a `_detect_ci_cd` step + `CI_CD_INDICATORS` map (GitHub Actions, Pytest, Deployment — Docker is left to the existing `TOOLS` detection), and wired `ingest_workflow(...)` into `IngestionPipeline`, one call per workflow file.
+
+**Next steps:**
+Finish `make check`/`make test-unit` self-review against the pre-existing baseline, open the draft PR for peer/mentor feedback, and address anything that comes back before marking it ready for review.
+
+**Blockers:**
+None.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/948
+
+**Branch:** `feat/14-github-action-parser-for-skills`
+
+**What you built:**
+A `WorkflowParser` that reads `.github/workflows/*.yml` content into text + metadata (triggers, job names, actions used, run commands), and a `SkillExtractor._detect_ci_cd` step that turns that output into CI/CD skill detections (GitHub Actions, Pytest, Deployment), all wired into `IngestionPipeline.ingest_workflow(...)`.
+
+**Tests added or updated:**
+`tests/unit/test_workflow_parser.py` (new, 16 tests covering standard/single-job/list-trigger workflows, malformed YAML, missing `jobs`/`steps`, bytes input, and metadata structure) and `tests/unit/test_skill_extractor.py` (5 new tests for GitHub Actions/Pytest/Deployment detection, CI/CD category tagging, and no false positives on unrelated text). Confirmed via `git stash` diffing that pre-existing ruff/mypy/test failures (183 ruff, 103 mypy, 53 test failures at baseline) are unchanged by these additions.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+**Draft PR feedback received from:** none yet

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,37 @@
+## Solution plan
+
+**Issue:** Add support for parsing GitHub Actions workflow files to detect CI/CD skills — [#14](https://github.com/ascherj/pathreview/issues/14)
+
+### Understand
+No parser reads `.github/workflows/*.yml`, so CI/CD skills (GitHub Actions, Docker, pytest, deployment) never get detected — only imports and README text are. `ingestion/parsers/workflow_parser.py` is currently just a placeholder comment.
+
+### Map
+- `ingestion/parsers/workflow_parser.py` — implement `WorkflowParser(BaseParser)`
+- `ingestion/parsers/skill_extractor.py` — add CI/CD keyword detection (actions used, docker, pytest, deploy)
+- `ingestion/pipeline.py` — add `ingest_workflow(...)`, instantiate parser in `__init__`
+- `pyproject.toml` — add `PyYAML` dependency (not currently present)
+- `tests/unit/test_workflow_parser.py` (new)
+
+### Plan
+1. Add `PyYAML` to `pyproject.toml`.
+2. Implement `WorkflowParser.parse()`: `yaml.safe_load` the content (str/bytes like `ReadmeParser`), extract triggers, job names, `uses:` actions, `run:` commands into `text` + `metadata` (source_type="workflow", job_count, trigger_events, actions_used). Raise `ValueError` on bad YAML.
+3. Extend `SkillExtractor` with a `_detect_ci_cd` step (or new keyword map) so actions/commands map to skills like GitHub Actions, Docker, pytest, Deployment.
+4. Wire `WorkflowParser` into `IngestionPipeline` with an `ingest_workflow` method mirroring `ingest_readme`.
+5. Add unit tests: valid workflow, multiple jobs, malformed YAML, missing `jobs` key.
+
+### Inputs & outputs
+- Input: workflow YAML as `str`/`bytes`.
+- Output: `ParseResult(text, metadata, source_type="workflow")` whose text, when run through `SkillExtractor`, yields CI/CD-related `SkillDetection`s.
+
+### Risks & unknowns
+- No YAML lib in the project yet — need to add `PyYAML`.
+- Overlap with `RepoAnalyzer._detect_ci`'s naive substring check — clarify if this replaces or complements it.
+- String-matching heuristics can false-positive (e.g. `run: echo docker`).
+- Reusable/composite workflow references (`uses: org/repo/.github/workflows/x.yml@main`) need a safe fallback.
+- Unclear if multiple workflow files per repo should be one ingestion call or one per file.
+
+### Edge cases
+- Empty/malformed YAML → `ValueError`, not a raw crash.
+- Missing or non-dict `jobs`; steps missing both `uses` and `run`.
+- `on:` as string, list, or dict (all valid GitHub syntax).
+- Non-UTF-8 bytes input (decode with `errors="replace"`).

--- a/ingestion/parsers/skill_extractor.py
+++ b/ingestion/parsers/skill_extractor.py
@@ -105,6 +105,13 @@ class SkillExtractor:
         "ansible": 0.85,
     }
 
+    CI_CD_INDICATORS = {
+        "github actions": ("GitHub Actions", 0.95),
+        "actions/": ("GitHub Actions", 0.90),
+        "pytest": ("Pytest", 0.85),
+        "deploy": ("Deployment", 0.80),
+    }
+
     def extract_skills(self, text: str, filename: Optional[str] = None) -> list[SkillDetection]:
         """
         Extract skills from source code or documentation text.
@@ -132,6 +139,9 @@ class SkillExtractor:
 
         # Detect tools
         self._detect_tools(text, detected_skills)
+
+        # Detect CI/CD-specific skills (GitHub Actions, pytest, deployment)
+        self._detect_ci_cd(text, detected_skills)
 
         # Sort by confidence
         return sorted(
@@ -274,3 +284,16 @@ class SkillExtractor:
                         confidence=confidence,
                         evidence=[f"Found '{tool}' reference in content"],
                     )
+
+    def _detect_ci_cd(self, text: str, skills_dict: dict) -> None:
+        """Detect CI/CD-specific skills (GitHub Actions, pytest, deployment)."""
+        text_lower = text.lower()
+
+        for indicator, (skill_name, confidence) in self.CI_CD_INDICATORS.items():
+            if indicator in text_lower and skill_name not in skills_dict:
+                skills_dict[skill_name] = SkillDetection(
+                    name=skill_name,
+                    category="CI/CD",
+                    confidence=confidence,
+                    evidence=[f"Found '{indicator}' reference in content"],
+                )

--- a/ingestion/parsers/workflow_parser.py
+++ b/ingestion/parsers/workflow_parser.py
@@ -1,0 +1,1 @@
+# This is where the parser to extract skills from the .yml files of github actions will be implemented.

--- a/ingestion/parsers/workflow_parser.py
+++ b/ingestion/parsers/workflow_parser.py
@@ -1,1 +1,115 @@
-# This is where the parser to extract skills from the .yml files of github actions will be implemented.
+import yaml
+
+from .base import BaseParser, ParseResult
+
+
+class WorkflowParser(BaseParser):
+    """Parser for GitHub Actions workflow YAML files (.github/workflows/*.yml)."""
+
+    def parse(self, content: str | bytes) -> ParseResult:
+        """
+        Parse a GitHub Actions workflow from YAML content.
+
+        Args:
+            content: Workflow YAML string or bytes
+
+        Returns:
+            ParseResult with extracted text and metadata
+
+        Raises:
+            ValueError: If content is not a valid string/bytes, or the YAML
+                is malformed or does not define a top-level mapping.
+        """
+        if isinstance(content, bytes):
+            content = content.decode("utf-8", errors="replace")
+        elif not isinstance(content, str):
+            raise ValueError("Content must be a string or bytes")
+
+        try:
+            workflow = yaml.safe_load(content)
+        except yaml.YAMLError as exc:
+            raise ValueError(f"Invalid workflow YAML: {exc}") from exc
+
+        if workflow is None:
+            workflow = {}
+        if not isinstance(workflow, dict):
+            raise ValueError("Workflow YAML must define a mapping at the top level")
+
+        # PyYAML's YAML 1.1 resolver treats the unquoted `on:` key as the
+        # boolean True, so the trigger config can land under either key.
+        trigger_events = self._extract_triggers(workflow.get("on", workflow.get(True)))
+
+        jobs = workflow.get("jobs")
+        jobs = jobs if isinstance(jobs, dict) else {}
+        job_names = [str(name) for name in jobs]
+        actions_used, run_commands = self._extract_steps(jobs)
+
+        text = self._build_text(
+            name=workflow.get("name"),
+            trigger_events=trigger_events,
+            job_names=job_names,
+            actions_used=actions_used,
+            run_commands=run_commands,
+        )
+
+        metadata = {
+            "source_type": "workflow",
+            "job_count": len(job_names),
+            "trigger_events": trigger_events,
+            "actions_used": actions_used,
+        }
+
+        return ParseResult(text=text, metadata=metadata, source_type="workflow")
+
+    def _extract_triggers(self, on_value: object) -> list[str]:
+        """Normalize the `on:` trigger config into a list of event names."""
+        if isinstance(on_value, str):
+            return [on_value]
+        if isinstance(on_value, list):
+            return [str(event) for event in on_value]
+        if isinstance(on_value, dict):
+            return [str(event) for event in on_value]
+        return []
+
+    def _extract_steps(self, jobs: dict) -> tuple[list[str], list[str]]:
+        """Collect `uses:` action references and `run:` commands across all jobs."""
+        actions_used: list[str] = []
+        run_commands: list[str] = []
+
+        for job in jobs.values():
+            if not isinstance(job, dict):
+                continue
+            steps = job.get("steps")
+            if not isinstance(steps, list):
+                continue
+            for step in steps:
+                if not isinstance(step, dict):
+                    continue
+                uses = step.get("uses")
+                if isinstance(uses, str):
+                    actions_used.append(uses)
+                run = step.get("run")
+                if isinstance(run, str):
+                    run_commands.append(run)
+
+        return actions_used, run_commands
+
+    def _build_text(
+        self,
+        name: object,
+        trigger_events: list[str],
+        job_names: list[str],
+        actions_used: list[str],
+        run_commands: list[str],
+    ) -> str:
+        """Build a text summary suitable for skill extraction and embedding."""
+        parts = [f"Workflow: {name if isinstance(name, str) else 'Unnamed workflow'}"]
+        if trigger_events:
+            parts.append(f"Triggers: {', '.join(trigger_events)}")
+        if job_names:
+            parts.append(f"Jobs: {', '.join(job_names)}")
+        if actions_used:
+            parts.append(f"Actions used: {', '.join(actions_used)}")
+        if run_commands:
+            parts.append("Run commands:\n" + "\n".join(run_commands))
+        return "\n".join(parts)

--- a/ingestion/pipeline.py
+++ b/ingestion/pipeline.py
@@ -10,6 +10,7 @@ from .embeddings.provider import EmbeddingProvider
 from .parsers.readme_parser import ReadmeParser
 from .parsers.repo_analyzer import RepoAnalyzer
 from .parsers.resume_parser import ResumeParser
+from .parsers.workflow_parser import WorkflowParser
 
 
 logger = structlog.get_logger()
@@ -51,6 +52,7 @@ class IngestionPipeline:
         self.resume_parser = ResumeParser()
         self.readme_parser = ReadmeParser()
         self.repo_analyzer = RepoAnalyzer()
+        self.workflow_parser = WorkflowParser()
 
     def ingest_resume(
         self,
@@ -194,6 +196,89 @@ class IngestionPipeline:
                 "README ingestion failed",
                 profile_id=profile_id,
                 repo_name=repo_name,
+                error=str(e),
+            )
+            raise
+
+    def ingest_workflow(
+        self,
+        profile_id: str,
+        repo_name: str,
+        workflow_filename: str,
+        content: str | bytes,
+    ) -> IngestResult:
+        """
+        Ingest a GitHub Actions workflow document.
+
+        Args:
+            profile_id: ID of the profile owner
+            repo_name: Name of the repository
+            workflow_filename: Name of the workflow file (e.g. "ci.yml")
+            content: Workflow content (YAML string or bytes)
+
+        Returns:
+            IngestResult with ingestion status
+        """
+        source_id = (
+            f"workflow_{profile_id}_{repo_name}_{workflow_filename}_"
+            f"{self._hash_content(content)}"
+        )
+
+        logger.info(
+            "Starting workflow ingestion",
+            profile_id=profile_id,
+            repo_name=repo_name,
+            workflow_filename=workflow_filename,
+            source_id=source_id,
+        )
+
+        # Check if already ingested
+        skip_result = self._check_skip(source_id, "workflow")
+        if skip_result:
+            return skip_result
+
+        try:
+            # Parse workflow
+            parse_result = self.workflow_parser.parse(content)
+            logger.info(
+                "Workflow parsed successfully",
+                job_count=parse_result.metadata.get("job_count"),
+                trigger_events=parse_result.metadata.get("trigger_events"),
+            )
+
+            # Prepare metadata
+            metadata = parse_result.metadata.copy()
+            metadata.update({
+                "source_id": source_id,
+                "profile_id": profile_id,
+                "repo_name": repo_name,
+                "workflow_filename": workflow_filename,
+                "source_type": "workflow",
+            })
+
+            # Chunk the content
+            chunks = self.strategy_selector.chunk(parse_result.text, metadata)
+            logger.info("Workflow chunked successfully", chunk_count=len(chunks))
+
+            # Generate embeddings and store
+            self.batch_processor.process(chunks)
+            logger.info("Workflow embeddings stored", chunk_count=len(chunks))
+
+            # Record in database
+            self._record_ingested_source(source_id, "workflow", profile_id, len(chunks))
+
+            return IngestResult(
+                source_id=source_id,
+                chunk_count=len(chunks),
+                skipped=False,
+            )
+
+        except Exception as e:
+            logger.error(
+                "Workflow ingestion failed",
+                profile_id=profile_id,
+                repo_name=repo_name,
+                workflow_filename=workflow_filename,
                 error=str(e),
             )
             raise

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "structlog>=24.1.0",
     "rank-bm25>=0.2.2",
     "numpy>=1.26.0",
+    "PyYAML>=6.0.1",
 ]
 
 [project.optional-dependencies]
@@ -50,6 +51,7 @@ dev = [
     "pre-commit>=3.6.0",
     "mutmut>=2.4.4",
     "types-redis>=4.6.0",
+    "types-PyYAML>=6.0.12",
 ]
 
 [tool.setuptools.packages.find]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,3 +40,29 @@ def sample_readme_text() -> str:
     - Tailwind CSS
     - OpenWeatherMap API
     """
+
+
+@pytest.fixture
+def sample_workflow_yaml() -> str:
+    """Return a sample GitHub Actions workflow YAML for testing."""
+    return """
+    name: CI
+    on:
+      push:
+        branches: [main]
+      pull_request: {}
+    jobs:
+      test:
+        runs-on: ubuntu-latest
+        steps:
+          - uses: actions/checkout@v4
+          - uses: actions/setup-python@v5
+          - run: pip install -r requirements.txt
+          - run: pytest
+      deploy:
+        runs-on: ubuntu-latest
+        needs: test
+        steps:
+          - uses: docker/build-push-action@v5
+          - run: ./deploy.sh production
+    """

--- a/tests/unit/test_skill_extractor.py
+++ b/tests/unit/test_skill_extractor.py
@@ -229,6 +229,50 @@ class TestSkillExtractor:
             assert isinstance(skill.confidence, float)
             assert 0.0 <= skill.confidence <= 1.0
 
+    def test_github_actions_detection(self, extractor):
+        """Test GitHub Actions detection from workflow-derived text."""
+        text = "Actions used: actions/checkout@v4, actions/setup-python@v5"
+        result = extractor.extract_skills(text)
+
+        skill_names = [s.name for s in result]
+        assert "GitHub Actions" in skill_names
+
+    def test_pytest_detection_from_workflow_run_commands(self, extractor):
+        """Test pytest detection from workflow run commands."""
+        text = "Run commands:\npip install -r requirements.txt\npytest"
+        result = extractor.extract_skills(text)
+
+        skill_names = [s.name for s in result]
+        assert "Pytest" in skill_names
+
+    def test_deployment_detection_from_workflow(self, extractor):
+        """Test deployment skill detection from workflow job/step content."""
+        text = "Jobs: deploy\nRun commands:\n./deploy.sh production"
+        result = extractor.extract_skills(text)
+
+        skill_names = [s.name for s in result]
+        assert "Deployment" in skill_names
+
+    def test_ci_cd_skills_have_ci_cd_category(self, extractor):
+        """Test that CI/CD-detected skills are tagged with the CI/CD category."""
+        text = "Actions used: actions/checkout@v4\nRun commands:\npytest"
+        result = extractor.extract_skills(text)
+
+        ci_cd_skills = [s for s in result if s.name in {"GitHub Actions", "Pytest"}]
+        assert ci_cd_skills
+        for skill in ci_cd_skills:
+            assert skill.category == "CI/CD"
+
+    def test_no_ci_cd_false_positive_on_unrelated_text(self, extractor):
+        """Test that plain non-CI/CD text does not trigger CI/CD skills."""
+        text = "This is a simple description of a personal blog project."
+        result = extractor.extract_skills(text)
+
+        skill_names = [s.name for s in result]
+        assert "GitHub Actions" not in skill_names
+        assert "Pytest" not in skill_names
+        assert "Deployment" not in skill_names
+
     def test_skill_detection_dataclass(self):
         """Test SkillDetection dataclass structure."""
         skill = SkillDetection(

--- a/tests/unit/test_workflow_parser.py
+++ b/tests/unit/test_workflow_parser.py
@@ -1,0 +1,177 @@
+"""Tests for workflow_parser.py"""
+
+import pytest
+
+from ingestion.parsers.base import ParseResult
+from ingestion.parsers.workflow_parser import WorkflowParser
+
+
+@pytest.mark.unit
+class TestWorkflowParser:
+    """Test suite for WorkflowParser."""
+
+    @pytest.fixture
+    def parser(self):
+        """Create a WorkflowParser instance."""
+        return WorkflowParser()
+
+    def test_parse_standard_workflow(self, parser, sample_workflow_yaml):
+        """Test parsing a standard multi-job workflow."""
+        result = parser.parse(sample_workflow_yaml)
+
+        assert isinstance(result, ParseResult)
+        assert result.source_type == "workflow"
+        assert result.metadata["source_type"] == "workflow"
+        assert "CI" in result.text
+        assert result.metadata["job_count"] == 2
+
+    def test_parse_extracts_trigger_events(self, parser, sample_workflow_yaml):
+        """Test that trigger events are extracted despite the YAML 'on' gotcha."""
+        result = parser.parse(sample_workflow_yaml)
+
+        assert "push" in result.metadata["trigger_events"]
+        assert "pull_request" in result.metadata["trigger_events"]
+
+    def test_parse_extracts_job_names(self, parser, sample_workflow_yaml):
+        """Test that job names appear in the parsed text."""
+        result = parser.parse(sample_workflow_yaml)
+
+        assert "test" in result.text
+        assert "deploy" in result.text
+
+    def test_parse_extracts_actions_used(self, parser, sample_workflow_yaml):
+        """Test that 'uses:' action references are extracted."""
+        result = parser.parse(sample_workflow_yaml)
+
+        assert "actions/checkout@v4" in result.metadata["actions_used"]
+        assert "actions/setup-python@v5" in result.metadata["actions_used"]
+        assert "docker/build-push-action@v5" in result.metadata["actions_used"]
+
+    def test_parse_extracts_run_commands(self, parser, sample_workflow_yaml):
+        """Test that 'run:' commands are extracted into the text."""
+        result = parser.parse(sample_workflow_yaml)
+
+        assert "pytest" in result.text
+        assert "./deploy.sh production" in result.text
+
+    def test_parse_single_job_workflow(self, parser):
+        """Test parsing a workflow with a single job and string trigger."""
+        workflow = """
+        name: Lint
+        on: push
+        jobs:
+          lint:
+            runs-on: ubuntu-latest
+            steps:
+              - uses: actions/checkout@v4
+              - run: ruff check .
+        """
+        result = parser.parse(workflow)
+
+        assert result.metadata["job_count"] == 1
+        assert result.metadata["trigger_events"] == ["push"]
+
+    def test_parse_list_style_triggers(self, parser):
+        """Test parsing a workflow with 'on:' as a list rather than a mapping."""
+        workflow = """
+        name: Multi-trigger
+        on: [push, pull_request]
+        jobs:
+          build:
+            runs-on: ubuntu-latest
+            steps:
+              - run: echo build
+        """
+        result = parser.parse(workflow)
+
+        assert result.metadata["trigger_events"] == ["push", "pull_request"]
+
+    def test_parse_malformed_yaml_raises_value_error(self, parser):
+        """Test that malformed YAML raises ValueError instead of crashing."""
+        malformed = """
+        name: Broken
+        on: [push
+        jobs:
+        """
+        with pytest.raises(ValueError):
+            parser.parse(malformed)
+
+    def test_parse_missing_jobs_key(self, parser):
+        """Test a workflow with no 'jobs' key parses without crashing."""
+        workflow = """
+        name: No Jobs Yet
+        on: push
+        """
+        result = parser.parse(workflow)
+
+        assert result.metadata["job_count"] == 0
+        assert result.metadata["actions_used"] == []
+
+    def test_parse_job_with_no_steps(self, parser):
+        """Test a job missing a 'steps' key does not crash the parser."""
+        workflow = """
+        name: Reusable
+        on: push
+        jobs:
+          call-shared:
+            uses: org/repo/.github/workflows/shared.yml@main
+        """
+        result = parser.parse(workflow)
+
+        assert result.metadata["job_count"] == 1
+        assert result.metadata["actions_used"] == []
+
+    def test_parse_step_with_neither_uses_nor_run(self, parser):
+        """Test a step missing both 'uses' and 'run' does not crash the parser."""
+        workflow = """
+        name: Weird Step
+        on: push
+        jobs:
+          build:
+            runs-on: ubuntu-latest
+            steps:
+              - name: Just a label
+        """
+        result = parser.parse(workflow)
+
+        assert result.metadata["job_count"] == 1
+        assert result.metadata["actions_used"] == []
+
+    def test_parse_empty_yaml(self, parser):
+        """Test parsing empty content returns an empty-but-valid result."""
+        result = parser.parse("")
+
+        assert isinstance(result, ParseResult)
+        assert result.metadata["job_count"] == 0
+        assert result.metadata["trigger_events"] == []
+        assert result.source_type == "workflow"
+
+    def test_parse_non_mapping_yaml_raises_value_error(self, parser):
+        """Test that a top-level YAML list (not a mapping) raises ValueError."""
+        with pytest.raises(ValueError):
+            parser.parse("- just\n- a\n- list\n")
+
+    def test_parse_bytes_input(self, parser):
+        """Test parsing workflow content from bytes."""
+        workflow_bytes = b"name: CI\non: push\njobs:\n  build:\n    steps:\n      - run: echo hi\n"
+        result = parser.parse(workflow_bytes)
+
+        assert isinstance(result, ParseResult)
+        assert "CI" in result.text
+
+    def test_parse_invalid_content_type(self, parser):
+        """Test that an invalid content type raises ValueError."""
+        with pytest.raises(ValueError) as exc_info:
+            parser.parse(12345)
+
+        assert "Content must be a string or bytes" in str(exc_info.value)
+
+    def test_metadata_structure(self, parser, sample_workflow_yaml):
+        """Test that metadata has the required structure."""
+        result = parser.parse(sample_workflow_yaml)
+
+        assert "source_type" in result.metadata
+        assert "job_count" in result.metadata
+        assert "trigger_events" in result.metadata
+        assert "actions_used" in result.metadata
+        assert result.metadata["source_type"] == "workflow"


### PR DESCRIPTION
## Summary
Adds a `WorkflowParser` that reads GitHub Actions workflow YAML (`.github/workflows/*.yml`) and extracts triggers, job names, actions used, and run commands, then wires that output into `SkillExtractor` so CI/CD skills (GitHub Actions, Pytest, Deployment) are detected alongside existing language/framework/tool detection.

## Issue
Closes #14

## Changes
- `ingestion/parsers/workflow_parser.py`: new `WorkflowParser(BaseParser)` — `yaml.safe_load`s workflow content into text + metadata (`job_count`, `trigger_events`, `actions_used`), handles PyYAML's `on:` → `True` boolean gotcha, and raises `ValueError` on malformed/non-mapping YAML.
- `ingestion/parsers/skill_extractor.py`: new `_detect_ci_cd` step + `CI_CD_INDICATORS` map, tagging GitHub Actions/Pytest/Deployment detections under a `CI/CD` category. Docker is intentionally left to the existing `TOOLS` detection to avoid duplicate category entries.
- `ingestion/pipeline.py`: new `ingest_workflow(...)` method mirroring `ingest_readme`'s parse/chunk/embed/record flow, keyed by `workflow_filename` to support multiple workflow files per repo.
- `pyproject.toml`: add `PyYAML` + `types-PyYAML` dependencies.
- `tests/conftest.py`: add `sample_workflow_yaml` fixture.
- `tests/unit/test_workflow_parser.py` (new) + `tests/unit/test_skill_extractor.py`: 21 new unit tests covering standard/edge-case workflow parsing and CI/CD skill detection.

## Testing
- [x] Unit tests pass (`make test-unit`) — 21 new tests pass; pre-existing 53 failures unrelated to this change are unchanged (see notes below)
- [ ] Integration tests pass (`make test-integration`) — not applicable, no integration test coverage for this path
- [x] Linter passes (`make lint`) — no new errors introduced (182 pre-existing errors, down from 183 baseline; the one delta is a pre-existing lint issue on the old placeholder file this PR replaces)
- [x] Type checker passes (`make typecheck`) — no new errors introduced (103 pre-existing errors, unchanged)
- [x] New/updated tests cover the changes

## Notes for Reviewers
This repo has pre-existing lint/type/test failures unrelated to this change (baseline: 183 ruff errors, 103 mypy errors, 53 failing unit tests before this PR). I verified via `git stash` diffing that none of my changes introduce new failures — all flagged issues in touched files (`skill_extractor.py`, `pipeline.py`) existed before at shifted line numbers. Five pre-existing failures in `test_skill_extractor.py` (e.g. a self-shadowing bug in `test_database_technology_detection`) are untouched and unrelated to CI/CD detection.

Design call: `ingest_workflow` is one call per workflow file (parameterized by `workflow_filename`) rather than batching all workflows in a repo into one call — open to feedback if a different granularity is preferred.