### PR TITLE
feat: add dependency audit tool for outdated major versions

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -51,3 +51,21 @@ Before implementation, `make test-unit` reported 375 passing and 53 failing test
 
 **Next steps:**
 Run the final self-review, verify no new regressions compared with the baseline, review the diff for scope and maintainability, complete PR documentation, and open the pull request.
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/1012
+
+**Branch:** feat/53-dependency-audit-tool
+
+**What you built:**
+Implemented a `DependencyAuditTool` that audits `requirements.txt`, `package.json`, and PEP 621 `pyproject.toml` dependencies and flags packages that are more than one major version behind their current PyPI or npm release. I also integrated the tool into the agent orchestrator so GitHub-backed projects automatically schedule a dependency audit.
+
+**Tests added or updated:**
+Added `tests/unit/test_dependency_audit_tool.py` to cover manifest parsing, the major-version threshold, malformed and unsupported inputs, registry failures, and mocked GitHub manifest fetching. Added `tests/unit/test_orchestrator.py` to verify dependency auditing is scheduled for GitHub-backed projects without removing the existing GitHub tool behavior. All 14 new targeted tests pass.
+
+**Self-review confirmation:**
+- [x] `make check` run — repo-wide check still reports pre-existing lint failures; this change introduced no new lint failures.
+- [x] `make test-unit` run — 53 pre-existing failures remain, while passing tests increased from 375 to 389 and all 14 new tests pass.
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -17,3 +17,19 @@ PathReview's agent system can analyze repository information, but it does not cu
 
 **Selection reasoning:**
 I chose this Tier 2 issue because, although the overall PathReview codebase was initially unfamiliar to me, the scope of this issue is bounded enough for me to reason about after tracing the existing agent tool structure. I reviewed `BaseTool`, existing tools such as `ReadmeScorer`, the agent orchestrator, and adjacent unit tests, and I was able to identify a clear implementation path: add one new dependency-audit tool, integrate it with the orchestrator, and test its behavior. I chose it over a simpler Tier 1 issue because it gives me experience working across multiple parts of the agent system while still having a defined feature boundary.
+
+## Week 8 - Reproduction & solution planning
+
+**Reproduction commit:** https://github.com/toju-commits/pathreview/commit/821a4d876886414ccbb4f9cd17dbf480956dbd49
+
+**Reproduction summary:**
+I confirmed locally that PathReview has no `DependencyAuditTool` implementation and that `Orchestrator._build_plan()` does not schedule a dependency-audit step even when `requirements.txt` and `package.json` are present in the profile's file list. The generated plan only scheduled `tech_detector` and `market_analyzer`, with `Dependency audit scheduled: False`.
+
+**PLAN.md:** https://github.com/toju-commits/pathreview/blob/feat/53-dependency-audit-tool/PLAN.md
+
+**Plan commit:** https://github.com/toju-commits/pathreview/commit/d12810f857ef0bdb8c5ebdc1157e951f0781b770
+
+**Walkthrough video:** Not recorded yet (optional)
+
+**Blockers / open questions:**
+The main open question is where the new tool should get the actual contents of `requirements.txt`, `package.json`, and `pyproject.toml`. The current agent flow exposes repository filenames to `tech_detector`, but that alone is not enough to inspect dependency versions. Before implementation, I need to trace the producer of `profile_data` and decide whether the dependency audit should receive manifest contents from an earlier layer or fetch them through the GitHub API.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -14,3 +14,6 @@ PathReview's agent system can analyze repository information, but it does not cu
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+**Selection reasoning:**
+I chose this Tier 2 issue because, although the overall PathReview codebase was initially unfamiliar to me, the scope of this issue is bounded enough for me to reason about after tracing the existing agent tool structure. I reviewed `BaseTool`, existing tools such as `ReadmeScorer`, the agent orchestrator, and adjacent unit tests, and I was able to identify a clear implementation path: add one new dependency-audit tool, integrate it with the orchestrator, and test its behavior. I chose it over a simpler Tier 1 issue because it gives me experience working across multiple parts of the agent system while still having a defined feature boundary.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -33,3 +33,21 @@ I confirmed locally that PathReview has no `DependencyAuditTool` implementation 
 
 **Blockers / open questions:**
 The main open question is where the new tool should get the actual contents of `requirements.txt`, `package.json`, and `pyproject.toml`. The current agent flow exposes repository filenames to `tech_detector`, but that alone is not enough to inspect dependency versions. Before implementation, I need to trace the producer of `profile_data` and decide whether the dependency audit should receive manifest contents from an earlier layer or fetch them through the GitHub API.
+
+## Week 9 — Implementation & PR submission
+
+### Check-in 1 — Implementation progress
+
+**Implementation commit:** https://github.com/toju-commits/pathreview/commit/d6615d4bc464063a8269b250256c390dedd08278
+
+**Progress:**
+Implemented `DependencyAuditTool` and integrated it into the agent orchestrator. The tool supports `requirements.txt`, `package.json`, and `pyproject.toml`, resolves current package versions through PyPI or npm, and flags dependencies that are more than one major version behind.
+
+**Testing completed:**
+Added focused unit tests for dependency parsing, version-gap behavior, malformed manifests, unsupported version specifications, registry lookup failures, and orchestrator scheduling. The targeted test suite passes with 13/13 tests.
+
+**Repository baseline:**
+Before implementation, `make test-unit` reported 375 passing and 53 failing tests. These failures were pre-existing and unrelated to Issue #53. The repository also had pre-existing repo-wide Ruff/mypy issues. My new files pass targeted Ruff, Black, and mypy checks; the commit used the existing Ruff and Black pre-commit hooks successfully, while the repo-wide mypy hook was skipped because it fails on existing unrelated agent files.
+
+**Next steps:**
+Run the final self-review, verify no new regressions compared with the baseline, review the diff for scope and maintainability, complete PR documentation, and open the pull request.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -69,3 +69,39 @@ Added `tests/unit/test_dependency_audit_tool.py` to cover manifest parsing, the 
 - [x] `make test-unit` run — 53 pre-existing failures remain, while passing tests increased from 375 to 389 and all 14 new tests pass.
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No maintainer or reviewer feedback has arrived on PR #1012 as of Week 10. I checked the PR for submitted reviews, inline review threads, and conversation comments.
+
+**How you responded:**
+
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+
+The hardest part was not writing the dependency parser itself, but understanding where the new tool belonged in an unfamiliar production codebase. I had to trace `BaseTool`, the orchestrator, existing agent tools, and the available repository data before realizing that filenames alone were not enough and that the audit needed a path to actual manifest contents.
+
+**What did you learn about working in a large codebase?**
+
+I learned that contributing to someone else's codebase is much more about understanding contracts and existing conventions than immediately writing code. The safest approach was to find analogous tools and tests, reproduce the missing behavior first, make a scoped plan, and compare my final results against a baseline so I could distinguish my changes from existing repository problems.
+
+**How did AI tools help — and where did they fall short?**
+
+AI was most useful for helping me navigate unfamiliar files, turn the issue into smaller implementation tasks, reason through version-parsing edge cases, and interpret test and lint output. It still required verification against the actual repository: for example, a new test initially ended up at the wrong indentation level and pytest interpreted `self` as a fixture, and AI assistance alone could not tell whether repo-wide failures were caused by my work without the baseline I had recorded.
+
+**What would you do differently if you started over?**
+
+I would trace the end-to-end data flow for repository contents earlier, before spending much time thinking about the parser in isolation. I would also establish the test and lint baseline immediately, run formatting before every commit attempt, and add the mocked GitHub-fetch path earlier instead of treating it as final hardening.
+
+**What are you most proud of from this module?**
+
+I am most proud that I took an issue in a codebase I initially understood only partially and turned it into a contribution I can actually explain from reproduction through implementation and testing. The repository still had the same 53 pre-existing unit-test failures at the end, while passing tests increased from 375 to 389, so all 14 tests added for my contribution passed without adding another repo-wide test failure.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,16 @@
+## Week 7 - Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/53
+
+**Issue title:** Implement a `DependencyAuditTool` that flags outdated major dependencies in project repos
+
+**Tier:** [ ] Tier 1  [x] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+PathReview's agent system can analyze repository information, but it does not currently check whether a project's declared dependencies are significantly outdated. Issue #53 asks for a new `DependencyAuditTool` that parses supported dependency files such as `requirements.txt`, `package.json`, and `pyproject.toml`, then flags dependencies that are more than one major version behind the current release. The tool will follow PathReview's existing agent tool structure and be integrated with the orchestrator. A successful fix will provide useful dependency freshness information without failing on unsupported or malformed dependency specifications.
+
+**Branch name:** feat/53-dependency-audit-tool
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,115 @@
+# Issue #53 Solution Plan
+
+**Issue:** Implement a `DependencyAuditTool` that flags outdated major dependencies in project repos
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/53
+
+## Understand
+
+PathReview currently has no agent tool that evaluates whether a submitted repository's declared dependencies are significantly outdated. My reproduction confirmed that `agent/tools/dependency_audit_tool.py` does not exist and that `Orchestrator._build_plan()` does not schedule dependency auditing even when `requirements.txt` and `package.json` appear in the repository file list.
+
+A correct implementation should add a `DependencyAuditTool` that supports `requirements.txt`, `package.json`, and `pyproject.toml`, determines the declared major version of each dependency, compares it with the current released major version, and flags dependencies that are more than one major version behind. The tool should follow the existing `BaseTool` / `ToolResult` contract and be included in the agent execution plan for repository-backed projects.
+
+The fix is complete when supported manifests can be audited without crashing, dependencies zero or one major version behind are not flagged, dependencies more than one major version behind are flagged, malformed or unsupported dependency specifications are handled safely, and unit tests plus the project checks pass.
+
+## Map
+
+The main files involved are:
+
+- `agent/tools/dependency_audit_tool.py` — new tool containing dependency manifest parsing, version comparison, and audit behavior.
+- `agent/tools/base.py` — defines the `BaseTool` interface and `ToolResult` structure that the new tool must follow. No change is expected unless implementation reveals a missing shared capability.
+- `agent/orchestrator.py` — `Orchestrator._build_plan()` will need to schedule the dependency audit when repository information is available.
+- `agent/tools/github_tool.py` — reference for the existing GitHub API, `httpx`, timeout, and graceful error-handling patterns.
+- `agent/tools/tech_detector.py` — shows that the current `files` input contains repository file paths and can recognize dependency-manifest filenames, but does not contain the manifest contents needed for an audit.
+- `ingestion/parsers/repo_analyzer.py` — currently detects technology/config-file presence from repository metadata and `file_structure`, but does not inspect dependency versions.
+- `tests/unit/test_dependency_audit_tool.py` — new unit tests for parsing, comparison, error handling, and output.
+- `tests/unit/test_orchestrator.py` — new focused tests for scheduling the dependency audit from `_build_plan()` because no dedicated orchestrator unit test file currently exists.
+
+## Plan
+
+1. Trace the manifest-content input path before implementing the tool. I will inspect how `profile_data` is constructed and where the `tools` dictionary passed to `Orchestrator` is assembled. The current orchestrator only receives a list of file names for `tech_detector`, so I need to confirm the smallest change that gives the new tool access to actual manifest contents.
+
+2. Create `agent/tools/dependency_audit_tool.py` with a `DependencyAuditTool(BaseTool)` implementation. The tool will expose the standard `execute(input_data)` method and return a `ToolResult`. Parsing logic will be separated into helper methods so `requirements.txt`, `package.json`, and `pyproject.toml` can be tested independently.
+
+3. Implement parsing for the three supported manifest types. `requirements.txt` parsing will extract package names and version specifications from usable requirement lines. `package.json` parsing will inspect dependency entries. `pyproject.toml` parsing will inspect standard Python project dependency declarations and any project-supported layout identified during implementation.
+
+4. Add a version-resolution layer that determines the current released version of each package. The proposed approach is to use PyPI for Python dependencies and the npm registry for JavaScript dependencies, following the existing `httpx` request/error-handling style in `GitHubTool`. The resolver will be isolated behind a helper or injectable boundary so unit tests can provide deterministic versions without depending on live network requests.
+
+5. Compare the declared and current major versions. A dependency will only be added to the outdated list when `latest_major - declared_major > 1`. Exactly one major version behind will not be flagged.
+
+6. Integrate the tool with `Orchestrator._build_plan()`. For a project with repository information, the plan should include a `dependency_audit` step with the repository or manifest input established in step 1. The tool should remain independent from unrelated RAG, safety, or review-generation code.
+
+7. Add `tests/unit/test_dependency_audit_tool.py` covering all three manifest formats, the major-version threshold, no-outdated-dependency behavior, malformed input, unsupported version specifications, missing manifests, and failed version lookups. Follow the existing pytest/tool testing pattern used by files such as `tests/unit/test_readme_scorer.py`.
+
+8. Add an orchestrator unit test confirming that a repository-backed project schedules the dependency-audit tool and that profiles without usable repository/dependency information do not schedule it unnecessarily.
+
+9. Run the targeted new tests first, then `make test-unit` and `make check`. Fix any regressions before opening the Week 9 pull request.
+
+## Inputs & Outputs
+
+### Planned external input
+
+The preferred input for the agent tool is repository identity already available to the agent flow:
+
+    {
+        "github_username": "example-user",
+        "repo_name": "example-project"
+    }
+
+If tracing the current data flow shows that manifest contents are already available before agent execution, the tool will instead accept those contents directly rather than performing a duplicate GitHub fetch. I will resolve this boundary before implementation and update this plan if the actual code path requires a different shape.
+
+### Internal manifest data
+
+Parsing helpers should work with content equivalent to:
+
+    {
+        "requirements.txt": "...",
+        "package.json": "...",
+        "pyproject.toml": "..."
+    }
+
+Only manifests that actually exist need to be present.
+
+### Output
+
+Successful execution should return a `ToolResult` whose data makes the audit understandable to downstream code. The planned structure is:
+
+    {
+        "outdated_dependencies": [
+            {
+                "name": "example-package",
+                "declared_version": "1.4.0",
+                "latest_version": "4.2.0",
+                "major_versions_behind": 3,
+                "source_file": "requirements.txt"
+            }
+        ],
+        "checked_count": 1,
+        "manifest_files": ["requirements.txt"]
+    }
+
+If no dependency is more than one major version behind, `outdated_dependencies` should be an empty list rather than an error.
+
+## Risks & Unknowns
+
+1. **Manifest contents are not currently present in `Orchestrator._build_plan()` input.** `agent/tools/tech_detector.py` receives file names only. I need to trace the producer of `profile_data` and the construction of the orchestrator tool dictionary before deciding whether `DependencyAuditTool` should fetch manifests through the GitHub Contents API or receive their contents from an earlier layer.
+
+2. **The issue says "current release" but does not specify version-registry behavior.** Live PyPI/npm lookups can timeout, rate-limit, return missing packages, or expose prereleases. I will isolate version lookup so failures for one dependency do not crash the entire audit and so unit tests can mock the current version.
+
+3. **Dependency version syntax is not always a single exact version.** Python requirements can contain operators, environment markers, URLs, editable installs, wildcards, or local paths, while npm supports caret, tilde, ranges, tags, Git URLs, and workspace references. The audit should avoid inventing a major version when one cannot be determined reliably.
+
+4. **`pyproject.toml` has multiple dependency layouts.** Standard `[project]` dependencies and tool-specific layouts such as Poetry may represent dependencies differently. I will inspect the expected project formats before deciding how much of each layout belongs in the initial implementation.
+
+5. **The live application does not appear to pass results from one agent tool directly into the next inside `_build_plan()`.** If manifest discovery depends on `GitHubTool` output, I will avoid a broad orchestrator redesign and choose the smallest input boundary that satisfies Issue #53.
+
+## Edge Cases
+
+- A repository contains none of the three supported manifest files. The tool should return successfully with no outdated dependencies rather than crash.
+- A dependency is exactly one major version behind the current release. It should not be flagged because the issue specifies more than one major version behind.
+- A dependency is two or more major versions behind. It should be flagged with the declared version, latest version, and difference.
+- `package.json` or `pyproject.toml` is malformed. The bad manifest should be handled gracefully instead of terminating the entire agent run.
+- `requirements.txt` contains blank lines, comments, environment markers, Git/local-path dependencies, or a version specification from which a major version cannot be determined. Unsupported entries should be skipped or reported without creating a false positive.
+- A registry lookup returns 404, times out, or is rate-limited for one package. Other dependencies should still be audited.
+- A package is already on the current major version or appears newer than the registry result. It should not be flagged.
+- An npm package uses a scoped name such as `@scope/package`; parsing and version lookup should preserve the complete package name.
+- The same dependency appears in more than one supported manifest. The output should avoid misleading duplicate warnings or clearly preserve which source file produced each result.

--- a/REPRODUCTION.md
+++ b/REPRODUCTION.md
@@ -1,0 +1,47 @@
+# Issue #53 Reproduction
+
+**Issue:** Implement a `DependencyAuditTool` that flags outdated major dependencies in project repos
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/53
+
+## What I reproduced
+
+Issue #53 is a feature gap rather than a crashing bug. PathReview currently has no `DependencyAuditTool`, and the agent orchestrator does not schedule any dependency-audit step when supported dependency manifest filenames are present.
+
+## Steps
+
+1. Confirmed I was working on `feat/53-dependency-audit-tool`.
+2. Listed the existing files in `agent/tools/`.
+3. Searched `agent/` and `tests/` for `dependency_audit` or `DependencyAudit`.
+4. Called `Orchestrator._build_plan()` with profile data containing `requirements.txt` and `package.json`.
+
+## Commands used
+
+    git branch --show-current
+    ls agent/tools
+    grep -R "dependency_audit\|DependencyAudit" agent tests -n || echo "No dependency audit implementation found"
+
+I also ran `Orchestrator._build_plan()` with:
+
+    profile_data = {
+        "files": ["requirements.txt", "package.json"]
+    }
+
+## Observed behavior
+
+The search returned:
+
+    No dependency audit implementation found
+
+The generated agent plan included:
+
+    tech_detector {'files': ['requirements.txt', 'package.json']}
+    market_analyzer {'detected_skills': {}}
+
+And reported:
+
+    Dependency audit scheduled: False
+
+## Expected behavior
+
+After Issue #53 is implemented, PathReview should have a dependency-audit agent tool capable of inspecting supported dependency manifests such as `requirements.txt`, `package.json`, and `pyproject.toml`. The agent flow should be able to invoke that functionality and report dependencies that are more than one major version behind the current release.

--- a/agent/orchestrator.py
+++ b/agent/orchestrator.py
@@ -1,12 +1,12 @@
 """Plan-execute orchestrator for agent tools."""
 
 import time
-import structlog
-from typing import Optional
 
-from .memory.session_store import SessionStore
-from .memory.context_manager import ContextManager
+import structlog
+
 from .error_handling import retry_with_backoff
+from .memory.context_manager import ContextManager
+from .memory.session_store import SessionStore
 
 logger = structlog.get_logger()
 
@@ -14,8 +14,9 @@ logger = structlog.get_logger()
 class Orchestrator:
     """Orchestrate tool execution with planning and memoization."""
 
-    def __init__(self, tools: dict, session_store: Optional[SessionStore] = None,
-                 tool_timeout: float = 30.0):
+    def __init__(
+        self, tools: dict, session_store: SessionStore | None = None, tool_timeout: float = 30.0
+    ):
         """Initialize orchestrator.
 
         Args:
@@ -53,7 +54,7 @@ class Orchestrator:
         for tool_name, tool_input in plan:
             try:
                 result = self._execute_tool(tool_name, tool_input)
-                results[tool_name] = result.data if hasattr(result, 'data') else result
+                results[tool_name] = result.data if hasattr(result, "data") else result
 
                 logger.info("tool_executed", tool=tool_name, success=True)
 
@@ -66,13 +67,12 @@ class Orchestrator:
             session_state.update(results)
             self.session_store.set(profile_id, session_state)
 
-        logger.info("orchestrator_complete", profile_id=profile_id,
-                   tools_executed=len(results))
+        logger.info("orchestrator_complete", profile_id=profile_id, tools_executed=len(results))
 
         return {
             "profile_id": profile_id,
             "tool_results": results,
-            "cached_results": self.context_manager.get_all_results()
+            "cached_results": self.context_manager.get_all_results(),
         }
 
     def _build_plan(self, profile_data: dict) -> list[tuple[str, dict]]:
@@ -86,49 +86,45 @@ class Orchestrator:
         """
         plan = []
 
-        # Conditionally add GitHub tool
+        # Conditionally add repository tools
         if profile_data.get("github_username"):
             for project in profile_data.get("projects", []):
                 if project.get("github_repo"):
-                    plan.append((
-                        "github_tool",
-                        {
-                            "github_username": profile_data["github_username"],
-                            "repo_name": project["github_repo"]
-                        }
-                    ))
+                    repo_input = {
+                        "github_username": profile_data["github_username"],
+                        "repo_name": project["github_repo"],
+                    }
+
+                    plan.append(("github_tool", repo_input))
+                    plan.append(("dependency_audit", repo_input.copy()))
+
                     break  # Only process first repo for now
 
         # Tech detector (if files available)
         if profile_data.get("files"):
-            plan.append((
-                "tech_detector",
-                {"files": profile_data["files"]}
-            ))
+            plan.append(("tech_detector", {"files": profile_data["files"]}))
 
         # README scorer
         if profile_data.get("readme_content"):
-            plan.append((
-                "readme_scorer",
-                {"readme_content": profile_data["readme_content"]}
-            ))
+            plan.append(("readme_scorer", {"readme_content": profile_data["readme_content"]}))
 
         # Skill extractor
         if profile_data.get("resume_text"):
-            plan.append((
-                "skill_extractor",
-                {
-                    "resume_text": profile_data["resume_text"],
-                    "repo_metadata": profile_data.get("repo_metadata", {})
-                }
-            ))
+            plan.append(
+                (
+                    "skill_extractor",
+                    {
+                        "resume_text": profile_data["resume_text"],
+                        "repo_metadata": profile_data.get("repo_metadata", {}),
+                    },
+                )
+            )
 
         # Market analyzer (if skills detected)
         if plan:  # Only if other tools executed
-            plan.append((
-                "market_analyzer",
-                {"detected_skills": {}}  # Will be populated by context
-            ))
+            plan.append(
+                ("market_analyzer", {"detected_skills": {}})  # Will be populated by context
+            )
 
         logger.info("plan_built", plan_size=len(plan))
         return plan
@@ -172,7 +168,7 @@ class Orchestrator:
             logger.error("tool_execution_error", tool=tool_name, error=str(e))
             raise
 
-    def _execute_with_timeout(self, tool, tool_input: dict, timeout: Optional[float] = None):
+    def _execute_with_timeout(self, tool, tool_input: dict, timeout: float | None = None):
         """Execute tool with timeout.
 
         Args:

--- a/agent/tools/dependency_audit_tool.py
+++ b/agent/tools/dependency_audit_tool.py
@@ -1,0 +1,420 @@
+"""Audit repository dependency manifests for outdated major versions."""
+
+import base64
+import json
+import re
+import tomllib
+from collections.abc import Callable
+from urllib.parse import quote
+
+import httpx
+import structlog
+
+from .base import BaseTool, ToolResult
+
+logger = structlog.get_logger()
+
+SUPPORTED_MANIFESTS = ("requirements.txt", "package.json", "pyproject.toml")
+
+
+class DependencyAuditTool(BaseTool):
+    """Flag dependencies that are more than one major version behind."""
+
+    name = "dependency_audit"
+    description = "Checks for outdated dependencies in project repos"
+
+    def __init__(
+        self,
+        api_token: str | None = None,
+        version_resolver: Callable[[str, str], str | None] | None = None,
+    ) -> None:
+        """Initialize the dependency audit tool.
+
+        Args:
+            api_token: Optional GitHub API token used when fetching manifests.
+            version_resolver: Optional resolver used to obtain current package
+                versions. Primarily useful for deterministic unit tests.
+        """
+        self.api_token = api_token
+        self.github_base_url = "https://api.github.com"
+        self.version_resolver = version_resolver or self._resolve_latest_version
+
+    def execute(self, input_data: dict) -> ToolResult:
+        """Audit supported dependency manifests.
+
+        Args:
+            input_data: Either a ``manifests`` mapping containing manifest
+                contents, or ``github_username`` and ``repo_name`` for a
+                repository whose root manifests should be fetched.
+
+        Returns:
+            ToolResult containing outdated dependencies and audit metadata.
+        """
+        manifests = input_data.get("manifests")
+        fetch_errors: list[str] = []
+
+        if manifests is not None:
+            if not isinstance(manifests, dict):
+                return ToolResult(
+                    success=False,
+                    data={},
+                    error="manifests must be a dictionary",
+                )
+
+            manifest_contents = {
+                filename: content
+                for filename, content in manifests.items()
+                if filename in SUPPORTED_MANIFESTS and isinstance(content, str)
+            }
+        else:
+            username = input_data.get("github_username")
+            repo_name = input_data.get("repo_name")
+
+            if not username or not repo_name:
+                return ToolResult(
+                    success=False,
+                    data={},
+                    error=("Provide manifests or both github_username and repo_name"),
+                )
+
+            manifest_contents, fetch_errors = self._fetch_manifests(
+                username,
+                repo_name,
+            )
+
+        dependencies: list[dict[str, str]] = []
+        parse_errors: list[str] = []
+
+        for filename, content in manifest_contents.items():
+            try:
+                dependencies.extend(self._parse_manifest(filename, content))
+            except (json.JSONDecodeError, tomllib.TOMLDecodeError, TypeError) as exc:
+                parse_errors.append(f"{filename}: {exc}")
+
+        outdated_dependencies: list[dict[str, object]] = []
+        skipped_dependencies: list[dict[str, str]] = []
+        lookup_failures: list[dict[str, str]] = []
+        checked_count = 0
+
+        for dependency in dependencies:
+            name = dependency["name"]
+            version_spec = dependency["version_spec"]
+            ecosystem = dependency["ecosystem"]
+            source_file = dependency["source_file"]
+
+            declared_major = self._extract_major_version(version_spec)
+            if declared_major is None:
+                skipped_dependencies.append(
+                    {
+                        "name": name,
+                        "version_spec": version_spec,
+                        "source_file": source_file,
+                        "reason": "Could not determine declared major version",
+                    }
+                )
+                continue
+
+            try:
+                latest_version = self.version_resolver(name, ecosystem)
+            except Exception as exc:
+                logger.warning(
+                    "dependency_version_lookup_failed",
+                    dependency=name,
+                    ecosystem=ecosystem,
+                    error=str(exc),
+                )
+                latest_version = None
+
+            if not latest_version:
+                lookup_failures.append(
+                    {
+                        "name": name,
+                        "ecosystem": ecosystem,
+                        "source_file": source_file,
+                    }
+                )
+                continue
+
+            latest_major = self._extract_major_version(latest_version)
+            if latest_major is None:
+                lookup_failures.append(
+                    {
+                        "name": name,
+                        "ecosystem": ecosystem,
+                        "source_file": source_file,
+                    }
+                )
+                continue
+
+            checked_count += 1
+            major_versions_behind = latest_major - declared_major
+
+            if major_versions_behind > 1:
+                outdated_dependencies.append(
+                    {
+                        "name": name,
+                        "declared_version": version_spec,
+                        "latest_version": latest_version,
+                        "major_versions_behind": major_versions_behind,
+                        "source_file": source_file,
+                        "ecosystem": ecosystem,
+                    }
+                )
+
+        data = {
+            "outdated_dependencies": outdated_dependencies,
+            "checked_count": checked_count,
+            "manifest_files": sorted(manifest_contents),
+            "skipped_dependencies": skipped_dependencies,
+            "lookup_failures": lookup_failures,
+            "parse_errors": parse_errors,
+            "fetch_errors": fetch_errors,
+        }
+
+        logger.info(
+            "dependency_audit_completed",
+            checked_count=checked_count,
+            outdated_count=len(outdated_dependencies),
+            manifest_count=len(manifest_contents),
+        )
+
+        return ToolResult(success=True, data=data)
+
+    def _fetch_manifests(
+        self,
+        username: str,
+        repo_name: str,
+    ) -> tuple[dict[str, str], list[str]]:
+        """Fetch supported root-level manifests from a GitHub repository.
+
+        Args:
+            username: Repository owner's GitHub username.
+            repo_name: Repository name.
+
+        Returns:
+            Tuple containing fetched manifest contents and fetch errors.
+        """
+        manifests: dict[str, str] = {}
+        errors: list[str] = []
+
+        headers = {"Accept": "application/vnd.github+json"}
+        if self.api_token:
+            headers["Authorization"] = f"Bearer {self.api_token}"
+
+        for filename in SUPPORTED_MANIFESTS:
+            url = f"{self.github_base_url}/repos/" f"{username}/{repo_name}/contents/{filename}"
+
+            try:
+                response = httpx.get(url, headers=headers, timeout=10.0)
+
+                if response.status_code == 404:
+                    continue
+
+                response.raise_for_status()
+                payload = response.json()
+
+                encoded_content = payload.get("content")
+                if not encoded_content:
+                    errors.append(f"{filename}: GitHub response had no content")
+                    continue
+
+                decoded = base64.b64decode(encoded_content).decode("utf-8")
+                manifests[filename] = decoded
+
+            except (httpx.HTTPError, ValueError, UnicodeDecodeError) as exc:
+                errors.append(f"{filename}: {exc}")
+
+        return manifests, errors
+
+    def _parse_manifest(
+        self,
+        filename: str,
+        content: str,
+    ) -> list[dict[str, str]]:
+        """Parse one supported dependency manifest.
+
+        Args:
+            filename: Supported dependency manifest filename.
+            content: Raw manifest contents.
+
+        Returns:
+            List of normalized dependency dictionaries.
+        """
+        if filename == "requirements.txt":
+            return self._parse_requirements(content)
+
+        if filename == "package.json":
+            return self._parse_package_json(content)
+
+        if filename == "pyproject.toml":
+            return self._parse_pyproject(content)
+
+        return []
+
+    def _parse_requirements(self, content: str) -> list[dict[str, str]]:
+        """Parse dependencies from requirements.txt content."""
+        dependencies: list[dict[str, str]] = []
+
+        for raw_line in content.splitlines():
+            line = raw_line.strip()
+
+            if not line or line.startswith(("#", "-", "git+", "http://", "https://")):
+                continue
+
+            requirement = line.split(";", maxsplit=1)[0].strip()
+
+            match = re.match(
+                r"^([A-Za-z0-9_.-]+)(?:\[[^\]]+\])?\s*(.*)$",
+                requirement,
+            )
+            if not match:
+                continue
+
+            name, version_spec = match.groups()
+            version_spec = version_spec.strip()
+
+            if not version_spec or version_spec.startswith("@"):
+                continue
+
+            dependencies.append(
+                {
+                    "name": name,
+                    "version_spec": version_spec,
+                    "ecosystem": "pypi",
+                    "source_file": "requirements.txt",
+                }
+            )
+
+        return dependencies
+
+    def _parse_package_json(self, content: str) -> list[dict[str, str]]:
+        """Parse dependencies from package.json content."""
+        payload = json.loads(content)
+
+        if not isinstance(payload, dict):
+            return []
+
+        dependencies: list[dict[str, str]] = []
+
+        sections = (
+            "dependencies",
+            "devDependencies",
+            "peerDependencies",
+            "optionalDependencies",
+        )
+
+        for section in sections:
+            values = payload.get(section, {})
+            if not isinstance(values, dict):
+                continue
+
+            for name, version_spec in values.items():
+                if not isinstance(name, str) or not isinstance(version_spec, str):
+                    continue
+
+                dependencies.append(
+                    {
+                        "name": name,
+                        "version_spec": version_spec,
+                        "ecosystem": "npm",
+                        "source_file": "package.json",
+                    }
+                )
+
+        return dependencies
+
+    def _parse_pyproject(self, content: str) -> list[dict[str, str]]:
+        """Parse dependencies from PEP 621 pyproject.toml content."""
+        payload = tomllib.loads(content)
+        project = payload.get("project", {})
+
+        if not isinstance(project, dict):
+            return []
+
+        raw_dependencies: list[str] = []
+
+        dependencies = project.get("dependencies", [])
+        if isinstance(dependencies, list):
+            raw_dependencies.extend(item for item in dependencies if isinstance(item, str))
+
+        optional = project.get("optional-dependencies", {})
+        if isinstance(optional, dict):
+            for group in optional.values():
+                if isinstance(group, list):
+                    raw_dependencies.extend(item for item in group if isinstance(item, str))
+
+        parsed: list[dict[str, str]] = []
+
+        for requirement in raw_dependencies:
+            requirement = requirement.split(";", maxsplit=1)[0].strip()
+
+            match = re.match(
+                r"^([A-Za-z0-9_.-]+)(?:\[[^\]]+\])?\s*(.*)$",
+                requirement,
+            )
+            if not match:
+                continue
+
+            name, version_spec = match.groups()
+            version_spec = version_spec.strip()
+
+            if not version_spec or version_spec.startswith("@"):
+                continue
+
+            parsed.append(
+                {
+                    "name": name,
+                    "version_spec": version_spec,
+                    "ecosystem": "pypi",
+                    "source_file": "pyproject.toml",
+                }
+            )
+
+        return parsed
+
+    @staticmethod
+    def _extract_major_version(version_spec: str) -> int | None:
+        """Extract the first numeric major version from a version string."""
+        match = re.search(r"(?<!\d)(\d+)(?:\.\d+)*", version_spec)
+        if not match:
+            return None
+
+        return int(match.group(1))
+
+    @staticmethod
+    def _resolve_latest_version(name: str, ecosystem: str) -> str | None:
+        """Resolve the current package version from PyPI or npm.
+
+        Args:
+            name: Package name.
+            ecosystem: Either ``pypi`` or ``npm``.
+
+        Returns:
+            Latest released version, or None when it cannot be resolved.
+        """
+        encoded_name = quote(name, safe="")
+
+        try:
+            if ecosystem == "pypi":
+                response = httpx.get(
+                    f"https://pypi.org/pypi/{encoded_name}/json",
+                    timeout=10.0,
+                )
+                response.raise_for_status()
+                version = response.json().get("info", {}).get("version")
+
+            elif ecosystem == "npm":
+                response = httpx.get(
+                    f"https://registry.npmjs.org/{encoded_name}/latest",
+                    timeout=10.0,
+                )
+                response.raise_for_status()
+                version = response.json().get("version")
+
+            else:
+                return None
+
+        except (httpx.HTTPError, ValueError):
+            return None
+
+        return version if isinstance(version, str) else None

--- a/tests/unit/test_dependency_audit_tool.py
+++ b/tests/unit/test_dependency_audit_tool.py
@@ -1,0 +1,243 @@
+"""Tests for DependencyAuditTool."""
+
+import pytest
+
+from agent.tools.dependency_audit_tool import DependencyAuditTool
+
+
+@pytest.mark.unit
+class TestDependencyAuditTool:
+    """Test suite for dependency auditing."""
+
+    def test_flags_requirements_dependency_more_than_one_major_behind(self) -> None:
+        """Flag a Python dependency more than one major version behind."""
+
+        def resolver(name: str, ecosystem: str) -> str | None:
+            versions = {
+                ("Django", "pypi"): "5.1.0",
+                ("requests", "pypi"): "2.32.0",
+            }
+            return versions.get((name, ecosystem))
+
+        tool = DependencyAuditTool(version_resolver=resolver)
+
+        result = tool.execute(
+            {"manifests": {"requirements.txt": ("Django==2.2.0\n" "requests>=2.31.0\n")}}
+        )
+
+        assert result.success is True
+        assert result.error is None
+        assert result.data["checked_count"] == 2
+        assert len(result.data["outdated_dependencies"]) == 1
+
+        finding = result.data["outdated_dependencies"][0]
+        assert finding["name"] == "Django"
+        assert finding["latest_version"] == "5.1.0"
+        assert finding["major_versions_behind"] == 3
+        assert finding["source_file"] == "requirements.txt"
+
+    def test_does_not_flag_dependency_exactly_one_major_behind(self) -> None:
+        """Do not flag a dependency exactly one major version behind."""
+
+        def resolver(name: str, ecosystem: str) -> str | None:
+            assert name == "react"
+            assert ecosystem == "npm"
+            return "19.1.0"
+
+        tool = DependencyAuditTool(version_resolver=resolver)
+
+        result = tool.execute(
+            {
+                "manifests": {
+                    "package.json": """
+                    {
+                        "dependencies": {
+                            "react": "^18.2.0"
+                        }
+                    }
+                    """
+                }
+            }
+        )
+
+        assert result.success is True
+        assert result.data["checked_count"] == 1
+        assert result.data["outdated_dependencies"] == []
+
+    def test_flags_package_json_dependency_two_majors_behind(self) -> None:
+        """Audit npm dependencies and flag a two-major gap."""
+
+        def resolver(name: str, ecosystem: str) -> str | None:
+            versions = {
+                ("lodash", "npm"): "4.17.21",
+                ("react", "npm"): "19.1.0",
+            }
+            return versions.get((name, ecosystem))
+
+        tool = DependencyAuditTool(version_resolver=resolver)
+
+        result = tool.execute(
+            {
+                "manifests": {
+                    "package.json": """
+                    {
+                        "dependencies": {
+                            "lodash": "^2.4.0"
+                        },
+                        "devDependencies": {
+                            "react": "^18.2.0"
+                        }
+                    }
+                    """
+                }
+            }
+        )
+
+        assert result.success is True
+
+        findings = result.data["outdated_dependencies"]
+        assert len(findings) == 1
+        assert findings[0]["name"] == "lodash"
+        assert findings[0]["major_versions_behind"] == 2
+        assert findings[0]["ecosystem"] == "npm"
+
+    def test_parses_pyproject_dependencies(self) -> None:
+        """Audit standard PEP 621 pyproject dependencies."""
+
+        def resolver(name: str, ecosystem: str) -> str | None:
+            versions = {
+                ("fastapi", "pypi"): "0.116.0",
+                ("pydantic", "pypi"): "4.0.0",
+                ("pytest", "pypi"): "9.0.0",
+            }
+            return versions.get((name, ecosystem))
+
+        tool = DependencyAuditTool(version_resolver=resolver)
+
+        result = tool.execute(
+            {
+                "manifests": {
+                    "pyproject.toml": """
+                    [project]
+                    name = "example"
+
+                    dependencies = [
+                        "fastapi>=0.109.0",
+                        "pydantic>=1.10.0"
+                    ]
+
+                    [project.optional-dependencies]
+                    dev = [
+                        "pytest>=7.4.0"
+                    ]
+                    """
+                }
+            }
+        )
+
+        assert result.success is True
+        assert result.data["checked_count"] == 3
+
+        names = {finding["name"] for finding in result.data["outdated_dependencies"]}
+        assert names == {"pydantic", "pytest"}
+
+    def test_skips_version_spec_without_numeric_major(self) -> None:
+        """Skip dependency specs whose major version cannot be determined."""
+        calls: list[tuple[str, str]] = []
+
+        def resolver(name: str, ecosystem: str) -> str | None:
+            calls.append((name, ecosystem))
+            return "5.0.0"
+
+        tool = DependencyAuditTool(version_resolver=resolver)
+
+        result = tool.execute(
+            {
+                "manifests": {
+                    "package.json": """
+                    {
+                        "dependencies": {
+                            "local-package": "workspace:*"
+                        }
+                    }
+                    """
+                }
+            }
+        )
+
+        assert result.success is True
+        assert result.data["checked_count"] == 0
+        assert result.data["outdated_dependencies"] == []
+        assert len(result.data["skipped_dependencies"]) == 1
+        assert result.data["skipped_dependencies"][0]["name"] == "local-package"
+        assert calls == []
+
+    def test_registry_lookup_failure_does_not_crash_audit(self) -> None:
+        """A failed package lookup should not fail the whole tool."""
+
+        def resolver(name: str, ecosystem: str) -> str | None:
+            raise RuntimeError(f"registry unavailable for {name}/{ecosystem}")
+
+        tool = DependencyAuditTool(version_resolver=resolver)
+
+        result = tool.execute({"manifests": {"requirements.txt": "Django==2.2.0\n"}})
+
+        assert result.success is True
+        assert result.data["checked_count"] == 0
+        assert result.data["outdated_dependencies"] == []
+        assert len(result.data["lookup_failures"]) == 1
+        assert result.data["lookup_failures"][0]["name"] == "Django"
+
+    def test_malformed_manifest_is_reported_without_crashing(self) -> None:
+        """Malformed supported manifests should be reported gracefully."""
+        tool = DependencyAuditTool(version_resolver=lambda name, ecosystem: "1.0.0")
+
+        result = tool.execute(
+            {
+                "manifests": {
+                    "package.json": "{not valid json",
+                    "pyproject.toml": "[project\ninvalid = true",
+                }
+            }
+        )
+
+        assert result.success is True
+        assert result.data["outdated_dependencies"] == []
+        assert result.data["checked_count"] == 0
+        assert len(result.data["parse_errors"]) == 2
+
+    def test_empty_supported_manifest_set_returns_empty_success(self) -> None:
+        """No supported manifests should produce an empty successful audit."""
+        tool = DependencyAuditTool(version_resolver=lambda name, ecosystem: "1.0.0")
+
+        result = tool.execute(
+            {
+                "manifests": {
+                    "Pipfile": "requests = '*'",
+                    "yarn.lock": "lockfile contents",
+                }
+            }
+        )
+
+        assert result.success is True
+        assert result.data["manifest_files"] == []
+        assert result.data["checked_count"] == 0
+        assert result.data["outdated_dependencies"] == []
+
+    def test_missing_input_returns_failure(self) -> None:
+        """Repository identity or direct manifest content is required."""
+        tool = DependencyAuditTool()
+
+        result = tool.execute({})
+
+        assert result.success is False
+        assert result.data == {}
+        assert result.error is not None
+
+    def test_extract_major_version_handles_common_specs(self) -> None:
+        """Extract major versions from common Python and npm constraints."""
+        assert DependencyAuditTool._extract_major_version("==2.4.1") == 2
+        assert DependencyAuditTool._extract_major_version(">=3.0") == 3
+        assert DependencyAuditTool._extract_major_version("^18.2.0") == 18
+        assert DependencyAuditTool._extract_major_version("~4.1.0") == 4
+        assert DependencyAuditTool._extract_major_version("workspace:*") is None

--- a/tests/unit/test_dependency_audit_tool.py
+++ b/tests/unit/test_dependency_audit_tool.py
@@ -241,3 +241,52 @@ class TestDependencyAuditTool:
         assert DependencyAuditTool._extract_major_version("^18.2.0") == 18
         assert DependencyAuditTool._extract_major_version("~4.1.0") == 4
         assert DependencyAuditTool._extract_major_version("workspace:*") is None
+
+    def test_fetches_manifest_from_github_repository(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Fetch and audit a dependency manifest through the GitHub API path."""
+        import base64
+
+        class FakeResponse:
+            def __init__(self, status_code: int, payload: dict | None = None) -> None:
+                self.status_code = status_code
+                self._payload = payload or {}
+
+            def raise_for_status(self) -> None:
+                return None
+
+            def json(self) -> dict:
+                return self._payload
+
+        requirements = base64.b64encode(b"Django==2.2.0\n").decode("utf-8")
+
+        def fake_get(url: str, **kwargs: object) -> FakeResponse:
+            if url.endswith("/contents/requirements.txt"):
+                return FakeResponse(
+                    200,
+                    {
+                        "content": requirements,
+                        "encoding": "base64",
+                    },
+                )
+
+            return FakeResponse(404)
+
+        monkeypatch.setattr(
+            "agent.tools.dependency_audit_tool.httpx.get",
+            fake_get,
+        )
+
+        tool = DependencyAuditTool(version_resolver=lambda name, ecosystem: "5.1.0")
+
+        result = tool.execute(
+            {
+                "github_username": "example-user",
+                "repo_name": "example-repo",
+            }
+        )
+
+        assert result.success is True
+        assert result.data["manifest_files"] == ["requirements.txt"]
+        assert result.data["checked_count"] == 1
+        assert len(result.data["outdated_dependencies"]) == 1
+        assert result.data["outdated_dependencies"][0]["name"] == "Django"

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -1,0 +1,71 @@
+"""Tests for agent orchestrator planning."""
+
+import pytest
+
+from agent.orchestrator import Orchestrator
+
+
+@pytest.mark.unit
+class TestOrchestratorPlanning:
+    """Tests for orchestrator plan construction."""
+
+    def test_repository_project_schedules_dependency_audit(self) -> None:
+        """A GitHub-backed project should schedule dependency auditing."""
+        orchestrator = Orchestrator(tools={})
+
+        plan = orchestrator._build_plan(
+            {
+                "github_username": "example-user",
+                "projects": [
+                    {
+                        "github_repo": "example-project",
+                    }
+                ],
+            }
+        )
+
+        assert (
+            "dependency_audit",
+            {
+                "github_username": "example-user",
+                "repo_name": "example-project",
+            },
+        ) in plan
+
+    def test_repository_project_keeps_github_tool(self) -> None:
+        """Adding dependency auditing should preserve GitHub metadata analysis."""
+        orchestrator = Orchestrator(tools={})
+
+        plan = orchestrator._build_plan(
+            {
+                "github_username": "example-user",
+                "projects": [
+                    {
+                        "github_repo": "example-project",
+                    }
+                ],
+            }
+        )
+
+        assert (
+            "github_tool",
+            {
+                "github_username": "example-user",
+                "repo_name": "example-project",
+            },
+        ) in plan
+
+    def test_profile_without_repository_does_not_schedule_dependency_audit(self) -> None:
+        """Profiles without a repository should not schedule the audit."""
+        orchestrator = Orchestrator(tools={})
+
+        plan = orchestrator._build_plan(
+            {
+                "github_username": "example-user",
+                "projects": [],
+            }
+        )
+
+        tool_names = [tool_name for tool_name, _ in plan]
+
+        assert "dependency_audit" not in tool_names


### PR DESCRIPTION
## Summary

Adds a `DependencyAuditTool` that inspects supported dependency manifests and flags packages that are more than one major version behind their current release. The tool supports Python and npm projects, can fetch root-level manifests from GitHub, and is scheduled by the agent orchestrator for GitHub-backed projects.

## Issue

Closes #53

## Changes

- Added `DependencyAuditTool` following the existing `BaseTool` / `ToolResult` interface.
- Added parsing for `requirements.txt`, `package.json`, and PEP 621 `pyproject.toml` dependencies.
- Added current-version resolution through PyPI and npm.
- Flagged dependencies only when they are more than one major version behind.
- Added graceful handling for malformed manifests, unsupported version specifications, lookup failures, and missing manifests.
- Integrated dependency auditing into `Orchestrator._build_plan()` for GitHub-backed projects.
- Added unit coverage for manifest parsing, version thresholds, error cases, orchestrator scheduling, and mocked GitHub manifest fetching.

## Testing

- [ ] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`)
- [ ] Linter passes (`make lint`)
- [ ] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes

Targeted verification:
- `tests/unit/test_dependency_audit_tool.py`
- `tests/unit/test_orchestrator.py`
- 14/14 targeted tests pass.
- Targeted Ruff, Black, and mypy checks for the new/touched implementation passed.

Repository baseline comparison:
- Before this change: 53 failed, 375 passed.
- After this change: 53 failed, 389 passed.
- The same 53 pre-existing unit-test failures remain; this change introduces no new unit-test failures.
- Repo-wide Ruff had 182 pre-existing errors before implementation and reports 179 after this change.

Manual verification:
1. Provide a GitHub username and repository containing a supported root dependency manifest.
2. Confirm the orchestrator schedules `dependency_audit`.
3. Confirm the tool parses declared dependency versions.
4. Confirm a dependency more than one major version behind is returned in `outdated_dependencies`.
5. Confirm a dependency exactly one major version behind is not flagged.

## Screenshots / Demo

N/A — backend agent-tool change with no UI changes.

## Notes for Reviewers

The repository currently has pre-existing unit-test and lint failures unrelated to this PR. I captured the baseline before implementation and compared it against the final state: the failure count remains at 53 while 14 new tests pass, and the repo-wide Ruff error count decreased from 182 to 179.

The dependency audit currently inspects supported manifests at the repository root and uses PyPI/npm as the current-version sources.