### PR TITLE
Fix stale embeddings on document re-ingestionFix/27 stale vector embeddings

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -48,6 +48,67 @@ Implemented a fix for stale embeddings during document re-ingestion. The ingesti
 **Tests added or updated:**
 Added `tests/unit/test_pipeline.py` with regression tests covering resume, README, and repository re-ingestion, document ID stability, deletion scoping, delete-before-add behavior, and unchanged ingestion behavior.
 
-**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+
+**Verification note:** The targeted ingestion pipeline tests pass (10/10). The full repository checks currently include pre-existing lint/formatting issues and unit-test failures outside the scope of this contribution.
 
 **Draft PR feedback received from:** none
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No maintainer or reviewer feedback was received on PR #1020 during this module. Reviewer
+feedback is not provided for the Summer 2026 cohort, so the pull request remains open and
+unreviewed. Because no review comments were raised, there were no reviewer-requested changes
+to address in this iteration.
+
+**How you responded:**
+N/A — no reviewer feedback was received.
+
+### Reflection
+
+This was my first open-source contribution. I worked on issue #27, where the vector store kept
+returning stale embeddings after a document was re-ingested. Almost all of the work happened in
+`ingestion/pipeline.py`, and the part I had to understand first was how a document's existing
+vectors are removed before its updated version is stored. That turned out to be the whole
+problem: the pipeline derives its `source_id` from a hash of the content, so editing a document
+produced a completely new identifier and the previous vectors were simply left behind, with
+nothing in the pipeline ever deleting them.
+
+The fix introduces a stable document identifier that does not change when content changes, stores
+it on every chunk, and uses it to clear the previous revision's vectors before the new ones are
+written. The last refinement was small: I changed the delete filter from the shorthand form
+`{"document_id": document_id}` to the explicit `{"document_id": {"$eq": document_id}}`, matching
+the convention already used in `rag/retriever/vector_store.py`. The work was submitted as PR #1020.
+
+The biggest challenge was the gap between the size of the change and the effort behind it. The
+final diff is small, but deciding that it was the right change took far more investigation:
+reading the chunking and batch-embedding code, working out where vector IDs actually come from,
+checking whether an upsert could solve it instead of a delete, and thinking through what happens
+if the embedding call fails after the old vectors are already gone. Most of my time went into
+understanding the surrounding behavior rather than writing lines of code.
+
+What I learned is that contributing to an existing codebase is mostly about fitting in. I had to
+follow the project's branch and commit conventions, write tests in the style already used in
+`tests/unit/`, work within the dependencies the project had chosen, and stay inside the scope of
+the issue. There were several things I noticed that I wanted to clean up — unsorted imports, some
+outdated type annotations — and leaving them alone was the correct decision, because unrelated
+changes make a pull request harder to review.
+
+AI tools were genuinely useful for navigating unfamiliar code, thinking through possible failure
+points, interpreting errors, and reasoning about the workflow. They did not replace the work. I
+still had to open the real files, run the tests, check the actual behavior of the vector store
+API, read the diff line by line, and judge whether a suggestion actually fit this project. Some
+suggestions did not, and recognizing that was part of the exercise.
+
+If I started again, I would narrow the issue down and trace the relevant execution path much
+earlier instead of exploring broad possibilities first. I spent a while considering causes that
+a careful read of the ingestion flow would have ruled out quickly.
+
+What I am most proud of is completing the full open-source workflow for the first time: choosing
+an issue, investigating a real production codebase, implementing a scoped fix, verifying the
+diff, and opening a genuine pull request.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -19,3 +19,19 @@ The current ingestion pipeline creates new embeddings when a repository or docum
 
 ### Selection notes:
 I chose this issue because it involves both backend data flow and AI/ML retrieval behavior. The scope is manageable because the problem is isolated to ingestion and vector storage, but it demonstrates understanding of RAG systems, embeddings lifecycle, and data consistency.
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** 
+PASTE_COMMIT_URL_HERE
+
+**Reproduction summary:**
+Reproduced the stale embedding behavior by re-ingesting an updated document and observing that previous vector data remained available during retrieval.
+
+**PLAN.md link:**
+https://github.com/ZainaNadeem/pathreview/blob/fix/27-stale-vector-embeddings/PLAN.md
+
+**Walkthrough video (recommended):**
+
+**Blockers or open questions:**
+Need to confirm whether stale results are caused by duplicate vector insertion, missing deletion, or vector store update behavior.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -35,3 +35,19 @@ https://github.com/ZainaNadeem/pathreview/blob/fix/27-stale-vector-embeddings/PL
 
 **Blockers or open questions:**
 Need to confirm whether stale results are caused by duplicate vector insertion, missing deletion, or vector store update behavior.
+
+### Check-in 2 (end of week)
+
+**PR link:** https://github.com/ascherj/pathreview/pull/1020
+
+**Branch:** fix/27-stale-vector-embeddings
+
+**What you built:**
+Implemented a fix for stale embeddings during document re-ingestion. The ingestion pipeline now uses a stable document identifier to remove vectors from the previous document revision before storing the updated embeddings.
+
+**Tests added or updated:**
+Added `tests/unit/test_pipeline.py` with regression tests covering resume, README, and repository re-ingestion, document ID stability, deletion scoping, delete-before-add behavior, and unchanged ingestion behavior.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+**Draft PR feedback received from:** none

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,21 @@
+# PathReview Contribution Journal
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/27
+
+**Issue title:** Vector store returns stale embeddings after a document is re-ingested
+
+**Tier:** [ ] Tier 1  [x] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+The current ingestion pipeline creates new embeddings when a repository or document is updated, but older embeddings are not removed from the vector store. This can cause retrieval results to include outdated information alongside newer content. The fix should ensure that re-ingesting a source replaces or invalidates previous embeddings so retrieval only uses current data. The affected areas are the ingestion pipeline and RAG vector store components.
+
+**Branch name:** fix/27-stale-vector-embeddings
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger
+
+### Selection notes:
+I chose this issue because it involves both backend data flow and AI/ML retrieval behavior. The scope is manageable because the problem is isolated to ingestion and vector storage, but it demonstrates understanding of RAG systems, embeddings lifecycle, and data consistency.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -50,7 +50,7 @@ Added `tests/unit/test_pipeline.py` with regression tests covering resume, READM
 
 **Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
 
-**Verification note:** The targeted ingestion pipeline tests pass (10/10). The full repository checks currently include pre-existing lint/formatting issues and unit-test failures outside the scope of this contribution.
+**Verification note:** The targeted ingestion pipeline tests pass (10/10). The full repository checks report lint/formatting issues and unit-test failures outside the files changed for this contribution.
 
 **Draft PR feedback received from:** none
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,85 @@
+# Solution plan
+
+## Issue:
+Vector store returns stale embeddings after a document is re-ingested  
+https://github.com/ZainaNadeem/pathreview/issues/27
+
+
+## Understand
+
+The issue occurs when an existing document is updated and ingested again, but
+the vector store continues returning the previous embedding.
+
+Expected behavior:
+When a document changes and is re-ingested, the previous embedding should be
+removed or updated and replaced with the new embedding.
+
+Actual behavior:
+The old embedding remains in the vector store, causing retrieval results to
+contain outdated information.
+
+The suspected root cause is missing update/delete handling during document
+re-ingestion.
+
+
+## Map
+
+Files expected to investigate:
+
+- `src/...` ingestion pipeline
+- `src/...` vector store implementation
+- `src/...` embedding generation logic
+- `tests/...` vector store tests
+
+Functions/modules involved:
+
+- document ingestion flow
+- embedding creation
+- vector database insert/update operations
+- retrieval query logic
+
+
+## Plan
+
+1. Trace the ingestion flow to identify where existing document embeddings
+   are stored and whether previous vectors are removed.
+
+2. Add logic to detect existing documents during ingestion and replace stale
+   embeddings instead of creating duplicates.
+
+3. Add tests covering:
+   - initial document ingestion
+   - document update and re-ingestion
+   - retrieval returning updated content
+
+4. Verify that unrelated documents and existing vector search behavior remain
+   unchanged.
+
+
+## Inputs & outputs
+
+Inputs:
+- Updated document content
+- Document identifier/metadata
+- Generated embedding vector
+
+Outputs:
+- Updated vector store entry containing the latest embedding
+- Retrieval results reflecting current document content
+
+
+## Risks & unknowns
+
+- Need to confirm whether stale embeddings are caused by duplicate inserts,
+  missing deletes, or cache behavior.
+- Vector store implementation may have different update semantics depending on
+  backend.
+- Existing metadata identifiers may not uniquely identify updated documents.
+
+
+## Edge cases
+
+- Same document ingested multiple times without changes.
+- Multiple versions of the same document.
+- Failed ingestion after deleting old embeddings.
+- Documents removed from the source but still present in the vector store.

--- a/ingestion/pipeline.py
+++ b/ingestion/pipeline.py
@@ -69,6 +69,7 @@ class IngestionPipeline:
         Returns:
             IngestResult with ingestion status
         """
+        document_id = self._document_id("resume", profile_id, filename)
         source_id = f"resume_{profile_id}_{self._hash_content(content)}"
 
         logger.info(
@@ -92,6 +93,7 @@ class IngestionPipeline:
             metadata = parse_result.metadata.copy()
             metadata.update({
                 "source_id": source_id,
+                "document_id": document_id,
                 "profile_id": profile_id,
                 "filename": filename,
                 "source_type": "resume",
@@ -100,6 +102,9 @@ class IngestionPipeline:
             # Chunk the content
             chunks = self.strategy_selector.chunk(parse_result.text, metadata)
             logger.info("Resume chunked successfully", chunk_count=len(chunks))
+
+            # Drop embeddings from any earlier version of this resume
+            self._delete_existing_vectors(document_id)
 
             # Generate embeddings and store
             self.batch_processor.process(chunks)
@@ -140,6 +145,7 @@ class IngestionPipeline:
         Returns:
             IngestResult with ingestion status
         """
+        document_id = self._document_id("readme", profile_id, repo_name)
         source_id = f"readme_{profile_id}_{repo_name}_{self._hash_content(content)}"
 
         logger.info(
@@ -167,6 +173,7 @@ class IngestionPipeline:
             metadata = parse_result.metadata.copy()
             metadata.update({
                 "source_id": source_id,
+                "document_id": document_id,
                 "profile_id": profile_id,
                 "repo_name": repo_name,
                 "source_type": "readme",
@@ -175,6 +182,9 @@ class IngestionPipeline:
             # Chunk the content
             chunks = self.strategy_selector.chunk(parse_result.text, metadata)
             logger.info("README chunked successfully", chunk_count=len(chunks))
+
+            # Drop embeddings from any earlier version of this README
+            self._delete_existing_vectors(document_id)
 
             # Generate embeddings and store
             self.batch_processor.process(chunks)
@@ -214,6 +224,7 @@ class IngestionPipeline:
             IngestResult with ingestion status
         """
         repo_name = repo_data.get("name", "unknown")
+        document_id = self._document_id("repo", profile_id, repo_name)
         source_id = f"repo_{profile_id}_{repo_name}_{self._hash_content(str(repo_data))}"
 
         logger.info(
@@ -241,6 +252,7 @@ class IngestionPipeline:
             metadata = parse_result.metadata.copy()
             metadata.update({
                 "source_id": source_id,
+                "document_id": document_id,
                 "profile_id": profile_id,
                 "source_type": "repo",
             })
@@ -248,6 +260,9 @@ class IngestionPipeline:
             # Chunk the content
             chunks = self.strategy_selector.chunk(parse_result.text, metadata)
             logger.info("Repository metadata chunked successfully", chunk_count=len(chunks))
+
+            # Drop embeddings from any earlier version of this repository
+            self._delete_existing_vectors(document_id)
 
             # Generate embeddings and store
             self.batch_processor.process(chunks)
@@ -270,6 +285,42 @@ class IngestionPipeline:
                 error=str(e),
             )
             raise
+
+    def _document_id(self, source_type: str, profile_id: str, name: str) -> str:
+        """
+        Build a stable identifier for a logical document.
+
+        Unlike source_id, this identifier excludes the content hash, so it stays the
+        same across every revision of the same document. It is the key that previously
+        stored embeddings are removed by when a document is re-ingested.
+
+        Args:
+            source_type: Type of source (resume, readme, repo)
+            profile_id: ID of the profile owner
+            name: Stable per-profile document name (filename or repo name)
+
+        Returns:
+            Stable document identifier
+        """
+        return f"{source_type}_{profile_id}_{name}"
+
+    def _delete_existing_vectors(self, document_id: str) -> None:
+        """
+        Remove embeddings left behind by a previous ingestion of the same document.
+
+        Changed content produces a new source_id and therefore new vector IDs, so
+        without this the earlier embeddings stay in the collection and retrieval
+        returns stale content alongside the current version.
+
+        Args:
+            document_id: Stable document identifier to purge
+
+        Raises:
+            Exception: Propagates vector store failures so that ingestion does not
+                continue while stale embeddings are still present.
+        """
+        self.vector_db.delete(where={"document_id": document_id})
+        logger.info("Deleted existing vectors for document", document_id=document_id)
 
     def _hash_content(self, content: str | bytes) -> str:
         """Generate a hash of content for deduplication."""

--- a/ingestion/pipeline.py
+++ b/ingestion/pipeline.py
@@ -319,7 +319,7 @@ class IngestionPipeline:
             Exception: Propagates vector store failures so that ingestion does not
                 continue while stale embeddings are still present.
         """
-        self.vector_db.delete(where={"document_id": document_id})
+        self.vector_db.delete(where={"document_id": {"$eq": document_id}})
         logger.info("Deleted existing vectors for document", document_id=document_id)
 
     def _hash_content(self, content: str | bytes) -> str:

--- a/reproduction.md
+++ b/reproduction.md
@@ -1,0 +1,23 @@
+# Issue #27 Reproduction
+
+## Steps
+
+1. Ingest document with initial content:
+   "The company was founded in 2020."
+
+2. Query vector store.
+
+3. Update document:
+   "The company was founded in 2025."
+
+4. Re-ingest document.
+
+5. Query again.
+
+## Expected
+
+Vector store should return the updated embedding/content.
+
+## Actual
+
+Old embedding remains and stale document information is returned.

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -55,7 +55,7 @@ class TestIngestionPipelineStaleEmbeddings:
         pipeline.ingest_resume("profile-1", updated_text, "resume.md")
 
         mock_vector_db.delete.assert_called_once_with(
-            where={"document_id": "resume_profile-1_resume.md"}
+            where={"document_id": {"$eq": "resume_profile-1_resume.md"}}
         )
 
     def test_reingesting_updated_resume_leaves_only_new_vectors(
@@ -107,8 +107,8 @@ class TestIngestionPipelineStaleEmbeddings:
 
         delete_filters = [call.kwargs["where"] for call in mock_vector_db.delete.call_args_list]
         assert delete_filters == [
-            {"document_id": "resume_profile-1_resume.md"},
-            {"document_id": "resume_profile-2_resume.md"},
+            {"document_id": {"$eq": "resume_profile-1_resume.md"}},
+            {"document_id": {"$eq": "resume_profile-2_resume.md"}},
         ]
 
     def test_first_ingestion_still_stores_chunks(
@@ -145,7 +145,7 @@ class TestIngestionPipelineStaleEmbeddings:
         pipeline.ingest_readme("profile-1", "weather-app", updated_text)
 
         mock_vector_db.delete.assert_called_once_with(
-            where={"document_id": "readme_profile-1_weather-app"}
+            where={"document_id": {"$eq": "readme_profile-1_weather-app"}}
         )
 
     def test_reingesting_updated_repo_metadata_deletes_previous_vectors(
@@ -160,7 +160,7 @@ class TestIngestionPipelineStaleEmbeddings:
         pipeline.ingest_repo_metadata("profile-1", {**repo_data, "stars": 12})
 
         mock_vector_db.delete.assert_called_once_with(
-            where={"document_id": "repo_profile-1_weather-app"}
+            where={"document_id": {"$eq": "repo_profile-1_weather-app"}}
         )
 
     def test_delete_failure_prevents_storing_new_chunks(

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -1,0 +1,175 @@
+"""Tests for pipeline.py"""
+
+from unittest.mock import Mock
+
+import pytest
+
+from ingestion.pipeline import IngestionPipeline
+
+
+@pytest.mark.unit
+class TestIngestionPipelineStaleEmbeddings:
+    """Test suite for stale embedding removal during re-ingestion."""
+
+    @pytest.fixture
+    def mock_embedding_provider(self):
+        """Create a mock embedding provider."""
+        provider = Mock()
+        provider.embed = Mock(side_effect=lambda texts: [[0.1] * 1536 for _ in texts])
+        return provider
+
+    @pytest.fixture
+    def mock_vector_db(self):
+        """Create a mock vector database collection."""
+        return Mock()
+
+    @pytest.fixture
+    def mock_db_session(self):
+        """Create a mock DB session that reports no previously ingested source."""
+        session = Mock()
+        session.query.return_value.filter_by.return_value.first.return_value = None
+        return session
+
+    @pytest.fixture
+    def pipeline(self, mock_vector_db, mock_db_session, mock_embedding_provider):
+        """Create an IngestionPipeline instance."""
+        return IngestionPipeline(mock_vector_db, mock_db_session, mock_embedding_provider)
+
+    def _stored_metadatas(self, mock_vector_db) -> list[dict]:
+        """Collect every metadata dict passed to the vector DB."""
+        return [
+            metadata
+            for call in mock_vector_db.add.call_args_list
+            for metadata in call.kwargs["metadatas"]
+        ]
+
+    def test_reingesting_updated_resume_deletes_previous_vectors(
+        self, pipeline, mock_vector_db, sample_resume_text
+    ):
+        """Regression for #27: updated content must purge the previous embeddings."""
+        updated_text = sample_resume_text.replace("2022-2024", "2022-2026")
+
+        pipeline.ingest_resume("profile-1", sample_resume_text, "resume.md")
+        mock_vector_db.reset_mock()
+
+        pipeline.ingest_resume("profile-1", updated_text, "resume.md")
+
+        mock_vector_db.delete.assert_called_once_with(
+            where={"document_id": "resume_profile-1_resume.md"}
+        )
+
+    def test_reingesting_updated_resume_leaves_only_new_vectors(
+        self, pipeline, mock_vector_db, sample_resume_text
+    ):
+        """Regression for #27: the delete must precede the new chunk writes."""
+        updated_text = sample_resume_text.replace("2022-2024", "2022-2026")
+
+        pipeline.ingest_resume("profile-1", sample_resume_text, "resume.md")
+        mock_vector_db.reset_mock()
+
+        pipeline.ingest_resume("profile-1", updated_text, "resume.md")
+
+        method_calls = [call[0] for call in mock_vector_db.method_calls]
+        assert "delete" in method_calls
+        assert "add" in method_calls
+        assert method_calls.index("delete") < method_calls.index("add")
+
+    def test_document_id_is_stable_across_content_changes(
+        self, pipeline, mock_vector_db, sample_resume_text
+    ):
+        """Document ID must not change when content changes, unlike source ID."""
+        updated_text = sample_resume_text.replace("2022-2024", "2022-2026")
+
+        pipeline.ingest_resume("profile-1", sample_resume_text, "resume.md")
+        first_metadatas = self._stored_metadatas(mock_vector_db)
+        mock_vector_db.reset_mock()
+
+        pipeline.ingest_resume("profile-1", updated_text, "resume.md")
+        second_metadatas = self._stored_metadatas(mock_vector_db)
+
+        assert first_metadatas[0]["document_id"] == second_metadatas[0]["document_id"]
+        assert first_metadatas[0]["source_id"] != second_metadatas[0]["source_id"]
+
+    def test_document_id_stored_on_every_chunk(self, pipeline, mock_vector_db, sample_resume_text):
+        """Every stored chunk carries the document_id used for deletion."""
+        pipeline.ingest_resume("profile-1", sample_resume_text, "resume.md")
+
+        metadatas = self._stored_metadatas(mock_vector_db)
+        assert metadatas
+        assert all(m["document_id"] == "resume_profile-1_resume.md" for m in metadatas)
+
+    def test_delete_is_scoped_to_the_ingested_document(
+        self, pipeline, mock_vector_db, sample_resume_text
+    ):
+        """Ingesting one document must not delete another profile's vectors."""
+        pipeline.ingest_resume("profile-1", sample_resume_text, "resume.md")
+        pipeline.ingest_resume("profile-2", sample_resume_text, "resume.md")
+
+        delete_filters = [call.kwargs["where"] for call in mock_vector_db.delete.call_args_list]
+        assert delete_filters == [
+            {"document_id": "resume_profile-1_resume.md"},
+            {"document_id": "resume_profile-2_resume.md"},
+        ]
+
+    def test_first_ingestion_still_stores_chunks(
+        self, pipeline, mock_vector_db, sample_resume_text
+    ):
+        """A no-op delete on first ingestion must not prevent storage."""
+        result = pipeline.ingest_resume("profile-1", sample_resume_text, "resume.md")
+
+        assert result.skipped is False
+        assert result.chunk_count > 0
+        assert mock_vector_db.add.called
+
+    def test_unchanged_content_is_skipped_without_deleting(
+        self, pipeline, mock_vector_db, mock_db_session, sample_resume_text
+    ):
+        """Re-ingesting unchanged content skips early and touches no vectors."""
+        mock_db_session.query.return_value.filter_by.return_value.first.return_value = Mock()
+
+        result = pipeline.ingest_resume("profile-1", sample_resume_text, "resume.md")
+
+        assert result.skipped is True
+        mock_vector_db.delete.assert_not_called()
+        mock_vector_db.add.assert_not_called()
+
+    def test_reingesting_updated_readme_deletes_previous_vectors(
+        self, pipeline, mock_vector_db, sample_readme_text
+    ):
+        """README re-ingestion purges the previous version's embeddings."""
+        updated_text = sample_readme_text.replace("React 18", "React 19")
+
+        pipeline.ingest_readme("profile-1", "weather-app", sample_readme_text)
+        mock_vector_db.reset_mock()
+
+        pipeline.ingest_readme("profile-1", "weather-app", updated_text)
+
+        mock_vector_db.delete.assert_called_once_with(
+            where={"document_id": "readme_profile-1_weather-app"}
+        )
+
+    def test_reingesting_updated_repo_metadata_deletes_previous_vectors(
+        self, pipeline, mock_vector_db
+    ):
+        """Repo metadata re-ingestion purges the previous version's embeddings."""
+        repo_data = {"name": "weather-app", "language": "TypeScript", "stars": 3}
+
+        pipeline.ingest_repo_metadata("profile-1", repo_data)
+        mock_vector_db.reset_mock()
+
+        pipeline.ingest_repo_metadata("profile-1", {**repo_data, "stars": 12})
+
+        mock_vector_db.delete.assert_called_once_with(
+            where={"document_id": "repo_profile-1_weather-app"}
+        )
+
+    def test_delete_failure_prevents_storing_new_chunks(
+        self, pipeline, mock_vector_db, sample_resume_text
+    ):
+        """A failed purge must abort ingestion rather than leave stale vectors."""
+        mock_vector_db.delete = Mock(side_effect=RuntimeError("vector store unavailable"))
+
+        with pytest.raises(RuntimeError):
+            pipeline.ingest_resume("profile-1", sample_resume_text, "resume.md")
+
+        mock_vector_db.add.assert_not_called()


### PR DESCRIPTION
## Summary

Removes stale embeddings when a document is re-ingested with updated content. The ingestion pipeline now assigns a stable document identifier and removes vectors associated with the previous version before storing embeddings for the updated document.

## Issue

Closes #27

## Changes

- Added a stable `document_id` for ingested resumes, READMEs, and repository metadata.
- Added `document_id` to chunk metadata so vectors can be associated with the logical document across content revisions.
- Delete existing vectors for the document before storing embeddings for the updated version.
- Added unit tests covering re-ingestion across resume, README, and repository ingestion paths.
- Added coverage for document ID stability, profile scoping, delete-before-add behavior, first ingestion, and unchanged-content behavior.

## Testing

- [ ] Unit tests pass (`make test-unit`)
- [ ] Integration tests pass (`make test-integration`)
- [ ] Linter passes (`make lint`)
- [ ] Type checker passes (`make typecheck`)
- [x] New/updated tests cover the changes

Added 10 unit tests in `tests/unit/test_pipeline.py`.

The new regression tests pass with the fix. The full unit suite contains 38 pre-existing failures in `test_skill_extractor`, `test_structural_chunker`, and `test_tech_detector`; the same failures were reproduced before these changes, and this PR introduces no new failures.

Pre-existing lint/format issues in `ingestion/pipeline.py` were also reproduced on the unmodified file and are unrelated to this change.

## Screenshots / Demo

Not applicable.