### PR TITLE
Feat/68 safety event count health check

### DIFF
--- a/api/routes/health.py
+++ b/api/routes/health.py
@@ -1,6 +1,7 @@
-from fastapi import APIRouter, HTTPException, status, Depends
+from datetime import datetime
+
 import structlog
-from datetime import datetime, timedelta
+from fastapi import APIRouter, Depends, HTTPException, status
 
 from core.database import get_db
 
@@ -39,6 +40,7 @@ async def health_check(db=Depends(get_db)):
     try:
         # Check Redis (if available)
         import redis
+
         from core.config import settings
 
         r = redis.Redis(

--- a/api/routes/health.py
+++ b/api/routes/health.py
@@ -76,6 +76,8 @@ async def health_check(db=Depends(get_db)):
     try:
         # This would be populated by actual safety event logging
         health_status["safety_events_last_hour"] = 0
+        # The safety events last hour hardcode return 0 instead of showing recent safety events.
+        # Reproduce the issue through health check endpoint and check the logs for safety_events_check_failed error.
     except Exception as exc:
         log.error("safety_events_check_failed", error=str(exc))
 

--- a/api/routes/health.py
+++ b/api/routes/health.py
@@ -1,22 +1,30 @@
 from datetime import datetime
+from typing import Annotated, Any, Protocol
 
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, status
 
 from core.database import get_db
+from safety.monitoring import SafetyMonitor
 
 log = structlog.get_logger()
 
 router = APIRouter(prefix="/health", tags=["health"])
 
 
+class SupportsExecute(Protocol):
+    """Minimal protocol for the database dependency used by the health route."""
+
+    async def execute(self, statement: str) -> None: ...
+
+
 @router.get("")
-async def health_check(db=Depends(get_db)):
+async def health_check(db: Annotated[SupportsExecute, Depends(get_db)]) -> dict[str, Any]:
     """
     Check health of PostgreSQL, Redis, and Vector DB.
     Returns 200 if all healthy, 503 if any dependency is down.
     """
-    health_status = {
+    health_status: dict[str, Any] = {
         "status": "healthy",
         "dependencies": {
             "postgres": "unknown",
@@ -37,19 +45,18 @@ async def health_check(db=Depends(get_db)):
         health_status["dependencies"]["postgres"] = "unhealthy"
         health_status["status"] = "unhealthy"
 
+    redis_client = None
     try:
         # Check Redis (if available)
         import redis
 
         from core.config import settings
 
-        r = redis.Redis(
-            host=settings.redis_host,
-            port=settings.redis_port,
-            db=0,
+        redis_client = redis.from_url(
+            settings.redis_url,
             decode_responses=True,
         )
-        r.ping()
+        redis_client.ping()
         health_status["dependencies"]["redis"] = "healthy"
         log.debug("redis_health_check_passed")
     except Exception as exc:
@@ -74,14 +81,16 @@ async def health_check(db=Depends(get_db)):
         health_status["dependencies"]["vector_db"] = "unhealthy"
         health_status["status"] = "unhealthy"
 
-    # Count safety events in last hour (placeholder)
+    # Count safety events in last hour
     try:
-        # This would be populated by actual safety event logging
-        health_status["safety_events_last_hour"] = 0
-        # The safety events last hour hardcode return 0 instead of showing recent safety events.
-        # Reproduce the issue through health check endpoint and check the logs for safety_events_check_failed error.
+        if redis_client is not None:
+            monitor = SafetyMonitor(redis_client)
+            health_status["safety_events_last_hour"] = monitor.get_total_event_count(window_hours=1)
+        else:
+            health_status["safety_events_last_hour"] = 0
     except Exception as exc:
         log.error("safety_events_check_failed", error=str(exc))
+        health_status["safety_events_last_hour"] = 0
 
     # Return 503 if any critical dependency is down
     if health_status["status"] == "unhealthy":

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -42,16 +42,18 @@ I ran into formatting errors when committing new changes and didn't fully unders
 
 ### Check-in 2 (end of week)
 
-**PR link:** [link to your submitted pull request]
+**PR link:** https://github.com/trihiennguye-ux/pathreview/pull/1
 
-**Branch:** [the branch name you worked on, e.g. `fix/123-short-description`]
+**Branch:** feat/68-safety-event-count-health-check
 
 **What you built:**
-[1–3 sentences summarizing what your fix does and how it works]
+I rewrote the SafetyMonitor class so that it stores safety events in Redis sorted sets rather than a simple counter, which enables an accurate rolling one-hour count via ZCOUNT and includes automatic trimming of entries older than a 24-hour retention window. The health route now builds a SafetyMonitor from the existing Redis client and populates safety_events_last_hour with the real aggregate count across all event types, falling back to 0 if Redis is unavailable so the endpoint remains resilient. Unit tests were added covering both the healthy zero-event case and a case with a non-zero rolling count, using a lightweight in-memory Redis stub to avoid network dependencies.
 
 **Tests added or updated:**
-[Which test files did you touch? What do they cover?]
+I created a new test file: tests/unit/test_health_route.py with a FakeRedis stub (sorted-set backed) covering:
+- Healthy status response with zero safety events
+- Correct propagation of a non-zero rolling-window event count into safety_events_last_hour
 
-**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
 
-**Draft PR feedback received from:** [name or Slack handle, or "none"]
+**Draft PR feedback received from:** none

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -24,3 +24,34 @@
 **PLAN.md link:** https://github.com/trihiennguye-ux/pathreview/blob/feat/68-safety-event-count-health-check/docs/PLAN.md
 
 **Blockers or open questions:**
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+I updated the monitoring file so that safety events are stored in a way that supports a true rolling one-hour count. I also updated the health endpoint to call the new monitoring helper and return the real count in the response payload.
+
+**Next steps:**
+I will write tests for both the monitoring logic and the health endpoint to verify the rolling-window count and confirm the endpoint field is populated correctly.
+
+**Blockers:**
+I ran into formatting errors when committing new changes and didn't fully understand the pre-commit requirements at first.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [link to your submitted pull request]
+
+**Branch:** [the branch name you worked on, e.g. `fix/123-short-description`]
+
+**What you built:**
+[1–3 sentences summarizing what your fix does and how it works]
+
+**Tests added or updated:**
+[Which test files did you touch? What do they cover?]
+
+**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+
+**Draft PR feedback received from:** [name or Slack handle, or "none"]

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -15,3 +15,12 @@
 **Setup confirmation:** App runs locally at localhost:5173
 
 **Cohort ledger:** Issue added to cohort ledger
+
+**Reproduction commit link:** https://github.com/trihiennguye-ux/pathreview/commit/efd3b6b7dd1a56278dc7cdd725542337b796cab9
+
+**Reproduction summary:**
+- I reproduced the issue through health check endpoint and check the logs for safety_events_check_failed error. I noticed the safety_events_last_hour return 0 instead of the actual value, this is because the endpoint does not read from the Redis-backed monitoring state.
+
+**PLAN.md link:** https://github.com/trihiennguye-ux/pathreview/blob/feat/68-safety-event-count-health-check/docs/PLAN.md
+
+**Blockers or open questions:**

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -1,0 +1,17 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/68
+
+**Issue title:** Add a safety event count to the health check endpoint
+
+**Tier:** Tier 1
+
+**Selection Reasoning:** I chose this Tier 1 issue as a good starting point because it is focused on a small, well-scoped change and gives me a manageable way to learn how this open source project is structured. It also connects to the existing safety monitoring code, which makes it a practical first contribution for someone new to the codebase.
+
+**Problem summary:** The /health endpoint currently reports service status, but it does not show recent safety activity. That makes it harder for operators to monitor safety events without checking a separate monitoring dashboard. A successful fix adds a safety_events_last_hour value to the health response so that information is available directly from the endpoint.
+
+**Branch name:** feat/68-safety-event-count-health-check
+
+**Setup confirmation:** App runs locally at localhost:5173
+
+**Cohort ledger:** Issue added to cohort ledger

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -57,3 +57,32 @@ I created a new test file: tests/unit/test_health_route.py with a FakeRedis stub
 **Self-review confirmation:** [x] make check passes  [x] make test-unit passes
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** Still awaiting review
+
+**Summary of feedback:**
+
+**How you responded:**
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Getting oriented in a codebase I didn't write was much harder than I expected. As a first-time contributor, I couldn't just jump to the fix, I had to slow down and figure out how the pieces fit together before I could trust myself to change anything.
+
+**What did you learn about working in a large codebase?**
+I learned that contributing isn't just about writing code that works, it's about understanding the existing structure and conventions well enough that your change fits naturally into it. I also learned the value of paying attention to a project's tooling and process early, since small things like formatting requirements can slow you down if you skip past them.
+
+**How did AI tools help — and where did they fall short?**
+AI tools helped me ramp up faster by summarizing unfamiliar code and pointing me toward the parts most relevant to my issue, which saved a lot of time compared to reading everything cold. Where they fell short was in the actual decision-making, understanding tradeoffs and confirming a change was correct still came down to me thinking it through myself rather than taking a suggestion at face value.
+
+**What would you do differently if you started over?**
+I would spend less time trying to understand the whole codebase up front and instead focus earlier on tracing the specific path tied to my issue, digging into the root cause sooner rather than building a broad mental map first.
+
+**What are you most proud of from this module?**
+I'm most proud that I was able to take on a codebase that was completely new to me, work through the unfamiliarity, and still land a real, tested contribution. It gave me more confidence in my ability to ramp up quickly on unfamiliar systems.

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -1,0 +1,50 @@
+## Solution plan
+
+**Issue:** Add a safety event count to the health check endpoint - https://github.com/ascherj/pathreview/issues/68
+
+### Understand
+What is the root cause of this issue? What behavior is expected vs. actual?
+- The root cause is that the `/health` route is currently a placeholder for safety monitoring: it initializes `safety_events_last_hour` to `0` and never queries the monitoring layer for recent activity.
+- Expected behavior: the health endpoint should return a numeric `safety_events_last_hour` value that reflects the number of safety events recorded in the most recent hour.
+- Actual behavior: the health response always reports `0` because the endpoint does not read from the Redis-backed monitoring state.
+
+### Map
+Which files, functions, or modules are involved?
+List the specific files you expect to touch.
+- `api/routes/health.py` — builds the health payload and should populate `safety_events_last_hour` from the monitoring subsystem.
+- `safety/monitoring.py` — implements Redis-backed safety event logging and should expose a rolling 1-hour count instead of a single hardcoded counter.
+
+### Plan
+What are the steps to fix this issue?
+Break it into 3–5 concrete sub-tasks.
+1. Reproduce the bug by inspecting the health response contract and confirming that `safety_events_last_hour` is hardcoded to `0`.
+2. Update the monitoring implementation so safety events are stored in a way that supports a true rolling one-hour count.
+3. Update the health endpoint to call the monitoring helper and return the real count in the response payload.
+4. Add targeted regression tests that verify the rolling-window count and confirm the endpoint field is populated correctly.
+5. Verify the fix by running the relevant unit test(s) and checking that the endpoint no longer returns a placeholder value.
+
+### Inputs & outputs
+What does your fix take as input? What should it produce or change?
+- Input: the Redis-backed safety event stream produced by `SafetyMonitor.log_event()` and the existing health endpoint request path.
+- Output: the `/health` response should include `safety_events_last_hour` as an integer representing all safety events recorded in the last hour.
+- If Redis is unavailable or a count cannot be computed, the endpoint should gracefully fall back to `0` and log the error instead of crashing.
+
+### Risks & unknowns
+What could go wrong? What are you still unsure about?
+- The current monitoring code only stores a simple count with a 24-hour TTL, so it does not accurately represent the last hour by itself.
+- The health route must avoid introducing a new dependency failure path for the health endpoint when Redis is temporarily unavailable.
+- The implementation should preserve the existing health-check structure and avoid larger changes to unrelated API behavior.
+
+### Edge cases
+What inputs or states should your fix handle gracefully?
+- No safety events exist in Redis for the last hour → return `0`.
+- Redis is down or the count query raises an exception → log the failure and return `0` instead of failing the whole health check.
+- Multiple safety event types are present → aggregate their counts into the total for the last hour.
+- Old event timestamps should naturally age out of the rolling window so the count remains accurate over time.
+
+### Test strategy
+How should this change be validated?
+- Add a unit test for `safety/monitoring.py` that verifies `get_event_count()` uses a rolling one-hour window and returns the expected numeric total.
+- Add a unit test that ensures `log_event()` stores entries in a timestamped structure compatible with that rolling-window count.
+- If the repository already has endpoint-level tests, add one assertion that `safety_events_last_hour` reflects the computed count instead of remaining hardcoded.
+- The completion criterion is: the health endpoint returns a non-placeholder numeric value for `safety_events_last_hour`, and the targeted regression tests pass.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -99,7 +99,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -449,7 +448,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -473,7 +471,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1561,7 +1558,6 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1579,7 +1575,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1972,7 +1967,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3507,7 +3501,6 @@
       "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^2.0.1",
         "cssstyle": "^4.0.1",
@@ -4094,7 +4087,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4107,7 +4099,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4771,7 +4762,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/safety/monitoring.py
+++ b/safety/monitoring.py
@@ -1,14 +1,27 @@
-"""Safety event monitoring."""
+"""Safety event monitoring.
+
+This module stores per-event-type occurrences in Redis sorted sets keyed by
+`safety:events:<event_type>` using the event timestamp as the score. This
+allows efficient rolling-window counts (e.g. last hour) using `ZCOUNT`.
+"""
+
+import time
+import uuid
+from datetime import datetime
 
 import redis
 import structlog
-from datetime import datetime, timedelta
 
 logger = structlog.get_logger()
 
 
 class SafetyMonitor:
-    """Monitor and log safety events."""
+    """Monitor and log safety events using Redis sorted sets.
+
+    Each event is added to a sorted set with the Unix timestamp (float seconds)
+    as the score and a unique member value. Old entries are trimmed to a
+    retention window (24 hours) to keep storage bounded.
+    """
 
     # Valid event types
     VALID_EVENT_TYPES = {
@@ -16,8 +29,11 @@ class SafetyMonitor:
         "injection_attempt",
         "content_filtered",
         "bias_detected",
-        "rate_limited"
+        "rate_limited",
     }
+
+    # Retain events for this many seconds (24 hours)
+    RETENTION_SECONDS = 86400
 
     def __init__(self, redis_client: redis.Redis):
         """Initialize safety monitor.
@@ -27,48 +43,84 @@ class SafetyMonitor:
         """
         self.redis = redis_client
 
+    def _key(self, event_type: str) -> str:
+        return f"safety:events:{event_type}"
+
     def log_event(self, event_type: str, details: dict) -> None:
         """Log a safety event.
 
-        Args:
-            event_type: Type of event (from VALID_EVENT_TYPES)
-            details: Event details dict
+        Stores the event in a Redis sorted set with the current timestamp as the
+        score so that rolling-window counts can be computed with `ZCOUNT`.
         """
         if event_type not in self.VALID_EVENT_TYPES:
             logger.warning("unknown_event_type", event_type=event_type)
             return
 
-        timestamp = datetime.utcnow().isoformat()
+        iso_ts = datetime.utcnow().isoformat()
+        ts = time.time()
 
         try:
-            # Log to structlog
-            logger.warning("safety_event", event_type=event_type, **details)
+            # Log to structlog for auditability
+            logger.warning("safety_event", event_type=event_type, timestamp=iso_ts, **details)
 
-            # Store count in Redis for monitoring
-            key = f"safety:events:{event_type}"
-            self.redis.incr(key)
-            # Set expiry to 24 hours
-            self.redis.expire(key, 86400)
+            key = self._key(event_type)
+
+            # Use a unique member value to allow duplicate timestamps
+            member = f"{ts}:{uuid.uuid4().hex}"
+
+            # Add to sorted set with timestamp score
+            # redis-py expects a mapping of member->score
+            self.redis.zadd(key, {member: ts})
+
+            # Trim entries older than retention window
+            max_allowed = ts - self.RETENTION_SECONDS
+            if max_allowed > 0:
+                try:
+                    self.redis.zremrangebyscore(key, 0, max_allowed)
+                except Exception:
+                    # best-effort trimming; don't fail the whole logging
+                    logger.debug("zremrangebyscore_failed", key=key)
+
+            # Ensure the key expires after at most retention seconds
+            try:
+                self.redis.expire(key, self.RETENTION_SECONDS)
+            except Exception:
+                logger.debug("expire_failed", key=key)
 
         except Exception as e:
             logger.error("safety_monitor_error", error=str(e))
 
     def get_event_count(self, event_type: str, window_hours: int = 1) -> int:
-        """Get count of safety events.
+        """Get count of safety events in a rolling window.
 
         Args:
             event_type: Type of event
-            window_hours: Time window in hours (not enforced here; for reference)
+            window_hours: Time window in hours to count
 
         Returns:
             Count of events in the window
         """
-        key = f"safety:events:{event_type}"
+        key = self._key(event_type)
+        now = time.time()
+        window_seconds = int(window_hours * 3600)
+        start = now - window_seconds
 
         try:
-            count = self.redis.get(key)
-            return int(count) if count else 0
+            # ZCOUNT min/max are inclusive; use start..now
+            count = self.redis.zcount(key, start, now)
+            return int(count) if count is not None else 0
 
         except Exception as e:
             logger.error("event_count_error", event_type=event_type, error=str(e))
+            return 0
+
+    def get_total_event_count(self, window_hours: int = 1) -> int:
+        """Return aggregate count across all event types for the window."""
+        total = 0
+        try:
+            for et in self.VALID_EVENT_TYPES:
+                total += self.get_event_count(et, window_hours=window_hours)
+            return total
+        except Exception as e:
+            logger.error("total_event_count_error", error=str(e))
             return 0

--- a/tests/unit/test_health_route.py
+++ b/tests/unit/test_health_route.py
@@ -1,0 +1,59 @@
+"""Tests for health route."""
+
+import pytest
+
+from api.routes import health as health_routes
+
+
+class DummyDB:
+    """Minimal database stub for health route tests."""
+
+    async def execute(self, query: str) -> None:
+        """Simulate a successful database query."""
+        return None
+
+
+class FakeRedis:
+    """Simple Redis stub used to avoid network access in tests."""
+
+    def ping(self) -> bool:
+        """Return a successful ping response."""
+        return True
+
+
+@pytest.mark.unit
+class TestHealthCheck:
+    """Test suite for health check endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_health_check_returns_healthy_status(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test health route returns a healthy status with zero events."""
+        monkeypatch.setattr("redis.from_url", lambda *args, **kwargs: FakeRedis())
+        monkeypatch.setattr(
+            "safety.monitoring.SafetyMonitor.get_total_event_count",
+            lambda self, window_hours=1: 0,
+        )
+
+        response = await health_routes.health_check(DummyDB())
+
+        assert response["status"] == "healthy"
+        assert response["dependencies"]["postgres"] == "healthy"
+        assert response["dependencies"]["redis"] == "healthy"
+        assert response["safety_events_last_hour"] == 0
+
+    @pytest.mark.asyncio
+    async def test_health_check_returns_real_safety_event_count(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test health route returns the real rolling safety-event count."""
+        monkeypatch.setattr("redis.from_url", lambda *args, **kwargs: FakeRedis())
+        monkeypatch.setattr(
+            "safety.monitoring.SafetyMonitor.get_total_event_count",
+            lambda self, window_hours=1: 3,
+        )
+
+        response = await health_routes.health_check(DummyDB())
+
+        assert response["safety_events_last_hour"] == 3

--- a/tests/unit/test_health_route.py
+++ b/tests/unit/test_health_route.py
@@ -1,8 +1,15 @@
 """Tests for health route."""
 
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, cast
+
 import pytest
 
 from api.routes import health as health_routes
+from safety.monitoring import SafetyMonitor
+
+if TYPE_CHECKING:
+    import redis
 
 
 class DummyDB:
@@ -16,8 +23,32 @@ class DummyDB:
 class FakeRedis:
     """Simple Redis stub used to avoid network access in tests."""
 
+    def __init__(self) -> None:
+        self.sorted_sets: dict[str, dict[str, float]] = {}
+
     def ping(self) -> bool:
         """Return a successful ping response."""
+        return True
+
+    def zadd(self, key: str, mapping: dict[str, float]) -> int:
+        self.sorted_sets.setdefault(key, {}).update(mapping)
+        return len(mapping)
+
+    def zremrangebyscore(self, key: str, min_score: float, max_score: float) -> int:
+        if key not in self.sorted_sets:
+            return 0
+        to_remove = [
+            member for member, score in self.sorted_sets[key].items() if score <= max_score
+        ]
+        for member in to_remove:
+            del self.sorted_sets[key][member]
+        return len(to_remove)
+
+    def zcount(self, key: str, min_score: float, max_score: float) -> int:
+        entries = self.sorted_sets.get(key, {})
+        return sum(1 for score in entries.values() if min_score <= score <= max_score)
+
+    def expire(self, key: str, ttl: int) -> bool:
         return True
 
 
@@ -57,3 +88,48 @@ class TestHealthCheck:
         response = await health_routes.health_check(DummyDB())
 
         assert response["safety_events_last_hour"] == 3
+
+    def test_monitoring_uses_a_rolling_one_hour_window(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Rolling counts should exclude events older than one hour."""
+        fake_redis = FakeRedis()
+        monitor = SafetyMonitor(cast("redis.Redis", fake_redis))
+        timestamps = iter([1000.0, 1000.0, 100.0, 4000.0])
+        monkeypatch.setattr("safety.monitoring.time.time", lambda: next(timestamps))
+
+        monitor.log_event("pii_detected", {"source": "test"})
+        monitor.log_event("pii_detected", {"source": "test"})
+        monitor.log_event("pii_detected", {"source": "test"})
+
+        assert monitor.get_event_count("pii_detected", window_hours=1) == 2
+
+    def test_log_event_stores_timestamped_entries(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Logged events should be stored as timestamped sorted-set entries."""
+        fake_redis = FakeRedis()
+        monitor = SafetyMonitor(cast("redis.Redis", fake_redis))
+        monkeypatch.setattr("safety.monitoring.time.time", lambda: 1700000000.0)
+        monkeypatch.setattr("safety.monitoring.uuid.uuid4", lambda: SimpleNamespace(hex="abc123"))
+
+        monitor.log_event("pii_detected", {"source": "test"})
+
+        entries = fake_redis.sorted_sets["safety:events:pii_detected"]
+        assert len(entries) == 1
+        member, score = next(iter(entries.items()))
+        assert score == 1700000000.0
+        assert member == "1700000000.0:abc123"
+
+    @pytest.mark.asyncio
+    async def test_health_check_populates_safety_count_field(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The health endpoint should expose the computed safety event count."""
+        monkeypatch.setattr("redis.from_url", lambda *args, **kwargs: FakeRedis())
+        monkeypatch.setattr(
+            "safety.monitoring.SafetyMonitor.get_total_event_count",
+            lambda self, window_hours=1: 7,
+        )
+
+        response = await health_routes.health_check(DummyDB())
+
+        assert response["safety_events_last_hour"] == 7


### PR DESCRIPTION
## Summary
This PR fixes the /health endpoint returning a hard-coded safety_events_last_hour value of 0 instead of a real count. The SafetyMonitor class was reworked to store safety events in Redis sorted sets (keyed by event type, scored by timestamp) rather than a simple counter, which enables an accurate rolling one-hour count via ZCOUNT and includes automatic trimming of entries older than a 24-hour retention window. The health route now builds a SafetyMonitor from the existing Redis client and populates safety_events_last_hour with the real aggregate count across all event types, falling back to 0 if Redis is unavailable so the endpoint remains resilient. Unit tests were added covering both the healthy zero-event case and a case with a non-zero rolling count, using a lightweight in-memory Redis stub to avoid network dependencies.

## Issue
Closes #68

## Changes
- Reworked SafetyMonitor to store safety events in Redis sorted sets (safety:events:<event_type>) keyed by timestamp, instead of a simple counter, enabling true rolling-window counts via ZCOUNT
- Added get_total_event_count() to SafetyMonitor to aggregate counts across all valid event types for a given window
- Added retention trimming (zremrangebyscore) and key expiry (24h) so Redis storage stays bounded
- Updated /health endpoint to instantiate SafetyMonitor from the Redis client and populate safety_events_last_hour with the real rolling one-hour count, instead of the hard-coded 0
- Switched Redis client construction in the health route to redis.from_url(settings.redis_url) and added type annotations (SupportsExecute protocol, return type) to health_check
- Falls back to 0 for safety_events_last_hour if Redis is unavailable or the count lookup fails, so the endpoint doesn't break when Redis is down
- Added tests/unit/test_health_route.py with a FakeRedis stub (sorted-set backed) covering:
- Healthy status response with zero safety events
- Correct propagation of a non-zero rolling-window event count into safety_events_last_hour

## Testing
- [x] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`)
- [ ] Linter passes (`make lint`)
- [ ] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes

1. Start the app locally
2. trigger a safety event by calling the health endpoint in http://0.0.0.0:8000/docs
3. curl /health and confirm safety_events_last_hour reflects it.

## Notes for Reviewers
- get_total_event_count iterates over all VALID_EVENT_TYPES and issues one ZCOUNT per type — fine at current scale, but worth flagging if event types grow significantly.
