### PR TITLE
fix: redact US phone numbers with whitespace separators

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -55,7 +55,8 @@ whitespace support
 
 **PLAN.md link:** https://github.com/SamuelApoya/pathreview/blob/fix/146-parenthesized-us-phone-pii/PLAN.md
 
-**Walkthrough video (recommended):** [link to your Loom video, ≤2 min — recommended, not graded]
+**Walkthrough video (recommended):** N/A
 
 **Blockers or open questions:**
-[Anything you're still uncertain about going into Week 9, or leave blank]
+Still deciding whether widening the separator to accept whitespace introduces
+new false positives elsewhere in `detect()`

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -117,3 +117,48 @@ detect() on the parenthesized phone number format.
 **Self-review confirmation:** [x] make check passes  [x] make test-unit passes
 
 **Draft PR feedback received from:** none
+
+
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [X] No — still awaiting review
+
+**Summary of feedback:**
+No reviewer feedback was received during the Summer 2026 course period. The PR remains open and GitHub shows that a review is still required.
+
+**How you responded:**
+No response was necessary because no reviewer feedback was received.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The hardest part was determining whether the test and lint failures I encountered were caused by my changes or were already present in the codebase. Running the full repository checks produced a large number of failures, including 49 unit test failures and many lint and type-checking errors. I had to investigate the failures and compare the results against the main branch rather than assuming that my PR was responsible for them. This took more time than I expected, but it helped me understand the importance of establishing a baseline when working in an existing codebase.
+
+I also encountered a secondary issue while fixing the original phone number regex. After allowing whitespace separators, I discovered that the opening parenthesis or plus sign could still be left outside of the match. I had to adjust the regex boundary and add tests to make sure the entire phone number was handled correctly.
+
+
+**What did you learn about working in a large codebase?**
+I learned that contributing to an existing codebase requires more investigation and caution than building something from scratch. Before making changes, I needed to understand the existing regex patterns, how scrub() and detect() worked, and how the project's tests were structured.
+
+I also learned that not every problem in a repository needs to be fixed as part of your contribution. The repository had unrelated failures in areas such as the review service, resume parser, tech detector, and bias detector. Since those were outside the scope of my issue, I focused on making the smallest change necessary to fix the phone number problem and verified that my changes did not introduce new failures.
+
+
+**How did AI tools help — and where did they fall short?**
+AI tools were useful for helping me understand unfamiliar code, reason about the regular expression, identify possible edge cases, and develop test cases. They also helped me interpret error messages and think through different approaches to the fix.
+
+However, AI could not replace actually testing the code. When the repository produced many failures, I needed to inspect the failures myself and compare them against the main branch to determine which ones were pre-existing. This was an important lesson because an AI-generated explanation can be useful for forming a hypothesis, but the actual repository and test results are what ultimately determine whether a change is correct.
+
+**What would you do differently if you started over?**
+If I started over, I would establish a baseline of the repository's existing test, lint, and type-checking results earlier in the process. That would make it easier to distinguish pre-existing problems from regressions immediately after making my changes.
+
+I would also plan the test cases before implementing the regex change. I initially focused on making the whitespace-separated formats match, but the process revealed another edge case involving the opening parenthesis and plus sign. Defining all of the expected formats and expected redaction behavior first would have made the implementation more systematic.
+
+**What are you most proud of from this module?**
+I am most proud of successfully making a focused contribution to an unfamiliar codebase and validating the change rather than simply assuming that it worked. I fixed the original PII detection issue, identified and fixed a secondary edge case in my own implementation, added targeted tests for both scrub() and detect(), and investigated the repository's existing failures to make sure they were not regressions from my work.
+
+The biggest takeaway for me is that contributing to a real codebase involves more than writing code. It requires understanding existing behavior, testing assumptions, keeping the scope focused, and being able to explain why you believe your changes are correct.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -38,3 +38,24 @@ blockers or dependencies.
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/SamuelApoya/pathreview/commit/1d3b201
+
+**Reproduction summary:**
+I reproduced the issue in a Python shell using `PIIScrubber().scrub()` and
+`.detect()` on "Call me at (555) 123-4567" — `scrub()` left the number
+completely untouched while correctly redacting a dashed-format number in the
+same string, and `detect()` returned zero PII items. Testing the regex
+directly confirmed the root cause is the separator pattern's lack of
+whitespace support
+
+**PLAN.md link:** https://github.com/SamuelApoya/pathreview/blob/fix/146-parenthesized-us-phone-pii/PLAN.md
+
+**Walkthrough video (recommended):** [link to your Loom video, ≤2 min — recommended, not graded]
+
+**Blockers or open questions:**
+[Anything you're still uncertain about going into Week 9, or leave blank]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -60,3 +60,60 @@ whitespace support
 **Blockers or open questions:**
 Still deciding whether widening the separator to accept whitespace introduces
 new false positives elsewhere in `detect()`
+
+
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the fix for issue #146 — widened the phone_us regex separators
+in safety/pii_scrubber.py to accept whitespace, not just dash/dot, so
+formats like (555) 123-4567 and +1 555 123 4567 are now redacted correctly.
+Also fixed a secondary bug my own fix introduced, where the leading `(` or
+`+` character was dropped from the redacted/detected output. Both changes
+are committed and pushed. Added two new unit tests
+(test_parenthesized_phone_fully_redacted and
+test_parenthesized_phone_fully_detected) verifying scrub() and detect()
+both handle the parenthesized format correctly, including the opening
+paren. All sub-tasks from my Week 8 PLAN.md are complete.
+
+Ran make check and make test-unit across the whole repo to check for
+regressions. make test-unit shows 49 failed / 381 passed; only one
+failure (test_mixed_pii_and_text) touches my file, and I confirmed by
+diffing against main that it's a pre-existing failure from an unrelated
+street_address regex bug, not caused by my change. The other 48 failures
+are in unrelated modules (review service, resume parser, tech detector,
+bias detector, etc.) I never touched. make check similarly shows
+pre-existing ruff/mypy issues confined to files and lines I didn't modify.
+
+**Next steps:**
+Open the PR with the full template filled in, documenting the confirmed
+pre-existing failures in Notes for Reviewers.
+
+**Blockers:**
+None.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/986
+
+**Branch:** fix/146-parenthesized-us-phone-pii
+
+**What you built:**
+Fixed the phone_us regex in safety/pii_scrubber.py so it redacts US phone
+numbers separated by whitespace (e.g. (555) 123-4567, +1 555 123 4567),
+not just dashes/dots, and fixed a secondary bug where the leading `(` or
+`+` character was dropped from the redacted output.
+
+**Tests added or updated:**
+tests/unit/test_pii_scrubber.py — added test_parenthesized_phone_fully_redacted
+and test_parenthesized_phone_fully_detected, covering both scrub() and
+detect() on the parenthesized phone number format.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,40 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/146
+
+**Issue title:** PII scrubber fails to redact parenthesized US phone numbers
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The PII scrubber in `safety/pii_scrubber.py` is supposed to detect and redact
+US phone numbers before review content is stored or returned, but its
+regex only matches dashed/dotted formats like 555-123-4567. Parenthesized
+formats like (555) 123-4567 pass through both `scrub()` and `detect()`
+completely unredacted, because the pattern anchors on a `\b` word boundary
+that doesn't match when the number starts with a non-word character like
+`(`. This is a real gap since parenthesized formatting is one of the most
+common ways US phone numbers are written, so a successful fix will update
+the regex to recognize that format alongside the existing ones, verified
+by the four currently-failing tests in `tests/unit/test_pii_scrubber.py`.
+
+**Issue selection reasoning ("Is this right for me?" checklist):**
+I can explain the bug without re-reading the issue: the phone_us regex in
+safety/pii_scrubber.py anchors on \b, which fails to match when a number
+opens with a non-word character like `(`, so parenthesized formats like
+(555) 123-4567 pass through scrub() and detect() unredacted while dashed
+formats are caught correctly. I opened safety/pii_scrubber.py and located
+the phone_us pattern, and read through tests/unit/test_pii_scrubber.py,
+including the four currently-failing tests this issue references. This is
+Tier 1, so the tier is a good match
+— the fix is scoped to a single regex in a single file. Several other
+students are also working this issue, but claims are non-exclusive.
+I estimate 2–4 hours of focused work,
+comfortably within the Week 8–9 window, and the issue has no listed
+blockers or dependencies.
+
+**Branch name:** fix/146-parenthesized-us-phone-pii
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -43,7 +43,7 @@ blockers or dependencies.
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** https://github.com/SamuelApoya/pathreview/commit/1d3b201
+**Reproduction commit link:** https://github.com/SamuelApoya/pathreview/commit/0362f2a
 
 **Reproduction summary:**
 I reproduced the issue in a Python shell using `PIIScrubber().scrub()` and

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,71 @@
+## Solution plan
+
+**Issue:** #146 — PII scrubber fails to redact parenthesized US phone numbers
+https://github.com/ascherj/pathreview/issues/146
+
+### Understand
+The separators between digit groups ('[-.]') only allow an optional dash or dot, but never a space.`(555) 123-4567` uses a space after the closing parenthesis, not a dash, so the match fails there.
+I confirmed this by testing `555 123 4567` (space-separated, no parens at all)
+against the pattern directly, which also returns `None`, proving spaces (not
+parentheses) are what's unhandled.
+
+**Expected behavior:** `(555) 123-4567` should be matched and redacted like
+any other US phone format.
+**Actual behavior:** it passes through both `scrub()` and `detect()` completely
+unredacted, because no separator variant in the pattern accepts whitespace.
+
+### Map
+Which files, functions, or modules are involved?
+List the specific files you expect to touch.
+Files involved:
+1. `safety/pii_scrubber.py` — `PIIScrubber.PII_PATTERNS["phone_us"]`. This is the only pattern I expect to change to fix this issue.
+
+2. `tests/unit/test_pii_scrubber.py` — the four failing tests referenced in the
+  issue: `test_us_phone_number_redaction`, `test_us_phone_formats`,
+  `test_detect_phone_pii`, `test_phone_at_start_of_text`. I won't add new tests
+  unless I find an edge case the existing four don't cover.
+
+
+### Plan
+1. Update the `phone_us` regex so each `[-.]?` separator also accepts a space
+   E.g. changing `[-.]?` to `[-.\s]?` in both places between digit groups.
+2. Also update the leading `(?:\+?1[-.]?)?` group the same way, since
+   `test_us_phone_formats` includes `"+1 555 123 4567"` (space-separated with
+   a country code prefix), which fails under the current pattern for the same
+   reason.
+3. Re-run my manual reproduction (`scrub()`/`detect()` on `(555) 123-4567`) to
+   confirm it's now redacted and detected.
+4. Run `.venv/bin/pytest tests/unit/test_pii_scrubber.py -v` to confirm all
+   four previously-failing tests pass, and that no other test in the file
+   regresses (especially `test_detect_no_false_positives`, since loosening
+   the separator could increase false matches).
+5. Run `make check` before committing the fix.
+
+
+### Inputs & outputs
+**Function:** `PIIScrubber.scrub(text: str) -> str` and
+`PIIScrubber.detect(text: str) -> list[dict]`
+
+- Input of both functions: a string that may contain a US phone number in any of: dashed
+  (`555-123-4567`), dotted (`555.123.4567`), parenthesized-with-space
+  (`(555) 123-4567`), or country-code-prefixed with spaces
+  (`+1 555 123 4567`).
+
+- Output of `scrub()`: the same string with any matched phone number replaced
+  by `[REDACTED]`.
+
+- Output of `detect()`: a list of dicts, each with `type: "phone_us"`,
+  `value`, `start`, `end` for every match found.
+
+### Risks & unknowns
+`[-.\s]?` only allows a single separator character, so double spaces
+between groups won't match. None of the four failing tests require this,
+so treating it as out of scope for now.
+
+### Edge cases
+- `(555) 123-4567` — primary case from the issue, must be redacted.
+- `+1 555 123 4567` — space-separated with country code, covered by
+  `test_us_phone_formats`.
+- `555 123 4567` — space-separated, no parens; same root cause, should also
+  be caught by the fix.
+- `(555)-123-4567` — already works today, must not regress.

--- a/safety/pii_scrubber.py
+++ b/safety/pii_scrubber.py
@@ -1,6 +1,7 @@
 """PII detection and scrubbing."""
 
 import re
+
 import structlog
 
 logger = structlog.get_logger()
@@ -12,7 +13,10 @@ class PIIScrubber:
     # Regex patterns for common PII
     PII_PATTERNS = {
         "email": r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b",
-        "phone_us": r"\b(?:\+?1[-.]?)?\(?([0-9]{3})\)?[-.]?([0-9]{3})[-.]?([0-9]{4})\b",
+        "phone_us": (
+            r"(?:\b|(?=[(+]))(?:\+?1[-.\s]?)?\(?([0-9]{3})\)?"
+            r"[-.\s]?([0-9]{3})[-.\s]?([0-9]{4})\b"
+        ),
         "phone_intl": r"\+[0-9]{1,3}[-.]?[0-9]{1,14}",
         "ssn": r"\b(?!000|666)[0-9]{3}-(?!00)[0-9]{2}-(?!0000)[0-9]{4}\b",
         "street_address": r"\b\d+\s+[A-Za-z\s]+(?:Street|St|Avenue|Ave|Road|Rd|Boulevard|Blvd|Drive|Dr|Lane|Ln|Court|Ct|Circle|Cir|Park|Pl|Plaza|Place|Drive|Dr|Way|Parkway|Pkwy|Point|Pt|Pike|Run|Summit|Summit|Terrace|Ter|Trail|Trl|Tunnel|Turnpike|View|Vista|Vlg|Village|Vly|Valley)",
@@ -47,13 +51,17 @@ class PIIScrubber:
 
         for pii_type, pattern in self.PII_PATTERNS.items():
             for match in re.finditer(pattern, text, flags=re.IGNORECASE):
-                detected.append({
-                    "type": pii_type,
-                    "value": match.group(),
-                    "start": match.start(),
-                    "end": match.end()
-                })
+                detected.append(
+                    {
+                        "type": pii_type,
+                        "value": match.group(),
+                        "start": match.start(),
+                        "end": match.end(),
+                    }
+                )
 
-        logger.info("pii_detected", count=len(detected), types=len(set(d["type"] for d in detected)))
+        logger.info(
+            "pii_detected", count=len(detected), types=len(set(d["type"] for d in detected))
+        )
 
         return detected

--- a/tests/unit/test_pii_scrubber.py
+++ b/tests/unit/test_pii_scrubber.py
@@ -53,6 +53,23 @@ class TestPIIScrubber:
             scrubbed = scrubber.scrub(text)
             assert "[REDACTED]" in scrubbed
 
+    def test_parenthesized_phone_fully_redacted(self, scrubber):
+        """Test that parenthesized phone numbers are fully redacted, including the opening paren."""
+        text = "Call me at (555) 123-4567"
+        scrubbed = scrubber.scrub(text)
+
+        assert scrubbed == "Call me at [REDACTED]"
+        assert "(" not in scrubbed
+
+    def test_parenthesized_phone_fully_detected(self, scrubber):
+        """Test detect() captures the full parenthesized number, including the opening paren."""
+        text = "Call me at (555) 123-4567"
+        detected = scrubber.detect(text)
+
+        phone_detections = [d for d in detected if d["type"] == "phone_us"]
+        assert len(phone_detections) == 1
+        assert phone_detections[0]["value"] == "(555) 123-4567"
+
     def test_international_phone_redaction(self, scrubber):
         """Test international phone number is redacted."""
         text = "Reach me at +44 20 7946 0958"


### PR DESCRIPTION
## Summary
The PII scrubber's `phone_us` regex only redacted phone numbers separated by dashes or dots, so formats using spaces — like `(555) 123-4567` and `+1 555 123 4567` — passed through `scrub()` and `detect()` completely unredacted. This PR widens the separator to also accept whitespace, and fixes a secondary issue (surfaced by my own initial fix) where the leading `(` or `+` character was dropped from the output instead of being redacted along with the rest of the number.

## Issue
Closes #146

## Changes
- `safety/pii_scrubber.py` — widened each `[-.]?` separator in the `phone_us` pattern to `[-.\s]?` so whitespace is accepted alongside dash/dot
- `safety/pii_scrubber.py` — changed the leading `\b` anchor to `(?:\b|(?=[(+]))`, since `\b` doesn't fire at a boundary immediately before `(` or `+` when preceded by another non-word character (like a space) — this was causing the opening paren/plus to be silently dropped from the redacted output even after the whitespace fix
- `tests/unit/test_pii_scrubber.py` — added `test_parenthesized_phone_fully_redacted` and `test_parenthesized_phone_fully_detected`, verifying both `scrub()` and `detect()` handle `(555) 123-4567` correctly, including the leading parenthesis

## Testing
- [x] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`)
- [x] Linter passes (`make lint`)
- [x] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes

**Reproduce the original bug (on `main`):**
```python
from safety.pii_scrubber import PIIScrubber
s = PIIScrubber()
print(s.scrub("Call me at (555) 123-4567"))
# observed: "Call me at (555) 123-4567" — completely unredacted
print(s.detect("Call me at (555) 123-4567"))
# observed: []
```

**Verify the fix (on this branch):**
```python
from safety.pii_scrubber import PIIScrubber
s = PIIScrubber()
print(s.scrub("Call me at (555) 123-4567"))
# expected: "Call me at [REDACTED]"
print(s.detect("Call me at (555) 123-4567"))
# expected: [{'type': 'phone_us', 'value': '(555) 123-4567', 'start': 11, 'end': 25}]
```

## Screenshots / Demo
N/A — backend-only change with no UI component. The observable behavior is shown in the reproduction/verification steps above.

## Notes for Reviewers
The Linter and Type checker boxes above are checked to mean "introduces no new
failures" — the codebase has pre-existing lint/type issues unrelated to this
change, confirmed below by diffing against `main` before making any edits:

- `safety/pii_scrubber.py` has 4 pre-existing ruff errors: unsorted imports, a
  283-char line in the `street_address` pattern, an unused `pii_type` loop
  variable, and a 101-char `logger.info` line. None touched by this PR.
- `tests/unit/test_pii_scrubber.py` has 26 pre-existing mypy errors (missing
  type annotations across the whole file) and 2 pre-existing ruff `F841`
  errors (unused `scrubbed`/`detected` variables in unrelated tests).
- `test_mixed_pii_and_text` fails on both `main` and this branch due to an
  unrelated bug in the `street_address` pattern (it falsely matches the `Pl`
  street-suffix abbreviation inside the word "applications"). Not touched by
  this PR.
- Ran `make check` and `make test-unit` across the whole repo: 49 test
  failures and widespread pre-existing lint issues exist in many unrelated
  files/modules (review service, resume parser, tech detector, bias
  detector, etc.). None are related to or introduced by this change.