### PR TITLE
fix: add fallback for heading-less documents in structural chunker

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,19 @@
+## Week 7 — Issue selection
+
+**Issue link:** [https://github.com/ascherj/pathreview/issues/149]
+
+**Issue title:** [Structural chunker silently drops documents that contain no headings]
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+[The StructuralChunker used by the ingestion pipeline currently fails to create chunks when a document does not contain markdown headings. In ingestion/chunking/structural_chunker.py, the _extract_sections() helper only captures content after detecting a heading, causing heading-free documents to return no chunks even when they contain valid text. This affects README ingestion because StructuralChunker is selected for README documents through the ingestion pipeline. A successful fix would ensure that any non-empty document can still produce at least one chunk while preserving the current behavior for empty documents.]
+
+**Branch name:** [fix/149-structural-chunker-fallback]
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger
+
+**Issue selection notes ("Is this right for me?" checklist):**
+[I chose this issue because it is my first open source contribution and I wanted to start with a manageable Tier 1 bug. I was able to understand the problem, locate the affected ingestion and chunking files, and identify what the expected behavior should be after the fix. The issue has clear reproduction steps and a related test, which makes it a good fit for learning how to contribute to a larger codebase while keeping the scope realistic for the project timeline.]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -18,6 +18,7 @@
 **Issue selection notes ("Is this right for me?" checklist):**
 [I chose this issue because it is my first open source contribution and I wanted to start with a manageable Tier 1 bug. I was able to understand the problem, locate the affected ingestion and chunking files, and identify what the expected behavior should be after the fix. The issue has clear reproduction steps and a related test, which makes it a good fit for learning how to contribute to a larger codebase while keeping the scope realistic for the project timeline.]
 
+---
 
 ## Week 8 — Reproduction & solution planning
 
@@ -37,3 +38,17 @@ print(c.chunk(text, {"source": "test"}))
 
 - The test fails because StructuralChunker.chunk() returns an empty list for a document without markdown headings
 - The issue originates in ingestion/chunking/structural_chunker.py, where _extract_sections() only collects content after encountering a markdown heading
+
+**Reproduction commit link:** 
+[(https://github.com/JairVilleda/pathreview/commit/8b851147b6b2d73ee5a711a93f915ca95782afea)] 
+
+**Reproduction summary:**
+I reproduced the issue by running the existing unit test for StructuralChunker and by testing it with a document containing no markdown headings. In both cases, StructuralChunker.chunk() returned an empty list instead of producing at least one chunk.
+
+**PLAN.md link:** 
+[(https://github.com/JairVilleda/pathreview/blob/fix/149-structural-chunker-fallback/PLAN.md)]
+
+**Blockers or open questions:**
+[None at this time.]
+
+---

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -83,3 +83,37 @@ Updated the structural chunker test for documents without headings in `tests/uni
 **Self-review confirmation:** [x] make check passes  [x] make test-unit passes
 
 **Draft PR feedback received from:** none
+
+---
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No review came in.
+
+**How you responded:**
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The hardest part was figuring out where the bug was actually coming from. The issue sounded pretty simple at first because the StructuralChunker was just returning an empty list when a document had no headings. Howevever, I had to spend time understanding how the ingestion pipeline worked and tracing how the document got to the chunker. What surprised me was that nothing crashed. The code ran normally, but the document was basically lost because no chunks were created. That made the problem harder to notice and understand.
+
+**What did you learn about working in a large codebase?**
+I learned that working in someone else's codebase takes more time to understand before you can safely make a change. When I work on my own projects, I already know how everything is organized and why I wrote the code a certain way. With PathReview, I had to figure out how different parts of the project worked together before deciding what to change. I also learned that the issue description doesn't always tell you exactly where the problem is. I had to use the tests and follow the code to figure that out.
+
+**How did AI tools help — and where did they fall short?**
+AI was really helpful for understanding parts of the codebase that I wasn't familiar with. It helped me break down the ingestion pipeline, understand the StructuralChunker, think about the root cause, and come up with possible tests. It also helped me with some of the GitHub and PR process, which I was still getting used to.
+
+At the same time, I learned that I can't just trust what AI tells me. I still had to run the tests, reproduce the bug myself, and look at the actual code. AI could suggest a solution, but I needed to verify that it actually worked in the project.
+
+**What would you do differently if you started over?**
+If I started over, I would spend more time understanding the codebase before thinking about the fix. I would trace how the data moves through the ingestion pipeline, read the related code and tests, and form my own idea of the root cause first. I would still use AI, but more as a second opinion instead of relying on it to explain everything to me. I would also focus on making the smallest change that fixes the actual problem rather than immediately thinking about what code needs to be added. I think this would make me more confident and independent when working in an unfamiliar codebase. At the end of the day, I know more practice will build good habits and make navigating and fixing code easier.
+
+**What are you most proud of from this module?**
+I am most proud that I was able to take an issue I didn't fully understand at first and work through it until I had a working solution and PR. This was my first open source contribution. I reproduced the bug, figured out why the StructuralChunker was dropping documents without headings, made the fix, tested it, and documented the process. More than just fixing the bug, I feel like I got more comfortable working in a codebase that I didn't create myself.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -17,3 +17,23 @@
 
 **Issue selection notes ("Is this right for me?" checklist):**
 [I chose this issue because it is my first open source contribution and I wanted to start with a manageable Tier 1 bug. I was able to understand the problem, locate the affected ingestion and chunking files, and identify what the expected behavior should be after the fix. The issue has clear reproduction steps and a related test, which makes it a good fit for learning how to contribute to a larger codebase while keeping the scope realistic for the project timeline.]
+
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction steps:**
+Option A:
+```bash
+python -m pytest tests/unit/test_structural_chunker.py::TestStructuralChunker::test_document_with_no_headings -v
+```
+
+Option B:
+```python
+from ingestion.chunking.structural_chunker import StructuralChunker
+c = StructuralChunker()
+text = "This is plain text without any markdown headings. " * 20
+print(c.chunk(text, {"source": "test"}))
+```
+
+- The test fails because StructuralChunker.chunk() returns an empty list for a document without markdown headings
+- The issue originates in ingestion/chunking/structural_chunker.py, where _extract_sections() only collects content after encountering a markdown heading

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -52,3 +52,34 @@ I reproduced the issue by running the existing unit test for StructuralChunker a
 [None at this time.]
 
 ---
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the fix for issue #149. Updated the structural chunker so documents without markdown headings are no longer silently dropped and can produce a chunk. The reproduction test for heading-less documents now passes.
+
+**Next steps:**
+Finish the final testing/checks, review the changes, update the PR, and complete the PR submission.
+
+**Blockers:**
+None.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [(https://github.com/ascherj/pathreview/pull/1032)]
+
+**Branch:** `fix/149-structural-chunker-fallback`
+
+**What you built:**
+Fixed issue #149 by updating the structural chunker so heading-less documents are captured instead of causing `StructuralChunker.chunk()` to return an empty list. This prevents documents without markdown headings from being silently dropped during ingestion.
+
+**Tests added or updated:**
+Updated the structural chunker test for documents without headings in `tests/unit/test_structural_chunker.py`. The test verifies that a document without markdown headings produces at least one chunk instead of an empty result.
+
+**Self-review confirmation:** [x] make check passes  [x] make test-unit passes
+
+**Draft PR feedback received from:** none

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,68 @@
+## Solution plan
+
+**Issue:** [Structural chunker silently drops documents that contain no headings #149
+https://github.com/ascherj/pathreview/issues/149]
+
+### Understand
+
+StructuralChunker.chunk() returns an empty list when processing a document without markdown headings. This causes the document to be skipped during ingestion because no chunks are created for embedding or indexing.
+
+The root cause is in ingestion/chunking/structural_chunker.py inside _extract_sections(). The function only collects content after a markdown heading has been detected. For heading-less documents:
+- heading_stack remains empty.
+- current_section_lines never receives content.
+- The final section is never saved because the save condition requires a heading.
+
+Expected behavior: Heading-less documents should still produce chunks and be included in retrieval.
+
+The fix should happen in _extract_sections() by allowing heading-less content to become a valid section. This allows the existing chunk() logic to continue handling token limits and semantic fallback behavior through SemanticChunker.
+
+### Map
+Files involved:
+
+- ingestion/chunking/structural_chunker.py
+  - _extract_sections() — currently drops content without headings
+  - chunk() — contains existing semantic fallback behavior for large sections
+
+- ingestion/chunking/semantic_chunker.py
+  - SemanticChunker.chunk() — existing chunking logic that can be reused for heading-less documents
+
+- tests/unit/test_structural_chunker.py
+  - test_document_with_no_headings — existing regression test that should be strengthened.
+  - New test for text appearing before the first markdown heading
+
+### Plan
+1. Update _extract_sections() so documents without markdown headings are returned as valid sections instead of being dropped.
+2. Ensure the existing chunk() flow handles these sections through the normal size checks and SemanticChunker fallback.
+3. Preserve metadata for heading-less sections, including an empty heading_path and appropriate heading level.
+4. Strengthen test_document_with_no_headings to verify:
+   - At least one chunk is returned.
+   - Original content is preserved.
+   - Source metadata is maintained.
+   - Heading metadata uses the expected fallback values.
+5. Add a test for pre-heading text to verify that content before the first markdown heading is not dropped.
+6. Run the relevant unit tests to confirm existing heading-based chunking behavior remains unchanged.
+
+### Inputs & outputs
+Input:
+- A document string with or without markdown headings.
+- Metadata containing source information
+
+Current output:
+- Documents without headings return an empty list
+
+Expected output:
+- Heading-less documents are passed through semantic chunking and return one or more valid chunks
+
+### Risks & unknowns
+- Adding support for heading-less sections changes current behavior because previously this content was silently ignored.
+- Need to confirm the expected metadata values for fallback sections (heading_path, heading_level).
+- Need to verify that documents with existing markdown headings continue producing the same chunk structure.
+- Need to ensure long heading-less documents still use semantic chunking instead of creating oversized chunks.
+
+### Edge cases
+- Empty documents
+- Documents containing only whitespace
+- Short documents without headings
+- Long documents without headings
+- Documents containing text before the first markdown heading
+- Documents with valid markdown heading sections

--- a/ingestion/chunking/structural_chunker.py
+++ b/ingestion/chunking/structural_chunker.py
@@ -88,16 +88,15 @@ class StructuralChunker(BaseChunker):
             heading_match = re.match(r"^(#{1,6})\s+(.+)$", line)
 
             if heading_match:
-                # Save previous section if exists
+                # Save previous section if exists (may precede the first heading)
                 if current_section_lines:
-                    if heading_stack:
-                        sections.append(
-                            {
-                                "content": "\n".join(current_section_lines).strip(),
-                                "path": [h[1] for h in heading_stack],
-                                "level": heading_stack[-1][0] if heading_stack else 0,
-                            }
-                        )
+                    sections.append(
+                        {
+                            "content": "\n".join(current_section_lines).strip(),
+                            "path": [h[1] for h in heading_stack],
+                            "level": heading_stack[-1][0] if heading_stack else 0,
+                        }
+                    )
                     current_section_lines = []
 
                 # Process new heading

--- a/ingestion/chunking/structural_chunker.py
+++ b/ingestion/chunking/structural_chunker.py
@@ -49,22 +49,26 @@ class StructuralChunker(BaseChunker):
             if section_tokens > self.SECTION_TOKEN_LIMIT:
                 # Sub-chunk using semantic chunker
                 section_metadata = metadata.copy()
-                section_metadata.update({
-                    "heading_path": heading_path,
-                    "heading_level": section["level"],
-                })
+                section_metadata.update(
+                    {
+                        "heading_path": heading_path,
+                        "heading_level": section["level"],
+                    }
+                )
                 sub_chunks = self.semantic_chunker.chunk(section_text, section_metadata)
                 chunks.extend(sub_chunks)
             else:
                 # Single chunk for this section
                 section_metadata = metadata.copy()
-                section_metadata.update({
-                    "heading_path": heading_path,
-                    "heading_level": section["level"],
-                    "chunk_index": len(chunks),
-                    "char_start": 0,
-                    "char_end": len(section_text),
-                })
+                section_metadata.update(
+                    {
+                        "heading_path": heading_path,
+                        "heading_level": section["level"],
+                        "chunk_index": len(chunks),
+                        "char_start": 0,
+                        "char_end": len(section_text),
+                    }
+                )
                 chunks.append(Chunk(text=section_text, metadata=section_metadata))
 
         return chunks
@@ -79,7 +83,6 @@ class StructuralChunker(BaseChunker):
         sections = []
         heading_stack = []  # Stack of (level, heading_text)
         current_section_lines = []
-        current_level = 0
 
         for line in lines:
             heading_match = re.match(r"^(#{1,6})\s+(.+)$", line)
@@ -88,11 +91,13 @@ class StructuralChunker(BaseChunker):
                 # Save previous section if exists
                 if current_section_lines:
                     if heading_stack:
-                        sections.append({
-                            "content": "\n".join(current_section_lines).strip(),
-                            "path": [h[1] for h in heading_stack],
-                            "level": heading_stack[-1][0] if heading_stack else 0,
-                        })
+                        sections.append(
+                            {
+                                "content": "\n".join(current_section_lines).strip(),
+                                "path": [h[1] for h in heading_stack],
+                                "level": heading_stack[-1][0] if heading_stack else 0,
+                            }
+                        )
                     current_section_lines = []
 
                 # Process new heading
@@ -104,19 +109,19 @@ class StructuralChunker(BaseChunker):
                     heading_stack.pop()
 
                 heading_stack.append((heading_level, heading_text))
-                current_level = heading_level
 
             else:
-                # Regular content line
-                if heading_stack or current_section_lines:  # Only collect if we have a heading
-                    current_section_lines.append(line)
+                # Regular content line (collected even before the first heading)
+                current_section_lines.append(line)
 
-        # Save final section
-        if current_section_lines and heading_stack:
-            sections.append({
-                "content": "\n".join(current_section_lines).strip(),
-                "path": [h[1] for h in heading_stack],
-                "level": heading_stack[-1][0] if heading_stack else 0,
-            })
+        # Save final section (may have no heading at all)
+        if current_section_lines:
+            sections.append(
+                {
+                    "content": "\n".join(current_section_lines).strip(),
+                    "path": [h[1] for h in heading_stack],
+                    "level": heading_stack[-1][0] if heading_stack else 0,
+                }
+            )
 
         return sections

--- a/tests/unit/test_structural_chunker.py
+++ b/tests/unit/test_structural_chunker.py
@@ -34,6 +34,16 @@ class TestStructuralChunker:
         assert isinstance(result[0], Chunk)
         assert all(isinstance(c, Chunk) for c in result)
 
+        # Content is preserved, not silently dropped
+        assert result[0].text == text.strip()
+
+        # Source metadata is carried through
+        assert result[0].metadata["source"] == "test"
+
+        # Heading-less sections fall back to an empty path at level 0
+        assert result[0].metadata["heading_path"] == ""
+        assert result[0].metadata["heading_level"] == 0
+
     def test_document_with_nested_headings(self, chunker):
         """Test document with nested headings preserves heading_path."""
         text = """# Main Title

--- a/tests/unit/test_structural_chunker.py
+++ b/tests/unit/test_structural_chunker.py
@@ -44,6 +44,29 @@ class TestStructuralChunker:
         assert result[0].metadata["heading_path"] == ""
         assert result[0].metadata["heading_level"] == 0
 
+    def test_text_before_first_heading_is_preserved(self, chunker):
+        """Test content before the first heading becomes its own section."""
+        text = """Introductory text before the heading.
+
+# Main Heading
+
+Body text under the heading.
+"""
+        result = chunker.chunk(text, {"source": "test"})
+
+        assert len(result) == 2
+
+        # Pre-heading content is not dropped
+        assert "Introductory text before the heading." in result[0].text
+        assert result[0].metadata["heading_path"] == ""
+        assert result[0].metadata["heading_level"] == 0
+        assert result[0].metadata["source"] == "test"
+
+        # Normal heading-based chunking still works
+        assert "Body text under the heading." in result[1].text
+        assert result[1].metadata["heading_path"] == "Main Heading"
+        assert result[1].metadata["heading_level"] == 1
+
     def test_document_with_nested_headings(self, chunker):
         """Test document with nested headings preserves heading_path."""
         text = """# Main Title


### PR DESCRIPTION
## Summary

`StructuralChunker.chunk()` returned an empty list for documents that contained no markdown headings, causing those documents to be silently dropped from the ingestion pipeline. This PR updates the structural chunking behavior so heading-less content is captured and can be processed instead of being discarded.

## Issue

Closes #149

## Changes

Root cause: `StructuralChunker._extract_sections()` only collected content when a markdown heading had been detected. For a document with no headings, `heading_stack` remained empty, so the document's content was never added to a section and `chunk()` ultimately returned an empty list.

- `ingestion/chunking/structural_chunker.py` — updated section extraction so content from documents without headings is captured instead of being silently dropped
- Preserved the existing structural chunking behavior for documents that do contain headings
- Added/updated test coverage for the heading-less document case so the regression is detected

## Testing

- [x] Unit tests pass
- [x] New/updated tests cover the changes

**Reproduce the original bug:**
1. Run the structural chunker test for a document with no markdown headings.
2. Before the fix, `StructuralChunker.chunk()` returned an empty list.
3. The test failed because it expected at least one chunk but received zero.

**Verify the fix:**
1. Activate the project virtual environment.
2. Run the structural chunker unit test:
   `python -m pytest tests/unit/test_structural_chunker.py::TestStructuralChunker::test_document_with_no_headings -v`
3. The test should now pass because the heading-less document produces a chunk instead of an empty list.
4. A minimal reproduction can also be tested with a plain-text document containing no markdown headings.

## Screenshots / Demo

N/A — this is a backend ingestion/chunking change with no visible UI changes. The observable behavior is verified through the structural chunker unit test.

## Notes for Reviewers

The implementation was verified with the project's testing/check commands after the fix. No unrelated changes are included in this PR.