### PR TITLE
Test/88 review no test when no ingest

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -24,3 +24,18 @@ Is this right for me?
 **Setup confirmation:** [X] App runs locally at localhost:5173
 
 **Cohort ledger:** [X] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [link to commit documenting the reproduced issue]
+
+**Reproduction summary:**
+[1–2 sentences: How did you reproduce the issue? What did you observe?]
+I reproduced the issue by checking whether the referenced test file existed using `test -f tests/unit/test_review_routes.py && echo "FILE EXISTS" || echo "FILE MISSING"`. The command returned `FILE MISSING`, confirming that the route-level test file for this scenario is not present in the current repository.
+
+**PLAN.md link:** [link to PLAN.md in your fork]
+
+**Walkthrough video (recommended):** Not available
+
+**Blockers or open questions:**
+[Anything you're still uncertain about going into Week 9, or leave blank]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,26 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/88#top
+
+**Issue title:** POST /reviews endpoint has no test for when the profile has no ingested documents
+
+**Tier:** [X] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The issue is that there is currently no test case for when a profile exists but has no associated ingested documents. In this situation, the review endpoint should handle the missing content gracefully rather than crashing. The test should verify that the endpoint returns an appropriate error response when no ingested documents are available. This mainly affects the review route logic in `api/routes/reviews.py` and its related tests.
+
+Is this right for me?
+- I can explain the issue: the review endpoint needs a test for when a profile exists but has no ingested content.
+- I found the relevant route in `api/routes/reviews.py`.
+- The issue references `tests/unit/test_review_routes.py`, which does not currently exist, so I may need to create it.
+- I found `tests/unit/test_review_service.py` and will use it to understand the project’s testing style.
+- “Done” means the endpoint returns an appropriate error instead of crashing.
+- This is a Tier 1 issue with a small, localized scope, which is a good fit for my first contribution.
+- The estimated 2–3 hours is realistic for me.
+- I will check the issue comments/ledger for other claims and confirm there are no blockers.
+
+**Branch name:** (test/88-review-no-test-when-no-ingest)
+
+**Setup confirmation:** [X] App runs locally at localhost:5173
+
+**Cohort ledger:** [X] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -58,7 +58,7 @@ The repository has pre-existing lint and unit-test failures unrelated to my chan
 
 ### Check-in 2 (end of week)
 
-**PR link:** [link to your submitted pull request]
+**PR link:** (https://github.com/ascherj/pathreview/pull/998)
 
 **Branch:** `test/88-review-no-test-when-no-ingest`
 
@@ -70,4 +70,5 @@ Created `tests/unit/test_review_routes.py` with `test_profile_no_ingested_docs`.
 
 **Self-review confirmation:** [X] make check passes  [X] make test-unit passes
 
-**Draft PR feedback received from:** [name or Slack handle, or "none"]
+**Draft PR feedback received from:** [name or Slack handle, or "none"] 
+none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -28,12 +28,13 @@ Is this right for me?
 ## Week 8 — Reproduction & solution planning
 
 **Reproduction commit link:** [link to commit documenting the reproduced issue]
+https://github.com/dkn345/pathreview/commit/7c7a7f711980797228581e27062d965b40674808
 
 **Reproduction summary:**
 [1–2 sentences: How did you reproduce the issue? What did you observe?]
 I reproduced the issue by checking whether the referenced test file existed using `test -f tests/unit/test_review_routes.py && echo "FILE EXISTS" || echo "FILE MISSING"`. The command returned `FILE MISSING`, confirming that the route-level test file for this scenario is not present in the current repository.
 
-**PLAN.md link:** [link to PLAN.md in your fork]
+**PLAN.md link:** [Link Text](PLAN.md)
 
 **Walkthrough video (recommended):** Not available
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -72,3 +72,34 @@ Created `tests/unit/test_review_routes.py` with `test_profile_no_ingested_docs`.
 
 **Draft PR feedback received from:** [name or Slack handle, or "none"] 
 none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [X] No — still awaiting review
+
+**Summary of feedback:**
+No review.
+
+**How you responded:**
+
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+I found navigating the exact files and understanding the behavior of the function to be a bit difficult since there were many "reviews" under many folders. I had to write a test for a review of profile with no documents and tracing the behavior was slightly difficult due to many versions being there. I was not expecting the function to span multiple folders, so that aspect surprised me.
+
+**What did you learn about working in a large codebase?**
+I found contributing to someone else's production code both easier and more difficult than my own project. The aspects I found easy was that there was already a layout to start off with which meant I did not have to plan from scratch. However, the difficult aspect was that there was already so much and I got overwhelmed trying to figure things out. What I learned was to leverage AI in this step especially since it can speed up ones understanding of the files and how they interact. By understanding quicker, the bug fix can also be quicker.
+
+**How did AI tools help — and where did they fall short?**
+AI was useful on understanding what to do with unfinished information. For my part, I was confused on the behavior of the review as the text files did not clearly show whether there was an error catching mechanism that I need to write a test for or do the whole logic on my own. In this case, AI helped me with the confusion and I got test cases that could help whether or not the logic was finished. What AI could not help with was the context. I knew the context and what files to model off of along with running and verifying the test was accurate. 
+
+**What would you do differently if you started over?**
+I would try to take more time with the understanding of the codebase instead of jumping straight in. Although I was better at being patient and understanding the code, I feel like I still rushed the process. Hence, I would take more time familiarizing, using AI for clarifying questions, and maybe even map out essential parts before going to the bug.
+
+**What are you most proud of from this module?**
+I am proud that I contributed to an open source project. This area has been intimidating for me, but I am glad I got out of the comfort zone and navigated through unfamiliar areas. I realized especially with many tools at hand that open source is not as intimidating and is more welcoming than expected.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -40,3 +40,34 @@ I reproduced the issue by checking whether the referenced test file existed usin
 
 **Blockers or open questions:**
 [Anything you're still uncertain about going into Week 9, or leave blank]
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+I created `tests/unit/test_review_routes.py` and added a unit test for the `POST /reviews` error path when no ingested documents are available. The test verifies that the route preserves the controlled HTTP error and does not schedule background processing.
+
+**Next steps:**
+I will commit and push the test, open a draft pull request, request peer or mentor feedback, address any relevant feedback, and finalize the PR.
+
+**Blockers:**
+The repository has pre-existing lint and unit-test failures unrelated to my change. My new test passes independently, and Ruff passes for `tests/unit/test_review_routes.py`.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [link to your submitted pull request]
+
+**Branch:** `test/88-review-no-test-when-no-ingest`
+
+**What you built:**
+I added route-level test coverage for the `POST /reviews` error path when no ingested documents are available. The test confirms that the endpoint preserves the controlled `400 Bad Request` response and does not queue the background review-processing task.
+
+**Tests added or updated:**
+Created `tests/unit/test_review_routes.py` with `test_profile_no_ingested_docs`. The new test passes independently.
+
+**Self-review confirmation:** [X] make check passes  [X] make test-unit passes
+
+**Draft PR feedback received from:** [name or Slack handle, or "none"]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -68,7 +68,7 @@ I added route-level test coverage for the `POST /reviews` error path when no ing
 **Tests added or updated:**
 Created `tests/unit/test_review_routes.py` with `test_profile_no_ingested_docs`. The new test passes independently.
 
-**Self-review confirmation:** [X] make check passes  [X] make test-unit passes
+**Self-review confirmation:** [] make check passes  [] make test-unit passes
 
 **Draft PR feedback received from:** [name or Slack handle, or "none"] 
 none

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,50 @@
+## Solution plan
+
+**Issue:** POST /reviews endpoint has no test for when the profile has no ingested documents
+https://github.com/ascherj/pathreview/issues/88#top
+
+### Understand
+What is the root cause of this issue? What behavior is expected vs. actual?
+The root cause of this issue is that the POST /reviews endpoint does not have a test for when a profile exists but has no associated ingested content. All cases must be tested and to ensure accuracy, there needs to be a test case. The expected behavior is that the endpoint returns a controlled error response instead of crashing.
+### Map
+Which files, functions, or modules are involved?
+List the specific files you expect to touch.
+The main files and functions involved are:
+
+- `api/routes/reviews.py` — contains the `create_review_endpoint` function for `POST /reviews`
+- `core/services/review_service.py` — contains review creation and processing behavior
+- `tests/unit/test_review_routes.py` — the route test file referenced by the issue; this file may need to be created
+- `tests/conftest.py` — may contain fixtures or mocks needed for authentication and database dependencies
+
+I only expect to use tests/unit/test_review_service.py as a reference for the project’s test style.
+
+### Plan
+What are the steps to fix this issue?
+Break it into 3–5 concrete sub-tasks.
+1. First, I look at the create_review_endpoint and functions around this to observe and understand behavior. I might even use AI to help check my understanding. 
+2. I will observe patterns in `tests/unit/test_review_service.py` to match with the test file I will make. 
+3. I will add the test case for profile with no ingested and check that status code/error message are accurate and not crashing. 
+4. I will run test and ensure it passes.
+
+### Inputs & outputs
+What does your fix take as input? What should it produce or change?
+Input:
+Authenticated user
+User profile
+No documents
+Request to POST /reviews
+
+Output:
+A clear error message
+Correct HTTP status code
+No crashing instead exception
+Passing the test case
+
+### Risks & unknowns
+What could go wrong? What are you still unsure about?
+I still need to confirm the exact status code and error message. Authentication and database dependencies may need to be mocked or overridden because I could not create a blank profile through the user interface. There are also unrelated failures in tests/unit/test_review_service.py, so I will run the new route test independently.
+
+### Edge cases
+What inputs or states should your fix handle gracefully?
+The profile exists but has no associated ingested content. The endpoint returns the expected controlled error instead of crashing.
+The authenticated user/profile setup is mocked correctly.

--- a/tests/unit/test_review_routes.py
+++ b/tests/unit/test_review_routes.py
@@ -1,0 +1,58 @@
+"""Tests for review_routes.py"""
+
+from unittest.mock import AsyncMock, Mock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException, status
+
+from api.routes.reviews import create_review_endpoint
+
+
+@pytest.mark.unit
+class TestReviewRoutes:
+    """Test suite for the reviews route module."""
+
+    @pytest.fixture
+    def mock_db_session(self) -> AsyncMock:
+        """Create a mock async database session."""
+        session = AsyncMock()
+        session.add = Mock()
+        session.commit = AsyncMock()
+        session.refresh = AsyncMock()
+        session.execute = AsyncMock()
+        return session
+
+    @pytest.mark.asyncio
+    async def test_profile_no_ingested_docs(self, mock_db_session: AsyncMock) -> None:
+        current_user = Mock()
+        current_user.id = uuid4()
+        data = Mock()
+        data.profile_id = uuid4()
+        background_tasks = Mock()
+        background_tasks.add_task = Mock()
+        with patch(
+            "api.routes.reviews.create_review",
+            new_callable=AsyncMock,
+        ) as mock_create_review:
+            mock_create_review.side_effect = HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="No ingested documents available",
+            )
+
+            with pytest.raises(HTTPException) as exc_info:
+                await create_review_endpoint(
+                    data=data,
+                    background_tasks=background_tasks,
+                    current_user=current_user,
+                    db=mock_db_session,
+                )
+
+            assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
+            assert exc_info.value.detail == "No ingested documents available"
+            mock_create_review.assert_awaited_once_with(
+                db=mock_db_session,
+                profile_id=data.profile_id,
+                user_id=current_user.id,
+            )
+            background_tasks.add_task.assert_not_called()


### PR DESCRIPTION
## Summary
<!-- One paragraph describing what this PR does and why -->
Adds route-level unit test coverage for the `POST /reviews` error path when no ingested documents are available. The test verifies that the endpoint preserves the controlled HTTP error and does not schedule background processing.

## Issue
Closes #88 

## Changes
<!-- Bullet list of the specific changes made -->
- Added `tests/unit/test_review_routes.py`
- Added a test for the no-ingested-documents error path
- Verified the route preserves the `400 Bad Request` response
- Verified the background processing task is not scheduled after the error
- Updated `JOURNAL.md` with Week 9 progress

## Testing
<!-- How did you verify your changes? -->
- [ ] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`)
- [ ] Linter passes (`make lint`)
- [ ] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes

## Screenshots / Demo
<!-- If applicable, add screenshots or a link to a demo video -->
Not applicable.

## Notes for Reviewers
<!-- Anything the reviewer should pay particular attention to -->
The new test passes independently, and Ruff and Black pass for the new test file. The repository currently has pre-existing failures in the full unit-test suite, lint checks, and type checking that are unrelated to this PR. Please review whether the mocking and assertions match the intended route-test pattern for issue #88.
