### PR TITLE
fix: mark review as failed when profile has no ingested sources (#88)

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,16 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/88
+
+**Issue title:** `POST /reviews` endpoint has no test for when the profile has no ingested documents
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The `POST /reviews` endpoint currently has no test coverage for the case where a user's profile exists but has no ingested documents attached to it. It's unclear whether the endpoint fails gracefully with a proper error response or crashes unexpectedly in this scenario, since nothing exercises that code path today. This affects the API layer, specifically the review-creation flow tested in `tests/unit/test_review_routes.py`. A successful fix will add a test that calls the endpoint under this condition and asserts it returns an appropriate error response rather than an unhandled exception, closing a gap in the test suite around edge-case handling.
+
+**Branch name:** test/88-reviews-no-documents-test
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -41,3 +41,19 @@ Open a draft PR and request peer/mentor feedback via Slack. Consider sub-task 5 
 
 **Blockers:**
 None currently - the fix is implemented and tested. Waiting on peer feedback before finalizing the PR.
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/983
+
+**Branch:** test/88-reviews-no-documents-test
+
+**What you built:**
+Added a check in `process_review` that detects when a profile has no ingested sources (no GitHub username, portfolio URL, or resume text) and marks the review as `status="failed"` with a logged reason, instead of proceeding to placeholder agent/RAG functions that previously fabricated generic "complete" feedback regardless of input.
+
+**Tests added or updated:**
+Added `test_process_review_marks_failed_when_no_ingested_sources` to `tests/unit/test_review_service.py`, verifying the fix. Kept the existing reproduction test documenting the original bug for reference.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+**Draft PR feedback received from:** Posted in dts-su26-ai201-program-help-2a Slack channel, awaiting response

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,4 +1,4 @@
-## Week 7 — Issue selection
+## Week 7 - Issue selection
 
 **Issue link:** https://github.com/ascherj/pathreview/issues/88
 
@@ -14,3 +14,17 @@ The `POST /reviews` endpoint currently has no test coverage for the case where a
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [ ] Issue added to cohort ledger
+
+## Week 8 - Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/Nolawikk/pathreview/commit/b5dc331
+
+**Reproduction summary:**
+I traced the bug by reading through `api/routes/reviews.py` and `core/services/review_service.py`. I found that `_run_agent_orchestration` and `_run_rag_retrieval_generation` are placeholder functions that ignore their input entirely, so I wrote a test calling them directly with an empty ingestion results list (simulating a profile with no documents). The test confirmed both functions still return fabricated, non-empty feedback and a normal-looking score, even with zero real input data.
+
+**PLAN.md link:** https://github.com/Nolawikk/pathreview/blob/test/88-reviews-no-documents-test/PLAN.md
+
+**Walkthrough video (recommended):** [not recorded]
+
+**Blockers or open questions:**
+Still unsure whether the correct fix is a new "no_data" status or reusing the existing "failed" status - need to check the Review model and how the frontend displays failure states before finalizing the plan.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -57,3 +57,34 @@ Added `test_process_review_marks_failed_when_no_ingested_sources` to `tests/unit
 **Self-review confirmation:** [x] make check passes  [x] make test-unit passes
 
 **Draft PR feedback received from:** Posted in dts-su26-ai201-program-help-2a Slack channel, awaiting response
+
+## Week 10 - Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No - still awaiting review
+
+**Summary of feedback:**
+No reviewer feedback arrived through the PR itself. Per the course note, reviewer feedback isn't a feature in Summer 2026. I did post in the program-help Slack channel asking a peer to review my draft PR (#983) but had not received a response by the end of the module.
+
+**How you responded:**
+N/A - no feedback received to respond to.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Environment setup took far longer than I expected - getting Docker, Node, and `make` all working correctly on Windows, especially the confusion between PowerShell and Git Bash (commands that worked in one shell silently failed in the other), cost me more time than the actual code fix did. I also didn't expect how much time I'd spend just locating the right files - the issue pointed to `test_review_routes.py`, which didn't even exist in the codebase, so I had to trace the real code path myself through `api/routes/reviews.py` and `core/services/review_service.py` before I understood what was actually broken.
+
+**What did you learn about working in a large codebase?**
+The biggest lesson was that the bug wasn't where the issue description implied it would be. The issue title suggested a missing test, but tracing the actual code revealed the real problem was two placeholder functions (`_run_agent_orchestration` and `_run_rag_retrieval_generation`) that silently ignored their input and fabricated output regardless of whether there was real data to analyze. In a codebase I hadn't written, I couldn't assume the surface-level description was the full story - I had to read the call chain end-to-end before I could even reproduce the issue correctly. I also learned to distinguish pre-existing failures from ones I introduced; running `make test-unit` and `make check` before touching anything gave me a baseline (53 failed/376 passed, 179 lint errors) that let me prove my change didn't make anything worse, which mattered a lot for the PR description.
+
+**How did AI tools help - and where did they fall short?**
+AI was most useful for tracing logic across multiple files quickly - once I pasted in the route handler and service code, it helped me see the actual data flow (ingestion pipeline returning an empty list, but the downstream functions ignoring that) faster than I would have on my own. It also helped me write mock-based tests that matched the existing test file's conventions. Where it fell short: it initially wrote a test using `AsyncMock()` for the wrong objects, which caused a `'coroutine' object has no attribute 'first'` error - the same failure pattern as a pre-existing, unrelated issue in the codebase (#158). I had to actually understand why that mocking pattern was wrong (AsyncMock makes every child attribute async too) rather than just accepting the first version. AI also couldn't fix filesystem/terminal issues on my machine - things like being in the wrong folder, PowerShell vs. Git Bash PATH differences, or a file with a corrupted name - those all needed direct troubleshooting.
+
+**What would you do differently if you started over?**
+I'd check the issue tracker's linked PRs before spending time reasoning about candidate issues - three of my top four choices (#155, #154, #146) already had open PRs, which I only discovered by checking each issue's page individually. I'd also verify my local dev shell (Git Bash vs. PowerShell) once at the very start and stick to it consistently, instead of bouncing between the two and hitting the same PATH problem multiple times across different weeks.
+
+**What are you most proud of from this module?**
+Tracing the actual root cause. The issue as written suggested a simple "add a missing test" task, but I found and proved a deeper, more interesting bug - that the review pipeline fabricates convincing-looking feedback even when there's no real data behind it. Writing a test that reproduced that exact behavior, then fixing it with a minimal, well-scoped change that didn't touch the placeholder functions themselves, felt like real debugging work rather than just following the issue title literally.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -28,3 +28,16 @@ I traced the bug by reading through `api/routes/reviews.py` and `core/services/r
 
 **Blockers or open questions:**
 Still unsure whether the correct fix is a new "no_data" status or reusing the existing "failed" status - need to check the Review model and how the frontend displays failure states before finalizing the plan.
+
+## Week 9 - Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Sub-tasks 1-4 from PLAN.md are complete. I added a guard in `process_review` (`core/services/review_service.py`) that checks if `_run_ingestion_pipeline` returns an empty list, and if so, marks the review as `status="failed"` and returns early instead of proceeding to the placeholder agent/RAG functions. I added a new test, `test_process_review_marks_failed_when_no_ingested_sources`, confirming this behavior, alongside the existing reproduction test that documents the original bug. Ran the full test suite (`make test-unit`) and confirmed no new failures: 53 pre-existing failures remain unchanged, and my new test brings the passing count from 376 to 377. Also ran `make check` and confirmed the lint error count is unchanged at 179 (all pre-existing, unrelated to my change).
+
+**Next steps:**
+Open a draft PR and request peer/mentor feedback via Slack. Consider sub-task 5 (manual verification through the running app) as a nice-to-have before finalizing.
+
+**Blockers:**
+None currently - the fix is implemented and tested. Waiting on peer feedback before finalizing the PR.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,34 @@
+﻿## Solution plan
+
+**Issue:** `POST /reviews` endpoint has no test for when the profile has no ingested documents — https://github.com/ascherj/pathreview/issues/88
+
+### Understand
+The `POST /reviews` endpoint (`api/routes/reviews.py`) creates a review with status="pending" and kicks off `process_review` as a background task, regardless of whether the profile has any ingested content. Inside `process_review` (`core/services/review_service.py`), `_run_ingestion_pipeline` correctly returns an empty list when a profile has no `github_username`, `portfolio_url`, or `resume_text`. However, `_run_agent_orchestration` and `_run_rag_retrieval_generation` are placeholder implementations that ignore their `ingestion_results` input entirely and always return hardcoded, fabricated feedback sections and a normal-looking score. As a result, a profile with zero ingested documents still ends up with a review marked "complete" containing fake feedback, rather than a clear error or a "no data to review" signal. Expected behavior: the endpoint (or the background processing) should detect the no-data case and mark the review as failed with a clear reason, instead of fabricating output.
+
+### Map
+Files involved:
+- `api/routes/reviews.py` — `create_review_endpoint`, the `POST /reviews` handler
+- `core/services/review_service.py` — `process_review`, `_run_ingestion_pipeline`, `_run_agent_orchestration`, `_run_rag_retrieval_generation`
+- `tests/unit/test_review_service.py` — where the reproduction test and eventual fix-validating test will live
+
+### Plan
+1. Add a check in `process_review` (or a new helper) that detects when `ingestion_results` is empty after `_run_ingestion_pipeline` runs.
+2. If no sources were ingested, set `review.status = "failed"` with a descriptive log/reason instead of proceeding to `_run_agent_orchestration`.
+3. Update `_run_agent_orchestration` and `_run_rag_retrieval_generation` (or skip calling them entirely in the no-data case) so they don't fabricate output when there's nothing to analyze.
+4. Add a test asserting that a profile with no ingested sources results in `review.status == "failed"` (replacing/extending the reproduction test that currently documents the buggy "complete" behavior).
+5. Manually verify via the running app: create a profile with no GitHub username, portfolio URL, or resume, trigger a review, and confirm it now fails clearly instead of showing fake "complete" feedback on the dashboard.
+
+### Inputs & outputs
+**Input:** a `profile_id` for a profile with `github_username=None`, `portfolio_url=None`, `resume_text=None`.
+**Output today:** a review with `status="complete"` and fabricated feedback sections.
+**Output after fix:** a review with `status="failed"` and no fabricated sections, ideally with a clear reason logged (e.g., "no ingested sources available").
+
+### Risks & unknowns
+- Unsure whether "failed" is the correct status to use, or if a new status like "no_data" would be more appropriate — need to check `Review` model and existing status values.
+- `_run_agent_orchestration` and `_run_rag_retrieval_generation` are explicitly placeholder functions per their docstrings — unclear if real implementations are already planned elsewhere, which could make this fix obsolete once genuine RAG logic lands.
+- Need to confirm how the frontend dashboard displays a "failed" review to make sure the messaging is coherent for users (we saw a "Failed" review status in the UI back in Week 7).
+
+### Edge cases
+- Profile has partial data (e.g., only a `portfolio_url` but no GitHub or resume) — should NOT be treated as "no data," since there IS something to analyze.
+- Profile fields exist but are empty strings (`""`) rather than `None` — need to confirm `_run_ingestion_pipeline`'s checks handle this correctly.
+- Ingestion pipeline itself throws an exception for one source (e.g., GitHub API failure) while others succeed — should still count as "has some data," not "no data."

--- a/core/services/review_service.py
+++ b/core/services/review_service.py
@@ -124,13 +124,27 @@ async def process_review(
 
         log.info("review_processing_started", review_id=str(review_id), profile_id=str(profile_id))
 
-        # Step 2: Run ingestion pipeline
+    # Step 2: Run ingestion pipeline
         ingestion_results = await _run_ingestion_pipeline(db, profile)
         log.info(
             "ingestion_pipeline_completed",
             review_id=str(review_id),
             sources_count=len(ingestion_results),
         )
+
+        # Guard: if no sources were ingested, there's nothing to review.
+        # Mark the review as failed rather than fabricating placeholder feedback.
+        if not ingestion_results:
+            log.warning(
+                "review_processing_no_ingested_sources",
+                review_id=str(review_id),
+                profile_id=str(profile_id),
+            )
+            review.status = "failed"
+            review.updated_at = datetime.utcnow()
+            db.add(review)
+            await db.commit()
+            return
 
         # Step 3: Run agent orchestration
         agent_output = await _run_agent_orchestration(profile, ingestion_results)

--- a/tests/unit/test_review_service.py
+++ b/tests/unit/test_review_service.py
@@ -1,9 +1,9 @@
 """Tests for review_service.py"""
 
-import pytest
-from uuid import uuid4
 from unittest.mock import AsyncMock, Mock, patch
-import asyncio
+from uuid import uuid4
+
+import pytest
 
 from core.services.review_service import (
     create_review,
@@ -45,7 +45,9 @@ class TestReviewService:
         return profile
 
     @pytest.mark.asyncio
-    async def test_create_review_returns_review_with_pending_status(self, mock_db_session, mock_review):
+    async def test_create_review_returns_review_with_pending_status(
+        self, mock_db_session, mock_review
+    ):
         """Test create_review returns Review with status='pending'."""
         profile_id = uuid4()
         user_id = uuid4()
@@ -55,7 +57,7 @@ class TestReviewService:
         mock_db_session.commit = AsyncMock()
         mock_db_session.refresh = AsyncMock()
 
-        with patch('core.services.review_service.Review') as MockReview:
+        with patch("core.services.review_service.Review") as MockReview:
             mock_instance = MockReview.return_value
             mock_instance.status = "pending"
             mock_instance.sections = None
@@ -66,7 +68,7 @@ class TestReviewService:
             # Check that Review was instantiated
             MockReview.assert_called()
             call_kwargs = MockReview.call_args[1]
-            assert call_kwargs['status'] == "pending"
+            assert call_kwargs["status"] == "pending"
 
     @pytest.mark.asyncio
     async def test_get_review_returns_review_for_correct_owner(self, mock_db_session):
@@ -133,9 +135,7 @@ class TestReviewService:
         mock_result.scalars.return_value.all.return_value = []
         mock_db_session.execute = AsyncMock(return_value=mock_result)
 
-        reviews, total = await list_reviews(
-            mock_db_session, user_id, page=2, page_size=page_size
-        )
+        reviews, total = await list_reviews(mock_db_session, user_id, page=2, page_size=page_size)
 
         # Second call should pass offset for page 2
         calls = mock_db_session.execute.call_args_list
@@ -165,7 +165,7 @@ class TestReviewService:
         profile_id = uuid4()
         user_id = uuid4()
 
-        with patch('core.services.review_service.Review'):
+        with patch("core.services.review_service.Review"):
             await create_review(mock_db_session, profile_id, user_id)
 
             mock_db_session.add.assert_called_once()
@@ -176,7 +176,7 @@ class TestReviewService:
         profile_id = uuid4()
         user_id = uuid4()
 
-        with patch('core.services.review_service.Review'):
+        with patch("core.services.review_service.Review"):
             await create_review(mock_db_session, profile_id, user_id)
 
             mock_db_session.commit.assert_called_once()
@@ -187,7 +187,7 @@ class TestReviewService:
         profile_id = uuid4()
         user_id = uuid4()
 
-        with patch('core.services.review_service.Review'):
+        with patch("core.services.review_service.Review"):
             await create_review(mock_db_session, profile_id, user_id)
 
             mock_db_session.refresh.assert_called_once()
@@ -244,13 +244,13 @@ class TestReviewService:
         profile_id = uuid4()
         user_id = uuid4()
 
-        with patch('core.services.review_service.Review') as MockReview:
+        with patch("core.services.review_service.Review") as MockReview:
             MockReview.return_value = Mock()
             await create_review(mock_db_session, profile_id, user_id)
 
             call_kwargs = MockReview.call_args[1]
-            assert 'profile_id' in call_kwargs
-            assert 'status' in call_kwargs
+            assert "profile_id" in call_kwargs
+            assert "status" in call_kwargs
 
     @pytest.mark.asyncio
     async def test_get_review_verifies_ownership(self, mock_db_session):
@@ -287,7 +287,7 @@ class TestReviewService:
         """Test list_reviews returns list of Review objects."""
         user_id = uuid4()
 
-        mock_reviews = [Mock(spec=['id', 'status']) for _ in range(3)]
+        mock_reviews = [Mock(spec=["id", "status"]) for _ in range(3)]
         mock_result = AsyncMock()
         mock_result.scalars.return_value.all.return_value = mock_reviews
         mock_db_session.execute = AsyncMock(return_value=mock_result)
@@ -302,13 +302,13 @@ class TestReviewService:
         profile_id = uuid4()
         user_id = uuid4()
 
-        with patch('core.services.review_service.Review') as MockReview:
+        with patch("core.services.review_service.Review") as MockReview:
             MockReview.return_value = Mock()
             await create_review(mock_db_session, profile_id, user_id)
 
             call_kwargs = MockReview.call_args[1]
-            assert call_kwargs['sections'] is None
-            assert call_kwargs['overall_score'] is None
+            assert call_kwargs["sections"] is None
+            assert call_kwargs["overall_score"] is None
 
     @pytest.mark.asyncio
     async def test_get_review_with_valid_uuid(self, mock_db_session):
@@ -338,3 +338,41 @@ class TestReviewService:
 
         # Should order by created_at descending
         mock_db_session.execute.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_agent_orchestration_and_rag_produce_output_even_with_no_ingested_sources(self):
+        """Reproduction for issue #88.
+
+        _run_agent_orchestration and _run_rag_retrieval_generation are
+        placeholder implementations that ignore their `ingestion_results`
+        input entirely. Even when a profile has zero ingested sources
+        (empty list), both functions still return fabricated, hardcoded
+        feedback sections with a normal-looking score, instead of
+        signaling that there was nothing to analyze. This is why
+        process_review marks reviews "complete" with fake feedback for
+        profiles with no ingested documents.
+        """
+        from core.services.review_service import (
+            _run_agent_orchestration,
+            _run_rag_retrieval_generation,
+        )
+
+        mock_profile = Mock()
+        mock_profile.github_username = None
+        mock_profile.portfolio_url = None
+        mock_profile.resume_text = None
+
+        empty_ingestion_results = []  # No sources were ingested
+
+        agent_output = await _run_agent_orchestration(mock_profile, empty_ingestion_results)
+        rag_output = await _run_rag_retrieval_generation(
+            mock_profile, empty_ingestion_results, agent_output
+        )
+
+        # BUG (issue #88): despite zero ingested sources, both functions
+        # still fabricate non-empty feedback sections with a normal-looking
+        # score, rather than indicating there was no data to review.
+        assert len(agent_output["sections"]) > 0
+        assert len(rag_output["sections"]) > 0
+        assert rag_output["overall_score"] is not None
+        assert rag_output["overall_score"] > 0

--- a/tests/unit/test_review_service.py
+++ b/tests/unit/test_review_service.py
@@ -1,4 +1,4 @@
-"""Tests for review_service.py"""
+﻿"""Tests for review_service.py"""
 
 from unittest.mock import AsyncMock, Mock, patch
 from uuid import uuid4
@@ -9,6 +9,7 @@ from core.services.review_service import (
     create_review,
     get_review,
     list_reviews,
+    process_review,
 )
 
 
@@ -376,3 +377,44 @@ class TestReviewService:
         assert len(rag_output["sections"]) > 0
         assert rag_output["overall_score"] is not None
         assert rag_output["overall_score"] > 0
+
+    @pytest.mark.asyncio
+    async def test_process_review_marks_failed_when_no_ingested_sources(self, mock_db_session):
+        """Fix verification for issue #88.
+
+        When _run_ingestion_pipeline returns no sources for a profile,
+        process_review should mark the review as "failed" and return
+        early, rather than proceeding to fabricate placeholder feedback.
+        """
+        review_id = uuid4()
+        profile_id = uuid4()
+
+        mock_review = Mock()
+        mock_review.id = review_id
+        mock_review.status = "pending"
+
+        mock_profile = Mock()
+        mock_profile.id = profile_id
+        mock_profile.github_username = None
+        mock_profile.portfolio_url = None
+        mock_profile.resume_text = None
+
+        review_result = Mock()
+        review_result.scalars.return_value.first.return_value = mock_review
+
+        profile_result = Mock()
+        profile_result.scalars.return_value.first.return_value = mock_profile
+
+        mock_db_session.execute = AsyncMock(side_effect=[review_result, profile_result])
+        mock_db_session.commit = AsyncMock()
+        mock_db_session.add = Mock()
+
+        with patch(
+            "core.services.review_service._run_ingestion_pipeline",
+            new=AsyncMock(return_value=[]),
+        ):
+            await process_review(mock_db_session, review_id, profile_id)
+
+        assert mock_review.status == "failed"
+
+


### PR DESCRIPTION
## Summary
Fixes a bug where creating a review for a profile with no ingested documents (no GitHub username, portfolio URL, or resume text) resulted in a review marked "complete" with fabricated, generic feedback instead of a clear failure. The underlying cause: `_run_agent_orchestration` and `_run_rag_retrieval_generation` are placeholder implementations that ignore their `ingestion_results` input entirely and always return hardcoded feedback, regardless of whether any data was actually ingested.

## Issue
Closes #88

## Changes
- Added a check in `process_review` (`core/services/review_service.py`) for an empty `ingestion_results` list after the ingestion pipeline runs.
- If no sources were ingested, the review is now marked `status="failed"` with a logged reason, and processing returns early instead of calling the placeholder agent/RAG functions.
- Added `test_process_review_marks_failed_when_no_ingested_sources` to `tests/unit/test_review_service.py` to verify this behavior, alongside the existing reproduction test that documents the original bug.

## Testing
- [x] Unit tests pass (`make test-unit`) — 53 pre-existing failures unchanged (unrelated to this issue, e.g. #146, #147, #148, #149, #150, #151, #152, #153, #158); passing count increased from 376 to 377 with the new test.
- [ ] Integration tests pass (`make test-integration`)
- [x] Linter passes (`make lint`) — 179 pre-existing errors unchanged, none introduced by this change
- [ ] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes

## Screenshots / Demo
N/A — backend logic change, no UI changes.

## Notes for Reviewers
This PR only handles the "zero ingested sources" case. It does not address the underlying placeholder nature of `_run_agent_orchestration` / `_run_rag_retrieval_generation` themselves, which will presumably be replaced with real implementations in future work. Also open to feedback on whether "failed" is the right status here vs. introducing a new status like "no_data" — noted as an open question in my PLAN.md.