### PR TITLE
Fix/154 health check raw sql

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -34,7 +34,7 @@ In `api/routes/health.py` line 22, `await db.execute("SELECT 1")` passes a bare 
 **Walkthrough video (recommended):** N/A
 
 **Blockers or open questions:**
-Need to inspect `tests/unit/api/test_health.py` to confirm whether the existing tests mock the DB session or use a live connection — this determines whether the fix will be automatically validated by the test suite or whether a new/updated test is needed.
+No `test_health.py` existed in the unit test suite — needed to write one from scratch following existing test patterns.
 
 ---
 
@@ -72,4 +72,37 @@ Created `tests/unit/test_health.py` with 5 unit tests:
 
 **Self-review confirmation:** [x] make check passes  [x] make test-unit passes
 
-**Draft PR feedback received from:** [name or "none"]
+**Draft PR feedback received from:** none
+
+---
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No reviewer feedback came in during the week. Per the Su26 course note, reviewer feedback is not a feature in Summer 2026. PR #995 remains open.
+
+**How you responded:**
+N/A — no feedback to respond to.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Setting up the local environment was significantly harder than expected. The project required Python 3.11, Docker for PostgreSQL and Redis, and a frontend Node.js stack — none of which were immediately obvious from the README. The `pyproject.toml` license field format caused pip install failures that took time to diagnose, and the venv was initially created with the wrong Python version. In a real contribution scenario this would have been resolved faster with better documentation of prerequisites, but navigating it taught me that environment setup is a skill in itself, separate from the actual code change.
+
+**What did you learn about working in a large codebase?**
+The most important thing was learning to navigate before touching anything. The pathreview codebase spans multiple modules — `api`, `core`, `rag`, `agent`, `safety`, `ingestion` — and the health check route only made sense once I understood that `get_db` is a FastAPI dependency that injects an async SQLAlchemy session. Reading `core/database.py` and the route's dependency chain before writing any fix prevented me from making incorrect assumptions about what type `db` actually was. In my own projects I usually just know — in someone else's codebase you have to earn that knowledge by reading.
+
+**How did AI tools help — and where did they fall short?**
+AI tools were most useful for orientation: summarizing what each service file does, explaining the difference between SQLAlchemy 1.x and 2.x execute() behavior, and generating the initial test structure. They were less useful for environment debugging — the pip version conflicts and Python version issues required reading actual error messages and checking package compatibility tables, which AI suggestions sometimes got wrong or out of date. The test file required human judgment about what was worth testing (a TextClause type assertion rather than just checking execute was called) that a generic AI suggestion wouldn't have produced without the specific context of the bug.
+
+**What would you do differently if you started over?**
+I would read `docs/SETUP.md` more carefully before running `make setup`, specifically to check Docker and Python version prerequisites before creating the venv. I also would have checked how many other contributors had already claimed issue #154 before committing to it — by the time the PR was submitted, several other contributors had already opened PRs for the same issue, which means the fix may not get merged. Choosing a less-claimed issue from the same tier would have given the contribution a better chance of actually landing.
+
+**What are you most proud of from this module?**
+Writing `tests/unit/test_health.py` from scratch with no existing test to reference. The test file didn't exist, the health route uses FastAPI's dependency injection which complicates mocking, and the core assertion — checking that `execute()` receives a `TextClause` instance, not just that it was called — required understanding both SQLAlchemy's type system and the specific failure mode of the bug. All 5 tests passed on the first run, which meant the mocking approach was correct. That's the part of the contribution I'm most confident in.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -18,4 +18,20 @@ The fix is a single-line change in one file (`api/routes/health.py`) with a clea
 
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
-**Cohort ledger:** [ ] Issue added to cohort ledger
+**Cohort ledger:** [x] Issue added to cohort ledger
+
+---
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [link to commit — update after pushing]
+
+**Reproduction summary:**
+In `api/routes/health.py` line 22, `await db.execute("SELECT 1")` passes a bare Python string to SQLAlchemy 2.x's `execute()` method. SQLAlchemy 2.x requires all textual SQL to be wrapped in `sqlalchemy.text()` — passing a raw string raises `ArgumentError: Textual SQL expression 'SELECT 1' should be explicitly declared as text('SELECT 1')`. This is caught by the `except` block, which sets `health_status["dependencies"]["postgres"] = "unhealthy"` and causes the endpoint to return `503` even when the database is reachable.
+
+**PLAN.md link:** [link to PLAN.md — update after pushing]
+
+**Walkthrough video (recommended):** N/A
+
+**Blockers or open questions:**
+Need to inspect `tests/unit/api/test_health.py` to confirm whether the existing tests mock the DB session or use a live connection — this determines whether the fix will be automatically validated by the test suite or whether a new/updated test is needed.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -24,14 +24,52 @@ The fix is a single-line change in one file (`api/routes/health.py`) with a clea
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [link to commit — update after pushing]
+**Reproduction commit link:** https://github.com/YugynDprodigy10/pathreview/commit/ea436cf292959fc6597f10e7d725d71ffbb76415
 
 **Reproduction summary:**
 In `api/routes/health.py` line 22, `await db.execute("SELECT 1")` passes a bare Python string to SQLAlchemy 2.x's `execute()` method. SQLAlchemy 2.x requires all textual SQL to be wrapped in `sqlalchemy.text()` — passing a raw string raises `ArgumentError: Textual SQL expression 'SELECT 1' should be explicitly declared as text('SELECT 1')`. This is caught by the `except` block, which sets `health_status["dependencies"]["postgres"] = "unhealthy"` and causes the endpoint to return `503` even when the database is reachable.
 
-**PLAN.md link:** [link to PLAN.md — update after pushing]
+**PLAN.md link:** https://github.com/YugynDprodigy10/pathreview/blob/fix/154-health-check-raw-sql/PLAN.md
 
 **Walkthrough video (recommended):** N/A
 
 **Blockers or open questions:**
 Need to inspect `tests/unit/api/test_health.py` to confirm whether the existing tests mock the DB session or use a live connection — this determines whether the fix will be automatically validated by the test suite or whether a new/updated test is needed.
+
+---
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the two-line fix in `api/routes/health.py`: added `from sqlalchemy import text` to the imports and changed `await db.execute("SELECT 1")` to `await db.execute(text("SELECT 1"))`. Confirmed no `test_health.py` existed in the unit test suite, so created `tests/unit/test_health.py` with 5 tests covering the core fix (TextClause type assertion), healthy path, unhealthy path, status field propagation, and execute call count.
+
+**Next steps:**
+Run `make check` and `make test-unit` to confirm the fix passes linting, formatting, type checking, and the new unit tests. Open a draft PR for early feedback, then finalize and submit.
+
+**Blockers:**
+Docker is not running locally, so `make test-integration` cannot be verified. Unit tests do not require Docker and run successfully.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [paste your PR URL here after opening it]
+
+**Branch:** `fix/154-health-check-raw-sql`
+
+**What you built:**
+Added `from sqlalchemy import text` to `api/routes/health.py` and wrapped the PostgreSQL probe in `text("SELECT 1")`. This is a two-line change that makes the health check compatible with SQLAlchemy 2.x, which requires all textual SQL to be explicitly declared via `sqlalchemy.text()` rather than passed as bare strings. The database probe now executes correctly and reports accurate health status.
+
+**Tests added or updated:**
+Created `tests/unit/test_health.py` with 5 unit tests:
+- `test_postgres_probe_uses_sqlalchemy_text` — asserts execute() receives a `TextClause`, not a raw string (the core regression test)
+- `test_postgres_healthy_when_execute_succeeds` — verifies postgres reports "healthy" when probe completes
+- `test_postgres_unhealthy_when_execute_raises` — verifies 503 + "unhealthy" when probe fails
+- `test_postgres_failure_sets_overall_status_unhealthy` — verifies top-level status propagation
+- `test_postgres_execute_called_exactly_once` — verifies probe fires exactly once per request
+
+**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+
+**Draft PR feedback received from:** [name or "none"]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,21 @@
+# Contribution Journal — pathreview
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/154
+
+**Issue title:** Health check DB probe passes a raw SQL string, which fails under SQLAlchemy 2.x
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The database health check in `api/routes/health.py` runs a connectivity probe by executing the literal string `"SELECT 1"` directly against the database session. SQLAlchemy 2.x removed support for passing raw strings to `execute()` and now requires textual SQL to be wrapped in `sqlalchemy.text()`. As a result, the probe raises an `ArgumentError` and the health check reports the database as unreachable even when it is fully operational. The fix is a one-line change: import `text` from `sqlalchemy` and change the probe to `text("SELECT 1")`.
+
+**Is this right for me? — scope reasoning:**
+The fix is a single-line change in one file (`api/routes/health.py`) with a clear root cause documented in the issue. The SQLAlchemy 2.x migration requirement is well-documented and the error message itself points directly to the solution. The scope is narrow enough that it won't require understanding the full codebase, and the existing health check tests provide a clear target for verifying the fix. This is appropriate for a first open-source contribution.
+
+**Branch name:** fix/154-health-check-raw-sql
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -55,7 +55,7 @@ Docker is not running locally, so `make test-integration` cannot be verified. Un
 
 ### Check-in 2 (end of week)
 
-**PR link:** [paste your PR URL here after opening it]
+**PR link:** https://github.com/ascherj/pathreview/pull/995
 
 **Branch:** `fix/154-health-check-raw-sql`
 
@@ -70,6 +70,6 @@ Created `tests/unit/test_health.py` with 5 unit tests:
 - `test_postgres_failure_sets_overall_status_unhealthy` — verifies top-level status propagation
 - `test_postgres_execute_called_exactly_once` — verifies probe fires exactly once per request
 
-**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
 
 **Draft PR feedback received from:** [name or "none"]

--- a/PLAN.md
+++ b/PLAN.md
@@ -2,6 +2,7 @@
 
 **Issue:** [Health check DB probe passes a raw SQL string, which fails under SQLAlchemy 2.x](https://github.com/ascherj/pathreview/issues/154)
 
+https://github.com/YugynDprodigy10/pathreview/commit/ea436cf292959fc6597f10e7d725d71ffbb76415
 ---
 
 ### Understand

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,88 @@
+## Solution plan
+
+**Issue:** [Health check DB probe passes a raw SQL string, which fails under SQLAlchemy 2.x](https://github.com/ascherj/pathreview/issues/154)
+
+---
+
+### Understand
+
+**Root cause:** Line 22 of `api/routes/health.py` calls `await db.execute("SELECT 1")` — passing a raw Python string to SQLAlchemy's `execute()`. SQLAlchemy 2.x enforces that all textual SQL must be explicitly wrapped in `sqlalchemy.text()`. Passing a bare string raises `ArgumentError: Textual SQL expression 'SELECT 1' should be explicitly declared as text('SELECT 1')`. This causes the PostgreSQL health check to fail and report the database as `"unhealthy"` even when it is fully reachable.
+
+**Expected behavior:** `GET /health` returns `200` with `"postgres": "healthy"` when the database is up.
+
+**Actual behavior:** `GET /health` catches the `ArgumentError` in the `except` block, sets `"postgres": "unhealthy"`, and returns `503 Service Unavailable`.
+
+---
+
+### Map
+
+**Files to touch:**
+
+| File | Change |
+|---|---|
+| `api/routes/health.py` | Add `from sqlalchemy import text` import; wrap `"SELECT 1"` in `text()` |
+
+**Files to read (no changes needed):**
+
+| File | Why |
+|---|---|
+| `core/database.py` | Understand what `get_db` yields — confirms `db` is an AsyncSession |
+| `tests/unit/api/test_health.py` | Understand existing test structure to verify fix passes |
+
+---
+
+### Plan
+
+1. **Open `api/routes/health.py`** and locate line 22: `await db.execute("SELECT 1")`
+
+2. **Add the import** at the top of the file:
+   ```python
+   from sqlalchemy import text
+   ```
+
+3. **Wrap the raw string** in `text()`:
+   ```python
+   await db.execute(text("SELECT 1"))
+   ```
+
+4. **Run the existing tests** to confirm the fix doesn't break anything:
+   ```bash
+   pytest tests/unit/api/test_health.py -v
+   ```
+
+5. **Commit with a conventional message** following `CONTRIBUTING.md`:
+   ```
+   fix(health): wrap SQL probe in sqlalchemy.text() for SQLAlchemy 2.x
+   ```
+
+---
+
+### Inputs & outputs
+
+**Input:** The `db` session injected by `get_db` dependency — an `AsyncSession` from SQLAlchemy 2.x.
+
+**Change:** `await db.execute("SELECT 1")` → `await db.execute(text("SELECT 1"))`
+
+**Output:** The PostgreSQL probe executes successfully, `health_status["dependencies"]["postgres"]` is set to `"healthy"`, and `GET /health` returns `200` when the database is reachable.
+
+---
+
+### Risks & unknowns
+
+- **Import conflict:** `text` is a common name — need to confirm nothing else in `health.py` shadows it. Looking at the current imports (`fastapi`, `structlog`, `datetime`, `core.database`), there is no conflict.
+
+- **AsyncSession compatibility:** `text()` is the correct wrapper for both sync and async SQLAlchemy 2.x sessions. No additional changes needed for async usage.
+
+- **Other raw SQL strings:** A project-wide search for other bare `execute("` calls might reveal similar issues elsewhere, but those are out of scope for this fix.
+
+- **Test coverage:** If `tests/unit/api/test_health.py` mocks the database session, the test may not exercise the actual `execute()` call. Need to inspect the test file to confirm the fix is validated by tests.
+
+---
+
+### Edge cases
+
+- **Database genuinely down:** The fix should not change behavior when the database is actually unreachable — the `except` block should still catch real connection errors and correctly report `"unhealthy"`.
+
+- **`text()` import already present:** If a future refactor adds `text` elsewhere in the file, the import is idempotent — no risk of duplication.
+
+- **Empty string or None:** Not applicable — `text("SELECT 1")` is a constant, not user input.

--- a/api/routes/health.py
+++ b/api/routes/health.py
@@ -1,11 +1,10 @@
 from fastapi import APIRouter, HTTPException, status, Depends
+from sqlalchemy import text
 import structlog
 from datetime import datetime, timedelta
-
 from core.database import get_db
 
 log = structlog.get_logger()
-
 router = APIRouter(prefix="/health", tags=["health"])
 
 
@@ -25,22 +24,21 @@ async def health_check(db=Depends(get_db)):
         "safety_events_last_hour": 0,
         "timestamp": datetime.utcnow().isoformat(),
     }
-
     try:
         # Check PostgreSQL
-        await db.execute("SELECT 1")
+        # Fix for issue #154: SQLAlchemy 2.x requires textual SQL to be wrapped
+        # in sqlalchemy.text(). Passing a raw string raises ArgumentError.
+        await db.execute(text("SELECT 1"))
         health_status["dependencies"]["postgres"] = "healthy"
         log.debug("postgres_health_check_passed")
     except Exception as exc:
         log.error("postgres_health_check_failed", error=str(exc))
         health_status["dependencies"]["postgres"] = "unhealthy"
         health_status["status"] = "unhealthy"
-
     try:
         # Check Redis (if available)
         import redis
         from core.config import settings
-
         r = redis.Redis(
             host=settings.redis_host,
             port=settings.redis_port,
@@ -54,12 +52,10 @@ async def health_check(db=Depends(get_db)):
         log.error("redis_health_check_failed", error=str(exc))
         health_status["dependencies"]["redis"] = "unhealthy"
         health_status["status"] = "unhealthy"
-
     try:
         # Check Vector DB (if available)
         # This is a placeholder - actual implementation depends on vector DB choice
         from core.config import settings
-
         # Attempt heartbeat to vector DB
         # For now, assume it's healthy if connection string exists
         if settings.vector_db_url:
@@ -71,19 +67,16 @@ async def health_check(db=Depends(get_db)):
         log.error("vector_db_health_check_failed", error=str(exc))
         health_status["dependencies"]["vector_db"] = "unhealthy"
         health_status["status"] = "unhealthy"
-
     # Count safety events in last hour (placeholder)
     try:
         # This would be populated by actual safety event logging
         health_status["safety_events_last_hour"] = 0
     except Exception as exc:
         log.error("safety_events_check_failed", error=str(exc))
-
     # Return 503 if any critical dependency is down
     if health_status["status"] == "unhealthy":
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail=health_status,
         )
-
     return health_status

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -1,0 +1,138 @@
+"""Tests for api/routes/health.py
+
+Covers the SQLAlchemy 2.x fix for issue #154: the PostgreSQL probe must wrap
+its SQL in sqlalchemy.text() rather than passing a bare string to execute().
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from fastapi import HTTPException
+from sqlalchemy import TextClause
+
+
+@pytest.mark.unit
+class TestHealthCheckPostgresProbe:
+    """Tests for the PostgreSQL connectivity probe in health_check()."""
+
+    @pytest.fixture
+    def mock_db(self):
+        """Mock async database session."""
+        db = AsyncMock()
+        db.execute = AsyncMock()
+        return db
+
+    @pytest.fixture
+    def mock_settings(self):
+        """Mock settings to avoid real Redis/VectorDB config."""
+        settings = MagicMock()
+        settings.redis_host = "localhost"
+        settings.redis_port = 6379
+        settings.vector_db_url = None
+        return settings
+
+    # ── Core fix: text() wrapper ──────────────────────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_postgres_probe_uses_sqlalchemy_text(self, mock_db, mock_settings):
+        """
+        The DB probe must pass a TextClause to execute(), not a raw string.
+
+        SQLAlchemy 2.x raises ArgumentError when execute() receives a bare
+        string: 'Textual SQL expression should be explicitly declared as
+        text(...)'. This test verifies the fix wraps the probe in text().
+        """
+        from api.routes.health import health_check
+
+        with patch("core.config.settings", mock_settings):
+            with patch("redis.Redis") as mock_redis_cls:
+                mock_redis_cls.return_value.ping.side_effect = Exception("no redis")
+                try:
+                    await health_check(db=mock_db)
+                except HTTPException:
+                    pass  # redis failure causes 503 — we only care about execute() call
+
+        mock_db.execute.assert_called_once()
+        call_arg = mock_db.execute.call_args[0][0]
+        assert isinstance(call_arg, TextClause), (
+            "db.execute() must receive a TextClause from sqlalchemy.text(), "
+            "not a raw string. SQLAlchemy 2.x rejects bare strings with "
+            "ArgumentError."
+        )
+
+    # ── Postgres healthy path ─────────────────────────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_postgres_healthy_when_execute_succeeds(self, mock_db, mock_settings):
+        """
+        When db.execute() completes without error, postgres status is 'healthy'.
+        """
+        from api.routes.health import health_check
+
+        with patch("core.config.settings", mock_settings):
+            with patch("redis.Redis") as mock_redis_cls:
+                # Redis fails so we get a 503, but postgres should still be healthy
+                mock_redis_cls.return_value.ping.side_effect = Exception("no redis")
+                with pytest.raises(HTTPException) as exc_info:
+                    await health_check(db=mock_db)
+
+        assert exc_info.value.detail["dependencies"]["postgres"] == "healthy"
+
+    # ── Postgres unhealthy path ───────────────────────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_postgres_unhealthy_when_execute_raises(self, mock_db, mock_settings):
+        """
+        When db.execute() raises, postgres status is 'unhealthy' and the
+        endpoint returns 503 Service Unavailable.
+        """
+        from api.routes.health import health_check
+
+        mock_db.execute = AsyncMock(side_effect=Exception("connection refused"))
+
+        with patch("core.config.settings", mock_settings):
+            with patch("redis.Redis") as mock_redis_cls:
+                mock_redis_cls.return_value.ping.side_effect = Exception("no redis")
+                with pytest.raises(HTTPException) as exc_info:
+                    await health_check(db=mock_db)
+
+        assert exc_info.value.status_code == 503
+        assert exc_info.value.detail["dependencies"]["postgres"] == "unhealthy"
+        assert exc_info.value.detail["status"] == "unhealthy"
+
+    # ── Status field propagation ──────────────────────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_postgres_failure_sets_overall_status_unhealthy(
+        self, mock_db, mock_settings
+    ):
+        """
+        A postgres probe failure must set top-level status to 'unhealthy'.
+        """
+        from api.routes.health import health_check
+
+        mock_db.execute = AsyncMock(side_effect=Exception("timeout"))
+
+        with patch("core.config.settings", mock_settings):
+            with patch("redis.Redis") as mock_redis_cls:
+                mock_redis_cls.return_value.ping.side_effect = Exception("no redis")
+                with pytest.raises(HTTPException) as exc_info:
+                    await health_check(db=mock_db)
+
+        assert exc_info.value.detail["status"] == "unhealthy"
+
+    @pytest.mark.asyncio
+    async def test_postgres_execute_called_exactly_once(self, mock_db, mock_settings):
+        """
+        The health check should probe postgres exactly once per request.
+        """
+        from api.routes.health import health_check
+
+        with patch("core.config.settings", mock_settings):
+            with patch("redis.Redis") as mock_redis_cls:
+                mock_redis_cls.return_value.ping.side_effect = Exception("no redis")
+                try:
+                    await health_check(db=mock_db)
+                except HTTPException:
+                    pass
+
+        assert mock_db.execute.call_count == 1


### PR DESCRIPTION
## Summary

Fixes #154 — the PostgreSQL connectivity probe in `api/routes/health.py` was passing a raw string to `db.execute()`, which SQLAlchemy 2.x no longer accepts.

## What changed

**`api/routes/health.py`**
- Added `from sqlalchemy import text` to imports
- Changed `await db.execute("SELECT 1")` → `await db.execute(text("SELECT 1"))`

**`tests/unit/test_health.py`** (new file)
- 5 unit tests covering the fix: TextClause type assertion, healthy path, unhealthy path, status propagation, and execute call count

## Root cause

SQLAlchemy 2.x removed implicit coercion of raw strings in `execute()`. The probe call `await db.execute("SELECT 1")` raised:

```
ArgumentError: Textual SQL expression 'SELECT 1' should be explicitly
declared as text('SELECT 1')
```

This exception was caught by the `except` block in the health check, which incorrectly set `postgres: "unhealthy"` and returned `503 Service Unavailable` even when the database was fully reachable.

## How to test

```bash
# Run the new unit tests
pytest tests/unit/test_health.py -v -m unit

# Run the full unit suite to confirm no regressions
make test-unit

# Run linting and type checks
make check
```

**Manual test (requires Docker):**
```bash
docker compose up -d
curl http://localhost:8000/health
# Should return 200 with "postgres": "healthy"
```

## Notes

- No database migrations required
- No breaking changes to the API response schema
- Integration tests require Docker (not available in this environment); unit tests are sufficient to verify the fix
