### PR TITLE
test: add snapshot tests for prompt template version drift

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,23 @@
+# Journal
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/soccerthomas/pathreview/commit/f53bbd8
+
+**Reproduction summary:**
+Ran the existing test suite and confirmed `test_template_snapshot_content_hash`
+passed regardless of template content, since it only checked that the hash
+was a 32-character string with no comparison to a fixed baseline. This
+confirmed the gap described in the issue: prompt template edits could
+happen silently with no test signal, even though prompt content directly
+affects review quality.
+
+**PLAN.md link:** https://github.com/soccerthomas/pathreview/blob/fix/prompt-template-snapshot-tests/PLAN.md
+
+**Blockers or open questions:**
+Unsure whether the maintainer expects MD5 (matching the original test) or
+SHA-256 (what I used) for the hash algorithm — flagging this for review
+when I open the PR in Week 9. Also uncertain whether the "soft guard"
+nature of this approach (a developer could regenerate the snapshot
+baseline without bumping the version) is an acceptable tradeoff or if a
+stricter enforcement mechanism is expected.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -21,3 +21,32 @@ when I open the PR in Week 9. Also uncertain whether the "soft guard"
 nature of this approach (a developer could regenerate the snapshot
 baseline without bumping the version) is an acceptable tradeoff or if a
 stricter enforcement mechanism is expected.
+## Week 9 — Implementation & validation
+
+**Implementation commit:** f53bbd8
+
+**What I changed:**
+Implemented snapshot-based checks for the versioned prompt templates so
+changes to prompt content produce a test failure instead of silently
+passing. The snapshots use the template name/version as the baseline for
+detecting unexpected content changes.
+
+**Testing:**
+- `make test-unit`: 53 failed, 381 passed. The failures were distributed
+  across existing unrelated modules; the prompt-template tests were not
+  among the reported failures.
+- `pytest tests/unit/test_prompt_templates.py -v`: 43 passed.
+- `ruff check tests/unit/test_prompt_templates.py`: passed.
+- `make check`: could not complete because the repository's full lint run
+  reports pre-existing failures across unrelated files.
+
+**Self-review:**
+Reviewed the changed prompt-template tests and ran targeted tests and
+linting. No unrelated files were changed as part of the contribution.
+
+**Open questions:**
+The implementation uses SHA-256 for the snapshot hashes. I still want
+maintainer/peer feedback on whether that is the preferred algorithm and
+whether the snapshot baseline should be treated as a soft guard.
+
+**PR:** To be added after the PR is opened.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -5,6 +5,7 @@
 **Reproduction commit link:** https://github.com/soccerthomas/pathreview/commit/f53bbd8
 
 **Reproduction summary:**
+
 Ran the existing test suite and confirmed `test_template_snapshot_content_hash`
 passed regardless of template content, since it only checked that the hash
 was a 32-character string with no comparison to a fixed baseline. This
@@ -15,38 +16,125 @@ affects review quality.
 **PLAN.md link:** https://github.com/soccerthomas/pathreview/blob/fix/prompt-template-snapshot-tests/PLAN.md
 
 **Blockers or open questions:**
+
 Unsure whether the maintainer expects MD5 (matching the original test) or
 SHA-256 (what I used) for the hash algorithm — flagging this for review
 when I open the PR in Week 9. Also uncertain whether the "soft guard"
 nature of this approach (a developer could regenerate the snapshot
 baseline without bumping the version) is an acceptable tradeoff or if a
 stricter enforcement mechanism is expected.
+
 ## Week 9 — Implementation & validation
 
 **Implementation commit:** f53bbd8
 
 **What I changed:**
+
 Implemented snapshot-based checks for the versioned prompt templates so
 changes to prompt content produce a test failure instead of silently
-passing. The snapshots use the template name/version as the baseline for
-detecting unexpected content changes.
+passing. The snapshots provide a fixed baseline for detecting unexpected
+prompt content changes.
 
 **Testing:**
+
 - `make test-unit`: 53 failed, 381 passed. The failures were distributed
-  across existing unrelated modules; the prompt-template tests were not
-  among the reported failures.
+  across unrelated modules; none were reported from the prompt-template
+  test file.
 - `pytest tests/unit/test_prompt_templates.py -v`: 43 passed.
 - `ruff check tests/unit/test_prompt_templates.py`: passed.
-- `make check`: could not complete because the repository's full lint run
-  reports pre-existing failures across unrelated files.
+- `make check`: did not complete because the repository-wide lint run
+  reported failures across unrelated files.
 
 **Self-review:**
+
 Reviewed the changed prompt-template tests and ran targeted tests and
-linting. No unrelated files were changed as part of the contribution.
+linting. I did not make changes to unrelated modules in response to the
+full-suite failures.
 
 **Open questions:**
-The implementation uses SHA-256 for the snapshot hashes. I still want
-maintainer/peer feedback on whether that is the preferred algorithm and
-whether the snapshot baseline should be treated as a soft guard.
+
+The implementation uses SHA-256 for the snapshot hashes. I would still
+welcome maintainer or peer feedback on whether that is the preferred
+algorithm and whether the snapshot baseline should be treated as a soft
+guard.
 
 **PR:** To be added after the PR is opened.
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [X] No
+
+**Summary of feedback:**
+
+No reviewer or maintainer feedback was received during the contribution
+cycle. Per the Su26 course note, reviewer feedback is not a feature this
+term.
+
+**How you responded:**
+
+N/A — there was no feedback to respond to. If feedback is provided later,
+I will address any comments that require changes.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+
+The implementation itself was fairly small, but understanding what the
+existing test was actually proving was harder than I expected. The
+original test checked that a generated hash had the expected format, but
+it did not compare the hash against a fixed baseline. That meant the test
+could pass even when the prompt content changed. I had to trace the
+existing prompt template tests and snapshot data before I could make the
+test verify the behavior described in the issue.
+
+**What did you learn about working in a large codebase?**
+
+I learned that a passing test does not necessarily mean that it is testing
+the behavior that matters. In this case, the existing test looked useful
+because it generated and checked a hash, but reading the assertion closely
+showed that it did not protect against prompt changes. Working in an
+existing repository also meant following the project's existing test
+structure instead of designing an entirely new testing approach.
+
+**How did AI tools help — and where did they fall short?**
+
+AI was useful for explaining snapshot testing, hashing, and possible ways
+to structure the assertions. It was less reliable when making assumptions
+about this specific repository. I had to verify the existing prompt
+template implementation, snapshot files, and test behavior directly in the
+source before deciding what the test should actually assert. This reinforced
+that AI suggestions are useful as a starting point but need to be checked
+against the actual codebase.
+
+**What would you do differently if you started over?**
+
+I would inspect the existing test and snapshot implementation more carefully
+before deciding on the solution. I initially had an open question about the
+hashing approach, and confirming the existing conventions earlier would
+have reduced some uncertainty. I would also run the targeted tests earlier
+instead of spending as much time thinking about the full repository test
+suite.
+
+**What are you most proud of from this module?**
+
+I am most proud that the contribution addresses a subtle testing gap rather
+than simply adding another test case. The original test could pass even
+when prompt content changed, so it did not provide much protection against
+silent prompt drift. The updated snapshot tests make prompt changes visible
+to the test suite while keeping the change focused on the existing testing
+structure.
+
+**Final validation:**
+
+The targeted prompt-template test suite passed with 43 tests:
+
+`pytest tests/unit/test_prompt_templates.py -v` — 43 passed.
+
+The targeted Ruff check also passed. The full repository test suite reported
+53 failures and 381 passing tests, while `make check` reported repository-wide
+lint failures. These results were documented rather than attempting unrelated
+changes outside the scope of the contribution.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -5,7 +5,6 @@
 **Reproduction commit link:** https://github.com/soccerthomas/pathreview/commit/f53bbd8
 
 **Reproduction summary:**
-
 Ran the existing test suite and confirmed `test_template_snapshot_content_hash`
 passed regardless of template content, since it only checked that the hash
 was a 32-character string with no comparison to a fixed baseline. This
@@ -16,7 +15,6 @@ affects review quality.
 **PLAN.md link:** https://github.com/soccerthomas/pathreview/blob/fix/prompt-template-snapshot-tests/PLAN.md
 
 **Blockers or open questions:**
-
 Unsure whether the maintainer expects MD5 (matching the original test) or
 SHA-256 (what I used) for the hash algorithm — flagging this for review
 when I open the PR in Week 9. Also uncertain whether the "soft guard"
@@ -29,34 +27,30 @@ stricter enforcement mechanism is expected.
 **Implementation commit:** f53bbd8
 
 **What I changed:**
-
 Implemented snapshot-based checks for the versioned prompt templates so
 changes to prompt content produce a test failure instead of silently
-passing. The snapshots provide a fixed baseline for detecting unexpected
-prompt content changes.
+passing. The snapshots use the template name/version as the baseline for
+detecting unexpected content changes.
 
 **Testing:**
 
-- `make test-unit`: 53 failed, 381 passed. The failures were distributed
-  across unrelated modules; none were reported from the prompt-template
-  test file.
+- `make test-unit`: 381 passed, 53 failed. The failures were distributed
+  across unrelated modules; the prompt-template tests were not among the
+  failures.
 - `pytest tests/unit/test_prompt_templates.py -v`: 43 passed.
 - `ruff check tests/unit/test_prompt_templates.py`: passed.
-- `make check`: did not complete because the repository-wide lint run
-  reported failures across unrelated files.
+- `make check`: the full repository check could not complete because the
+  repository currently reports failures in unrelated areas.
 
 **Self-review:**
-
 Reviewed the changed prompt-template tests and ran targeted tests and
-linting. I did not make changes to unrelated modules in response to the
-full-suite failures.
+linting. No unrelated source files were changed as part of the
+contribution.
 
 **Open questions:**
-
-The implementation uses SHA-256 for the snapshot hashes. I would still
-welcome maintainer or peer feedback on whether that is the preferred
-algorithm and whether the snapshot baseline should be treated as a soft
-guard.
+The implementation uses SHA-256 for the snapshot hashes. I still want
+maintainer/peer feedback on whether that is the preferred algorithm and
+whether the snapshot baseline should be treated as a soft guard.
 
 **PR:** To be added after the PR is opened.
 
@@ -64,18 +58,17 @@ guard.
 
 ### Reviewer feedback
 
-**Feedback received:** [ ] Yes  [X] No
+**Feedback received:** [ ] Yes [X] No — still awaiting review
 
 **Summary of feedback:**
 
-No reviewer or maintainer feedback was received during the contribution
-cycle. Per the Su26 course note, reviewer feedback is not a feature this
-term.
+No reviewer or maintainer feedback came in during the contribution cycle.
+Per the Su26 course note, reviewer feedback is not a feature this term.
 
 **How you responded:**
 
-N/A — there was no feedback to respond to. If feedback is provided later,
-I will address any comments that require changes.
+N/A — no feedback to respond to. If the PR is reviewed later, I will
+address any comments then.
 
 ---
 
@@ -84,20 +77,20 @@ I will address any comments that require changes.
 **What was harder than you expected?**
 
 The implementation itself was fairly small, but understanding what the
-existing test was actually proving was harder than I expected. The
-original test checked that a generated hash had the expected format, but
-it did not compare the hash against a fixed baseline. That meant the test
-could pass even when the prompt content changed. I had to trace the
-existing prompt template tests and snapshot data before I could make the
-test verify the behavior described in the issue.
+existing test was actually proving was harder than I expected. The original
+test checked that a generated hash had the expected format, but it did not
+compare the hash against a fixed snapshot. That meant the test could pass
+even when the prompt content changed. I had to trace the existing prompt
+template tests and snapshot data before I could make the test verify the
+thing the issue was actually concerned about.
 
 **What did you learn about working in a large codebase?**
 
-I learned that a passing test does not necessarily mean that it is testing
+I learned that a test passing does not necessarily mean that it is testing
 the behavior that matters. In this case, the existing test looked useful
-because it generated and checked a hash, but reading the assertion closely
-showed that it did not protect against prompt changes. Working in an
-existing repository also meant following the project's existing test
+at first because it generated and checked a hash, but reading the assertion
+closely showed that it did not protect against prompt changes. Working in
+an existing repository also meant following the project's existing test
 structure instead of designing an entirely new testing approach.
 
 **How did AI tools help — and where did they fall short?**
@@ -105,19 +98,19 @@ structure instead of designing an entirely new testing approach.
 AI was useful for explaining snapshot testing, hashing, and possible ways
 to structure the assertions. It was less reliable when making assumptions
 about this specific repository. I had to verify the existing prompt
-template implementation, snapshot files, and test behavior directly in the
-source before deciding what the test should actually assert. This reinforced
-that AI suggestions are useful as a starting point but need to be checked
-against the actual codebase.
+template implementation, snapshot files, and test behavior directly in
+the source before deciding what the test should actually assert. This
+reinforced that AI suggestions are useful as a starting point but need to
+be checked against the codebase.
 
 **What would you do differently if you started over?**
 
-I would inspect the existing test and snapshot implementation more carefully
-before deciding on the solution. I initially had an open question about the
-hashing approach, and confirming the existing conventions earlier would
-have reduced some uncertainty. I would also run the targeted tests earlier
-instead of spending as much time thinking about the full repository test
-suite.
+I would inspect the existing test and snapshot implementation more
+carefully before deciding on the solution. I initially had an open
+question about the hashing approach, and confirming the existing
+conventions earlier would have reduced some uncertainty. I would also run
+the targeted tests earlier instead of spending as much time thinking about
+the full repository test suite.
 
 **What are you most proud of from this module?**
 
@@ -134,7 +127,8 @@ The targeted prompt-template test suite passed with 43 tests:
 
 `pytest tests/unit/test_prompt_templates.py -v` — 43 passed.
 
-The targeted Ruff check also passed. The full repository test suite reported
-53 failures and 381 passing tests, while `make check` reported repository-wide
-lint failures. These results were documented rather than attempting unrelated
-changes outside the scope of the contribution.
+The targeted Ruff check also passed. The full repository test suite and
+`make check` currently report failures in unrelated areas of the repository;
+those were documented rather than attempting unrelated fixes.
+
+**PR:** To be added after the PR is opened.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,43 +1,73 @@
-# Plan: Snapshot tests for prompt template version drift
+## Solution plan
 
-## Issue
-[paste your issue link here]
+**Issue:** Issue  #37: Add snapshot tests for prompt templates to catch accidental changes
 
-## Problem
-Prompt templates directly shape review quality, but the existing test
-(`test_template_snapshot_content_hash`) only checked that a hash was a
-32-character string — it never compared against a fixed baseline. This
-meant a developer could silently edit a template's text and CI would
-still pass, with no signal that review-affecting prompt content had
-changed without a version bump.
 
-## Approach
-- Added `tests/unit/prompt_template_snapshots.py`: a checked-in baseline
-  storing a SHA-256 hash per (template_name, version) pair.
-- Added `tests/unit/generate_prompt_snapshots.py`: a script to regenerate
-  the baseline. Only meant to be run when intentionally adding or
-  changing a template version.
-- Replaced the old no-op hash test in `test_prompt_templates.py` with a
-  new `TestPromptTemplateSnapshots` class:
-  - `test_template_content_matches_snapshot` — parametrized over every
-    template/version, fails if content no longer matches the recorded hash.
-  - `test_no_untracked_template_versions` — fails if a template/version
-    exists in code but has no snapshot recorded.
-  - `test_no_orphaned_snapshots` — fails if a snapshot exists for a
-    template/version that's since been removed from the code.
 
-## Why this enforces version bumps
-Editing v1's text in place changes its hash, so the test fails. The
-intended fix is to add a new version key (v2) with the updated text,
-leaving v1's hash as a historical record, then regenerate snapshots.
+### Understand
+The existing `test_template_snapshot_content_hash` test computed a
+combined MD5 hash of all prompt template content but never compared it
+against a fixed baseline — it only asserted the hash was a 32-character
+string. Since prompt templates directly shape review quality, this meant
+a developer could silently edit a template's wording and CI would still
+pass, with no signal that review-affecting content changed without a
+conscious version bump. Expected behavior: editing a template's text
+without adding a new version key should fail tests. Actual behavior
+(before fix): any edit passed silently.
 
-This is a soft guard — a developer could technically regenerate the
-baseline without bumping the version. Enforcement ultimately relies on
-reviewers noticing a diff to `prompt_template_snapshots.py` in a PR that
-doesn't also show a new version key being added in `prompt_templates.py`.
+### Map
+- `rag/generator/prompt_templates.py` — source of truth, contains
+  `PROMPT_TEMPLATES` dict and `get_template()`. Not modified, only read.
+- `tests/unit/test_prompt_templates.py` — removed the no-op hash test,
+  added a new `TestPromptTemplateSnapshots` class.
+- `tests/unit/prompt_template_snapshots.py` (new) — checked-in baseline
+  of per-version SHA-256 hashes.
+- `tests/unit/generate_prompt_snapshots.py` (new) — script to regenerate
+  the baseline when a version is intentionally added or changed.
 
-## Testing
-- Ran `python -m pytest tests/unit/test_prompt_templates.py -v` — 43 passed.
-- Verified failure mode by editing skills_feedback v1 text without a
-  version bump; confirmed the test failed with the expected guidance
-  message; reverted the change and confirmed 43 passed again.
+### Plan
+1. Add a baseline snapshot file storing one hash per (template_name, version).
+2. Add a generator script that computes hashes from `PROMPT_TEMPLATES`
+   and writes the baseline file.
+3. Replace the old no-op snapshot test with a parametrized test that
+   compares each live template's hash against its recorded baseline hash.
+4. Add coverage for drift in the other direction: a template/version
+   with no snapshot recorded, and a snapshot with no matching template
+   left in code.
+5. Run the generator once to populate real baseline hashes, verify all
+   tests pass, then verify the guard actually fails when template text
+   changes without a version bump.
+
+### Inputs & outputs
+- Input: `PROMPT_TEMPLATES` dict (name -> version -> template string) in
+  `prompt_templates.py`.
+- Output: a pass/fail test result. Failing output includes a message
+  telling the developer to add a new version key rather than edit the
+  existing one in place, plus the exact regeneration command to run
+  once that's done.
+
+### Risks & unknowns
+- This is a soft guard: a developer could regenerate the baseline
+  without actually bumping the version key, defeating the purpose.
+  Real enforcement depends on a reviewer noticing a
+  `prompt_template_snapshots.py` diff without a corresponding new
+  version key in `prompt_templates.py` — I should call this out in the
+  PR description in Week 9.
+- Encoding: `Path.write_text()` defaults to the OS locale encoding on
+  Windows, which broke on an em-dash in my docstring. Fixed by passing
+  `encoding="utf-8"` explicitly — worth double-checking other file-write
+  calls in the codebase for the same issue if I touch them later.
+- Uncertain whether the maintainer wants MD5 or SHA-256 for the hash —
+  I used SHA-256 since it's the modern default, but the original test
+  used MD5, so this might get flagged in review.
+
+### Edge cases
+- A template name exists in code but has no snapshot recorded (new
+  template added) — caught by `test_no_untracked_template_versions`.
+- A snapshot exists for a template/version that's been removed from
+  code (stale entry) — caught by `test_no_orphaned_snapshots`.
+- A version's text changes without a version bump — caught by
+  `test_template_content_matches_snapshot`.
+- Multiple versions of the same template (e.g. v1 and v2 coexisting) —
+  each gets its own independent hash entry, so old versions keep
+  working even after a new one is added.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,43 @@
+# Plan: Snapshot tests for prompt template version drift
+
+## Issue
+[paste your issue link here]
+
+## Problem
+Prompt templates directly shape review quality, but the existing test
+(`test_template_snapshot_content_hash`) only checked that a hash was a
+32-character string — it never compared against a fixed baseline. This
+meant a developer could silently edit a template's text and CI would
+still pass, with no signal that review-affecting prompt content had
+changed without a version bump.
+
+## Approach
+- Added `tests/unit/prompt_template_snapshots.py`: a checked-in baseline
+  storing a SHA-256 hash per (template_name, version) pair.
+- Added `tests/unit/generate_prompt_snapshots.py`: a script to regenerate
+  the baseline. Only meant to be run when intentionally adding or
+  changing a template version.
+- Replaced the old no-op hash test in `test_prompt_templates.py` with a
+  new `TestPromptTemplateSnapshots` class:
+  - `test_template_content_matches_snapshot` — parametrized over every
+    template/version, fails if content no longer matches the recorded hash.
+  - `test_no_untracked_template_versions` — fails if a template/version
+    exists in code but has no snapshot recorded.
+  - `test_no_orphaned_snapshots` — fails if a snapshot exists for a
+    template/version that's since been removed from the code.
+
+## Why this enforces version bumps
+Editing v1's text in place changes its hash, so the test fails. The
+intended fix is to add a new version key (v2) with the updated text,
+leaving v1's hash as a historical record, then regenerate snapshots.
+
+This is a soft guard — a developer could technically regenerate the
+baseline without bumping the version. Enforcement ultimately relies on
+reviewers noticing a diff to `prompt_template_snapshots.py` in a PR that
+doesn't also show a new version key being added in `prompt_templates.py`.
+
+## Testing
+- Ran `python -m pytest tests/unit/test_prompt_templates.py -v` — 43 passed.
+- Verified failure mode by editing skills_feedback v1 text without a
+  version bump; confirmed the test failed with the expected guidance
+  message; reverted the change and confirmed 43 passed again.

--- a/tests/unit/generate_prompt_snapshots.py
+++ b/tests/unit/generate_prompt_snapshots.py
@@ -1,0 +1,53 @@
+"""
+Generate baseline hashes for prompt_templates snapshot tests.
+
+Run this to (re)create tests/unit/prompt_template_snapshots.py:
+
+    python -m tests.unit.generate_prompt_snapshots
+
+Only run this when you're intentionally accepting new/changed template
+content. If you're changing prompt behavior for an existing template,
+bump its version key (v1 -> v2) in PROMPT_TEMPLATES first, so the old
+v1 hash stays as a record of what shipped before.
+"""
+import hashlib
+from pathlib import Path
+
+from rag.generator.prompt_templates import PROMPT_TEMPLATES
+
+
+def compute_hash(text: str) -> str:
+    return hashlib.sha256(text.encode()).hexdigest()
+
+
+def main():
+    lines = [
+        '"""',
+        "Snapshot hashes for prompt templates.",
+        "",
+        "Regenerate with: python -m tests.unit.generate_prompt_snapshots",
+        "",
+        "Only regenerate when you've intentionally added/changed a version key.",
+        'If a hash here changes for an EXISTING version (e.g. "v1" -> new hash)',
+        "without a new version key being added, that's the exact thing this",
+        "snapshot system exists to catch — don't just silently regenerate it.",
+        '"""',
+        "",
+        "TEMPLATE_SNAPSHOTS = {",
+    ]
+    for name in sorted(PROMPT_TEMPLATES.keys()):
+        lines.append(f'    "{name}": {{')
+        for version in sorted(PROMPT_TEMPLATES[name].keys()):
+            h = compute_hash(PROMPT_TEMPLATES[name][version])
+            lines.append(f'        "{version}": "{h}",')
+        lines.append("    },")
+    lines.append("}")
+    lines.append("")
+
+    out_path = Path(__file__).parent / "prompt_template_snapshots.py"
+    out_path.write_text("\n".join(lines), encoding="utf-8")
+    print(f"Wrote {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/prompt_template_snapshots.py
+++ b/tests/unit/prompt_template_snapshots.py
@@ -1,0 +1,28 @@
+"""
+Snapshot hashes for prompt templates.
+
+Regenerate with: python -m tests.unit.generate_prompt_snapshots
+
+Only regenerate when you've intentionally added/changed a version key.
+If a hash here changes for an EXISTING version (e.g. "v1" -> new hash)
+without a new version key being added, that's the exact thing this
+snapshot system exists to catch — don't just silently regenerate it.
+"""
+
+TEMPLATE_SNAPSHOTS = {
+    "first_impression": {
+        "v1": "9e7697ff3efd892c82c63ffcc8365690685fb1c29f79d45d84e057b2d0672dd0",
+    },
+    "gaps_feedback": {
+        "v1": "b2673a1a1f018f2f2fdf37b2dfb6b30634404ba7bb2c241cc01b6240b9097950",
+    },
+    "presentation_feedback": {
+        "v1": "87230b7045d66a1fae7d06e2509c6fae31046e0c4e8d30a3c3d6fe9ad2a7a3d7",
+    },
+    "projects_feedback": {
+        "v1": "7e53575582f45389e4a3e4f93c7c137da629d3a14809e16f746732b9a06740d1",
+    },
+    "skills_feedback": {
+        "v1": "a24d6d717d4f365c28a686f28b3e77f47204c325ce892fc32d68eb82259f6816",
+    },
+}

--- a/tests/unit/test_prompt_templates.py
+++ b/tests/unit/test_prompt_templates.py
@@ -4,6 +4,7 @@ import pytest
 import hashlib
 
 from rag.generator.prompt_templates import PROMPT_TEMPLATES, get_template
+from tests.unit.prompt_template_snapshots import TEMPLATE_SNAPSHOTS
 
 
 @pytest.mark.unit
@@ -172,21 +173,6 @@ class TestPromptTemplates:
 
         assert template_default == template_v1
 
-    def test_template_snapshot_content_hash(self):
-        """Snapshot test: verify template content hash."""
-        # Create hash of all template content
-        template_content = ""
-        for name in sorted(PROMPT_TEMPLATES.keys()):
-            for version in sorted(PROMPT_TEMPLATES[name].keys()):
-                template_content += PROMPT_TEMPLATES[name][version]
-
-        content_hash = hashlib.md5(template_content.encode()).hexdigest()
-
-        # Expected hash - update if templates intentionally change
-        # This helps detect unintended changes to templates
-        assert isinstance(content_hash, str)
-        assert len(content_hash) == 32  # MD5 hash length
-
     def test_skills_feedback_requests_json_format(self):
         """Test skills_feedback requests JSON output."""
         template = PROMPT_TEMPLATES["skills_feedback"]["v1"]
@@ -271,3 +257,65 @@ class TestPromptTemplates:
                 assert "context" in placeholders
                 assert "github_username" in placeholders
                 assert "project_count" in placeholders
+
+
+@pytest.mark.unit
+class TestPromptTemplateSnapshots:
+    """
+    Guards against silent edits to template content.
+
+    Prompt templates directly shape review output. If this test class
+    fails, a template's text changed without its version key changing.
+
+    - Intentional prompt change -> add a new version key (e.g. "v2")
+      alongside the existing one in PROMPT_TEMPLATES, then regenerate:
+      python -m tests.unit.generate_prompt_snapshots
+    - Accidental change -> revert it.
+    """
+
+    @staticmethod
+    def _hash(text: str) -> str:
+        return hashlib.sha256(text.encode()).hexdigest()
+
+    def test_no_untracked_template_versions(self):
+        """Every template/version in PROMPT_TEMPLATES must have a recorded snapshot."""
+        for name, versions in PROMPT_TEMPLATES.items():
+            for version in versions:
+                assert version in TEMPLATE_SNAPSHOTS.get(name, {}), (
+                    f"No snapshot recorded for {name} {version}. "
+                    f"Run: python -m tests.unit.generate_prompt_snapshots"
+                )
+
+    def test_no_orphaned_snapshots(self):
+        """Every recorded snapshot must map to a real template/version (catches stale entries)."""
+        for name, versions in TEMPLATE_SNAPSHOTS.items():
+            for version in versions:
+                assert name in PROMPT_TEMPLATES and version in PROMPT_TEMPLATES[name], (
+                    f"Snapshot exists for {name} {version} but that "
+                    f"template/version no longer exists in PROMPT_TEMPLATES."
+                )
+
+    @pytest.mark.parametrize(
+        "template_name,version",
+        [
+            (name, version)
+            for name, versions in PROMPT_TEMPLATES.items()
+            for version in versions
+        ],
+    )
+    def test_template_content_matches_snapshot(self, template_name, version):
+        """Fails if template content changed without a version bump."""
+        actual_hash = self._hash(PROMPT_TEMPLATES[template_name][version])
+        expected_hash = TEMPLATE_SNAPSHOTS.get(template_name, {}).get(version)
+
+        assert expected_hash is not None, (
+            f"No baseline snapshot for {template_name} {version}. "
+            f"Run: python -m tests.unit.generate_prompt_snapshots"
+        )
+        assert actual_hash == expected_hash, (
+            f"Content of {template_name} {version} changed since the last "
+            f"snapshot. If this is an intentional prompt change, add a new "
+            f"version key instead of editing {version} in place (e.g. copy "
+            f"it to v{int(version[1:]) + 1} with your changes), then "
+            f"regenerate snapshots."
+        )


### PR DESCRIPTION
## Summary

Adds snapshot-based tests for the versioned prompt templates so unexpected
prompt content changes are detected by the test suite.

The existing test generated a hash but only verified its format, meaning
prompt content could change without causing a test failure. This change
compares the generated snapshot against the expected baseline.

## Issue

Closes #37

## Changes

- Added snapshot checks for versioned prompt templates.
- Added fixed snapshot expectations for prompt content.
- Uses SHA-256 hashes to detect prompt content changes.
- Kept the change focused on the existing prompt-template test structure.

### Testing

- `pytest tests/unit/test_prompt_templates.py -v` — 43 passed
- `ruff check tests/unit/test_prompt_templates.py` — passed
- `make test-unit` — 381 passed, 53 failed in unrelated existing modules
- `make check` — could not complete because the repository has existing lint failures outside this change

The targeted prompt-template tests pass successfully.

## Notes for Reviewers

The snapshot baseline is intended as a lightweight guard against unexpected
prompt drift. The hashing approach and baseline policy remain open to
feedback.