### PR TITLE
fix(safety): redact parenthesized and space-separated US phone numbers (#146)

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,53 @@
+# Module 3 Journal
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/146
+
+**Issue title:** PII scrubber fails to redact parenthesized US phone numbers
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The PII scrubber in `safety/pii_scrubber.py` uses a phone-number regex that only
+matches the dashed format (e.g. `555-123-4567`) and misses the parenthesized
+format `(555) 123-4567`, which is one of the most common ways US phone numbers
+are written. Because of this gap, `scrub()` leaves parenthesized numbers in the
+text unredacted and `detect()` reports no PII for them — a real safety leak, since
+the whole point of this module is to strip personal information before it reaches
+the model. A successful fix broadens the phone pattern to cover the parenthesized
+area-code form (and the space/format variants around it) so both `scrub()` and
+`detect()` handle it, making the four related tests in
+`tests/unit/test_pii_scrubber.py` pass without regressing the dashed format.
+
+**Branch name:** fix/146-pii-scrubber-parenthesized-phone
+
+**Setup confirmation:** [ ] App runs locally at localhost:5173
+> Backing services (PostgreSQL, Redis, ChromaDB) run via Docker, which is not yet
+> installed on this machine, so the full app has not been launched at localhost:5173
+> yet. Environment is otherwise prepared: fork cloned, `upstream` remote added,
+> `.env` created (defaults to the `mock` LLM provider — no API key needed), and
+> `make` is on PATH. This issue is unit-test-driven, so it can be developed and
+> verified with `make test-unit` against `tests/unit/test_pii_scrubber.py`
+> independently of the running web app.
+
+**Cohort ledger:** [ ] Issue added to cohort ledger
+> To be completed manually on the cohort ledger spreadsheet (name, GitHub
+> username `shahriarshabib`, issue #146).
+
+### "Is this right for me?" — scope reasoning
+
+- **Scope is small and well-bounded.** The bug lives in a single regex in one file
+  (`safety/pii_scrubber.py`); the failing tests already exist and define exactly
+  what "fixed" means, so success is unambiguous.
+- **No cross-module or architectural knowledge required.** It doesn't touch the
+  RAG pipeline, the agent orchestrator, the API, or the frontend — just a
+  standalone safety utility.
+- **Reproducible and testable without the full stack.** The issue includes a
+  concrete repro snippet, and verification is a focused unit-test run rather than
+  end-to-end app usage — which fits my current environment (Docker not yet set up).
+- **Right difficulty for a first contribution.** Tier 1 / "good first issue"; the
+  main risk is over-broadening the regex and matching non-phone text, which the
+  existing dashed-format test guards against.
+- **Conclusion:** appropriately scoped for Week 7 — no hidden dependencies or
+  scope creep expected.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -51,3 +51,36 @@ area-code form (and the space/format variants around it) so both `scrub()` and
   existing dashed-format test guards against.
 - **Conclusion:** appropriately scoped for Week 7 — no hidden dependencies or
   scope creep expected.
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/shahriarshabib/pathreview/commit/6fb7d3fc84a926334f87a977eaa0557da648649a
+
+**Reproduction summary:**
+In my freshly cloned fork I created a lightweight virtualenv (`pytest` +
+`structlog`, no Docker needed for this safety-layer unit) and ran the four phone
+tests in `tests/unit/test_pii_scrubber.py` — all four fail
+(`test_us_phone_number_redaction`, `test_us_phone_formats`, `test_detect_phone_pii`,
+`test_phone_at_start_of_text`). The issue's repro snippet reproduces it directly:
+`scrub("Call me at (555) 123-4567 or 555-123-4567")` returns
+`"Call me at (555) 123-4567 or [REDACTED]"` (only the dashed number is redacted)
+and `detect("(555) 123-4567")` returns `[]`. This confirms the `phone_us` regex in
+`safety/pii_scrubber.py` cannot consume the space after `)`, so the most common US
+phone format leaks through unredacted. The reproduction commit pins a `BUG(#146)`
+comment on the exact regex line.
+
+**PLAN.md link:** https://github.com/shahriarshabib/pathreview/blob/fix/146-pii-scrubber-parenthesized-phone/PLAN.md
+
+**Walkthrough video (recommended):** _(not recorded)_
+
+**Blockers or open questions:**
+- The full app still isn't running at `localhost:5173` (Docker not installed on
+  this machine), but issue #146 is a self-contained safety-layer unit, so it is
+  reproduced and will be verified via `tests/unit/test_pii_scrubber.py` rather than
+  the running web app.
+- Open question for Week 9: whether `+1 555 123 4567` should be matched by
+  `phone_us` or `phone_intl` (the `test_us_phone_formats` fixture includes it).
+- Noted but out of scope: `test_mixed_pii_and_text` also fails, for an unrelated
+  reason — the `street_address` regex over-matches (`"Pl"` inside "applications"),
+  which redacts "Python". Not part of #146; flagged so I don't confuse it with a
+  regression from my fix.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -84,3 +84,60 @@ comment on the exact regex line.
   reason — the `street_address` regex over-matches (`"Pl"` inside "applications"),
   which redacts "Python". Not part of #146; flagged so I don't confuse it with a
   regression from my fix.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the fix from PLAN.md. Reworked the `phone_us` regex in
+`safety/pii_scrubber.py` so number separators accept space/dot/hyphen (not just
+`[-.]`) and switched the anchors to lookarounds `(?<!\w)…(?!\w)` so the leading
+`(` is redacted too. PLAN.md sub-tasks 1–3 are done: the four target tests
+(`test_us_phone_number_redaction`, `test_us_phone_formats`, `test_detect_phone_pii`,
+`test_phone_at_start_of_text`) now pass, and the full `tests/unit/test_pii_scrubber.py`
+run is 26 passed / 1 pre-existing-unrelated failure. `mypy safety/pii_scrubber.py`
+is clean and `ruff` reports nothing on the changed lines.
+
+**Next steps:**
+Sub-tasks 4–5: add the focused regression tests, do the final self-review, open a
+draft PR for peer feedback, then mark it ready.
+
+**Blockers:**
+Full `make check` / `make test-unit` can't run locally (Docker + full deps like
+`tiktoken` not installed), so I verify the affected module with a minimal venv and
+rely on repo CI for the rest.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/997
+
+**Branch:** `fix/146-pii-scrubber-parenthesized-phone`
+
+**What you built:**
+Broadened the `phone_us` PII pattern so parenthesized and space-separated US phone
+numbers (`(555) 123-4567`, `555 123 4567`, `+1 555 123 4567`) are now redacted by
+`scrub()` and reported by `detect()`, while the previously-working dashed/dotted
+formats are unchanged. The separator class is space/dot/hyphen (not `\s`) so a
+match can't span a line break and merge two numbers.
+
+**Tests added or updated:**
+`tests/unit/test_pii_scrubber.py` — added `test_parenthesized_phone_regression_issue_146`
+(asserts full redaction incl. the leading paren, an accurate `detect()` span, and
+no regression on the other formats) and `test_phone_pattern_does_not_span_line_break`.
+The four pre-existing phone tests in the same file now pass.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+> "Passes" here follows the course rule for a codebase with documented
+> pre-existing failures: **my changes introduce no new failures.** What I actually
+> ran (full `make` targets need Docker/deps not on this machine): `mypy
+> safety/pii_scrubber.py` → clean; `ruff` → no findings on changed lines (only
+> pre-existing repo findings remain on untouched code); `pytest
+> tests/unit/test_pii_scrubber.py` → 26 passed, 1 pre-existing unrelated failure
+> (`test_mixed_pii_and_text`, the `street_address` regex). Baseline before my
+> change was 5 failed / 20 passed in that file.
+
+**Draft PR feedback received from:** none yet — draft PR opened for peer review in
+Slack; will address feedback and mark ready before the deadline.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -141,3 +141,76 @@ The four pre-existing phone tests in the same file now pass.
 
 **Draft PR feedback received from:** none yet — draft PR opened for peer review in
 Slack; will address feedback and mark ready before the deadline.
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No reviewer or maintainer feedback arrived on PR #997 by the end of the week (0
+review comments, 0 reviews as of submission). Per the Summer 2026 note, reviewer
+feedback isn't a feature this term, so this is expected rather than a sign that
+anything was wrong. The 30 comments on issue #146 itself are other cohort members
+claiming the same "good first issue," not review of my change.
+
+**How you responded:**
+No feedback to respond to. If a maintainer comments after the deadline I'll reply
+professionally and push follow-up commits, but there's nothing to address right now.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The environment, not the code. The actual fix was a one-line regex change, but
+getting to the point where I could *trust* it took much longer. `make setup`
+assumes Docker + Postgres/Redis/Chroma and heavy deps like `tiktoken`, none of
+which I had, so I couldn't run the full `make check` / `make test-unit`. I had to
+build a minimal venv (`pytest` + `structlog`) just to exercise
+`tests/unit/test_pii_scrubber.py`. The other genuinely hard part was
+*disambiguating failures*: when I first ran the file, **five** tests failed, but
+only four were mine — the fifth (`test_mixed_pii_and_text`) turned out to be an
+unrelated `street_address` regex over-matching `"Pl"` inside "app**pl**ications"
+and eating "Python". Proving that was pre-existing (and not something I broke)
+mattered more than writing the fix.
+
+**What did you learn about working in a large codebase?**
+Restraint. In my own projects I'd have "cleaned up" the pre-existing `ruff`/`black`
+findings and the buggy `street_address` regex while I was in the file. Here the
+right move was the opposite: keep the diff to the single `phone_us` line + its
+tests, and *document* everything else as out-of-scope. I also learned to let the
+existing tests define "done" — the four failing tests were effectively the spec —
+and to match the repo's conventions (Conventional Commit scopes like
+`fix(safety):`, the `<type>/<issue#>-<desc>` branch name, Google-style docstrings)
+instead of my own habits. Contributing to someone else's production code is
+graded on "don't make it worse," not "leave your mark."
+
+**How did AI tools help — and where did they fall short?**
+AI was most useful for *tracing and reasoning*: pinpointing why the regex failed
+(the missing space separator after `)`), reasoning through the `\b` vs
+`(?<!\w)…(?!\w)` anchor trade-off so the leading `(` gets redacted, and drafting
+PLAN.md and the regression tests quickly. Where it fell short: it couldn't install
+Docker or run the full suite for me, so "does the whole thing actually pass in CI"
+is still something I can't verify locally — I had to reason about pre-existing vs
+new failures myself. It also can't make the judgment calls: whether checking the
+"make check passes" box is honest given I couldn't literally run it, or whether the
+`street_address` bug was worth scoping in. Those were mine to decide.
+
+**What would you do differently if you started over?**
+I'd verify the environment *before* committing to an issue — specifically confirm I
+can run `make test-unit` end to end (Docker installed) so my "passes" claims are
+literal, not "no new failures." I got lucky that #146 was verifiable with a tiny
+venv; a different issue might have been unreproducible for me locally. I'd also
+open the draft PR a day or two earlier to leave real room for peer feedback instead
+of opening it close to the deadline.
+
+**What are you most proud of from this module?**
+The paper trail, more than the one-line fix. I have a clean four-week arc — issue
+selection → a documented reproduction commit that pinpoints the exact regex → a
+PLAN.md that predicted the real risks (over-broadening, `\s` spanning line breaks,
+the `+1` format question) → a minimal, tested fix → an honest PR that documents
+pre-existing failures instead of hiding them or over-reaching to "fix" the repo.
+Being able to say exactly what I changed, what I deliberately didn't, and why, is
+the part I'd want a real maintainer to see.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,95 @@
+# Solution plan
+
+**Issue:** [PII scrubber fails to redact parenthesized US phone numbers](https://github.com/ascherj/pathreview/issues/146) — #146 (Tier 1, `safety`)
+
+### Understand
+
+The `phone_us` pattern in `safety/pii_scrubber.py` is:
+
+```
+\b(?:\+?1[-.]?)?\(?([0-9]{3})\)?[-.]?([0-9]{3})[-.]?([0-9]{4})\b
+```
+
+The **root cause** is the separator classes: between the (optionally
+parenthesized) area code and the exchange digits it allows only an *optional*
+`[-.]`. In the very common `(555) 123-4567` form there is a **space** after the
+`)`, and the pattern has no way to consume it, so matching fails right after the
+area code. The same limitation breaks other space-separated forms such as
+`+1 555 123 4567`.
+
+- **Expected:** `scrub("(555) 123-4567")` returns `"[REDACTED]"`, and
+  `detect("(555) 123-4567")` returns one `phone_us` entry with accurate
+  `start`/`end`.
+- **Actual:** `scrub()` returns the number unchanged and `detect()` returns
+  `[]` — a real safety leak, since the module exists to strip PII before text
+  reaches the model.
+
+### Map
+
+Files I expect to touch:
+
+- **`safety/pii_scrubber.py`** — the *only* production change: the
+  `PII_PATTERNS["phone_us"]` regex string. `scrub()` and `detect()` consume the
+  pattern unchanged, so no logic changes are needed there.
+- **`tests/unit/test_pii_scrubber.py`** — the four tests that already define
+  "done" (`test_us_phone_number_redaction`, `test_us_phone_formats`,
+  `test_detect_phone_pii`, `test_phone_at_start_of_text`). I may add one focused
+  regression test for `(555) 123-4567` covering both `scrub()` and `detect()`.
+
+Read-only reference (no edits expected):
+
+- Callers of `PIIScrubber` in the `safety` layer, to confirm nothing depends on
+  the current numbered capture groups `([0-9]{3})...` or on the buggy behavior.
+
+### Plan
+
+1. **Broaden the separators** in `phone_us` so the area-code → exchange and
+   exchange → line-number joins accept a space as well as `-`/`.` (and handle
+   the `(555) ` case), while still matching the working `555-123-4567` and
+   `555.123.4567` forms.
+2. **Verify the leading boundary** still works when the string starts with `(`
+   (word boundary sits before the first digit), so `test_phone_at_start_of_text`
+   passes.
+3. **Run the four target tests, then the full `tests/unit/test_pii_scrubber.py`**
+   to confirm the fix and catch regressions (especially `test_text_with_no_pii`,
+   `test_detect_no_false_positives`, and the dashed/dotted-format tests).
+4. **Add a targeted regression test** for the parenthesized form in both
+   `scrub()` and `detect()` if existing coverage leaves a gap.
+5. **Lint/format** the file (`ruff`, `black`) and keep the production diff scoped
+   to the single regex line.
+
+### Inputs & outputs
+
+- **Input:** arbitrary user-supplied text passed to `PIIScrubber.scrub(text)`
+  and `PIIScrubber.detect(text)`.
+- **Output / change:** parenthesized and space-separated US phone numbers are
+  replaced with `[REDACTED]` by `scrub()` and reported by `detect()` (type
+  `phone_us`, correct `start`/`end`). Non-phone text and already-working formats
+  are unchanged; `scrub()` stays idempotent.
+
+### Risks & unknowns
+
+- **Over-broadening → false positives.** Loosening separators could match
+  non-phone digit runs (dates, version strings, "5 123 4567"). Guarded by
+  `test_text_with_no_pii`, `test_detect_no_false_positives`, and
+  `test_scrub_idempotent`.
+- **`\s` spans newlines.** If I allow `\s` between groups it could bridge two
+  unrelated numbers across lines. Mitigation: use a space-only/bounded separator
+  (e.g. `[ ]` or a limited `[-.\s]`) and test multiline input.
+- **`detect()` positions.** `start`/`end` must stay accurate after the pattern
+  changes.
+- **Unknown — `+1 555 123 4567` ownership.** `test_us_phone_formats` includes
+  this form, so either `phone_us` or `phone_intl` must cover it; I'll decide
+  which pattern owns it during implementation.
+- **Out of scope (noted, won't fix here):** `test_mixed_pii_and_text` currently
+  fails for an *unrelated* reason — the `street_address` regex over-matches
+  (`"Pl"` inside "app**pl**ications" redacts "Python"). That is a separate bug,
+  not #146; I flag it only so I don't mistake it for a regression I introduced.
+
+### Edge cases
+
+- Formats: `(555) 123-4567`, `(555)123-4567` (no space), `555-123-4567`,
+  `555.123.4567`, `+1 555 123 4567`, `+1 (555) 123-4567`.
+- Position: phone at the start of text, at the end, and embedded mid-sentence.
+- Non-PII text stays byte-for-byte unchanged; double-scrub is idempotent.
+- Multiline text so the separator doesn't bridge two separate numbers.

--- a/safety/pii_scrubber.py
+++ b/safety/pii_scrubber.py
@@ -12,6 +12,12 @@ class PIIScrubber:
     # Regex patterns for common PII
     PII_PATTERNS = {
         "email": r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b",
+        # BUG(#146): after the (optional) area code this pattern only allows an
+        # optional [-.] separator, so it cannot consume the space in the common
+        # "(555) 123-4567" form. scrub() leaves such numbers unredacted and
+        # detect() returns [] for them. Reproduced by the failing unit tests
+        # test_us_phone_number_redaction, test_us_phone_formats,
+        # test_detect_phone_pii, and test_phone_at_start_of_text.
         "phone_us": r"\b(?:\+?1[-.]?)?\(?([0-9]{3})\)?[-.]?([0-9]{3})[-.]?([0-9]{4})\b",
         "phone_intl": r"\+[0-9]{1,3}[-.]?[0-9]{1,14}",
         "ssn": r"\b(?!000|666)[0-9]{3}-(?!00)[0-9]{2}-(?!0000)[0-9]{4}\b",

--- a/safety/pii_scrubber.py
+++ b/safety/pii_scrubber.py
@@ -12,13 +12,14 @@ class PIIScrubber:
     # Regex patterns for common PII
     PII_PATTERNS = {
         "email": r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b",
-        # BUG(#146): after the (optional) area code this pattern only allows an
-        # optional [-.] separator, so it cannot consume the space in the common
-        # "(555) 123-4567" form. scrub() leaves such numbers unredacted and
-        # detect() returns [] for them. Reproduced by the failing unit tests
-        # test_us_phone_number_redaction, test_us_phone_formats,
-        # test_detect_phone_pii, and test_phone_at_start_of_text.
-        "phone_us": r"\b(?:\+?1[-.]?)?\(?([0-9]{3})\)?[-.]?([0-9]{3})[-.]?([0-9]{4})\b",
+        # US phone numbers. Separators may be a space, dot, or hyphen, so the
+        # common parenthesized form "(555) 123-4567" (space after the area code)
+        # is covered alongside "555-123-4567", "555.123.4567", "555 123 4567",
+        # and an optional "+1"/"1" country code. Lookaround anchors let the
+        # leading "(" be part of the match while still avoiding digits that are
+        # glued to surrounding word characters. The separator class is space/
+        # dot/hyphen (not \s) so a match never spans a line break.
+        "phone_us": r"(?<!\w)(?:\+?1[ .-]?)?\(?([0-9]{3})\)?[ .-]?([0-9]{3})[ .-]?([0-9]{4})(?!\w)",
         "phone_intl": r"\+[0-9]{1,3}[-.]?[0-9]{1,14}",
         "ssn": r"\b(?!000|666)[0-9]{3}-(?!00)[0-9]{2}-(?!0000)[0-9]{4}\b",
         "street_address": r"\b\d+\s+[A-Za-z\s]+(?:Street|St|Avenue|Ave|Road|Rd|Boulevard|Blvd|Drive|Dr|Lane|Ln|Court|Ct|Circle|Cir|Park|Pl|Plaza|Place|Drive|Dr|Way|Parkway|Pkwy|Point|Pt|Pike|Run|Summit|Summit|Terrace|Ter|Trail|Trl|Tunnel|Turnpike|View|Vista|Vlg|Village|Vly|Valley)",

--- a/tests/unit/test_pii_scrubber.py
+++ b/tests/unit/test_pii_scrubber.py
@@ -53,6 +53,38 @@ class TestPIIScrubber:
             scrubbed = scrubber.scrub(text)
             assert "[REDACTED]" in scrubbed
 
+    def test_parenthesized_phone_regression_issue_146(self, scrubber):
+        """Regression for #146: parenthesized/space-separated US phones.
+
+        The old pattern only allowed a `[-.]` separator after the area code, so
+        `(555) 123-4567` (space after the `)`) leaked through unredacted and
+        `detect()` reported nothing. Verify the whole number — including the
+        leading `(` — is redacted, that `detect()` reports it as `phone_us` with
+        an accurate span, and that the previously-working dashed form is intact.
+        """
+        # scrub() fully removes the parenthesized number (no stray digits/parens)
+        scrubbed = scrubber.scrub("Reach me at (555) 123-4567 today")
+        assert scrubbed == "Reach me at [REDACTED] today"
+
+        # detect() reports it as a phone with the full value and correct offsets
+        detected = scrubber.detect("(555) 123-4567")
+        phones = [d for d in detected if d["type"] == "phone_us"]
+        assert len(phones) == 1
+        assert phones[0]["value"] == "(555) 123-4567"
+        assert phones[0]["start"] == 0
+        assert phones[0]["end"] == len("(555) 123-4567")
+
+        # No regression on the other common formats
+        for phone in ["555-123-4567", "555.123.4567", "555 123 4567", "+1 (555) 123-4567"]:
+            assert "[REDACTED]" in scrubber.scrub(f"Call {phone}")
+
+    def test_phone_pattern_does_not_span_line_break(self, scrubber):
+        """Two separate numbers on adjacent lines must not merge into one match."""
+        text = "Home: 555 123\nWork: 4567 890 1234"
+        detected = scrubber.detect(text)
+        for d in detected:
+            assert "\n" not in d["value"]
+
     def test_international_phone_redaction(self, scrubber):
         """Test international phone number is redacted."""
         text = "Reach me at +44 20 7946 0958"


### PR DESCRIPTION
## Summary

The US phone pattern in `safety/pii_scrubber.py` only allowed a `[-.]` separator
after the area code, so the very common parenthesized form `(555) 123-4567`
(which has a **space** after the `)`) was never matched. As a result `scrub()`
left such numbers in the text unredacted and `detect()` reported no PII for them
— a real leak for a module whose job is to strip PII before it reaches the model.
This PR broadens the separator handling so parenthesized and space-separated US
numbers are redacted, without regressing the formats that already worked.

## Issue

Closes #146

## Changes

- `safety/pii_scrubber.py` — reworked the `phone_us` regex:
  - Separators between number groups now accept **space, dot, or hyphen** (`[ .-]`)
    instead of only `[-.]`, covering `(555) 123-4567`, `555 123 4567`, and
    `+1 555 123 4567` alongside the existing `555-123-4567` / `555.123.4567`.
  - Switched the outer anchors from `\b…\b` to lookarounds `(?<!\w)…(?!\w)` so the
    leading `(` is part of the match and the number is redacted cleanly (no stray
    `(` left behind).
  - The separator class is deliberately `[ .-]` (space/dot/hyphen), **not** `\s`,
    so a single match can never span a line break and merge two separate numbers.
- `tests/unit/test_pii_scrubber.py` — added two regression tests:
  - `test_parenthesized_phone_regression_issue_146`: asserts `scrub()` fully
    redacts `(555) 123-4567` (including the leading paren), that `detect()`
    reports it as `phone_us` with an accurate `start`/`end`, and that the
    dashed/dotted/spaced/`+1` formats still redact.
  - `test_phone_pattern_does_not_span_line_break`: guards the no-newline-span
    invariant.

## Testing

Verified with the affected module's unit tests and code-quality tools on the
changed files:

- [x] Unit tests pass (`make test-unit`) — for the affected module:
  `pytest tests/unit/test_pii_scrubber.py` → **26 passed, 1 failed**. The four
  target tests (`test_us_phone_number_redaction`, `test_us_phone_formats`,
  `test_detect_phone_pii`, `test_phone_at_start_of_text`) now pass. The single
  remaining failure is **pre-existing and unrelated** (see Notes).
- [ ] Integration tests pass (`make test-integration`) — not run; this change is
  a self-contained safety-layer regex and touches no integration surface.
- [x] Linter passes (`make lint`) — `ruff check` reports **no findings on the
  changed lines**; the pre-existing repo-wide `ruff` findings are on untouched
  code (see Notes).
- [x] Type checker passes (`make typecheck`) — `mypy safety/pii_scrubber.py` →
  `Success: no issues found`.
- [x] New/updated tests cover the changes.

## Screenshots / Demo

Reproduction before the fix:

```python
>>> from safety.pii_scrubber import PIIScrubber
>>> s = PIIScrubber()
>>> s.scrub("Call me at (555) 123-4567 or 555-123-4567")
'Call me at (555) 123-4567 or [REDACTED]'   # parenthesized number leaks
>>> s.detect("(555) 123-4567")
[]
```

After the fix:

```python
>>> s.scrub("Call me at (555) 123-4567 or 555-123-4567")
'Call me at [REDACTED] or [REDACTED]'
>>> s.detect("(555) 123-4567")
[{'type': 'phone_us', 'value': '(555) 123-4567', 'start': 0, 'end': 14}]
```

## Notes for Reviewers

**Pre-existing failures (unrelated to this change), per the contribution guide:**

- `tests/unit/test_pii_scrubber.py::test_mixed_pii_and_text` fails **before and
  after** this PR. It is caused by the separate `street_address` regex
  over-matching (`"Pl"` inside "app**pl**ications" redacts "Python"), not by the
  phone pattern. I intentionally scoped it out of this issue.
- `make lint` / `make format` report pre-existing findings on untouched code
  (import sorting, the long `street_address`/`logger.info` lines, an unused loop
  variable in `scrub()`, and two unused locals in pre-existing tests). I left
  these alone to keep the diff scoped to #146.

**Local environment note:** the full `make setup` (Docker + Postgres/Redis/Chroma
and deps like `tiktoken`) is not installed on my machine, so the *entire*
`make test-unit` suite can't be collected locally (9 unrelated modules fail to
import). I verified the affected module directly with a minimal venv
(`pytest` + `structlog`). CI on this repo can confirm the rest.

I confirmed my changes introduce **no new** test/lint/type failures relative to
the pre-existing baseline.
