### PR TITLE
Feat/69 feedback tone check

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -83,7 +83,7 @@ No other blockers.
 
 ### Check-in 2 (end of week)
 
-**PR link:** <!-- PASTE the PR URL here after opening it: https://github.com/ascherj/pathreview/pull/NNN -->
+**PR link:** https://github.com/ascherj/pathreview/pull/1006
 
 **Branch:** `feat/69-feedback-tone-check`
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -32,3 +32,26 @@ window. Main risk: the regenerate loop needs a retry cap to avoid infinite
 loops — noted for the implementation phase.
 
 **Cohort ledger:** [ ] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [paste the pushed commit URL here after `git push`]
+
+**Reproduction summary:**
+Traced the gap through the codebase: `core/services/review_service.py:365`
+lists "Validate feedback tone and constructiveness" as a placeholder comment in
+`_run_safety_checks` that is never implemented, `safety/content_filter.py` only
+regex-matches a short list of harmful phrases (no constructive-vs-negative
+classification), and `rag/generator/review_generator.py` has no
+regenerate-on-fail path. So a dismissive or discouraging (but not "harmful")
+feedback section is delivered untouched — confirming the missing step is real
+and I know exactly where it lives.
+
+**PLAN.md link:** [paste PLAN.md URL, e.g. .../tree/feat/69-feedback-tone-check/PLAN.md]
+
+**Walkthrough video (recommended):** [optional Loom link, ≤2 min — not graded]
+
+**Blockers or open questions:**
+Need to confirm whether the tone classifier should reuse the existing
+`openai.OpenAI` client/config from `ReviewGenerator` or get its own in the
+safety layer. Otherwise plan is clear going into Week 9.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -22,7 +22,7 @@ understanding how those two modules connect.
 
 **Branch name:** feat/69-feedback-tone-check
 
-**Setup confirmation:** [ ] App runs locally at localhost:5173
+**Setup confirmation:** [x] App runs locally at localhost:5173
 
 **"Is this right for me?" checklist / scope reasoning:**
 Tier 2, estimated 5–8 hours. Scope is bounded to two named files plus a new

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -35,7 +35,7 @@ loops — noted for the implementation phase.
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [paste the pushed commit URL here after `git push`]
+**Reproduction commit link:** https://github.com/Jordy-03/pathreview/commit/80b57b79ba7129906028d3fbfd1d50d93aae7dbb
 
 **Reproduction summary:**
 Traced the gap through the codebase: `core/services/review_service.py:365`
@@ -47,9 +47,7 @@ regenerate-on-fail path. So a dismissive or discouraging (but not "harmful")
 feedback section is delivered untouched — confirming the missing step is real
 and I know exactly where it lives.
 
-**PLAN.md link:** [paste PLAN.md URL, e.g. .../tree/feat/69-feedback-tone-check/PLAN.md]
-
-**Walkthrough video (recommended):** [optional Loom link, ≤2 min — not graded]
+**PLAN.md link:** https://github.com/Jordy-03/pathreview/blob/feat/69-feedback-tone-check/PLAN.md
 
 **Blockers or open questions:**
 Need to confirm whether the tone classifier should reuse the existing

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,34 @@
+# PathReview — Module 3 Journal
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/69
+
+**Issue title:** Add a "feedback tone check" that ensures all generated feedback is written constructively
+
+**Tier:** [ ] Tier 1  [x] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+Right now the review generator produces feedback without any check on how that
+feedback is phrased, so a section can come out vague, dismissive, or
+discouraging and still reach the user. This issue asks for a tone-classification
+step that runs after generation: a prompt classifies each feedback section as
+constructive (actionable, specific, encouraging) or negative (discouraging,
+vague, dismissive). Sections that fail are rejected and regenerated. A
+successful fix guarantees every delivered feedback section reads
+constructively. It touches the safety layer (`safety/content_filter.py`) and
+the generation path (`rag/generator/review_generator.py`), so it requires
+understanding how those two modules connect.
+
+**Branch name:** feat/69-feedback-tone-check
+
+**Setup confirmation:** [ ] App runs locally at localhost:5173
+
+**"Is this right for me?" checklist / scope reasoning:**
+Tier 2, estimated 5–8 hours. Scope is bounded to two named files plus a new
+classifier prompt, no schema or infra changes. Cross-module (safety + rag) but
+each module is understandable on its own. Fits within the Weeks 8–9 build
+window. Main risk: the regenerate loop needs a retry cap to avoid infinite
+loops — noted for the implementation phase.
+
+**Cohort ledger:** [ ] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -53,3 +53,64 @@ and I know exactly where it lives.
 Need to confirm whether the tone classifier should reuse the existing
 `openai.OpenAI` client/config from `ReviewGenerator` or get its own in the
 safety layer. Otherwise plan is clear going into Week 9.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the core of the fix from PLAN.md. Done so far:
+- Sub-task 1 — added `TONE_CHECK_TEMPLATE` + `get_tone_check_prompt()` and a new
+  `ToneClassifier` in `safety/content_filter.py` that returns
+  `(is_constructive, reason)` from an LLM call.
+- Sub-task 2 — wired the reject-and-regenerate loop into
+  `rag/generator/review_generator.py` (`generate_section` now regenerates
+  non-constructive sections up to `max_tone_retries`), extracting `_generate_once()`.
+- Sub-task 4 — added structured logging (`tone_check_failed`, `tone_regenerated_ok`,
+  `tone_retries_exhausted`).
+
+**Next steps:**
+Finish sub-task 5 (unit tests for the classifier and the loop), run the full
+`make check` / `make test-unit` against the recorded baseline, and open a draft PR
+for peer feedback.
+
+**Blockers:**
+Resolved the Week 8 open question — the classifier reuses the generator's existing
+OpenAI client (injected in `ReviewGenerator.__init__`), which keeps it testable.
+No other blockers.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** <!-- PASTE the PR URL here after opening it: https://github.com/ascherj/pathreview/pull/NNN -->
+
+**Branch:** `feat/69-feedback-tone-check`
+
+**What you built:**
+An LLM-based tone check for generated portfolio feedback. After each section is
+generated, a `ToneClassifier` labels it constructive or non-constructive; the
+generator rejects and regenerates non-constructive sections (with corrective
+guidance) up to a bounded retry cap, then delivers the best attempt. The check
+fails open on errors so it can never block or crash a review.
+
+**Tests added or updated:**
+- `tests/unit/test_content_filter.py` (new) — covers `ToneClassifier`: constructive
+  feedback passes, negative feedback is flagged, the JSON verdict is extracted even
+  when wrapped in prose, and all three fail-open paths (empty text, unparseable
+  response, LLM error) default to constructive without blocking. Also keeps two
+  regression tests for the existing `ContentFilter`.
+- `tests/unit/test_review_generator.py` (new) — covers the regenerate loop: no
+  regeneration when the first draft is constructive, exactly one regeneration when
+  the first draft fails then passes, best-effort delivery when all retries are
+  exhausted, and that disabling `tone_check_enabled` skips the classifier entirely.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+<!-- "passes" per Module 3 guidance = my changes introduce NO NEW failures.
+     Baseline (branch base): 53 failing unit tests + pre-existing lint/type errors.
+     After my changes: identical 53-failure set (verified by sorted diff of FAILED
+     lines); passing tests 375 -> 387 (+12 new). My changed files add no new lint
+     errors. See PR "Testing" section for the documented pre-existing failures. -->
+
+**Draft PR feedback received from:** none yet (draft PR to be posted in the cohort
+Slack channel for peer review)

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -114,3 +114,77 @@ fails open on errors so it can never block or crash a review.
 
 **Draft PR feedback received from:** none yet (draft PR to be posted in the cohort
 Slack channel for peer review)
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No reviewer or maintainer feedback arrived on PR #1006 by the end of the week.
+(Per the Summer 2026 note, reviewer feedback isn't a provided feature this term.)
+The PR is open and in the "Awaiting approval" state on `ascherj/pathreview#1006`.
+
+**How you responded:**
+No feedback to respond to yet. If a reviewer comments after the deadline, I plan
+to reply within 48 hours per CONTRIBUTING.md, address anything I agree with in a
+follow-up commit, and explain my reasoning where I'd push back (e.g. the
+fail-open design choice).
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Getting the app running locally was by far the hardest part, and it had nothing
+to do with the actual issue. `make setup` failed immediately because `make`
+isn't installed on Windows, and when I ran the steps by hand the Alembic
+migration blew up with `ConnectionRefusedError [WinError 1225]`. The real
+problem was two missing prerequisites nobody spelled out in order — Docker
+Desktop wasn't running and I hadn't copied `.env.example` to `.env` (Postgres is
+on port 5433 on Windows, not 5432). I expected "clone and run" and instead spent
+most of the first sitting on environment setup before writing a single line of
+the fix.
+
+**What did you learn about working in a large codebase?**
+The biggest shift was that I spent far more time reading than writing. Before
+touching anything I traced the gap through three files and found that
+`core/services/review_service.py:365` literally had a comment — "Validate
+feedback tone and constructiveness" — for a check that was never implemented,
+while `safety/content_filter.py` only did regex matching. On my own projects I
+hold the whole design in my head; here I had to match existing conventions I
+didn't invent — the `(bool, reason)` return shape from `BiasDetector`, the
+`@pytest.mark.unit` test style, structured `structlog` logging — instead of
+doing it my own way. I also learned to respect an existing diff: the repo wasn't
+`black`-clean, so I deliberately kept my change additive rather than letting the
+formatter churn 60 lines of code I didn't write.
+
+**How did AI tools help — and where did they fall short?**
+AI was most useful for orientation and grunt work: quickly locating the relevant
+files, surfacing that placeholder comment in `review_service.py`, mirroring the
+existing test patterns, and diffing my post-change test failures against the
+53-failure baseline to prove I introduced none. Where it fell short was the local
+setup — the first by-hand setup steps I got were confidently wrong: they skipped
+`docker compose up -d` and the `.env` copy entirely, which is exactly why the
+migration failed. It took actually reading the traceback and `docs/SETUP.md` to
+find the Windows port-5433 detail. AI accelerated the parts I could verify, but
+the environment debugging only got solved by reading the real error output.
+
+**What would you do differently if you started over?**
+I'd read `docs/SETUP.md` end-to-end and get Docker + `.env` running *before*
+trying any `make` command, instead of improvising steps and debugging a stack
+trace. On the issue itself, I'd open the draft PR earlier in the week for peer
+feedback rather than near the deadline. I might also have scoped a second gate in
+`review_service._run_safety_checks` from the start, since the placeholder comment
+lives there — I ended up deciding to keep enforcement only at generation time,
+but I'd rather have made that call deliberately up front than discover it mid-implementation.
+
+**What are you most proud of from this module?**
+Handling the 53 pre-existing test failures honestly instead of panicking or
+pretending I fixed them. I recorded a sorted baseline of the failing tests before
+I started, re-ran it after my changes, and proved with a diff that the failing
+set was byte-for-byte identical while passing tests went 375 → 387. Then I
+documented that transparently in both the PR and my check-in. It would have been
+easy to hand-wave "tests pass," and instead I could show exactly what my change
+did and didn't touch.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,63 @@
+## Solution plan
+
+**Issue:** Add a "feedback tone check" that ensures all generated feedback is
+written constructively — https://github.com/ascherj/pathreview/issues/69
+
+### Understand
+Generated feedback is never checked for *tone*. Expected: every delivered
+feedback section reads constructively (actionable, specific, encouraging).
+Actual: nothing classifies tone. `safety/content_filter.py` only regex-matches a
+short list of genuinely harmful phrases; a section that is dismissive, vague, or
+discouraging (but not "harmful") passes untouched. `_run_safety_checks` in
+`core/services/review_service.py:365` even lists "Validate feedback tone and
+constructiveness" as a numbered comment — the intent is documented but never
+implemented. Root cause: a missing classification-and-regeneration step between
+generation and delivery.
+
+### Map
+Files I expect to touch:
+- `safety/content_filter.py` — add a `ToneClassifier` (LLM prompt → constructive
+  vs negative + reason). New logic lives in the safety layer, matching the issue.
+- `rag/generator/review_generator.py` — in `generate_full_review` /
+  `generate_section`, after generating a section, run the tone check and
+  regenerate on failure (with a retry cap).
+- `rag/generator/prompt_templates.py` — add the tone-classification prompt.
+- `core/services/review_service.py` — wire the real tone check into
+  `_run_safety_checks` (replace placeholder comment #2).
+- `tests/unit/` — new tests for the classifier and the regenerate loop.
+
+### Plan
+1. Add tone-classification prompt template + a `ToneClassifier` in the safety
+   layer that returns `(is_constructive: bool, reason: str)` from an LLM call.
+2. In `ReviewGenerator`, wrap section generation in a loop: generate → classify
+   → if negative, regenerate; stop after `MAX_TONE_RETRIES` (e.g. 2) and fall
+   back to the best attempt so delivery never blocks.
+3. Wire the classifier result into `_run_safety_checks` so tone is a real gate.
+4. Add structured logging (`tone_check_failed`, `tone_regenerated`) mirroring
+   existing `structlog` calls.
+5. Add unit tests (mock the LLM): constructive passes, negative triggers
+   regenerate, retry cap respected.
+
+### Inputs & outputs
+- Input: a generated `FeedbackSection.content` string (per section).
+- Output: either the same section (passed) or a regenerated one; plus a
+  boolean/verdict consumed by `_run_safety_checks`. No schema change to
+  `api/schemas/review.py`.
+
+### Risks & unknowns
+- Infinite/expensive regeneration — mitigated by `MAX_TONE_RETRIES` cap.
+- Extra LLM call per section = latency + token cost; may batch or make optional
+  via config in `ReviewConfig`.
+- Classifier false-positives could reject good feedback — tune prompt, log
+  reason for debugging.
+- Unknown: does the LLM client (`openai.OpenAI` in review_generator) get reused
+  by the safety layer, or does `ToneClassifier` need its own client? Need to
+  check how config/keys are passed.
+
+### Edge cases
+- Empty or error-fallback sections (`content="Error generating ..."`) — skip
+  tone check, don't loop.
+- LLM classifier call itself failing/timing out — fail open (deliver original)
+  and log, never crash the review.
+- Very short sections / non-English content — ensure prompt handles gracefully.
+- All retries exhausted — deliver best attempt, flag in logs.

--- a/rag/generator/prompt_templates.py
+++ b/rag/generator/prompt_templates.py
@@ -114,6 +114,44 @@ Provide only the summary text, no JSON formatting needed.
 }
 
 
+TONE_CHECK_TEMPLATE = """You are reviewing one section of automated portfolio feedback for tone.
+
+Classify whether the feedback below is written CONSTRUCTIVELY. Constructive feedback is:
+- actionable (points to a concrete next step, not just a complaint)
+- specific (references the portfolio, not vague generalities)
+- encouraging (respectful and motivating, even when critical)
+
+Feedback is NON-constructive if it is discouraging, dismissive, condescending, or vague.
+
+Feedback section to classify:
+\"\"\"
+{feedback}
+\"\"\"
+
+Respond with ONLY a JSON object, no prose, in this exact shape:
+{{"constructive": true or false, "reason": "one short sentence explaining the verdict"}}
+"""
+
+
+REGENERATION_GUIDANCE = (
+    "\n\nIMPORTANT: A previous draft of this section was flagged as non-constructive "
+    "for the following reason: {reason}. Rewrite the feedback so it is actionable, "
+    "specific, and encouraging while keeping it honest. Do not be dismissive or vague."
+)
+
+
+def get_tone_check_prompt(feedback: str) -> str:
+    """Build the tone-classification prompt for a feedback section.
+
+    Args:
+        feedback: The generated feedback text to classify
+
+    Returns:
+        Prompt string instructing the LLM to classify tone as JSON
+    """
+    return TONE_CHECK_TEMPLATE.format(feedback=feedback)
+
+
 def get_template(name: str, version: str = "v1") -> str:
     """Retrieve a prompt template.
 

--- a/rag/generator/review_generator.py
+++ b/rag/generator/review_generator.py
@@ -1,12 +1,14 @@
 """LLM-based review generation."""
 
 from dataclasses import dataclass
-from typing import Optional
+
 import openai
 import structlog
 
-from .prompt_templates import get_template
-from .output_parser import parse_review_output, FeedbackSection
+from safety.content_filter import ToneClassifier
+
+from .output_parser import FeedbackSection, parse_review_output
+from .prompt_templates import REGENERATION_GUIDANCE, get_template
 
 logger = structlog.get_logger()
 
@@ -19,6 +21,9 @@ class ReviewConfig:
     model: str
     temperature: float = 0.7
     max_tokens: int = 2000
+    # Tone-check settings (issue #69)
+    tone_check_enabled: bool = True
+    max_tone_retries: int = 2
 
 
 class ReviewGenerator:
@@ -34,6 +39,10 @@ class ReviewGenerator:
         self.client = openai.OpenAI(
             api_key=config.api_key,
             base_url=config.base_url
+        )
+        # Tone classifier reuses the same client/model (issue #69)
+        self.tone_classifier = (
+            ToneClassifier(self.client, config.model) if config.tone_check_enabled else None
         )
 
     def generate_section(self, section_name: str, context_chunks: list[dict],
@@ -62,6 +71,43 @@ class ReviewGenerator:
             project_count=project_count
         )
 
+        # Generate, then run a tone check and regenerate non-constructive
+        # sections up to max_tone_retries times (issue #69).
+        section = self._generate_once(section_name, prompt)
+
+        if self.tone_classifier is None:
+            return section
+
+        for attempt in range(1, self.config.max_tone_retries + 1):
+            is_constructive, reason = self.tone_classifier.classify(section.content)
+            if is_constructive:
+                if attempt > 1:
+                    logger.info("tone_regenerated_ok", section=section_name, attempt=attempt)
+                return section
+
+            logger.warning(
+                "tone_check_failed", section=section_name, attempt=attempt, reason=reason
+            )
+            # Append constructive-rewrite guidance and try again
+            retry_prompt = prompt + REGENERATION_GUIDANCE.format(reason=reason)
+            section = self._generate_once(section_name, retry_prompt)
+
+        # Retries exhausted — deliver the best attempt but flag it
+        logger.warning(
+            "tone_retries_exhausted", section=section_name, max_retries=self.config.max_tone_retries
+        )
+        return section
+
+    def _generate_once(self, section_name: str, prompt: str) -> FeedbackSection:
+        """Call the LLM once for a section and parse the result.
+
+        Args:
+            section_name: Section name (used for the default fallback)
+            prompt: Fully-formatted user prompt
+
+        Returns:
+            The first parsed FeedbackSection, or a low-confidence default.
+        """
         # Call LLM
         response = self.client.chat.completions.create(
             model=self.config.model,

--- a/safety/content_filter.py
+++ b/safety/content_filter.py
@@ -1,6 +1,8 @@
 """Content filter for generated feedback."""
 
+import json
 import re
+
 import structlog
 
 logger = structlog.get_logger()
@@ -40,3 +42,88 @@ class ContentFilter:
                 filtered_text = re.sub(pattern, "[CONTENT REMOVED]", filtered_text, flags=re.IGNORECASE)
 
         return filtered_text, was_filtered
+
+
+class ToneClassifier:
+    """Classify whether generated feedback is written constructively.
+
+    Unlike ``ContentFilter`` (which uses regex to catch genuinely harmful
+    phrases), this uses an LLM to judge *tone*: feedback that is dismissive,
+    discouraging, or vague passes the harmful-content filter but should still
+    be rejected and regenerated.
+
+    The LLM client is injected so the classifier stays testable and reuses the
+    same provider/config as the generator (see ``rag.generator``).
+    """
+
+    def __init__(self, client, model: str):
+        """Initialize the tone classifier.
+
+        Args:
+            client: An OpenAI-compatible client with ``chat.completions.create``
+            model: Model identifier to use for classification
+        """
+        self.client = client
+        self.model = model
+
+    def classify(self, text: str) -> tuple[bool, str]:
+        """Classify whether a feedback section is constructive.
+
+        Args:
+            text: Feedback section content to classify
+
+        Returns:
+            Tuple of (is_constructive, reason). Fails open: if the text is
+            empty or the classification call/parse fails, returns
+            ``(True, <reason>)`` so tone-checking never blocks delivery.
+        """
+        # Local import avoids a circular import (rag imports safety indirectly)
+        from rag.generator.prompt_templates import get_tone_check_prompt
+
+        if not text or not text.strip():
+            return True, "empty feedback, nothing to classify"
+
+        try:
+            response = self.client.chat.completions.create(
+                model=self.model,
+                messages=[
+                    {"role": "system", "content": "You are a strict feedback-tone reviewer."},
+                    {"role": "user", "content": get_tone_check_prompt(text)},
+                ],
+                temperature=0.0,
+                max_tokens=200,
+            )
+            raw = response.choices[0].message.content or ""
+            verdict = self._parse_verdict(raw)
+            if verdict is None:
+                logger.warning("tone_classification_unparseable", raw_snippet=raw[:120])
+                return True, "tone verdict unparseable, defaulting to constructive"
+
+            is_constructive, reason = verdict
+            logger.info("tone_classified", constructive=is_constructive, reason=reason)
+            return is_constructive, reason
+
+        except Exception as exc:  # fail open — never block delivery on a tone-check error
+            logger.error("tone_classification_failed", error=str(exc))
+            return True, "tone check unavailable, defaulting to constructive"
+
+    @staticmethod
+    def _parse_verdict(raw: str) -> tuple[bool, str] | None:
+        """Extract the (constructive, reason) verdict from an LLM response.
+
+        Args:
+            raw: Raw LLM response text (expected to contain a JSON object)
+
+        Returns:
+            Parsed (is_constructive, reason) tuple, or None if not parseable.
+        """
+        match = re.search(r"\{.*\}", raw, re.DOTALL)
+        if not match:
+            return None
+        try:
+            data = json.loads(match.group(0))
+        except json.JSONDecodeError:
+            return None
+        if "constructive" not in data:
+            return None
+        return bool(data["constructive"]), str(data.get("reason", ""))

--- a/tests/unit/test_content_filter.py
+++ b/tests/unit/test_content_filter.py
@@ -1,0 +1,101 @@
+"""Tests for content_filter.py — ContentFilter and ToneClassifier (issue #69)."""
+
+from unittest.mock import Mock
+
+import pytest
+
+from safety.content_filter import ContentFilter, ToneClassifier
+
+
+def _mock_client(content: str) -> Mock:
+    """Build a mock OpenAI-compatible client returning a fixed message content."""
+    client = Mock()
+    message = Mock()
+    message.content = content
+    choice = Mock()
+    choice.message = message
+    response = Mock()
+    response.choices = [choice]
+    client.chat.completions.create.return_value = response
+    return client
+
+
+@pytest.mark.unit
+class TestContentFilter:
+    """Existing harmful-content filtering behavior."""
+
+    def test_clean_text_passes_through(self):
+        text = "Your projects show strong Python skills."
+        filtered, was_filtered = ContentFilter.filter(text)
+        assert was_filtered is False
+        assert filtered == text
+
+    def test_harmful_phrase_is_redacted(self):
+        text = "You are a worthless person and should give up."
+        filtered, was_filtered = ContentFilter.filter(text)
+        assert was_filtered is True
+        assert "[CONTENT REMOVED]" in filtered
+
+
+@pytest.mark.unit
+class TestToneClassifier:
+    """Tone classification for constructive vs non-constructive feedback."""
+
+    def test_constructive_feedback_passes(self):
+        client = _mock_client('{"constructive": true, "reason": "actionable and specific"}')
+        classifier = ToneClassifier(client, model="test-model")
+
+        is_constructive, reason = classifier.classify(
+            "Add a README with setup steps to make your projects easier to run."
+        )
+
+        assert is_constructive is True
+        assert reason == "actionable and specific"
+
+    def test_negative_feedback_is_flagged(self):
+        client = _mock_client('{"constructive": false, "reason": "dismissive and vague"}')
+        classifier = ToneClassifier(client, model="test-model")
+
+        is_constructive, reason = classifier.classify("This portfolio is bad. Start over.")
+
+        assert is_constructive is False
+        assert reason == "dismissive and vague"
+
+    def test_verdict_extracted_from_surrounding_prose(self):
+        # LLM sometimes wraps JSON in extra text; parser should still find it.
+        client = _mock_client(
+            'Here is my verdict:\n{"constructive": false, "reason": "too harsh"}\nThanks.'
+        )
+        classifier = ToneClassifier(client, model="test-model")
+
+        is_constructive, _ = classifier.classify("harsh feedback")
+
+        assert is_constructive is False
+
+    def test_empty_text_fails_open(self):
+        client = _mock_client('{"constructive": false, "reason": "unused"}')
+        classifier = ToneClassifier(client, model="test-model")
+
+        is_constructive, _ = classifier.classify("   ")
+
+        # Empty input should not even call the LLM; it defaults to constructive.
+        assert is_constructive is True
+        client.chat.completions.create.assert_not_called()
+
+    def test_unparseable_response_fails_open(self):
+        client = _mock_client("I could not produce JSON, sorry.")
+        classifier = ToneClassifier(client, model="test-model")
+
+        is_constructive, _ = classifier.classify("some feedback")
+
+        assert is_constructive is True
+
+    def test_llm_error_fails_open(self):
+        client = Mock()
+        client.chat.completions.create.side_effect = RuntimeError("api down")
+        classifier = ToneClassifier(client, model="test-model")
+
+        is_constructive, reason = classifier.classify("some feedback")
+
+        assert is_constructive is True
+        assert "unavailable" in reason

--- a/tests/unit/test_review_generator.py
+++ b/tests/unit/test_review_generator.py
@@ -1,0 +1,102 @@
+"""Tests for the tone-check regenerate loop in ReviewGenerator (issue #69)."""
+
+from unittest.mock import Mock
+
+import pytest
+
+from rag.generator.review_generator import ReviewConfig, ReviewGenerator
+
+
+def _make_response(content: str) -> Mock:
+    """Build a mock chat-completion response wrapping ``content``."""
+    message = Mock()
+    message.content = content
+    choice = Mock()
+    choice.message = message
+    response = Mock()
+    response.choices = [choice]
+    return response
+
+
+def _make_generator(**config_overrides) -> ReviewGenerator:
+    """Construct a ReviewGenerator with a dummy config (no network calls)."""
+    config = ReviewConfig(
+        api_key="test-key",
+        base_url="https://example.invalid/v1",
+        model="test-model",
+        **config_overrides,
+    )
+    return ReviewGenerator(config)
+
+
+PROFILE = {"github_username": "octocat", "projects": [{"name": "p1"}]}
+CHUNKS = [{"text": "some context", "metadata": {"source_id": "s1"}, "score": 0.9}]
+
+
+@pytest.mark.unit
+class TestToneRegenerationLoop:
+    """generate_section should regenerate non-constructive sections."""
+
+    def test_constructive_first_try_no_regeneration(self):
+        gen = _make_generator()
+        gen.client = Mock()
+        gen.client.chat.completions.create.return_value = _make_response(
+            "Great, actionable feedback."
+        )
+        gen.tone_classifier = Mock()
+        gen.tone_classifier.classify.return_value = (True, "constructive")
+
+        section = gen.generate_section("first_impression", CHUNKS, PROFILE)
+
+        assert section.content == "Great, actionable feedback."
+        # Only one generation call — no regeneration needed.
+        assert gen.client.chat.completions.create.call_count == 1
+
+    def test_negative_then_constructive_triggers_one_regeneration(self):
+        gen = _make_generator(max_tone_retries=2)
+        gen.client = Mock()
+        gen.client.chat.completions.create.side_effect = [
+            _make_response("This is dismissive junk."),
+            _make_response("Here is a specific, encouraging rewrite."),
+        ]
+        gen.tone_classifier = Mock()
+        gen.tone_classifier.classify.side_effect = [
+            (False, "dismissive"),
+            (True, "now constructive"),
+        ]
+
+        section = gen.generate_section("first_impression", CHUNKS, PROFILE)
+
+        assert section.content == "Here is a specific, encouraging rewrite."
+        # Original attempt + one regeneration.
+        assert gen.client.chat.completions.create.call_count == 2
+
+    def test_retries_exhausted_returns_best_effort(self):
+        gen = _make_generator(max_tone_retries=2)
+        gen.client = Mock()
+        gen.client.chat.completions.create.side_effect = [
+            _make_response("draft one"),
+            _make_response("draft two"),
+            _make_response("draft three"),
+        ]
+        gen.tone_classifier = Mock()
+        # Never constructive.
+        gen.tone_classifier.classify.return_value = (False, "still bad")
+
+        section = gen.generate_section("first_impression", CHUNKS, PROFILE)
+
+        # 1 original + 2 retries = 3 generation calls; last draft delivered.
+        assert gen.client.chat.completions.create.call_count == 3
+        assert section.content == "draft three"
+
+    def test_tone_check_disabled_skips_classifier(self):
+        gen = _make_generator(tone_check_enabled=False)
+        gen.client = Mock()
+        gen.client.chat.completions.create.return_value = _make_response("whatever tone")
+
+        assert gen.tone_classifier is None
+
+        section = gen.generate_section("first_impression", CHUNKS, PROFILE)
+
+        assert section.content == "whatever tone"
+        assert gen.client.chat.completions.create.call_count == 1


### PR DESCRIPTION
## Summary

This PR adds a **feedback tone check** to the review-generation pipeline so that every feedback section delivered to a user is written constructively. Previously the only post-generation safety gate was `ContentFilter`, which uses regex to catch genuinely harmful phrases — feedback that was dismissive, discouraging, or vague ("this portfolio is bad, start over") passed straight through. This change introduces an LLM-based `ToneClassifier` and wires a **reject-and-regenerate** loop into `ReviewGenerator`: after a section is generated, its tone is classified as constructive (actionable, specific, encouraging) or non-constructive; if it fails, the section is regenerated with corrective guidance, up to a bounded number of retries.

## Issue

Closes #69

## Changes

- **`safety/content_filter.py`** — added `ToneClassifier`, an LLM-backed classifier with a `classify(text) -> (is_constructive, reason)` API mirroring the existing `BiasDetector.detect_bias` signature. It **fails open** (returns "constructive") on empty input, unparseable responses, or API errors so tone-checking can never block delivery.
- **`rag/generator/prompt_templates.py`** — added `TONE_CHECK_TEMPLATE` (strict JSON verdict), `REGENERATION_GUIDANCE` (appended to the prompt on a retry), and a `get_tone_check_prompt()` helper.
- **`rag/generator/review_generator.py`** — `ReviewConfig` gains `tone_check_enabled` (default `True`) and `max_tone_retries` (default `2`). `generate_section` now generates → classifies → regenerates on failure up to the retry cap, then delivers the best attempt. Extracted the single-shot LLM call into `_generate_once()`. The classifier reuses the generator's existing OpenAI client.
- **`tests/unit/test_content_filter.py`** (new) and **`tests/unit/test_review_generator.py`** (new) — unit coverage for the classifier and the regenerate loop (12 tests).

## Testing

- [x] Unit tests pass (`make test-unit`) — see pre-existing-failure note below
- [ ] Integration tests pass (`make test-integration`) — not run; no integration paths changed
- [x] Linter passes (`make lint`) — my changed files add no new lint errors
- [x] Type checker passes (`make typecheck`) — no new type errors introduced
- [x] New/updated tests cover the changes

**How to manually verify:**
1. `pytest tests/unit/test_content_filter.py tests/unit/test_review_generator.py -v` — all 12 new tests pass.
2. Set `tone_check_enabled=False` in `ReviewConfig` and confirm the original single-pass behavior is preserved; set it back to `True` and confirm a non-constructive section triggers a regeneration (see `test_review_generator.py::TestToneRegenerationLoop`).

**Pre-existing failures (per Module 3 guidance):** on this branch's base commit, `make test-unit` already reports **53 failing tests** (e.g. `test_skill_extractor.py`, `test_tech_detector.py`, `test_review_service.py`) and `make lint`/`typecheck` report pre-existing errors, all unrelated to issue #69. After my changes the failing set is **identical** (verified by a sorted diff of `FAILED` lines) and passing tests rose 375 → 387 (+12). My changes introduce no new failures.

## Screenshots / Demo

N/A — backend-only change with no UI surface; behavior is demonstrated by the unit tests above.

## Notes for Reviewers

- **Fail-open by design:** a tone-check outage degrades to the prior behavior (deliver the original section), never crashes or hangs a review. All error paths return `(True, reason)` and are tested.
- **Retry cap** (`max_tone_retries`, default 2) bounds cost/latency and prevents an infinite regenerate loop.
- I kept enforcement at **generation time** (the issue's "reject and regenerate") rather than adding a second gate in `review_service._run_safety_checks`, to avoid duplicate LLM calls. Happy to add that gate if preferred.
- Diff is intentionally **additive** — I did not reformat surrounding pre-existing code (not currently `black`-clean) to keep the review surface minimal.
