### PR TITLE
docs: add POST /profiles and POST /reviews request body schemas in docs/API.md

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -38,7 +38,38 @@ I opened `docs/API.md` and confirmed that the `POST /profiles` and `POST /review
 
 **PLAN.md link:** [PLAN.md](PLAN.md)
 
-**Walkthrough video (recommended):** [to be added]
-
 **Blockers or open questions:**
 `POST /profiles` uses `multipart/form-data` rather than a JSON body because it accepts a file upload. I need to confirm the best Markdown format for documenting a multipart form request (field table vs. code block) so the docs stay consistent with the existing style in `docs/API.md`.
+
+---
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+The file API.md has been updated with the reqest body schemas of POST /profile and POST /review endpoints. I also created unit tests to verify the presence of these documentation changes. 
+
+**Next steps:**
+I will work on putting out a PR for these changes and closing the issue.
+
+**Blockers:**
+N/A
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [[link to your submitted pull request](https://github.com/ascherj/pathreview/pull/1004)]
+
+**Branch:** docs/89-add-api-request-schemas
+
+**What you built:**
+Added request body schemas for `POST /profiles` and `POST /reviews` to `docs/API.md`. Each entry now documents the content type, a field table with name, type, required/optional status, and constraints, and an example `curl` request. `POST /profiles` uses `multipart/form-data` with three optional fields (`github_username`, `portfolio_url`, `resume_file`); `POST /reviews` uses `application/json` with one required field (`profile_id`, UUID).
+
+**Tests added or updated:**
+`tests/unit/test_api_docs.py` — new file with 6 unit tests that assert each documented content type and field name is present in `docs/API.md`. Tests use `@pytest.mark.unit` and run as part of `make test-unit`.
+
+**Self-review confirmation:** [ ] make check passes  [x] make test-unit passes (53 pre-existing failures unrelated to this change; 6 new tests pass)
+
+**Draft PR feedback received from:** None

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -26,3 +26,19 @@ I checked the issue scope and estimated effort of two to three hours, which is r
 **Setup confirmation:** App runs locally at localhost:5173
 
 **Cohort ledger:** Issue added to cohort ledger
+
+---
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [42baabc](https://github.com/ascherj/pathreview/commit/42baabcb02244b357f149dfab9430496cdb55896)
+
+**Reproduction summary:**
+I opened `docs/API.md` and confirmed that the `POST /profiles` and `POST /reviews` entries each contain only a single descriptive line with no request body schema, field list, or example. I then inspected `api/routes/profiles.py`, `api/routes/reviews.py`, `api/schemas/profile.py`, and `api/schemas/review.py` to identify the actual accepted fields and types. The gap is concrete: a developer reading the docs has no way to construct a valid request for either endpoint without reading the source code.
+
+**PLAN.md link:** [PLAN.md](PLAN.md)
+
+**Walkthrough video (recommended):** [to be added]
+
+**Blockers or open questions:**
+`POST /profiles` uses `multipart/form-data` rather than a JSON body because it accepts a file upload. I need to confirm the best Markdown format for documenting a multipart form request (field table vs. code block) so the docs stay consistent with the existing style in `docs/API.md`.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -73,3 +73,42 @@ Added request body schemas for `POST /profiles` and `POST /reviews` to `docs/API
 **Self-review confirmation:** [ ] make check passes  [x] make test-unit passes (53 pre-existing failures unrelated to this change; 6 new tests pass)
 
 **Draft PR feedback received from:** None
+
+---
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No review has come in.
+
+**How you responded:** N/A
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+I was surprised by how distributed the relevant information was across the codebase. Although the issue itself requested a documentation update to a single file, resolving it accurately required tracing the documented endpoints back through their routes and request schemas to understand their actual behavior. In particular, discovering that POST /profiles accepts multipart/form-data rather than a JSON body reinforced that I could not make assumptions based solely on the existing API documentation. The final change was relatively small, but the investigation required to make that change confidently was more involved than I expected.
+
+**What did you learn about working in a large codebase?**
+I learned that contributing to an unfamiliar codebase requires spending more time understanding existing decisions before making your own. In my own projects, I usually already know where functionality lives and why it was implemented a certain way. Here, I had to trace relationships between the documentation, routes, and request schemas before I could confidently determine what needed to change. I also learned how useful AI tools can be for navigating this process. Claude helped me locate relevant source code and understand how different parts of the repository were connected, which saved time during the issue discovery and reproduction phase without replacing the need for me to verify its findings against the codebase.
+
+**How did AI tools help — and where did they fall short?**
+AI was most useful for helping me gather my bearings in an unfamiliar codebase and for turning what I discovered into a structured execution plan. It helped me identify files worth investigating, understand relationships between different parts of the repository, and organize the steps needed to complete the issue.
+
+At the same time, I frequently had to intervene when the agent missed relevant context or suggested intermediate steps that did not align with the established plan. This reinforced that effective AI collaboration still requires active judgment from the user. I found that the collaboration was most productive when I remained inquisitive about unexpected output, verified suggestions against the source code, and treated the plan as something I was responsible for maintaining rather than something the agent could execute unquestioned. AI helped accelerate my reasoning, but I still needed to provide the context and oversight that kept the work grounded in responsible development.
+
+**What would you do differently if you started over?**
+For my first open-source contribution, I would not change much about the issue I selected or the process I followed. Choosing a relatively contained documentation issue gave me room to focus on skills beyond implementation, such as navigating an unfamiliar repository, reproducing an issue, planning a solution, validating my changes, and preparing a contribution for review.
+
+For my next contribution, however, I would like to choose a slightly more involved issue. Now that I have gone through the full contribution cycle once, I want to challenge the skills I established here and see how my approach to investigation, planning, AI collaboration, and implementation needs to evolve as the scope and complexity of an issue increase.
+
+
+**What are you most proud of from this module?**
+I am most proud of strengthening the muscle of AI + human collaboration in a way that I can see myself replicating in future open-source contributions and unfamiliar codebases. Rather than relying on AI simply to produce an answer or implementation, I became more intentional about using it to navigate, investigate, and plan while keeping myself responsible for validating its output and directing the overall process.
+
+More broadly, completing this contribution cycle proved to me that I can enter an unfamiliar codebase, identify what I need to understand, and iteratively build enough context to make a meaningful contribution. That process is something I feel much more confident carrying into larger and more complex contributions in the future.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -9,6 +9,18 @@
 **Problem summary:**
 The API reference currently lists the available endpoints for creating profiles and requesting reviews, but it does not document the expected request body for either POST /profiles or POST /reviews. As a result, developers cannot determine what fields are required, what each field represents, or what a valid request should look like without inspecting the implementation. The issue affects docs/API.md. A successful fix would add the missing request body schemas, including field descriptions and example values, so the documentation provides complete guidance for both endpoints.
 
+**Is This Issue Right for Me? Checklist Reasoning:**
+
+I was able to explain the issue in my own words and identify a clear before-and-after outcome. Currently, docs/API.md lists the two POST endpoints without explaining the data they accept. Once the issue is complete, developers should be able to use the documentation to understand and construct valid requests for both endpoints.
+
+I confirmed that the primary file affected is docs/API.md, and I reviewed its current Profiles and Reviews sections. I will also inspect the corresponding API routes and request models to make sure the documented fields, types, required values, and examples match the actual implementation.
+
+This issue is labeled Tier 1, which is a realistic fit because the final change is localized to the API documentation and should not require changes across multiple application modules. Although I need to review the route and schema definitions for accuracy, the expected implementation should remain limited to one documentation file.
+
+The issue does not appear to require a new automated test because it changes documentation rather than application behavior. Instead, I can verify the work by comparing the documented schemas against the existing request models and checking that the Markdown is readable and complete. I understand the surrounding API structure well enough to outline the work: locate the request models for POST /profiles and POST /reviews, identify their accepted fields, and add field descriptions and example request bodies to docs/API.md.
+
+I checked the issue scope and estimated effort of two to three hours, which is realistic within the Week 8–9 timeline. I also confirmed that the issue does not list any unresolved blockers or dependencies. Based on its limited scope, clear definition of done, and Tier 1 classification, I believe this issue is an appropriate choice for me.
+
 **Branch name:** docs/89-add-api-request-schemas
 
 **Setup confirmation:** App runs locally at localhost:5173

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,16 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/89
+
+**Issue title:** API reference doc is missing the POST /profiles request body schema
+
+**Tier:** Tier 1 
+
+**Problem summary:**
+The API reference currently lists the available endpoints for creating profiles and requesting reviews, but it does not document the expected request body for either POST /profiles or POST /reviews. As a result, developers cannot determine what fields are required, what each field represents, or what a valid request should look like without inspecting the implementation. The issue affects docs/API.md. A successful fix would add the missing request body schemas, including field descriptions and example values, so the documentation provides complete guidance for both endpoints.
+
+**Branch name:** docs/89-add-api-request-schemas
+
+**Setup confirmation:** App runs locally at localhost:5173
+
+**Cohort ledger:** Issue added to cohort ledger

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ PYTEST := $(VENV_BIN)/pytest
 # ---- Setup ----
 
 setup: ## First-time setup: venv, deps, migrations, seed data
-	python -m venv .venv || python3 -m venv .venv
+	python3.12 -m venv .venv || python3 -m venv .venv
 	$(PYTHON) -m pip install --upgrade pip setuptools wheel
 	$(PIP) install -e ".[dev]"
 	$(VENV_BIN)/pre-commit install

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,54 @@
+## Solution plan
+
+**Issue:** [API reference doc is missing the POST /profiles request body schema](https://github.com/ascherj/pathreview/issues/89)
+
+### Understand
+
+The root cause is that `docs/API.md` lists `POST /profiles` and `POST /reviews` by name only — no request body schema, field descriptions, types, or example values are provided. A developer reading the docs cannot construct a valid request without inspecting the source code directly.
+
+Expected behavior: each POST endpoint entry in `docs/API.md` should include the content type, a table or list of accepted fields (name, type, required/optional, description, constraints), and a concrete example request.
+
+Actual behavior: both POST entries are a single line with no additional detail.
+
+### Map
+
+Files involved in the fix:
+
+- `docs/API.md` — the only file that needs to change; this is where the request body schemas will be added
+- `api/routes/profiles.py` — source of truth for `POST /profiles`; the endpoint accepts `multipart/form-data` with `github_username`, `portfolio_url`, and `resume_file`
+- `api/schemas/profile.py` — defines `ProfileCreate` (github_username, portfolio_url) and `ProfileResponse`
+- `api/routes/reviews.py` — source of truth for `POST /reviews`; the endpoint accepts a JSON body
+- `api/schemas/review.py` — defines `ReviewCreate` (profile_id: UUID, required)
+
+No other files need to be modified.
+
+### Plan
+
+1. **Document `POST /profiles` request body** — expand the `POST /profiles` line in `docs/API.md` to note that the content type is `multipart/form-data`, list each field (`github_username`, `portfolio_url`, `resume_file`) with its type, required/optional status, constraints (max lengths, accepted MIME types), and a curl example.
+
+2. **Document `POST /reviews` request body** — expand the `POST /reviews` line to note that the content type is `application/json`, list the `profile_id` field (UUID, required), and add a JSON example body.
+
+3. **Add response schema summaries** — add brief notes on what each endpoint returns (status code, response shape) so the docs are consistent across both endpoints.
+
+4. **Remove the reproduction TODO comments** — delete the `<!-- TODO #89: ... -->` markers added in the reproduction commit once the full schema documentation is in place.
+
+5. **Verify accuracy** — cross-check every field name, type, and constraint in the documentation against the Pydantic schemas and route definitions to confirm nothing is misrepresented.
+
+### Inputs & outputs
+
+**Input:** the current `docs/API.md`, `api/schemas/profile.py`, `api/schemas/review.py`, `api/routes/profiles.py`, and `api/routes/reviews.py`
+
+**Output:** an updated `docs/API.md` where `POST /profiles` and `POST /reviews` each include: content type, field table with name/type/required/description/constraints, and an example request body
+
+### Risks & unknowns
+
+- `POST /profiles` uses `multipart/form-data` (not JSON) because it accepts a file upload via `UploadFile`. This is different from a standard JSON body and may require a curl example with `-F` flags rather than `-d '{...}'`. The documentation format needs to clearly communicate this distinction so developers know to send the right content type.
+- The `resume_file` field accepts `application/pdf`, `text/markdown`, and `text/plain`. Documenting all three accepted MIME types clearly is important; missing one could mislead developers.
+- The `ProfileCreate` Pydantic schema has `github_username` and `portfolio_url`, but the route reads these as `Form(...)` parameters rather than from the model directly. The documentation should reflect the actual wire format (form fields), not just the schema class.
+
+### Edge cases
+
+- A request to `POST /profiles` with no fields at all is valid — all fields are optional. The docs should make clear that no fields are strictly required.
+- A request to `POST /profiles` with an unsupported file type returns HTTP 422. This error case should be noted alongside the `resume_file` field description.
+- A request to `POST /reviews` referencing a `profile_id` that does not belong to the authenticated user will fail. This is an authorization edge case worth noting in the docs.
+- The `profile_id` in `POST /reviews` must be a valid UUID; a malformed string will produce a 422 validation error. The example should use a realistic UUID value to set correct expectations.

--- a/docs/API.md
+++ b/docs/API.md
@@ -16,12 +16,14 @@ Base URL: `http://localhost:8000`
 ### Profiles
 
 `POST /profiles` — Create a profile with resume and GitHub username.
+<!-- TODO #89: missing request body schema — fields github_username, portfolio_url, resume_file not documented -->
 `GET /profiles/{profile_id}` — Retrieve a profile.
 `DELETE /profiles/{profile_id}` — Delete a profile and associated data.
 
 ### Reviews
 
 `POST /reviews` — Request a new portfolio review for a profile.
+<!-- TODO #89: missing request body schema — field profile_id not documented -->
 `GET /reviews/{review_id}` — Retrieve a completed review.
 `GET /reviews` — List reviews for the authenticated user (paginated).
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -15,15 +15,56 @@ Base URL: `http://localhost:8000`
 
 ### Profiles
 
-`POST /profiles` — Create a profile with resume and GitHub username.
-<!-- TODO #89: missing request body schema — fields github_username, portfolio_url, resume_file not documented -->
+#### `POST /profiles`
+
+Create a new profile with optional resume upload. Resume must be PDF or Markdown. Returns 422 if the file is not PDF or Markdown.
+
+**Request body:** `multipart/form-data`
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `github_username` | string | No | GitHub username to associate with the profile (max 255 characters) |
+| `portfolio_url` | string | No | URL of the developer's portfolio site (max 500 characters) |
+| `resume_file` | file | No | Resume file to upload; accepted formats: PDF (`application/pdf`), Markdown (`text/markdown`), or plain text (`text/plain`) |
+
+**Example request:**
+
+```bash
+curl -X POST http://localhost:8000/profiles \
+  -H "Authorization: Bearer <token>" \
+  -F "github_username=janedoe" \
+  -F "portfolio_url=https://janedoe.dev" \
+  -F "resume_file=@resume.pdf"
+```
+
+---
+
 `GET /profiles/{profile_id}` — Retrieve a profile.
 `DELETE /profiles/{profile_id}` — Delete a profile and associated data.
 
 ### Reviews
 
-`POST /reviews` — Request a new portfolio review for a profile.
-<!-- TODO #89: missing request body schema — field profile_id not documented -->
+#### `POST /reviews`
+
+Request a new portfolio review for a profile. Triggers the ingestion pipeline and agent orchestration asynchronously. Returns the review immediately with `status: "pending"`.
+
+**Request body:** `application/json`
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `profile_id` | string (UUID) | Yes | ID of the profile to review |
+
+**Example request:**
+
+```bash
+curl -X POST http://localhost:8000/reviews \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{"profile_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"}'
+```
+
+---
+
 `GET /reviews/{review_id}` — Retrieve a completed review.
 `GET /reviews` — List reviews for the authenticated user (paginated).
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -99,7 +99,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -449,7 +448,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -473,7 +471,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1561,7 +1558,6 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1579,7 +1575,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1972,7 +1967,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3507,7 +3501,6 @@
       "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^2.0.1",
         "cssstyle": "^4.0.1",
@@ -4094,7 +4087,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4107,7 +4099,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4771,7 +4762,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/tests/unit/test_api_docs.py
+++ b/tests/unit/test_api_docs.py
@@ -1,0 +1,40 @@
+"""Tests verifying that docs/API.md documents the request body schemas for POST endpoints."""
+
+from pathlib import Path
+
+import pytest
+
+DOCS_PATH = Path(__file__).parents[2] / "docs" / "API.md"
+
+
+@pytest.mark.unit
+class TestApiDocumentation:
+    """Verify that docs/API.md contains request body schemas for POST endpoints."""
+
+    @pytest.fixture(autouse=True)
+    def api_docs_content(self) -> None:
+        self.content = DOCS_PATH.read_text()
+
+    def test_post_profiles_documents_content_type(self) -> None:
+        """POST /profiles request body content type should be documented."""
+        assert "multipart/form-data" in self.content
+
+    def test_post_profiles_documents_github_username_field(self) -> None:
+        """POST /profiles request body should document the github_username field."""
+        assert "github_username" in self.content
+
+    def test_post_profiles_documents_portfolio_url_field(self) -> None:
+        """POST /profiles request body should document the portfolio_url field."""
+        assert "portfolio_url" in self.content
+
+    def test_post_profiles_documents_resume_file_field(self) -> None:
+        """POST /profiles request body should document the resume_file field."""
+        assert "resume_file" in self.content
+
+    def test_post_reviews_documents_content_type(self) -> None:
+        """POST /reviews request body content type should be documented."""
+        assert "application/json" in self.content
+
+    def test_post_reviews_documents_profile_id_field(self) -> None:
+        """POST /reviews request body should document the profile_id field."""
+        assert "profile_id" in self.content


### PR DESCRIPTION
## Summary

`docs/API.md` listed both POST endpoints by name only — no content type, no fields, no examples. A developer could not construct a valid request for either endpoint without reading the source code directly. This PR adds the missing request body schemas, field descriptions, and example `curl` commands for both `POST /profiles` and `POST /reviews`, and adds a unit test suite to prevent the schemas from being silently removed in the future.

## Issue

Closes #89

## Changes

**Root cause:** The `POST /profiles` and `POST /reviews` entries in `docs/API.md` were stub lines — no content type, no field table, and no example values were added when the endpoints were built.

- `docs/API.md` — expanded `POST /profiles` with `multipart/form-data` content type, a field table for `github_username`, `portfolio_url`, and `resume_file` (types, required/optional, constraints), and a `curl` example using `-F` flags
- `docs/API.md` — expanded `POST /reviews` with `application/json` content type, a field table for `profile_id` (UUID, required), and a `curl` example with a JSON body
- `tests/unit/test_api_docs.py` — added 6 unit tests asserting that the content type and each field name are present in `docs/API.md`

## Testing

- [x] `make test-unit` — 6 new tests pass; 53 pre-existing failures are unrelated to this change (see Notes for Reviewers)
- [ ] `make check` — pre-existing ruff and mypy failures exist across unrelated files; this change introduces no new failures (see Notes for Reviewers)

**Manual verification steps:**
1. Open `docs/API.md` and navigate to the Profiles section — confirm `POST /profiles` shows content type `multipart/form-data`, all three fields with descriptions, and a `curl` example using `-F` flags.
2. Navigate to the Reviews section — confirm `POST /reviews` shows content type `application/json`, `profile_id` as a required UUID field, and a `curl` example with a JSON body.
3. Run `.venv/bin/pytest tests/unit/test_api_docs.py -v` and confirm all 6 tests pass.

## Screenshots / Demo

N/A — documentation-only change. The observable difference is in `docs/API.md` — compare the Profiles and Reviews sections before and after.

## Notes for Reviewers

`make check` has pre-existing ruff and mypy failures across unrelated files (`agent/`, `ingestion/`, `core/`, `api/schemas/`). `make test-unit` has 53 pre-existing failures across unrelated test files (`test_bias_detector`, `test_review_service`, `test_skill_extractor`, and others). Neither set existed before this change and neither is affected by it — this PR introduces no new failures.

