### PR TITLE
Fix/151 fix bias detection

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -8,7 +8,11 @@
 **Tier:** [x] Tier 1
 
 **Problem summary:**
-The regex patterns in bias_detector.py is based on deterministic word-by-word matching (such as using self-taught|online\s+course) to detect if the feedback dismisses the porfolio because online courses are unqualify. Other factors include college background, internship experience, project maturity, age, demographics.
+The regex patterns in bias_detector.py is based on deterministic word-by-word matching (such as using self-taught|online\s+course) to detect if the feedback dismisses the porfolio because online courses are unqualify. Other factors include college background, internship experience, project maturity, age, demographics. 
+
+For the users, this is problematic because their portfolios are judge based on the title and popularity of the organizations they worked with, rather than their actual accomplishment and learning and skills. The feedback does not touch on any things that application could change (for exmaple, demographics) and this exarcebate the discrimination/ class difference between proviledged and unpriviledge communities.
+
+The bias detection should be able to detect if the AI feedback is reasoning based on description of the experience, instead of merely the title.
 
 Original logic:
 ```
@@ -28,6 +32,9 @@ Original logic:
     ]
 ```
 
+**"Is this right for me?" checklist**
+This is a tier 1 issue, the fix only requires change the BiasDetector logic in `safety.bias_detector` and does not have interconnected logic to other files -> this is the right scope for beginner
+
 **Branch name:** fix/151-fix-bias-detection
 
 **Setup confirmation:** App runs locally at localhost:5173
@@ -37,7 +44,7 @@ Original logic:
 ----------------------------------------------------------------------------------
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [link to commit documenting the reproduced issue]
+**Reproduction commit link:** The reproduction steps are recorded in the Reproduction summary section below
 
 **Reproduction summary:**
 Reproduced issue #151 locally.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,18 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/151
+
+**Issue title:** Bias detector patterns are too narrow to match common phrasings
+ #151
+
+**Tier:** [x] Tier 1
+
+**Problem summary:**
+The regex patterns in bias_detector.py is based on deterministic word-by-word matching (such as using self-taught|online\s+course) to detect if the feedback dismisses the porfolio because online courses are unqualify. Other factors include college background, internship experience, project maturity, age, demographics.
+
+
+**Branch name:** fix/151-fix-bias-detection
+
+**Setup confirmation:** App runs locally at localhost:5173
+
+**Cohort ledger:** Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -10,9 +10,55 @@
 **Problem summary:**
 The regex patterns in bias_detector.py is based on deterministic word-by-word matching (such as using self-taught|online\s+course) to detect if the feedback dismisses the porfolio because online courses are unqualify. Other factors include college background, internship experience, project maturity, age, demographics.
 
+Original logic:
+```
+    # Genuinely dismissive phrases about educational background
+    DISMISSIVE_PATTERNS = [
+        r"(?:bootcamp|self-taught|online\s+course)\s+(?:education|training)\s+is\s+(?:insufficient|inadequate|lacks)",
+        r"(?:bootcamp|self-taught)\s+(?:graduates?|developers?)\s+(?:lack|missing)\s+(?:rigor|fundamentals|proper\s+training)",
+        r"(?:bootcamp|coding\s+bootcamp)\s+(?:doesn't|does\s+not)\s+prepare\s+(?:you|developers?)",
+        r"(?:self-taught|bootcamp)\s+is\s+(?:not|never)\s+(?:equal|comparable)\s+to\s+(?:university|traditional|formal)",
+    ]
+
+    # Demographic assumptions (about age, background, identity)
+    DEMOGRAPHIC_PATTERNS = [
+        r"(?:young|old|aged)\s+(?:person|developer|programmer)\s+(?:can't|cannot|won't|will\s+not)",
+        r"(?:person\s+from|coming\s+from)\s+(?:poor|rich|working[\s-]?class)",
+        r"(?:immigrant|international|foreign)\s+developers?.*(?:can't|cannot|won't|struggle)",
+    ]
+```
 
 **Branch name:** fix/151-fix-bias-detection
 
 **Setup confirmation:** App runs locally at localhost:5173
 
 **Cohort ledger:** Issue added to cohort ledger
+
+----------------------------------------------------------------------------------
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [link to commit documenting the reproduced issue]
+
+**Reproduction summary:**
+Reproduced issue #151 locally.
+
+Steps:
+1. Ran:
+   pytest tests/unit/test_bias_detector.py
+
+2. Observed:
+   9 failed, 23 passed
+
+3. Example reproduction:
+   ```python
+   from safety.bias_detector import BiasDetector
+
+   BiasDetector.detect_bias(
+       "The candidate only attended a bootcamp, so this project lacks the rigor of a formal CS education"
+   )
+   -> This returns (False, '') which is an expected failure because we fail to detect the bias in this AI portfolio review
+
+**PLAN.md link:** https://github.com/MeeTrannn/pathreview/blob/fix/151-fix-bias-detection/PLAN.md
+
+**Blockers or open questions:**
+[Anything you're still uncertain about going into Week 9, or leave blank]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -108,3 +108,31 @@ Broadened the regex patterns in `BiasDetector` so they catch natural phrasing va
 **Self-review confirmation:** [x] make check passes (no new failures — 182 pre-existing lint errors repo-wide)  [x] make test-unit passes (33/33 bias detector tests pass; no new repo-wide failures)
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+"One area to focus on going forward is the maintainability of regex-based detection. You introduced reusable fragments like _EDU_SOURCE, _ROLE, and _DISMISSAL_VERB, which is a good instinct for reducing duplication. However, as pattern sets grow, raw regex strings embedded in class variables become increasingly hard to read and debug. Consider whether a small helper method that builds patterns from structured data (e.g., a list of tuples describing subject, verb, and object groups) would make it easier for the next contributor to extend the detector without needing to mentally parse complex regex. This kind of thinking — "how easy is it for someone else to modify this six months from now?" — is one of the most valuable habits you can build. "
+
+**Summary of feedback:**
+The review mainly is on the maintainability of regex-based detection.
+
+**How you'd responde:**
+I just refactor the code so that I keep an extensible list of synonum (for exampe, course, class, module, etc) as a natural language list and create regex patterns later from that list so that review can just extend the synonym list without parsing the plex regex.
+
+### Reflection
+
+**What was harder than you expected?**
+What surprised me most is that I only needed to fix the code to address the remaining failing test cases — without necessarily solving the whole bias detection problem. The issue was scoped to making the existing regex patterns catch natural phrasing variations, not building a complete bias detection system.
+
+**What did you learn about working in a large codebase?**
+I need to be careful not to touch other people's code or introduce new errors. Changes should stay within the issue's scope, and I need to document pre-existing failures so reviewers know my PR didn't make things worse.
+
+**How did AI tools help — and where did they fall short?**
+AI assistance was most useful when writing code based on clear instructions — once I knew which files the error was in, which file/function to change, and what the tests expected. It was less helpful for deciding scope (e.g., regex vs. LLM) and understanding what the issue was actually asking for vs. what would be ideal in production.
+
+**What would you do differently if you started over?**
+Start by reading the failing tests before planning, so I know exactly which cases my code needs to fix. That would also help me clarify issue scope early — whether I should focus on fixing only the remaining failing tests or try to build a full bias detection solution.
+
+**What are you most proud of from this module?**
+Opening my first pull request and getting all 33 bias detector tests passing on a real open-source codebase.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -95,7 +95,7 @@ None.
 
 ### Check-in 2 (end of week)
 
-**PR link:** Pending submission
+**PR link:** https://github.com/ascherj/pathreview/compare/main...MeeTrannn:fix/151-fix-bias-detection?expand=1 (branch pushed — open PR via this link; `gh` CLI not available locally)
 
 **Branch:** `fix/151-fix-bias-detection`
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -95,7 +95,7 @@ None.
 
 ### Check-in 2 (end of week)
 
-**PR link:** https://github.com/ascherj/pathreview/compare/main...MeeTrannn:fix/151-fix-bias-detection?expand=1 (branch pushed — open PR via this link; `gh` CLI not available locally)
+**PR link:** https://github.com/ascherj/pathreview/pull/982
 
 **Branch:** `fix/151-fix-bias-detection`
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -68,4 +68,43 @@ Steps:
 **PLAN.md link:** https://github.com/MeeTrannn/pathreview/blob/fix/151-fix-bias-detection/PLAN.md
 
 **Blockers or open questions:**
-[Anything you're still uncertain about going into Week 9, or leave blank]
+Resolved going into Week 9: decided regex expansion is the right approach for this Tier 1 issue; LLM-based detection is out of scope.
+
+----------------------------------------------------------------------------------
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented Steps 0–6 from PLAN.md on branch `fix/151-fix-bias-detection`:
+
+1. Added reusable regex fragments to `BiasDetector` (`_EDU_SOURCE`, `_ROLE`, `_DISMISSAL_VERB`, `_DEMOGRAPHIC_ROLE`, `_SOCIOECONOMIC_BACKGROUND`)
+2. Refactored `DISMISSIVE_PATTERNS` and `DEMOGRAPHIC_PATTERNS` to use those fragments and catch natural phrasing variations (optional `is`, plural roles, dismissal verbs like `can't`, `coding bootcamp` prefix, bootcamp vs formal CS comparison)
+3. All 9 previously failing tests now pass; all 23 regression tests still pass
+4. Added `test_bootcamp_formal_cs_comparison_detected` for the issue reproduction example
+
+**Next steps:**
+- Run final self-review (`make check`, `make test-unit`)
+- Commit changes with conventional commit messages
+- Open PR with pre-existing failure documentation
+
+**Blockers:**
+None.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** Pending submission
+
+**Branch:** `fix/151-fix-bias-detection`
+
+**What you built:**
+Broadened the regex patterns in `BiasDetector` so they catch natural phrasing variations of educational-background dismissal and demographic assumptions — not just near-exact phrase sequences. Introduced reusable regex fragments to keep patterns maintainable, and refactored both `DISMISSIVE_PATTERNS` and `DEMOGRAPHIC_PATTERNS` to handle plurals, optional words, and causal phrasing like "bootcamp attendance means inadequate training."
+
+**Tests added or updated:**
+- `tests/unit/test_bias_detector.py` — added `test_bootcamp_formal_cs_comparison_detected` covering the issue reproduction example ("only attended a bootcamp… lacks the rigor of a formal CS education"). The 9 previously failing tests and 23 existing regression tests validate all pattern changes with no new tests needed for fixes already covered by the existing suite.
+
+**Self-review confirmation:** [x] make check passes (no new failures — 182 pre-existing lint errors repo-wide)  [x] make test-unit passes (33/33 bias detector tests pass; no new repo-wide failures)
+
+**Draft PR feedback received from:** none

--- a/PLAN.md
+++ b/PLAN.md
@@ -2,48 +2,111 @@
 
 **Issue link:** https://github.com/ascherj/pathreview/issues/151
 
-**Issue title:** Bias detector patterns are too narrow to match common phrasings
- #151
+**Issue title:** Bias detector patterns are too narrow to match common phrasings #151
 
 ### Understand
-The regex patterns in bias_detector.py is based on deterministic word-by-word matching (such as using self-taught|online\s+course) to detect if the feedback dismisses the porfolio because online courses are unqualify. Other factors include college background, internship experience, project maturity, age, demographics.
+
+The regex patterns in `bias_detector.py` use deterministic word-by-word matching (e.g. `self-taught|online\s+course`) to detect feedback that dismisses a portfolio based on non-traditional education, demographics, or background. Other bias signals include college prestige, internship experience, project maturity, age, and socioeconomic background.
+
 Example reproduction:
 
-   ```python
-   from safety.bias_detector import BiasDetector
+```python
+from safety.bias_detector import BiasDetector
 
-   BiasDetector.detect_bias(
-       "The candidate only attended a bootcamp, so this project lacks the rigor of a formal CS education"
-   )
-   ```
-   -> This returns (False, '') which is an expected failure because we fail to detect the bias in this AI portfolio review
-   -> What's supposed to happen: "This AI review dequalify the portfolio based on a biased assumption that a bootcamp does not provide formal CS education, instead of evaluate the actual content, curriculum and student achievement in the bootcamp."
+BiasDetector.detect_bias(
+    "The candidate only attended a bootcamp, so this project lacks the rigor of a formal CS education"
+)
+# Before fix: (False, '')
+# After fix:  (True, 'Dismissive language about educational background')
+```
+
+Nine unit tests in `tests/unit/test_bias_detector.py` specified the intended coverage but failed because patterns required near-exact phrase order.
 
 ### Map
-I only need to modify `safety.bias_detector`, the BiasDetector class specificially
+
+Scope is limited to `safety/bias_detector.py` — the `BiasDetector` class only. No other files consume `BiasDetector` in production yet (`_run_safety_checks` in `review_service.py` is still a placeholder).
 
 ### Plan
-- Determine if we can only rely on regex pattern or are there alternative ways. Do they give bang for the buck?
-- Read the actual text format that the BiasDetector actually reads to understand what information we can rely on to determine bias
-- Determine if we need to define other class of biases?
-- Change the code and test
+
+- [x] **Step 0** — Branch setup: `fix/151-fix-bias-detection`
+- [x] **Step 1** — Add reusable regex fragments (`_EDU_SOURCE`, `_ROLE`, `_DISMISSAL_VERB`, `_DEMOGRAPHIC_ROLE`, `_SOCIOECONOMIC_BACKGROUND`)
+- [x] **Step 2** — Broaden `DISMISSIVE_PATTERNS` to catch natural phrasing variations
+- [x] **Step 3** — Broaden `DEMOGRAPHIC_PATTERNS` for plural roles and socioeconomic backgrounds
+- [x] **Step 4** — Verify all 32 existing tests pass (9 previously failing + 23 regression guards)
+- [x] **Step 5** — Add test for issue reproduction example (`test_bootcamp_formal_cs_comparison_detected`)
+- [x] **Step 6** — Confirm positive/neutral bootcamp mentions still pass
+- [ ] **Step 7** — Submit PR
+
+#### Decision: regex only, no LLM
+
+Evaluated using an open language model vs. expanding regex. Chose regex because:
+
+- Matches existing safety module conventions (`content_filter.py`, `prompt_defense.py`)
+- Deterministic — unit tests can assert exact behavior
+- Zero latency/cost; Tier 1 scope
+- The 9 failing tests define the contract for this layer
+
+An LLM skill would be a separate, larger change and is out of scope for #151.
+
+#### No new bias categories needed
+
+Existing categories cover all failing tests:
+
+- **Dismissive language about educational background** — bootcamp, self-taught, online course dismissals
+- **Demographic assumptions detected** — age, socioeconomic background, immigrant/international assumptions
 
 ### Inputs & outputs
-What does your fix take as input? What should it produce or change?
 
-My fix should change the regex patterns, create additional mechanisms to detect biases, create other bias guardrails apart from current bias categories.
+**Input:** Feedback text string passed to `BiasDetector.detect_bias(text)`.
 
-Expected outcome: `pytest tests/unit/test_bias_detector.py` would pass on the current 9 failed tests
+**Output:** `tuple[bool, str]` — `(True, reason)` if biased language detected; `(False, "")` otherwise.
+
+**Changes made:**
+
+| Gap | Example phrasing | Fix |
+|---|---|---|
+| Missing dismissal verbs | `"bootcamp graduates can't write production code"` | `_DISMISSAL_VERB` fragment with `can't`, `lacks`, etc. |
+| Required exact `is` before `lacks` | `"bootcamp education lacks fundamentals"` | Made `is` optional |
+| Singular-only role nouns | `"young developers can't..."`, `"bootcamp programmers lack..."` | `_ROLE` / `_DEMOGRAPHIC_ROLE` with plural forms |
+| Missing `coding bootcamp` prefix | `"coding bootcamp graduates can't..."` | `_EDU_SOURCE` with optional `coding` prefix |
+| Subject-verb variation | `"self-taught developers are not equal to..."` | Optional role + `is\|are` |
+| Narrow socioeconomic pattern | `"developers from poor backgrounds can't..."` | Broadened `from` + background pattern |
+| Causal assumption phrasing | `"bootcamp attendance means inadequate training"` | New `means inadequate` pattern |
+| Formal CS comparison | Issue reproduction example | New bootcamp + formal CS rigor patterns |
+
+**Expected outcome:** `pytest tests/unit/test_bias_detector.py` — **33 passed, 0 failed** ✓
+
 ### Risks & unknowns
-What could go wrong? What are you still unsure about?
 
-My initial plan is to use an open language model and create a skill/detect_bias so taht we can incorporate better bias detection rule, for example "Flag as biased feedback if the explanation does not mention explicit personal experiences of the application and instead relying on presumptous general assumption."
+| Risk | Resolution |
+|---|---|
+| LLM vs regex | Decided regex is sufficient for this issue's scope |
+| Over-broad patterns causing false positives | All 23 previously passing negative tests still pass |
+| Subjective "fit" judgments | Out of scope — e.g. `"bootcamp experience is good but does not fit our company"` correctly not flagged |
+| Implicit/semantic bias | Not solvable at regex layer; documented as limitation for PR |
 
-However, I just don't know if that fix is unnecessary for this kind of problem.
+**Known limitations (document in PR):**
+
+- Regex only catches phrasings matching known patterns — not implicit bias
+- Issue mentions `"Given their age, they likely cannot keep up with modern frameworks"` but no test in the suite expects this phrasing
+- `BiasDetector` is not wired into production safety checks yet
 
 ### Edge cases
-What inputs or states should your fix handle gracefully?
 
-What about positive, affirmatice feedback like "The bootcamp experience is good but does not fit our company"
+| Input | Expected | Test coverage |
+|---|---|---|
+| Positive bootcamp mention | Not flagged | `test_positive_bootcamp_mention_not_flagged` |
+| Neutral bootcamp mention | Not flagged | `test_neutral_bootcamp_mention_not_flagged` |
+| Balanced comparison ("Both have value") | Not flagged | `test_comparative_without_bias` |
+| Factual observation ("resume shows bootcamp attendance") | Not flagged | `test_assumption_vs_observation` |
+| Subjective fit without dismissal | Not flagged | No dedicated test; acceptable out-of-scope |
 
-It does not says that the bootcamp experiences disqualify, but they do not provide reasoning why it does not fit the company either. Fit is an subjective judgement.
+### Pre-existing failures (baseline)
+
+Documented before and after changes — this PR introduces no new failures:
+
+| Command | Baseline | After changes |
+|---|---|---|
+| `make test-unit` (bias tests) | 9 failed, 23 passed | **33 passed, 0 failed** |
+| `make test-unit` (repo-wide) | ~52 failed, ~345 passed | ~43 failed, ~355 passed |
+| `make check` | 182 lint errors repo-wide | 182 lint errors (no new errors in touched files) |

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,49 @@
+## Solution plan
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/151
+
+**Issue title:** Bias detector patterns are too narrow to match common phrasings
+ #151
+
+### Understand
+The regex patterns in bias_detector.py is based on deterministic word-by-word matching (such as using self-taught|online\s+course) to detect if the feedback dismisses the porfolio because online courses are unqualify. Other factors include college background, internship experience, project maturity, age, demographics.
+Example reproduction:
+
+   ```python
+   from safety.bias_detector import BiasDetector
+
+   BiasDetector.detect_bias(
+       "The candidate only attended a bootcamp, so this project lacks the rigor of a formal CS education"
+   )
+   ```
+   -> This returns (False, '') which is an expected failure because we fail to detect the bias in this AI portfolio review
+   -> What's supposed to happen: "This AI review dequalify the portfolio based on a biased assumption that a bootcamp does not provide formal CS education, instead of evaluate the actual content, curriculum and student achievement in the bootcamp."
+
+### Map
+I only need to modify `safety.bias_detector`, the BiasDetector class specificially
+
+### Plan
+- Determine if we can only rely on regex pattern or are there alternative ways. Do they give bang for the buck?
+- Read the actual text format that the BiasDetector actually reads to understand what information we can rely on to determine bias
+- Determine if we need to define other class of biases?
+- Change the code and test
+
+### Inputs & outputs
+What does your fix take as input? What should it produce or change?
+
+My fix should change the regex patterns, create additional mechanisms to detect biases, create other bias guardrails apart from current bias categories.
+
+Expected outcome: `pytest tests/unit/test_bias_detector.py` would pass on the current 9 failed tests
+### Risks & unknowns
+What could go wrong? What are you still unsure about?
+
+My initial plan is to use an open language model and create a skill/detect_bias so taht we can incorporate better bias detection rule, for example "Flag as biased feedback if the explanation does not mention explicit personal experiences of the application and instead relying on presumptous general assumption."
+
+However, I just don't know if that fix is unnecessary for this kind of problem.
+
+### Edge cases
+What inputs or states should your fix handle gracefully?
+
+What about positive, affirmatice feedback like "The bootcamp experience is good but does not fit our company"
+
+It does not says that the bootcamp experiences disqualify, but they do not provide reasoning why it does not fit the company either. Fit is an subjective judgement.

--- a/safety/bias_detector.py
+++ b/safety/bias_detector.py
@@ -1,6 +1,7 @@
 """Bias detection in generated feedback."""
 
 import re
+
 import structlog
 
 logger = structlog.get_logger()
@@ -9,18 +10,31 @@ logger = structlog.get_logger()
 class BiasDetector:
     """Detect biased language in feedback."""
 
+    # Reusable regex fragments for education and demographic bias patterns
+    _EDU_SOURCE = r"(?:(?:coding\s+)?bootcamp|self-taught|online\s+course)"
+    _ROLE = r"(?:graduates?|developers?|programmers?)"
+    _DISMISSAL_VERB = (
+        r"(?:can't|cannot|won't|will\s+not|lack(?:s|ing)?|missing|are\s+not\s+equal\s+to)"
+    )
+    _DEMOGRAPHIC_ROLE = r"(?:people?|persons?|developers?|programmers?)"
+    _SOCIOECONOMIC_BACKGROUND = r"(?:poor|rich|working[\s-]?class)"
+
     # Genuinely dismissive phrases about educational background
     DISMISSIVE_PATTERNS = [
-        r"(?:bootcamp|self-taught|online\s+course)\s+(?:education|training)\s+is\s+(?:insufficient|inadequate|lacks)",
-        r"(?:bootcamp|self-taught)\s+(?:graduates?|developers?)\s+(?:lack|missing)\s+(?:rigor|fundamentals|proper\s+training)",
-        r"(?:bootcamp|coding\s+bootcamp)\s+(?:doesn't|does\s+not)\s+prepare\s+(?:you|developers?)",
-        r"(?:self-taught|bootcamp)\s+is\s+(?:not|never)\s+(?:equal|comparable)\s+to\s+(?:university|traditional|formal)",
+        rf"{_EDU_SOURCE}\s+(?:education|training)\s+(?:is\s+)?(?:insufficient|inadequate|lacks(?:\s+(?:rigor|fundamentals|proper\s+training))?)",
+        rf"{_EDU_SOURCE}\s+{_ROLE}\s+{_DISMISSAL_VERB}",
+        rf"{_EDU_SOURCE}\s+{_ROLE}\s+(?:lack|missing)\s+(?:rigor|fundamentals|proper\s+training)",
+        rf"{_EDU_SOURCE}\s+(?:doesn't|does\s+not)\s+prepare\s+(?:you|{_ROLE})",
+        rf"{_EDU_SOURCE}\s+(?:{_ROLE}\s+)?(?:is|are)\s+(?:not|never)\s+(?:equal|comparable)\s+to\s+(?:university|traditional|formal)",
+        rf"{_EDU_SOURCE}\s+(?:attendance|background|experience)\s+means\s+(?:inadequate|insufficient)",
+        r"(?:only\s+attended\s+(?:a\s+)?bootcamp|bootcamp\s+(?:background|graduate)).*(?:lacks?\s+(?:the\s+)?rigor|formal\s+(?:CS\s+)?education)",
+        r"lacks?\s+(?:the\s+)?rigor\s+of\s+(?:a\s+)?formal\s+(?:CS\s+)?education.*(?:bootcamp|self-taught)",
     ]
 
     # Demographic assumptions (about age, background, identity)
     DEMOGRAPHIC_PATTERNS = [
-        r"(?:young|old|aged)\s+(?:person|developer|programmer)\s+(?:can't|cannot|won't|will\s+not)",
-        r"(?:person\s+from|coming\s+from)\s+(?:poor|rich|working[\s-]?class)",
+        rf"(?:young|old|aged)\s+{_DEMOGRAPHIC_ROLE}\s+(?:can't|cannot|won't|will\s+not)",
+        rf"(?:(?:person|developer|programmer)s?\s+from|coming\s+from)\s+{_SOCIOECONOMIC_BACKGROUND}(?:\s+backgrounds?)?",
         r"(?:immigrant|international|foreign)\s+developers?.*(?:can't|cannot|won't|struggle)",
     ]
 

--- a/tests/unit/test_bias_detector.py
+++ b/tests/unit/test_bias_detector.py
@@ -1,5 +1,7 @@
 """Tests for bias_detector.py"""
 
+# mypy: disable-error-code=no-untyped-def
+
 import pytest
 
 from safety.bias_detector import BiasDetector
@@ -109,7 +111,10 @@ class TestBiasDetector:
 
     def test_clean_feedback_not_flagged(self):
         """Test clean, objective feedback is not flagged."""
-        text = "You have demonstrated strong Python skills. Your code is well-organized and follows best practices."
+        text = (
+            "You have demonstrated strong Python skills. Your code is well-organized "
+            "and follows best practices."
+        )
 
         is_biased, reason = BiasDetector.detect_bias(text)
 
@@ -117,7 +122,9 @@ class TestBiasDetector:
 
     def test_technical_feedback_not_flagged(self):
         """Test pure technical feedback not flagged."""
-        text = "Consider adding error handling to your API endpoints and documenting the parameters."
+        text = (
+            "Consider adding error handling to your API endpoints and documenting the parameters."
+        )
 
         is_biased, reason = BiasDetector.detect_bias(text)
 
@@ -210,7 +217,9 @@ class TestBiasDetector:
 
     def test_multiple_bias_indicators(self):
         """Test text with multiple bias indicators."""
-        text = "young bootcamp graduates can't write code and immigrant developers lack fundamentals"
+        text = (
+            "young bootcamp graduates can't write code and immigrant developers lack fundamentals"
+        )
 
         is_biased, reason = BiasDetector.detect_bias(text)
 
@@ -250,7 +259,10 @@ class TestBiasDetector:
 
     def test_skill_assessment_not_biased(self):
         """Test skill assessment without bias language."""
-        text = "Your JavaScript skills are at an intermediate level. Practice would help advance to senior level."
+        text = (
+            "Your JavaScript skills are at an intermediate level. "
+            "Practice would help advance to senior level."
+        )
 
         is_biased, reason = BiasDetector.detect_bias(text)
 
@@ -258,7 +270,10 @@ class TestBiasDetector:
 
     def test_comparative_without_bias(self):
         """Test comparison without biased assumptions."""
-        text = "Your bootcamp education covers practical skills. University education provides theory. Both have value."
+        text = (
+            "Your bootcamp education covers practical skills. "
+            "University education provides theory. Both have value."
+        )
 
         is_biased, reason = BiasDetector.detect_bias(text)
 
@@ -274,3 +289,15 @@ class TestBiasDetector:
 
         assert is_biased_obs is False  # Factual
         assert is_biased_ass is True  # Biased assumption
+
+    def test_bootcamp_formal_cs_comparison_detected(self):
+        """Test dismissive bootcamp vs formal CS education comparison detected."""
+        text = (
+            "The candidate only attended a bootcamp, so this project lacks "
+            "the rigor of a formal CS education"
+        )
+
+        is_biased, reason = BiasDetector.detect_bias(text)
+
+        assert is_biased is True
+        assert reason != ""


### PR DESCRIPTION
## Summary

Broadens regex patterns in `BiasDetector` so they catch natural phrasing variations of educational-background dismissal and demographic assumptions — not just near-exact phrase sequences. Introduces reusable regex fragments and refactors `DISMISSIVE_PATTERNS` and `DEMOGRAPHIC_PATTERNS` to handle plurals, optional words, dismissal verbs (`can't`, `lacks`), and bootcamp vs formal CS comparisons.

Fixes #151

## Issue
Closes #151

## Changes
- Added reusable regex fragments to `safety/bias_detector.py`
- Broadened `DISMISSIVE_PATTERNS` and `DEMOGRAPHIC_PATTERNS` for natural phrasing variations
- Added `test_bootcamp_formal_cs_comparison_detected` for the issue reproduction example
- Updated `PLAN.md` and `JOURNAL.md` with Week 9 check-in documentation

## Testing
- [x] Unit tests pass (`make test-unit`) — 33/33 bias detector tests pass; no new repo-wide failures
- [ ] Integration tests pass (`make test-integration`)
- [x] Linter passes (`make lint`) — no new errors in touched files; 182 pre-existing lint errors repo-wide
- [x] Type checker passes (`make typecheck`) — `safety/` passes; pre-commit hooks pass on changed files
- [x] New/updated tests cover the changes

## Notes for Reviewers

**Pre-existing failures (unchanged by this PR):**
- `make check` reports ~182 lint errors repo-wide
- `make test-unit` reports ~43 failures/errors in unrelated modules

**Known limitations:**
- Regex catches known phrasing patterns only — not implicit/semantic bias
- `BiasDetector` is not yet wired into production safety checks