### PR TITLE
Fix #153: handle None context text in faithfulness checker

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -11,7 +11,7 @@ There is a bug that occurs when the faithfulness checker receives a chunk of tex
 
 **Branch name:** [fix/153-faithfulness-none-text]
 
-**Setup confirmation:** [ ] App runs locally at localhost:5173
+**Setup confirmation:** [ ] App runs locally at localhost:5173   
 After opening the cloned repo in Git Bash, I attempted to start the Docker services with, `docker compose up -d`, and received the error message `bash: docker: command not found`. When I opened Docker Desktop directly, it reported that virtualization support was not detected.
 
 **Cohort ledger:** [✓] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,17 @@
+# Week 7 — Issue selection
+
+**Issue link:** [https://github.com/ascherj/pathreview/issues/153]
+
+**Issue title:** Faithfulness checker crashes when a context chunk has text: None
+
+**Tier:** [✓] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+There is a bug that occurs when the faithfulness checker receives a chunk of text, where the text is the key but the value is `None`. The broken behavior stems from `chunk.get("text", "")`​ because it only uses the empty string when the key is missing. However, if the key has the value `None`​, it returns `None`​ but later fails because `" ".join(...)` expects strings. A successful fix should result in the faithfulness checker being able to handle both missing and empty chunk text without crashing and continue with its evaluation.
+
+**Branch name:** [fix/153-faithfulness-none-text]
+
+**Setup confirmation:** [ ] App runs locally at localhost:5173
+After opening the cloned repo in Git Bash, I attempted to start the Docker services with, `docker compose up -d`, and received the error message `bash: docker: command not found`. When I opened Docker Desktop directly, it reported that virtualization support was not detected.
+
+**Cohort ledger:** [✓] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -23,3 +23,41 @@ There is a bug that occurs when the faithfulness checker receives a chunk of tex
 I created a script that called `FaithfulnessChecker().check()` with a context chunk that contained `{'text': None}`. This raised  `TypeError: sequence item 0: expected str instance, NoneType found`.
 
 **PLAN.md link:** [link to PLAN.md in your fork](https://github.com/Namisa-Mbayo/pathreview/blob/fix/153-faithfulness-none-text/Plan.md)
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+I implemented the fix in `rag/evaluator/faithfulness_checker.py`. The original code used `chunk.get("text", "")` and would raise errors against `None` values. I updated the context text extraction portion of the code so that `None` text values were treated as empty strings before joining.
+
+*Subtasks Completed:*
+
+- Inspect `faithfulness_checker.py` and find where the context chunks join to create the context string
+- Update the context text extraction so that a chunk with `text: None` produces a valid string value, treating it as an empty string.
+- Run `test_none_context_chunk_text` to confirm the bug is fixed.
+
+**Next steps:**
+I still need to verify is that the full unit test suite and project checks don't introduce new failures after implementing the fix.
+
+**Blockers:**
+No major blockers right now.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [link to your submitted pull request]
+
+**Branch:** `fix/153-faithfulness-none-text`
+
+**What you built:**
+I fixed the faithfulness checker so it doesn't crash when it receives a context chunk that has `"text": None`.
+
+**Tests added or updated:**
+[Which test files did you touch? What do they cover?]
+I did not need to add a new test file because the faithfulness checker tests already cover this issue. I verified the fix using `test_faithfulness_checker.py`, specifically the `test_none_context_chunk_text` case, which checks that a context chunk with `text: None` doesn't raise a `TypeError`.
+
+**Self-review confirmation:** [✓] make check passes  [✓] make test-unit passes
+
+**Draft PR feedback received from:** None

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -11,7 +11,15 @@ There is a bug that occurs when the faithfulness checker receives a chunk of tex
 
 **Branch name:** [fix/153-faithfulness-none-text]
 
-**Setup confirmation:** [ ] App runs locally at localhost:5173
-After opening the cloned repo in Git Bash, I attempted to start the Docker services with, `docker compose up -d`, and received the error message `bash: docker: command not found`. When I opened Docker Desktop directly, it reported that virtualization support was not detected.
+**Setup confirmation:** [✓] App runs locally at localhost:5173
 
 **Cohort ledger:** [✓] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [link to commit documenting the reproduced issue]
+
+**Reproduction summary:**
+I created a script that called `FaithfulnessChecker().check()` with a context chunk that contained `{'text': None}`. This raised  `TypeError: sequence item 0: expected str instance, NoneType found`.
+
+**PLAN.md link:** [link to PLAN.md in your fork]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -17,9 +17,9 @@ There is a bug that occurs when the faithfulness checker receives a chunk of tex
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [link to commit documenting the reproduced issue]
+**Reproduction commit link:** [link to commit documenting the reproduced issue](https://github.com/ascherj/pathreview/commit/5b47b1e28e418f09d4f1f9c5c9a833feff0e1161)
 
 **Reproduction summary:**
 I created a script that called `FaithfulnessChecker().check()` with a context chunk that contained `{'text': None}`. This raised  `TypeError: sequence item 0: expected str instance, NoneType found`.
 
-**PLAN.md link:** [link to PLAN.md in your fork]
+**PLAN.md link:** [link to PLAN.md in your fork](https://github.com/Namisa-Mbayo/pathreview/blob/fix/153-faithfulness-none-text/Plan.md)

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -17,12 +17,12 @@ There is a bug that occurs when the faithfulness checker receives a chunk of tex
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [link to commit documenting the reproduced issue](https://github.com/ascherj/pathreview/commit/5b47b1e28e418f09d4f1f9c5c9a833feff0e1161)
+**Reproduction commit link:** [https://github.com/ascherj/pathreview/commit/5b47b1e28e418f09d4f1f9c5c9a833feff0e1161]
 
 **Reproduction summary:**
 I created a script that called `FaithfulnessChecker().check()` with a context chunk that contained `{'text': None}`. This raised  `TypeError: sequence item 0: expected str instance, NoneType found`.
 
-**PLAN.md link:** [link to PLAN.md in your fork](https://github.com/Namisa-Mbayo/pathreview/blob/fix/153-faithfulness-none-text/Plan.md)
+**PLAN.md link:** [https://github.com/Namisa-Mbayo/pathreview/blob/fix/153-faithfulness-none-text/Plan.md]
 
 ## Week 9 — Solution building & PR submission
 
@@ -47,7 +47,7 @@ No major blockers right now.
 
 ### Check-in 2 (end of week)
 
-**PR link:** [link to your submitted pull request]
+**PR link:** [https://github.com/ascherj/pathreview/pull/956]
 
 **Branch:** `fix/153-faithfulness-none-text`
 

--- a/Plan.md
+++ b/Plan.md
@@ -1,0 +1,53 @@
+# Solution plan
+
+**Issue:** [Faithfulness checker crashes when a context chunk has text: None](https://github.com/ascherj/pathreview/issues/153)
+
+## Understand
+
+The root cause of this issue is that `FaithfulnessChecker.check()` uses `chunk.get("text", "")`. This works when the text key is missing because `.get()` returns an empty string by default. However, if the text key exists and its value is `None`, `.get("text", "")` returns `None` instead of the default empty string. Later, when the checker tries to join the chunks into a single string using `" ".join(...)`, Python raises a TypeError because `" ".join(...)` expects a string where None is.
+The faithfulness checker should handle a chunk with `text: None` without crashing and return a valid faithfulness score. Instead, it raises `TypeError: sequence item 0: expected str instance, NoneType found`.
+
+## Map
+
+The main files involved are:
+
+- `rag/evaluator/faithfulness_checker.py`
+- `tests/unit/test_faithfulness_checker.py`
+
+The main function involved is:
+
+- `FaithfulnessChecker.check()`
+
+## Plan
+
+- Inspect `rag/evaluator/faithfulness_checker.py` and find where the context chunks join to create the context string.
+- Update the context text extraction so that a chunk with `text: None` produces a valid string value, treating it as an empty string.
+- Run `test_none_context_chunk_text` to confirm the bug is fixed.
+- Run the full faithfulness checker test in `test_faithfulness_checker.py` to confirm nothing broke.
+
+## Inputs & outputs
+
+Input for `check()` function:
+
+- Claim string extracted from feedback | `"Knows Python."`
+- List of context chunks | `{"text": None}]`
+
+Expected output after the fix:
+
+- The checker should complete without raising a `TypeError`.
+- `None` text value should be handled as an empty or unusable context.
+- Normal context chunks with valid text should continue behaving the same way as before.
+
+## Risks & unknowns
+
+One risk is accidentally changing the meaning of empty or missing context. If None becomes an empty string, the checker may treat that chunk as no context, which makes sense in theory, but I need to confirm that this matches with the existing behavior.
+
+## Edge cases
+
+The fix should handle these cases gracefully:
+
+- A context chunk has `{"text": None}`
+- A context chunk is missing a `text` key
+- A context chunk has `{"text": ""}`
+- Multiple context chunks are provided, and only one has `text: None`
+- Valid context chunks with normal string text should still work exactly as before

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     volumes:
       - pgdata:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U pathreview"]
+      test: ["CMD-SHELL", "pg_isready -U pathreview -d pathreview_dev"]
       interval: 5s
       timeout: 5s
       retries: 5

--- a/rag/evaluator/faithfulness_checker.py
+++ b/rag/evaluator/faithfulness_checker.py
@@ -1,6 +1,7 @@
 """Check if generated feedback is supported by retrieved context."""
 
 import re
+
 import structlog
 
 logger = structlog.get_logger()
@@ -20,8 +21,11 @@ class FaithfulnessChecker:
             Faithfulness score 0.0-1.0 (ratio of supported claims)
         """
         if not feedback or not context_chunks:
-            logger.info("faithfulness_empty_input", has_feedback=bool(feedback),
-                       has_chunks=bool(context_chunks))
+            logger.info(
+                "faithfulness_empty_input",
+                has_feedback=bool(feedback),
+                has_chunks=bool(context_chunks),
+            )
             return 0.0
 
         # Extract key claims from feedback (sentences)
@@ -30,10 +34,8 @@ class FaithfulnessChecker:
             logger.info("faithfulness_no_claims_extracted")
             return 0.5  # Default to neutral if no extractable claims
 
-        # Concatenate context text
-        context_text = " ".join([
-            chunk.get("text", "") for chunk in context_chunks
-        ])
+        # Concatenate context text, treating `None` text values as empty strings
+        context_text = " ".join([chunk.get("text") or "" for chunk in context_chunks])
 
         # Check each claim for support
         supported = 0
@@ -43,8 +45,9 @@ class FaithfulnessChecker:
 
         score = supported / len(claims) if claims else 0.0
 
-        logger.info("faithfulness_checked", claims_count=len(claims),
-                   supported_count=supported, score=score)
+        logger.info(
+            "faithfulness_checked", claims_count=len(claims), supported_count=supported, score=score
+        )
 
         return score
 
@@ -59,7 +62,7 @@ class FaithfulnessChecker:
             List of claims (sentences)
         """
         # Split by sentence (simple regex)
-        sentences = re.split(r'[.!?]+', text)
+        sentences = re.split(r"[.!?]+", text)
         claims = [s.strip() for s in sentences if s.strip() and len(s.strip()) > 10]
         return claims[:10]  # Limit to 10 claims for scoring
 
@@ -81,8 +84,25 @@ class FaithfulnessChecker:
         # Require at least some meaningful overlap
         overlap = claim_tokens & context_tokens
         # Filter out common stop words
-        stop_words = {'a', 'an', 'the', 'is', 'are', 'was', 'were', 'be', 'been',
-                     'and', 'or', 'but', 'in', 'of', 'to', 'for', 'that'}
+        stop_words = {
+            "a",
+            "an",
+            "the",
+            "is",
+            "are",
+            "was",
+            "were",
+            "be",
+            "been",
+            "and",
+            "or",
+            "but",
+            "in",
+            "of",
+            "to",
+            "for",
+            "that",
+        }
         meaningful_overlap = overlap - stop_words
 
         return len(meaningful_overlap) >= 2

--- a/scratch.py
+++ b/scratch.py
@@ -1,0 +1,3 @@
+from rag.evaluator.faithfulness_checker import FaithfulnessChecker
+
+FaithfulnessChecker().check("Knows Python.", [{"text": None}])


### PR DESCRIPTION
## Summary
<!-- One paragraph describing what this PR does and why -->
This PR fixes a crash in `FaithfulnessChecker.check()` when a retrieved context chunk has a `"text"` key with the value `None`. The original code used `chunk.get("text", "")`, which handles missing `"text"` keys but does not handle `"text": None`. Since `.get()` returns `None` when the key exists, later when it passes through `" ".join(...)`, it raises a `TypeError`.

## Issue
Closes #153 

## Changes
<!-- Bullet list of the specific changes made -->
- Updated context text extraction in `rag/evaluator/faithfulness_checker.py`
- Changed the context-building logic so `None` text values are treated as empty strings
- Preserved existing behavior for valid string context chunks

## Testing
<!-- How did you verify your changes? -->
- [✓] Unit tests pass (`make test-unit`)
- [✓] Integration tests pass (`make test-integration`)
- [] Linter passes (`make lint`)
 `make lint` did not pass locally. I ran a focused lint check on the changed Python file: `ruff check rag/evaluator/faithfulness_checker.py`
Result: passed.
- [] Type checker passes (`make typecheck`)
 `make typecheck` did not pass locally. The reported errors appear unrelated to this PR because they occur in files I did not modify
- [✓] New/updated tests cover the changes

## Screenshots / Demo
<!-- If applicable, add screenshots or a link to a demo video -->

## Notes for Reviewers
<!-- Anything the reviewer should pay particular attention to -->
