### PR TITLE
fix(api): stop fabricating reviews for profiles with no documents

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -12,3 +12,17 @@ Currently, the codebase lacks a unit test to verify how the `POST /reviews` endp
 **Branch name:** test/88-review-endpoint-missing-documents
 **Setup confirmation:** [x] App runs locally at localhost:5173
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/lakshita1212/pathreview/commit/323b79b5b283bbd6a8e8dbdf5c7bab89c4da7532
+
+**Reproduction summary:**
+Ran `process_review` against a mocked profile with zero ingested documents (no GitHub, portfolio, or resume). Ingestion correctly returned 0 sources, yet the review was still marked `complete` with 3 fabricated sections and `overall_score=0.81` — because the agent/RAG steps return hard-coded placeholder output regardless of input. Captured this in [tests/unit/test_review_routes.py](tests/unit/test_review_routes.py) as a passing root-cause test plus a strict `xfail` test pinning the desired behavior.
+
+**PLAN.md link:** [PLAN.md](PLAN.md)
+
+**Walkthrough video (recommended):** _not recorded_
+
+**Blockers or open questions:**
+Which terminal state is the intended contract for an empty-document review — `failed`, a new `empty` status, or `complete` with empty sections? Need to confirm with the maintainer / `docs/API.md` since the frontend may branch on `status`. The issue is framed as test-coverage, so I may need to confirm whether the accompanying behavior guard is in scope or should ship separately.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,5 +1,14 @@
 # Module 3 Contribution Journal
 
-## Week 7
-- **Issue:** #88 - POST /reviews endpoint has no test for when the profile has no ingested documents
-- **Status:** Forked the repository, set up the local environment, and created the working branch.
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/88
+**Issue title:** POST /reviews endpoint has no test for when the profile has no ingested documents
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+Currently, the codebase lacks a unit test to verify how the `POST /reviews` endpoint behaves when a user profile attempts to generate a review but has zero ingested documents. This gap in test coverage means potential edge-case failures or unhandled exceptions under empty document states might go unnoticed. A successful fix will involve writing mock test cases in the backend test suite to ensure the system gracefully handles empty-document profiles, returning the correct error code or empty response payload. This directly affects the backend routing and review service modules.
+
+**Branch name:** test/88-review-endpoint-missing-documents
+**Setup confirmation:** [x] App runs locally at localhost:5173
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,5 @@
+# Module 3 Contribution Journal
+
+## Week 7
+- **Issue:** #88 - POST /reviews endpoint has no test for when the profile has no ingested documents
+- **Status:** Forked the repository, set up the local environment, and created the working branch.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -98,3 +98,145 @@ declared in `pyproject.toml` but were missing from my local venv.
 **Draft PR feedback received from:** none — PR #993 was opened directly as ready
 for review rather than as a draft, so no peer feedback was gathered before
 submission.
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No feedback came in. PR #993 is still open with no reviews, no reviewer
+assignments, and no comments. This is expected for Summer 2026, where reviewer
+feedback isn't part of the course. Worth noting that the upstream repo had ~807
+open PRs when I submitted, so a real maintainer response was never likely on a
+one-week horizon.
+
+I did retitle the PR after submitting. GitHub had auto-generated the title from
+my branch name (`Test/88 review endpoint missing documents`), which doesn't match
+the Conventional Commits standard in `docs/CONTRIBUTING.md`. Since maintainers on
+a repo that size almost certainly squash-merge using the PR title, that would
+have put a non-conforming commit on `main`. It's now
+`fix(api): stop fabricating reviews for profiles with no documents`.
+
+**How you responded:**
+No feedback to respond to.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+
+Verifying my own work was harder than writing it. The fix itself was about 15
+lines; establishing that it was correct took longer than implementing it.
+
+The sharpest example: to prove my tests actually caught the bug, I removed the
+guard and re-ran them. The script I wrote to do this crashed on a Windows path
+issue *before* it modified anything — but the test run afterward still printed
+`7 passed`, which read exactly like confirmation. I nearly accepted that as proof
+my tests were sound, when it proved nothing at all: the tests passed because the
+fix was still in place. Re-running it properly showed 5 of 7 tests failing without
+the guard, and that the 2 still passing were exactly the two that should (the
+ingestion root-cause test and the happy-path regression guard). The failure mode
+that scared me wasn't a broken test, it was a green result that meant nothing.
+
+The second hard part was separating my breakage from the repo's. The suite had 45
+failures and 7 collection errors before I touched anything, so "did the tests
+pass?" was the wrong question. I had to diff the *set* of failing tests before and
+after in the same environment. That also caught a red herring: an "un-awaited
+coroutine" warning that pytest attributed to an unrelated `test_tech_detector`
+test. It looked like mine. It wasn't — it came from the pre-existing
+`AsyncMock().scalars()` misuse in `test_review_service.py`, and reproduced with my
+file excluded entirely.
+
+**What did you learn about working in a large codebase?**
+
+That the answers to design questions are usually already written down in the code,
+just not where you'd look for them.
+
+I went into Week 9 with an open question I'd flagged as needing a maintainer:
+should an empty-document review be `failed`, a new `empty` status, or `complete`
+with no sections? I expected to be blocked. Instead I found the contract stated in
+three places — `core/models/review.py` comments the vocabulary as
+`pending`/`processing`/`complete`/`failed`, `frontend/src/types/index.ts` pins it
+as a closed TypeScript union, and `useReviewStatus.ts` only stops polling on
+`complete` or `failed`. That last one settled it: a new `empty` status would have
+left the UI polling forever. And `ReviewPage.tsx` already renders `error_message`
+for failed reviews, so the honest failure state had a UI path with no new work.
+
+That's the real difference from my own projects. In my own code I *am* the
+contract, so a question like this is a preference. Here the decision was already
+constrained by consumers I didn't write and wouldn't have thought to check — the
+frontend was the deciding evidence for a backend change. Reading outward from the
+change to everything that depends on it is a habit my own projects never taught me,
+because nothing else ever depended on them.
+
+The other lesson: the blast radius of a "small" change is a judgment call. My issue
+was framed as *test coverage*, but writing an honest test meant asserting behavior
+that didn't exist, which meant changing behavior. I flagged that scope tension
+explicitly in the PR rather than quietly expanding it, and noted I'd be happy to
+split the guard into a separate PR if maintainers preferred tests-only.
+
+**How did AI tools help — and where did they fall short?**
+
+Most useful for orientation and for mechanical correctness. Tracing how
+`process_review` reached the fabricated output, finding every place the status
+vocabulary was defined across both the Python and TypeScript sides, and matching
+the existing test file's mocking conventions were all much faster than they would
+have been by hand. It was also good at the boring rigor — remembering to diff the
+failure set before and after rather than eyeballing a pass count, checking that
+`mypy` reported the same 7 errors before and after rather than assuming.
+
+Where it fell short: it can't tell you what's *correct*, only what's *consistent*.
+The `failed`-vs-`empty` decision came from reading the frontend and reasoning about
+what would strand the UI — AI surfaced the evidence quickly but the call was a
+judgment about a product contract. Same with scope: nothing in the tooling tells
+you that a test-framed issue shouldn't quietly become a behavior change.
+
+And it produced the exact failure I described above — a verification script that
+silently no-opped and returned a result that looked like success. The tooling was
+confident; the output was meaningless. What actually caught it was noticing the
+result didn't square with what I expected to see. That's the part I couldn't
+delegate: not generating the check, but being suspicious of a green one.
+
+A limitation I'll own rather than paper over — my tests are heavily mocked. They
+pin the guard's logic precisely, but they'd miss a real SQLAlchemy session or
+migration problem, and I never ran the integration suite because it needs Docker
+services I don't have. I'm confident about the branch I added, not about the full
+path through a live database.
+
+**What would you do differently if you started over?**
+
+Open the draft PR early, in Week 8, instead of going straight to a finished PR in
+Week 9. I skipped the peer-review step entirely and documented it honestly as
+"none," but that was the one part of the process I actually lost value from. My
+Week 8 open question about the terminal state was exactly the kind of thing a
+draft PR exists to resolve — I ended up answering it myself by reading the
+frontend, and I think the answer is right, but I never got it checked. A draft with
+"is `failed` the contract you want here?" in the description would have cost
+nothing.
+
+I'd also set the environment up properly on day one. `make` isn't available on my
+Windows setup, and `tiktoken` and `httpx` were declared in `pyproject.toml` but
+missing from my venv — which meant 7 test modules couldn't even be collected. I
+worked around that for two weeks by invoking `.venv/Scripts/python.exe` directly
+before finally just installing the missing packages. The workaround was slower
+than the fix, and it muddied my baseline measurements until I fixed it.
+
+**What are you most proud of from this module?**
+
+Not the fix — the moment I distrusted a passing test run.
+
+Everything about that result said I was done: 7 tests, all green, on a fix I'd
+just written. Chasing down why it *shouldn't* be trusted, and finding that my
+verification had silently never run, is the thing I'd want to be judged on. The
+guard itself is fifteen lines that any competent developer would write. Knowing
+that "the tests pass" and "the tests would catch this bug" are different claims —
+and building the experiment that separates them — is the part I didn't have four
+weeks ago.
+
+The related thing I'll keep: writing the failing test first, as a strict `xfail` in
+Week 8. It meant that by the time I wrote the fix, the definition of "correct" was
+already committed to the repo and couldn't quietly bend to whatever I happened to
+implement.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -95,4 +95,6 @@ Pre-existing issues I did not touch: 13 `AsyncMock().scalars()` failures in
 declared in `pyproject.toml` but were missing from my local venv.
 `make test-integration` was not run — it requires Docker services I don't have.
 
-**Draft PR feedback received from:** none yet — draft PR opened for peer review in Slack
+**Draft PR feedback received from:** none — PR #993 was opened directly as ready
+for review rather than as a draft, so no peer feedback was gathered before
+submission.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -26,3 +26,73 @@ Ran `process_review` against a mocked profile with zero ingested documents (no G
 
 **Blockers or open questions:**
 Which terminal state is the intended contract for an empty-document review — `failed`, a new `empty` status, or `complete` with empty sections? Need to confirm with the maintainer / `docs/API.md` since the frontend may branch on `status`. The issue is framed as test-coverage, so I may need to confirm whether the accompanying behavior guard is in scope or should ship separately.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Resolved the Week 8 open question about the terminal state without needing to
+wait on the maintainer, by reading the contract off the code: `core/models/review.py`
+documents the status vocabulary as `pending`/`processing`/`complete`/`failed`, and
+the frontend pins it as a closed union in `frontend/src/types/index.ts`. The polling
+hook (`useReviewStatus.ts`) only stops on `complete` or `failed`, so inventing an
+`empty` status would leave the UI polling forever, and `ReviewPage.tsx` already
+renders `error_message` for failed reviews. That made `failed` + `error_message`
+the clear choice — and it needs no migration, since `error_message` already exists
+on the model and on `ReviewResponse`.
+
+Done from PLAN.md: steps 1–4. The guard is implemented in `process_review`
+(step 2), the `xfail` test is flipped to a passing assertion, and the companion
+plus endpoint-level tests are written — `tests/unit/test_review_routes.py` went
+from 2 tests to 7, all passing.
+
+**Next steps:**
+Step 5 — full verification against contribution standards, then the draft PR.
+
+**Blockers:**
+None remaining. `make` isn't available on my Windows setup, so I run the Makefile
+targets through `.venv/Scripts/python.exe` directly.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** _to be filled in — see "Submission" note below_
+
+**Branch:** `test/88-review-endpoint-missing-documents`
+
+**What you built:**
+`POST /reviews` was marking reviews `complete` with three fabricated feedback
+sections and `overall_score=0.81` for profiles that had ingested zero documents,
+because the agent and RAG steps return hard-coded placeholder output regardless
+of their input. I added an early guard in `process_review` that stops right after
+ingestion when no sources were produced, recording `status="failed"` with empty
+sections, a null score, and an explanatory `error_message` the existing UI already
+knows how to display.
+
+**Tests added or updated:**
+`tests/unit/test_review_routes.py` — expanded from 2 tests to 7, covering the
+terminal state, the error message, that the agent/RAG steps are skipped entirely,
+the empty-string `resume_text` edge case, a regression guard that populated
+profiles still reach `complete`, and an endpoint-level `TestClient` test asserting
+`POST /reviews` returns `pending` immediately before the background task resolves
+the review to `failed`. I confirmed the tests genuinely catch the bug by removing
+the guard and re-running: 5 of the 7 fail, and the 2 that still pass are exactly
+the ones that should.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+Both pass in the sense the course defines for a codebase with documented
+pre-existing failures — my changes introduce no new ones. Measured in the same
+environment before and after: **46 failed / 299 passed / 1 xfailed** before,
+**46 failed / 305 passed** after, with an identical set of failing tests (I diffed
+the `FAILED`/`ERROR` lines). The +6 passing are my 5 net-new tests plus the
+previously-`xfail` test that now passes. `ruff` is clean on both changed files and
+`mypy` reports the same 7 pre-existing errors before and after — 0 introduced.
+Pre-existing issues I did not touch: 13 `AsyncMock().scalars()` failures in
+`test_review_service.py`, and collection errors from `tiktoken`/`httpx`, which are
+declared in `pyproject.toml` but were missing from my local venv.
+`make test-integration` was not run — it requires Docker services I don't have.
+
+**Draft PR feedback received from:** none yet — draft PR opened for peer review in Slack

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -58,7 +58,7 @@ targets through `.venv/Scripts/python.exe` directly.
 
 ### Check-in 2 (end of week)
 
-**PR link:** _to be filled in — see "Submission" note below_
+**PR link:** https://github.com/ascherj/pathreview/pull/993
 
 **Branch:** `test/88-review-endpoint-missing-documents`
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,96 @@
+## Solution plan
+
+**Issue:** [#88 — POST /reviews endpoint has no test for when the profile has no ingested documents](https://github.com/ascherj/pathreview/issues/88)
+
+### Understand
+
+**Root cause.** `POST /reviews` accepts a `profile_id`, creates a `pending`
+review, and schedules `process_review` as a background task. Inside
+`process_review` (`core/services/review_service.py`), the ingestion pipeline
+(`_run_ingestion_pipeline`) correctly returns an **empty** source list when a
+profile has no `github_username`, `portfolio_url`, or `resume_text`. But the
+downstream steps never check whether ingestion produced anything:
+`_run_agent_orchestration` and `_run_rag_retrieval_generation` return
+hard-coded placeholder sections regardless of their inputs. As a result the
+review is marked `"complete"` with fabricated feedback and a non-null
+`overall_score`.
+
+There is **no test** covering this empty-document path — the stated Tier-1
+gap — so the fabrication goes unnoticed.
+
+**Expected vs. actual** (for a profile with zero ingested documents):
+
+| | Expected | Actual |
+|---|---|---|
+| Ingested sources | 0 | 0 |
+| Review status | not `complete` (e.g. `failed` / `empty`) | `complete` |
+| Sections | none / explanatory | 3 fabricated sections |
+| overall_score | `None` | `0.81` |
+
+Reproduced locally — see the reproduction commit and
+[tests/unit/test_review_routes.py](tests/unit/test_review_routes.py).
+
+### Map
+
+Files/functions involved:
+
+- [core/services/review_service.py](core/services/review_service.py)
+  - `process_review` — needs an early guard after ingestion.
+  - `_run_ingestion_pipeline` — source of the empty list (behaves correctly; no change expected).
+- [api/routes/reviews.py](api/routes/reviews.py) — `create_review_endpoint` (endpoint under test; likely unchanged).
+- [tests/unit/test_review_routes.py](tests/unit/test_review_routes.py) — where the new coverage lands (**primary deliverable**).
+- [api/schemas/review.py](api/schemas/review.py) — confirm the shape a no-document review should return.
+
+Files I expect to touch:
+1. `tests/unit/test_review_routes.py` — add the empty-document test(s).
+2. `core/services/review_service.py` — add the empty-ingestion guard.
+
+### Plan
+
+1. **Keep the reproduction tests** already added to `test_review_routes.py`
+   (root-cause test + `xfail` desired-behavior test).
+2. **Add the guard** in `process_review`: after `_run_ingestion_pipeline`, if
+   `ingestion_results` is empty, stop the pipeline and set a terminal state
+   (`status="failed"` with an empty `sections=[]` and `overall_score=None`),
+   logging a `review_empty_profile` event — instead of running agent/RAG steps.
+3. **Flip the `xfail`** into a passing assertion once the guard exists, and add
+   companion tests: (a) empty profile → non-`complete` terminal status with no
+   fabricated sections; (b) non-empty profile still reaches `complete`
+   (regression guard so the fix doesn't break the happy path).
+4. **Add an endpoint-level test** with FastAPI `TestClient`, overriding
+   `get_current_user` / `get_db`, asserting `POST /reviews` returns a `pending`
+   review immediately and that the background task leaves an empty profile in
+   the terminal non-`complete` state.
+5. **Run** `make test-unit` (or `pytest tests/unit -m unit`) and confirm green.
+
+### Inputs & outputs
+
+- **Input:** a `Profile` with all source fields empty/`None` (and a valid
+  authenticated user), driven through `create_review` → `process_review`.
+- **Output/change:** new assertions in the test suite; a small behavioral
+  guard so an empty-document review terminates in a truthful state
+  (`failed`/empty) rather than a fabricated `complete` one.
+
+### Risks & unknowns
+
+- **Which terminal state is "correct"?** `failed` vs. a new `empty`/`skipped`
+  status vs. `complete` with empty sections. Need to confirm the intended
+  contract with the maintainer / `docs/API.md`; the frontend may branch on
+  `status`. I'll default to `failed` + `sections=[]` and flag it in the PR.
+- **Scope creep:** the issue is framed as *test coverage*. The guard is a
+  minimal behavior change to make the desired test pass; if maintainers prefer
+  tests-only, I can land the tests as `xfail` documenting the gap and open the
+  behavior change separately.
+- **Pre-existing async-mock failures** in `test_review_service.py` (13 fail due
+  to `AsyncMock().scalars()` returning a coroutine) — out of scope, but I'll use
+  plain `Mock` result objects to avoid the same trap.
+
+### Edge cases
+
+- Profile with **some** sources missing but at least one present → must still
+  reach `complete` (only *fully* empty profiles are affected).
+- Profile that doesn't exist → already handled (`status="failed"`).
+- Whitespace-only / empty-string `resume_text` (`""`) → treated as no source
+  (falsy), should follow the empty path; confirm with a test.
+- Background-task exceptions → existing `except` sets `status="failed"`; the
+  new guard should not mask genuine failures.

--- a/core/services/review_service.py
+++ b/core/services/review_service.py
@@ -1,15 +1,23 @@
-from uuid import UUID
-import structlog
 import json
 from datetime import datetime
-from sqlalchemy import select, and_
+from uuid import UUID
 
-from core.models.review import Review
-from core.models.profile import Profile
-from core.models.ingested_source import IngestedSource
+import structlog
+from sqlalchemy import and_, select
+
 from api.schemas.review import FeedbackSection
+from core.models.ingested_source import IngestedSource
+from core.models.profile import Profile
+from core.models.review import Review
 
 log = structlog.get_logger()
+
+#: Shown to the user when a review is requested for a profile that has no
+#: ingestable sources. Surfaced through ``Review.error_message``.
+EMPTY_PROFILE_ERROR_MESSAGE = (
+    "No documents were found for this profile. Add a GitHub username, "
+    "a portfolio URL, or a resume before requesting a review."
+)
 
 
 async def create_review(
@@ -40,8 +48,8 @@ async def get_review(
     """
     Get a review by ID, checking that it belongs to the user's profile.
     """
-    stmt = select(Review).join(Profile).where(
-        and_(Review.id == review_id, Profile.user_id == user_id)
+    stmt = (
+        select(Review).join(Profile).where(and_(Review.id == review_id, Profile.user_id == user_id))
     )
     result = await db.execute(stmt)
     return result.scalars().first()
@@ -89,6 +97,9 @@ async def process_review(
     Steps:
     1. Set status="processing"
     2. Run ingestion pipeline on profile's sources
+       2a. If ingestion produced no sources, set status="failed" with an
+           explanatory error_message and stop — generating feedback from
+           zero documents would fabricate it.
     3. Run agent orchestration
     4. Run RAG retrieval + generation
     5. Run safety checks on output
@@ -131,6 +142,25 @@ async def process_review(
             review_id=str(review_id),
             sources_count=len(ingestion_results),
         )
+
+        # Step 2a: Stop early when the profile has no ingested documents.
+        # The agent and RAG steps generate feedback unconditionally, so
+        # continuing here would fabricate a "complete" review from no
+        # evidence at all (see issue #88).
+        if not ingestion_results:
+            log.warning(
+                "review_empty_profile",
+                review_id=str(review_id),
+                profile_id=str(profile_id),
+            )
+            review.status = "failed"
+            review.sections = []
+            review.overall_score = None
+            review.error_message = EMPTY_PROFILE_ERROR_MESSAGE
+            review.updated_at = datetime.utcnow()
+            db.add(review)
+            await db.commit()
+            return
 
         # Step 3: Run agent orchestration
         agent_output = await _run_agent_orchestration(profile, ingestion_results)

--- a/tests/unit/test_review_routes.py
+++ b/tests/unit/test_review_routes.py
@@ -1,0 +1,108 @@
+"""Tests for the POST /reviews flow — issue #88.
+
+Reproduction for issue #88:
+    "POST /reviews endpoint has no test for when the profile has no
+     ingested documents"
+    https://github.com/ascherj/pathreview/issues/88
+
+Context
+-------
+When a review is created for a profile that has zero ingested documents
+(no github_username, no portfolio_url, no resume_text), the ingestion
+pipeline returns an empty source list. However, `process_review` never
+checks whether ingestion produced anything: `_run_agent_orchestration`
+and `_run_rag_retrieval_generation` return hard-coded placeholder
+sections regardless of input, so the review is still marked "complete"
+with fabricated feedback and a non-null overall_score.
+
+The two tests below pin down that gap:
+  * `test_empty_profile_ingests_zero_sources` documents the confirmed
+    root cause — ingestion yields 0 sources for an empty profile.
+  * `test_empty_document_profile_should_not_fabricate_review` expresses
+    the DESIRED behavior and is marked xfail until the Week 9 fix lands
+    (see PLAN.md). It currently fails because the review is fabricated.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, Mock
+from uuid import uuid4
+
+from core.services.review_service import _run_ingestion_pipeline, process_review
+
+
+def _make_empty_profile():
+    """A profile with no ingestable sources of any kind."""
+    profile = Mock()
+    profile.id = uuid4()
+    profile.user_id = uuid4()
+    profile.github_username = None
+    profile.portfolio_url = None
+    profile.resume_text = None
+    profile.resume_filename = None
+    return profile
+
+
+def _make_pending_review():
+    review = Mock()
+    review.id = uuid4()
+    review.status = "pending"
+    review.sections = None
+    review.overall_score = None
+    return review
+
+
+def _make_db(review, profile):
+    """Mock async session. `process_review` runs select(Review) then
+    select(Profile); use plain Mock results so `.scalars().first()` is sync."""
+    db = AsyncMock()
+    db.add = Mock()
+    db.commit = AsyncMock()
+
+    review_result = Mock()
+    review_result.scalars.return_value.first.return_value = review
+    profile_result = Mock()
+    profile_result.scalars.return_value.first.return_value = profile
+    db.execute = AsyncMock(side_effect=[review_result, profile_result])
+    return db
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_empty_profile_ingests_zero_sources():
+    """Root cause: ingestion yields 0 sources for an empty-document profile."""
+    profile = _make_empty_profile()
+    db = AsyncMock()
+    db.add = Mock()
+    db.commit = AsyncMock()
+
+    sources = await _run_ingestion_pipeline(db, profile)
+
+    assert sources == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.xfail(
+    reason="issue #88: process_review fabricates a complete review for a "
+    "profile with zero ingested documents instead of surfacing the empty "
+    "state. Fix planned in Week 9 (see PLAN.md).",
+    strict=True,
+)
+async def test_empty_document_profile_should_not_fabricate_review():
+    """DESIRED behavior: an empty-document profile must NOT yield a
+    'complete' review full of fabricated sections.
+
+    Currently FAILS (xfail): process_review marks the review 'complete'
+    with 3 placeholder sections and overall_score=0.81.
+    """
+    profile = _make_empty_profile()
+    review = _make_pending_review()
+    db = _make_db(review, profile)
+
+    await process_review(db, review.id, profile.id)
+
+    # A profile with no documents should not produce fabricated feedback.
+    assert review.status != "complete", (
+        f"empty-document profile produced status={review.status!r} with "
+        f"{len(review.sections or [])} sections and score={review.overall_score}"
+    )

--- a/tests/unit/test_review_routes.py
+++ b/tests/unit/test_review_routes.py
@@ -1,6 +1,6 @@
 """Tests for the POST /reviews flow — issue #88.
 
-Reproduction for issue #88:
+Issue #88:
     "POST /reviews endpoint has no test for when the profile has no
      ingested documents"
     https://github.com/ascherj/pathreview/issues/88
@@ -9,25 +9,34 @@ Context
 -------
 When a review is created for a profile that has zero ingested documents
 (no github_username, no portfolio_url, no resume_text), the ingestion
-pipeline returns an empty source list. However, `process_review` never
-checks whether ingestion produced anything: `_run_agent_orchestration`
-and `_run_rag_retrieval_generation` return hard-coded placeholder
-sections regardless of input, so the review is still marked "complete"
-with fabricated feedback and a non-null overall_score.
+pipeline returns an empty source list. `_run_agent_orchestration` and
+`_run_rag_retrieval_generation` return hard-coded placeholder sections
+regardless of their input, so before the fix `process_review` marked such
+a review "complete" with fabricated feedback and a non-null overall_score.
 
-The two tests below pin down that gap:
-  * `test_empty_profile_ingests_zero_sources` documents the confirmed
-    root cause — ingestion yields 0 sources for an empty profile.
-  * `test_empty_document_profile_should_not_fabricate_review` expresses
-    the DESIRED behavior and is marked xfail until the Week 9 fix lands
-    (see PLAN.md). It currently fails because the review is fabricated.
+`process_review` now stops after ingestion when no sources were produced
+and records a terminal `failed` state with an explanatory `error_message`.
+These tests cover both the service-level guard and the endpoint behaviour
+that exercises it through a background task.
 """
 
-import pytest
-from unittest.mock import AsyncMock, Mock
+from datetime import datetime
+from unittest.mock import AsyncMock, Mock, patch
 from uuid import uuid4
 
-from core.services.review_service import _run_ingestion_pipeline, process_review
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.middleware.auth import get_current_user
+from api.routes import reviews as reviews_routes
+from core.database import get_db
+from core.models.review import Review
+from core.services.review_service import (
+    EMPTY_PROFILE_ERROR_MESSAGE,
+    _run_ingestion_pipeline,
+    process_review,
+)
 
 
 def _make_empty_profile():
@@ -42,12 +51,20 @@ def _make_empty_profile():
     return profile
 
 
+def _make_populated_profile():
+    """A profile with at least one ingestable source."""
+    profile = _make_empty_profile()
+    profile.github_username = "octocat"
+    return profile
+
+
 def _make_pending_review():
     review = Mock()
     review.id = uuid4()
     review.status = "pending"
     review.sections = None
     review.overall_score = None
+    review.error_message = None
     return review
 
 
@@ -82,27 +99,132 @@ async def test_empty_profile_ingests_zero_sources():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-@pytest.mark.xfail(
-    reason="issue #88: process_review fabricates a complete review for a "
-    "profile with zero ingested documents instead of surfacing the empty "
-    "state. Fix planned in Week 9 (see PLAN.md).",
-    strict=True,
-)
-async def test_empty_document_profile_should_not_fabricate_review():
-    """DESIRED behavior: an empty-document profile must NOT yield a
-    'complete' review full of fabricated sections.
-
-    Currently FAILS (xfail): process_review marks the review 'complete'
-    with 3 placeholder sections and overall_score=0.81.
-    """
+async def test_empty_document_profile_does_not_fabricate_review():
+    """An empty-document profile must not yield a 'complete' review."""
     profile = _make_empty_profile()
     review = _make_pending_review()
     db = _make_db(review, profile)
 
     await process_review(db, review.id, profile.id)
 
-    # A profile with no documents should not produce fabricated feedback.
-    assert review.status != "complete", (
-        f"empty-document profile produced status={review.status!r} with "
-        f"{len(review.sections or [])} sections and score={review.overall_score}"
+    assert review.status == "failed"
+    assert review.sections == []
+    assert review.overall_score is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_empty_document_profile_sets_explanatory_error_message():
+    """The failure is explained to the user via Review.error_message."""
+    profile = _make_empty_profile()
+    review = _make_pending_review()
+    db = _make_db(review, profile)
+
+    await process_review(db, review.id, profile.id)
+
+    assert review.error_message == EMPTY_PROFILE_ERROR_MESSAGE
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_empty_document_profile_skips_agent_and_rag_steps():
+    """The guard short-circuits before any feedback is generated."""
+    profile = _make_empty_profile()
+    review = _make_pending_review()
+    db = _make_db(review, profile)
+
+    with (
+        patch(
+            "core.services.review_service._run_agent_orchestration",
+            new=AsyncMock(),
+        ) as agent,
+        patch(
+            "core.services.review_service._run_rag_retrieval_generation",
+            new=AsyncMock(),
+        ) as rag,
+    ):
+        await process_review(db, review.id, profile.id)
+
+    agent.assert_not_called()
+    rag.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_empty_string_resume_text_is_treated_as_no_document():
+    """An empty-string resume is not a document and follows the empty path."""
+    profile = _make_empty_profile()
+    profile.resume_text = ""
+    review = _make_pending_review()
+    db = _make_db(review, profile)
+
+    await process_review(db, review.id, profile.id)
+
+    assert review.status == "failed"
+    assert review.error_message == EMPTY_PROFILE_ERROR_MESSAGE
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_profile_with_one_source_still_completes():
+    """Regression guard: the fix must only affect fully empty profiles."""
+    profile = _make_populated_profile()
+    review = _make_pending_review()
+    db = _make_db(review, profile)
+
+    await process_review(db, review.id, profile.id)
+
+    assert review.status == "complete"
+    assert review.sections
+    assert review.overall_score is not None
+
+
+def _build_test_app(db):
+    """A minimal app exposing only the reviews router, with auth and the
+    database session replaced by test doubles."""
+    app = FastAPI()
+    app.include_router(reviews_routes.router)
+
+    user = Mock()
+    user.id = uuid4()
+
+    app.dependency_overrides[get_current_user] = lambda: user
+    app.dependency_overrides[get_db] = lambda: db
+    return app
+
+
+@pytest.mark.unit
+def test_create_review_endpoint_with_empty_profile_returns_pending_then_fails():
+    """POST /reviews returns a pending review immediately; the background
+    task then leaves an empty-document profile in the terminal failed state."""
+    profile = _make_empty_profile()
+    now = datetime.utcnow()
+    review = Review(
+        id=str(uuid4()),
+        profile_id=str(profile.id),
+        status="pending",
+        sections=None,
+        overall_score=None,
+        error_message=None,
+        created_at=now,
+        updated_at=now,
     )
+    db = _make_db(review, profile)
+    app = _build_test_app(db)
+
+    with (
+        patch.object(reviews_routes, "create_review", new=AsyncMock(return_value=review)),
+        TestClient(app) as client,
+    ):
+        response = client.post("/reviews", json={"profile_id": str(profile.id)})
+
+    # The endpoint responds before the background task runs.
+    assert response.status_code == 200
+    assert response.json()["status"] == "pending"
+
+    # TestClient runs background tasks before returning, so by now the
+    # empty-document profile has been resolved to a truthful terminal state.
+    assert review.status == "failed"
+    assert review.sections == []
+    assert review.overall_score is None
+    assert review.error_message == EMPTY_PROFILE_ERROR_MESSAGE


### PR DESCRIPTION
## Summary

`POST /reviews` schedules `process_review` as a background task. After the ingestion step, `process_review` ran agent orchestration and RAG generation unconditionally â€” and both return hard-coded placeholder sections regardless of their input. A profile with no `github_username`, `portfolio_url`, or `resume_text` therefore ingested **zero** sources but still finished as a `"complete"` review with three fabricated feedback sections and `overall_score=0.81`. Issue #88 reported the missing test for this path; writing that test surfaced the underlying fabrication, so this PR adds the coverage **and** a minimal guard that makes the empty-document path terminate truthfully.

## Issue

Closes #88

## Changes

- `core/services/review_service.py`
  - Added an early guard in `process_review` immediately after `_run_ingestion_pipeline`: when ingestion produces no sources, the review is set to `status="failed"` with `sections=[]`, `overall_score=None`, and an explanatory `error_message`, and a `review_empty_profile` event is logged. The agent and RAG steps are skipped entirely.
  - Added the `EMPTY_PROFILE_ERROR_MESSAGE` constant so the service and its tests share one wording.
  - Extended the `process_review` docstring to document the new step 2a.
- `tests/unit/test_review_routes.py` â€” expanded from 2 tests to 7 (see below).

**Why `failed` rather than a new `empty` status:** the status vocabulary is fixed at `pending` / `processing` / `complete` / `failed` in `core/models/review.py:31-33` and is a closed TypeScript union in `frontend/src/types/index.ts:25`. `useReviewStatus.ts:25` stops polling only on `complete` or `failed`, so a new status would poll forever, and `ReviewPage.tsx:105` already renders `error_message` for failed reviews â€” which is exactly the surface this fix needs. No schema or migration change is required; `error_message` already exists on the model and on `ReviewResponse`.

## Testing

- [x] Unit tests pass (`make test-unit`) â€” no new failures; see the pre-existing-failures note below
- [ ] Integration tests pass (`make test-integration`) â€” **not run**, requires Docker services that aren't available in my environment
- [x] Linter passes (`make lint`) â€” `ruff` clean on both changed files
- [x] Type checker passes (`make typecheck`) â€” `mypy` reports the same 7 pre-existing errors before and after my change; 0 introduced
- [x] New/updated tests cover the changes

Tests in `tests/unit/test_review_routes.py`:

| Test | Covers |
|---|---|
| `test_empty_profile_ingests_zero_sources` | Root cause: ingestion yields 0 sources |
| `test_empty_document_profile_does_not_fabricate_review` | Terminal state is `failed`, no sections, null score |
| `test_empty_document_profile_sets_explanatory_error_message` | `error_message` is set for the UI |
| `test_empty_document_profile_skips_agent_and_rag_steps` | Guard short-circuits before any generation |
| `test_empty_string_resume_text_is_treated_as_no_document` | Edge case: `resume_text=""` follows the empty path |
| `test_profile_with_one_source_still_completes` | Regression guard: populated profiles still reach `complete` |
| `test_create_review_endpoint_with_empty_profile_returns_pending_then_fails` | Endpoint level â€” `POST /reviews` returns `pending` immediately, background task then resolves to `failed` |

I verified these tests genuinely catch the bug: with the guard removed (tests unchanged), **5 of the 7 fail**. The 2 that still pass are the ingestion root-cause test and the populated-profile regression guard, which are expected to pass either way.

The endpoint test builds a minimal `FastAPI` app containing only the reviews router and overrides `get_current_user` / `get_db`, so it stays a unit test with no database or network.

## Pre-existing failures (not caused by this PR)

The unit suite is already red on `main`. I measured before and after my change in the same environment:

- **Before:** 46 failed, 299 passed, 1 xfailed, 5 collection errors
- **After:** 46 failed, 305 passed, 5 collection errors

The set of failing tests is **identical** before and after â€” I diffed the `FAILED`/`ERROR` lines. The +6 passing are my 5 net-new tests plus the previously-`xfail` test that now passes because the bug is fixed.

Notable pre-existing issues I did **not** touch:

- 13 failures in `tests/unit/test_review_service.py` caused by `AsyncMock().scalars()` returning a coroutine (`object of type 'coroutine' has no len()`). My tests deliberately use plain `Mock` result objects to avoid the same trap.
- The `coroutine ... was never awaited` RuntimeWarning during full-suite runs originates from those same tests; it still reproduces with my test file excluded.
- Collection errors from optional dependencies (`tiktoken`, `httpx`) that are declared in `pyproject.toml` but were missing from my local venv â€” an environment gap, not a code issue.

## Notes for Reviewers

- **The scope call is worth a look.** Issue #88 is framed as a *test-coverage* gap. I judged that landing only a test asserting the current fabricated-`complete` behavior would enshrine a bug, so I included the minimal guard needed to make the desired behavior true. If you would rather split this, I'm happy to land the tests as `xfail` in this PR and move the guard to a separate one â€” say the word.
- **Terminal-state choice.** I defaulted to `failed` + `error_message` based on the frontend evidence cited above. If the intended UX is a distinct "nothing to review yet" state rather than an error, that's a larger change spanning the model, the TS union, and `StatusBadge`, and I'd rather do it deliberately in a follow-up.
- `sections` is set to `[]` rather than `None` to distinguish "we ran and found nothing" from "not processed yet". Happy to f