### PR TITLE
Feat/34 re ranking chunks

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -14,3 +14,17 @@ Currently, chunks are retrieved and ranked based on a hybrid approach, using sem
 **Setup confirmation:** [Y] App runs locally at localhost:5173
 
 **Cohort ledger:** [Y] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [link to commit documenting the reproduced issue]
+
+**Reproduction summary:**
+[1–2 sentences: How did you reproduce the issue? What did you observe?]
+
+**PLAN.md link:** [link to PLAN.md in your fork]
+
+**Walkthrough video (recommended):** [link to your Loom video, ≤2 min — recommended, not graded]
+
+**Blockers or open questions:**
+[Anything you're still uncertain about going into Week 9, or leave blank]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -32,35 +32,63 @@ I created a mock vector store with mock chunks, 2 of which are actual relevant c
 **Blockers or open questions:**
 [Anything you're still uncertain about going into Week 9, or leave blank]
 
-53 failed, 378 passed, 2 warnings
 
 ## Week 9 — Solution building & PR submission
 
 ### Check-in 1 (mid-week)
 
 **Current progress:**
-[What have you implemented so far? Which sub-tasks from PLAN.md are done?]
+All 5 sub-tasks from PLAN.md are done: (1) implemented `Reranker` in `rag/retriever/reranker.py`
+using an LLM call to score candidate chunks, with defensive parsing and fallback to the
+existing blended score on any failure; (2) added `tests/unit/test_reranker.py` proving it in
+isolation, including that it corrects the exact keyword-stuffing bias `test_hybrid_keyword_bias.py`
+showcased; (3) widened `HybridRetriever`'s candidate pool (`candidate_multiplier`) and wired
+`Reranker` into `retrieve()` as an optional, opt-in dependency so existing behavior is unchanged
+when no reranker is configured; (4) added `tests/unit/test_hybrid_with_reranker.py` proving the
+fix end-to-end (retriever + reranker together flip the "stuffed" vs "relevant" ranking).
 
 **Next steps:**
-[What are you working on for the rest of the week?]
+Open a PR, get it reviewed, and consider tightening the LLM's structured-output enforcement
+(currently relies on prompt instructions + regex fallback, not the API's native JSON mode).
 
 **Blockers:**
-[Anything slowing you down? Or leave blank.]
+None currently.
 
 ---
 
 ### Check-in 2 (end of week)
 
-**PR link:** [link to your submitted pull request]
+**PR link:** (https://github.com/Phuc1Le/pathreview/pull/1)
 
-**Branch:** [the branch name you worked on, e.g. `fix/123-short-description`]
+**Branch:** feat/34-re-ranking-chunks
 
 **What you built:**
-[1–3 sentences summarizing what your fix does and how it works]
+An LLM-based re-ranking step (`rag/retriever/reranker.py`) that sits downstream of
+`HybridRetriever`'s vector/keyword blend. `HybridRetriever` now optionally accepts a `Reranker`
+and, when configured, widens its candidate pool before handing it to the LLM for final scoring
+and ordering, correcting cases where keyword repetition previously outranked genuinely relevant
+chunks. Falls back gracefully to the original blended-score order if the LLM call fails or
+returns unparseable output.
 
 **Tests added or updated:**
-[Which test files did you touch? What do they cover?]
+- `tests/unit/test_hybrid.py` — reproduces and confirms the fix for a separate, blocking bug
+  found along the way (`keyword_score` always 0.0, because `KeywordSearcher` was never indexed).
+- `tests/unit/test_hybrid_keyword_bias.py` — showcases issue #34 itself: without a reranker, a
+  keyword-stuffed but off-topic chunk outranks a genuinely relevant one.
+- `tests/unit/test_reranker.py` — unit tests for `Reranker` in isolation (mocked LLM client):
+  empty input, correcting the keyword-stuffing bias, `top_k` truncation, and three fallback
+  paths (LLM error, malformed output, partially-scored response).
+- `tests/unit/test_hybrid_with_reranker.py` — end-to-end: `HybridRetriever` + `Reranker` wired
+  together actually flip the ranking, plus a sanity check that the bias still reproduces without
+  a reranker configured (isolating that the fix, not some other change, is what flips it).
 
-**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+**Self-review confirmation:** [x] make check passes*  [x] make test-unit passes*
 
-**Draft PR feedback received from:** [name or Slack handle, or "none"]
+*Scoped to files touched for this issue: `ruff`/`black` clean on `rag/retriever/` and the four
+test files above; `mypy` unverifiable directly in this environment (blocked by a local
+Application Control policy) but passes via the pre-commit hook used for every commit.
+`test-unit` full-suite run: 386 passed, 53 failed — all 53 failures are pre-existing, in files
+unrelated to this issue (e.g. `test_pii_scrubber.py`, `test_review_service.py`,
+`test_resume_parser.py`); none of the 11 tests added/touched for issue #34 are among them.
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,16 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/34
+
+**Issue title:** Implement a re-ranking step that uses an LLM to score retrieved chunks before generation
+
+**Tier:** [ ] Tier 1  [ ] Tier 2  [Y] Tier 3
+
+**Problem summary:**
+Currently, chunks are retrieved and ranked based on a hybrid approach, using semantic and keyword search. However, this ranking is not in the perfect order, for example because keyword search might rank a document higher just because it contains a specific keyword multiple times. Hence, the need for re-ranking.
+
+**Branch name:** feat/34-re-ranking-chunks
+
+**Setup confirmation:** [Y] App runs locally at localhost:5173
+
+**Cohort ledger:** [Y] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -18,10 +18,13 @@ Currently, chunks are retrieved and ranked based on a hybrid approach, using sem
 ## Week 8 — Reproduction & solution planning
 
 **Reproduction commit link:** [link to commit documenting the reproduced issue]
-
+https://github.com/Phuc1Le/pathreview/commit/c5c9db5
+This first commit is to fix another issue, keyword_score is always 0, which was reproduced and fix-verified with tests/unit/test_hybrid.py
+https://github.com/Phuc1Le/pathreview/commit/81ea29f
+This is the reproduction of issue #34
 **Reproduction summary:**
 [1–2 sentences: How did you reproduce the issue? What did you observe?]
-
+I created a mock vector store with mock chunks, 2 of which are actual relevant chunk and keyword-stuffed chunk. Without the re ranker, the stuffed chunk score is higher than the actual relevant chunk.
 **PLAN.md link:** [link to PLAN.md in your fork]
 
 **Walkthrough video (recommended):** [link to your Loom video, ≤2 min — recommended, not graded]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -92,3 +92,42 @@ unrelated to this issue (e.g. `test_pii_scrubber.py`, `test_review_service.py`,
 `test_resume_parser.py`); none of the 11 tests added/touched for issue #34 are among them.
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [X] No — still awaiting review
+
+**Summary of feedback:**
+[What did reviewers comment on? Or note that no review came in.]
+No reviewer came in yet
+
+**How you responded:**
+[What changes did you make, or what did you reply? If no feedback,
+leave blank.]
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+[Be specific — what part of the process, codebase, or workflow
+surprised you?]
+There were issues that were non-related to mine, but I had to fix them in order for mine to work
+**What did you learn about working in a large codebase?**
+[What's different about contributing to someone else's production code
+vs. building your own project?]
+Every changes must be cocumented clearly, otherwise it'll be hard for other people to understand and navigate the codebase. Also I learn to make sure that my changes don't affect other components via testing.
+**How did AI tools help — and where did they fall short?**
+[Where was AI assistance most useful this module? Where did you need
+to go beyond what AI could give you?]
+AI's still great at writing the code. This time it even helped me point out relevant issues I needed to fix aside from mine.
+**What would you do differently if you started over?**
+[Issue selection, planning, implementation, or process — anything
+you'd change?]
+I guess not. I implemented a good new feature, tested it, and created a PR. Maybe I'd start sooner if I were to do it again. That way I'd have more time to write the code myself, instead of letting Claude do most of the work and check later on.
+
+**What are you most proud of from this module?**
+[One thing — it doesn't have to be the PR itself.]
+Reading and following the documentations to maintain a proper, professional workfloww

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -31,3 +31,36 @@ I created a mock vector store with mock chunks, 2 of which are actual relevant c
 
 **Blockers or open questions:**
 [Anything you're still uncertain about going into Week 9, or leave blank]
+
+53 failed, 378 passed, 2 warnings
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+[What have you implemented so far? Which sub-tasks from PLAN.md are done?]
+
+**Next steps:**
+[What are you working on for the rest of the week?]
+
+**Blockers:**
+[Anything slowing you down? Or leave blank.]
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [link to your submitted pull request]
+
+**Branch:** [the branch name you worked on, e.g. `fix/123-short-description`]
+
+**What you built:**
+[1–3 sentences summarizing what your fix does and how it works]
+
+**Tests added or updated:**
+[Which test files did you touch? What do they cover?]
+
+**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+
+**Draft PR feedback received from:** [name or Slack handle, or "none"]

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,84 @@
+## Solution plan
+
+**Issue:** 
+Issue #34, https://github.com/ascherj/pathreview/issues/34
+
+### Understand
+What is the root cause of this issue? What behavior is expected vs. actual?
+There is no re-ranker after retrieving the chunks. The optimal pipeline should include a re-ranking step.
+
+### Map
+Which files, functions, or modules are involved?
+List the specific files you expect to touch.
+rag/retriever/hybrid.py: contains the retriever
+rag/retriever/reranker.py: the new file I created to implement re-ranking.
+
+### Plan
+What are the steps to fix this issue?
+Break it into 3–5 concrete sub-tasks.
+
+1. **Widen the candidate pool before truncation.** `HybridRetriever.retrieve()` currently
+   blends vector + keyword scores and truncates straight to `max_chunks` (`hybrid.py:111-115`).
+   Re-ranking needs a bigger pool to work with than the final answer size, or it can only
+   reorder chunks that were already going to be returned. Add a `candidate_multiplier`
+   (e.g. fetch/keep `max_chunks * 3` after blending) and pass that pool to the reranker
+   before the final cut to `max_chunks`.
+2. **Implement `Reranker` in `rag/retriever/reranker.py`.** Takes `(query, candidate_chunks)`,
+   builds a single prompt listing each candidate (id + text, truncated to a token budget),
+   and asks the LLM to return a relevance score (or rank order) per chunk id as JSON.
+   Reuse the OpenAI-client pattern already used in `rag/generator/review_generator.py`
+   (`ReviewConfig`, `openai.OpenAI(...)`) instead of inventing a new one.
+3. **Parse the LLM output into per-chunk scores.** Mirror `rag/generator/output_parser.py`'s
+   approach: parse expected JSON, and if parsing fails or a candidate id is missing from the
+   response, fall back to that chunk's existing blended `score` rather than dropping it.
+4. **Wire `Reranker` into `HybridRetriever.retrieve()`** (or as an explicit step the caller
+   invokes after `retrieve()` — TBD in review) so re-ranking happens on the widened pool,
+   then truncate to `max_chunks` only after re-ranking, not before.
+5. **Add unit tests with a mocked LLM client** (no real API calls in CI): confirm the
+   reranker can invert the ordering demonstrated in
+   `tests/unit/test_hybrid_keyword_bias.py` — i.e. that "relevant" outranks "stuffed"
+   once re-ranking is applied, closing the loop on the showcased bug.
+
+### Inputs & outputs
+What does your fix take as input? What should it produce or change?
+
+- **Input:** the original `query` string, plus the widened candidate pool from
+  `HybridRetriever` — each a dict with `id`, `text`, `metadata`, `score`, `vector_score`,
+  `keyword_score` (same shape `retrieve()` already returns).
+- **Output:** the same list of chunk dicts, reordered by relevance, with an added
+  `rerank_score` field (kept separate from the original `score` so the blended score
+  stays inspectable/debuggable), truncated to `max_chunks`. No change to the shape
+  consumers (`ReviewGenerator.generate_section`) expect — they already just read
+  `chunk["text"]`, `chunk["metadata"]`, `chunk["score"]`.
+
+### Risks & unknowns
+What could go wrong? What are you still unsure about?
+
+- **Cost/latency:** an extra LLM call per retrieval (potentially per section, per review)
+  multiplies cost and adds latency to every review — need to confirm whether this is
+  one re-rank call per `retrieve()` invocation or something batched/cached across sections.
+- **Garbage in, garbage out:** if the true best chunk was never in vector/keyword's
+  top-N to begin with (dropped before blending), re-ranking can't recover it — the
+  candidate pool widening in step 1 only helps up to how many are fetched from
+  `vector_store.query`/`keyword_searcher.search` in the first place.
+- **Non-determinism:** LLM-based scoring can be inconsistent run-to-run; need low
+  temperature and/or structured output (JSON mode) to keep it stable enough for tests
+  and reproducible reviews.
+- **Testing without hitting the real API:** need a mock/fake LLM client in unit tests
+  (same concern `ReviewGenerator` already has) — haven't decided the mocking pattern yet.
+- **Failure handling:** what happens if the LLM call errors, times out, or returns
+  malformed output — unsure yet whether to fall back silently to blended-score order
+  or surface a warning/log.
+
+### Edge cases
+What inputs or states should your fix handle gracefully?
+
+- Empty candidate list (nothing retrieved) — reranker should no-op, not call the LLM.
+- LLM response missing scores for some candidate ids — fall back to that chunk's
+  existing blended `score` instead of dropping the chunk.
+- LLM call fails or times out — fall back to the existing blended-score ordering
+  (i.e. re-ranking failure should degrade to current behavior, not break retrieval).
+- Candidate pool larger than the LLM's context/token budget — cap how many chunks
+  are sent to the reranker (e.g. top N by blended score) rather than truncating text
+  mid-chunk unpredictably.
+- Tied rerank scores — stable sort falling back to original blended score as tiebreaker.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -99,7 +99,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -449,7 +448,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -473,7 +471,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1561,7 +1558,6 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1579,7 +1575,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1972,7 +1967,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3507,7 +3501,6 @@
       "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^2.0.1",
         "cssstyle": "^4.0.1",
@@ -4094,7 +4087,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4107,7 +4099,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4771,7 +4762,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/rag/retriever/hybrid.py
+++ b/rag/retriever/hybrid.py
@@ -3,6 +3,7 @@
 import structlog
 
 from .keyword_search import KeywordSearcher
+from .reranker import Reranker
 from .vector_store import VectorStore
 
 logger = structlog.get_logger()
@@ -17,6 +18,8 @@ class HybridRetriever:
         keyword_searcher: KeywordSearcher,
         vector_weight: float = 0.7,
         keyword_weight: float = 0.3,
+        reranker: Reranker | None = None,
+        candidate_multiplier: int = 3,
     ):
         """Initialize hybrid retriever.
 
@@ -25,11 +28,20 @@ class HybridRetriever:
             keyword_searcher: KeywordSearcher instance
             vector_weight: Weight for vector scores (0-1)
             keyword_weight: Weight for keyword scores (0-1)
+            reranker: Optional Reranker to re-score candidates before the
+                final max_chunks cut. When omitted, behavior is unchanged
+                from the original vector/keyword blend.
+            candidate_multiplier: When a reranker is configured, how many
+                times max_chunks worth of candidates to fetch/keep before
+                re-ranking, so the reranker has more than just the final
+                answer size to choose from. Ignored when reranker is None.
         """
         self.vector_store = vector_store
         self.keyword_searcher = keyword_searcher
         self.vector_weight = vector_weight
         self.keyword_weight = keyword_weight
+        self.reranker = reranker
+        self.candidate_multiplier = candidate_multiplier
 
     def retrieve(
         self,
@@ -53,15 +65,21 @@ class HybridRetriever:
         """
         collection_name = f"profile_{profile_id}"
 
+        # When re-ranking, fetch a wider candidate pool -- re-ranking can only
+        # reorder what's already in the pool, so it needs more than just
+        # max_chunks worth of candidates to be useful.
+        pool_multiplier = self.candidate_multiplier if self.reranker else 2
+        fetch_size = max_chunks * pool_multiplier
+
         # Vector search
         vector_results = self.vector_store.query(
-            query_embedding, collection_name, n_results=max_chunks * 2
+            query_embedding, collection_name, n_results=fetch_size
         )
 
         # Keyword search - need to fetch all chunks first
         all_chunks = self._get_all_chunks(collection_name)
         self.keyword_searcher.index(all_chunks)
-        keyword_results = self.keyword_searcher.search(query, top_k=max_chunks * 2)
+        keyword_results = self.keyword_searcher.search(query, top_k=fetch_size)
 
         # Create id-to-chunk mapping for both approaches
         vector_map = {r["id"]: r for r in vector_results}
@@ -111,8 +129,14 @@ class HybridRetriever:
         results = [r for r in blended.values() if r["score"] >= min_score]
         results.sort(key=lambda x: x["score"], reverse=True)
 
-        # Return top max_chunks
-        final_results = results[:max_chunks]
+        # Keep a wider candidate pool for the reranker to choose from; without
+        # a reranker this is just the final max_chunks, same as before.
+        candidate_pool = results[:fetch_size] if self.reranker else results[:max_chunks]
+
+        if self.reranker is not None:
+            final_results = self.reranker.rerank(query, candidate_pool, top_k=max_chunks)
+        else:
+            final_results = candidate_pool
 
         logger.info(
             "hybrid_retrieval_complete",
@@ -121,6 +145,7 @@ class HybridRetriever:
             keyword_results=len(keyword_results),
             blended_count=len(blended),
             filtered_count=len(results),
+            reranked=self.reranker is not None,
             final_count=len(final_results),
         )
 

--- a/rag/retriever/hybrid.py
+++ b/rag/retriever/hybrid.py
@@ -1,8 +1,9 @@
 """Hybrid retriever combining vector and keyword search."""
 
 import structlog
-from .vector_store import VectorStore
+
 from .keyword_search import KeywordSearcher
+from .vector_store import VectorStore
 
 logger = structlog.get_logger()
 
@@ -10,8 +11,13 @@ logger = structlog.get_logger()
 class HybridRetriever:
     """Combines vector similarity and BM25 keyword search."""
 
-    def __init__(self, vector_store: VectorStore, keyword_searcher: KeywordSearcher,
-                 vector_weight: float = 0.7, keyword_weight: float = 0.3):
+    def __init__(
+        self,
+        vector_store: VectorStore,
+        keyword_searcher: KeywordSearcher,
+        vector_weight: float = 0.7,
+        keyword_weight: float = 0.3,
+    ):
         """Initialize hybrid retriever.
 
         Args:
@@ -25,8 +31,14 @@ class HybridRetriever:
         self.vector_weight = vector_weight
         self.keyword_weight = keyword_weight
 
-    def retrieve(self, query: str, profile_id: str, query_embedding: list[float],
-                 max_chunks: int = 10, min_score: float = 0.3) -> list[dict]:
+    def retrieve(
+        self,
+        query: str,
+        profile_id: str,
+        query_embedding: list[float],
+        max_chunks: int = 10,
+        min_score: float = 0.3,
+    ) -> list[dict]:
         """Retrieve chunks using hybrid approach.
 
         Args:
@@ -48,6 +60,7 @@ class HybridRetriever:
 
         # Keyword search - need to fetch all chunks first
         all_chunks = self._get_all_chunks(collection_name)
+        self.keyword_searcher.index(all_chunks)
         keyword_results = self.keyword_searcher.search(query, top_k=max_chunks * 2)
 
         # Create id-to-chunk mapping for both approaches
@@ -67,18 +80,23 @@ class HybridRetriever:
             keyword_score = 0.0
 
             if chunk_id in vector_map:
-                vector_score = (vector_map[chunk_id]["score"] / vector_scores_max) if vector_scores_max > 0 else 0
+                vector_score = (
+                    (vector_map[chunk_id]["score"] / vector_scores_max)
+                    if vector_scores_max > 0
+                    else 0
+                )
                 base_chunk = vector_map[chunk_id]
             else:
                 base_chunk = keyword_map[chunk_id]
 
             if chunk_id in keyword_map:
-                keyword_score = (keyword_map[chunk_id].get("bm25_score", 0) / keyword_scores_max) if keyword_scores_max > 0 else 0
+                keyword_score = (
+                    (keyword_map[chunk_id].get("bm25_score", 0) / keyword_scores_max)
+                    if keyword_scores_max > 0
+                    else 0
+                )
 
-            blended_score = (
-                self.vector_weight * vector_score +
-                self.keyword_weight * keyword_score
-            )
+            blended_score = self.vector_weight * vector_score + self.keyword_weight * keyword_score
 
             blended[chunk_id] = {
                 "id": chunk_id,
@@ -86,7 +104,7 @@ class HybridRetriever:
                 "metadata": base_chunk.get("metadata", {}),
                 "score": blended_score,
                 "vector_score": vector_score,
-                "keyword_score": keyword_score
+                "keyword_score": keyword_score,
             }
 
         # Filter by min_score and sort
@@ -96,10 +114,15 @@ class HybridRetriever:
         # Return top max_chunks
         final_results = results[:max_chunks]
 
-        logger.info("hybrid_retrieval_complete", query_len=len(query),
-                   vector_results=len(vector_results), keyword_results=len(keyword_results),
-                   blended_count=len(blended), filtered_count=len(results),
-                   final_count=len(final_results))
+        logger.info(
+            "hybrid_retrieval_complete",
+            query_len=len(query),
+            vector_results=len(vector_results),
+            keyword_results=len(keyword_results),
+            blended_count=len(blended),
+            filtered_count=len(results),
+            final_count=len(final_results),
+        )
 
         return final_results
 
@@ -117,13 +140,7 @@ class HybridRetriever:
 
         chunks = []
         for doc_id, text, metadata in zip(
-            all_docs["ids"],
-            all_docs["documents"],
-            all_docs["metadatas"]
+            all_docs["ids"], all_docs["documents"], all_docs["metadatas"], strict=False
         ):
-            chunks.append({
-                "id": doc_id,
-                "text": text,
-                "metadata": metadata
-            })
+            chunks.append({"id": doc_id, "text": text, "metadata": metadata})
         return chunks

--- a/rag/retriever/keyword_search.py
+++ b/rag/retriever/keyword_search.py
@@ -1,7 +1,7 @@
 """BM25-based keyword search retriever."""
 
-from rank_bm25 import BM25Okapi
 import structlog
+from rank_bm25 import BM25Okapi
 
 logger = structlog.get_logger()
 
@@ -9,10 +9,10 @@ logger = structlog.get_logger()
 class KeywordSearcher:
     """BM25-based keyword retrieval for sparse search."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize keyword searcher."""
-        self.bm25 = None
-        self.chunks = []
+        self.bm25: BM25Okapi | None = None
+        self.chunks: list[dict] = []
 
     def index(self, chunks: list[dict]) -> None:
         """Build BM25 index from chunks.
@@ -21,9 +21,7 @@ class KeywordSearcher:
             chunks: List of chunk dicts with 'text' field
         """
         self.chunks = chunks
-        tokenized_corpus = [
-            self._tokenize(chunk["text"]) for chunk in chunks
-        ]
+        tokenized_corpus = [self._tokenize(chunk["text"]) for chunk in chunks]
         self.bm25 = BM25Okapi(tokenized_corpus)
         logger.info("keyword_index_built", chunk_count=len(chunks))
 
@@ -45,9 +43,7 @@ class KeywordSearcher:
         scores = self.bm25.get_scores(query_tokens)
 
         # Create list of (chunk, score) tuples
-        scored_chunks = [
-            (self.chunks[i], scores[i]) for i in range(len(self.chunks))
-        ]
+        scored_chunks = [(self.chunks[i], scores[i]) for i in range(len(self.chunks))]
 
         # Sort by score descending
         scored_chunks.sort(key=lambda x: x[1], reverse=True)
@@ -59,8 +55,9 @@ class KeywordSearcher:
             result["bm25_score"] = float(score)
             results.append(result)
 
-        logger.info("keyword_search_complete", query_len=len(query_tokens),
-                   results_count=len(results))
+        logger.info(
+            "keyword_search_complete", query_len=len(query_tokens), results_count=len(results)
+        )
         return results
 
     @staticmethod

--- a/rag/retriever/reranker.py
+++ b/rag/retriever/reranker.py
@@ -1,0 +1,150 @@
+"""LLM-based re-ranking of retrieved chunks."""
+
+import json
+import re
+from dataclasses import dataclass
+
+import openai
+import structlog
+
+logger = structlog.get_logger()
+
+
+@dataclass
+class RerankerConfig:
+    """Configuration for LLM-based re-ranking."""
+
+    api_key: str
+    base_url: str
+    model: str
+    temperature: float = 0.0
+    max_tokens: int = 500
+
+
+class Reranker:
+    """Re-rank retrieved chunks by relevance to a query using an LLM.
+
+    Sits downstream of HybridRetriever.retrieve(): the vector/keyword blend
+    can be fooled by keyword repetition (see tests/unit/test_hybrid_keyword_bias.py),
+    so this re-scores the candidate pool with an LLM before the caller takes
+    the final top-k.
+    """
+
+    def __init__(self, config: RerankerConfig):
+        """Initialize the reranker.
+
+        Args:
+            config: RerankerConfig with API settings
+        """
+        self.config = config
+        self.client = openai.OpenAI(api_key=config.api_key, base_url=config.base_url)
+
+    def rerank(self, query: str, chunks: list[dict], top_k: int | None = None) -> list[dict]:
+        """Re-rank chunks by LLM-judged relevance to the query.
+
+        Args:
+            query: The original search query
+            chunks: Candidate chunks (each a dict with at least "id", "text", "score")
+            top_k: If given, truncate the reranked list to this many chunks
+
+        Returns:
+            Chunks reordered by relevance, each with an added "rerank_score" field.
+            Falls back to the existing blended "score" order if the LLM call
+            fails or its output can't be parsed.
+        """
+        if not chunks:
+            return []
+
+        try:
+            response = self.client.chat.completions.create(
+                model=self.config.model,
+                messages=[
+                    {
+                        "role": "system",
+                        "content": (
+                            "You are a relevance-scoring assistant. "
+                            "Respond only with a JSON object, no other text."
+                        ),
+                    },
+                    {"role": "user", "content": self._build_prompt(query, chunks)},
+                ],
+                temperature=self.config.temperature,
+                max_tokens=self.config.max_tokens,
+            )
+            content = response.choices[0].message.content
+        except Exception as e:
+            logger.error("rerank_llm_call_failed", error=str(e), chunk_count=len(chunks))
+            return self._fallback_order(chunks, top_k)
+
+        scores = self._parse_scores(content)
+        if not scores:
+            logger.warning("rerank_parse_failed", raw_response=(content or "")[:200])
+            return self._fallback_order(chunks, top_k)
+
+        reranked = [
+            {**chunk, "rerank_score": scores.get(str(chunk.get("id")), chunk.get("score", 0.0))}
+            for chunk in chunks
+        ]
+        reranked.sort(key=lambda c: c["rerank_score"], reverse=True)
+
+        logger.info(
+            "rerank_complete",
+            chunk_count=len(chunks),
+            scored_count=len(scores),
+            top_k=top_k,
+        )
+
+        return reranked[:top_k] if top_k is not None else reranked
+
+    @staticmethod
+    def _build_prompt(query: str, chunks: list[dict]) -> str:
+        """Build the relevance-scoring prompt for a batch of candidate chunks."""
+        lines = [
+            f"Query: {query}",
+            "",
+            "Rate how relevant each numbered chunk below is to the query, "
+            "on a scale from 0.0 (irrelevant) to 1.0 (highly relevant). "
+            "Judge true topical relevance -- do not give a high score just "
+            "because a chunk repeats a keyword from the query.",
+            "Respond ONLY with a JSON object mapping chunk id to score, "
+            'e.g. {"c1": 0.9, "c2": 0.1}.',
+            "",
+        ]
+        for chunk in chunks:
+            lines.append(f'[{chunk.get("id")}] {chunk.get("text", "")}')
+        return "\n".join(lines)
+
+    @staticmethod
+    def _parse_scores(content: str | None) -> dict[str, float]:
+        """Parse the LLM's JSON response into a chunk_id -> score mapping.
+
+        Returns an empty dict (triggering the fallback order) if the response
+        is missing, not valid JSON, or not a JSON object.
+        """
+        if not content:
+            return {}
+
+        json_match = re.search(r"\{.*\}", content, re.DOTALL)
+        raw = json_match.group(0) if json_match else content
+
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            return {}
+
+        if not isinstance(data, dict):
+            return {}
+
+        scores: dict[str, float] = {}
+        for chunk_id, value in data.items():
+            try:
+                scores[str(chunk_id)] = float(value)
+            except (TypeError, ValueError):
+                continue
+        return scores
+
+    @staticmethod
+    def _fallback_order(chunks: list[dict], top_k: int | None) -> list[dict]:
+        """Fall back to the existing blended-score order when re-ranking fails."""
+        ordered = sorted(chunks, key=lambda c: c.get("score", 0.0), reverse=True)
+        return ordered[:top_k] if top_k is not None else ordered

--- a/rag/retriever/vector_store.py
+++ b/rag/retriever/vector_store.py
@@ -1,7 +1,6 @@
 """ChromaDB-backed vector store for semantic retrieval."""
 
 import chromadb
-from chromadb.config import Settings
 import structlog
 
 logger = structlog.get_logger()
@@ -18,7 +17,7 @@ class VectorStore:
         """
         self.client = chromadb.PersistentClient(path=persist_dir)
 
-    def get_collection(self, name: str):
+    def get_collection(self, name: str) -> chromadb.Collection:
         """Get or create a collection.
 
         Args:
@@ -31,10 +30,7 @@ class VectorStore:
             collection = self.client.get_collection(name=name)
             logger.info("retrieved_collection", collection_name=name)
         except Exception:
-            collection = self.client.create_collection(
-                name=name,
-                metadata={"hnsw:space": "cosine"}
-            )
+            collection = self.client.create_collection(name=name, metadata={"hnsw:space": "cosine"})
             logger.info("created_collection", collection_name=name)
         return collection
 
@@ -56,23 +52,23 @@ class VectorStore:
             ids.append(chunk.id)
             embeddings.append(embedding)
             documents.append(chunk.text)
-            metadatas.append({
-                "source_id": chunk.source_id,
-                "chunk_index": chunk.chunk_index,
-                "section": chunk.section or "",
-            })
+            metadatas.append(
+                {
+                    "source_id": chunk.source_id,
+                    "chunk_index": chunk.chunk_index,
+                    "section": chunk.section or "",
+                }
+            )
 
         if ids:
             collection.upsert(
-                ids=ids,
-                embeddings=embeddings,
-                documents=documents,
-                metadatas=metadatas
+                ids=ids, embeddings=embeddings, documents=documents, metadatas=metadatas
             )
             logger.info("added_chunks", count=len(ids), collection=collection_name)
 
-    def query(self, query_embedding: list[float], collection_name: str,
-              n_results: int = 10) -> list[dict]:
+    def query(
+        self, query_embedding: list[float], collection_name: str, n_results: int = 10
+    ) -> list[dict]:
         """Search for similar vectors.
 
         Args:
@@ -88,7 +84,7 @@ class VectorStore:
         results = collection.query(
             query_embeddings=[query_embedding],
             n_results=n_results,
-            include=["embeddings", "documents", "metadatas", "distances"]
+            include=["embeddings", "documents", "metadatas", "distances"],
         )
 
         retrieved = []
@@ -97,19 +93,18 @@ class VectorStore:
                 results["documents"][0],
                 results["metadatas"][0],
                 results["distances"][0],
-                results["ids"][0]
+                results["ids"][0],
+                strict=False,
             ):
                 # ChromaDB distances are euclidean by default; convert to similarity score
                 similarity = 1 / (1 + distance)
-                retrieved.append({
-                    "id": chunk_id,
-                    "text": doc,
-                    "metadata": metadata,
-                    "score": similarity
-                })
+                retrieved.append(
+                    {"id": chunk_id, "text": doc, "metadata": metadata, "score": similarity}
+                )
 
-        logger.info("vector_query_complete", collection=collection_name,
-                   results_count=len(retrieved))
+        logger.info(
+            "vector_query_complete", collection=collection_name, results_count=len(retrieved)
+        )
         return retrieved
 
     def delete_by_source_id(self, source_id: str, collection_name: str) -> None:
@@ -122,11 +117,13 @@ class VectorStore:
         collection = self.get_collection(collection_name)
 
         # Get all documents and filter by source_id
-        all_docs = collection.get(
-            where={"source_id": {"$eq": source_id}}
-        )
+        all_docs = collection.get(where={"source_id": {"$eq": source_id}})
 
         if all_docs["ids"]:
             collection.delete(ids=all_docs["ids"])
-            logger.info("deleted_by_source", source_id=source_id,
-                       count=len(all_docs["ids"]), collection=collection_name)
+            logger.info(
+                "deleted_by_source",
+                source_id=source_id,
+                count=len(all_docs["ids"]),
+                collection=collection_name,
+            )

--- a/tests/unit/test_hybrid.py
+++ b/tests/unit/test_hybrid.py
@@ -1,0 +1,134 @@
+"""Tests for hybrid.py
+
+Confirms the fix for issue #34 follow-on bug: HybridRetriever was blending in
+a keyword_score that was always 0.0, because KeywordSearcher.index() was never
+called before KeywordSearcher.search() in HybridRetriever.retrieve(). Now that
+hybrid.py indexes all_chunks before searching, keyword_score should reflect
+actual BM25 relevance.
+"""
+
+import logging
+from unittest.mock import Mock
+
+import pytest
+
+from rag.retriever.hybrid import HybridRetriever
+from rag.retriever.keyword_search import KeywordSearcher
+
+
+@pytest.mark.unit
+class TestHybridRetrieverKeywordScoring:
+    """Reproduces keyword_score always being 0.0 in HybridRetriever."""
+
+    @pytest.fixture
+    def chunks(self) -> list[dict]:
+        """Sample chunks: one keyword-heavy, one keyword-sparse but relevant, one irrelevant."""
+        return [
+            {
+                "id": "c1",
+                "text": "kubernetes kubernetes kubernetes deployment scaling kubernetes",
+                "metadata": {"source_id": "s1"},
+            },
+            {
+                "id": "c2",
+                "text": "container orchestration platform used for scaling deployment",
+                "metadata": {"source_id": "s2"},
+            },
+            {
+                "id": "c3",
+                "text": "grandmother's chocolate cake recipe with frosting",
+                "metadata": {"source_id": "s3"},
+            },
+        ]
+
+    @pytest.fixture
+    def mock_vector_store(self, chunks: list[dict]) -> Mock:
+        """Mock VectorStore returning fixed vector-similarity hits and full corpus."""
+        store = Mock()
+
+        # Vector search "finds" c2 and c3 as semantically similar to the query,
+        # deliberately excluding the keyword-heavy c1.
+        store.query.return_value = [
+            {
+                "id": "c2",
+                "text": chunks[1]["text"],
+                "metadata": chunks[1]["metadata"],
+                "score": 0.9,
+            },
+            {
+                "id": "c3",
+                "text": chunks[2]["text"],
+                "metadata": chunks[2]["metadata"],
+                "score": 0.4,
+            },
+        ]
+
+        # get_collection(...).get(...) returns the full corpus, mirroring ChromaDB's shape.
+        collection = Mock()
+        collection.get.return_value = {
+            "ids": [c["id"] for c in chunks],
+            "documents": [c["text"] for c in chunks],
+            "metadatas": [c["metadata"] for c in chunks],
+        }
+        store.get_collection.return_value = collection
+
+        return store
+
+    @pytest.fixture
+    def retriever(self, mock_vector_store: Mock) -> HybridRetriever:
+        """HybridRetriever wired with a real (un-indexed) KeywordSearcher."""
+        return HybridRetriever(mock_vector_store, KeywordSearcher())
+
+    def test_keyword_score_reflects_bm25_relevance(
+        self, retriever: HybridRetriever, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Confirms the fix: keyword_score now reflects real BM25 relevance.
+
+        HybridRetriever.retrieve() now indexes all_chunks before calling
+        keyword_searcher.search(), so BM25 scores differentiate between the
+        keyword-heavy chunk ("c1"), the keyword-sparse-but-relevant chunk
+        ("c2"), and the keyword-irrelevant chunk ("c3").
+        """
+        with caplog.at_level(logging.WARNING):
+            results = retriever.retrieve(
+                query="kubernetes deployment",
+                profile_id="profile1",
+                query_embedding=[0.1, 0.2, 0.3],
+                max_chunks=5,
+                min_score=0.0,
+            )
+        for r in results:
+            print(
+                f'{r["id"]}: keyword_score={r["keyword_score"]}, vector_score={r["vector_score"]}'
+            )
+
+        assert len(results) == 3  # c1 now surfaces via the keyword path
+        assert "keyword_search_empty_index" not in caplog.text
+
+        by_id = {r["id"]: r for r in results}
+
+        # c1 repeats "kubernetes" heavily and contains "deployment" -> highest keyword score.
+        assert by_id["c1"]["keyword_score"] > 0.0
+        # c2 contains "deployment" only -> nonzero but lower than c1.
+        assert 0.0 < by_id["c2"]["keyword_score"] < by_id["c1"]["keyword_score"]
+        # c3 shares no terms with the query -> BM25 contributes nothing.
+        assert by_id["c3"]["keyword_score"] == 0.0
+
+    def test_keyword_searcher_indexed_on_retrieve(
+        self, retriever: HybridRetriever, chunks: list[dict]
+    ) -> None:
+        """Confirms the fix: retrieve() now indexes the collection's chunks."""
+        assert retriever.keyword_searcher.bm25 is None
+        assert retriever.keyword_searcher.chunks == []
+
+        retriever.retrieve(
+            query="kubernetes deployment",
+            profile_id="profile1",
+            query_embedding=[0.1, 0.2, 0.3],
+            max_chunks=5,
+            min_score=0.0,
+        )
+
+        # Now indexed with the full corpus fetched via _get_all_chunks().
+        assert retriever.keyword_searcher.bm25 is not None
+        assert {c["id"] for c in retriever.keyword_searcher.chunks} == {c["id"] for c in chunks}

--- a/tests/unit/test_hybrid_keyword_bias.py
+++ b/tests/unit/test_hybrid_keyword_bias.py
@@ -1,0 +1,138 @@
+"""Tests for hybrid.py
+
+Showcases issue #34: HybridRetriever's linear vector/keyword score blend can
+rank a chunk that merely repeats a technology name above a chunk that is
+genuinely more relevant, because keyword repetition inflates the normalized
+BM25 score enough to outweigh a real (but not maximal) vector-similarity gap.
+This does NOT fix the issue -- it only demonstrates it, to motivate the
+LLM re-ranking step this issue asks for.
+"""
+
+from unittest.mock import Mock
+
+import pytest
+
+from rag.retriever.hybrid import HybridRetriever
+from rag.retriever.keyword_search import KeywordSearcher
+
+
+@pytest.mark.unit
+class TestHybridRetrieverKeywordBias:
+    """Demonstrates keyword repetition overriding a stronger vector-similarity signal."""
+
+    @pytest.fixture
+    def chunks(self) -> list[dict]:
+        """A small realistic corpus: a keyword-stuffed off-topic chunk, a genuinely
+        relevant chunk, and unrelated filler chunks so "kubernetes" is a rare,
+        distinctive term (needed for BM25's IDF to behave realistically -- with
+        too few chunks a term appearing in most of them gets a near-zero or
+        negative IDF, which masks the effect this test is showcasing)."""
+        return [
+            {
+                "id": "stuffed",
+                # Repeats the query's tech name many times; otherwise unrelated content.
+                "text": (
+                    "kubernetes kubernetes kubernetes kubernetes kubernetes kubernetes "
+                    "pizza toppings recipe with extra cheese"
+                ),
+                "metadata": {"source_id": "s1"},
+            },
+            {
+                "id": "relevant",
+                # Mentions the tech name once, in a coherent, genuinely on-topic sentence.
+                "text": "our team migrated the payment service to a managed kubernetes cluster",
+                "metadata": {"source_id": "s2"},
+            },
+            {
+                "id": "filler1",
+                "text": "built a responsive marketing website using react and tailwind css",
+                "metadata": {"source_id": "s3"},
+            },
+            {
+                "id": "filler2",
+                "text": "wrote unit tests and integration tests for the billing microservice",
+                "metadata": {"source_id": "s4"},
+            },
+            {
+                "id": "filler3",
+                "text": "designed a rest api for the mobile app backend using flask",
+                "metadata": {"source_id": "s5"},
+            },
+        ]
+
+    @pytest.fixture
+    def mock_vector_store(self, chunks: list[dict]) -> Mock:
+        """Mock VectorStore where 'relevant' is the stronger semantic match, but only
+        by a realistic margin -- exactly the close-call case re-ranking should help with."""
+        store = Mock()
+
+        store.query.return_value = [
+            {
+                "id": "relevant",
+                "text": chunks[1]["text"],
+                "metadata": chunks[1]["metadata"],
+                "score": 0.9,
+            },
+            {
+                "id": "stuffed",
+                "text": chunks[0]["text"],
+                "metadata": chunks[0]["metadata"],
+                "score": 0.75,
+            },
+        ]
+
+        collection = Mock()
+        collection.get.return_value = {
+            "ids": [c["id"] for c in chunks],
+            "documents": [c["text"] for c in chunks],
+            "metadatas": [c["metadata"] for c in chunks],
+        }
+        store.get_collection.return_value = collection
+
+        return store
+
+    @pytest.fixture
+    def retriever(self, mock_vector_store: Mock) -> HybridRetriever:
+        """HybridRetriever with default weights (vector_weight=0.7, keyword_weight=0.3)."""
+        return HybridRetriever(mock_vector_store, KeywordSearcher())
+
+    def test_keyword_stuffing_can_outrank_the_more_relevant_chunk(
+        self, retriever: HybridRetriever
+    ) -> None:
+        """Showcases the bug driving issue #34: keyword repetition flips the ranking.
+
+        "relevant" has the stronger vector-similarity score (0.9 vs 0.75 raw,
+        i.e. normalized vector_score of 1.0 vs ~0.83), which is what a human
+        reviewer would judge as the better chunk for this query -- a realistic,
+        close-call gap, not a landslide. But "stuffed" repeats the query's tech
+        name 6x, so its normalized BM25 score dominates its result set (1.0)
+        enough that, blended with the default 0.7/0.3 weights, it ends up
+        ranked ABOVE "relevant" -- exactly the "keyword search might rank a
+        document higher just because it contains a specific keyword multiple
+        times" problem this issue describes. This test only documents the
+        behavior; it does not fix it.
+        """
+        results = retriever.retrieve(
+            query="kubernetes deployment",
+            profile_id="profile1",
+            query_embedding=[0.1, 0.2, 0.3],
+            max_chunks=5,
+            min_score=0.0,
+        )
+
+        by_id = {r["id"]: r for r in results}
+        for r in results:
+            print(
+                f'{r["id"]}: blended={r["score"]:.3f}, '
+                f'vector={r["vector_score"]:.3f}, keyword={r["keyword_score"]:.3f}'
+            )
+
+        # Vector search alone correctly prefers "relevant".
+        assert by_id["relevant"]["vector_score"] > by_id["stuffed"]["vector_score"]
+
+        # But the blended score flips the ranking: the keyword-stuffed, off-topic
+        # chunk ends up ranked first (of the two candidates vector search actually
+        # surfaced) despite being the weaker semantic match.
+        candidates_in_rank_order = [r["id"] for r in results if r["id"] in ("stuffed", "relevant")]
+        assert candidates_in_rank_order[0] == "stuffed"
+        assert by_id["stuffed"]["score"] > by_id["relevant"]["score"]

--- a/tests/unit/test_hybrid_with_reranker.py
+++ b/tests/unit/test_hybrid_with_reranker.py
@@ -1,0 +1,133 @@
+"""Tests for hybrid.py + reranker.py wired together end-to-end.
+
+Confirms issue #34's fix: when a Reranker is configured, HybridRetriever
+widens its candidate pool and defers the final ranking to the LLM, correcting
+the keyword-stuffing bias demonstrated in tests/unit/test_hybrid_keyword_bias.py.
+"""
+
+import json
+from unittest.mock import Mock, patch
+
+import pytest
+
+from rag.retriever.hybrid import HybridRetriever
+from rag.retriever.keyword_search import KeywordSearcher
+from rag.retriever.reranker import Reranker, RerankerConfig
+
+
+def _make_llm_response(content: str) -> Mock:
+    response = Mock()
+    response.choices = [Mock(message=Mock(content=content))]
+    return response
+
+
+@pytest.mark.unit
+class TestHybridRetrieverWithReranker:
+    """End-to-end: HybridRetriever + Reranker together fix the keyword-bias ranking."""
+
+    @pytest.fixture
+    def chunks(self) -> list[dict]:
+        """Same corpus as test_hybrid_keyword_bias.py."""
+        return [
+            {
+                "id": "stuffed",
+                "text": (
+                    "kubernetes kubernetes kubernetes kubernetes kubernetes kubernetes "
+                    "pizza toppings recipe with extra cheese"
+                ),
+                "metadata": {"source_id": "s1"},
+            },
+            {
+                "id": "relevant",
+                "text": "our team migrated the payment service to a managed kubernetes cluster",
+                "metadata": {"source_id": "s2"},
+            },
+            {
+                "id": "filler1",
+                "text": "built a responsive marketing website using react and tailwind css",
+                "metadata": {"source_id": "s3"},
+            },
+            {
+                "id": "filler2",
+                "text": "wrote unit tests and integration tests for the billing microservice",
+                "metadata": {"source_id": "s4"},
+            },
+            {
+                "id": "filler3",
+                "text": "designed a rest api for the mobile app backend using flask",
+                "metadata": {"source_id": "s5"},
+            },
+        ]
+
+    @pytest.fixture
+    def mock_vector_store(self, chunks: list[dict]) -> Mock:
+        store = Mock()
+        store.query.return_value = [
+            {
+                "id": "relevant",
+                "text": chunks[1]["text"],
+                "metadata": chunks[1]["metadata"],
+                "score": 0.9,
+            },
+            {
+                "id": "stuffed",
+                "text": chunks[0]["text"],
+                "metadata": chunks[0]["metadata"],
+                "score": 0.75,
+            },
+        ]
+        collection = Mock()
+        collection.get.return_value = {
+            "ids": [c["id"] for c in chunks],
+            "documents": [c["text"] for c in chunks],
+            "metadatas": [c["metadata"] for c in chunks],
+        }
+        store.get_collection.return_value = collection
+        return store
+
+    @pytest.fixture
+    def reranker(self) -> Reranker:
+        config = RerankerConfig(
+            api_key="test-key", base_url="https://example.invalid/v1", model="test-model"
+        )
+        with patch("rag.retriever.reranker.openai.OpenAI"):
+            r = Reranker(config)
+        r.client.chat.completions.create.return_value = _make_llm_response(
+            json.dumps({"relevant": 0.95, "stuffed": 0.1})
+        )
+        return r
+
+    def test_reranker_fixes_keyword_stuffing_bias_end_to_end(
+        self, mock_vector_store: Mock, reranker: Reranker
+    ) -> None:
+        """Without a reranker, "stuffed" outranks "relevant" (see
+        test_hybrid_keyword_bias.py). With one wired in, HybridRetriever
+        widens its candidate pool and the LLM's judgment wins instead."""
+        retriever = HybridRetriever(mock_vector_store, KeywordSearcher(), reranker=reranker)
+
+        results = retriever.retrieve(
+            query="kubernetes deployment",
+            profile_id="profile1",
+            query_embedding=[0.1, 0.2, 0.3],
+            max_chunks=2,
+            min_score=0.0,
+        )
+
+        assert [r["id"] for r in results] == ["relevant", "stuffed"]
+        assert results[0]["rerank_score"] == 0.95
+
+    def test_without_reranker_bias_still_reproduces(self, mock_vector_store: Mock) -> None:
+        """Sanity check: the same setup, minus the reranker, still shows the
+        original bug -- confirming the fix is what flips the outcome above,
+        not some other change to the corpus/mocks."""
+        retriever = HybridRetriever(mock_vector_store, KeywordSearcher())
+
+        results = retriever.retrieve(
+            query="kubernetes deployment",
+            profile_id="profile1",
+            query_embedding=[0.1, 0.2, 0.3],
+            max_chunks=2,
+            min_score=0.0,
+        )
+
+        assert [r["id"] for r in results] == ["stuffed", "relevant"]

--- a/tests/unit/test_reranker.py
+++ b/tests/unit/test_reranker.py
@@ -1,0 +1,118 @@
+"""Tests for reranker.py"""
+
+import json
+from unittest.mock import Mock, patch
+
+import pytest
+
+from rag.retriever.reranker import Reranker, RerankerConfig
+
+
+def _make_response(content: str) -> Mock:
+    """Build a fake OpenAI chat-completions response with the given content."""
+    response = Mock()
+    response.choices = [Mock(message=Mock(content=content))]
+    return response
+
+
+@pytest.mark.unit
+class TestReranker:
+    """Test suite for Reranker."""
+
+    @pytest.fixture
+    def config(self) -> RerankerConfig:
+        return RerankerConfig(
+            api_key="test-key", base_url="https://example.invalid/v1", model="test-model"
+        )
+
+    @pytest.fixture
+    def reranker(self, config: RerankerConfig) -> Reranker:
+        with patch("rag.retriever.reranker.openai.OpenAI"):
+            return Reranker(config)
+
+    @pytest.fixture
+    def chunks(self) -> list[dict]:
+        """The same keyword-stuffing-vs-relevance scenario from test_hybrid_keyword_bias.py."""
+        return [
+            {"id": "stuffed", "text": "kubernetes " * 6 + "pizza toppings recipe", "score": 0.883},
+            {
+                "id": "relevant",
+                "text": "our team migrated the payment service to a managed kubernetes cluster",
+                "score": 0.851,
+            },
+        ]
+
+    def test_empty_chunks_returns_empty(self, reranker: Reranker) -> None:
+        """No chunks in -> no LLM call, empty list out."""
+        assert reranker.rerank("kubernetes deployment", []) == []
+
+    def test_reranker_corrects_keyword_stuffing_bias(
+        self, reranker: Reranker, chunks: list[dict]
+    ) -> None:
+        """Confirms the reranker can invert the ordering test_hybrid_keyword_bias.py showcased.
+
+        HybridRetriever's blended score ranked "stuffed" (0.883) above "relevant"
+        (0.851) purely due to keyword repetition. Here the (mocked) LLM correctly
+        judges "relevant" as more topically relevant, and the reranker output
+        should reflect that corrected order.
+        """
+        reranker.client.chat.completions.create.return_value = _make_response(
+            json.dumps({"relevant": 0.95, "stuffed": 0.1})
+        )
+
+        results = reranker.rerank("kubernetes deployment", chunks)
+
+        assert [r["id"] for r in results] == ["relevant", "stuffed"]
+        assert results[0]["rerank_score"] == 0.95
+        assert results[1]["rerank_score"] == 0.1
+
+    def test_top_k_truncates_results(self, reranker: Reranker, chunks: list[dict]) -> None:
+        reranker.client.chat.completions.create.return_value = _make_response(
+            json.dumps({"relevant": 0.95, "stuffed": 0.1})
+        )
+
+        results = reranker.rerank("kubernetes deployment", chunks, top_k=1)
+
+        assert len(results) == 1
+        assert results[0]["id"] == "relevant"
+
+    def test_llm_call_failure_falls_back_to_blended_score_order(
+        self, reranker: Reranker, chunks: list[dict]
+    ) -> None:
+        """If the LLM call errors, fall back to the original blended-score order
+        rather than breaking retrieval -- this still exhibits the keyword-bias
+        problem, but degrades safely instead of raising."""
+        reranker.client.chat.completions.create.side_effect = RuntimeError("API unavailable")
+
+        results = reranker.rerank("kubernetes deployment", chunks)
+
+        assert [r["id"] for r in results] == ["stuffed", "relevant"]
+        assert "rerank_score" not in results[0]
+
+    def test_malformed_llm_output_falls_back_to_blended_score_order(
+        self, reranker: Reranker, chunks: list[dict]
+    ) -> None:
+        """If the LLM doesn't return parseable JSON, fall back gracefully."""
+        reranker.client.chat.completions.create.return_value = _make_response(
+            "sorry, I cannot help with that"
+        )
+
+        results = reranker.rerank("kubernetes deployment", chunks)
+
+        assert [r["id"] for r in results] == ["stuffed", "relevant"]
+
+    def test_missing_chunk_id_in_response_falls_back_to_its_blended_score(
+        self, reranker: Reranker, chunks: list[dict]
+    ) -> None:
+        """If the LLM only scores some chunks, the unscored ones keep their
+        original blended score rather than being dropped or scored 0."""
+        reranker.client.chat.completions.create.return_value = _make_response(
+            json.dumps({"relevant": 0.95})
+        )
+
+        results = reranker.rerank("kubernetes deployment", chunks)
+
+        by_id = {r["id"]: r for r in results}
+        assert by_id["stuffed"]["rerank_score"] == 0.883  # fell back to its own "score"
+        assert by_id["relevant"]["rerank_score"] == 0.95
+        assert [r["id"] for r in results] == ["relevant", "stuffed"]


### PR DESCRIPTION
## Summary
<!-- One paragraph describing what this PR does and why -->
This PR implements the fix for issue 34: Implement a re-ranking step that uses an LLM to score retrieved chunks before generation. The PR first fixed an existing bug that completely overlooked sparse retrieval. I then verified the fix, then created testcases where the lack of a re-ranking step results in poor retrieval results. Finally, I implemented the re-ranking step in rag/retriever/reranker.py.

## Issue
Closes #34
# 34: Implement a re-ranking step that uses an LLM to score retrieved chunks before generation
## Changes
<!-- Bullet list of the specific changes made -->
- Fix missing keyword_result bug
- Create test file test_hybrid.py to verify the fix
- Create test file test_hybrid_keyword_bias.py to verify issue #34
- Implement fix for issue #34, with reranker.py
- Create test_reranker.py to verify the fix
- Create test_hybrid_with_reranker.py to verify the whole reranking pipeline.

## Testing
<!-- How did you verify your changes? -->
- [386] Unit tests pass (`make test-unit`)
- [0: this is another issue] Integration tests pass (`make test-integration`)
- [173 errors before and after changes] Linter passes (`make lint`)
- [] Type checker passes (`make typecheck`): I can't run this due to Application Control policy, but it's non related to my issue
- [4/4] New/updated tests cover the changes

## Screenshots / Demo
<!-- If applicable, add screenshots or a link to a demo video -->

## Notes for Reviewers
<!-- Anything the reviewer should pay particular attention to -->
