### PR TITLE
Test/57 mock GitHub api server pr

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,5 +14,5 @@ repos:
     rev: v1.8.0
     hooks:
       - id: mypy
-        additional_dependencies: [types-redis]
+        additional_dependencies: [types-redis, httpx]
         args: [--ignore-missing-imports]

--- a/agent/tools/github_tool.py
+++ b/agent/tools/github_tool.py
@@ -2,6 +2,7 @@
 
 import httpx
 import structlog
+
 from .base import BaseTool, ToolResult
 
 logger = structlog.get_logger()
@@ -35,44 +36,30 @@ class GitHubTool(BaseTool):
         repo_name = input_data.get("repo_name")
 
         if not username or not repo_name:
-            return ToolResult(
-                success=False,
-                data={},
-                error="Missing github_username or repo_name"
-            )
+            return ToolResult(success=False, data={}, error="Missing github_username or repo_name")
 
         try:
             repo_data = self._fetch_repo_metadata(username, repo_name)
             return ToolResult(success=True, data=repo_data)
 
         except httpx.HTTPStatusError as e:
-            logger.error("github_request_failed", status=e.response.status_code,
-                        username=username, repo=repo_name)
+            logger.error(
+                "github_request_failed",
+                status=e.response.status_code,
+                username=username,
+                repo=repo_name,
+            )
             if e.response.status_code == 404:
-                return ToolResult(
-                    success=False,
-                    data={},
-                    error="Repository not found"
-                )
+                return ToolResult(success=False, data={}, error="Repository not found")
             elif e.response.status_code == 403:
-                return ToolResult(
-                    success=False,
-                    data={},
-                    error="Rate limited or access denied"
-                )
+                return ToolResult(success=False, data={}, error="Rate limited or access denied")
             return ToolResult(
-                success=False,
-                data={},
-                error=f"GitHub API error: {e.response.status_code}"
+                success=False, data={}, error=f"GitHub API error: {e.response.status_code}"
             )
 
         except Exception as e:
             logger.error("github_tool_error", error=str(e))
-            return ToolResult(
-                success=False,
-                data={},
-                error=str(e)
-            )
+            return ToolResult(success=False, data={}, error=str(e))
 
     def _fetch_repo_metadata(self, username: str, repo_name: str) -> dict:
         """Fetch repository metadata from GitHub API.
@@ -109,8 +96,13 @@ class GitHubTool(BaseTool):
             "homepage": repo_json.get("homepage") or "",
         }
 
-        logger.info("github_repo_fetched", username=username, repo=repo_name,
-                   language=metadata["primary_language"], stars=metadata["star_count"])
+        logger.info(
+            "github_repo_fetched",
+            username=username,
+            repo=repo_name,
+            language=metadata["primary_language"],
+            stars=metadata["star_count"],
+        )
 
         return metadata
 

--- a/agent/tools/github_tool.py
+++ b/agent/tools/github_tool.py
@@ -14,14 +14,18 @@ class GitHubTool(BaseTool):
     name = "github_tool"
     description = "Fetch repository metadata from GitHub"
 
-    def __init__(self, api_token: str | None = None):
+    def __init__(
+        self, api_token: str | None = None, base_url: str = "https://api.github.com"
+    ) -> None:
         """Initialize GitHub tool.
 
         Args:
             api_token: GitHub API token (optional for unauthenticated requests)
+            base_url: Root URL of the GitHub API. Defaults to the public API;
+                override it to point the tool at a mock server in tests.
         """
         self.api_token = api_token
-        self.base_url = "https://api.github.com"
+        self.base_url = base_url
 
     def execute(self, input_data: dict) -> ToolResult:
         """Fetch GitHub repository metadata.

--- a/tests/fixtures/github_responses/not_found.json
+++ b/tests/fixtures/github_responses/not_found.json
@@ -1,0 +1,5 @@
+{
+  "message": "Not Found",
+  "documentation_url": "https://docs.github.com/rest/repos/repos#get-a-repository",
+  "status": "404"
+}

--- a/tests/fixtures/github_responses/rate_limited.json
+++ b/tests/fixtures/github_responses/rate_limited.json
@@ -1,0 +1,4 @@
+{
+  "message": "API rate limit exceeded for 203.0.113.42. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)",
+  "documentation_url": "https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting"
+}

--- a/tests/fixtures/github_responses/repo_full.json
+++ b/tests/fixtures/github_responses/repo_full.json
@@ -1,0 +1,26 @@
+{
+  "id": 892341567,
+  "name": "pathreview",
+  "full_name": "ascherj/pathreview",
+  "private": false,
+  "html_url": "https://github.com/ascherj/pathreview",
+  "description": "AI-powered portfolio review assistant",
+  "fork": false,
+  "homepage": "https://pathreview.dev",
+  "language": "Python",
+  "stargazers_count": 8,
+  "watchers_count": 8,
+  "forks_count": 3,
+  "open_issues_count": 130,
+  "topics": [
+    "ai",
+    "fastapi",
+    "portfolio",
+    "rag"
+  ],
+  "visibility": "public",
+  "default_branch": "main",
+  "created_at": "2026-01-14T18:22:07Z",
+  "updated_at": "2026-07-18T00:05:16Z",
+  "pushed_at": "2026-07-18T00:05:16Z"
+}

--- a/tests/fixtures/github_responses/repo_minimal_nulls.json
+++ b/tests/fixtures/github_responses/repo_minimal_nulls.json
@@ -1,0 +1,20 @@
+{
+  "id": 705118342,
+  "name": "scratch",
+  "full_name": "octocat/scratch",
+  "private": false,
+  "html_url": "https://github.com/octocat/scratch",
+  "description": null,
+  "fork": false,
+  "homepage": null,
+  "language": null,
+  "stargazers_count": 0,
+  "watchers_count": 0,
+  "forks_count": 0,
+  "open_issues_count": 0,
+  "visibility": "public",
+  "default_branch": "main",
+  "created_at": "2026-03-02T09:41:55Z",
+  "updated_at": "2026-03-02T09:44:12Z",
+  "pushed_at": "2026-03-02T09:44:12Z"
+}

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,126 @@
+"""Fixtures for the mock GitHub API server used by integration tests.
+
+`pytest_httpserver` starts a real HTTP server on an ephemeral localhost port,
+so these tests exercise the genuine `httpx` request path — headers, status
+codes, timeouts and all — without touching the network or needing credentials.
+
+Response bodies are recorded GitHub payloads stored under
+`tests/fixtures/github_responses/`, trimmed to the fields the tool reads.
+"""
+
+import json
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pytest_httpserver import HTTPServer
+
+from agent.tools.github_tool import GitHubTool
+
+FIXTURE_DIR = Path(__file__).parent.parent / "fixtures" / "github_responses"
+
+
+def load_response(name: str) -> dict[str, Any]:
+    """Load a recorded GitHub API response body.
+
+    Args:
+        name: Fixture file name without the `.json` suffix
+
+    Returns:
+        The parsed JSON body
+
+    Raises:
+        FileNotFoundError: If no such fixture exists
+    """
+    path = FIXTURE_DIR / f"{name}.json"
+    if not path.exists():
+        raise FileNotFoundError(f"No GitHub response fixture named {name!r} in {FIXTURE_DIR}")
+
+    parsed: dict[str, Any] = json.loads(path.read_text(encoding="utf-8"))
+    return parsed
+
+
+def expect_repo(
+    httpserver: HTTPServer,
+    username: str,
+    repo_name: str,
+    body: dict[str, Any] | None = None,
+    status: int = 200,
+) -> None:
+    """Register the `GET /repos/{username}/{repo_name}` endpoint on the mock.
+
+    Args:
+        httpserver: The running mock server
+        username: GitHub username in the request path
+        repo_name: Repository name in the request path
+        body: JSON body to return, defaults to an empty object
+        status: HTTP status code to return
+    """
+    httpserver.expect_request(f"/repos/{username}/{repo_name}", method="GET").respond_with_json(
+        body if body is not None else {}, status=status
+    )
+
+
+def expect_readme(
+    httpserver: HTTPServer,
+    username: str,
+    repo_name: str,
+    status: int = 200,
+) -> None:
+    """Register the `HEAD /repos/{username}/{repo_name}/readme` endpoint on the mock.
+
+    A single `execute()` call fans out to two requests, because `_has_readme`
+    is invoked while building the metadata dict. The second one is a HEAD, and
+    a HEAD response carries no body.
+
+    Args:
+        httpserver: The running mock server
+        username: GitHub username in the request path
+        repo_name: Repository name in the request path
+        status: HTTP status code to return
+    """
+    httpserver.expect_request(
+        f"/repos/{username}/{repo_name}/readme", method="HEAD"
+    ).respond_with_data("", status=status)
+
+
+@pytest.fixture(scope="session")
+def httpserver_listen_address() -> tuple[str, int]:
+    """Bind the mock server to the IPv4 loopback address on an ephemeral port.
+
+    Overrides `pytest_httpserver`'s default of `localhost`, which is worth the
+    two lines: on a dual-stack host `localhost` resolves to `::1` before
+    `127.0.0.1`, and since the server listens on IPv4 only, every request first
+    burns ~2.6s on the dead IPv6 address before falling back. Binding to the
+    literal IP takes the suite from ~60s to a few seconds.
+    """
+    return ("127.0.0.1", 0)
+
+
+@pytest.fixture
+def mock_github_url(httpserver: HTTPServer) -> str:
+    """Return the mock server's base URL with no trailing slash.
+
+    `url_for("")` yields `http://127.0.0.1:<port>/`, and the tool builds URLs
+    by concatenation (`f"{base_url}/repos/..."`), so the slash has to go or
+    every path arrives as `//repos/...` and matches no handler.
+    """
+    # Annotated rather than returned directly: the pre-commit mypy hook runs in
+    # an isolated env without pytest-httpserver, where url_for() is untyped and
+    # would otherwise trip warn_return_any.
+    root: str = httpserver.url_for("")
+    return root.rstrip("/")
+
+
+@pytest.fixture
+def github_tool(httpserver: HTTPServer, mock_github_url: str) -> Iterator[GitHubTool]:
+    """Return an unauthenticated `GitHubTool` pointed at the mock server.
+
+    On teardown it asserts every request the tool made was matched by a
+    registered handler. That check matters here: `_has_readme` swallows all
+    exceptions and returns `False`, so a mock that never matched would
+    otherwise surface as a quietly passing test rather than an error.
+    """
+    yield GitHubTool(base_url=mock_github_url)
+    httpserver.check_assertions()

--- a/tests/integration/test_github_tool.py
+++ b/tests/integration/test_github_tool.py
@@ -1,0 +1,232 @@
+"""Integration tests for `GitHubTool` against a mock GitHub API server.
+
+Covers issue #57. Every test runs offline against `pytest_httpserver` — no
+network access, no GitHub credentials, no rate limits, and no assertions on
+values that drift (star counts, push timestamps) because the payloads are
+frozen fixtures rather than live responses.
+
+See `conftest.py` for the mock server fixtures.
+"""
+
+import pytest
+from pytest_httpserver import HTTPServer
+
+from agent.tools.github_tool import GitHubTool
+
+from .conftest import expect_readme, expect_repo, load_response
+
+
+@pytest.mark.integration
+class TestSuccessfulFetch:
+    """Responses the tool is expected to parse into metadata."""
+
+    def test_returns_full_metadata_for_a_well_formed_repo(
+        self, httpserver: HTTPServer, github_tool: GitHubTool
+    ) -> None:
+        """The happy path: every metadata field is mapped from the response."""
+        expect_repo(httpserver, "ascherj", "pathreview", load_response("repo_full"))
+        expect_readme(httpserver, "ascherj", "pathreview")
+
+        result = github_tool.execute({"github_username": "ascherj", "repo_name": "pathreview"})
+
+        assert result.success is True
+        assert result.error is None
+        assert result.data == {
+            "name": "pathreview",
+            "description": "AI-powered portfolio review assistant",
+            "primary_language": "Python",
+            "star_count": 8,
+            "fork_count": 3,
+            "open_issues_count": 130,
+            "last_commit_date": "2026-07-18T00:05:16Z",
+            "has_readme": True,
+            "topics": ["ai", "fastapi", "portfolio", "rag"],
+            "homepage": "https://pathreview.dev",
+        }
+
+    def test_coerces_null_description_language_and_homepage(
+        self, httpserver: HTTPServer, github_tool: GitHubTool
+    ) -> None:
+        """GitHub sends JSON `null` for unset fields; the tool substitutes defaults."""
+        expect_repo(httpserver, "octocat", "scratch", load_response("repo_minimal_nulls"))
+        expect_readme(httpserver, "octocat", "scratch")
+
+        result = github_tool.execute({"github_username": "octocat", "repo_name": "scratch"})
+
+        assert result.success is True
+        assert result.data["description"] == ""
+        assert result.data["primary_language"] == "Unknown"
+        assert result.data["homepage"] == ""
+
+    def test_defaults_topics_to_empty_list_when_key_is_absent(
+        self, httpserver: HTTPServer, github_tool: GitHubTool
+    ) -> None:
+        """A response with no `topics` key must not raise a KeyError."""
+        body = load_response("repo_minimal_nulls")
+        assert "topics" not in body, "fixture must omit topics for this test to mean anything"
+        expect_repo(httpserver, "octocat", "scratch", body)
+        expect_readme(httpserver, "octocat", "scratch")
+
+        result = github_tool.execute({"github_username": "octocat", "repo_name": "scratch"})
+
+        assert result.success is True
+        assert result.data["topics"] == []
+
+
+@pytest.mark.integration
+class TestErrorResponses:
+    """HTTP failures the tool maps onto `ToolResult.error` messages."""
+
+    def test_maps_404_to_repository_not_found(
+        self, httpserver: HTTPServer, github_tool: GitHubTool
+    ) -> None:
+        """A missing repo becomes a friendly message, not a raised exception."""
+        expect_repo(httpserver, "ascherj", "nonexistent", load_response("not_found"), status=404)
+
+        result = github_tool.execute({"github_username": "ascherj", "repo_name": "nonexistent"})
+
+        assert result.success is False
+        assert result.data == {}
+        assert result.error == "Repository not found"
+
+    def test_maps_403_to_rate_limited_or_access_denied(
+        self, httpserver: HTTPServer, github_tool: GitHubTool
+    ) -> None:
+        """The unauthenticated rate limit is the most likely real-world failure."""
+        expect_repo(httpserver, "ascherj", "pathreview", load_response("rate_limited"), status=403)
+
+        result = github_tool.execute({"github_username": "ascherj", "repo_name": "pathreview"})
+
+        assert result.success is False
+        assert result.data == {}
+        assert result.error == "Rate limited or access denied"
+
+    def test_reports_the_status_code_for_unmapped_errors(
+        self, httpserver: HTTPServer, github_tool: GitHubTool
+    ) -> None:
+        """Anything other than 404/403 falls through to a generic message."""
+        expect_repo(httpserver, "ascherj", "pathreview", {"message": "Server Error"}, status=500)
+
+        result = github_tool.execute({"github_username": "ascherj", "repo_name": "pathreview"})
+
+        assert result.success is False
+        assert result.data == {}
+        assert result.error == "GitHub API error: 500"
+
+    def test_returns_error_without_making_a_request_when_input_is_missing(
+        self, httpserver: HTTPServer, github_tool: GitHubTool
+    ) -> None:
+        """Input validation short-circuits before any HTTP call is attempted."""
+        result = github_tool.execute({"github_username": "ascherj"})
+
+        assert result.success is False
+        assert result.error == "Missing github_username or repo_name"
+        assert httpserver.log == [], "expected no HTTP request for invalid input"
+
+    def test_returns_error_when_the_server_is_unreachable(self) -> None:
+        """The CI failure mode before this change: no egress means no result.
+
+        Port 9 (discard) has nothing listening. The error *message* is
+        deliberately not asserted on — a refused connection surfaces as
+        "WinError 10061" on Windows and "Connection refused" on Linux.
+        """
+        tool = GitHubTool(base_url="http://127.0.0.1:9")
+
+        result = tool.execute({"github_username": "ascherj", "repo_name": "pathreview"})
+
+        assert result.success is False
+        assert result.data == {}
+        assert result.error
+
+
+@pytest.mark.integration
+class TestReadmeDetection:
+    """`_has_readme` fans a second, HEAD request out to a separate endpoint."""
+
+    def test_reports_no_readme_when_the_endpoint_returns_404(
+        self, httpserver: HTTPServer, github_tool: GitHubTool
+    ) -> None:
+        """A repo without a README still yields a successful result."""
+        expect_repo(httpserver, "ascherj", "pathreview", load_response("repo_full"))
+        expect_readme(httpserver, "ascherj", "pathreview", status=404)
+
+        result = github_tool.execute({"github_username": "ascherj", "repo_name": "pathreview"})
+
+        assert result.success is True
+        assert result.data["has_readme"] is False
+
+    def test_readme_failure_does_not_fail_the_whole_result(
+        self, httpserver: HTTPServer, github_tool: GitHubTool
+    ) -> None:
+        """A broken README endpoint degrades one field, it does not raise."""
+        expect_repo(httpserver, "ascherj", "pathreview", load_response("repo_full"))
+        expect_readme(httpserver, "ascherj", "pathreview", status=500)
+
+        result = github_tool.execute({"github_username": "ascherj", "repo_name": "pathreview"})
+
+        assert result.success is True
+        assert result.data["has_readme"] is False
+        assert result.data["name"] == "pathreview"
+
+    def test_one_execute_call_hits_both_endpoints(
+        self, httpserver: HTTPServer, github_tool: GitHubTool
+    ) -> None:
+        """Pins the two-request fan-out any future mock or cache has to honour."""
+        expect_repo(httpserver, "ascherj", "pathreview", load_response("repo_full"))
+        expect_readme(httpserver, "ascherj", "pathreview")
+
+        github_tool.execute({"github_username": "ascherj", "repo_name": "pathreview"})
+
+        assert [(req.method, req.path) for req, _ in httpserver.log] == [
+            ("GET", "/repos/ascherj/pathreview"),
+            ("HEAD", "/repos/ascherj/pathreview/readme"),
+        ]
+
+
+@pytest.mark.integration
+class TestAuthentication:
+    """Token propagation, asserted on the requests the server actually received."""
+
+    def test_sends_the_token_on_both_requests(
+        self, httpserver: HTTPServer, mock_github_url: str
+    ) -> None:
+        """The README HEAD needs the token too, or it 404s on private repos."""
+        expect_repo(httpserver, "ascherj", "pathreview", load_response("repo_full"))
+        expect_readme(httpserver, "ascherj", "pathreview")
+        tool = GitHubTool(api_token="ghp_testtoken", base_url=mock_github_url)
+
+        tool.execute({"github_username": "ascherj", "repo_name": "pathreview"})
+
+        sent = [req.headers.get("Authorization") for req, _ in httpserver.log]
+        assert sent == ["token ghp_testtoken", "token ghp_testtoken"]
+
+    def test_sends_no_authorization_header_when_no_token_is_given(
+        self, httpserver: HTTPServer, github_tool: GitHubTool
+    ) -> None:
+        """Unauthenticated requests must not send an empty or malformed header."""
+        expect_repo(httpserver, "ascherj", "pathreview", load_response("repo_full"))
+        expect_readme(httpserver, "ascherj", "pathreview")
+
+        github_tool.execute({"github_username": "ascherj", "repo_name": "pathreview"})
+
+        assert [req.headers.get("Authorization") for req, _ in httpserver.log] == [None, None]
+
+
+@pytest.mark.integration
+class TestBaseUrlInjection:
+    """The seam that makes all of the above possible (issue #57)."""
+
+    def test_defaults_to_the_public_github_api(self) -> None:
+        """Production behaviour is unchanged when no base URL is supplied."""
+        assert GitHubTool().base_url == "https://api.github.com"
+
+    def test_accepts_an_override_without_a_token(self) -> None:
+        """`base_url` is keyword-usable on its own, not just alongside a token."""
+        assert GitHubTool(base_url="http://localhost:1234").base_url == "http://localhost:1234"
+
+    def test_first_positional_argument_is_still_the_token(self) -> None:
+        """Backwards compatibility for existing positional call sites."""
+        tool = GitHubTool("ghp_positional")
+
+        assert tool.api_token == "ghp_positional"
+        assert tool.base_url == "https://api.github.com"


### PR DESCRIPTION
## Summary

`GitHubTool` had no test coverage of any kind, because the only way to exercise it was a live call to `api.github.com` â€” rate limited at 60 req/hr unauthenticated, needing a token for more, and returning values that drift. This PR adds a `pytest-httpserver`-based mock GitHub API and the first integration test suite in the repo: 16 tests that run fully offline, with no credentials, against recorded response fixtures. Making that possible needed one small production change â€” an optional `base_url` argument on `GitHubTool.__init__`, defaulting to the public API â€” since the URL was previously hardcoded with no injection point.

## Issue

Closes #57

## Changes

- **`agent/tools/github_tool.py`** â€” added an optional `base_url` parameter to `__init__`, defaulting to `https://api.github.com`. This is the only behavioural change in the PR. Existing positional call sites (`GitHubTool(token)`) are unaffected, and the orchestrator path is untouched.
- **`tests/integration/conftest.py`** *(new)* â€” `github_tool` and `mock_github_url` fixtures wrapping `pytest_httpserver`, plus `expect_repo` / `expect_readme` helpers and a fixture loader.
- **`tests/integration/test_github_tool.py`** *(new)* â€” 16 tests across metadata mapping, null-field coercion, absent `topics`, 404/403/5xx mapping, input validation, README detection, token propagation, and the `base_url` default.
- **`tests/fixtures/github_responses/*.json`** *(new)* â€” four recorded GitHub payloads (`repo_full`, `repo_minimal_nulls`, `not_found`, `rate_limited`), trimmed to the fields the tool reads.
- **`.pre-commit-config.yaml`** â€” added `httpx` to the mypy hook's `additional_dependencies`. The hook ran in an isolated env without httpx types, so `response.status_code` degraded to `Any` and `warn_return_any` failed on `github_tool.py`, blocking commits to any file importing that module while CI passed on the same code.

Commits are split so the behavioural change is readable on its own: a formatting-only commit first (the repo's own pre-commit hooks rewrite `github_tool.py` the moment it is staged), then the two-line `base_url` change, then the tests.

## Testing

- [x] Unit tests pass (`make test-unit`) â€” **no new failures.** See pre-existing failures below.
- [x] Integration tests pass (`make test-integration`) â€” 16/16, up from 0 collected.
- [x] Linter passes (`make lint`) â€” clean on every file this PR touches; repo-wide count goes **down**. See below.
- [x] Type checker passes (`make typecheck`) â€” clean on every file this PR touches.
- [x] New/updated tests cover the changes

### Pre-existing failures on `main`

I measured these on `upstream/main` before starting, and again on this branch. This PR does not affect any of them:

| | `upstream/main` | this branch |
|---|---|---|
| `pytest tests/unit -m unit` | 53 failed, 375 passed | 53 failed, 375 passed |
| `pytest tests/integration` | 0 collected, exit 5 | **16 passed** |
| `ruff check .` | 182 errors | 181 errors |
| `black --check .` | 52 files | 51 files |

The 53 unit failures (`test_tech_detector`, `test_review_service`, `test_skill_extractor` and others) are unrelated to the GitHub tool and were not touched. The ruff and black counts each drop by one because `github_tool.py` is now formatted; the rest of the repo is left alone deliberately, to keep this diff reviewable.

Note that `make check` runs `black .`, not `black --check .`, so running it reformats 51 unrelated files. I formatted only `github_tool.py` and verified the rest with `--check`.

## Screenshots / Demo

```
$ pytest tests/integration -v -m integration
tests/integration/test_github_tool.py::TestSuccessfulFetch::test_returns_full_metadata_for_a_well_formed_repo PASSED
tests/integration/test_github_tool.py::TestSuccessfulFetch::test_coerces_null_description_language_and_homepage PASSED
tests/integration/test_github_tool.py::TestSuccessfulFetch::test_defaults_topics_to_empty_list_when_key_is_absent PASSED
tests/integration/test_github_tool.py::TestErrorResponses::test_maps_404_to_repository_not_found PASSED
tests/integration/test_github_tool.py::TestErrorResponses::test_maps_403_to_rate_limited_or_access_denied PASSED
tests/integration/test_github_tool.py::TestErrorResponses::test_reports_the_status_code_for_unmapped_errors PASSED
tests/integration/test_github_tool.py::TestErrorResponses::test_returns_error_without_making_a_request_when_input_is_missing PASSED
tests/integration/test_github_tool.py::TestErrorResponses::test_returns_error_when_the_server_is_unreachable PASSED
tests/integration/test_github_tool.py::TestReadmeDetection::test_reports_no_readme_when_the_endpoint_returns_404 PASSED
tests/integration/test_github_tool.py::TestReadmeDetection::test_readme_failure_does_not_fail_the_whole_result PASSED
tests/integration/test_github_tool.py::TestReadmeDetection::test_one_execute_call_hits_both_endpoints PASSED
tests/integration/test_github_tool.py::TestAuthentication::test_sends_the_token_on_both_requests PASSED
tests/integration/test_github_tool.py::TestAuthentication::test_sends_no_authorization_header_when_no_token_is_given PASSED
tests/integration/test_github_tool.py::TestBaseUrlInjection::test_defaults_to_the_public_github_api PASSED
tests/integration/test_github_tool.py::TestBaseUrlInjection::test_accepts_an_override_without_a_token PASSED
tests/integration/test_github_tool.py::TestBaseUrlInjection::test_first_positional_argument_is_still_the_token PASSED

```

## Notes for Reviewers

Four things I'd like your call on:

**1. The production change.** #57 names only test files, and I'd have preferred a zero-diff-to-`agent/` PR. But `base_url` was hardcoded with no seam, and the alternative â€” assigning `tool.base_url = ...` on an instance from the test â€” leans on an undeclared implementation detail that nothing stops a future refactor from breaking. I went with the constructor parameter. Happy to switch to instance assignment if you'd rather keep production code untouched on a test-labelled issue.

**2. The `integration` marker is semantically wrong here, either way.** `pyproject.toml` documents it as "require Docker services", and the CI `test-integration` job provisions Postgres and Redis. These tests need neither â€” they're hermetic. But the Makefile runs `pytest tests/integration -v -m integration`, so *without* the marker they collect nothing locally. I marked them and am flagging it rather than silently picking. A `mock`/`hermetic` marker, or dropping `-m integration` from the Makefile, would both be cleaner â€” happy to do either.

**3. The Makefile and CI disagree on flags.** `make test-integration` filters on `-m integration`; the CI job runs `pytest tests/integration -v --tb=short` with no filter. Unmarked tests would pass CI while silently collecting zero tests locally. I verified this suite collects all 16 under both invocations, but the mismatch is a trap for the next contributor and probably worth fixing separately.

**4. Two details that cost me real time, both now documented in code.**

- One `execute()` fans out to **two** requests â€” `GET /repos/{u}/{r}` and `HEAD /repos/{u}/{r}/readme` â€” because `_has_readme` is invoked while the metadata dict is being built, and the second is a HEAD. `_has_readme` also swallows every exception and returns `False`, so a mock that failed to match produces `has_readme: False` rather than an error â€” a broken test that looks like a passing one. The `github_tool` fixture calls `check_assertions()` on teardown specifically to turn that into a failure; I verified it by deliberately mis-registering the handler as GET and confirming the suite goes red.
- `httpserver_listen_address` is pinned to `127.0.0.1`. `pytest-httpserver` defaults to `localhost`, which on a dual-stack host resolves to `::1` first while the server listens on IPv4 only â€” every request burns ~2.6s on the dead address before falling back. That alone took the suite from ~60s to ~17s. It may not reproduce on the Linux runner, but the pin is harmless and saves the next person on Windows the same hunt.

Fixtures are frozen recordings, not live captures, so nothing here asserts on star counts or push timestamps.
