### PR TITLE
Fix/152 faithfulness short claims

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -71,3 +71,63 @@ tuning that graded model (and the stop-word list) so a fully supported claim
 still scores > 0.5 while a partially supported one lands in 0.2–0.8, without
 letting unsupported claims score as supported. I'll validate the exact numbers
 against the test suite in Week 9.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the core fix in `rag/evaluator/faithfulness_checker.py`. Worked
+through all five PLAN.md sub-tasks: added punctuation-aware tokenization
+(`[a-z0-9]+`) so `"Python,"` matches `"python"`; replaced the binary
+`overlap >= 2` rule with a graded per-claim score `overlap / (overlap + 2)`;
+averaged those scores in `check()`; lowered the claim length filter so short
+claims like "Knows SQL" survive; and made `check()` tolerate `None`/missing
+chunk text. All 23 tests in `tests/unit/test_faithfulness_checker.py` pass,
+including the three the issue named and my #152 reproduction test.
+
+**Next steps:**
+Run the full `make check` / `make test-unit` to document pre-existing failures,
+open a draft PR for peer feedback, then mark it ready.
+
+**Blockers:**
+None blocking. Noted that `main` already has repo-wide lint and unit-test
+failures unrelated to this issue; confirming my change adds none.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** <!-- PASTE your PR URL here after opening it, e.g. https://github.com/ascherj/pathreview/pull/NN -->
+
+**Branch:** `fix/152-faithfulness-short-claims`
+
+**What you built:**
+The faithfulness checker now grades each claim by how many meaningful tokens it
+shares with the retrieved context (`overlap / (overlap + 2)`) instead of
+requiring two or more shared tokens, so short single-term claims like
+"Knows Python." are credited as supported and feedback of short grounded claims
+no longer scores 0.0. Tokenization is punctuation-aware, short claims are kept,
+and missing/`None` chunk text is handled gracefully.
+
+**Tests added or updated:**
+`tests/unit/test_faithfulness_checker.py` — added
+`test_short_single_token_claims_are_supported_issue_152` (reproduction/regression
+for the exact issue example) and gave the previously assertion-less
+`test_common_words_filtered_in_overlap` a real assertion. The three tests named
+in the issue plus `test_none_context_chunk_text` now pass; 23/23 in the file.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+<!--
+"Passes" = introduces no NEW failures, per the assignment's pre-existing-failures
+guidance. Verified with LLM_PROVIDER=mock:
+  - Full unit suite: main = 53 failed / 375 passed; this branch = 49 failed / 380 passed.
+  - Diff of failing-test sets: 0 new failures; this branch fixes the 4 faithfulness tests.
+  - The 49 remaining failures are pre-existing and unrelated (test_resume_parser,
+    test_review_service, test_security, test_skill_extractor, test_structural_chunker,
+    test_tech_detector). `ruff check .` and `black --check .` also already fail on main
+    repo-wide; the files changed here are ruff/black/mypy clean.
+-->
+
+**Draft PR feedback received from:** none <!-- replace with peer/mentor name or Slack handle if you get review -->
+

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -44,3 +44,30 @@ grounding without newly rewarding unsupported claims. The bug lives in
   checker too lax and mark genuinely unsupported claims as supported. I'll need
   to keep the existing partial/varying-support tests green, not just the failing
   ones.
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/Adeola03/pathreview/commit/d0de22b
+
+**Reproduction summary:**
+Running the issue's exact snippet against the checker in a local venv returned
+`0.0` for feedback whose claims are fully supported by the context, and the
+three referenced unit tests fail for the same reason. I captured this in a new
+failing test (`test_short_single_token_claims_are_supported_issue_152`) that
+asserts a fully supported short claim must score above 0.0; it fails with
+`assert 0.0 > 0.0`, pinning the bug to the `>= 2` overlap threshold in
+`_is_supported`.
+
+**PLAN.md link:** https://github.com/Adeola03/pathreview/blob/fix/152-faithfulness-short-claims/PLAN.md
+
+**Walkthrough video (recommended):** [not recorded yet]
+
+**Blockers or open questions:**
+Reproducing the bug surfaced that this is more than a one-line threshold change:
+`test_partial_support_returns_middle_score` expects a *middle* score for a
+single partially-grounded claim, which a binary supported/unsupported model
+can't produce — so the fix needs graded per-claim scoring. The open question is
+tuning that graded model (and the stop-word list) so a fully supported claim
+still scores > 0.5 while a partially supported one lands in 0.2–0.8, without
+letting unsupported claims score as supported. I'll validate the exact numbers
+against the test suite in Week 9.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,46 @@
+# Module 3 Journal
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/152
+
+**Issue title:** Faithfulness checker can never mark short claims as supported
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The RAG evaluator's faithfulness checker decides whether a feedback claim is
+backed by the retrieved context by counting how many meaningful (non-stopword)
+words the claim and the context share, and it only counts a claim as "supported"
+when that overlap is at least two words. Short but perfectly valid claims — like
+"Knows Python." — carry only one content word, so even when the context fully
+supports them they always fall below the threshold and are scored as unsupported.
+As a result, feedback made up of short, well-grounded claims can score 0.0, and
+three unit tests in `tests/unit/test_faithfulness_checker.py` fail. A successful
+fix would let single-content-word claims be recognized as supported when that
+word genuinely appears in the context, so faithfulness scores reflect real
+grounding without newly rewarding unsupported claims. The bug lives in
+`rag/evaluator/faithfulness_checker.py`, in the `_is_supported` helper.
+
+**Branch name:** fix/152-faithfulness-short-claims
+
+**Setup confirmation:** [ ] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger
+
+### "Is this right for me?" — scope reasoning
+
+- **Contained blast radius.** The defect is a single threshold in one helper
+  (`_is_supported`) in one file. I can reason about the whole function without
+  needing to understand the entire RAG pipeline.
+- **Clear, reproducible failure.** The issue ships a minimal repro and names the
+  exact failing tests, so I have an unambiguous definition of "done" (those tests
+  pass) before I write any code.
+- **Tier 1 fit.** As a first contribution to a large codebase, a well-specified
+  single-function bug with existing test coverage is the right size — small
+  enough to finish cleanly, real enough to exercise the full fork → branch →
+  PR workflow.
+- **Risk I'm watching:** the naive fix (drop the threshold to 1) could make the
+  checker too lax and mark genuinely unsupported claims as supported. I'll need
+  to keep the existing partial/varying-support tests green, not just the failing
+  ones.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -131,3 +131,73 @@ guidance. Verified with LLM_PROVIDER=mock:
 
 **Draft PR feedback received from:** none <!-- replace with peer/mentor name or Slack handle if you get review -->
 
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No reviewer or maintainer comments came in on the PR this week. (Per the Summer
+2026 note, structured reviewer feedback isn't part of the workflow this term.)
+
+**How you responded:**
+No changes were required in response to review. I re-read my own diff against the
+pre-submission checklist one more time and confirmed the PR still applies cleanly
+and the faithfulness tests still pass.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The issue read like a one-line change — drop the `>= 2` overlap threshold — but
+reproducing it showed that wasn't enough. `test_partial_support_returns_middle_score`
+expects a *middle* score for a **single** claim, which a binary supported/
+unsupported model can never produce, so the fix actually required moving to a
+graded per-claim score. Two more contributing factors were hiding in the same
+file: tokenizing with `str.split()` meant `"Python,"` never matched `"python"`,
+and the `_extract_claims` length filter silently dropped short claims like
+"Knows SQL". Working out a scoring curve (`overlap / (overlap + 2)`) that
+satisfied several tests with *conflicting* numeric expectations at once — one
+claim wanting > 0.5, another single claim wanting 0.2–0.8 — took real
+pen-and-paper analysis before I wrote any code.
+
+**What did you learn about working in a large codebase?**
+The tests, not my intuition, defined "correct" — so most of the work was reading
+the existing test file closely to reverse-engineer the intended behavior. I also
+learned to respect boundaries I didn't create: `_is_supported` is called directly
+by several tests and `check()` is consumed by `eval_suite.py`, so I kept those
+signatures stable instead of refactoring freely. The biggest difference from my
+own projects was the pre-existing mess: `main` already had 53 failing unit tests
+and repo-wide lint failures. On my own code I'd just fix everything; here the
+right move was to prove my change introduced *zero* new failures (I diffed the
+failing-test sets between a clean `main` worktree and my branch) and document the
+pre-existing state honestly in the PR, rather than expanding scope.
+
+**How did AI tools help — and where did they fall short?**
+AI was most useful for navigation and mechanical rigor: locating the relevant
+files, setting up an isolated venv, running the suite, and diffing the
+main-vs-branch failure sets to back up my "no new regressions" claim. Where it
+fell short was the actual design judgment — choosing the smoothing constant and
+confirming the scoring curve cleared every test's numeric band was something I
+had to reason through and verify by running the tests, not something to take on
+faith from generated code. Every AI-suggested change still had to be checked
+against the project's conventions (conventional commits, black/ruff/mypy) before
+I trusted it.
+
+**What would you do differently if you started over?**
+I'd run the full test suite as part of *reproduction* in Week 8, not Week 9.
+Discovering the single-claim-middle-score requirement earlier would have shaped
+my PLAN.md scoring approach from the start instead of forcing a mid-week rethink.
+I'd also have surfaced the design decision (which scoring curve) as an explicit
+question earlier, since it's the kind of thing a maintainer might have an opinion
+on before I committed to it.
+
+**What are you most proud of from this module?**
+Not the fix itself, but the discipline around it: in a codebase that was already
+partly broken, I proved with a reproducible baseline diff that my change fixed
+exactly the 4 intended tests and broke nothing, and I kept the diff tight and
+honest instead of quietly reformatting unrelated code to make the checks look
+greener than they were.
+

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -98,7 +98,7 @@ failures unrelated to this issue; confirming my change adds none.
 
 ### Check-in 2 (end of week)
 
-**PR link:** <!-- PASTE your PR URL here after opening it, e.g. https://github.com/ascherj/pathreview/pull/NN -->
+**PR link:** https://github.com/ascherj/pathreview/pull/1007
 
 **Branch:** `fix/152-faithfulness-short-claims`
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,117 @@
+# Solution plan
+
+**Issue:** Faithfulness checker can never mark short claims as supported —
+https://github.com/ascherj/pathreview/issues/152
+
+### Understand
+
+**Expected:** A feedback claim that is genuinely backed by the retrieved
+context should count toward the faithfulness score, regardless of how short the
+claim is. Feedback made up of short, fully supported claims should score well
+above 0.0.
+
+**Actual:** `FaithfulnessChecker._is_supported` marks a claim supported only
+when the claim and context share **at least two** meaningful (non-stopword)
+tokens (`return len(meaningful_overlap) >= 2`). A short claim such as
+"Knows Python." shares only one content word with a fully supporting context,
+so it is always scored unsupported and such feedback scores 0.0.
+
+**Root cause:** the hard `>= 2` overlap threshold, combined with a binary
+all-or-nothing per-claim decision. Reproducing the bug surfaced three
+contributing factors in the same file that the fix must account for:
+
+1. **Threshold** — `>= 2` rejects any single-content-word claim.
+2. **Tokenization** — tokens come from `str.split()` with no punctuation
+   stripping, so `"Python,"` never matches `"python"`. This is why
+   `test_multiple_context_chunks` fails even though the claim overlaps the
+   context on Python/JavaScript/Docker.
+3. **Claim extraction** — `_extract_claims` drops sentences of length `<= 10`
+   chars, so `"Knows SQL"` (9 chars) is silently discarded before scoring.
+4. **Binary scoring** — `test_partial_support_returns_middle_score` expects a
+   *middle* score for a **single** claim that is only partially grounded. A
+   binary supported/unsupported result can only ever yield 0.0 or 1.0 for one
+   claim, so satisfying that test requires **graded per-claim support**, not
+   just a lower threshold.
+
+### Map
+
+All changes are contained in the RAG evaluator and its test module:
+
+- `rag/evaluator/faithfulness_checker.py` — the fix lives here:
+  - `_is_supported` (lines ~66–88) → becomes a graded support score.
+  - `check` (lines ~12–49) → averages per-claim scores.
+  - `_extract_claims` (lines ~51–64) → revisit the `> 10` length filter.
+  - a small tokenization/normalization helper (new) shared by claim + context.
+- `tests/unit/test_faithfulness_checker.py` — the reproduction test
+  (`test_short_single_token_claims_are_supported_issue_152`) plus the three
+  existing failing tests define the target behavior.
+
+No other modules import scoring internals, so blast radius is limited to this
+package. (`agent/orchestrator.py` and the API consume the public `check()`
+signature only, which will not change.)
+
+### Plan
+
+1. **Add a normalization helper** — a `_tokenize(text)` that lowercases, strips
+   punctuation, splits on whitespace, and drops stop words. Use it for both the
+   claim and the context so `"Python,"` and `"python"` match. Consider moving
+   the stop-word set to a module-level constant.
+2. **Make per-claim support graded** — replace the binary `_is_supported` with
+   `_claim_support(claim, context) -> float` returning the fraction of the
+   claim's meaningful tokens present in the context (0.0–1.0). A single-token
+   claim that is present scores 1.0; a claim with one of two key terms scores
+   ~0.5.
+3. **Average per-claim scores in `check()`** — sum the graded per-claim scores
+   and divide by the number of claims, keeping the 0.0–1.0 contract and the
+   empty-input / no-claims guards.
+4. **Revisit `_extract_claims` length filter** — lower/replace the `> 10` guard
+   so short valid claims ("Knows SQL") survive, while still discarding empty or
+   whitespace-only fragments.
+5. **Tune against the full suite** — run
+   `tests/unit/test_faithfulness_checker.py` and adjust the stop-word set /
+   scoring until all faithfulness tests pass, including the #152 reproduction
+   test and the three currently-failing tests, with no regressions elsewhere.
+
+### Inputs & outputs
+
+- **Input (unchanged):** `check(feedback: str, context_chunks: list[dict])`,
+  where each chunk may carry a `"text"` string (possibly missing or `None`).
+- **Output (unchanged type, changed values):** a `float` in `[0.0, 1.0]`. The
+  behavioral change is that short, well-grounded claims now contribute positive
+  support, and partially grounded claims yield intermediate scores rather than
+  collapsing to 0.0.
+
+### Risks & unknowns
+
+- **Test tension between "fully supported" and "partial" (highest risk).**
+  `test_feedback_fully_supported_by_context` asserts `score > 0.5` for a single
+  claim, while `test_partial_support_returns_middle_score` asserts
+  `0.2 < score < 0.8`. A naive "fraction of claim tokens found" model can drop a
+  genuinely-supported claim below 0.5 (e.g. ~0.375 once neutral words like
+  "developer"/"has"/"skills" dilute the denominator). I may need a curated
+  stop-word list or to score over *content* terms only. This must be validated
+  numerically against `tests/unit/test_faithfulness_checker.py`, not assumed.
+- **Loosening support must not resurrect false positives** —
+  `test_feedback_with_no_support_in_context` (Rust vs Python/JS) must still
+  score `< 0.5`. Verify the graded model yields ~0 when there is no content
+  overlap.
+- **Changing `_extract_claims` may ripple** — `test_extract_claims`,
+  `test_extract_claims_with_punctuation`, and `test_very_long_feedback` depend
+  on current extraction behavior; the length-filter change must keep them green.
+- **Purely lexical, not semantic** — the checker matches tokens, not meaning, so
+  synonyms ("SQL" vs "database") still won't match. This matches the existing
+  design and is out of scope for #152, but worth noting.
+
+### Edge cases
+
+- Single-content-word claims ("Knows Python.") — the core case; must score > 0.0.
+- Punctuation-attached tokens ("Python," / "experience.") must normalize.
+- Case differences ("PYTHON" vs "python") — already handled, keep handling.
+- Claims consisting entirely of stop words — should not divide by zero; treat as
+  neutral/unsupported without crashing.
+- `context_chunks` with `"text": None` or a missing `"text"` key
+  (`test_none_context_chunk_text`, `test_missing_text_key_in_chunk`) — must not
+  raise.
+- Empty feedback / empty context / both empty — keep returning 0.0.
+- Very long feedback and very long context — must stay in `[0.0, 1.0]` and not
+  blow up (claims already capped at 10).

--- a/rag/evaluator/faithfulness_checker.py
+++ b/rag/evaluator/faithfulness_checker.py
@@ -1,9 +1,49 @@
 """Check if generated feedback is supported by retrieved context."""
 
 import re
+
 import structlog
 
 logger = structlog.get_logger()
+
+# Common function words excluded when measuring meaningful overlap between a
+# claim and its context. Kept small and lexical on purpose — the checker is a
+# cheap keyword heuristic, not a semantic matcher.
+STOP_WORDS = {
+    "a",
+    "an",
+    "the",
+    "is",
+    "are",
+    "was",
+    "were",
+    "be",
+    "been",
+    "and",
+    "or",
+    "but",
+    "in",
+    "of",
+    "to",
+    "for",
+    "that",
+}
+
+# Smoothing constant for graded claim support. With one grounded key term a
+# claim earns partial credit (1 / (1 + 2) = 0.33); each additional grounded
+# term pushes the score toward 1.0 with diminishing returns. This replaces the
+# old all-or-nothing rule that required >= 2 shared terms and therefore scored
+# every short, single-term claim as unsupported (issue #152).
+_SUPPORT_SMOOTHING = 2
+
+# Minimum length (in characters) for a sentence to count as a scorable claim.
+# Low enough to keep genuinely short claims like "Knows SQL", high enough to
+# drop stray punctuation fragments left behind by sentence splitting.
+_MIN_CLAIM_LEN = 3
+
+# Word tokens: runs of letters/digits, which strips attached punctuation so
+# "Python," and "python" compare equal.
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
 
 
 class FaithfulnessChecker:
@@ -13,15 +53,18 @@ class FaithfulnessChecker:
         """Check faithfulness of feedback to context.
 
         Args:
-            feedback: Generated feedback text
-            context_chunks: Retrieved context chunks
+            feedback: Generated feedback text.
+            context_chunks: Retrieved context chunks.
 
         Returns:
-            Faithfulness score 0.0-1.0 (ratio of supported claims)
+            Faithfulness score 0.0-1.0 (mean per-claim support).
         """
         if not feedback or not context_chunks:
-            logger.info("faithfulness_empty_input", has_feedback=bool(feedback),
-                       has_chunks=bool(context_chunks))
+            logger.info(
+                "faithfulness_empty_input",
+                has_feedback=bool(feedback),
+                has_chunks=bool(context_chunks),
+            )
             return 0.0
 
         # Extract key claims from feedback (sentences)
@@ -30,21 +73,14 @@ class FaithfulnessChecker:
             logger.info("faithfulness_no_claims_extracted")
             return 0.5  # Default to neutral if no extractable claims
 
-        # Concatenate context text
-        context_text = " ".join([
-            chunk.get("text", "") for chunk in context_chunks
-        ])
+        # Concatenate context text, tolerating missing/None chunk text.
+        context_text = " ".join((chunk.get("text") or "") for chunk in context_chunks)
 
-        # Check each claim for support
-        supported = 0
-        for claim in claims:
-            if self._is_supported(claim, context_text):
-                supported += 1
+        # Average the graded support of each claim.
+        scores = [self._support_score(claim, context_text) for claim in claims]
+        score = sum(scores) / len(scores)
 
-        score = supported / len(claims) if claims else 0.0
-
-        logger.info("faithfulness_checked", claims_count=len(claims),
-                   supported_count=supported, score=score)
+        logger.info("faithfulness_checked", claims_count=len(claims), score=score)
 
         return score
 
@@ -53,36 +89,65 @@ class FaithfulnessChecker:
         """Extract key claims from feedback text.
 
         Args:
-            text: Feedback text
+            text: Feedback text.
 
         Returns:
-            List of claims (sentences)
+            List of claims (sentences), capped at 10.
         """
         # Split by sentence (simple regex)
-        sentences = re.split(r'[.!?]+', text)
-        claims = [s.strip() for s in sentences if s.strip() and len(s.strip()) > 10]
+        sentences = re.split(r"[.!?]+", text)
+        claims = [s.strip() for s in sentences if len(s.strip()) >= _MIN_CLAIM_LEN]
         return claims[:10]  # Limit to 10 claims for scoring
 
-    @staticmethod
-    def _is_supported(claim: str, context: str) -> bool:
-        """Check if a claim is supported by context.
+    @classmethod
+    def _meaningful_tokens(cls, text: str) -> set[str]:
+        """Return the set of meaningful (non-stopword) tokens in ``text``.
 
         Args:
-            claim: Claim text
-            context: Context text
+            text: Text to tokenize; may be empty.
 
         Returns:
-            True if claim is supported
+            Lowercased word tokens with stop words removed.
         """
-        # Tokenize and check for keyword overlap
-        claim_tokens = set(claim.lower().split())
-        context_tokens = set(context.lower().split())
+        if not text:
+            return set()
+        return {token for token in _TOKEN_RE.findall(text.lower()) if token not in STOP_WORDS}
 
-        # Require at least some meaningful overlap
-        overlap = claim_tokens & context_tokens
-        # Filter out common stop words
-        stop_words = {'a', 'an', 'the', 'is', 'are', 'was', 'were', 'be', 'been',
-                     'and', 'or', 'but', 'in', 'of', 'to', 'for', 'that'}
-        meaningful_overlap = overlap - stop_words
+    @classmethod
+    def _support_score(cls, claim: str, context: str) -> float:
+        """Grade how well ``context`` supports ``claim``.
 
-        return len(meaningful_overlap) >= 2
+        The score grows with the number of meaningful tokens the claim shares
+        with the context, with diminishing returns, so a single shared term
+        yields partial support rather than none.
+
+        Args:
+            claim: Claim text.
+            context: Context text.
+
+        Returns:
+            Support score in the range 0.0-1.0.
+        """
+        claim_tokens = cls._meaningful_tokens(claim)
+        if not claim_tokens:
+            return 0.0
+
+        overlap = len(claim_tokens & cls._meaningful_tokens(context))
+        if overlap == 0:
+            return 0.0
+
+        return overlap / (overlap + _SUPPORT_SMOOTHING)
+
+    @classmethod
+    def _is_supported(cls, claim: str, context: str) -> bool:
+        """Check if a claim has any meaningful support in the context.
+
+        Args:
+            claim: Claim text.
+            context: Context text.
+
+        Returns:
+            True if the claim shares at least one meaningful token with the
+            context.
+        """
+        return cls._support_score(claim, context) > 0.0

--- a/tests/unit/test_faithfulness_checker.py
+++ b/tests/unit/test_faithfulness_checker.py
@@ -215,8 +215,9 @@ class TestFaithfulnessChecker:
 
         supported = checker._is_supported(claim, context)
 
-        # Despite word overlap, should look for meaningful overlap (not stop words)
-        # This depends on implementation
+        # Support comes from meaningful overlap ("project", "documented"), not
+        # from shared stop words like "the"/"is" — so this is still supported.
+        assert supported is True
 
     def test_minimum_overlap_required(self, checker):
         """Test that minimum meaningful overlap is required for support."""

--- a/tests/unit/test_faithfulness_checker.py
+++ b/tests/unit/test_faithfulness_checker.py
@@ -264,6 +264,27 @@ class TestFaithfulnessChecker:
 
         assert score1 == score2
 
+    def test_short_single_token_claims_are_supported_issue_152(self, checker):
+        """Reproduction for issue #152.
+
+        Short factual claims that share exactly one meaningful (non-stopword)
+        token with a fully supporting context are currently scored as
+        unsupported, because ``_is_supported`` requires >= 2 overlapping
+        meaningful tokens. This test encodes the *expected* behavior from the
+        issue: both claims are fully supported, so the score should be 1.0.
+
+        Currently fails (observed 0.0); should pass once #152 is fixed.
+        The exact target score depends on the scoring model chosen in the fix
+        (see PLAN.md), so this reproduction only asserts the defining property
+        of the bug: a fully supported short claim must not score 0.0.
+        """
+        score = checker.check(
+            "Knows Python. Knows SQL.",
+            [{"text": "python expert"}, {"text": "sql expert"}],
+        )
+
+        assert score > 0.0
+
     def test_specialized_technical_terms(self, checker):
         """Test support check with specialized technical terms."""
         claim = "Experienced with PostgreSQL and ORM frameworks"


### PR DESCRIPTION
## Summary
The RAG faithfulness checker marked a claim as supported only when it shared at
least **two** meaningful (non-stopword) tokens with the retrieved context. Short
factual claims such as "Knows Python." share only one content word with a fully
supporting context, so they were always scored unsupported — feedback made up of
short, well-grounded claims scored `0.0`. This PR replaces the all-or-nothing
rule with a graded per-claim support score so short, grounded claims are
credited, while keeping unsupported claims low.

## Issue
Closes #152

## Changes
- **Graded per-claim support** in `rag/evaluator/faithfulness_checker.py`:
  replaced the boolean `len(meaningful_overlap) >= 2` rule with
  `overlap / (overlap + 2)`. One grounded key term earns partial credit (~0.33)
  and additional grounded terms approach full support. This also lets a single
  partially-grounded claim land in the middle of the range instead of collapsing
  to 0.0 or 1.0.
- **Punctuation-aware tokenization**: tokens are now extracted with a
  `[a-z0-9]+` regex, so `"Python,"` matches `"python"` (previously `str.split()`
  left punctuation attached and blocked the match).
- **Keep short claims**: lowered the sentence-length filter in `_extract_claims`
  so genuinely short claims (e.g. "Knows SQL") are scored instead of discarded.
- **Robust context handling**: `check()` tolerates chunks whose `"text"` is
  `None` or missing without raising.
- `_is_supported` is retained as a boolean helper (now: any meaningful overlap)
  for the direct unit tests and any external callers; the public `check()`
  signature and return type are unchanged.
- Added a regression test for the issue's exact example and gave a pre-existing
  no-assertion test a real assertion.

## Testing
- [x] Unit tests pass (`make test-unit`) — see note on pre-existing failures below
- [ ] Integration tests pass (`make test-integration`) — not run (requires Docker services)
- [x] Linter passes (`make lint`) — changed files are clean; see note
- [x] Type checker passes (`make typecheck`) — `mypy` clean on the changed module
- [x] New/updated tests cover the changes

`tests/unit/test_faithfulness_checker.py`: **23/23 pass** (was 20/23 on `main`).
The three failing tests named in the issue
(`test_partial_support_returns_middle_score`, `test_multiple_context_chunks`,
`test_multiple_claims_varying_support`) plus `test_none_context_chunk_text` now
pass, along with a new `test_short_single_token_claims_are_supported_issue_152`.

### Pre-existing failures (not introduced by this PR)
`main` already has repo-wide failures unrelated to this issue. Verified with the
full unit suite (`pytest tests/unit -m unit`, `LLM_PROVIDER=mock`):

| | Failed | Passed |
|---|---|---|
| `main` (baseline) | 53 | 375 |
| this branch | 49 | 380 |

Diffing the failing-test sets: **zero new failures**; this branch *fixes* the 4
faithfulness tests above and adds no regressions. The remaining 49 failures live
in unrelated modules (`test_resume_parser`, `test_review_service`,
`test_security`, `test_skill_extractor`, `test_structural_chunker`,
`test_tech_detector`) and are present on `main`. Likewise, `ruff check .` and
`black --check .` already fail on `main` repo-wide; the files changed here are
ruff/black/mypy clean.

## Notes for Reviewers
- The smoothing constant `_SUPPORT_SMOOTHING = 2` sets how quickly support
  saturates. It was chosen so a single grounded term yields partial (not full)
  credit and multiple terms approach 1.0; it satisfies all existing
  faithfulness tests. Happy to tune if you prefer a different curve.
- The checker remains a purely lexical keyword heuristic (no semantic/synonym
  matching), consistent with the existing design — out of scope for this issue.
- I intentionally did **not** reformat the pre-existing (unrelated) lines in the
  test file with `black`, to keep this diff focused on the fix.
