### PR TITLE
feat(api): add caching layer for repeated identical portfolio queries

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -14,3 +14,17 @@ If a user submits the same portfolio twice without editing anything, they sit th
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/codyholm/pathreview/commit/163ae55
+
+**Reproduction summary:**
+Submitted the same unchanged profile twice via `POST /reviews` and observed two distinct reviews created, the full pipeline running twice in the server logs with byte-identical output (same sections, same 0.81 score), and the profile's review history growing from 3 to 5 rows. The reproduction commit adds `tests/unit/test_review_cache.py`, whose 6 failing tests pin the expected caching behavior — return the stored review when profile content is unchanged — against the current code in `core/services/review_service.py`, which unconditionally creates a new review on every submit.
+
+**PLAN.md link:** https://github.com/codyholm/pathreview/blob/feat/32-portfolio-query-cache/PLAN.md
+
+**Walkthrough video (recommended):** Not recorded
+
+**Blockers or open questions:**
+None

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,16 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/32
+
+**Issue title:** Implement a caching layer for repeated identical portfolio queries
+
+**Tier:** [ ] Tier 1  [x] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+If a user submits the same portfolio twice without editing anything, they sit through the full review process again and get back feedback they already had. Nothing in that path checks for prior work, create_review() in core/services/review_service.py just starts another pending review, and retrieval and generation run from scratch every time. So identical input costs the same time and API calls it cost the first time, and leaves a duplicate entry in the user's review history. A successful fix would key a cache on a hash of the profile's content, return the stored review when nothing has changed, and regenerate only when it has. I chose this Tier 2 issue because RAG systems and hand-rolled LLM caching are both things I have worked with in this class and in personal projects recently, so the concepts are familiar, and the real stretch for me is working inside an unfamiliar codebase and getting the invalidation right.
+
+**Branch name:** feat/32-portfolio-query-cache
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -24,7 +24,33 @@ Submitted the same unchanged profile twice via `POST /reviews` and observed two 
 
 **PLAN.md link:** https://github.com/codyholm/pathreview/blob/feat/32-portfolio-query-cache/PLAN.md
 
-**Walkthrough video (recommended):** Not recorded
+## Week 9 — Solution building & PR submission
 
-**Blockers or open questions:**
-None
+### Check-in 1 (mid-week)
+
+**Current progress:**
+I have written the tests for caching layer which are intended to fail before implementation. Wrote the plan for implementation, checked on pre-existing test failures and lint errors.
+
+**Next steps:**
+Steps 2–5 of PLAN.md: the content-hash helper and migration, the cache lookup in create_review, route wiring, and end-to-end verification.
+
+**Blockers:**
+The various pre-existing issues in codebase took some sorting and working around, deciding what should be addressed in this PR or left alone took some time.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/953
+
+**Branch:** feat/32-portfolio-query-cache
+
+**What you built:**
+Implemented a caching layer for portfolio review queries. Each completed review stores a hash of the profile content it was generated from, so resubmitting an unchanged profile returns the stored review — same review, no pipeline rerun, no duplicate history entry. Editing the profile changes the hash, so the next submit regenerates.
+
+**Tests added or updated:**
+`tests/unit/test_review_cache.py`: 8 tests covering the content hash (identical content hashes identically, any field change or all-empty profile handled) and `create_review` behavior (unchanged resubmit returns the stored review with no new row; first submits and failed priors still create a fresh one). `tests/integration/test_review_cache_db.py`: 5 tests running the lookup against real Postgres to pin the SQL predicate itself. Also updated the mock session fixture in `tests/unit/test_review_service.py` for the new lookup.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+**Draft PR feedback received from:** [Claude]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -54,3 +54,28 @@ Implemented a caching layer for portfolio review queries. Each completed review 
 **Self-review confirmation:** [x] make check passes  [x] make test-unit passes
 
 **Draft PR feedback received from:** [Claude]
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Distinguishing issues and failing tests that were in scope for this PR, and what should be left alone.
+
+**What did you learn about working in a large codebase?**
+That there will be different implementations or conventions that you might not agree with, but need to learn how to work around it. When working an issue, focus on implementing what is needed without making the code worse and don't worry about fixing every unrelated thing you might come across. When working on my own projects it makes more sense to handle issues as I see them or soon after, since in the end it's all my code and I might forget about it later. When contributing to someone else's code it's better to stay focused on the slice of the codebase that your changes directly impact.
+
+**How did AI tools help — and where did they fall short?**
+AI assisted greatly in exploring the codebase and mapping the files that we would be needing for the caching layer. It also helped implement the code changes from the written PLAN.md along with the tests. Before opening the PR I also had a second model do a review of the branch. This caught that the unit tests used a mocked session, so they still passed even with the cache's SQL filters deleted. That led to adding integration tests against real Postgres and a fix to return the newest matching review. It fell short because not every finding from that review was accurate, so I had to verify each one against the actual code and reject the ones that didn't hold up instead of applying them wholesale. And the tests with the blind spot were AI-written in the first place — they looked thorough and passed, which was a good reminder that passing AI-generated tests aren't proof by themselves.
+
+**What would you do differently if you started over?**
+I don't think there is much I would do differently except perhaps the planning phase. At the beginning when I had AI review the plan things started to get a bit over-engineered and they spent a lot of time chasing down edge cases and failing tests before I redirected them. The clearest example was a request-coalescing design for concurrent submits that I cut once I checked the issue tracker and found concurrency was already its own separate issue (#82). Next time I'd check the scope boundary against the tracker before the design discussion instead of after.
+
+**What are you most proud of from this module?**
+Successfully implementing a caching layer into a large codebase with unfamiliar code, with a real test-first arc: the six failing tests I committed as the Week 8 reproduction are the exact tests passing in the PR.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,122 @@
+## Solution plan
+
+**Issue:** Implement a caching layer for repeated identical portfolio queries — https://github.com/ascherj/pathreview/issues/32
+
+### Understand
+
+Submitting the same profile twice runs the full review pipeline twice and leaves
+two entries in the user's review history.
+
+The submit path never checks for prior work. `POST /reviews`
+(`api/routes/reviews.py`, `create_review_endpoint`) calls `create_review()` in
+`core/services/review_service.py`, which unconditionally inserts a new
+`Review(status="pending")` row, then queues `process_review()` as a background
+task. `process_review()` runs ingestion, agent orchestration, RAG
+retrieval/generation, and safety checks from scratch every time — nothing keys
+off whether the profile's content has changed since the last completed review.
+
+- **Expected:** resubmitting a profile whose content is unchanged returns the
+  already-completed review immediately, with no new pipeline run and no
+  duplicate history entry. If the profile's content has changed, a fresh review
+  is generated.
+- **Actual:** every submit creates a new review row and re-runs the entire
+  pipeline, regardless of whether anything changed.
+
+Cache-hit contract: on a hit, return the existing review — same review ID, no
+new row. This matches the issue text ("return the stored review when nothing
+has changed") and directly fixes the duplicate-history complaint.
+
+One subtlety: the request body only carries `profile_id`, so "identical input"
+must mean the *content* of the `Profile` row (`github_username`,
+`portfolio_url`, `resume_text`, `resume_filename`), not the request itself. The
+cache key is a hash of those fields.
+
+### Map
+
+- `core/services/review_service.py` — `create_review()` gains the cache lookup;
+  a new helper computes the profile content hash; `process_review()` stores the
+  hash on the review when processing starts. Functions touched here also gain
+  type annotations: the repo's pre-commit mypy hook enforces
+  `disallow_untyped_defs`, which this module does not yet satisfy.
+- `core/models/review.py` — new nullable `content_hash` column (indexed) on
+  `Review`. The completed review row in Postgres *is* the cached value; the
+  hash is how we find it.
+- `alembic/versions/` — new migration `003` adding `content_hash` to `reviews`.
+- `api/routes/reviews.py` — `create_review_endpoint` only queues
+  `process_review` when the service created a fresh review (cache miss).
+- `core/models/profile.py` — read-only; source of the fields being hashed.
+- `tests/unit/test_review_service.py` (or a new sibling test file) — failing
+  tests written first, defining the contract above.
+
+### Plan
+
+1. **Reproduce and pin the contract with failing tests.** Reproduce live:
+   submit the same profile twice via `POST /reviews`, record the two distinct
+   review IDs and duplicated history. Write unit tests asserting the desired
+   behavior: (a) unchanged content → second submit returns the same review,
+   (b) no new history row on a hit, (c) changed content → new review,
+   (d) prior review not `complete` → no cache hit. Commit with the tests
+   failing — this is the Week 8 reproduction commit.
+2. **Add the cache key.** Write a pure helper (e.g. `compute_content_hash`)
+   that canonicalizes the profile's content fields (stable field order,
+   explicit handling of `None`) and returns a sha256 hex digest. Add the
+   `content_hash` column to `Review` plus migration `003`.
+3. **Cache lookup in `create_review()`.** Compute the hash from the profile,
+   query for a `complete` review with the same `profile_id` and
+   `content_hash`, and return it on a hit. On a miss, create the pending
+   review with the hash stored, as today. Return a flag (or tuple) so the
+   route knows whether to queue `process_review`. Annotate the signatures of
+   the functions this step touches so the changes pass the pre-commit mypy
+   gate (`disallow_untyped_defs`), which the module currently fails.
+4. **Wire the route and verify invalidation.** Skip the background task on a
+   hit. Editing any hashed profile field changes the hash, so the next submit
+   misses and regenerates — confirm with the invalidation test from step 1.
+5. **Verify end to end.** All step-1 tests pass, the full unit suite stays
+   green, and a live double-submit returns the same review ID the second time
+   with only one history entry.
+
+### Inputs & outputs
+
+- **Input:** the same `POST /reviews` request as today — `{profile_id}` plus
+  the authenticated user. No API schema changes.
+- **Output on cache hit:** the existing completed `Review` (same ID, status
+  `complete`, sections populated), returned immediately; no background task,
+  no new row.
+- **Output on cache miss:** unchanged from today — new pending review,
+  pipeline queued.
+- **Schema change:** `reviews.content_hash` (nullable string, indexed) via
+  migration `003`.
+
+### Risks & unknowns
+
+- **Storage choice:** the plan stores the hash on the `Review` row in Postgres
+  rather than in Redis. Redis is running in the stack, but the cached value
+  *is* a Postgres row — a Redis entry would be a second source of truth that
+  can drift (and vanish on restart) while the review persists. Confirm this
+  reasoning holds during implementation; revisit if reviewers expect Redis.
+- **Concurrent submits:** two rapid submits of the same profile both miss
+  (the first review is still `pending`/`processing`, not `complete`) and both
+  run the pipeline. This is deliberately out of scope: concurrent review
+  requests are their own issue (#82, "Concurrent review requests for the same
+  profile can produce inconsistent results"), which prescribes a per-profile
+  lock. This fix only dedupes against *completed* reviews.
+- **Where the hash is computed vs. stored:** `create_review()` needs the
+  `Profile` loaded to hash it; today it only receives `profile_id`. Need to
+  confirm the profile fetch there doesn't conflict with the route's existing
+  ownership checks.
+- **Unit-test style:** existing tests mock the db session heavily; asserting
+  "returns the same review" through mocks may pin implementation details.
+  May need one test that fakes the lookup result rather than the SQL.
+
+### Edge cases
+
+- **Profile content changed between submits** — hash differs, must regenerate
+  (the core invalidation case).
+- **Prior review exists but is `failed` or still `processing`** — not a cache
+  hit; a new review is created so the user isn't served a failure or blocked.
+- **Profile with all content fields `None`** — hash of empty content is still
+  a valid, stable key; two empty submits should still hit the cache.
+- **Same content, different profile** — hash matches but `profile_id`
+  differs; lookup keys on both, so no cross-profile (or cross-user) leakage.
+- **Pre-existing reviews with `content_hash = NULL`** (rows from before the
+  migration) — never match a lookup; first resubmit regenerates and caches.

--- a/PLAN.md
+++ b/PLAN.md
@@ -64,10 +64,13 @@ cache key is a hash of those fields.
 3. **Cache lookup in `create_review()`.** Compute the hash from the profile,
    query for a `complete` review with the same `profile_id` and
    `content_hash`, and return it on a hit. On a miss, create the pending
-   review with the hash stored, as today. Return a flag (or tuple) so the
-   route knows whether to queue `process_review`. Annotate the signatures of
-   the functions this step touches so the changes pass the pre-commit mypy
-   gate (`disallow_untyped_defs`), which the module currently fails.
+   review as today; `process_review` stores the hash when processing starts,
+   so it reflects the content actually processed. The signature stays
+   `-> Review` (as the step-1 tests pin it): status is the hit/miss signal,
+   since a hit is always `complete` and a miss always `pending`, so the
+   route queues `process_review` only for `pending`. Annotate the signatures
+   of the functions this step touches so the changes pass the pre-commit
+   mypy gate (`disallow_untyped_defs`), which the module currently fails.
 4. **Wire the route and verify invalidation.** Skip the background task on a
    hit. Editing any hashed profile field changes the hash, so the next submit
    misses and regenerates — confirm with the invalidation test from step 1.

--- a/alembic/versions/003_add_content_hash_to_reviews.py
+++ b/alembic/versions/003_add_content_hash_to_reviews.py
@@ -1,0 +1,28 @@
+"""Add content_hash column to reviews table.
+
+Revision ID: 003
+Revises: 002
+Create Date: 2026-08-04 00:00:00.000000
+"""
+
+import sqlalchemy as sa
+
+from alembic import op  # type: ignore[attr-defined]
+
+revision = "003"
+down_revision = "002"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "reviews",
+        sa.Column("content_hash", sa.String(length=64), nullable=True),
+    )
+    op.create_index("ix_reviews_content_hash", "reviews", ["content_hash"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_reviews_content_hash", table_name="reviews")
+    op.drop_column("reviews", "content_hash")

--- a/api/routes/reviews.py
+++ b/api/routes/reviews.py
@@ -28,26 +28,29 @@ async def create_review_endpoint(
 ):
     """
     Create a new review for a profile.
-    Triggers ingestion pipeline and agent orchestration asynchronously.
-    Returns review with status="pending" immediately.
+    Triggers ingestion pipeline and agent orchestration asynchronously and
+    returns the review with status="pending" immediately — unless the
+    profile's content is unchanged since its last completed review, in which
+    case that review is returned as-is with no reprocessing.
     """
     try:
-        # Create review with status="pending"
         review = await create_review(
             db=db,
             profile_id=data.profile_id,
             user_id=current_user.id,
         )
 
-        # Add background task for processing
-        background_tasks.add_task(process_review, db, review.id, data.profile_id)
+        # A cache hit comes back "complete"; only a fresh review needs the
+        # pipeline.
+        if review.status == "pending":
+            background_tasks.add_task(process_review, db, review.id, data.profile_id)
 
-        log.info(
-            "review_created",
-            review_id=str(review.id),
-            profile_id=str(data.profile_id),
-            user_id=str(current_user.id),
-        )
+            log.info(
+                "review_created",
+                review_id=str(review.id),
+                profile_id=str(data.profile_id),
+                user_id=str(current_user.id),
+            )
 
         return ReviewResponse.model_validate(review)
 

--- a/core/models/review.py
+++ b/core/models/review.py
@@ -34,6 +34,9 @@ class Review(Base):
     sections: Mapped[dict | None] = mapped_column(JSON, nullable=True)  # Structured review output
     overall_score: Mapped[float | None] = mapped_column(Float, nullable=True)
     error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
+    content_hash: Mapped[str | None] = mapped_column(
+        String(64), nullable=True
+    )  # sha256 of the profile content this review was generated from
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, default=datetime.utcnow
     )
@@ -48,6 +51,7 @@ class Review(Base):
         Index("ix_reviews_profile_id", "profile_id"),
         Index("ix_reviews_status", "status"),
         Index("ix_reviews_created_at", "created_at"),
+        Index("ix_reviews_content_hash", "content_hash"),
     )
 
     def __repr__(self) -> str:

--- a/core/models/review.py
+++ b/core/models/review.py
@@ -31,7 +31,9 @@ class Review(Base):
     status: Mapped[str] = mapped_column(
         String(50), nullable=False, default="pending"
     )  # "pending", "processing", "complete", "failed"
-    sections: Mapped[dict | None] = mapped_column(JSON, nullable=True)  # Structured review output
+    sections: Mapped[list[dict] | None] = mapped_column(
+        JSON, nullable=True
+    )  # Structured review output
     overall_score: Mapped[float | None] = mapped_column(Float, nullable=True)
     error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
     content_hash: Mapped[str | None] = mapped_column(

--- a/core/services/review_service.py
+++ b/core/services/review_service.py
@@ -1,25 +1,75 @@
-from uuid import UUID
-import structlog
+import hashlib
 import json
 from datetime import datetime
-from sqlalchemy import select, and_
+from uuid import UUID
 
-from core.models.review import Review
-from core.models.profile import Profile
-from core.models.ingested_source import IngestedSource
+import structlog
+from sqlalchemy import and_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from api.schemas.review import FeedbackSection
+from core.models.ingested_source import IngestedSource
+from core.models.profile import Profile
+from core.models.review import Review
 
 log = structlog.get_logger()
 
 
+def compute_content_hash(profile: Profile) -> str:
+    """
+    Hash the profile content fields the review pipeline consumes.
+
+    Profiles with identical content hash identically regardless of row
+    identity, so a completed review can be reused when nothing has changed.
+    JSON canonicalization gives a stable field order and represents missing
+    fields explicitly as null.
+    """
+    content = json.dumps(
+        {
+            "github_username": profile.github_username,
+            "portfolio_url": profile.portfolio_url,
+            "resume_filename": profile.resume_filename,
+            "resume_text": profile.resume_text,
+        },
+        sort_keys=True,
+    )
+    return hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+
 async def create_review(
-    db,
+    db: AsyncSession,
     profile_id: UUID,
     user_id: UUID,
 ) -> Review:
     """
-    Create a new review with status="pending".
+    Create a new review with status="pending", unless a completed review
+    already exists for the profile's current content — then return that
+    review instead (cache hit). Callers can tell the two apart by status:
+    a cache hit is always "complete", a fresh review is always "pending".
     """
+    stmt = select(Profile).where(Profile.id == profile_id)
+    result = await db.execute(stmt)
+    profile = result.scalars().first()
+
+    if profile is not None:
+        content_hash = compute_content_hash(profile)
+        cached_stmt = select(Review).where(
+            and_(
+                Review.profile_id == profile_id,
+                Review.content_hash == content_hash,
+                Review.status == "complete",
+            )
+        )
+        cached_result = await db.execute(cached_stmt)
+        cached: Review | None = cached_result.scalars().first()
+        if cached is not None:
+            log.info(
+                "review_cache_hit",
+                review_id=str(cached.id),
+                profile_id=str(profile_id),
+            )
+            return cached
+
     review = Review(
         profile_id=profile_id,
         status="pending",
@@ -33,22 +83,23 @@ async def create_review(
 
 
 async def get_review(
-    db,
+    db: AsyncSession,
     review_id: UUID,
     user_id: UUID,
 ) -> Review | None:
     """
     Get a review by ID, checking that it belongs to the user's profile.
     """
-    stmt = select(Review).join(Profile).where(
-        and_(Review.id == review_id, Profile.user_id == user_id)
+    stmt = (
+        select(Review).join(Profile).where(and_(Review.id == review_id, Profile.user_id == user_id))
     )
     result = await db.execute(stmt)
-    return result.scalars().first()
+    review: Review | None = result.scalars().first()
+    return review
 
 
 async def list_reviews(
-    db,
+    db: AsyncSession,
     user_id: UUID,
     page: int = 1,
     page_size: int = 20,
@@ -74,13 +125,13 @@ async def list_reviews(
         .limit(page_size)
     )
     result = await db.execute(stmt)
-    reviews = result.scalars().all()
+    reviews = list(result.scalars().all())
 
     return reviews, total
 
 
 async def process_review(
-    db,
+    db: AsyncSession,
     review_id: UUID,
     profile_id: UUID,
 ) -> None:
@@ -117,8 +168,11 @@ async def process_review(
             await db.commit()
             return
 
-        # Step 1: Set status to processing
+        # Step 1: Set status to processing. The hash is taken from the profile
+        # as fetched here, so it reflects the content this run actually
+        # processes even if the profile is edited while the pipeline runs.
         review.status = "processing"
+        review.content_hash = compute_content_hash(profile)
         db.add(review)
         await db.commit()
 
@@ -194,7 +248,7 @@ async def process_review(
             log.error("review_status_update_failed", review_id=str(review_id), error=str(e))
 
 
-async def _run_ingestion_pipeline(db, profile: Profile) -> list[dict]:
+async def _run_ingestion_pipeline(db: AsyncSession, profile: Profile) -> list[dict]:
     """
     Run ingestion pipeline to extract data from profile sources.
     Returns list of ingested source data.

--- a/core/services/review_service.py
+++ b/core/services/review_service.py
@@ -53,12 +53,19 @@ async def create_review(
 
     if profile is not None:
         content_hash = compute_content_hash(profile)
-        cached_stmt = select(Review).where(
-            and_(
-                Review.profile_id == profile_id,
-                Review.content_hash == content_hash,
-                Review.status == "complete",
+        cached_stmt = (
+            select(Review)
+            .where(
+                and_(
+                    Review.profile_id == profile_id,
+                    Review.content_hash == content_hash,
+                    Review.status == "complete",
+                )
             )
+            # Concurrent submits can complete twice with the same hash (see
+            # #82), so pin the hit to the newest matching review.
+            .order_by(Review.created_at.desc())
+            .limit(1)
         )
         cached_result = await db.execute(cached_stmt)
         cached: Review | None = cached_result.scalars().first()
@@ -253,7 +260,7 @@ async def _run_ingestion_pipeline(db: AsyncSession, profile: Profile) -> list[di
     Run ingestion pipeline to extract data from profile sources.
     Returns list of ingested source data.
     """
-    sources = []
+    sources: list[dict] = []
 
     # Ingest from GitHub if available
     if profile.github_username:

--- a/tests/integration/test_review_cache_db.py
+++ b/tests/integration/test_review_cache_db.py
@@ -1,0 +1,160 @@
+"""Integration tests for the review cache lookup (#32).
+
+The unit suite's session double cannot evaluate SQL, so these tests pin the
+cache predicate against the real Postgres from docker compose: a hit
+requires matching profile_id, matching content_hash, and status="complete",
+and ties resolve to the newest matching review. Each test runs inside an
+outer transaction that is rolled back, leaving the database unchanged.
+"""
+
+from collections.abc import AsyncIterator
+from datetime import datetime, timedelta
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+
+from core.config import settings
+from core.models.profile import Profile
+from core.models.review import Review
+from core.models.user import User
+from core.services.review_service import compute_content_hash, create_review
+
+
+@pytest_asyncio.fixture
+async def db() -> AsyncIterator[AsyncSession]:
+    """Session bound to an outer transaction that is always rolled back.
+
+    create_review commits its own work, so the session joins the outer
+    transaction through savepoints; the rollback at the end discards
+    everything a test wrote.
+    """
+    engine = create_async_engine(settings.database_url)
+    connection = await engine.connect()
+    transaction = await connection.begin()
+    session = AsyncSession(
+        bind=connection,
+        expire_on_commit=False,
+        join_transaction_mode="create_savepoint",
+    )
+    try:
+        yield session
+    finally:
+        await session.close()
+        await transaction.rollback()
+        await connection.close()
+        await engine.dispose()
+
+
+async def seed_profile(db: AsyncSession) -> Profile:
+    """Insert a user and a profile with representative content."""
+    user = User(
+        id=str(uuid4()),
+        email=f"cache-test-{uuid4()}@example.com",
+        hashed_password="not-a-real-hash",
+    )
+    profile = Profile(
+        id=str(uuid4()),
+        user_id=user.id,
+        github_username="janedoe",
+        portfolio_url="https://janedoe.dev",
+        resume_filename="resume.pdf",
+        resume_text="Jane Doe. Software Engineer. Python, FastAPI, PostgreSQL.",
+    )
+    db.add(user)
+    db.add(profile)
+    await db.commit()
+    return profile
+
+
+def completed_review(profile: Profile, created_at: datetime | None = None) -> Review:
+    """Build a complete review carrying the profile's current content hash."""
+    review = Review(
+        id=str(uuid4()),
+        profile_id=profile.id,
+        status="complete",
+        sections=[
+            {
+                "section_name": "Technical Skills",
+                "content": "Feedback on technical skills",
+                "confidence": 0.85,
+                "suggestions": [],
+            }
+        ],
+        overall_score=0.81,
+        content_hash=compute_content_hash(profile),
+    )
+    if created_at is not None:
+        review.created_at = created_at
+        review.updated_at = created_at
+    return review
+
+
+@pytest.mark.integration
+class TestReviewCachePredicate:
+    """The lookup's WHERE clause, exercised through real SQL."""
+
+    @pytest.mark.asyncio
+    async def test_unchanged_resubmit_returns_stored_review(self, db: AsyncSession) -> None:
+        profile = await seed_profile(db)
+        cached = completed_review(profile)
+        db.add(cached)
+        await db.commit()
+
+        result = await create_review(db, profile.id, profile.user_id)
+
+        assert result.id == cached.id
+        assert result.status == "complete"
+
+    @pytest.mark.asyncio
+    async def test_changed_content_misses_cache(self, db: AsyncSession) -> None:
+        profile = await seed_profile(db)
+        cached = completed_review(profile)
+        db.add(cached)
+        profile.resume_text = "Jane Doe. Senior Engineer. Go, Kubernetes."
+        await db.commit()
+
+        result = await create_review(db, profile.id, profile.user_id)
+
+        assert result.id != cached.id
+        assert result.status == "pending"
+
+    @pytest.mark.asyncio
+    async def test_failed_review_is_not_a_cache_hit(self, db: AsyncSession) -> None:
+        profile = await seed_profile(db)
+        failed = completed_review(profile)
+        failed.status = "failed"
+        db.add(failed)
+        await db.commit()
+
+        result = await create_review(db, profile.id, profile.user_id)
+
+        assert result.id != failed.id
+        assert result.status == "pending"
+
+    @pytest.mark.asyncio
+    async def test_same_content_on_other_profile_does_not_leak(self, db: AsyncSession) -> None:
+        profile_a = await seed_profile(db)
+        profile_b = await seed_profile(db)
+        cached_a = completed_review(profile_a)
+        db.add(cached_a)
+        await db.commit()
+
+        result = await create_review(db, profile_b.id, profile_b.user_id)
+
+        assert result.id != cached_a.id
+        assert result.status == "pending"
+
+    @pytest.mark.asyncio
+    async def test_hit_returns_newest_matching_review(self, db: AsyncSession) -> None:
+        profile = await seed_profile(db)
+        older = completed_review(profile, created_at=datetime.utcnow() - timedelta(days=1))
+        newer = completed_review(profile)
+        db.add(older)
+        db.add(newer)
+        await db.commit()
+
+        result = await create_review(db, profile.id, profile.user_id)
+
+        assert result.id == newer.id

--- a/tests/unit/test_review_cache.py
+++ b/tests/unit/test_review_cache.py
@@ -1,0 +1,205 @@
+"""Tests for review caching on repeated identical portfolio queries (#32).
+
+Submitting a profile whose content is unchanged should return the stored
+review instead of creating a new row and re-running the pipeline. The cache
+key is a hash of the profile's content fields, and only reviews with
+status="complete" are cache candidates.
+
+Content-change invalidation is covered by the hash tests: the session double
+below cannot evaluate SQL filters, so it only models whether a completed
+review exists at all. The cache lookup is expected to key on
+(profile_id, content_hash, status="complete").
+"""
+
+from collections.abc import Callable, Sequence
+from typing import Any, cast
+from uuid import uuid4
+
+import pytest
+
+from core.models.profile import Profile
+from core.models.review import Review
+from core.services.review_service import create_review
+
+
+def make_profile(**overrides: str | None) -> Profile:
+    """Build a Profile with representative content fields."""
+    fields: dict[str, str | None] = dict(
+        id=str(uuid4()),
+        user_id=str(uuid4()),
+        github_username="janedoe",
+        portfolio_url="https://janedoe.dev",
+        resume_filename="resume.pdf",
+        resume_text="Jane Doe. Software Engineer. Python, FastAPI, PostgreSQL.",
+    )
+    fields.update(overrides)
+    return Profile(**fields)
+
+
+def make_review(profile: Profile, status: str = "complete") -> Review:
+    """Build a Review as the pipeline would have left it."""
+    return Review(
+        id=str(uuid4()),
+        profile_id=profile.id,
+        status=status,
+        sections=(
+            [
+                {
+                    "section_name": "Technical Skills",
+                    "content": "Feedback on technical skills",
+                    "confidence": 0.85,
+                    "suggestions": ["Add more detail on AI/ML experience"],
+                }
+            ]
+            if status == "complete"
+            else None
+        ),
+        overall_score=0.81 if status == "complete" else None,
+    )
+
+
+class _Result:
+    """Stand-in for a SQLAlchemy Result."""
+
+    def __init__(self, value: Any) -> None:
+        self._value = value
+
+    def scalars(self) -> "_Result":
+        return self
+
+    def first(self) -> Any:
+        return self._value
+
+    def all(self) -> list[Any]:
+        return [self._value] if self._value is not None else []
+
+
+class FakeSession:
+    """Minimal async session double for the cache contract.
+
+    Answers Profile selects with the configured profile, and Review selects
+    with the first configured review whose status is "complete" — the only
+    kind the contract allows as a cache hit. Records added objects so tests
+    can assert whether a new row was created.
+    """
+
+    def __init__(self, profile: Profile | None = None, reviews: Sequence[Review] = ()) -> None:
+        self.profile = profile
+        self.reviews = list(reviews)
+        self.added: list[Any] = []
+
+    async def execute(self, stmt: Any) -> _Result:
+        entity = stmt.column_descriptions[0]["entity"]
+        if entity is Profile:
+            return _Result(self.profile)
+        if entity is Review:
+            hit = next((r for r in self.reviews if r.status == "complete"), None)
+            return _Result(hit)
+        return _Result(None)
+
+    def add(self, obj: Any) -> None:
+        self.added.append(obj)
+
+    async def commit(self) -> None:
+        pass
+
+    async def refresh(self, obj: Any) -> None:
+        pass
+
+    async def rollback(self) -> None:
+        pass
+
+
+@pytest.mark.unit
+class TestContentHash:
+    """Contract for the profile content hash (cache key)."""
+
+    def _hash(self) -> Callable[[Profile], str]:
+        # Imported lazily so a missing helper fails these tests without
+        # breaking collection of the rest of the module. The type ignore
+        # comes off once the helper exists.
+        from core.services.review_service import compute_content_hash  # type: ignore[attr-defined]
+
+        return cast(Callable[[Profile], str], compute_content_hash)
+
+    def test_identical_content_produces_identical_hash(self) -> None:
+        compute_content_hash = self._hash()
+        a = make_profile()
+        # Different row identity, same content: the hash must key on content.
+        b = make_profile(id=str(uuid4()), user_id=str(uuid4()))
+
+        assert compute_content_hash(a) == compute_content_hash(b)
+
+    def test_changed_resume_text_changes_hash(self) -> None:
+        compute_content_hash = self._hash()
+        a = make_profile()
+        b = make_profile(resume_text="Jane Doe. Senior Engineer. Python, FastAPI.")
+
+        assert compute_content_hash(a) != compute_content_hash(b)
+
+    def test_changed_portfolio_url_changes_hash(self) -> None:
+        compute_content_hash = self._hash()
+        a = make_profile()
+        b = make_profile(portfolio_url="https://janedoe.io")
+
+        assert compute_content_hash(a) != compute_content_hash(b)
+
+    def test_all_none_content_fields_hash_stably(self) -> None:
+        compute_content_hash = self._hash()
+        empty = dict(
+            github_username=None,
+            portfolio_url=None,
+            resume_filename=None,
+            resume_text=None,
+        )
+        a = make_profile(**empty)
+        b = make_profile(id=str(uuid4()), **empty)
+
+        assert compute_content_hash(a) == compute_content_hash(b)
+
+
+@pytest.mark.unit
+class TestReviewCache:
+    """Contract for create_review when a completed review already exists."""
+
+    @pytest.mark.asyncio
+    async def test_unchanged_resubmit_returns_stored_review(self) -> None:
+        profile = make_profile()
+        cached = make_review(profile, status="complete")
+        db = FakeSession(profile=profile, reviews=[cached])
+
+        result = await create_review(db, profile.id, profile.user_id)
+
+        assert result is cached
+
+    @pytest.mark.asyncio
+    async def test_unchanged_resubmit_does_not_create_new_row(self) -> None:
+        profile = make_profile()
+        cached = make_review(profile, status="complete")
+        db = FakeSession(profile=profile, reviews=[cached])
+
+        await create_review(db, profile.id, profile.user_id)
+
+        assert db.added == []
+
+    @pytest.mark.asyncio
+    async def test_no_prior_review_creates_pending_review(self) -> None:
+        profile = make_profile()
+        db = FakeSession(profile=profile, reviews=[])
+
+        result = await create_review(db, profile.id, profile.user_id)
+
+        assert result.status == "pending"
+        assert len(db.added) == 1
+
+    @pytest.mark.asyncio
+    async def test_failed_review_is_not_a_cache_hit(self) -> None:
+        profile = make_profile()
+        failed = make_review(profile, status="failed")
+        db = FakeSession(profile=profile, reviews=[failed])
+
+        result = await create_review(db, profile.id, profile.user_id)
+
+        assert result is not failed
+        assert result.status == "pending"
+        assert len(db.added) == 1

--- a/tests/unit/test_review_cache.py
+++ b/tests/unit/test_review_cache.py
@@ -12,7 +12,7 @@ review exists at all. The cache lookup is expected to key on
 """
 
 from collections.abc import Callable, Sequence
-from typing import Any, cast
+from typing import Any
 from uuid import uuid4
 
 import pytest
@@ -116,11 +116,10 @@ class TestContentHash:
 
     def _hash(self) -> Callable[[Profile], str]:
         # Imported lazily so a missing helper fails these tests without
-        # breaking collection of the rest of the module. The type ignore
-        # comes off once the helper exists.
-        from core.services.review_service import compute_content_hash  # type: ignore[attr-defined]
+        # breaking collection of the rest of the module.
+        from core.services.review_service import compute_content_hash
 
-        return cast(Callable[[Profile], str], compute_content_hash)
+        return compute_content_hash
 
     def test_identical_content_produces_identical_hash(self) -> None:
         compute_content_hash = self._hash()

--- a/tests/unit/test_review_service.py
+++ b/tests/unit/test_review_service.py
@@ -23,7 +23,12 @@ class TestReviewService:
         session.add = Mock()
         session.commit = AsyncMock()
         session.refresh = AsyncMock()
-        session.execute = AsyncMock()
+        # Queries against this session find nothing by default, so
+        # create_review's cache lookup misses; tests that need a result
+        # override execute themselves.
+        empty_result = Mock()
+        empty_result.scalars.return_value.first.return_value = None
+        session.execute = AsyncMock(return_value=empty_result)
         return session
 
     @pytest.fixture


### PR DESCRIPTION
## Summary
Submitting an unchanged profile re-runs the full review pipeline and adds a
duplicate entry to the user's review history, even though the output is
identical. This PR adds a content-hash cache: each completed review stores a
sha256 of the profile content it was generated from, and `POST /reviews`
returns the stored review — same review ID, no pipeline run, no new history
row — when a resubmitted profile's content is unchanged. Editing any profile
field changes the hash, so the next submit regenerates.

## Issue
Closes #32

## Changes
- `core/models/review.py`, `alembic/versions/003_add_content_hash_to_reviews.py`:
  nullable indexed `content_hash` column on `reviews`
- `core/services/review_service.py`: `compute_content_hash()` helper
  (canonicalized JSON of `github_username`, `portfolio_url`, `resume_filename`,
  `resume_text` → sha256); `create_review()` returns the newest completed
  review matching `(profile_id, content_hash)` before creating a new one;
  `process_review()` stamps the hash from the profile as fetched at
  processing time
- `api/routes/reviews.py`: queues the background pipeline only for fresh
  `pending` reviews; a cache hit returns the `complete` review immediately
- Type annotations on the touched service module (`disallow_untyped_defs`):
  7 mypy errors → 0

## Testing
- [x] Unit tests pass (`make test-unit`)
- [x] Integration tests pass (`make test-integration`)
- [x] Linter passes (`make lint`)
- [x] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes

The suite has 53 pre-existing unit-test failures and repo-wide lint/type
errors unrelated to this change. The failure list is identical before and
after this branch — no new failures, and no new lint, format, or type errors.
`api/routes/reviews.py` and `tests/unit/test_review_service.py` carry
pre-existing lint/mypy debt this PR leaves untouched.

New coverage: `tests/unit/test_review_cache.py` (8 tests) pins the hash
contract and `create_review` behavior; `tests/integration/test_review_cache_db.py`
(5 tests) exercises the lookup against real Postgres — verified by mutation:
deleting the `content_hash`/`status` filters fails 2 of the 5.

To verify manually:
1. `docker compose up -d db redis`, then `make migrate && make run`
2. Log in as a seeded user (`user1@example.com` / `password1`) and note one
   of their profile IDs
3. `POST /reviews` with that `profile_id`; poll `GET /reviews/{id}/status`
   until `complete`
4. `POST /reviews` again with the same body — the response returns the
   **same review ID**, already `complete`, and `GET /reviews` shows no new
   history entry (the server logs a `review_cache_hit`)
5. Edit any profile field via `PUT /profiles/{id}` and submit again — a
   **new** review is created and processed

## Screenshots / Demo
Two identical submits for a seeded profile, run against the local stack:

```
$ GET /reviews  (history before)
total reviews: 2

$ POST /reviews  (submit 1 - new review, pipeline runs)
id: 3e7beef0-d9cb-43da-b2ef-6a33badb5b30 | status: pending | score: None

$ POST /reviews  (submit 2 - identical input)
id: 3e7beef0-d9cb-43da-b2ef-6a33badb5b30 | status: complete | score: 0.81

$ GET /reviews  (history after)
total reviews: 3
```

Same review ID back on the second submit, already complete, and one new
history row from the two submits. The profile's two pre-existing reviews
(created before this change, `content_hash = NULL`) correctly did not match.

## Notes for Reviewers
- The hash lives on the `Review` row in Postgres rather than Redis: the
  cached value *is* the review row, and a Redis copy would be a second
  source of truth that can drift.
- Pre-migration reviews have `content_hash = NULL` and never match, so each
  existing profile regenerates once before caching kicks in. Intentional —
  a backfill would have to replicate the Python canonicalization in SQL.
- The hash covers profile fields only. Changes to live GitHub/portfolio
  content behind an unchanged profile aren't detected, and there's no
  `force` parameter; both would be follow-ups.
- Concurrent duplicate submits both miss while the first is incomplete.
  That race is deliberately left to #82 (per-profile lock), which this
  change doesn't preempt.
