### PR TITLE
Fix/152 faithfulness short claims not supported

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,16 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/152
+
+**Issue title:** Faithfulness checker can never mark short claims as supported
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+FaithfulnessChecker._is_supported() (rag/evaluator/faithfulness_checker.py) marks a claim as supported only if it shares at least two non-stop-word tokens with the retrieved context. Short claims like "Good indentation" have just two or three content words total, so nearly every token must match the context to hit the threshold. If there were any small thing to break it, like a plural, tense change, or synonym, it drops the overlap to one and fails the claim even when it's true. This fixed threshold makes it so short correct claims can structurally never clear. A fix should scale the required overlap to claim length rather than using a flat >= 2 cutoff.
+
+**Branch name:** fix/152-faithfulness-short-claims-not-supported
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [ ] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -14,3 +14,14 @@ FaithfulnessChecker._is_supported() (rag/evaluator/faithfulness_checker.py) mark
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** https://github.com/gzam1028/pathreview/commit/a49fe21
+
+**Reproduction summary:** Added a failing unit test in `tests/unit/test_faithfulness_checker.py` showing that `FaithfulnessChecker._is_supported()` requires at least two non-stop-word tokens to overlap between a claim and the context, regardless of how many content words the claim actually has. A short claim like "Good communicator" (2 meaningful tokens: "good", "communicator") is checked against the paraphrased context "Excellent communicator with clients and stakeholders" — only "communicator" overlaps (1 token, since "excellent" isn't "good"), so it's marked unsupported even though the claim is clearly true. The test asserts `supported is True` and currently fails with `assert False is True`, proving the bug is real and not just a misreading of the issue description.
+
+**PLAN.md link:** https://github.com/gzam1028/pathreview/blob/fix/152-faithfulness-short-claims-not-supported/PLAN.md
+
+**Blockers or open questions:**
+The fix will require flipping the expected value of an existing test (`test_minimum_overlap_required`) since it currently documents the same buggy threshold behavior on purpose. Need to make sure that change is explained clearly in the PR so it doesn't look like an accidental regression. No blockers on the environment or reproduction itself.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -13,4 +13,4 @@ FaithfulnessChecker._is_supported() (rag/evaluator/faithfulness_checker.py) mark
 
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
-**Cohort ledger:** [ ] Issue added to cohort ledger
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -25,3 +25,20 @@ FaithfulnessChecker._is_supported() (rag/evaluator/faithfulness_checker.py) mark
 
 **Blockers or open questions:**
 The fix will require flipping the expected value of an existing test (`test_minimum_overlap_required`) since it currently documents the same buggy threshold behavior on purpose. Need to make sure that change is explained clearly in the PR so it doesn't look like an accidental regression. No blockers on the environment or reproduction itself.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/1015
+
+**Branch:** fix/152-faithfulness-short-claims-not-supported
+
+**What you built:** `FaithfulnessChecker._is_supported()` (rag/evaluator/faithfulness_checker.py) now lowers the required token overlap to 1 for claims with 2 or fewer meaningful tokens, instead of always requiring 2 regardless of claim length. Longer claims still require the original 2-token floor, so vague or padded claims still need real evidence rather than a single lucky keyword match.
+
+**Tests added or updated:** `tests/unit/test_faithfulness_checker.py` — flipped the reproduction test (`test_short_claim_with_partial_paraphrase_should_be_supported`) to pass, updated `test_minimum_overlap_required`'s expected value with an explanation for why it changed, and added three new edge-case tests: a single-meaningful-token claim that matches, one that doesn't, and a longer claim confirming the original 2-token floor still holds.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+(Both pass for the files this PR touches. `make check`/`make test-unit` fail at the whole-repo level due to pre-existing, unrelated issues — documented in the PR description with a before/after comparison confirming this PR introduces no new failures.)
+
+**Draft PR feedback received from:** none — opened directly as ready for review, no draft review cycle this time.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -42,3 +42,34 @@ The fix will require flipping the expected value of an existing test (`test_mini
 (Both pass for the files this PR touches. `make check`/`make test-unit` fail at the whole-repo level due to pre-existing, unrelated issues — documented in the PR description with a before/after comparison confirming this PR introduces no new failures.)
 
 **Draft PR feedback received from:** none — opened directly as ready for review, no draft review cycle this time.
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No feedback has come in on PR #1015 as of this entry. Per the course's Su26 note, reviewer feedback isn't part of this cycle, so there's nothing further to document here.
+
+**How you responded:**
+N/A — no feedback received.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The pre-existing state of the repo, not the actual bug. The fix itself — scaling the overlap threshold instead of using a flat cutoff — took less time than expected once I'd pinned down the root cause. What actually slowed me down was that the moment I touched `test_faithfulness_checker.py`, pre-commit hooks surfaced 26+ mypy errors and a ruff unused-variable error that had nothing to do with my change — the whole file had apparently never passed those hooks before. I had to add type annotations across every test function in the file and complete two pre-existing tests that asserted nothing, just to get my own change to commit cleanly. I hadn't anticipated that fixing one bug would mean cleaning up unrelated debt just to get through the door.
+
+**What did you learn about working in a large codebase?**
+The biggest shift was realizing I couldn't trust "my tests pass" in isolation — I had to explicitly diff the full failure list before and after my change (using `git stash` to compare) to prove I hadn't broken anything else, because the suite already had dozens of unrelated pre-existing failures scattered across the codebase. In my own projects I'd just run the tests and call it done; here, "passing" only meant something once I'd separated my change's effect from the codebase's existing rot. I also learned that pre-commit hooks apply to the whole file you touch, not just your diff — so a small, well-scoped fix can pull in unrelated cleanup work whether you plan for it or not.
+
+**How did AI tools help — and where did they fall short?**
+AI was most useful early on: reading the actual source for several candidate issues in parallel and reporting back real difficulty (not just what the issue title implied) helped me pick a problem that was genuinely medium difficulty instead of over- or under-shooting it. It was also fast at pinpointing the exact line responsible for the bug and building a concrete before/after repro I could run myself. Where it fell short was on the first attempt at the actual fix — the first scaling formula it proposed looked reasonable on paper but, when we ran the full test suite instead of just the new test, it turned out to make longer claims stricter than before and broke a previously-passing test. That only surfaced because we actually executed the change against the whole file's tests rather than trusting the formula's logic by inspection. It reinforced that AI-generated code needs to be run and verified, not just reasoned about.
+
+**What would you do differently if you started over?**
+I'd pick a different issue. #152 was a reasonable "medium" pick on its own, but it turned out to be entangled with two other known bugs in the same file (#153's `None`-crash and a separate `_extract_claims()` comma-splitting bug), which made it harder to cleanly tell "is this failure mine or pre-existing?" every time I ran the tests. An issue more isolated from other in-flight bugs in the same file would have let me verify my own change faster and with more confidence, instead of having to cross-check against a noisy baseline every time.
+
+**What are you most proud of from this module?**
+Diagnosing the root cause precisely. Rather than stopping at "short claims sometimes fail," I traced it to the exact line (`len(meaningful_overlap) >= 2`) and built a minimal, concrete example — "Good communicator" vs. a paraphrased context — that showed exactly one token short of the threshold. Having that precise a repro made both the fix and the PR description much easier to write, because there was no ambiguity about what "fixed" actually meant.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,97 @@
+# PLAN.md — Issue #152: Faithfulness checker can never mark short claims as supported
+
+## Problem
+
+`FaithfulnessChecker._is_supported()` in `rag/evaluator/faithfulness_checker.py`
+requires a flat `>= 2` meaningful (non-stop-word) token overlap between a claim
+and the retrieved context before marking the claim as supported. Short claims
+(2-3 content words) can only ever satisfy this if every one of those words
+appears verbatim in the context — any paraphrase, tense change, or synonym
+drops the overlap below 2 and the claim is wrongly marked unsupported.
+Reproduced in `tests/unit/test_faithfulness_checker.py::test_short_claim_with_partial_paraphrase_should_be_supported`
+(commit a49fe21): claim "Good communicator" vs. context "Excellent
+communicator with clients and stakeholders" overlaps on only "communicator"
+(1 token) and fails, despite being clearly supported.
+
+## Files to change
+
+- `rag/evaluator/faithfulness_checker.py` — the actual fix, in `_is_supported()`.
+- `tests/unit/test_faithfulness_checker.py` — flip the reproduction test to
+  assert `True`; update `test_minimum_overlap_required`'s expected value
+  (see Risks below); add new tests for the scaling rule's edge cases.
+
+## Fix approach
+
+Replace the flat threshold with one that scales to the claim's own meaningful
+token count, requiring a majority overlap instead of a fixed count of 2:
+
+```python
+claim_meaningful = claim_tokens - stop_words
+required_overlap = max(1, (len(claim_meaningful) + 1) // 2)  # majority, rounded up
+return len(meaningful_overlap) >= required_overlap
+```
+
+- Short claims (1-2 meaningful tokens): `required_overlap = 1` — one real
+  keyword match is enough. Fixes the reported bug.
+- Longer claims (4+ meaningful tokens): `required_overlap` grows past 2, so
+  vague or padded claims still need real evidence, not a single lucky match.
+- Zero-meaningful-token claims (all stop words): `required_overlap` floors
+  at 1, so an empty-content claim can never spuriously pass.
+
+## Sub-tasks (in order)
+
+1. Add a `claim_tokens - stop_words` computation in `_is_supported()` to get
+   the claim's own meaningful token count (context side already computes
+   `meaningful_overlap`, but currently nothing measures the claim's total).
+2. Replace `return len(meaningful_overlap) >= 2` with the scaled
+   `required_overlap` rule above.
+3. Update `test_minimum_overlap_required` — "Python expertise" vs. "Python"
+   is a 2-meaningful-token claim, so under the new rule
+   `required_overlap = 1` and it now passes with 1 overlap. Change its
+   assertion from `False` to `True` and update the docstring/comment to
+   explain why.
+4. Flip `test_short_claim_with_partial_paraphrase_should_be_supported`'s
+   assertion comment (it already asserts `True`; just remove the "currently
+   fails" note once it passes).
+5. Add new unit tests for the rule's edge cases:
+   - A single-meaningful-token claim (e.g. "Python.") that matches exactly
+     one word in context — should pass.
+   - A single-meaningful-token claim that matches nothing — should fail.
+   - An all-stop-word claim (if reachable — `_extract_claims` filters by
+     length so check whether this is actually reachable in practice) —
+     should not spuriously pass.
+   - A long, vague claim (4+ tokens) with only 1 real overlap — should still
+     fail, confirming the stricter bar is preserved for longer claims.
+6. Run `make test-unit` and confirm no other test in the suite (e.g.
+   `test_partial_support_returns_middle_score`, `test_multiple_context_chunks`,
+   `test_multiple_claims_varying_support` — currently failing for unrelated
+   reasons per the Week 8 reproduction) changes status unexpectedly because
+   of this change; note any that do.
+7. Run `make check` (lint + format + typecheck) before opening the PR.
+
+## Risks and edge cases
+
+- **`test_minimum_overlap_required` intentionally flips.** This is expected,
+  not a regression — it currently documents the *buggy* behavior. Needs a
+  clear commit message explaining why its assertion changed.
+- **Interaction with issue #153** (`text: None` crash) — that bug currently
+  makes `test_none_context_chunk_text` fail before `_is_supported()` is even
+  reached. Not in scope for #152, but worth noting so the PR doesn't
+  accidentally get blamed for that failure.
+- **Over-leniency for medium-length claims.** The `(n+1)//2` majority rule is
+  a judgment call — a 3-token claim now only needs 2 matches (same as
+  before), but a 2-token claim needs only 1 (down from 2). Need to sanity
+  check this doesn't make faithfulness scores too generous in the
+  `test_score_never_returns_hardcoded_value`-style checks that expect scores
+  to meaningfully vary.
+- **Stop-word filtering is still naive.** `test_common_words_filtered_in_overlap`
+  already documents that opposite-meaning claims ("well documented" vs.
+  "poorly documented") can pass due to shared non-opposite tokens. The
+  scaling fix doesn't address this — it's a separate, deeper limitation of
+  keyword-overlap matching, explicitly out of scope for #152.
+
+## Testing strategy
+
+- Unit tests only (`tests/unit/test_faithfulness_checker.py`) — this is a
+  pure-function change with no DB/API/frontend surface, so `make test-unit`
+  is sufficient; no integration test changes expected.

--- a/rag/evaluator/faithfulness_checker.py
+++ b/rag/evaluator/faithfulness_checker.py
@@ -1,6 +1,7 @@
 """Check if generated feedback is supported by retrieved context."""
 
 import re
+
 import structlog
 
 logger = structlog.get_logger()
@@ -20,8 +21,11 @@ class FaithfulnessChecker:
             Faithfulness score 0.0-1.0 (ratio of supported claims)
         """
         if not feedback or not context_chunks:
-            logger.info("faithfulness_empty_input", has_feedback=bool(feedback),
-                       has_chunks=bool(context_chunks))
+            logger.info(
+                "faithfulness_empty_input",
+                has_feedback=bool(feedback),
+                has_chunks=bool(context_chunks),
+            )
             return 0.0
 
         # Extract key claims from feedback (sentences)
@@ -31,9 +35,7 @@ class FaithfulnessChecker:
             return 0.5  # Default to neutral if no extractable claims
 
         # Concatenate context text
-        context_text = " ".join([
-            chunk.get("text", "") for chunk in context_chunks
-        ])
+        context_text = " ".join([chunk.get("text", "") for chunk in context_chunks])
 
         # Check each claim for support
         supported = 0
@@ -43,8 +45,9 @@ class FaithfulnessChecker:
 
         score = supported / len(claims) if claims else 0.0
 
-        logger.info("faithfulness_checked", claims_count=len(claims),
-                   supported_count=supported, score=score)
+        logger.info(
+            "faithfulness_checked", claims_count=len(claims), supported_count=supported, score=score
+        )
 
         return score
 
@@ -59,7 +62,7 @@ class FaithfulnessChecker:
             List of claims (sentences)
         """
         # Split by sentence (simple regex)
-        sentences = re.split(r'[.!?]+', text)
+        sentences = re.split(r"[.!?]+", text)
         claims = [s.strip() for s in sentences if s.strip() and len(s.strip()) > 10]
         return claims[:10]  # Limit to 10 claims for scoring
 
@@ -81,8 +84,34 @@ class FaithfulnessChecker:
         # Require at least some meaningful overlap
         overlap = claim_tokens & context_tokens
         # Filter out common stop words
-        stop_words = {'a', 'an', 'the', 'is', 'are', 'was', 'were', 'be', 'been',
-                     'and', 'or', 'but', 'in', 'of', 'to', 'for', 'that'}
+        stop_words = {
+            "a",
+            "an",
+            "the",
+            "is",
+            "are",
+            "was",
+            "were",
+            "be",
+            "been",
+            "and",
+            "or",
+            "but",
+            "in",
+            "of",
+            "to",
+            "for",
+            "that",
+        }
         meaningful_overlap = overlap - stop_words
 
-        return len(meaningful_overlap) >= 2
+        # A flat ">= 2" makes short claims (which may only have 1-2
+        # meaningful tokens total) structurally unable to ever be marked
+        # supported, since any paraphrase or synonym drops the overlap below
+        # the fixed floor. Lower the bar to 1 for claims that short, while
+        # keeping the original floor of 2 for longer claims that have room
+        # for a paraphrase and still need real evidence.
+        claim_meaningful = claim_tokens - stop_words
+        required_overlap = 1 if len(claim_meaningful) <= 2 else 2
+
+        return len(meaningful_overlap) >= required_overlap

--- a/tests/unit/test_faithfulness_checker.py
+++ b/tests/unit/test_faithfulness_checker.py
@@ -1,5 +1,7 @@
 """Tests for faithfulness_checker.py"""
 
+from typing import Any
+
 import pytest
 
 from rag.evaluator.faithfulness_checker import FaithfulnessChecker
@@ -10,17 +12,15 @@ class TestFaithfulnessChecker:
     """Test suite for FaithfulnessChecker."""
 
     @pytest.fixture
-    def checker(self):
+    def checker(self) -> FaithfulnessChecker:
         """Create a FaithfulnessChecker instance."""
         return FaithfulnessChecker()
 
-    def test_feedback_fully_supported_by_context(self, checker):
+    def test_feedback_fully_supported_by_context(self, checker: FaithfulnessChecker) -> None:
         """Test feedback fully supported by context returns score close to 1.0."""
         feedback = "The developer has strong Python skills and experience with Django."
         context_chunks = [
-            {
-                "text": "The portfolio shows Python expertise and Django framework experience."
-            },
+            {"text": "The portfolio shows Python expertise and Django framework experience."},
         ]
 
         score = checker.check(feedback, context_chunks)
@@ -30,13 +30,11 @@ class TestFaithfulnessChecker:
         # Should be high score due to support
         assert score > 0.5
 
-    def test_feedback_with_no_support_in_context(self, checker):
+    def test_feedback_with_no_support_in_context(self, checker: FaithfulnessChecker) -> None:
         """Test feedback with no support in context returns score close to 0.0."""
         feedback = "This developer is an expert in Rust systems programming."
         context_chunks = [
-            {
-                "text": "The developer has Python and JavaScript experience."
-            },
+            {"text": "The developer has Python and JavaScript experience."},
         ]
 
         score = checker.check(feedback, context_chunks)
@@ -44,13 +42,11 @@ class TestFaithfulnessChecker:
         assert isinstance(score, float)
         assert score < 0.5  # Should be low score
 
-    def test_partial_support_returns_middle_score(self, checker):
+    def test_partial_support_returns_middle_score(self, checker: FaithfulnessChecker) -> None:
         """Test partial support returns score between 0 and 1."""
         feedback = "The developer shows Python expertise and Kubernetes knowledge."
         context_chunks = [
-            {
-                "text": "Strong Python programming skills demonstrated in projects."
-            },
+            {"text": "Strong Python programming skills demonstrated in projects."},
         ]
 
         score = checker.check(feedback, context_chunks)
@@ -60,36 +56,34 @@ class TestFaithfulnessChecker:
         # Partial support should be middle range
         assert 0.2 < score < 0.8
 
-    def test_empty_feedback_returns_zero(self, checker):
+    def test_empty_feedback_returns_zero(self, checker: FaithfulnessChecker) -> None:
         """Test empty feedback returns 0.0."""
         feedback = ""
-        context_chunks = [
-            {"text": "Some context"}
-        ]
+        context_chunks = [{"text": "Some context"}]
 
         score = checker.check(feedback, context_chunks)
 
         assert score == 0.0
 
-    def test_empty_context_chunks_returns_zero(self, checker):
+    def test_empty_context_chunks_returns_zero(self, checker: FaithfulnessChecker) -> None:
         """Test empty context chunks returns 0.0."""
         feedback = "Some feedback"
-        context_chunks = []
+        context_chunks: list[dict[str, Any]] = []
 
         score = checker.check(feedback, context_chunks)
 
         assert score == 0.0
 
-    def test_both_empty_returns_zero(self, checker):
+    def test_both_empty_returns_zero(self, checker: FaithfulnessChecker) -> None:
         """Test both empty returns 0.0."""
         feedback = ""
-        context_chunks = []
+        context_chunks: list[dict[str, Any]] = []
 
         score = checker.check(feedback, context_chunks)
 
         assert score == 0.0
 
-    def test_multiple_context_chunks(self, checker):
+    def test_multiple_context_chunks(self, checker: FaithfulnessChecker) -> None:
         """Test multiple context chunks contribute to score."""
         feedback = "The developer has Python, JavaScript, and Docker experience."
         context_chunks = [
@@ -105,7 +99,7 @@ class TestFaithfulnessChecker:
         # All three claims supported
         assert score > 0.5
 
-    def test_extract_claims(self, checker):
+    def test_extract_claims(self, checker: FaithfulnessChecker) -> None:
         """Test claim extraction from feedback."""
         feedback = "The developer is skilled. They have experience. They work well."
         claims = checker._extract_claims(feedback)
@@ -114,7 +108,7 @@ class TestFaithfulnessChecker:
         assert len(claims) > 0
         assert all(isinstance(c, str) for c in claims)
 
-    def test_extract_claims_with_punctuation(self, checker):
+    def test_extract_claims_with_punctuation(self, checker: FaithfulnessChecker) -> None:
         """Test claim extraction handles various punctuation."""
         feedback = "First claim! Second claim? Third claim. Fourth claim"
         claims = checker._extract_claims(feedback)
@@ -122,7 +116,7 @@ class TestFaithfulnessChecker:
         assert isinstance(claims, list)
         # Should extract at least some claims
 
-    def test_is_supported_with_keyword_overlap(self, checker):
+    def test_is_supported_with_keyword_overlap(self, checker: FaithfulnessChecker) -> None:
         """Test that claim is marked as supported with keyword overlap."""
         claim = "The developer has Python skills"
         context = "Python programming skills demonstrated throughout portfolio"
@@ -132,7 +126,7 @@ class TestFaithfulnessChecker:
         assert isinstance(supported, bool)
         assert supported is True
 
-    def test_is_supported_without_keywords(self, checker):
+    def test_is_supported_without_keywords(self, checker: FaithfulnessChecker) -> None:
         """Test that claim is unsupported without keyword overlap."""
         claim = "Expert in Rust systems programming"
         context = "Strong background in Python web development"
@@ -142,7 +136,7 @@ class TestFaithfulnessChecker:
         assert isinstance(supported, bool)
         assert supported is False
 
-    def test_case_insensitive_support_check(self, checker):
+    def test_case_insensitive_support_check(self, checker: FaithfulnessChecker) -> None:
         """Test that support check is case insensitive."""
         claim = "PYTHON PROGRAMMING SKILLS"
         context = "python programming skills are demonstrated"
@@ -151,31 +145,25 @@ class TestFaithfulnessChecker:
 
         assert supported is True
 
-    def test_score_never_returns_hardcoded_value(self, checker):
+    def test_score_never_returns_hardcoded_value(self, checker: FaithfulnessChecker) -> None:
         """Test that score varies with input, never hardcoded 1.0 or 0.0."""
         # First test: fully supported
         score1 = checker.check(
-            "Python and JavaScript skills",
-            [{"text": "Expert in Python and JavaScript"}]
+            "Python and JavaScript skills", [{"text": "Expert in Python and JavaScript"}]
         )
 
         # Second test: no support
-        score2 = checker.check(
-            "Rust expertise",
-            [{"text": "Java programming background"}]
-        )
+        score2 = checker.check("Rust expertise", [{"text": "Java programming background"}])
 
         # Scores should be different
         assert score1 != score2
         # First should be higher
         assert score1 > score2
 
-    def test_multiple_claims_varying_support(self, checker):
+    def test_multiple_claims_varying_support(self, checker: FaithfulnessChecker) -> None:
         """Test scoring with multiple claims of varying support."""
         feedback = "Python expert. Knows Rust. Skilled with Docker."
-        context_chunks = [
-            {"text": "Python and Docker expertise shown in projects."}
-        ]
+        context_chunks = [{"text": "Python and Docker expertise shown in projects."}]
 
         score = checker.check(feedback, context_chunks)
 
@@ -183,31 +171,27 @@ class TestFaithfulnessChecker:
         assert isinstance(score, float)
         assert 0.2 < score < 0.8
 
-    def test_very_long_feedback(self, checker):
+    def test_very_long_feedback(self, checker: FaithfulnessChecker) -> None:
         """Test handling of very long feedback text."""
         feedback = "The developer. " * 100
-        context_chunks = [
-            {"text": "Developer portfolio content"}
-        ]
+        context_chunks = [{"text": "Developer portfolio content"}]
 
         score = checker.check(feedback, context_chunks)
 
         assert isinstance(score, float)
         assert 0.0 <= score <= 1.0
 
-    def test_very_long_context(self, checker):
+    def test_very_long_context(self, checker: FaithfulnessChecker) -> None:
         """Test handling of very long context."""
         feedback = "The developer has Python skills."
-        context_chunks = [
-            {"text": "Python " * 1000}
-        ]
+        context_chunks = [{"text": "Python " * 1000}]
 
         score = checker.check(feedback, context_chunks)
 
         assert isinstance(score, float)
         assert 0.0 <= score <= 1.0
 
-    def test_common_words_filtered_in_overlap(self, checker):
+    def test_common_words_filtered_in_overlap(self, checker: FaithfulnessChecker) -> None:
         """Test that common stop words are filtered in overlap calculation."""
         # This test verifies that "the", "is", "and" etc. don't count as meaningful overlap
         claim = "The project is well documented"
@@ -215,10 +199,13 @@ class TestFaithfulnessChecker:
 
         supported = checker._is_supported(claim, context)
 
-        # Despite word overlap, should look for meaningful overlap (not stop words)
-        # This depends on implementation
+        # Documents current behavior: "project" and "documented" overlap (2
+        # meaningful tokens), so this is marked supported even though the
+        # meaning is reversed by "well" vs "poorly" — a known limitation of
+        # pure keyword-overlap matching, out of scope for issue #152.
+        assert supported is True
 
-    def test_minimum_overlap_required(self, checker):
+    def test_minimum_overlap_required(self, checker: FaithfulnessChecker) -> None:
         """Test that minimum meaningful overlap is required for support."""
         claim = "Python expertise"
         context = "Python"  # Only one word match
@@ -227,13 +214,12 @@ class TestFaithfulnessChecker:
 
         assert isinstance(supported, bool)
         # Need at least 2 meaningful tokens for support
+        assert supported is False
 
-    def test_none_context_chunk_text(self, checker):
+    def test_none_context_chunk_text(self, checker: FaithfulnessChecker) -> None:
         """Test handling of None in context chunk text."""
         feedback = "Has Python skills"
-        context_chunks = [
-            {"text": None}
-        ]
+        context_chunks = [{"text": None}]
 
         score = checker.check(feedback, context_chunks)
 
@@ -241,12 +227,10 @@ class TestFaithfulnessChecker:
         assert isinstance(score, float)
         assert 0.0 <= score <= 1.0
 
-    def test_missing_text_key_in_chunk(self, checker):
+    def test_missing_text_key_in_chunk(self, checker: FaithfulnessChecker) -> None:
         """Test handling of missing 'text' key in context chunk."""
         feedback = "Has Python skills"
-        context_chunks = [
-            {"content": "Python skills"}  # Wrong key
-        ]
+        context_chunks = [{"content": "Python skills"}]  # Wrong key
 
         score = checker.check(feedback, context_chunks)
 
@@ -254,7 +238,7 @@ class TestFaithfulnessChecker:
         assert isinstance(score, float)
         assert 0.0 <= score <= 1.0
 
-    def test_score_consistency(self, checker):
+    def test_score_consistency(self, checker: FaithfulnessChecker) -> None:
         """Test that same input produces same score."""
         feedback = "The developer has strong Python skills."
         context_chunks = [{"text": "Expert Python programmer"}]
@@ -264,7 +248,24 @@ class TestFaithfulnessChecker:
 
         assert score1 == score2
 
-    def test_specialized_technical_terms(self, checker):
+    def test_short_claim_with_partial_paraphrase_should_be_supported(
+        self, checker: FaithfulnessChecker
+    ) -> None:
+        """Reproduces #152: short claims can't pass with only 1 of 2 tokens overlapping.
+
+        "Good communicator" only has two meaningful tokens ("good", "communicator").
+        The context paraphrases "good" as "excellent", so only one token overlaps —
+        one short of the hardcoded `>= 2` threshold — even though the claim is
+        clearly supported by the context.
+        """
+        claim = "Good communicator"
+        context = "Excellent communicator with clients and stakeholders"
+
+        supported = checker._is_supported(claim, context)
+
+        assert supported is True  # currently fails: overlap is only 1 ("communicator")
+
+    def test_specialized_technical_terms(self, checker: FaithfulnessChecker) -> None:
         """Test support check with specialized technical terms."""
         claim = "Experienced with PostgreSQL and ORM frameworks"
         context = "Database design with PostgreSQL, SQLAlchemy ORM"

--- a/tests/unit/test_faithfulness_checker.py
+++ b/tests/unit/test_faithfulness_checker.py
@@ -206,14 +206,53 @@ class TestFaithfulnessChecker:
         assert supported is True
 
     def test_minimum_overlap_required(self, checker: FaithfulnessChecker) -> None:
-        """Test that minimum meaningful overlap is required for support."""
+        """Test overlap requirement for a short (<=2 meaningful token) claim.
+
+        "Python expertise" has only 2 meaningful tokens, so per the fix for
+        #152 it only needs 1 of them to overlap with the context — not the
+        flat 2 previously required, which made claims this short impossible
+        to ever mark as supported.
+        """
         claim = "Python expertise"
         context = "Python"  # Only one word match
 
         supported = checker._is_supported(claim, context)
 
         assert isinstance(supported, bool)
-        # Need at least 2 meaningful tokens for support
+        assert supported is True
+
+    def test_long_claim_with_single_overlap_stays_unsupported(
+        self, checker: FaithfulnessChecker
+    ) -> None:
+        """Test that longer claims still require the original 2-token floor.
+
+        Unlike short claims, a claim with more than 2 meaningful tokens
+        should still need 2 overlapping tokens, not just 1 — otherwise a
+        single lucky keyword match would be enough for any vague claim.
+        """
+        claim = "Extensive leadership and mentorship experience across teams"
+        context = "Worked on a small team"  # Only "team"/"teams" overlaps, and not exactly
+
+        supported = checker._is_supported(claim, context)
+
+        assert supported is False
+
+    def test_single_meaningful_token_claim_matches(self, checker: FaithfulnessChecker) -> None:
+        """Test that a single-token claim is supported when that token matches."""
+        claim = "Python"
+        context = "Strong Python background"
+
+        supported = checker._is_supported(claim, context)
+
+        assert supported is True
+
+    def test_single_meaningful_token_claim_no_match(self, checker: FaithfulnessChecker) -> None:
+        """Test that a single-token claim is unsupported when it doesn't match."""
+        claim = "Rust"
+        context = "Strong Python background"
+
+        supported = checker._is_supported(claim, context)
+
         assert supported is False
 
     def test_none_context_chunk_text(self, checker: FaithfulnessChecker) -> None:
@@ -255,15 +294,16 @@ class TestFaithfulnessChecker:
 
         "Good communicator" only has two meaningful tokens ("good", "communicator").
         The context paraphrases "good" as "excellent", so only one token overlaps —
-        one short of the hardcoded `>= 2` threshold — even though the claim is
-        clearly supported by the context.
+        one short of the previously-hardcoded `>= 2` threshold — even though the
+        claim is clearly supported by the context. Fixed by lowering the
+        required overlap to 1 for claims with 2 or fewer meaningful tokens.
         """
         claim = "Good communicator"
         context = "Excellent communicator with clients and stakeholders"
 
         supported = checker._is_supported(claim, context)
 
-        assert supported is True  # currently fails: overlap is only 1 ("communicator")
+        assert supported is True
 
     def test_specialized_technical_terms(self, checker: FaithfulnessChecker) -> None:
         """Test support check with specialized technical terms."""


### PR DESCRIPTION
## Summary
`FaithfulnessChecker._is_supported()` required a flat `>= 2` meaningful token overlap between a claim and its context, regardless of how many content words the claim actually had. Short claims (2 or fewer meaningful tokens, e.g. "Good communicator") could never be marked supported once one of those words was paraphrased in the context, since the overlap could never reach 2. This PR lowers the required overlap to 1 for claims with 2 or fewer meaningful tokens, while keeping the original floor of 2 for longer claims that still need real evidence.

## Issue
Closes #152

## Changes
- `rag/evaluator/faithfulness_checker.py`: `_is_supported()` now computes the claim's own meaningful token count and requires only 1 overlapping token when that count is 2 or fewer, instead of a flat 2.
- `tests/unit/test_faithfulness_checker.py`:
  - Added `test_short_claim_with_partial_paraphrase_should_be_supported` (the reproduction test for #152 — now passes).
  - Updated `test_minimum_overlap_required`'s expected value ("Python expertise" vs. "Python" now correctly passes under the new 1-token floor for short claims — it previously asserted `False` on purpose to document the bug).
  - Added `test_long_claim_with_single_overlap_stays_unsupported`, `test_single_meaningful_token_claim_matches`, `test_single_meaningful_token_claim_no_match` for edge case coverage.
  - Added missing type annotations across the file and completed two pre-existing tests that asserted nothing, so pre-commit hooks pass.

## Testing
- [x] Unit tests pass (`make test-unit`) — see note below on pre-existing failures
- [ ] Integration tests pass (`make test-integration`) — not applicable, no integration surface for this change
- [x] Linter passes (`make lint`) — for the files changed in this PR (`ruff check` on both files passes clean; the full-repo `make lint` fails on 180 pre-existing, unrelated errors — see note)
- [x] Type checker passes (`make typecheck`) — for the files changed in this PR
- [x] New/updated tests cover the changes

**Note on pre-existing failures:** This repo has known pre-existing issues unrelated to #152. I confirmed via `git stash` comparison that none of the following are introduced by this PR:
- `test_partial_support_returns_middle_score` and `test_multiple_context_chunks` fail due to a separate bug in `_extract_claims()` not splitting claims on commas/"and".
- `test_none_context_chunk_text` fails due to issue #153 (crash when a context chunk's `text` is `None`).
- `make lint`/`make check` fail repo-wide due to 180 pre-existing ruff errors across unrelated files (181 without this PR's changes — this PR fixes one pre-existing import-order issue in the file it touches and introduces zero new lint errors).

## Screenshots / Demo
N/A — backend logic change, no UI surface.

## Notes for Reviewers
The threshold change is intentionally conservative: it only lowers the bar for short claims (≤2 meaningful tokens) and leaves the original `>= 2` requirement in place for everything else, to avoid making longer/vaguer claims too easy to pass on a single lucky keyword match. See `PLAN.md` on this branch for the full reasoning and the risks I considered (particularly the intentional flip of `test_minimum_overlap_required`'s expected value).