### PR TITLE
Test/57 mock GitHub server

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,15 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/57
+**Issue title:** Add a mock GitHub API server for integration tests
+
+**Tier:** [ ] Tier 1  [X] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The current codebase skip Github tool tests because they require live Github access. The goal is creating a mock Github server that answers with pre-saved fake data in order to run Github tool tests without sending requests to Github. This issue involves adding the Github tool tests (`tests/integration/test_github_tool.py`) and fixture responses (`tests/fixtures/github_responses/`) to the codebase.
+
+**Branch name:** test/57-mock-github-server
+
+**Setup confirmation:** [X] App runs locally at localhost:5173
+
+**Cohort ledger:** [X] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -48,7 +48,7 @@ N/A
 
 ### Check-in 2 (end of week)
 
-**PR link:** [link to your submitted pull request]
+**PR link:** https://github.com/ascherj/pathreview/pull/966#issue-5067937138
 
 **Branch:** `test/57-mock-github-server`
 
@@ -58,6 +58,13 @@ Added a mock-GitHub-API integration test suite for `GitHubTool` using `pytest-ht
 **Tests added or updated:**
 `tests/integration/test_github_tool.py` (9 tests) covering the success path with full metadata, null/missing-field fallbacks, README present/absent detection, and error mapping for 404 (not found), 403 (rate limited), and generic 500 responses, plus missing-argument validation. Also added fixture responses under `tests/fixtures/github_responses/` (`repo_success.json`, `repo_nulls.json`, `error_403.json`, `error_404.json`, `error_500.json`).
 
-**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+**Self-review confirmation:** [] make check passes  [] make test-unit passes
+Note: There are pre-existing failures in unit tests before the fix of this issue (53 failed, 384 passed). This number didn't change after the fix of this issue. `make check` also have pre-existing failures. To ensure that linter and typecheck pass for the code files touched by the fix, the following commands were ran on to achieve the same effect:
+- `.venv/Scripts/ruff.exe check tests/integration/test_github_tool.py`
+- `.venv/Scripts/black.exe tests/integration/test_github_tool.py`
+- `.venv/Scripts/mypy.exe tests/integration/test_github_tool.py`
+- `.venv/Scripts/ruff.exe check agent/tools/github_tool.py`
+- `.venv/Scripts/black.exe agent/tools/github_tool.py`
+- `.venv/Scripts/mypy.exe agent/tools/github_tool.py`
 
-**Draft PR feedback received from:** [name or Slack handle, or "none"]
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -68,3 +68,35 @@ Note: There are pre-existing failures in unit tests before the fix of this issue
 - `.venv/Scripts/mypy.exe agent/tools/github_tool.py`
 
 **Draft PR feedback received from:** none
+
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [X] No — still awaiting review
+
+**Summary of feedback:**
+No review came in.
+
+**How you responded:**
+N/A
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Passing the checks was the most surprising piece. I did not expect to encounter type check error during committing. I got an error that was "returning any from function declared to return "bool" from the `github_tool.py`. Even though I didn't touch the production code in that file, but the type error was still caught. Everything else went smoother than expected. 
+
+**What did you learn about working in a large codebase?**
+If one thing I learned, I would say reading the docs before working on the code. Especially, the doc on architecture helped understanding how directories are organized in the codebase, which helped me understand what parts of the codebase might be relevant to the issue. This is different from my own project, because for my own projects I know how things are organized and where to look for things. In a large codebase that has many files, I think understanding the organization of the directories is part of understanding the architecture.
+
+**How did AI tools help — and where did they fall short?**
+AI was the most useful when there are errors show up, particularly when involving the `make` commands (the setup and `make check`) and in general anything with the command lines. I also personally find AI to be useful when "double checking" the work. Sometimes I manually implemented or wrote things, then asked AI what could be alternatives or what were things not covered, I found AI very useful, even sometimes more useful than generating things from zero. I think AI does a good job implementing things based on existing plan, but when I tried to use it for the planning phase, I found myself often need to modify manually or go through many rounds back and forth.
+
+**What would you do differently if you started over?**
+I think I might choose an issue that is not about writing tests, but actually fix some logic or implement some features - something that is slightly less isolated with the existing code. 
+
+**What are you most proud of from this module?**
+Getting through the whole workflow was great, and organizing the commit history to be clean to look at was very satisfying.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -29,3 +29,35 @@ N/A
 
 **Blockers or open questions:**
 N/A
+
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+I have not implemented anything so far. None of the sub-tasks from PLAN.md are done.
+
+**Next steps:**
+Implement the solutions, document the implementation, and submit a PR.
+
+**Blockers:**
+N/A
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [link to your submitted pull request]
+
+**Branch:** `test/57-mock-github-server`
+
+**What you built:**
+Added a mock-GitHub-API integration test suite for `GitHubTool` using `pytest-httpserver`, so the tool's GitHub interactions can be tested without live GitHub access. Each test points `tool.base_url` at a local mock server that answers repo-metadata and README requests with pre-saved JSON fixtures.
+
+**Tests added or updated:**
+`tests/integration/test_github_tool.py` (9 tests) covering the success path with full metadata, null/missing-field fallbacks, README present/absent detection, and error mapping for 404 (not found), 403 (rate limited), and generic 500 responses, plus missing-argument validation. Also added fixture responses under `tests/fixtures/github_responses/` (`repo_success.json`, `repo_nulls.json`, `error_403.json`, `error_404.json`, `error_500.json`).
+
+**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+
+**Draft PR feedback received from:** [name or Slack handle, or "none"]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -13,3 +13,19 @@ The current codebase skip Github tool tests because they require live Github acc
 **Setup confirmation:** [X] App runs locally at localhost:5173
 
 **Cohort ledger:** [X] Issue added to cohort ledger
+
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/xxy361/pathreview/commit/7bc126023c004fe8894f0c7c103efb56c1a44f0a
+
+**Reproduction summary:**
+Since the issue is on creating tests for GitHub tools, I focused on understanding the existing implementation for GitHub tools (`agent\tools\github_tool.py`), particularly looking at the try-and-except blocks to see what errors are expected. The docstrings are very helpful for understanding the functions, as well as inputs/outputs.
+
+**PLAN.md link:** https://github.com/xxy361/pathreview/blob/test/57-mock-github-server/PLAN.md
+
+**Walkthrough video (recommended):** 
+N/A
+
+**Blockers or open questions:**
+N/A

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,83 @@
+## Solution plan
+
+**Issue #57:** Add a mock GitHub API server for integration tests (https://github.com/ascherj/pathreview/issues/57)
+
+### Understand
+<!--
+What is the root cause of this issue? What behavior is expected vs. actual?
+-->
+The current codebase skip Github tool tests because they require live Github access. The goal is creating a mock Github server that answers with pre-saved fake data in order to run Github tool tests without sending requests to Github.
+
+- Actual bahavior: GitHub tool behavior is unverified as tests are skipped
+- Expected behavior: Tests for GitHub tool run on a local mock server and confirm that the Github tool functions properly
+
+### Map
+<!--
+Which files, functions, or modules are involved?
+List the specific files you expect to touch.
+-->
+Existing modules involved: 
+- `agent\tools\github_tool.py`
+    - `_fetch_repo_metadata` → `GET {base_url}/repos/{user}/{repo}`
+    - `_has_readme` → `HEAD {base_url}/repos/{user}/{repo}/readme`
+    - `execute` → maps errors
+        - 404 Not Found: "Repository not found"
+        - 403 Forbidden: "Rate limited or access denied"
+
+Files to create:
+- `tests/integration/test_github_tool.py` - GitHub tool tests
+- `tests/fixtures/github_responses/` - pre-save fixtures
+
+Dependency:
+- `pytest-httpserver` (already a dependency)
+
+### Plan
+<!--
+What are the steps to fix this issue?
+Break it into 3–5 concrete sub-tasks.
+-->
+1. First write out the fixtures based on the implementation of GitHub tool that covers the following
+    - note that `repo_json = response.json()` for GitHub metadata, so a full success response should be in the json format (`repo_success.json`)
+    - a response with some nulls to test out how the nulls are being handled when extract metadata (lines 98-110 in `github_tool.py`)
+    - a response with `status_code` as `404`, `403`, and another generic error for fetching metadata. See if error messages for the`HTTPStatusError`exception are correct
+    - a HEAD handler retruning `200` when README is present
+    - a HEAD handler r
+2. Set up the mock server and write out the names for the tests needed without implementing them
+    - need to inject `tool.base_url = httpserver.url_for("")`
+3. Implement the tests the cover:
+    - success path (using fixture)
+    - null-fallbacks (using fixture)
+    - README absence
+    - error messages (using fixture)
+    - missing input
+
+### Inputs & outputs
+<!--
+What does your fix take as input? What should it produce or change?
+-->
+Input:
+- Tool input: `{"github_username", "repo_name"}`
+- Injected `tool.base_url` pointing at the local mock server
+
+Output:
+- New files only: `tests/integration/test_github_tool.py` + fixtures in `tests/fixtures/github_responses/`
+- No production code change (base_url injected in the test)
+- GitHub tool tests run offline in CI without live GitHub access
+
+### Risks & unknowns
+<!--
+What could go wrong? What are you still unsure about?
+-->
+- For `_has_readme`, ` except Exception: return False` so all exceptions are covered. The tests might silently pass if no `HEAD` handler
+- Fixture JSON must use real GitHub field names (stargazers_count, forks_count, pushed_at, topics, homepage) for .get() extraction. This would have to assume to be true, and the test meeds to follow the naming strictly.
+
+
+### Edge cases
+<!--
+What inputs or states should your fix handle gracefully?
+-->
+- Null `description` / `language` / `homepage` → fallbacks (`""`, `"Unknown"`)
+- Missing `topics` / `homepage` keys → defaults
+- 404 (repo not found), 403 (rate limited), other/generic status → mapped error messages
+- README present (`HEAD` 200) vs. absent 
+- Missing `github_username` or `repo_name` → `success=False`, no server call

--- a/PLAN.md
+++ b/PLAN.md
@@ -41,7 +41,6 @@ Break it into 3–5 concrete sub-tasks.
     - a response with some nulls to test out how the nulls are being handled when extract metadata (lines 98-110 in `github_tool.py`)
     - a response with `status_code` as `404`, `403`, and another generic error for fetching metadata. See if error messages for the`HTTPStatusError`exception are correct
     - a HEAD handler retruning `200` when README is present
-    - a HEAD handler r
 2. Set up the mock server and write out the names for the tests needed without implementing them
     - need to inject `tool.base_url = httpserver.url_for("")`
 3. Implement the tests the cover:

--- a/agent/tools/github_tool.py
+++ b/agent/tools/github_tool.py
@@ -2,6 +2,7 @@
 
 import httpx
 import structlog
+
 from .base import BaseTool, ToolResult
 
 logger = structlog.get_logger()
@@ -35,44 +36,30 @@ class GitHubTool(BaseTool):
         repo_name = input_data.get("repo_name")
 
         if not username or not repo_name:
-            return ToolResult(
-                success=False,
-                data={},
-                error="Missing github_username or repo_name"
-            )
+            return ToolResult(success=False, data={}, error="Missing github_username or repo_name")
 
         try:
             repo_data = self._fetch_repo_metadata(username, repo_name)
             return ToolResult(success=True, data=repo_data)
 
         except httpx.HTTPStatusError as e:
-            logger.error("github_request_failed", status=e.response.status_code,
-                        username=username, repo=repo_name)
+            logger.error(
+                "github_request_failed",
+                status=e.response.status_code,
+                username=username,
+                repo=repo_name,
+            )
             if e.response.status_code == 404:
-                return ToolResult(
-                    success=False,
-                    data={},
-                    error="Repository not found"
-                )
+                return ToolResult(success=False, data={}, error="Repository not found")
             elif e.response.status_code == 403:
-                return ToolResult(
-                    success=False,
-                    data={},
-                    error="Rate limited or access denied"
-                )
+                return ToolResult(success=False, data={}, error="Rate limited or access denied")
             return ToolResult(
-                success=False,
-                data={},
-                error=f"GitHub API error: {e.response.status_code}"
+                success=False, data={}, error=f"GitHub API error: {e.response.status_code}"
             )
 
         except Exception as e:
             logger.error("github_tool_error", error=str(e))
-            return ToolResult(
-                success=False,
-                data={},
-                error=str(e)
-            )
+            return ToolResult(success=False, data={}, error=str(e))
 
     def _fetch_repo_metadata(self, username: str, repo_name: str) -> dict:
         """Fetch repository metadata from GitHub API.
@@ -109,8 +96,13 @@ class GitHubTool(BaseTool):
             "homepage": repo_json.get("homepage") or "",
         }
 
-        logger.info("github_repo_fetched", username=username, repo=repo_name,
-                   language=metadata["primary_language"], stars=metadata["star_count"])
+        logger.info(
+            "github_repo_fetched",
+            username=username,
+            repo=repo_name,
+            language=metadata["primary_language"],
+            stars=metadata["star_count"],
+        )
 
         return metadata
 
@@ -132,6 +124,6 @@ class GitHubTool(BaseTool):
 
         try:
             response = httpx.head(url, headers=headers, timeout=5.0)
-            return response.status_code == 200
+            return bool(response.status_code == 200)
         except Exception:
             return False

--- a/tests/fixtures/github_responses/error_403.json
+++ b/tests/fixtures/github_responses/error_403.json
@@ -1,0 +1,5 @@
+{
+  "message": "API rate limit exceeded for 203.0.113.0. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)",
+  "documentation_url": "https://docs.github.com/rest/overview/rate-limits-for-the-rest-api",
+  "status": "403"
+}

--- a/tests/fixtures/github_responses/error_404.json
+++ b/tests/fixtures/github_responses/error_404.json
@@ -1,0 +1,5 @@
+{
+  "message": "Not Found",
+  "documentation_url": "https://docs.github.com/rest/repos/repos#get-a-repository",
+  "status": "404"
+}

--- a/tests/fixtures/github_responses/error_500.json
+++ b/tests/fixtures/github_responses/error_500.json
@@ -1,0 +1,5 @@
+{
+  "message": "Server Error",
+  "documentation_url": "https://docs.github.com/rest",
+  "status": "500"
+}

--- a/tests/fixtures/github_responses/repo_nulls.json
+++ b/tests/fixtures/github_responses/repo_nulls.json
@@ -1,0 +1,25 @@
+{
+  "id": 223456789,
+  "name": "sparse-repo",
+  "full_name": "octocat/sparse-repo",
+  "owner": {
+    "login": "octocat",
+    "id": 111222,
+    "type": "User"
+  },
+  "private": false,
+  "html_url": "https://github.com/octocat/sparse-repo",
+  "description": null,
+  "fork": false,
+  "language": null,
+  "stargazers_count": 0,
+  "watchers_count": 0,
+  "forks_count": 0,
+  "open_issues_count": 0,
+  "default_branch": "main",
+  "homepage": null,
+  "created_at": "2025-09-10T12:00:00Z",
+  "updated_at": "2025-09-10T12:00:00Z",
+  "pushed_at": "2025-09-10T12:00:00Z",
+  "license": null
+}

--- a/tests/fixtures/github_responses/repo_success.json
+++ b/tests/fixtures/github_responses/repo_success.json
@@ -1,0 +1,29 @@
+{
+  "id": 123456789,
+  "name": "pathreview",
+  "full_name": "ascherj/pathreview",
+  "owner": {
+    "login": "ascherj",
+    "id": 987654,
+    "type": "User"
+  },
+  "private": false,
+  "html_url": "https://github.com/ascherj/pathreview",
+  "description": "A code review tool",
+  "fork": false,
+  "language": "Python",
+  "stargazers_count": 128,
+  "watchers_count": 128,
+  "forks_count": 12,
+  "open_issues_count": 3,
+  "default_branch": "main",
+  "topics": ["python", "fastapi", "ai"],
+  "homepage": "https://pathreview.dev",
+  "created_at": "2025-06-01T08:00:00Z",
+  "updated_at": "2026-01-15T09:00:00Z",
+  "pushed_at": "2026-01-15T10:30:00Z",
+  "license": {
+    "key": "mit",
+    "name": "MIT License"
+  }
+}

--- a/tests/integration/test_github_tool.py
+++ b/tests/integration/test_github_tool.py
@@ -1,0 +1,188 @@
+"""Integration tests for GitHubTool against a mock GitHub API server.
+
+These tests exercise ``agent.tools.github_tool.GitHubTool`` end-to-end without
+touching live GitHub. A local ``pytest-httpserver`` instance answers requests
+with pre-saved fixtures from ``tests/fixtures/github_responses/``.
+
+The tool hardcodes ``base_url = "https://api.github.com"`` but exposes it as a
+plain attribute, so each test points it at the mock via
+``tool.base_url = httpserver.url_for("")``.
+"""
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pytest_httpserver import HTTPServer
+
+from agent.tools.github_tool import GitHubTool
+
+FIXTURES_DIR = Path(__file__).parent.parent / "fixtures" / "github_responses"
+
+USERNAME = "octocat"
+REPO = "hello-world"
+REPO_PATH = f"/repos/{USERNAME}/{REPO}"
+README_PATH = f"/repos/{USERNAME}/{REPO}/readme"
+
+
+def load_fixture(name: str) -> dict[Any, Any]:
+    """Load a JSON fixture from tests/fixtures/github_responses/.
+
+    Args:
+        name: Fixture filename, e.g. "repo_success.json".
+
+    Returns:
+        Parsed JSON as a dict.
+    """
+    result: dict[Any, Any] = json.loads((FIXTURES_DIR / name).read_text())
+    return result
+
+
+def fixture_status(response: dict[Any, Any]) -> int:
+    """HTTP status for a fixture: its ``status`` field, or 200 if absent."""
+    return int(response.get("status", 200))
+
+
+@pytest.mark.integration
+class TestGitHubTool:
+    """Test suite for GitHubTool backed by a mock GitHub API server."""
+
+    @pytest.fixture
+    def tool(self, httpserver: HTTPServer) -> GitHubTool:
+        """Return a GitHubTool pointed at the local mock server."""
+        tool = GitHubTool()
+        tool.base_url = httpserver.url_for("")
+        return tool
+
+    def test_execute_success_returns_full_metadata(
+        self, tool: GitHubTool, httpserver: HTTPServer
+    ) -> None:
+        """Success path: full fixture maps to all metadata fields."""
+        response = load_fixture("repo_success.json")
+        httpserver.expect_request(REPO_PATH, method="GET").respond_with_json(
+            response, status=fixture_status(response)
+        )
+        httpserver.expect_request(README_PATH, method="HEAD").respond_with_data("", status=200)
+
+        result = tool.execute({"github_username": USERNAME, "repo_name": REPO})
+
+        assert result.success is True
+        assert result.error is None
+        assert result.data == {
+            "name": "pathreview",
+            "description": "A code review tool",
+            "primary_language": "Python",
+            "star_count": 128,
+            "fork_count": 12,
+            "open_issues_count": 3,
+            "last_commit_date": "2026-01-15T10:30:00Z",
+            "has_readme": True,
+            "topics": ["python", "fastapi", "ai"],
+            "homepage": "https://pathreview.dev",
+        }
+
+    def test_execute_handles_null_fields_with_fallbacks(
+        self, tool: GitHubTool, httpserver: HTTPServer
+    ) -> None:
+        """Null description/language/homepage and missing topics use fallbacks."""
+        response = load_fixture("repo_nulls.json")
+        httpserver.expect_request(REPO_PATH, method="GET").respond_with_json(
+            response, status=fixture_status(response)
+        )
+        httpserver.expect_request(README_PATH, method="HEAD").respond_with_data("", status=200)
+
+        result = tool.execute({"github_username": USERNAME, "repo_name": REPO})
+
+        assert result.success is True
+        assert result.data["description"] == ""
+        assert result.data["primary_language"] == "Unknown"
+        assert result.data["homepage"] == ""
+        assert result.data["topics"] == []
+
+    def test_execute_reports_readme_absent(self, tool: GitHubTool, httpserver: HTTPServer) -> None:
+        """has_readme is False when the README HEAD request is not 200."""
+        response = load_fixture("repo_success.json")
+        httpserver.expect_request(REPO_PATH, method="GET").respond_with_json(
+            response, status=fixture_status(response)
+        )
+        httpserver.expect_request(README_PATH, method="HEAD").respond_with_data("", status=404)
+
+        result = tool.execute({"github_username": USERNAME, "repo_name": REPO})
+
+        assert result.success is True
+        assert result.data["has_readme"] is False
+
+    def test_execute_reports_readme_present(self, tool: GitHubTool, httpserver: HTTPServer) -> None:
+        """has_readme is True when the README HEAD request returns 200."""
+        response = load_fixture("repo_success.json")
+        httpserver.expect_request(REPO_PATH, method="GET").respond_with_json(
+            response, status=fixture_status(response)
+        )
+        httpserver.expect_request(README_PATH, method="HEAD").respond_with_data("", status=200)
+
+        result = tool.execute({"github_username": USERNAME, "repo_name": REPO})
+
+        assert result.success is True
+        assert result.data["has_readme"] is True
+
+    def test_execute_404_returns_repository_not_found(
+        self, tool: GitHubTool, httpserver: HTTPServer
+    ) -> None:
+        """404 metadata response maps to 'Repository not found'."""
+        response = load_fixture("error_404.json")
+        httpserver.expect_request(REPO_PATH, method="GET").respond_with_json(
+            response, status=fixture_status(response)
+        )
+
+        result = tool.execute({"github_username": USERNAME, "repo_name": REPO})
+
+        assert result.success is False
+        assert result.data == {}
+        assert result.error == "Repository not found"
+
+    def test_execute_403_returns_rate_limited(
+        self, tool: GitHubTool, httpserver: HTTPServer
+    ) -> None:
+        """403 metadata response maps to 'Rate limited or access denied'."""
+        response = load_fixture("error_403.json")
+        httpserver.expect_request(REPO_PATH, method="GET").respond_with_json(
+            response, status=fixture_status(response)
+        )
+
+        result = tool.execute({"github_username": USERNAME, "repo_name": REPO})
+
+        assert result.success is False
+        assert result.data == {}
+        assert result.error == "Rate limited or access denied"
+
+    def test_execute_generic_error_returns_status_message(
+        self, tool: GitHubTool, httpserver: HTTPServer
+    ) -> None:
+        """Other status (e.g. 500) maps to 'GitHub API error: <code>'."""
+        response = load_fixture("error_500.json")
+        httpserver.expect_request(REPO_PATH, method="GET").respond_with_json(
+            response, status=fixture_status(response)
+        )
+
+        result = tool.execute({"github_username": USERNAME, "repo_name": REPO})
+
+        assert result.success is False
+        assert result.data == {}
+        assert result.error == "GitHub API error: 500"
+
+    def test_execute_missing_username_returns_error(self, tool: GitHubTool) -> None:
+        """Missing github_username fails without calling the server."""
+        result = tool.execute({"repo_name": REPO})
+
+        assert result.success is False
+        assert result.data == {}
+        assert result.error == "Missing github_username or repo_name"
+
+    def test_execute_missing_repo_name_returns_error(self, tool: GitHubTool) -> None:
+        """Missing repo_name fails without calling the server."""
+        result = tool.execute({"github_username": USERNAME})
+
+        assert result.success is False
+        assert result.data == {}
+        assert result.error == "Missing github_username or repo_name"


### PR DESCRIPTION
## Summary
Enables the previously-skipped GitHubTool integration tests to run offline. Adds a mock GitHub API server (via `pytest-httpserver`) backed by pre-saved response fixtures, so the tool's metadata parsing and error-mapping logic is verified in CI without requiring live GitHub access. The tool's base_url is injected at test time to point at the local mock server, so no production behavior changes.

## Issue
Closes #57 

## Changes
- Add `tests/integration/test_github_tool.py` covering the tool's success path, null-field fallbacks, README presence/absence, HTTP error mapping (404/403/generic), and missing-input handling
- Add fixtures in `tests/fixtures/github_responses/`: `repo_success.json`, `repo_nulls.json`, `error_403.json`, `error_404.json`, `error_500.json`
- Reformat `agent/tools/github_tool.py` in black style and wrap the README status check in bool(...) (`bool(response.status_code == 200)`) — there is no behavioral change
- Add `PLAN.md` and update `JOURNAL.md` documenting the reproduction and solution plan

## Testing
- [ ] Unit tests pass (`make test-unit`)
- [x] Integration tests pass (`make test-integration`)
- [ ] Linter passes (`make lint`)
- [ ] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes


## Screenshots / Demo
<img width="1984" height="474" alt="integration_tests" src="https://github.com/user-attachments/assets/81bf5be1-9d19-4f1f-b1b0-5b24874428c5" />


## Notes for Reviewers
There are existing failures in unit tests before the fix of this issue (53 failed, 384 passed). This number didn't change after the fix of this issue. Similarly,`make lint` and `make typecheck` have pre-existing failures. To ensure that linter and typecheck pass for the code files touched by the fix, the following commands were ran:

`.venv/Scripts/ruff.exe check tests/integration/test_github_tool.py`
`.venv/Scripts/black.exe tests/integration/test_github_tool.py`
`.venv/Scripts/mypy.exe tests/integration/test_github_tool.py`

`.venv/Scripts/ruff.exe check agent/tools/github_tool.py`
`.venv/Scripts/black.exe agent/tools/github_tool.py`
`.venv/Scripts/mypy.exe agent/tools/github_tool.py`
