### PR TITLE
fix(agent): exclude vendored/build files from tech detection (#150)

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -23,7 +23,7 @@ place. This affects the agent subsystem (`agent/tools/tech_detector.py`).
 
 **Branch name:** fix/150-tech-detector-vendored-files
 
-**Setup confirmation:** [ ] App runs locally at localhost:5173
+**Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [ ] Issue added to cohort ledger
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -42,3 +42,30 @@ place. This affects the agent subsystem (`agent/tools/tech_detector.py`).
   `good first issue`; the logic is a filtering step, not a design change, so it
   fits a first pass through an unfamiliar codebase.
 - **Conclusion:** Good fit — realistic to finish and easy to explain.
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction summary:**
+Ran the two vendored/build exclusion tests against the current code and both
+fail: `primary_language` comes back `"JavaScript"` instead of `"Python"`, and
+the tool log reports `languages_count=2` — confirming the vendored
+`node_modules/` and build-output `build/` JavaScript files are being counted
+instead of skipped. Root cause: the `/node_modules/` and `/build/` patterns in
+`_should_skip_file()` are slash-wrapped, so they only match mid-path and miss
+root-relative paths (no leading slash); those files survive the filter and are
+counted, and `sorted(languages)[0]` then picks `"JavaScript"` alphabetically.
+
+Reproduction command and observed output:
+
+```text
+$ .venv/Scripts/python -m pytest tests/unit/test_tech_detector.py \
+    -k "node_modules_excluded or build_directory_excluded" -v
+
+>       assert data["primary_language"] == "Python"
+E       AssertionError: assert 'JavaScript' == 'Python'
+[info] tech_detected  frameworks_count=0 languages_count=2 primary_lang=JavaScript
+
+FAILED tests/unit/test_tech_detector.py::TestTechDetector::test_node_modules_excluded
+FAILED tests/unit/test_tech_detector.py::TestTechDetector::test_build_directory_excluded
+2 failed, 1 passed, 24 deselected
+```

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -45,6 +45,8 @@ place. This affects the agent subsystem (`agent/tools/tech_detector.py`).
 
 ## Week 8 — Reproduction & solution planning
 
+**Reproduction commit link:** https://github.com/VincentTLe/pathreview/commit/f0358585adf3cd6d6164526b5d226c234440505b
+
 **Reproduction summary:**
 Ran the two vendored/build exclusion tests against the current code and both
 fail: `primary_language` comes back `"JavaScript"` instead of `"Python"`, and
@@ -69,3 +71,13 @@ FAILED tests/unit/test_tech_detector.py::TestTechDetector::test_node_modules_exc
 FAILED tests/unit/test_tech_detector.py::TestTechDetector::test_build_directory_excluded
 2 failed, 1 passed, 24 deselected
 ```
+
+**PLAN.md link:** https://github.com/VincentTLe/pathreview/blob/fix/150-tech-detector-vendored-files/PLAN.md
+
+**Walkthrough video (recommended):** _(optional — not recorded; not graded)_
+
+**Blockers or open questions:**
+Keeping the Week 9 fix scoped to the vendored/build exclusion. The separate
+`sorted(languages)[0]` "primary = alphabetical, not most-common" behavior is a
+real but distinct bug; leaning toward raising it as a follow-up rather than
+expanding this Tier-1 PR.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,44 @@
+# PathReview — Module 3 Journal
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/150
+
+**Issue title:** Tech detector counts vendored and build-output files, skewing language detection
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The agent system's `tech_detector.py` tool decides a repository's primary
+programming language by counting files per language, but it counts every file
+in the repo — including third-party dependencies in `node_modules/` and
+compiled output in `build/`. Because those vendored directories are usually
+full of JavaScript, a project that is actually written in Python can be
+mislabeled as "primarily JavaScript." A successful fix will make the detector
+ignore vendored and build-output paths before it counts languages, so the
+primary language reflects the code the developer actually wrote. The two
+existing tests `test_node_modules_excluded` and `test_build_directory_excluded`
+in `tests/unit/test_tech_detector.py` should pass once the filtering is in
+place. This affects the agent subsystem (`agent/tools/tech_detector.py`).
+
+**Branch name:** fix/150-tech-detector-vendored-files
+
+**Setup confirmation:** [ ] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger
+
+### "Is this right for me?" — scope reasoning
+
+- **Scope is small and well-bounded.** The fix touches a single tool file
+  (`agent/tools/tech_detector.py`) plus its test file
+  (`tests/unit/test_tech_detector.py`) — no cross-module changes.
+- **Clear, reproducible bug.** The issue includes exact reproduction code and
+  the expected vs. observed output, so I can confirm the bug and verify the fix
+  objectively.
+- **Tests already exist.** `test_node_modules_excluded` and
+  `test_build_directory_excluded` give me a definition of "done" — the fix is
+  correct when they pass, which keeps the change honest.
+- **Right tier for a first contribution.** Labeled `tier-1` and
+  `good first issue`; the logic is a filtering step, not a design change, so it
+  fits a first pass through an unfamiliar codebase.
+- **Conclusion:** Good fit — realistic to finish and easy to explain.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -25,7 +25,7 @@ place. This affects the agent subsystem (`agent/tools/tech_detector.py`).
 
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
-**Cohort ledger:** [ ] Issue added to cohort ledger
+**Cohort ledger:** [x] Issue added to cohort ledger
 
 ### "Is this right for me?" — scope reasoning
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -81,3 +81,61 @@ Keeping the Week 9 fix scoped to the vendored/build exclusion. The separate
 `sorted(languages)[0]` "primary = alphabetical, not most-common" behavior is a
 real but distinct bug; leaning toward raising it as a follow-up rather than
 expanding this Tier-1 PR.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+The fix is implemented and pushed
+([`fbeb3e4`](https://github.com/VincentTLe/pathreview/commit/fbeb3e4)).
+Sub-tasks from PLAN.md that are done:
+
+- Rewrote `_should_skip_file()` to match **path segments** instead of
+  slash-wrapped substrings — normalize `\` → `/`, split on `/`, and skip the
+  file when any segment is a known vendored/build directory.
+- Added the directory names as a class-level `SKIP_DIRS` frozenset.
+- Added regression tests in a new file
+  `tests/unit/test_tech_detector_vendored.py` (root-level, nested,
+  Windows-separator, and look-alike cases).
+- Verified: the two pre-existing tests `test_node_modules_excluded` and
+  `test_build_directory_excluded` now pass, and the full unit suite went from
+  **53 failed / 375 passed** (baseline, before my change) to **51 failed /
+  382 passed** — i.e. my two target tests fixed, five new tests added, and no
+  new failures introduced. The remaining 51 failures are pre-existing and
+  belong to other issues.
+
+**Next steps:**
+Open a draft PR and request peer/mentor feedback in Slack; address any feedback;
+fill in Check-in 2 with the PR link and mark the PR ready for review.
+
+**Blockers:**
+None. Note: `make check` and `make test-unit` have extensive pre-existing
+failures across the repo (182 ruff findings, 52 unformatted files, and 53
+failing unit tests before my change) that are unrelated to issue #150; my change
+keeps its edited files lint/format/type clean and introduces no new test
+failures.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** _(to be filled when the PR is opened)_
+
+**Branch:** `fix/150-tech-detector-vendored-files`
+
+**What you built:**
+`TechDetector` now excludes vendored dependencies and build output before
+counting languages, by matching each path segment against a `SKIP_DIRS` set, so
+the reported primary language reflects first-party source instead of bundled
+JavaScript.
+
+**Tests added or updated:**
+Added `tests/unit/test_tech_detector_vendored.py` (5 tests: root-level vendor
+and node_modules exclusion, Windows-separator build output, nested vendored
+dirs, and look-alike names that must not be skipped). The change also turns the
+existing `test_node_modules_excluded` and `test_build_directory_excluded` green.
+
+**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+
+**Draft PR feedback received from:** _(to be filled)_

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -136,7 +136,13 @@ and node_modules exclusion, Windows-separator build output, nested vendored
 dirs, and look-alike names that must not be skipped). The change also turns the
 existing `test_node_modules_excluded` and `test_build_directory_excluded` green.
 
-**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+_"Passes" here means my changes introduce no new failures: my edited files are
+ruff/black/mypy-clean (verified by the pre-commit hooks on the fix commit), and
+`make test-unit` went from 53 failed / 375 passed (baseline) to 51 failed / 382
+passed — the two target tests fixed and five new tests added, no new failures.
+The repo's remaining pre-existing lint/type/test failures are unrelated to #150._
 
 **Draft PR feedback received from:** none yet — draft PR shared in the cohort
 Slack; no responses at the time of writing.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -120,7 +120,7 @@ failures.
 
 ### Check-in 2 (end of week)
 
-**PR link:** _(to be filled when the PR is opened)_
+**PR link:** https://github.com/ascherj/pathreview/pull/959
 
 **Branch:** `fix/150-tech-detector-vendored-files`
 
@@ -138,4 +138,5 @@ existing `test_node_modules_excluded` and `test_build_directory_excluded` green.
 
 **Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
 
-**Draft PR feedback received from:** _(to be filled)_
+**Draft PR feedback received from:** none yet — draft PR shared in the cohort
+Slack; no responses at the time of writing.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -146,3 +146,61 @@ The repo's remaining pre-existing lint/type/test failures are unrelated to #150.
 
 **Draft PR feedback received from:** none yet — draft PR shared in the cohort
 Slack; no responses at the time of writing.
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No comments came in on PR #959. Summer 2026 doesn't run the reviewer-feedback
+process, and although I posted the PR in the cohort Slack, nobody responded by
+the end of the week.
+
+**How you responded:**
+Nothing to respond to.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Honestly the fix itself was quick. Fighting the repo was the slow part. The first
+time I ran `make check` and `make test-unit` the whole thing was already a mess —
+182 ruff errors, 52 files black wanted to reformat, mypy crashing, and 53 tests
+failing before I'd touched anything. I spent a while confused, thinking I'd broken
+something, until it clicked that the repo just ships like that and "passing" only
+means I didn't make it worse. Then my first commit got blocked because the mypy
+hook wanted type annotations on my test functions, even though none of the
+existing tests have them. Small stuff like that ate more time than the bug did.
+
+**What did you learn about working in a large codebase?**
+Mostly that you have to hold back. While I was in there I spotted a second real
+bug — it picks the "main" language alphabetically instead of by how many files
+use it — and I really wanted to just fix that too. But it's a separate problem,
+and jamming it in would've made my PR messier to review, so I left it as a note
+for later. On my own projects I clean up whatever I touch. Here I had to keep the
+change small and do things their way (commit style, branch names, the hooks)
+instead of mine.
+
+**How did AI tools help — and where did they fall short?**
+AI was genuinely useful for finding my footing: understanding how the parts
+connect, reproducing the bug, writing tests that matched the ones already there,
+and working out why the commit hooks kept failing. Where it didn't help much was
+the actual decisions — what to leave alone, whether to drop my tests in a
+separate file. And this reflection too; it can list what happened, but what was
+actually annoying or satisfying is on me.
+
+**What would you do differently if you started over?**
+Run the tests and `make check` on day one, before reading any code. If I'd known
+the repo was already red from the start, I wouldn't have wasted time
+second-guessing whether my change was the thing that broke it. I'd also skim the
+pre-commit config early so the hooks didn't catch me off guard at commit time.
+
+**What are you most proud of from this module?**
+That I kept it honest. The fix is small, the tests actually cover the annoying
+cases (nested folders, Windows paths, folders that look like build output but
+aren't), and I said plainly in the PR which failures were already there and which
+were mine. It would've been easy to tick the boxes and hope nobody looked
+closely — I'd rather the numbers be real.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,96 @@
+## Solution plan
+
+**Issue:** [Tech detector counts vendored and build-output files, skewing
+language detection — #150](https://github.com/ascherj/pathreview/issues/150)
+
+### Understand
+
+The tech detector reports the wrong primary language for repositories whose only
+non-source code is vendored or build output.
+
+Root cause: `TechDetector._should_skip_file()` in `agent/tools/tech_detector.py`
+skips vendored/build directories using slash-wrapped substrings (`/node_modules/`,
+`/build/`, `/vendor/`, `/dist/`, ...). Each pattern starts with `/`, so it only
+matches when the directory appears in the middle of a path. Repository file lists
+are root-relative, so a top-level path such as `node_modules/pkg/index.js` or
+`build/bundle.js` has no leading slash and never matches `"/node_modules/"` /
+`"/build/"`. Those files pass the filter and get counted.
+
+Two behaviors combine to produce the visible bug:
+
+1. Vendored/build JavaScript files are counted alongside real source.
+2. `_detect_tech()` chooses the primary language with `sorted(languages)[0]`
+   (alphabetical, not frequency — `languages` is a `set`, so counts are already
+   discarded), and `"JavaScript"` sorts before `"Python"`.
+
+Expected vs. actual (verified locally):
+
+- `test_node_modules_excluded` expects `primary_language == "Python"`; actual
+  `"JavaScript"`.
+- `test_build_directory_excluded` expects `primary_language == "Python"`; actual
+  `"JavaScript"`.
+- Tool log shows `languages_count=2`, confirming vendored files are counted.
+
+### Map
+
+- `agent/tools/tech_detector.py` — the fix lives in `_should_skip_file()`
+  (approx. lines 143-164) and its skip-pattern list. This is a private static
+  method used only by `_detect_tech()` in the same file; the public
+  `execute({"files": [...]}) -> ToolResult` contract does not change.
+- `tests/unit/test_tech_detector.py` — the acceptance tests already exist
+  (`test_node_modules_excluded`, `test_build_directory_excluded`,
+  `test_vendor_files_excluded`). I will add regression cases (nested vendored
+  path, Windows separators, look-alike directory names).
+
+### Plan
+
+1. Rewrite `_should_skip_file()` to match **path segments** instead of
+   slash-wrapped substrings: normalize `\` -> `/`, split the path on `/`, and
+   skip the file if any segment exactly equals a vendored/build directory name.
+2. Store the directory names as a class-level `frozenset`
+   (`node_modules`, `vendor`, `dist`, `build`, `.git`, `__pycache__`, `.venv`,
+   `venv`) so the list is clear and easy to extend.
+3. Run the existing tech-detector tests; confirm `test_node_modules_excluded`
+   and `test_build_directory_excluded` pass and nothing else regresses.
+4. Add regression tests: a nested vendored path (`src/node_modules/x.js`), a
+   Windows-style path (`build\bundle.js`), and non-vendored look-alikes
+   (`distribution/app.py`, `rebuild.py`) that must NOT be skipped.
+5. Run `make check` (black / ruff / mypy) and `make test-unit`; be format- and
+   lint-clean before opening the PR.
+
+### Inputs & outputs
+
+- Input: the `files` list passed to `TechDetector.execute({"files": [...]})` —
+  repository-root-relative path strings.
+- Output: `_should_skip_file()` returns `True` for vendored/build files whether
+  the directory is at the repo root or nested, so `_detect_tech()` counts only
+  first-party source. `primary_language`, `all_languages`, and `frameworks` then
+  reflect the developer's own code. The public return shape is unchanged.
+
+### Risks & unknowns
+
+- **Substring false positives.** A naive `"build" in path` would wrongly skip
+  `distribution/`, `rebuild.py`, or `mybuild/`. Segment-equality matching avoids
+  this; the regression tests lock it in.
+- **Path separators.** Inputs may use `/` or `\`. Normalizing before the split
+  handles both; the GitHub ingestion path emits `/`, so normalization is a
+  safety net rather than a correctness dependency.
+- **Out-of-scope latent bug.** `sorted(languages)[0]` is alphabetical, not
+  "most common." The exclusion fix alone makes issue #150's tests green, so this
+  change stays minimal and does NOT rework primary-language selection. I will
+  flag the alphabetical-vs-frequency behavior in the PR description as a
+  potential separate follow-up so scope stays Tier-1.
+- **Case sensitivity.** Directory names match case-sensitively (canonical
+  lowercase), matching the current behavior and real vendored dir names.
+
+### Edge cases
+
+- Vendored dir at repo root: `node_modules/pkg/index.js`, `build/bundle.js` ->
+  skipped.
+- Vendored dir nested: `packages/web/node_modules/x.js` -> skipped.
+- Windows separators: `build\generated.js` -> normalized, skipped.
+- Look-alikes that must NOT be skipped: `distribution/app.py`, `rebuild.py`,
+  `src/builder/main.py`.
+- Empty / missing `files` key -> existing early-return unchanged
+  (`primary_language == "Unknown"`).
+- Unrecognized extensions -> ignored, as today.

--- a/agent/tools/tech_detector.py
+++ b/agent/tools/tech_detector.py
@@ -1,6 +1,7 @@
 """Technology stack detector tool."""
 
 import structlog
+
 from .base import BaseTool, ToolResult
 
 logger = structlog.get_logger()
@@ -56,6 +57,21 @@ class TechDetector(BaseTool):
         "cmake": ("CMake", "Build"),
     }
 
+    # Directories whose contents are vendored dependencies or build output,
+    # not first-party source. Matched per path segment (see _should_skip_file).
+    SKIP_DIRS = frozenset(
+        {
+            "node_modules",
+            "vendor",
+            "dist",
+            "build",
+            ".git",
+            "__pycache__",
+            ".venv",
+            "venv",
+        }
+    )
+
     def execute(self, input_data: dict) -> ToolResult:
         """Detect tech stack from files.
 
@@ -75,7 +91,7 @@ class TechDetector(BaseTool):
                     "primary_language": "Unknown",
                     "all_languages": [],
                     "frameworks": [],
-                }
+                },
             )
 
         try:
@@ -84,11 +100,7 @@ class TechDetector(BaseTool):
 
         except Exception as e:
             logger.error("tech_detector_error", error=str(e))
-            return ToolResult(
-                success=False,
-                data={},
-                error=str(e)
-            )
+            return ToolResult(success=False, data={}, error=str(e))
 
     def _detect_tech(self, files: list[str]) -> dict:
         """Detect technologies from file list.
@@ -100,10 +112,7 @@ class TechDetector(BaseTool):
             Dict with detected languages and frameworks
         """
         # Filter out vendor/build directories
-        filtered_files = [
-            f for f in files
-            if not self._should_skip_file(f)
-        ]
+        filtered_files = [f for f in files if not self._should_skip_file(f)]
 
         languages = set()
         frameworks = set()
@@ -131,8 +140,12 @@ class TechDetector(BaseTool):
         all_languages = sorted(languages)
         all_frameworks = sorted(frameworks)
 
-        logger.info("tech_detected", primary_lang=primary,
-                   languages_count=len(all_languages), frameworks_count=len(all_frameworks))
+        logger.info(
+            "tech_detected",
+            primary_lang=primary,
+            languages_count=len(all_languages),
+            frameworks_count=len(all_frameworks),
+        )
 
         return {
             "primary_language": primary,
@@ -140,25 +153,25 @@ class TechDetector(BaseTool):
             "frameworks": all_frameworks,
         }
 
-    @staticmethod
-    def _should_skip_file(filepath: str) -> bool:
-        """Check if file should be skipped.
+    @classmethod
+    def _should_skip_file(cls, filepath: str) -> bool:
+        """Check if a file should be skipped.
+
+        A file is skipped when any directory segment of its path is a vendored
+        dependency or build-output directory (see ``SKIP_DIRS``). Matching is
+        done per path *segment* rather than by substring, so:
+
+        * root-relative paths like ``node_modules/pkg/index.js`` are handled the
+          same as nested ones like ``packages/web/node_modules/pkg/index.js``;
+        * Windows-style separators are normalized first; and
+        * look-alike names such as ``distribution/`` or ``rebuild.py`` are NOT
+          skipped.
 
         Args:
-            filepath: File path
+            filepath: File path (``/`` or ``\\`` separators)
 
         Returns:
             True if file should be skipped
         """
-        skip_patterns = [
-            "/node_modules/",
-            "/vendor/",
-            "/dist/",
-            "/build/",
-            "/.git/",
-            "/__pycache__/",
-            "/.venv/",
-            "/venv/",
-        ]
-
-        return any(pattern in filepath for pattern in skip_patterns)
+        segments = filepath.replace("\\", "/").split("/")
+        return any(segment in cls.SKIP_DIRS for segment in segments)

--- a/tests/unit/test_tech_detector_vendored.py
+++ b/tests/unit/test_tech_detector_vendored.py
@@ -1,0 +1,90 @@
+"""Regression tests for issue #150 — tech detector counts vendored/build files.
+
+See https://github.com/ascherj/pathreview/issues/150.
+
+These live in a dedicated file to keep the fix focused on #150. The root-level
+``node_modules``/``build`` cases are also asserted by ``test_tech_detector.py``
+(``test_node_modules_excluded``, ``test_build_directory_excluded``); the cases
+below additionally cover nested directories, Windows path separators, and
+look-alike directory names that must NOT be skipped.
+"""
+
+import pytest
+
+from agent.tools.tech_detector import TechDetector
+
+
+@pytest.mark.unit
+class TestTechDetectorVendoredExclusion:
+    """TechDetector must exclude vendored/build dirs by path segment."""
+
+    @pytest.fixture
+    def detector(self) -> TechDetector:
+        """Create a TechDetector instance."""
+        return TechDetector()
+
+    def test_vendor_dir_at_root_excluded(self, detector: TechDetector) -> None:
+        """A root-level vendor/ directory must not count toward languages."""
+        files = [
+            "src/main.py",
+            "vendor/lib.js",
+            "vendor/framework.js",
+            "app.py",
+        ]
+
+        data = detector.execute({"files": files}).data
+
+        assert data["primary_language"] == "Python"
+        assert "JavaScript" not in data["all_languages"]
+
+    def test_node_modules_at_root_excluded(self, detector: TechDetector) -> None:
+        """A root-level node_modules/ directory must not count toward languages."""
+        files = [
+            "app.py",
+            "node_modules/react/index.js",
+            "node_modules/react/umd.js",
+        ]
+
+        data = detector.execute({"files": files}).data
+
+        assert data["primary_language"] == "Python"
+        assert "JavaScript" not in data["all_languages"]
+
+    def test_build_dir_with_windows_separators_excluded(self, detector: TechDetector) -> None:
+        """Build output is skipped even when paths use Windows separators."""
+        files = [
+            "src\\main.py",
+            "build\\generated.js",
+            "build\\bundle.js",
+        ]
+
+        data = detector.execute({"files": files}).data
+
+        assert data["primary_language"] == "Python"
+        assert "JavaScript" not in data["all_languages"]
+
+    def test_nested_vendored_dir_excluded(self, detector: TechDetector) -> None:
+        """Vendored dirs nested below the repo root are also skipped."""
+        files = [
+            "app.py",
+            "packages/web/node_modules/react/index.js",
+            "packages/web/node_modules/react/umd.js",
+        ]
+
+        data = detector.execute({"files": files}).data
+
+        assert data["primary_language"] == "Python"
+        assert "JavaScript" not in data["all_languages"]
+
+    def test_lookalike_dirs_not_skipped(self, detector: TechDetector) -> None:
+        """Names that merely resemble vendored dirs must NOT be skipped."""
+        files = [
+            "distribution/app.py",
+            "rebuild.py",
+            "src/builder/main.py",
+        ]
+
+        data = detector.execute({"files": files}).data
+
+        assert data["primary_language"] == "Python"
+        assert "Python" in data["all_languages"]


### PR DESCRIPTION
## Summary
The tech detector reported the wrong primary language for repositories whose only non-source files were vendored dependencies or build output. `TechDetector._should_skip_file()` skipped those directories using slash-wrapped substrings (`"/node_modules/"`, `"/build/"`, …), which never match root-relative repository paths like `node_modules/pkg/index.js` (no leading slash). Those files were counted, and because `_detect_tech()` picks the primary language alphabetically, bundled JavaScript masked the real language (e.g. Python). This PR makes the detector match vendored/build directories by path *segment* so they are excluded whether they sit at the repo root or nested below it.

## Issue
Closes #150

## Changes
- Rewrote `_should_skip_file()` to match **path segments** instead of slash-wrapped substrings: normalize `\` → `/`, split on `/`, and skip the file when any segment is a known vendored/build directory.
- Introduced a class-level `SKIP_DIRS` frozenset (`node_modules`, `vendor`, `dist`, `build`, `.git`, `__pycache__`, `.venv`, `venv`) as a single, easy-to-extend source of truth.
- Added `tests/unit/test_tech_detector_vendored.py` with regression tests for root-level, nested, Windows-separator, and look-alike directory cases.
- Incidental: sorted the import block in `tech_detector.py` to satisfy ruff.

## Testing
- [x] Unit tests pass (`make test-unit`) — no new failures (see note below)
- [ ] Integration tests pass (`make test-integration`) — not run; the change is unit-scoped and does not touch DB/services
- [x] Linter passes (`make lint`) — edited files are ruff-clean (see note below)
- [x] Type checker passes (`make typecheck`) — edited files are mypy-clean (see note below)
- [x] New/updated tests cover the changes

Before this change the pre-existing tests `test_node_modules_excluded` and `test_build_directory_excluded` failed; they now pass, and five new regression tests were added.

## Screenshots / Demo
N/A — logic-only change in a backend tool, fully covered by unit tests.

## Notes for Reviewers

**Pre-existing failures (unrelated to this PR).** The repository has substantial pre-existing failures independent of issue #150. Before my change `make test-unit` reported **53 failed / 375 passed**; after my change it reports **51 failed / 382 passed** — exactly the two target tests fixed plus five new passing tests, with **no new failures introduced**. The remaining 51 failures belong to other issues. Similarly, `make lint` (ruff) reports 182 pre-existing findings repo-wide and `make check`'s `black` would reformat 52 files; I kept only my edited files lint/format/type-clean, verified by the pre-commit hooks (ruff, black, mypy all passed on the fix commit).

**Out of scope (possible follow-up).** `_detect_tech()` selects the primary language with `sorted(languages)[0]` — alphabetical order, not "most common" as the comment claims (`languages` is a `set`, so frequency is already discarded). The exclusion fix here is sufficient to resolve #150, so I intentionally left the alphabetical-vs-frequency behavior unchanged to keep this Tier-1 PR focused. Happy to open a separate issue/PR for it.
