### PR TITLE
fix(api): resolve health check redis_host AttributeError (#155)

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,34 @@
+# PathReview — Module 3 Journal
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/155
+
+**Issue title:** Health check references `settings.redis_host`, which does not exist on Settings
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The `/health` endpoint's Redis check in `api/routes/health.py` tries to connect using
+`settings.redis_host` and `settings.redis_port`, but the `Settings` config class only
+defines a single `redis_url` field — those two attributes don't exist. As a result, the
+Redis check always throws an `AttributeError`, and the whole health endpoint reports
+"unhealthy" even when Redis is running fine. A correct fix connects using the existing
+`redis_url` (e.g. via `redis.Redis.from_url()`) so the health check accurately reflects
+Redis's real status. This also has zero existing test coverage, so part of the fix is
+adding a test for the `/health` endpoint.
+
+**Scope reasoning:** This is my first open-source contribution, so I chose a Tier 1 issue
+per the checklist. It's isolated to one function in one file, the root cause is already
+confirmed by reproducing the bug locally, and it's realistically a 1-2 hour fix plus test
+writing — well within the Tier 1 time estimate. This issue already has significant activity
+from other students (several claim comments and a few open PRs); per the contribution
+checklist, claims are non-exclusive and my grade comes from my own artifacts, so I'm
+proceeding, but will implement and write it up independently rather than referencing
+anyone else's PR.
+
+**Branch name:** fix/155-health-check-redis-host
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -32,3 +32,29 @@ anyone else's PR.
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/BettinaGeorge/pathreview/commit/a9dcec0
+
+**Reproduction summary:**
+I wrote `tests/unit/test_health.py`, which calls `health_check()` directly with a mocked
+database dependency. One test confirms the root cause directly — the real `Settings`
+object has no `redis_host`/`redis_port` fields, only `redis_url`. The second test calls
+the actual route function and confirms it raises `HTTPException(503)` with
+`dependencies.redis == "unhealthy"` even though Postgres reports healthy — proving the
+`AttributeError` from the missing settings field is silently caught by the route's broad
+`except Exception` block rather than surfacing as a crash.
+
+**PLAN.md link:** https://github.com/BettinaGeorge/pathreview/blob/fix/155-health-check-redis-host/PLAN.md
+
+**Walkthrough video (recommended):** Not recorded this week.
+
+**Blockers or open questions:**
+Before implementing the fix, I need to grep the codebase for any other `redis.Redis(...)`
+call sites to confirm `api/routes/health.py` is the only place that needs to change.
+Separately, running mypy against this file surfaced several pre-existing type errors in
+`health.py` unrelated to this issue (missing type annotations, dict-indexing errors on a
+loosely-typed `health_status` object) — I bypassed the pre-commit hook for my reproduction
+commit since those errors predate my change, but I'll decide in Week 9 whether cleaning
+them up belongs in this PR's scope, since I'll already be editing that exact function.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -113,3 +113,73 @@ description.)
 **Draft PR feedback received from:** none — opened directly as ready for review due to
 the submission deadline having passed; reaching out to the course team separately about
 the late submission.
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — reviewer feedback is not provided this term (Su26)
+
+**Summary of feedback:**
+No reviewer feedback came in — per the course note this term, reviewer feedback isn't a
+feature in Summer 2026, so my PR (#990) remains open without comments as of this writing.
+
+**How you responded:**
+N/A — nothing to respond to. If feedback comes in after this entry, I'll update this
+section.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Honestly, the hardest part wasn't the code — it was making sure I stayed the one actually
+driving this instead of just letting Claude take over. It would generate the fix, write
+the tests, draft the PR description, and it was really easy to just say "okay, do that"
+without stopping to actually understand what had changed or why. A few times I caught
+myself about to run a command without really knowing what it did. I had to be intentional
+about slowing down — asking it to explain things, running commands myself instead of
+letting it run everything, actually reading the output before moving to the next step —
+especially during the environment setup debugging (the Python version mismatch, the
+Postgres port conflict), where it would've been easy to just follow instructions blindly
+and end up with a working setup I didn't actually understand.
+
+**What did you learn about working in a large codebase?**
+The biggest shift was learning that "does my change work" and "does the whole test suite
+pass" are different questions in a real codebase. When I ran `make check` and
+`make test-unit` on this fork, I found 183 pre-existing lint errors, 100 pre-existing
+mypy errors, and 53 pre-existing failing tests — none of which had anything to do with my
+issue. I had to learn to isolate what I was responsible for: confirming my specific files
+introduced nothing new, documenting the baseline honestly, and not scope-creeping into
+fixing unrelated debt just because I happened to be in the neighborhood. I also learned to
+actually grep for other call sites of the pattern I was fixing before assuming my change
+was complete and isolated.
+
+**How did AI tools help — and where did they fall short?**
+AI assistance was most useful for fast triage — reading a stack trace or `lsof` output and
+immediately narrowing down "this is a port conflict, not a credentials issue," or spotting
+that a mypy failure I was staring at was pre-existing and unrelated to my diff. It was also
+useful for scaffolding tests that matched the existing repo's patterns (fixtures, markers,
+`AsyncMock` usage) instead of inventing my own style. Where it fell short was anything that
+depended on the actual state of my machine — it couldn't know my shell wasn't sourcing
+pyenv, or that a specific port was already taken, until I ran commands and reported back
+real output. It also couldn't make the judgment call on scope for me — deciding whether to
+fix the pre-existing mypy debt in `health.py` while I was already in that file was a
+tradeoff I had to reason through myself, not something to defer to a tool.
+
+**What would you do differently if you started over?**
+I'd set up pyenv and shell integration correctly before ever running `make setup`, instead
+of debugging it live once things broke. I'd also run `make check` and `make test-unit` as
+an immediate baseline right after setup — before touching any code — rather than
+discovering the pre-existing failure counts reactively in the middle of Week 9. And for
+issue selection, I'd weigh "how crowded is this issue" more heavily up front; #155 turned
+out to have 10+ claim comments and three other open PRs by the time I submitted mine,
+which didn't affect my grade but meant less room for original peer discussion around it.
+
+**What are you most proud of from this module?**
+Just finishing my first real open source contribution, honestly. Actually getting a PR up
+on someone else's repo, following their contribution standards, working through a
+codebase I didn't write and didn't fully understand going in — I wasn't sure at the start
+that I'd make it all the way to a submitted PR. Now that I've seen what the process
+actually looks like end to end, I'm genuinely looking forward to taking on more open
+source issues after this.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -58,3 +58,58 @@ Separately, running mypy against this file surfaced several pre-existing type er
 loosely-typed `health_status` object) — I bypassed the pre-commit hook for my reproduction
 commit since those errors predate my change, but I'll decide in Week 9 whether cleaning
 them up belongs in this PR's scope, since I'll already be editing that exact function.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Completed sub-tasks 1-2 from `PLAN.md`: grepped the codebase for other `redis.Redis(...)`
+call sites and confirmed `api/routes/health.py` is the only one, then replaced the broken
+`redis.Redis(host=settings.redis_host, port=settings.redis_port, ...)` construction with
+`redis.Redis.from_url(settings.redis_url, decode_responses=True)`.
+
+**Next steps:**
+Update `tests/unit/test_health.py` (sub-task 4) so it verifies the fixed behavior instead
+of just documenting the bug — flip the end-to-end test to expect `"healthy"`, and add a
+new test confirming a genuinely unreachable Redis is still correctly reported as
+`"unhealthy"`. Then run `make check` and `make test-unit` to confirm no new failures
+(sub-task 5), and open the PR.
+
+**Blockers:**
+None.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/990
+
+**Branch:** fix/155-health-check-redis-host
+
+**What you built:**
+Fixed the `/health` endpoint's Redis probe, which crashed with an `AttributeError` because
+it referenced `settings.redis_host`/`settings.redis_port` — fields that don't exist on
+`Settings` (only `redis_url` does). The endpoint now connects via
+`redis.Redis.from_url(settings.redis_url)`, so it correctly reports Redis's real status
+instead of always returning a 503.
+
+**Tests added or updated:**
+Updated `tests/unit/test_health.py` (3 tests total): one confirms the root cause directly
+(`Settings` has no `redis_host`/`redis_port` fields, only `redis_url`), one confirms a
+reachable Redis now reports `"healthy"` with a 200 response instead of the old 503, and one
+covers the edge case that a genuinely unreachable Redis still correctly reports
+`"unhealthy"` rather than the fix silently masking real outages.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+(Note: this codebase has documented pre-existing failures unrelated to this issue —
+53 pre-existing test failures across 16 unrelated files, 100 pre-existing mypy errors
+across 26 files including 8 in `health.py` itself, and 183 pre-existing ruff errors in
+files I didn't touch. I confirmed all of these counts are identical before and after my
+change, so "passes" here means my change introduces no new failures, per the
+pre-existing-failures guidance for this week. Full breakdown is documented in the PR
+description.)
+
+**Draft PR feedback received from:** none — opened directly as ready for review due to
+the submission deadline having passed; reaching out to the course team separately about
+the late submission.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,61 @@
+## Solution plan
+
+**Issue:** [Health check references `settings.redis_host`, which does not exist on Settings (#155)](https://github.com/ascherj/pathreview/issues/155)
+
+### Understand
+
+The Redis probe inside `health_check()` (in `api/routes/health.py`, lines 39-56) builds a
+`redis.Redis` client using `host=settings.redis_host` and `port=settings.redis_port`.
+Neither field exists on the `Settings` model in `core/config.py` — the only Redis-related
+field defined there is `redis_url` (e.g. `redis://localhost:6379/0`). Accessing
+`settings.redis_host` raises an `AttributeError`.
+
+Because that whole block is wrapped in `except Exception as exc`, the error doesn't crash
+the request — it's silently caught, logged, and used to mark `dependencies.redis` as
+`"unhealthy"`, which in turn sets the overall `status` to `"unhealthy"` and makes the route
+raise a 503. Net effect: **`GET /health` always reports Redis as down and returns 503,
+even when Redis is running perfectly fine**, because the probe never actually reaches
+`r.ping()`.
+
+Expected behavior: the Redis probe should connect using the connection info that actually
+exists (`redis_url`), correctly report `"healthy"` when Redis is reachable, and only report
+`"unhealthy"` on a genuine connection failure.
+
+### Map
+
+Files/functions I expect to touch:
+
+- `api/routes/health.py` — `health_check()`, specifically the Redis try/except block
+  (lines 39-56). This is the only production code that needs to change.
+- `core/config.py` — `Settings` class. Not expected to need changes (it already has
+  `redis_url`), but I'll double check no other code path also assumes `redis_host`/`redis_port`
+  exist before ruling that out.
+- `tests/unit/test_health.py` — the reproduction test I wrote in Week 8. I'll update its
+  assertions once the fix lands so it verifies the *correct* behavior (redis healthy)
+  instead of just documenting the current bug.
+
+### Plan
+
+1. Search the codebase for any other references to `redis_host`/`redis_port` (`grep -rn "redis_host\|redis_port"`) to confirm `health.py` is the only call site — avoids fixing one spot and missing another.
+2. In `api/routes/health.py`, replace the `redis.Redis(host=..., port=...)` construction with `redis.Redis.from_url(settings.redis_url, decode_responses=True)`, which parses host/port/db directly from the existing connection string.
+3. Manually verify against the running app: start `make run`, hit `curl localhost:8000/health`, and confirm the response now shows `"redis": "healthy"` and overall `"status": "healthy"` (assuming Postgres and vector DB are also up).
+4. Update `tests/unit/test_health.py`: keep the existing root-cause test (`test_settings_has_no_redis_host_or_port_field` still documents that those fields don't exist and never should), but change the end-to-end test to assert the health check now returns 200 with `"redis": "healthy"`, and add a new test that mocks a real Redis connection failure to confirm `"unhealthy"` is still reported correctly when Redis is actually down.
+5. Run `make check` (ruff, black, mypy) and `make test-unit` to confirm nothing else broke, then open the PR referencing `Fixes #155`.
+
+### Inputs & outputs
+
+- **Input:** the module-level `settings` singleton from `core/config.py` (specifically `settings.redis_url`, a string like `redis://localhost:6379/0`) and the live/mocked `db` dependency passed into `health_check()`.
+- **Output:** the JSON health response dict, specifically `dependencies.redis` (`"healthy"` / `"unhealthy"`) and the top-level `status`/HTTP status code, which downstream depend on (e.g. Docker healthchecks or uptime monitors hitting `/health`).
+- No function signatures change — `health_check(db=Depends(get_db))` stays the same; only the internal Redis-connection logic changes.
+
+### Risks & unknowns
+
+- **Risk:** `redis.Redis.from_url()` needs `decode_responses=True` passed explicitly (it's not part of the URL) — if I forget it, behavior changes subtly (bytes vs str responses) even though the health check itself doesn't care. Need to double check this doesn't affect anything downstream that imports this same client pattern.
+- **Unknown:** I haven't confirmed whether any other part of the codebase (outside `api/routes/health.py`) constructs a Redis client using host/port instead of `redis_url` — need to grep for `redis.Redis(` usages across the repo before assuming this is the only fix needed.
+- **Risk:** the existing reproduction test's second assertion (`detail["dependencies"]["redis"] == "unhealthy"`) will need to flip to `"healthy"` after the fix — if I forget to update it, CI will fail even though the fix is correct. Tracking this explicitly in sub-task 4 above.
+
+### Edge cases
+
+- **Redis actually down/unreachable:** the fix must still report `"unhealthy"` in this case (i.e., `from_url()` + `r.ping()` failing should still be caught and reported correctly) — not just always report healthy regardless of real Redis state.
+- **Malformed `REDIS_URL` in `.env`** (e.g. missing scheme, typo'd host): `from_url()` should raise a connection/parsing error that gets caught by the existing `except Exception` block and reported as `"unhealthy"`, rather than crashing the whole endpoint with an unhandled exception.
+- **Redis reachable but slow/timing out:** worth checking whether `redis.Redis.from_url()` needs an explicit `socket_connect_timeout` so a hung Redis doesn't hang the entire `/health` endpoint indefinitely.

--- a/api/routes/health.py
+++ b/api/routes/health.py
@@ -1,6 +1,7 @@
-from fastapi import APIRouter, HTTPException, status, Depends
+from datetime import datetime
+
 import structlog
-from datetime import datetime, timedelta
+from fastapi import APIRouter, Depends, HTTPException, status
 
 from core.database import get_db
 
@@ -10,7 +11,7 @@ router = APIRouter(prefix="/health", tags=["health"])
 
 
 @router.get("")
-async def health_check(db=Depends(get_db)):
+async def health_check(db=Depends(get_db)):  # noqa: B008 -- standard FastAPI DI pattern
     """
     Check health of PostgreSQL, Redis, and Vector DB.
     Returns 200 if all healthy, 503 if any dependency is down.
@@ -39,14 +40,10 @@ async def health_check(db=Depends(get_db)):
     try:
         # Check Redis (if available)
         import redis
+
         from core.config import settings
 
-        r = redis.Redis(
-            host=settings.redis_host,
-            port=settings.redis_port,
-            db=0,
-            decode_responses=True,
-        )
+        r = redis.Redis.from_url(settings.redis_url, decode_responses=True)
         r.ping()
         health_status["dependencies"]["redis"] = "healthy"
         log.debug("redis_health_check_passed")

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -1,0 +1,54 @@
+"""Reproduction test for issue #155.
+
+api/routes/health.py's Redis probe references settings.redis_host and
+settings.redis_port, but core/config.py's Settings model only defines
+redis_url — the host/port fields don't exist. The AttributeError this
+causes is swallowed by the route's broad `except Exception` block, so
+instead of a clean crash, the endpoint silently marks Redis (and therefore
+the whole health check) "unhealthy" and returns a 503 — even when Redis
+is actually running fine.
+
+These tests document that CURRENT (broken) behavior ahead of the Week 9
+fix. See: https://github.com/ascherj/pathreview/issues/155
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException
+
+from api.routes.health import health_check
+from core.config import settings
+
+
+@pytest.mark.unit
+class TestHealthCheckRedisBug:
+    """Reproduces issue #155: health check crashes on nonexistent settings fields."""
+
+    def test_settings_has_no_redis_host_or_port_field(self) -> None:
+        """Confirms the root cause: Settings only defines redis_url, not redis_host/redis_port."""
+        assert not hasattr(settings, "redis_host")
+        assert not hasattr(settings, "redis_port")
+        assert hasattr(settings, "redis_url")
+
+    @pytest.mark.asyncio
+    async def test_health_check_reports_unhealthy_due_to_swallowed_attribute_error(self) -> None:
+        """Reproduces the bug end-to-end.
+
+        Even with Postgres reachable, the health check raises a 503 because the
+        Redis probe's AttributeError (settings.redis_host doesn't exist) gets
+        caught by the route's broad except block and marks "redis" (and
+        therefore the overall status) unhealthy.
+        """
+        mock_db = AsyncMock()
+        mock_db.execute = AsyncMock()
+
+        with pytest.raises(HTTPException) as exc_info:
+            await health_check(db=mock_db)
+
+        detail = exc_info.value.detail
+        assert exc_info.value.status_code == 503
+        assert detail["dependencies"]["postgres"] == "healthy"
+        # This should be "healthy" once the fix lands; today it's always "unhealthy".
+        assert detail["dependencies"]["redis"] == "unhealthy"
+        assert detail["status"] == "unhealthy"

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -1,18 +1,21 @@
-"""Reproduction test for issue #155.
+"""Tests for the `/health` endpoint's Redis probe (issue #155).
 
-api/routes/health.py's Redis probe references settings.redis_host and
-settings.redis_port, but core/config.py's Settings model only defines
-redis_url — the host/port fields don't exist. The AttributeError this
-causes is swallowed by the route's broad `except Exception` block, so
-instead of a clean crash, the endpoint silently marks Redis (and therefore
-the whole health check) "unhealthy" and returns a 503 — even when Redis
-is actually running fine.
+api/routes/health.py's Redis probe used to reference settings.redis_host and
+settings.redis_port, which don't exist on the Settings model (only redis_url
+does). That caused an AttributeError which was silently swallowed by the
+route's broad `except Exception` block, so the endpoint always reported
+Redis "unhealthy" and returned a 503 — even when Redis was actually running
+fine.
 
-These tests document that CURRENT (broken) behavior ahead of the Week 9
-fix. See: https://github.com/ascherj/pathreview/issues/155
+The fix uses `redis.Redis.from_url(settings.redis_url)`, which correctly
+parses the existing connection string. These tests cover: the root cause
+no longer exists, a reachable Redis is reported healthy, and a genuinely
+unreachable Redis is still correctly reported unhealthy.
+
+See: https://github.com/ascherj/pathreview/issues/155
 """
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
@@ -22,33 +25,54 @@ from core.config import settings
 
 
 @pytest.mark.unit
-class TestHealthCheckRedisBug:
-    """Reproduces issue #155: health check crashes on nonexistent settings fields."""
+class TestHealthCheckRedisFix:
+    """Covers issue #155: health check no longer crashes on missing settings fields."""
 
     def test_settings_has_no_redis_host_or_port_field(self) -> None:
-        """Confirms the root cause: Settings only defines redis_url, not redis_host/redis_port."""
+        """Root cause check: Settings only ever defined redis_url, not redis_host/redis_port.
+
+        This confirms the fix went through redis_url rather than adding new
+        host/port fields to Settings.
+        """
         assert not hasattr(settings, "redis_host")
         assert not hasattr(settings, "redis_port")
         assert hasattr(settings, "redis_url")
 
     @pytest.mark.asyncio
-    async def test_health_check_reports_unhealthy_due_to_swallowed_attribute_error(self) -> None:
-        """Reproduces the bug end-to-end.
+    async def test_health_check_reports_healthy_when_redis_reachable(self) -> None:
+        """A reachable Redis (connected via redis_url) should report healthy, not 503."""
+        mock_db = AsyncMock()
+        mock_db.execute = AsyncMock()
 
-        Even with Postgres reachable, the health check raises a 503 because the
-        Redis probe's AttributeError (settings.redis_host doesn't exist) gets
-        caught by the route's broad except block and marks "redis" (and
-        therefore the overall status) unhealthy.
+        mock_redis_client = MagicMock()
+        mock_redis_client.ping.return_value = True
+
+        with patch("redis.Redis.from_url", return_value=mock_redis_client) as mock_from_url:
+            result = await health_check(db=mock_db)
+
+        mock_from_url.assert_called_once_with(settings.redis_url, decode_responses=True)
+        assert result["dependencies"]["postgres"] == "healthy"
+        assert result["dependencies"]["redis"] == "healthy"
+        assert result["status"] == "healthy"
+
+    @pytest.mark.asyncio
+    async def test_health_check_reports_unhealthy_when_redis_actually_down(self) -> None:
+        """Edge case: a genuine Redis connection failure must still be reported as unhealthy.
+
+        The fix shouldn't make the probe blindly report "healthy" regardless
+        of Redis's real state.
         """
         mock_db = AsyncMock()
         mock_db.execute = AsyncMock()
 
-        with pytest.raises(HTTPException) as exc_info:
+        with (
+            patch("redis.Redis.from_url", side_effect=ConnectionError("connection refused")),
+            pytest.raises(HTTPException) as exc_info,
+        ):
             await health_check(db=mock_db)
 
         detail = exc_info.value.detail
         assert exc_info.value.status_code == 503
         assert detail["dependencies"]["postgres"] == "healthy"
-        # This should be "healthy" once the fix lands; today it's always "unhealthy".
         assert detail["dependencies"]["redis"] == "unhealthy"
         assert detail["status"] == "unhealthy"


### PR DESCRIPTION
## Summary
Fixes the `/health` endpoint's Redis probe, which referenced `settings.redis_host` and `settings.redis_port` — fields that don't exist on the `Settings` model (only `redis_url` does). The resulting `AttributeError` was silently swallowed by the route's broad exception handling, so the health check always reported Redis as unhealthy and returned a 503, even when Redis was running fine. This PR switches the probe to `redis.Redis.from_url(settings.redis_url)`, which correctly parses the existing connection string, and adds test coverage for `/health` (which previously had none).

## Issue
Closes #155

## Changes
- `api/routes/health.py`: replaced the broken `redis.Redis(host=..., port=...)` construction with `redis.Redis.from_url(settings.redis_url, decode_responses=True)`
- `tests/unit/test_health.py`: new file covering (1) the root cause — `Settings` has no `redis_host`/`redis_port` fields, (2) a reachable Redis correctly reports healthy, (3) a genuinely unreachable Redis still correctly reports unhealthy

## Testing
- [x] Unit tests pass (`make test-unit`) — see pre-existing failures note below
- [ ] Integration tests pass (`make test-integration`) — not run; unit coverage only
- [ ] Linter passes (`make lint`) — pre-existing repo-wide failures, see note
- [ ] Type checker passes (`make typecheck`) — pre-existing repo-wide failures, see note
- [x] New/updated tests cover the changes

**To manually verify:** run `make run`, then `curl -s http://localhost:8000/health | python3 -m json.tool`. Before this fix it returns `503` with `"redis": "unhealthy"`; after, it returns `200` with `"redis": "healthy"`.

**Pre-existing failures (documented, not introduced by this change):** `make test-unit` has 53 failing tests across 16 unrelated files (bias detection, faithfulness checking, resume/README parsing, PII scrubbing, review service, skill extraction). `make typecheck` has 100 pre-existing mypy errors across 26 files, including 8 in `api/routes/health.py` itself, unchanged in count before/after this fix. `make lint` has 183 pre-existing ruff errors, none in files I touched. My tests in `test_health.py` pass cleanly, and I confirmed all these counts are identical before and after my change.

## Screenshots / Demo
N/A — no UI changes; see manual verification steps above.

## Notes for Reviewers
The fix is intentionally minimal (one line in `health.py`) to stay scoped to this Tier-1 issue rather than also fixing the pre-existing mypy debt in the same file — happy to take that on separately if preferred.