### PR TITLE
Fix/153 faithfulness checker none text

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,31 @@
+# Journal
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/153
+
+**Issue title:** Faithfulness checker crashes when a context chunk has `text: None`
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The `FaithfulnessChecker.check()` method builds its context string by pulling
+`text` out of each chunk dict with `chunk.get("text", "")`, assuming that
+missing keys are the only case it needs to guard against. But `.get()` only
+falls back to the default when the key is absent — if a chunk explicitly has
+`"text": None`, `.get()` returns `None`, and the subsequent `" ".join(...)`
+call raises a `TypeError` because it can't join a `NoneType` into a string.
+In practice this means any upstream chunk that legitimately has a null/empty
+text field (rather than a missing one) crashes the faithfulness check instead
+of being skipped or treated as empty. A correct fix should coerce `None`
+values to an empty string (or filter the chunk out) before joining, so the
+checker degrades gracefully instead of raising. This touches
+`rag/evaluator/faithfulness_checker.py`, and there's already a failing test,
+`test_none_context_chunk_text`, in `tests/unit/test_faithfulness_checker.py`
+that should pass once the fix is in.
+
+**Branch name:** fix/153-faithfulness-checker-none-text
+
+**Setup confirmation:** [ ] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -29,3 +29,17 @@ that should pass once the fix is in.
 **Setup confirmation:** [ ] App runs locally at localhost:5173
 
 **Cohort ledger:** [ ] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/adedotdev/pathreview/commit/966b683 (branch `fix/153-faithfulness-checker-none-text`)
+
+**Reproduction summary:**
+Ran the existing (failing) test `tests/unit/test_faithfulness_checker.py::test_none_context_chunk_text`, which calls `FaithfulnessChecker.check()` with a chunk `{"text": None}`. It raised `TypeError: sequence item 0: expected str instance, NoneType found` at `rag/evaluator/faithfulness_checker.py:39`, confirming `chunk.get("text", "")` returns `None` (not the default) when the key is present but explicitly `None`. Documented the reproduction with an inline comment at the crash site.
+
+**PLAN.md link:** https://github.com/adedotdev/pathreview/blob/fix/153-faithfulness-checker-none-text/PLAN.md
+
+**Walkthrough video (recommended):** _not recorded yet_
+
+**Blockers or open questions:**
+The same `chunk.get("text", "")` pattern also exists in `review_generator.py`, `relevance_scorer.py`, and `hybrid.py` and likely has the same latent bug, but issue #153 only scopes the fix to `faithfulness_checker.py`. Also, 3 tests in `test_faithfulness_checker.py` fail today for reasons unrelated to this issue (claim-extraction/overlap-scoring logic) — need to confirm with a mentor whether that's separately tracked before I touch it in Week 9.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -43,3 +43,40 @@ Ran the existing (failing) test `tests/unit/test_faithfulness_checker.py::test_n
 
 **Blockers or open questions:**
 The same `chunk.get("text", "")` pattern also exists in `review_generator.py`, `relevance_scorer.py`, and `hybrid.py` and likely has the same latent bug, but issue #153 only scopes the fix to `faithfulness_checker.py`. Also, 3 tests in `test_faithfulness_checker.py` fail today for reasons unrelated to this issue (claim-extraction/overlap-scoring logic) — need to confirm with a mentor whether that's separately tracked before I touch it in Week 9.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the fix from PLAN.md step 1: `faithfulness_checker.py` now builds
+`context_text` with `chunk.get("text") or ""` instead of
+`chunk.get("text", "")`, so a chunk with `"text": None` is treated the same as
+a missing/empty one instead of crashing. `test_none_context_chunk_text` now
+passes. Added `test_mixed_none_missing_and_valid_text_chunks` to cover a
+`context_chunks` list with `None` text, a missing key, and valid text in the
+same call (PLAN.md's "mixed" edge case) — it passes too.
+
+Before changing anything I captured a baseline: `pytest tests/unit -m unit`
+had 53 pre-existing failures unrelated to #153 (bias detector, PII scrubber,
+resume parser, review service, etc. — none touch faithfulness/context
+handling). After the fix, the suite has 52 failures — the exact same set
+minus `test_none_context_chunk_text`, confirmed via diff. `ruff check` and
+`black --check` on the two touched files show only pre-existing issues I
+didn't introduce (an unsorted-import warning already in
+`faithfulness_checker.py`, and an unused-variable warning in an untouched
+test method) — my own added/changed lines are clean. `mypy` on
+`faithfulness_checker.py` alone passes; a full-tree `mypy` run fails in this
+environment due to missing third-party type stubs (`PyPDF2`, `jose`,
+`passlib`, `rank_bm25`) and a numpy stub/Python-version mismatch, all
+pre-existing and unrelated to this change.
+
+**Next steps:**
+Open a draft PR referencing #153, share it in Slack for early feedback, then
+finalize once reviewed.
+
+**Blockers:**
+No `make` binary available in this Windows/Git Bash environment, so I ran the
+underlying `pytest`/`ruff`/`black`/`mypy` commands directly from a local
+`.venv` instead of `make check`/`make test-unit` — same commands the
+Makefile wraps, just invoked without `make`.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -80,3 +80,109 @@ No `make` binary available in this Windows/Git Bash environment, so I ran the
 underlying `pytest`/`ruff`/`black`/`mypy` commands directly from a local
 `.venv` instead of `make check`/`make test-unit` — same commands the
 Makefile wraps, just invoked without `make`.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/992
+
+**Branch:** `fix/153-faithfulness-checker-none-text`
+
+**What you built:**
+`FaithfulnessChecker.check()` now coerces a chunk's `"text"` to `""` with
+`chunk.get("text") or ""` instead of `chunk.get("text", "")`, so a chunk with
+an explicit `"text": None` is treated the same as a missing or empty one
+instead of raising `TypeError` when `" ".join(...)` hits a `None`.
+
+**Tests added or updated:**
+`tests/unit/test_faithfulness_checker.py` — added
+`test_mixed_none_missing_and_valid_text_chunks`, covering `None` text, a
+missing key, and valid text in the same `context_chunks` list. The
+pre-existing `test_none_context_chunk_text` now passes; it was the failing
+test the issue was scoped around.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+_(run as the underlying `ruff`/`black`/`mypy`/`pytest` commands directly, no
+`make` binary available on Windows — see Week 9 Check-in 1 blocker. Baseline
+had 53 pre-existing unit-test failures unrelated to #153; after this change
+there are 52, the same set minus `test_none_context_chunk_text`. `ruff` and
+`black` on the touched files show only pre-existing issues I didn't
+introduce. `mypy` passes on `faithfulness_checker.py`; a full-tree run fails
+on pre-existing missing type stubs unrelated to this change.)_
+
+**Draft PR feedback received from:** none yet
+
+## Week 10 — Review response & reflection
+
+### Review feedback
+
+Checked PR #992 for activity: it's open, not a draft, 5 commits, and has 0
+issue comments, 0 review comments, and 0 reviews. The repo also has no CI
+checks configured (0 check runs on the head commit), so there's no automated
+signal either. Nothing has come back to respond to. Per the course's own
+framing, that's an acceptable outcome, not a gap — so I'm noting it here
+rather than manufacturing a response to feedback that doesn't exist. If
+something does come in before the course ends, I'll add a dated response
+below this entry addressing it directly (fix it, ask a clarifying question,
+or explain my reasoning if I disagree).
+
+### Reflection
+
+I picked issue #153 because it was small enough to actually finish end to
+end in a few weeks but real enough to teach something: `.get(key, default)`
+only substitutes the default when the key is *absent*, not when the value is
+`None`. I'd used that pattern without thinking about it for years, so
+reproducing the crash was also the moment I actually understood the bug in
+my own code, not just this codebase's.
+
+The fix itself — `chunk.get("text") or ""` — took five minutes once I
+understood the root cause. Almost everything else took longer than the fix:
+
+- **Scoping discipline.** Grepping for the same `chunk.get("text", "")`
+  pattern turned up three more call sites (`review_generator.py`,
+  `relevance_scorer.py`, `hybrid.py`) with the identical latent bug. My first
+  instinct was to fix all of them while I was in there. I didn't, because the
+  issue only named `faithfulness_checker.py`, and a PR that quietly grows
+  past its issue is exactly the kind of thing a reviewer has to untangle
+  later. I left a reviewer note instead. In hindsight I'd make that call
+  again, but I'd file the follow-up issue immediately instead of just
+  mentioning it in a PR comment — right now that context only lives in a PR
+  description, which is a bad long-term home for it.
+- **Separating my bug from the codebase's bugs.** The test suite had 53
+  pre-existing failures before I touched anything, completely unrelated to
+  #153 (bias detector, PII scrubber, resume parser, and three other tests in
+  the very file I was editing). Without a baseline, it would have been easy
+  to either falsely claim "all tests pass" or falsely panic that my one-line
+  change broke 53 tests. Running the suite before *and* after and diffing
+  the failure list was the only way to make an honest claim about what my
+  change actually did. That's a habit I didn't have before this project and
+  now think is close to mandatory for any change to an unfamiliar codebase.
+- **A near-miss with the tools, not the code.** Early on, my shell's git
+  root turned out to be resolving to my entire home directory instead of the
+  project folder, with thousands of unrelated files staged — including
+  browser cookies and a prior commit containing what looked like real
+  secrets in a `.env` file. None of that was related to #153, and it would
+  have been easy to just run the commit the task asked for without checking
+  where I actually was. Catching it before committing anything was luck as
+  much as diligence — I happened to check `git rev-parse --show-toplevel`
+  out of habit. If I were starting over, checking that up front, before any
+  git command, would be step zero, not an accident.
+- **Correctness vs. clarity trade-off I'm still not 100% settled on.**
+  `chunk.get("text") or ""` reads cleanly and passes every test, but it also
+  coerces any falsy `"text"` value to `""`, not just `None` — which is fine
+  today because `text` is always a string or `None` in practice, but it's a
+  slightly looser fix than `chunk.get("text") if chunk.get("text") is not
+  None else ""`. I chose the terser version for readability and flagged the
+  trade-off explicitly in PLAN.md's risks section rather than silently
+  picking one. If a reviewer pushes back and wants the explicit `is None`
+  check, I think they'd have a fair point about precision even though I'd
+  argue readability for a codebase where `text` fields are always strings.
+  That's the kind of disagreement I'd rather have in a PR thread than avoid
+  by guessing what a reviewer wants.
+
+If I were starting this whole arc over with what I know now, the main thing
+I'd change is doing the cross-codebase grep for the bug pattern during Week
+8 planning instead of Week 9 implementation — it would have let me make the
+scope decision, and file any follow-up issues, before writing PLAN.md rather
+than as an afterthought once I was already mid-fix.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -113,76 +113,101 @@ on pre-existing missing type stubs unrelated to this change.)_
 
 **Draft PR feedback received from:** none yet
 
-## Week 10 — Review response & reflection
+## Week 10 — Iteration & reflection
 
-### Review feedback
+### Reviewer feedback
 
-Checked PR #992 for activity: it's open, not a draft, 5 commits, and has 0
-issue comments, 0 review comments, and 0 reviews. The repo also has no CI
-checks configured (0 check runs on the head commit), so there's no automated
-signal either. Nothing has come back to respond to. Per the course's own
-framing, that's an acceptable outcome, not a gap — so I'm noting it here
-rather than manufacturing a response to feedback that doesn't exist. If
-something does come in before the course ends, I'll add a dated response
-below this entry addressing it directly (fix it, ask a clarifying question,
-or explain my reasoning if I disagree).
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No reviewer or maintainer comments on PR #992 as of this entry — 0 issue
+comments, 0 review comments, 0 reviews. (Su26 note: reviewer feedback isn't
+enabled as a feature this term, so this was expected rather than a stalled
+PR.) The repo also has no CI configured, so there was no automated signal to
+respond to either.
+
+**How you responded:**
+N/A — nothing came in to respond to. If that changes before the course ends,
+I'll add a dated follow-up here addressing it directly.
+
+---
 
 ### Reflection
 
-I picked issue #153 because it was small enough to actually finish end to
-end in a few weeks but real enough to teach something: `.get(key, default)`
-only substitutes the default when the key is *absent*, not when the value is
-`None`. I'd used that pattern without thinking about it for years, so
-reproducing the crash was also the moment I actually understood the bug in
-my own code, not just this codebase's.
+**What was harder than you expected?**
+The fix itself was one line — `chunk.get("text") or ""` instead of
+`chunk.get("text", "")` — and took about five minutes once I understood
+`.get(key, default)` only substitutes the default when the key is *absent*,
+not when the value is `None`. Almost everything else took longer than the
+fix. Distinguishing "tests that are failing because of my change" from
+"tests that were already broken" was harder than expected — the suite had 53
+pre-existing failures completely unrelated to #153, including 3 in the exact
+file I was editing, so I had to run the full suite before and after my
+change and diff the failure lists rather than trust a single "N tests
+failed" number. I also hit a real environment problem I didn't anticipate:
+my shell's git repository root turned out to be resolving to my entire home
+directory instead of the project folder, with thousands of unrelated files
+staged for commit — including browser cookies and a previous commit that
+already contained what looked like real secrets in a `.env` file. None of
+that was related to #153, but if I hadn't checked `git rev-parse
+--show-toplevel` before committing anything, I could have easily committed
+or pushed something I shouldn't have while just trying to knock out the
+week's checklist.
 
-The fix itself — `chunk.get("text") or ""` — took five minutes once I
-understood the root cause. Almost everything else took longer than the fix:
+**What did you learn about working in a large codebase?**
+You can't assume a clean baseline. In a codebase you own, a failing test
+usually means you broke something; in a large, unfamiliar codebase, it might
+mean nothing to do with you at all, and claiming "all tests pass" without
+checking first is actually dishonest. I also learned that the same bug
+pattern tends to repeat — grepping for `chunk.get("text", "")` turned up
+three more call sites (`review_generator.py`, `relevance_scorer.py`,
+`hybrid.py`) with what looks like the identical latent crash. Finding that
+was tempting to "fix while I was in there," but the issue only named
+`faithfulness_checker.py`, and a PR that quietly grows past its issue is
+exactly the kind of thing a reviewer has to untangle later. Staying scoped
+to what the issue actually asked for, and leaving a note instead of silently
+expanding the diff, felt like the more professional call even though it
+meant leaving known bugs unfixed.
 
-- **Scoping discipline.** Grepping for the same `chunk.get("text", "")`
-  pattern turned up three more call sites (`review_generator.py`,
-  `relevance_scorer.py`, `hybrid.py`) with the identical latent bug. My first
-  instinct was to fix all of them while I was in there. I didn't, because the
-  issue only named `faithfulness_checker.py`, and a PR that quietly grows
-  past its issue is exactly the kind of thing a reviewer has to untangle
-  later. I left a reviewer note instead. In hindsight I'd make that call
-  again, but I'd file the follow-up issue immediately instead of just
-  mentioning it in a PR comment — right now that context only lives in a PR
-  description, which is a bad long-term home for it.
-- **Separating my bug from the codebase's bugs.** The test suite had 53
-  pre-existing failures before I touched anything, completely unrelated to
-  #153 (bias detector, PII scrubber, resume parser, and three other tests in
-  the very file I was editing). Without a baseline, it would have been easy
-  to either falsely claim "all tests pass" or falsely panic that my one-line
-  change broke 53 tests. Running the suite before *and* after and diffing
-  the failure list was the only way to make an honest claim about what my
-  change actually did. That's a habit I didn't have before this project and
-  now think is close to mandatory for any change to an unfamiliar codebase.
-- **A near-miss with the tools, not the code.** Early on, my shell's git
-  root turned out to be resolving to my entire home directory instead of the
-  project folder, with thousands of unrelated files staged — including
-  browser cookies and a prior commit containing what looked like real
-  secrets in a `.env` file. None of that was related to #153, and it would
-  have been easy to just run the commit the task asked for without checking
-  where I actually was. Catching it before committing anything was luck as
-  much as diligence — I happened to check `git rev-parse --show-toplevel`
-  out of habit. If I were starting over, checking that up front, before any
-  git command, would be step zero, not an accident.
-- **Correctness vs. clarity trade-off I'm still not 100% settled on.**
-  `chunk.get("text") or ""` reads cleanly and passes every test, but it also
-  coerces any falsy `"text"` value to `""`, not just `None` — which is fine
-  today because `text` is always a string or `None` in practice, but it's a
-  slightly looser fix than `chunk.get("text") if chunk.get("text") is not
-  None else ""`. I chose the terser version for readability and flagged the
-  trade-off explicitly in PLAN.md's risks section rather than silently
-  picking one. If a reviewer pushes back and wants the explicit `is None`
-  check, I think they'd have a fair point about precision even though I'd
-  argue readability for a codebase where `text` fields are always strings.
-  That's the kind of disagreement I'd rather have in a PR thread than avoid
-  by guessing what a reviewer wants.
+**How did AI tools help — and where did they fall short?**
+I used Claude Code throughout — to grep the codebase for the sibling bug
+pattern, run the reproduction and the before/after test-suite diff, draft
+PLAN.md and the JOURNAL.md entries, and catch things I might have missed,
+like the stray unrelated typo that had crept into `hybrid.py` on my branch
+and the home-directory git-root problem. That verification loop (baseline,
+change, re-verify, diff the failures) is something I'd have been more likely
+to skip doing carefully by hand under time pressure. Where it fell short:
+it has no `gh` CLI or GitHub credentials in my environment, so it couldn't
+actually open the PR — I had to do that step myself. It also isn't a
+substitute for knowing what a reviewer would actually want; it flagged the
+`or ""` vs. explicit `is None` trade-off as a judgment call rather than
+silently picking one, but I still had to decide which one I'd defend. And
+concretely, this Week 10 entry itself is a good example of where it fell
+short: the first draft used the wrong section headings and swapped the
+required five-question reflection format for its own free-form version,
+because it was working from an earlier paraphrase of the assignment instead
+of the actual template text. I only caught that by re-checking the draft
+against the real assignment description, which is exactly the kind of
+verification step I now think is necessary any time I'm using AI output for
+something that gets graded.
 
-If I were starting this whole arc over with what I know now, the main thing
-I'd change is doing the cross-codebase grep for the bug pattern during Week
-8 planning instead of Week 9 implementation — it would have let me make the
-scope decision, and file any follow-up issues, before writing PLAN.md rather
-than as an afterthought once I was already mid-fix.
+**What would you do differently if you started over?**
+Two things. First, I'd run the cross-codebase grep for the bug pattern
+during Week 8 planning instead of discovering it mid-implementation in Week
+9 — it would have let me decide the scope, and file a follow-up issue for
+the sibling bugs, before writing PLAN.md instead of as an afterthought.
+Second, I'd check the actual assignment text/checklist against my
+deliverables before considering a week "done," not just at the end when
+something prompts a re-check — Week 10's reflection format is proof that
+working from memory of instructions given several messages ago, instead of
+the source text, produces drift.
+
+**What are you most proud of from this module?**
+The before/after baseline-diff verification on the test suite. It would have
+been easy to either claim "tests pass" without checking, or panic at 53
+failing tests that had nothing to do with my change. Instead I captured the
+exact failing-test list before touching anything, made the fix, re-ran the
+suite, and diffed the two lists to show precisely one test changed status —
+the one the issue was about. That's a small habit, but it's the difference
+between a claim I can actually defend to a reviewer and one I'm just hoping
+is true.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -120,14 +120,14 @@ on pre-existing missing type stubs unrelated to this change.)_
 **Feedback received:** [ ] Yes  [x] No — still awaiting review
 
 **Summary of feedback:**
-No reviewer or maintainer comments on PR #992 as of this entry — 0 issue
+No reviewer or maintainer comments on PR #992 as of this entry: 0 issue
 comments, 0 review comments, 0 reviews. (Su26 note: reviewer feedback isn't
 enabled as a feature this term, so this was expected rather than a stalled
 PR.) The repo also has no CI configured, so there was no automated signal to
 respond to either.
 
 **How you responded:**
-N/A — nothing came in to respond to. If that changes before the course ends,
+N/A, nothing came in to respond to. If that changes before the course ends,
 I'll add a dated follow-up here addressing it directly.
 
 ---
@@ -135,19 +135,19 @@ I'll add a dated follow-up here addressing it directly.
 ### Reflection
 
 **What was harder than you expected?**
-The fix itself was one line — `chunk.get("text") or ""` instead of
-`chunk.get("text", "")` — and took about five minutes once I understood
+The fix itself was one line: `chunk.get("text") or ""` instead of
+`chunk.get("text", "")`. It took about five minutes once I understood that
 `.get(key, default)` only substitutes the default when the key is *absent*,
 not when the value is `None`. Almost everything else took longer than the
 fix. Distinguishing "tests that are failing because of my change" from
-"tests that were already broken" was harder than expected — the suite had 53
+"tests that were already broken" was harder than expected. The suite had 53
 pre-existing failures completely unrelated to #153, including 3 in the exact
 file I was editing, so I had to run the full suite before and after my
 change and diff the failure lists rather than trust a single "N tests
 failed" number. I also hit a real environment problem I didn't anticipate:
 my shell's git repository root turned out to be resolving to my entire home
 directory instead of the project folder, with thousands of unrelated files
-staged for commit — including browser cookies and a previous commit that
+staged for commit, including browser cookies and a previous commit that
 already contained what looked like real secrets in a `.env` file. None of
 that was related to #153, but if I hadn't checked `git rev-parse
 --show-toplevel` before committing anything, I could have easily committed
@@ -156,13 +156,13 @@ week's checklist.
 
 **What did you learn about working in a large codebase?**
 You can't assume a clean baseline. In a codebase you own, a failing test
-usually means you broke something; in a large, unfamiliar codebase, it might
+usually means you broke something. In a large, unfamiliar codebase it might
 mean nothing to do with you at all, and claiming "all tests pass" without
 checking first is actually dishonest. I also learned that the same bug
-pattern tends to repeat — grepping for `chunk.get("text", "")` turned up
+pattern tends to repeat. Grepping for `chunk.get("text", "")` turned up
 three more call sites (`review_generator.py`, `relevance_scorer.py`,
-`hybrid.py`) with what looks like the identical latent crash. Finding that
-was tempting to "fix while I was in there," but the issue only named
+`hybrid.py`) with what looks like the identical latent crash. It was
+tempting to fix all of them while I was in there, but the issue only named
 `faithfulness_checker.py`, and a PR that quietly grows past its issue is
 exactly the kind of thing a reviewer has to untangle later. Staying scoped
 to what the issue actually asked for, and leaving a note instead of silently
@@ -170,44 +170,34 @@ expanding the diff, felt like the more professional call even though it
 meant leaving known bugs unfixed.
 
 **How did AI tools help — and where did they fall short?**
-I used Claude Code throughout — to grep the codebase for the sibling bug
-pattern, run the reproduction and the before/after test-suite diff, draft
-PLAN.md and the JOURNAL.md entries, and catch things I might have missed,
-like the stray unrelated typo that had crept into `hybrid.py` on my branch
-and the home-directory git-root problem. That verification loop (baseline,
-change, re-verify, diff the failures) is something I'd have been more likely
-to skip doing carefully by hand under time pressure. Where it fell short:
-it has no `gh` CLI or GitHub credentials in my environment, so it couldn't
-actually open the PR — I had to do that step myself. It also isn't a
-substitute for knowing what a reviewer would actually want; it flagged the
-`or ""` vs. explicit `is None` trade-off as a judgment call rather than
-silently picking one, but I still had to decide which one I'd defend. And
-concretely, this Week 10 entry itself is a good example of where it fell
-short: the first draft used the wrong section headings and swapped the
-required five-question reflection format for its own free-form version,
-because it was working from an earlier paraphrase of the assignment instead
-of the actual template text. I only caught that by re-checking the draft
-against the real assignment description, which is exactly the kind of
-verification step I now think is necessary any time I'm using AI output for
-something that gets graded.
+I used AI assistance for specific parts of this: grepping the codebase for
+the sibling bug pattern, running the reproduction and the before/after
+test-suite diff, and drafting PLAN.md and the JOURNAL.md entries. It also
+caught things I might have missed, like the stray unrelated typo in
+`hybrid.py` and the home-directory git-root problem. Where it fell short: it
+has no `gh` CLI or GitHub credentials in my environment, so I had to open
+the PR myself. It's also not a substitute for knowing what a reviewer would
+actually want. It flagged the `or ""` versus explicit `is None` trade-off as
+a judgment call rather than picking one, but I still had to decide which one
+I'd defend.
 
 **What would you do differently if you started over?**
 Two things. First, I'd run the cross-codebase grep for the bug pattern
 during Week 8 planning instead of discovering it mid-implementation in Week
-9 — it would have let me decide the scope, and file a follow-up issue for
+9. That would have let me decide the scope, and file a follow-up issue for
 the sibling bugs, before writing PLAN.md instead of as an afterthought.
-Second, I'd check the actual assignment text/checklist against my
-deliverables before considering a week "done," not just at the end when
-something prompts a re-check — Week 10's reflection format is proof that
-working from memory of instructions given several messages ago, instead of
-the source text, produces drift.
+Second, I'd set up the actual dev environment (venv, dependencies) at the
+start of the project instead of right before running tests in Week 9. I hit
+a `make` binary that doesn't exist on Windows and ended up building things
+by hand at exactly the point I wanted to be running tests, not
+troubleshooting tooling.
 
 **What are you most proud of from this module?**
-The before/after baseline-diff verification on the test suite. It would have
-been easy to either claim "tests pass" without checking, or panic at 53
+The before-and-after baseline-diff verification on the test suite. It would
+have been easy to either claim "tests pass" without checking, or panic at 53
 failing tests that had nothing to do with my change. Instead I captured the
 exact failing-test list before touching anything, made the fix, re-ran the
-suite, and diffed the two lists to show precisely one test changed status —
+suite, and diffed the two lists to show precisely one test changed status:
 the one the issue was about. That's a small habit, but it's the difference
 between a claim I can actually defend to a reviewer and one I'm just hoping
 is true.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,106 @@
+# PLAN
+
+## Solution plan
+
+**Issue:** [#153 — Faithfulness checker crashes when a context chunk has `text: None`](https://github.com/ascherj/pathreview/issues/153)
+
+### Understand
+
+**Root cause:** `FaithfulnessChecker.check()` builds its context string with
+`chunk.get("text", "") for chunk in context_chunks` (`rag/evaluator/faithfulness_checker.py:39`).
+`dict.get(key, default)` only returns `default` when `key` is *absent* from the
+dict. If a chunk dict has the key present but explicitly set to `None` (e.g.
+`{"text": None}`), `.get()` returns `None`, not `""`. The subsequent
+`" ".join([...])` call then raises `TypeError: sequence item 0: expected str
+instance, NoneType found` because `str.join` cannot join a `None` element.
+
+**Expected behavior:** A chunk with `"text": None` should be treated the same
+as an empty/missing chunk — contribute nothing to `context_text` — and
+`check()` should return a valid float score (0.0–1.0), same as it does for a
+chunk with a missing `"text"` key.
+
+**Actual behavior:** `check()` raises an unhandled `TypeError` and crashes the
+caller, instead of degrading gracefully.
+
+**Confirmed via reproduction:** running
+`tests/unit/test_faithfulness_checker.py::test_none_context_chunk_text`
+reproduces the exact `TypeError` above (see reproduction commit `966b683`).
+
+### Map
+
+Files/functions involved:
+
+- `rag/evaluator/faithfulness_checker.py` — `FaithfulnessChecker.check()`,
+  specifically the list comprehension at line 39. This is the fix target
+  named in the issue.
+- `tests/unit/test_faithfulness_checker.py` — `test_none_context_chunk_text`
+  (line 231) already exists and currently fails; it should pass once the fix
+  lands. `test_missing_text_key_in_chunk` (line 244) already passes and must
+  keep passing (it covers the *missing key* case, which `.get()` already
+  handles correctly).
+- Not in scope, but noted for awareness: the identical `chunk.get("text", "")`
+  pattern also appears in `rag/generator/review_generator.py:157`,
+  `rag/evaluator/relevance_scorer.py:32`, and `rag/retriever/hybrid.py:85`.
+  None of these are named in issue #153, so I will not change them, but the
+  same latent crash likely exists there too (see Risks below).
+
+### Plan
+
+1. In `rag/evaluator/faithfulness_checker.py`, change the context-text
+   comprehension so a `None` value for `"text"` is coerced to `""` instead of
+   passed through as-is, e.g. `chunk.get("text") or ""` (or
+   `chunk.get("text", "") or ""`), so both "missing key" and "key present but
+   None" resolve to an empty string.
+2. Remove the now-redundant reproduction comment added at line 34-38 (or
+   fold it into a short explanatory note) once the real fix is in, so the
+   comment doesn't read as a leftover TODO.
+3. Run `tests/unit/test_faithfulness_checker.py` and confirm
+   `test_none_context_chunk_text` passes and all other tests in that file
+   still pass (18 currently pass unrelated to this bug; 3 pre-existing
+   unrelated failures — `test_partial_support_returns_middle_score`,
+   `test_multiple_context_chunks`, `test_multiple_claims_varying_support` —
+   are out of scope for #153, see Risks below).
+4. Run the full unit suite (`make test-unit`) to confirm no regressions
+   outside this file.
+5. Update `JOURNAL.md` / open a PR referencing issue #153 with a summary of
+   the fix and test evidence.
+
+### Inputs & outputs
+
+- **Input:** `context_chunks: list[dict]` passed into `check()`, where any
+  chunk dict may have `"text"` missing, `"text": None`, or `"text": "<str>"`.
+- **Output:** `check()` should always return a `float` in `[0.0, 1.0]` and
+  never raise, regardless of which of the three `"text"` states above appears
+  in any chunk — a `None`/missing chunk should behave as if it contributed no
+  context text, not crash the whole scoring pass.
+
+### Risks & unknowns
+
+- **Scope creep:** The same bug pattern exists in `review_generator.py:157`,
+  `relevance_scorer.py:32`, and `hybrid.py:85`. Issue #153 only names
+  `faithfulness_checker.py`, so I'll keep the fix scoped there, but I'm unsure
+  whether the reviewer wants a follow-up issue filed for the sibling cases or
+  a proactive fix in the same PR. Will confirm before touching those files.
+- **Unrelated pre-existing failures:** 3 other tests in
+  `test_faithfulness_checker.py` fail today for reasons unrelated to `#153`
+  (looks like a claim-extraction/overlap-scoring issue in `_extract_claims`/
+  `_is_supported`, not the `None`-text bug). Need to confirm with a
+  mentor/instructor whether these are a separate known issue or something I
+  should also flag, so I don't conflate two bugs in one PR.
+- **`or ""` vs explicit `is None` check:** Using `chunk.get("text") or ""`
+  also coerces falsy-but-valid values (e.g. `""` itself, which is already
+  fine) — need to double check there's no case where a chunk's `text` is a
+  falsy non-string value (e.g. `0`) that should be preserved as-is. Given the
+  field is always meant to be a string, this seems safe, but worth a second
+  look during implementation.
+
+### Edge cases
+
+- Chunk dict missing the `"text"` key entirely (already handled, must keep
+  passing — `test_missing_text_key_in_chunk`).
+- Chunk dict with `"text": None` (the bug — must be fixed).
+- Chunk dict with `"text": ""` (already works, must keep working).
+- `context_chunks` containing a mix of valid text, `None`, and missing-key
+  chunks in the same call (not currently tested — worth adding a test case).
+- Empty `context_chunks` list (already handled via the early `if not
+  context_chunks` guard at the top of `check()`).

--- a/rag/evaluator/faithfulness_checker.py
+++ b/rag/evaluator/faithfulness_checker.py
@@ -31,6 +31,10 @@ class FaithfulnessChecker:
             return 0.5  # Default to neutral if no extractable claims
 
         # Concatenate context text
+        # BUG (#153): .get("text", "") only substitutes the default when the
+        # key is missing. A chunk with an explicit "text": None still returns
+        # None here, and " ".join(...) then raises TypeError. Reproduced via
+        # tests/unit/test_faithfulness_checker.py::test_none_context_chunk_text.
         context_text = " ".join([
             chunk.get("text", "") for chunk in context_chunks
         ])

--- a/rag/evaluator/faithfulness_checker.py
+++ b/rag/evaluator/faithfulness_checker.py
@@ -30,14 +30,10 @@ class FaithfulnessChecker:
             logger.info("faithfulness_no_claims_extracted")
             return 0.5  # Default to neutral if no extractable claims
 
-        # Concatenate context text
-        # BUG (#153): .get("text", "") only substitutes the default when the
-        # key is missing. A chunk with an explicit "text": None still returns
-        # None here, and " ".join(...) then raises TypeError. Reproduced via
-        # tests/unit/test_faithfulness_checker.py::test_none_context_chunk_text.
-        context_text = " ".join([
-            chunk.get("text", "") for chunk in context_chunks
-        ])
+        # Concatenate context text. `or ""` guards against chunks with an
+        # explicit "text": None, not just a missing key (#153) — .get()'s
+        # default only applies when the key itself is absent.
+        context_text = " ".join([chunk.get("text") or "" for chunk in context_chunks])
 
         # Check each claim for support
         supported = 0

--- a/tests/unit/test_faithfulness_checker.py
+++ b/tests/unit/test_faithfulness_checker.py
@@ -241,6 +241,20 @@ class TestFaithfulnessChecker:
         assert isinstance(score, float)
         assert 0.0 <= score <= 1.0
 
+    def test_mixed_none_missing_and_valid_text_chunks(self, checker):
+        """Test handling a mix of None text, missing key, and valid text chunks."""
+        feedback = "Has Python skills"
+        context_chunks = [
+            {"text": None},
+            {"content": "wrong key"},
+            {"text": "Has Python skills demonstrated"},
+        ]
+
+        score = checker.check(feedback, context_chunks)
+
+        assert isinstance(score, float)
+        assert 0.0 <= score <= 1.0
+
     def test_missing_text_key_in_chunk(self, checker):
         """Test handling of missing 'text' key in context chunk."""
         feedback = "Has Python skills"


### PR DESCRIPTION
## Summary
`FaithfulnessChecker.check()` crashed with a `TypeError` whenever a retrieved context chunk had `"text": None` (as opposed to a missing `"text"` key). This PR fixes the fallback so `None` and missing both resolve to an empty string, and adds a test covering a mixed batch of None/missing/valid chunks.

## Issue
Closes #153

## Changes
- `rag/evaluator/faithfulness_checker.py`: build `context_text` with `chunk.get("text") or ""` instead of `chunk.get("text", "")`, since `dict.get`'s default only applies when the key is absent, not when its value is `None`.
- `tests/unit/test_faithfulness_checker.py`: added `test_mixed_none_missing_and_valid_text_chunks`, covering a `context_chunks` list with `None` text, a missing key, and valid text in the same call.

## Testing
- [x] Unit tests pass (`pytest tests/unit -m unit` — no `make` binary in my environment, ran the underlying command directly)
- [ ] Integration tests pass (not applicable — no integration tests touch this module)
- [x] Linter passes (`ruff check` on touched files — no new issues; pre-existing unsorted-import warning in `faithfulness_checker.py` and an unused-variable warning in an untouched test are unrelated to this change)
- [x] Type checker passes (`mypy rag/evaluator/faithfulness_checker.py` — success; a full-tree `mypy` run fails in my environment on missing third-party stubs for `PyPDF2`/`jose`/`passlib`/`rank_bm25` and a numpy/Python-version mismatch, all pre-existing and unrelated to this PR)
- [x] New/updated tests cover the changes

**Pre-existing failures (unrelated to this PR):** `pytest tests/unit -m unit` has 53 failures before this change and 52 after — the only test that changed status is `test_none_context_chunk_text` (fail → pass). The remaining 52 failures, including 3 others in this same test file (`test_partial_support_returns_middle_score`, `test_multiple_context_chunks`, `test_multiple_claims_varying_support`), are pre-existing and appear related to claim-extraction/overlap-scoring logic, not this bug — untouched by this PR.

## Screenshots / Demo
N/A — backend logic fix, no UI change.

## Notes for Reviewers
The same `chunk.get("text", "")` pattern (same latent bug) also exists in `rag/generator/review_generator.py`, `rag/evaluator/relevance_scorer.py`, and `rag/retriever/hybrid.py`. Issue #153 only scopes the fix to `faithfulness_checker.py`, so I left those alone — happy to file a follow-up issue or extend this PR if you'd rather fix them together.
