### PR TITLE
feat(agent): add has_tests detection to GitHubTool

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,16 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/50
+
+**Issue title:** Add a `has_tests` boolean to the repo analysis output
+
+**Tier:** [X] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+Detection logic needs to be added to check for the presence of test coverage in a repository. This issue asks for a has_tests boolean to be added as the detection logic. A successful fix would accomplish an automatic confirmation of test coverage in a repository. Relevant files are agent/tools/github_tool.py and ingestion/parsers/repo_analyzer.py, which the latter is incorrectly stated in the issues description.
+
+**Branch name:** test/50-add-has-test-boolean
+
+**Setup confirmation:** [X] App runs locally at localhost:5173
+
+**Cohort ledger:** [X] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -17,11 +17,11 @@ Detection logic needs to be added to check for the presence of test coverage in 
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [link to commit documenting the reproduced issue]
+**Reproduction commit link:** https://github.com/amyng939/pathreview/commit/95a528c6a51c423645ddd654d1db4f52ccdcdcb8#diff-46b5a285f91f98e0792efcd3027382c5e08bdd89ace225610da6e03f353be190
 
 **Reproduction summary:**
 Ran in the project venv: `python -c "from agent.tools.github_tool import GitHubTool; d = GitHubTool().execute({'github_username':'octocat','repo_name':'Hello-World'}).data; print(sorted(d)); print('has_tests present?', 'has_tests' in d)"`; the returned keys were ['description', 'fork_count', 'has_readme', 'homepage', 'last_commit_date', 'name', 'open_issues_count', 'primary_language', 'star_count', 'topics'] — confirming no has_tests key exists. The gap is in _fetch_repo_metadata() at agent/tools/github_tool.py:100, which builds the metadata dict but has no has_tests entry and the class has no _detect_tests() method (only _has_readme()).
 
-**PLAN.md link:** [link to PLAN.md in your fork]
+**PLAN.md link:** https://github.com/amyng939/pathreview/blob/test/50-add-has-test-boolean/PLAN.md
 
 **Blockers or open questions:**

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -14,3 +14,14 @@ Detection logic needs to be added to check for the presence of test coverage in 
 **Setup confirmation:** [X] App runs locally at localhost:5173
 
 **Cohort ledger:** [X] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [link to commit documenting the reproduced issue]
+
+**Reproduction summary:**
+Ran in the project venv: `python -c "from agent.tools.github_tool import GitHubTool; d = GitHubTool().execute({'github_username':'octocat','repo_name':'Hello-World'}).data; print(sorted(d)); print('has_tests present?', 'has_tests' in d)"`; the returned keys were ['description', 'fork_count', 'has_readme', 'homepage', 'last_commit_date', 'name', 'open_issues_count', 'primary_language', 'star_count', 'topics'] — confirming no has_tests key exists. The gap is in _fetch_repo_metadata() at agent/tools/github_tool.py:100, which builds the metadata dict but has no has_tests entry and the class has no _detect_tests() method (only _has_readme()).
+
+**PLAN.md link:** [link to PLAN.md in your fork]
+
+**Blockers or open questions:**

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -57,3 +57,33 @@ Wrote `tests/unit/test_github_tool.py` into a mocked, network-free unit suite of
 Ensuring that no changes have been made to previous passes after adding new code
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [X] No — still awaiting review
+
+**Summary of feedback:**
+no review came in
+
+**How you responded:**
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+I didn't expect to be so stumped working on an easy issue and that there are so many varied issues to work on. From the title of adding a boolean, it sounded easy but then actually looking into the codebase was overwhelming and the fix didn't stand out to me as clearly as I thought it would've been. The addition of present has_test boolean in a relevant file made it seem like the issue was already fixed but it was the other file that needed the logic added.
+
+**What did you learn about working in a large codebase?**
+That there are a lot of steps to working in a large codebase before, during, and after coding the actual issue. For example, I learned to look for a CONTRIBUTING.md file and other reading files to understand the structure of the codebase and knowing what the conventions are, whereas the self projects I've worked on didn't have that documentation.
+
+**How did AI tools help — and where did they fall short?**
+AI was most useful in helping me navigate my confusion throughout the issue in that I didn't know initally what repo analysis output was and how the relevant files given were related to each other. I needed to do more searching on my own between the issue description and checking the codebase to further understand what AI was giving me because it wasn't clear at first, and then I was able to break down the AI explanation to get its responses to reflect ny thoughts.
+
+**What would you do differently if you started over?**
+If I had more time, I probably would've chosen a different issue because the issue I worked on wasn't necessarily the most interesting to me. It didn't dive into the codebase as much as I would've liked because it was mostly a standalone file I was working on.
+
+**What are you most proud of from this module?**
+I am proud of figuring out the issue and understanding the fix for it. I dedicated time to go through an unfamiliar codebase and learned to be patient and address my confusion better with AI to get the explanations I needed.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -25,3 +25,35 @@ Ran in the project venv: `python -c "from agent.tools.github_tool import GitHubT
 **PLAN.md link:** https://github.com/amyng939/pathreview/blob/test/50-add-has-test-boolean/PLAN.md
 
 **Blockers or open questions:**
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+So far I started implementing the first sub-task from PLAN.md which is adding a _detect_tests() method to githubtool.
+
+**Next steps:**
+Finishing up the _detect_tests() method, adding has_tests to the metadata dict, and adding a unit test to ensure correct behavior.
+
+**Blockers:**
+
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/1000
+
+**Branch:** test/50-add-has-test-boolean
+
+**What you built:**
+Added a `has_tests` boolean to `GitHubTool`'s output. A new `_detect_tests()` method fetches the repository's recursive git tree (`GET /repos/{owner}/{repo}/git/trees/{default_branch}?recursive=1`) and returns `True` if any path is a `tests/`/`test/` directory, a `pytest.ini`, or a `test_*.py` file — matching whole path segments (so `contest/`/`latest/` don't false-positive) and case-insensitively, failing safe to `False` on any error. `_fetch_repo_metadata()` now reads `default_branch` from the API response (falling back to `"main"`) and includes `"has_tests"` in the returned metadata dict, next to `has_readme`.
+
+**Tests added or updated:**
+Wrote `tests/unit/test_github_tool.py` into a mocked, network-free unit suite of 13 cases across two classes. `TestDetectTests` covers detection via a `tests/`/`test/` dir, `pytest.ini`, and root-level `test_*.py`; case-insensitivity; the `contest/`/`latest/` false-positive guard; empty repo; fail-safe on request error; and the API-token auth header. `TestFetchRepoMetadata` covers the end-to-end `execute()` output (asserting `has_tests` plus no regression on existing fields) and the `default_branch` fallback to `main`.
+
+**Self-review confirmation:** [X] make check passes  [X] make test-unit passes
+Ensuring that no changes have been made to previous passes after adding new code
+
+**Draft PR feedback received from:** none

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,51 @@
+## Solution plan
+
+**Issue:** [Add a `has_tests` boolean to the repo analysis output](https://github.com/ascherj/pathreview/issues/50)
+
+### Understand
+<!-- What is the root cause of this issue? What behavior is expected vs. actual? -->
+The `_fetch_repo_metadata()` function in `agent/tools/github_tool.py` never determines whether a repository has tests. It returns metadata like name, stars, language, and `has_readme`, but no test-coverage signal at all. Expected: the analysis output includes `has_tests: True` for a repo that contains a `tests/` directory, a `pytest.ini`, or `test_*.py` files. Actual: there is no `has_tests` field in `GitHubTool`'s output.
+
+### Map
+<!-- Which files, functions, or modules are involved?
+List the specific files you expect to touch. -->
+`agent/tools/github_tool.py` and `ingestion/parsers/repo_analyzer.py` are both involved, but no changes need to be made to `repo_analyzer.py` — the `has_tests` boolean already exists in its output and the detection logic already exists in its `_detect_tests()`. The two files are separate subsystems and no live code path connects them, so the fix stays entirely in `github_tool.py`.
+
+Files to touch:
+- `agent/tools/github_tool.py` — the file we change.
+  - Add a new `_detect_tests(username, repo_name, default_branch) -> bool` method, modeled on the existing `_has_readme()` method.
+  - In `_fetch_repo_metadata()`, capture `default_branch` from the API response and add `"has_tests": self._detect_tests(...)` to the returned `metadata` dict, next to `has_readme`.
+- `tests/unit/test_github_tool.py` — add a unit test with a mocked GitHub tree response.
+
+Deliberately not changed:
+- `ingestion/parsers/repo_analyzer.py` — its `_detect_tests()` and `has_tests` output already exist and are out of scope. We are not wiring the ingestion pipeline to `GitHubTool` (that is a separate, currently-dead code path).
+
+### Plan
+<!-- What are the steps to fix this issue?
+Break it into 3–5 concrete sub-tasks. -->
+1. Add a `_detect_tests()` method to `GitHubTool` that fetches the repository's recursive git tree (`GET /repos/{owner}/{repo}/git/trees/{default_branch}?recursive=1`) and returns `True` if any path indicates tests: a `tests/` or `test/` directory, a `pytest.ini`, or a `test_*.py` file. Reuse the auth-header and try/except-returns-False style from `_has_readme()`.
+2. In `_fetch_repo_metadata()`, read `default_branch` from the API response (`repo_json.get("default_branch", "main")`) and add `"has_tests"` to the returned `metadata` dict.
+3. Add a unit test that mocks the tree endpoint and asserts `has_tests` is `True` when test paths are present and `False` when they are not.
+4. Run the test suite and confirm no regressions in existing `GitHubTool` behavior.
+
+### Inputs & outputs
+<!-- What does your fix take as input? What should it produce or change? -->
+- Input: a `github_username` and `repo_name` (same as the tool already takes), plus the repo's `default_branch` obtained from the existing API response.
+- Network input: the GitHub git-tree API response (list of path entries).
+- Output change: `GitHubTool`'s returned metadata dict gains a `has_tests: bool` field alongside `has_readme`. No change to any other field or to `repo_analyzer.py`.
+
+### Risks & unknowns
+<!-- What could go wrong? What are you still unsure about? -->
+- Extra API call: detecting tests requires one more GitHub request per repo, adding latency and consuming rate limit. The tool already handles 403 (rate-limited) at the `execute()` level; `_detect_tests()` should fail safe to `False` on any error rather than raising.
+- Truncated trees: the git-tree API sets a `truncated` flag for very large repos, so test files could be missed. Acceptable for a portfolio signal, but worth noting.
+- Duplicated logic: test detection now exists in two places (`GitHubTool` and `RepoAnalyzer._detect_tests`). This is deliberate — they consume different inputs — but should be called out so it isn't read as an accidental divergence.
+- Default branch assumption: repos may not use `main`; we take `default_branch` from the API response and fall back to `"main"` only if it is absent.
+
+### Edge cases
+<!-- What inputs or states should your fix handle gracefully? -->
+- Repo with no tests → `has_tests: False`.
+- Empty repo / no default branch / tree fetch fails or times out → `has_tests: False` (fail safe, no exception).
+- Tests present only as root-level `test_*.py` files or `pytest.ini` (no `tests/` dir) → still `True`.
+- Case sensitivity: match paths case-insensitively (`Tests/`, `TEST_foo.py`).
+- Directory named like a test but not one (e.g. `contest/`, `latest/`) → must not false-positive; match on `tests/` / `test/` path boundaries, not a bare `test` substring.
+- Missing API token (unauthenticated request) → still works, just under stricter rate limits.

--- a/agent/tools/github_tool.py
+++ b/agent/tools/github_tool.py
@@ -2,6 +2,7 @@
 
 import httpx
 import structlog
+
 from .base import BaseTool, ToolResult
 
 logger = structlog.get_logger()
@@ -35,44 +36,30 @@ class GitHubTool(BaseTool):
         repo_name = input_data.get("repo_name")
 
         if not username or not repo_name:
-            return ToolResult(
-                success=False,
-                data={},
-                error="Missing github_username or repo_name"
-            )
+            return ToolResult(success=False, data={}, error="Missing github_username or repo_name")
 
         try:
             repo_data = self._fetch_repo_metadata(username, repo_name)
             return ToolResult(success=True, data=repo_data)
 
         except httpx.HTTPStatusError as e:
-            logger.error("github_request_failed", status=e.response.status_code,
-                        username=username, repo=repo_name)
+            logger.error(
+                "github_request_failed",
+                status=e.response.status_code,
+                username=username,
+                repo=repo_name,
+            )
             if e.response.status_code == 404:
-                return ToolResult(
-                    success=False,
-                    data={},
-                    error="Repository not found"
-                )
+                return ToolResult(success=False, data={}, error="Repository not found")
             elif e.response.status_code == 403:
-                return ToolResult(
-                    success=False,
-                    data={},
-                    error="Rate limited or access denied"
-                )
+                return ToolResult(success=False, data={}, error="Rate limited or access denied")
             return ToolResult(
-                success=False,
-                data={},
-                error=f"GitHub API error: {e.response.status_code}"
+                success=False, data={}, error=f"GitHub API error: {e.response.status_code}"
             )
 
         except Exception as e:
             logger.error("github_tool_error", error=str(e))
-            return ToolResult(
-                success=False,
-                data={},
-                error=str(e)
-            )
+            return ToolResult(success=False, data={}, error=str(e))
 
     def _fetch_repo_metadata(self, username: str, repo_name: str) -> dict:
         """Fetch repository metadata from GitHub API.
@@ -96,6 +83,7 @@ class GitHubTool(BaseTool):
         repo_json = response.json()
 
         # Extract metadata, handling null values
+        # metadata currently missing has_tests boolean along with a detection logic function to use
         metadata = {
             "name": repo_json.get("name", ""),
             "description": repo_json.get("description") or "",
@@ -109,8 +97,13 @@ class GitHubTool(BaseTool):
             "homepage": repo_json.get("homepage") or "",
         }
 
-        logger.info("github_repo_fetched", username=username, repo=repo_name,
-                   language=metadata["primary_language"], stars=metadata["star_count"])
+        logger.info(
+            "github_repo_fetched",
+            username=username,
+            repo=repo_name,
+            language=metadata["primary_language"],
+            stars=metadata["star_count"],
+        )
 
         return metadata
 
@@ -132,6 +125,6 @@ class GitHubTool(BaseTool):
 
         try:
             response = httpx.head(url, headers=headers, timeout=5.0)
-            return response.status_code == 200
+            return bool(response.status_code == 200)
         except Exception:
             return False

--- a/agent/tools/github_tool.py
+++ b/agent/tools/github_tool.py
@@ -81,9 +81,9 @@ class GitHubTool(BaseTool):
         response.raise_for_status()
 
         repo_json = response.json()
+        repo_default_branch = repo_json.get("default_branch", "main")
 
         # Extract metadata, handling null values
-        # metadata currently missing has_tests boolean along with a detection logic function to use
         metadata = {
             "name": repo_json.get("name", ""),
             "description": repo_json.get("description") or "",
@@ -93,6 +93,7 @@ class GitHubTool(BaseTool):
             "open_issues_count": repo_json.get("open_issues_count", 0),
             "last_commit_date": repo_json.get("pushed_at", ""),
             "has_readme": self._has_readme(username, repo_name),
+            "has_tests": self._detect_tests(username, repo_name, repo_default_branch),
             "topics": repo_json.get("topics", []),
             "homepage": repo_json.get("homepage") or "",
         }
@@ -126,5 +127,46 @@ class GitHubTool(BaseTool):
         try:
             response = httpx.head(url, headers=headers, timeout=5.0)
             return bool(response.status_code == 200)
+        except Exception:
+            return False
+
+    def _detect_tests(self, username: str, repo_name: str, repo_default_branch: str) -> bool:
+        """Check if repository has test coverage.
+
+        Args:
+            username: GitHub username
+            repo_name: Repository name
+            repo_default_branch: Repository default branch
+
+        Returns:
+            True if test files or directories are present
+        """
+        url = (
+            f"{self.base_url}/repos/{username}/{repo_name}"
+            f"/git/trees/{repo_default_branch}?recursive=1"
+        )
+
+        headers = {}
+        if self.api_token:
+            headers["Authorization"] = f"token {self.api_token}"
+
+        try:
+            response = httpx.get(url, headers=headers, timeout=5.0)
+            response.raise_for_status()
+            tree = response.json().get("tree", [])
+
+            for entry in tree:
+                path = str(entry.get("path", "")).lower()
+                segments = path.split("/")
+                filename = segments[-1]
+
+                if "tests" in segments or "test" in segments:
+                    return True
+                if filename == "pytest.ini":
+                    return True
+                if filename.startswith("test_") and filename.endswith(".py"):
+                    return True
+
+            return False
         except Exception:
             return False

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -99,7 +99,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -449,7 +448,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -473,7 +471,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1561,7 +1558,6 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1579,7 +1575,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1972,7 +1967,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3507,7 +3501,6 @@
       "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^2.0.1",
         "cssstyle": "^4.0.1",
@@ -4094,7 +4087,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4107,7 +4099,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4771,7 +4762,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/tests/unit/test_github_tool.py
+++ b/tests/unit/test_github_tool.py
@@ -1,0 +1,171 @@
+"""Tests for agent/tools/github_tool.py"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from agent.tools.github_tool import GitHubTool
+
+
+def _tree_response(paths: list[str]) -> Mock:
+    """Build a mock httpx response mimicking the git-tree API."""
+    response = Mock()
+    response.raise_for_status = Mock()
+    response.json = Mock(
+        return_value={
+            "tree": [{"path": p} for p in paths],
+            "truncated": False,
+        }
+    )
+    return response
+
+
+@pytest.mark.unit
+class TestDetectTests:
+    """Test suite for GitHubTool._detect_tests."""
+
+    @pytest.fixture
+    def tool(self) -> GitHubTool:
+        """Create a GitHubTool instance."""
+        return GitHubTool()
+
+    @pytest.mark.parametrize(
+        "paths",
+        [
+            ["tests/test_foo.py"],  # tests/ directory
+            ["src/main.py", "test/helper.py"],  # test/ directory
+            ["pytest.ini", "src/app.py"],  # pytest config file
+            ["test_main.py"],  # root-level test_*.py, no tests/ dir
+            ["src/Tests/TEST_Foo.py"],  # case-insensitive match
+        ],
+    )
+    def test_returns_true_when_tests_present(self, tool: GitHubTool, paths: list[str]) -> None:
+        """has_tests is True when any path indicates tests."""
+        with patch(
+            "agent.tools.github_tool.httpx.get",
+            return_value=_tree_response(paths),
+        ):
+            assert tool._detect_tests("octocat", "repo", "main") is True
+
+    @pytest.mark.parametrize(
+        "paths",
+        [
+            [],  # empty repo
+            ["src/main.py", "README.md"],  # no tests at all
+            ["contest/results.py", "latest/x.py"],  # substrings, not real test dirs
+            ["src/mytest.py"],  # 'test' not a segment, no test_ prefix
+        ],
+    )
+    def test_returns_false_when_no_tests(self, tool: GitHubTool, paths: list[str]) -> None:
+        """has_tests is False when no path indicates tests (no false positives)."""
+        with patch(
+            "agent.tools.github_tool.httpx.get",
+            return_value=_tree_response(paths),
+        ):
+            assert tool._detect_tests("octocat", "repo", "main") is False
+
+    def test_returns_false_on_request_error(self, tool: GitHubTool) -> None:
+        """Detection fails safe to False on any network error."""
+        with patch(
+            "agent.tools.github_tool.httpx.get",
+            side_effect=Exception("boom"),
+        ):
+            assert tool._detect_tests("octocat", "repo", "main") is False
+
+    def test_detects_with_api_token(self) -> None:
+        """Detection still works (and sends auth header) when a token is set."""
+        tool = GitHubTool(api_token="secret")
+        captured: dict[str, object] = {}
+
+        def get_side_effect(url: str, headers: dict | None = None, **kwargs: object) -> Mock:
+            captured["headers"] = headers
+            return _tree_response(["tests/test_foo.py"])
+
+        with patch(
+            "agent.tools.github_tool.httpx.get",
+            side_effect=get_side_effect,
+        ):
+            assert tool._detect_tests("octocat", "repo", "main") is True
+        assert captured["headers"]["Authorization"] == "token secret"  # type: ignore[index]
+
+
+@pytest.mark.unit
+class TestFetchRepoMetadata:
+    """Test suite for GitHubTool metadata output, including has_tests."""
+
+    @pytest.fixture
+    def tool(self) -> GitHubTool:
+        """Create a GitHubTool instance."""
+        return GitHubTool()
+
+    def test_execute_includes_has_tests(self, tool: GitHubTool) -> None:
+        """execute() surfaces has_tests without dropping existing fields."""
+        repo_response = Mock()
+        repo_response.raise_for_status = Mock()
+        repo_response.json = Mock(
+            return_value={
+                "name": "repo",
+                "description": "desc",
+                "language": "Python",
+                "stargazers_count": 5,
+                "forks_count": 1,
+                "open_issues_count": 0,
+                "pushed_at": "2024-01-01T00:00:00Z",
+                "topics": [],
+                "homepage": None,
+                "default_branch": "develop",
+            }
+        )
+        tree_response = _tree_response(["tests/test_app.py"])
+
+        def get_side_effect(url: str, **kwargs: object) -> Mock:
+            # The repo call and the tree call both go through httpx.get;
+            # route by URL so default_branch ("develop") is exercised too.
+            return tree_response if "/git/trees/" in url else repo_response
+
+        with (
+            patch(
+                "agent.tools.github_tool.httpx.get",
+                side_effect=get_side_effect,
+            ),
+            patch(
+                "agent.tools.github_tool.httpx.head",
+                return_value=Mock(status_code=200),
+            ),
+        ):
+            result = tool.execute({"github_username": "octocat", "repo_name": "repo"})
+
+        assert result.success is True
+        assert result.data["has_tests"] is True
+        # regression: existing fields still present and correct
+        assert result.data["has_readme"] is True
+        assert result.data["name"] == "repo"
+        assert result.data["primary_language"] == "Python"
+        assert result.data["star_count"] == 5
+
+    def test_defaults_branch_to_main_when_absent(self, tool: GitHubTool) -> None:
+        """When the API omits default_branch, the tree is fetched from 'main'."""
+        repo_response = Mock()
+        repo_response.raise_for_status = Mock()
+        repo_response.json = Mock(return_value={"name": "repo"})  # no default_branch
+        called_urls: list[str] = []
+
+        def get_side_effect(url: str, **kwargs: object) -> Mock:
+            called_urls.append(url)
+            return _tree_response([]) if "/git/trees/" in url else repo_response
+
+        with (
+            patch(
+                "agent.tools.github_tool.httpx.get",
+                side_effect=get_side_effect,
+            ),
+            patch(
+                "agent.tools.github_tool.httpx.head",
+                return_value=Mock(status_code=200),
+            ),
+        ):
+            result = tool.execute({"github_username": "octocat", "repo_name": "repo"})
+
+        assert result.success is True
+        assert result.data["has_tests"] is False
+        assert any("/git/trees/main?recursive=1" in u for u in called_urls)


### PR DESCRIPTION
## Summary
`GitHubTool` returned repository metadata (stars, language, `has_readme`, …) but had
no signal for whether a repo contains tests. This PR adds test detection: the tool now
inspects the repository's git tree and includes a `has_tests` boolean in its output,
giving the analysis pipeline a portfolio-quality signal it was previously missing.

## Issue
Closes #50

## Changes
- **Root cause:** `_fetch_repo_metadata()` never computed a test signal — the returned
  metadata dict had `has_readme` but no `has_tests`, and the class had no detection method.
- Add `_detect_tests(username, repo_name, repo_default_branch)` to `GitHubTool`. It fetches
  the recursive git tree (`GET /repos/{owner}/{repo}/git/trees/{default_branch}?recursive=1`)
  and returns `True` if any path is a `tests/`/`test/` directory, a `pytest.ini`, or a
  `test_*.py` file. Matching is on whole path **segments** (so `contest/`, `latest/` don't
  false-positive) and **case-insensitive**; any error fails safe to `False`.
- In `_fetch_repo_metadata()`, read `default_branch` from the API response
  (`repo_json.get("default_branch", "main")`) and add `"has_tests"` to the metadata dict,
  next to `has_readme`.
- Harden `_has_readme()` to return an explicit `bool(...)` (fixes a `mypy` `no-any-return`
  surfaced when this file entered the commit).
- Add `tests/unit/test_github_tool.py` — 13 mocked cases (no network) covering the PLAN
  edge cases: tests present via dir / `pytest.ini` / root-level `test_*.py`, case-insensitivity,
  the `contest/`/`latest/` false-positive guard, empty repo, request failure, API-token
  auth header, `default_branch` fallback to `main`, and the end-to-end `execute()` output.

## Testing
- [x] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`) — N/A, no integration tests touched;
      all new tests are unit-level with mocked HTTP.
- [x] Linter passes (`make lint`)
- [x] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes

**Manual verification:**
1. From the project venv, run:
python -c "from agent.tools.github_tool import GitHubTool; d = GitHubTool().execute({'github_username':'octocat','repo_name':'Hello-World'}).data; print('has_tests' in d, d.get('has_tests'))"
Before this change the key was absent; now it prints `True <bool>`.
2. `pytest tests/unit/test_github_tool.py -v` → 13 passed.

## Screenshots / Demo
<img width="678" height="579" alt="image" src="https://github.com/user-attachments/assets/045e7aaf-17d7-4078-af30-09e055056dbe" />
<img width="703" height="762" alt="image" src="https://github.com/user-attachments/assets/fbd880fc-6f43-44b3-8531-95f9caebf089" />

## Notes for Reviewers
- **Deliberate duplication:** test-detection logic now exists in both `GitHubTool._detect_tests`
and `RepoAnalyzer._detect_tests`. This is intentional — they consume different inputs (a live
git-tree API response vs. a `file_structure` string) and no live code path connects them.
Per the issue scope, `repo_analyzer.py` is left unchanged.
- **Extra API call:** detection adds one git-tree request per repo. It fails safe to `False`
on rate-limit/timeout rather than raising.
- **Truncated trees:** the git-tree API sets `truncated: true` for very large repos, so a test
file could theoretically be missed. Accepted as a portfolio signal.
- **Pre-existing `make check` state:** none observed related to this change; the only mypy fix
needed was the incidental `_has_readme` `bool(...)` noted above.
