### PR TITLE
fix(agent): exclude vendored files from tech detection

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,19 @@
+## Week 7 - Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/150
+
+**Issue title:** Tech detector counts vendored and build-output files, skewing language detection
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The tech detector currently tries to exclude generated and dependency directories, but its path checks miss common relative paths such as `node_modules/lib/index.js` and `build/bundle.js`. This affects `agent/tools/tech_detector.py`, where repository file paths are converted into detected languages and a primary language. The bug matters because vendored or bundled JavaScript can drown out the user's real source files, causing PathReview to misidentify a mostly Python project as JavaScript. The fix should normalize file paths, skip ignored directory names wherever they appear in the path, and choose the primary language from real source-file counts.
+
+**Selection notes:**
+This is a good first issue because it is isolated to one agent tool and has a clear reproduction example in the issue description. The related tests live in `tests/unit/test_tech_detector.py`, so the validation path is narrow and does not require the full app stack. The scope is small enough for Week 7/8, but still meaningful because it improves the accuracy of repository analysis.
+
+**Branch name:** fix/150-exclude-vendored-build-files
+
+**Setup confirmation:** [ ] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -17,3 +17,17 @@ This is a good first issue because it is isolated to one agent tool and has a cl
 **Setup confirmation:** [ ] App runs locally at localhost:5173
 
 **Cohort ledger:** [ ] Issue added to cohort ledger
+
+## Week 8 - Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/JohnsonGNEP/pathreview/commit/96a97240a534624b6569ce0fa9ada2db8cbc91f8
+
+**Reproduction summary:**
+I reproduced the issue with a file list containing real Python files plus generated JavaScript paths like `node_modules/lib/index.js` and `build/bundle.js`. The original path filter only matched slash-wrapped directory patterns, so root-relative ignored paths were not skipped and could skew detected languages away from the user's real source files.
+
+**PLAN.md link:** https://github.com/JohnsonGNEP/pathreview/blob/fix/150-exclude-vendored-build-files/PLAN.md
+
+**Loom walkthrough:** TODO - add Loom link after recording the <=2 minute walkthrough.
+
+**Blockers or open questions:**
+No code blockers. The remaining course deliverable is recording and adding the Loom walkthrough link.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -31,3 +31,39 @@ I reproduced the issue with a file list containing real Python files plus genera
 
 **Blockers or open questions:**
 No code blockers. The remaining course deliverable is recording and adding the Loom walkthrough link.
+
+## Week 9 - Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the issue #150 fix from `PLAN.md`. The tech detector now filters ignored directories by normalized path parts, so root-relative and nested paths such as `node_modules/lib/index.js` and `build/bundle.js` do not affect language detection. Added/updated unit coverage in `tests/unit/test_tech_detector.py`, including a regression test for vendored and build-output JavaScript files not dominating a Python project.
+
+**Next steps:**
+Open a pull request from `fix/150-exclude-vendored-build-files` to `ascherj/pathreview:main`, paste the completed PR description, request peer or mentor feedback, and update this journal with the final PR link.
+
+**Blockers:**
+`make` is not installed in this PowerShell environment, so I could not run the literal `make check` or `make test-unit` commands here. Running the equivalent checks directly showed pre-existing repo-wide failures outside this issue's files: `ruff check .` reports 173 unrelated lint issues, and `python -m pytest tests/unit -v -m unit` reports 50 failed, 348 passed, and 31 errors. The issue-specific checks pass.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** TODO - add the GitHub pull request link after opening the PR.
+
+**What you built:**
+The fix normalizes repository paths, splits them into directory/file parts, and skips files when any path part matches ignored dependency, vendor, build, cache, virtualenv, or git metadata directories. It also chooses the primary language from counted real source/config signals instead of a sorted set, which prevents ignored generated JavaScript from skewing the result.
+
+**Tests added or updated:**
+Updated `tests/unit/test_tech_detector.py`. The new regression coverage verifies that JavaScript files under `node_modules` and `build` are ignored and that Python remains the only detected language for the reproduction case.
+
+**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+
+Direct validation completed because `make` is unavailable in this shell:
+
+- [x] `ruff check agent/tools/tech_detector.py tests/unit/test_tech_detector.py` passes
+- [x] `python -m pytest tests/unit/test_tech_detector.py -v -m unit` passes: 28 passed
+- [ ] Repo-wide `ruff check .` passes: currently fails with pre-existing unrelated lint issues
+- [ ] Repo-wide `python -m pytest tests/unit -v -m unit` passes: currently 50 failed, 348 passed, 31 errors in unrelated areas
+
+**Draft PR feedback received from:** TODO - add reviewer name/handle, or `none` if no peer or mentor feedback is received before submission.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -66,4 +66,35 @@ Direct validation completed because `make` is unavailable in this shell:
 - [ ] Repo-wide `ruff check .` passes: currently fails with pre-existing unrelated lint issues
 - [ ] Repo-wide `python -m pytest tests/unit -v -m unit` passes: currently 50 failed, 348 passed, 31 errors in unrelated areas
 
-**Draft PR feedback received from:** TODO - add reviewer name/handle, or `none` if no peer or mentor feedback is received before submission.
+**Draft PR feedback received from:** none
+
+## Week 10 - Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No - still awaiting review
+
+**Summary of feedback:**
+No reviewer feedback has come in yet on https://github.com/ascherj/pathreview/pull/978. The PR is open and not marked as a draft, but it is still waiting for a maintainer review and workflow approval.
+
+**How you responded:**
+No code-review response was needed yet. I kept the PR ready for review and documented the local validation results and known repo-wide pre-existing failures so reviewers have the context they need.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The hardest part was separating my issue from the rest of the codebase noise. The tech detector fix itself was focused, but the repo-wide checks surfaced many unrelated lint and unit-test failures. It took more care than expected to document those failures honestly without trying to fix unrelated modules or make the PR larger than issue #150 required.
+
+**What did you learn about working in a large codebase?**
+I learned that the first job is understanding boundaries. In my own projects I might clean up surrounding code while I am nearby, but in someone else's repository a good contribution stays narrow, follows existing patterns, and proves the exact behavior it changes. Reading the existing tests and contribution guide helped me keep the fix limited to `agent/tools/tech_detector.py` and `tests/unit/test_tech_detector.py`.
+
+**How did AI tools help - and where did they fall short?**
+AI tools helped me trace the issue, turn the reproduction into a regression test, and check that the implementation matched the repository's style. They were also useful for interpreting validation output and drafting the PR description. Where they fell short was external project context: I still had to inspect the actual code, run the tests, verify the GitHub PR state, and make judgment calls about what was pre-existing versus caused by my change.
+
+**What would you do differently if you started over?**
+I would run the focused test file and the repo-wide checks before making any code changes, then save those baseline results immediately. That would make the Week 9 PR notes easier to write and would make it clearer which failures were already present before my branch. I would also update the journal continuously instead of waiting until each weekly deliverable was due.
+
+**What are you most proud of from this module?**
+I am most proud that the fix is small but meaningful. It addresses a realistic bug where generated JavaScript from `node_modules` or `build` could misrepresent a developer's actual project language, and the regression test now protects that behavior for future contributors.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -49,7 +49,7 @@ Open a pull request from `fix/150-exclude-vendored-build-files` to `ascherj/path
 
 ### Check-in 2 (end of week)
 
-**PR link:** TODO - add the GitHub pull request link after opening the PR.
+**PR link:** https://github.com/ascherj/pathreview/pull/978
 
 **What you built:**
 The fix normalizes repository paths, splits them into directory/file parts, and skips files when any path part matches ignored dependency, vendor, build, cache, virtualenv, or git metadata directories. It also chooses the primary language from counted real source/config signals instead of a sorted set, which prevents ignored generated JavaScript from skewing the result.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,58 @@
+﻿## Solution plan
+
+**Issue:** Tech detector counts vendored and build-output files, skewing language detection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/150
+
+### Understand
+
+The tech detector receives a list of repository file paths and uses file extensions plus known config files to identify languages and frameworks. The bug is in path filtering: generated, vendored, and dependency directories are intended to be skipped, but the original check only looked for slash-wrapped substrings such as `/node_modules/`. Relative paths like `node_modules/lib/index.js` and `build/bundle.js` do not start with a leading slash, so they are counted as real source files.
+
+Expected behavior: dependency, vendor, build, cache, virtualenv, and git metadata paths should not influence detected languages, frameworks, or the primary language.
+
+Actual behavior: files under paths such as `node_modules/...` and `build/...` can be counted, allowing generated JavaScript to skew the detected language set and primary language.
+
+### Map
+
+Files involved:
+
+- `agent/tools/tech_detector.py`
+- `tests/unit/test_tech_detector.py`
+
+Relevant functions:
+
+- `TechDetector._detect_tech`
+- `TechDetector._should_skip_file`
+
+### Plan
+
+1. Add a regression test with real Python files plus ignored JavaScript paths under `node_modules` and `build`.
+2. Normalize incoming paths by replacing Windows separators with `/` and lowercasing before filtering.
+3. Split each normalized path into parts and skip the file when any part exactly matches an ignored directory name.
+4. Count detected languages from the filtered file list so the primary language is based on real source files only.
+5. Run the focused unit test suite for `tests/unit/test_tech_detector.py`.
+
+### Inputs & outputs
+
+Input: a dictionary passed to `TechDetector.execute` with a `files` list containing repository-relative file paths.
+
+Output: a `ToolResult` whose `data` includes:
+
+- `primary_language`: the most representative language after ignored paths are removed.
+- `all_languages`: sorted detected languages from real source and supported config files.
+- `frameworks`: sorted detected frameworks from supported config files.
+
+### Risks & unknowns
+
+The main risk is over-filtering legitimate project paths whose directory names match ignored names, such as a source folder literally named `vendor` or `build`. This is acceptable for this issue because these names conventionally identify dependency or generated-output directories, and the detector already intended to exclude them.
+
+Another risk is changing primary-language behavior for mixed-language repos. The fix should preserve deterministic output by using counts and a stable tie-breaker.
+
+### Edge cases
+
+- Paths with no leading slash, such as `node_modules/lib/index.js`
+- Nested ignored directories, such as `packages/app/build/bundle.js`
+- Windows-style paths, such as `src\__pycache__\module.pyc`
+- Mixed-case extensions, such as `Main.PY`
+- Empty file lists
+- Repositories with only ignored files

--- a/agent/tools/tech_detector.py
+++ b/agent/tools/tech_detector.py
@@ -1,6 +1,9 @@
 """Technology stack detector tool."""
 
+from collections import Counter
+
 import structlog
+
 from .base import BaseTool, ToolResult
 
 logger = structlog.get_logger()
@@ -75,7 +78,7 @@ class TechDetector(BaseTool):
                     "primary_language": "Unknown",
                     "all_languages": [],
                     "frameworks": [],
-                }
+                },
             )
 
         try:
@@ -84,11 +87,7 @@ class TechDetector(BaseTool):
 
         except Exception as e:
             logger.error("tech_detector_error", error=str(e))
-            return ToolResult(
-                success=False,
-                data={},
-                error=str(e)
-            )
+            return ToolResult(success=False, data={}, error=str(e))
 
     def _detect_tech(self, files: list[str]) -> dict:
         """Detect technologies from file list.
@@ -99,40 +98,47 @@ class TechDetector(BaseTool):
         Returns:
             Dict with detected languages and frameworks
         """
-        # Filter out vendor/build directories
-        filtered_files = [
-            f for f in files
-            if not self._should_skip_file(f)
-        ]
+        filtered_files = [f for f in files if not self._should_skip_file(f)]
 
-        languages = set()
+        language_counts: Counter[str] = Counter()
+        first_seen: dict[str, int] = {}
         frameworks = set()
 
         # Detect by file extension
-        for filepath in filtered_files:
+        for index, filepath in enumerate(filtered_files):
+            normalized_path = filepath.lower()
             for ext, lang in self.EXT_TO_LANG.items():
-                if filepath.endswith(ext):
-                    languages.add(lang)
+                if normalized_path.endswith(ext):
+                    language_counts[lang] += 1
+                    first_seen.setdefault(lang, index)
 
         # Detect by config files
-        for filepath in filtered_files:
+        for index, filepath in enumerate(filtered_files):
+            normalized_path = filepath.lower()
             for config_file, (framework, lang) in self.CONFIG_INDICATORS.items():
-                if filepath.endswith(config_file):
-                    languages.add(lang)
+                if normalized_path.endswith(config_file.lower()):
+                    language_counts[lang] += 1
+                    first_seen.setdefault(lang, index)
                     if framework not in ("Docker", "Infrastructure", "CI/CD", "Build"):
                         frameworks.add(framework)
 
         # Determine primary language (most common)
         primary = "Unknown"
-        if languages:
-            lang_list = sorted(languages)
-            primary = lang_list[0]
+        if language_counts:
+            primary = min(
+                language_counts,
+                key=lambda lang: (-language_counts[lang], first_seen[lang], lang),
+            )
 
-        all_languages = sorted(languages)
+        all_languages = sorted(language_counts)
         all_frameworks = sorted(frameworks)
 
-        logger.info("tech_detected", primary_lang=primary,
-                   languages_count=len(all_languages), frameworks_count=len(all_frameworks))
+        logger.info(
+            "tech_detected",
+            primary_lang=primary,
+            languages_count=len(all_languages),
+            frameworks_count=len(all_frameworks),
+        )
 
         return {
             "primary_language": primary,
@@ -150,15 +156,18 @@ class TechDetector(BaseTool):
         Returns:
             True if file should be skipped
         """
-        skip_patterns = [
-            "/node_modules/",
-            "/vendor/",
-            "/dist/",
-            "/build/",
-            "/.git/",
-            "/__pycache__/",
-            "/.venv/",
-            "/venv/",
-        ]
+        skip_patterns = {
+            "node_modules",
+            "vendor",
+            "dist",
+            "build",
+            ".git",
+            "__pycache__",
+            ".venv",
+            "venv",
+        }
 
-        return any(pattern in filepath for pattern in skip_patterns)
+        normalized_path = filepath.replace("\\", "/").lower()
+        path_parts = [part for part in normalized_path.split("/") if part]
+
+        return any(part in skip_patterns for part in path_parts)

--- a/tests/unit/test_tech_detector.py
+++ b/tests/unit/test_tech_detector.py
@@ -59,9 +59,8 @@ class TestTechDetector:
 
         data = result.data
         assert "Python" in data["all_languages"]
-        # Should not include JSON or data-only language
         detected_lower = [lang.lower() for lang in data["all_languages"]]
-        # .ipynb should be treated as Python, not JSON
+        assert "json" not in detected_lower
 
     def test_node_modules_excluded(self, detector):
         """Test node_modules/ directory is excluded from counts."""
@@ -89,7 +88,9 @@ class TestTechDetector:
 
         result = detector.execute({"files": files})
 
-        # Python should be primary despite vendor files
+        data = result.data
+        assert data["primary_language"] == "Python"
+        assert data["all_languages"] == ["Python"]
 
     def test_build_directory_excluded(self, detector):
         """Test build directory is excluded."""
@@ -103,6 +104,25 @@ class TestTechDetector:
 
         data = result.data
         assert data["primary_language"] == "Python"
+
+    def test_vendored_and_build_outputs_do_not_dominate_primary_language(self, detector):
+        """Test ignored JavaScript paths do not outweigh real source files."""
+        files = [
+            "main.py",
+            "core/app.py",
+            "node_modules/lib/index.js",
+            "node_modules/lib/util.js",
+            "node_modules/x/a.js",
+            "node_modules/y/b.js",
+            "build/bundle.js",
+            "build/vendor.js",
+        ]
+
+        result = detector.execute({"files": files})
+
+        data = result.data
+        assert data["primary_language"] == "Python"
+        assert data["all_languages"] == ["Python"]
 
     def test_config_file_detection(self, detector):
         """Test detection from config files."""
@@ -127,7 +147,9 @@ class TestTechDetector:
 
         result = detector.execute({"files": files})
 
-        # Should detect Python as primary language
+        data = result.data
+        assert data["primary_language"] == "Python"
+        assert "Python" in data["all_languages"]
 
     def test_github_actions_detection(self, detector):
         """Test GitHub Actions detection."""
@@ -139,7 +161,7 @@ class TestTechDetector:
         result = detector.execute({"files": files})
 
         data = result.data
-        # Should detect both Python and CI/CD
+        assert "Python" in data["all_languages"]
 
     def test_makefile_detection(self, detector):
         """Test Makefile detection."""
@@ -150,7 +172,8 @@ class TestTechDetector:
 
         result = detector.execute({"files": files})
 
-        # Should detect Makefile as build tool
+        data = result.data
+        assert "Build" in data["all_languages"]
 
     def test_typescript_detection(self, detector):
         """Test TypeScript detection."""
@@ -255,7 +278,9 @@ class TestTechDetector:
 
         result = detector.execute({"files": files})
 
-        # Should detect frameworks
+        data = result.data
+        assert "Node.js" in data["frameworks"]
+        assert "Python" in data["frameworks"]
 
     def test_unknown_extensions(self, detector):
         """Test handling of unknown file extensions."""
@@ -283,7 +308,9 @@ class TestTechDetector:
         result = detector.execute({"files": files})
 
         data = result.data
-        # Should still detect languages despite case
+        assert data["primary_language"] == "Python"
+        assert "JavaScript" in data["all_languages"]
+        assert "Python" in data["all_languages"]
 
     def test_multiple_extensions_same_file(self, detector):
         """Test file with multiple dots in name."""
@@ -362,4 +389,5 @@ class TestTechDetector:
         result = detector.execute({"files": files})
 
         data = result.data
-        # Should detect C++ (from .cpp files)
+        assert data["primary_language"] == "C++"
+        assert "C++" in data["all_languages"]


### PR DESCRIPTION
## Summary
Fixes tech stack detection so vendored, dependency, build-output, cache, virtualenv, and git metadata paths do not affect detected languages or the primary language. This prevents generated JavaScript files under paths like `node_modules/` and `build/` from making a mostly Python repo look like JavaScript.

## Issue
Closes #150

## Changes
- Normalize repository file paths before filtering.
- Skip files when any path part matches ignored directories such as `node_modules`, `vendor`, `dist`, or `build`.
- Count detected languages from filtered real source/config files.
- Add regression coverage for root-relative vendored and build-output paths.

## Testing
- [ ] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`)
- [ ] Linter passes (`make lint`)
- [ ] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes

Direct validation:
- [x] `ruff check agent/tools/tech_detector.py tests/unit/test_tech_detector.py`
- [x] `python -m pytest tests/unit/test_tech_detector.py -v -m unit` — 28 passed

Note: `make` is not installed in my local PowerShell environment. Running the equivalent repo-wide checks directly showed pre-existing unrelated failures outside this issue's files:
- `ruff check .` reports 173 unrelated lint issues.
- `python -m pytest tests/unit -v -m unit` reports 50 failed, 348 passed, and 31 errors in unrelated modules.

## Screenshots / Demo
N/A

## Notes for Reviewers
Please focus on `agent/tools/tech_detector.py` and `tests/unit/test_tech_detector.py`. The issue-specific lint and unit tests pass locally.