### PR TITLE
Fix TypeError when context chunk text is None (Issue153)

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,18 @@
+# JOURNAL
+
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/153
+
+**Issue title:** Faithfulness check
+
+**Tier:** [x] Tier 1  [ ] Tier 2  [ ] Tier 3
+
+**Problem summary:**
+This issue addresses an edge case in the faithfulness checker when a context chunk contains `{"text": None}`. The current implementation uses the chunk’s `text` value when building the combined context, but `None` is not a string and causes `join()` to raise a `TypeError`. A successful fix will normalize `None` text values into a safe string value while preserving existing behavior for valid context chunks.
+
+**Branch name:** feat/153-faithfulness-check
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -16,3 +16,17 @@ This issue addresses an edge case in the faithfulness checker when a context chu
 **Setup confirmation:** [x] App runs locally at localhost:5173
 
 **Cohort ledger:** [x] Issue added to cohort ledger
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [link to commit documenting the reproduced issue]
+
+**Reproduction summary:**
+I reproduced Issue #153 by running `TestFaithfulnessChecker::test_none_context_chunk_text` in `tests/unit/test_faithfulness_checker.py`. The test fails because `FaithfulnessChecker.check()` passes a `None` value from a context chunk into `join()`, causing a TypeError instead of handling the missing text gracefully.
+
+**PLAN.md link:** [link to PLAN.md in your fork]
+
+**Walkthrough video (recommended):** [link to your Loom video, ≤2 min — recommended, not graded]
+
+**Blockers or open questions:**
+Not at the moment.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -19,12 +19,12 @@ This issue addresses an edge case in the faithfulness checker when a context chu
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [link to commit documenting the reproduced issue]
+**Reproduction commit link:** [\[link to commit documenting the reproduced issue\]](https://github.com/mxdmichael1-code/pathreview/commit/08975d3)
 
 **Reproduction summary:**
 I reproduced Issue #153 by running `TestFaithfulnessChecker::test_none_context_chunk_text` in `tests/unit/test_faithfulness_checker.py`. The test fails because `FaithfulnessChecker.check()` passes a `None` value from a context chunk into `join()`, causing a TypeError instead of handling the missing text gracefully.
 
-**PLAN.md link:** [link to PLAN.md in your fork]
+**PLAN.md link:** [\[link to PLAN.md in your fork\]](https://github.com/mxdmichael1-code/pathreview/blob/feat/153-faithfulness-check/PLAN.md)
 
 **Walkthrough video (recommended):** [link to your Loom video, ≤2 min — recommended, not graded]
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -61,3 +61,35 @@ Verified that the existing regression test for context chunks containing `"text"
 **Self-review confirmation:** [X] make check passes  [X] make test-unit passes
 
 **Draft PR feedback received from:** None
+
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No reviewer feedback received yet.
+
+**How you responded:**
+None.
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+Working with Git and GitHub was harder than I expected. I ran into several issues with staging, committing, pushing, and creating a pull request, and relied on AI to help me troubleshoot the workflow step by step.
+
+**What did you learn about working in a large codebase?**
+I learned that contributing to a large codebase is very different from working on a personal project. There are many existing issues to choose from, and contributions are expected to be small, focused, and reviewed by others before they are merged.
+
+**How did AI tools help — and where did they fall short?**
+AI was very helpful for understanding the issue, navigating the repository, explaining Git workflows, and debugging environment and tooling problems. However, it could not reliably determine whether project-wide test failures were pre-existing or caused by my changes without me verifying the results manually.
+
+**What would you do differently if you started over?**
+I would choose a different issue, possibly from another tier, to experience a different type of contribution. I would also spend more time becoming familiar with the repository and Git workflow before starting implementation.
+
+**What are you most proud of from this module?**
+I'm most proud of becoming comfortable with the overall GitHub contribution workflow—from reproducing an issue and implementing a fix to creating a pull request and participating in the open-source review process.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -30,3 +30,34 @@ I reproduced Issue #153 by running `TestFaithfulnessChecker::test_none_context_c
 
 **Blockers or open questions:**
 Not at the moment.
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+Implemented the fix for Issue #153 by safely handling context chunks where `"text"` is `None` in `FaithfulnessChecker`. Verified that the new regression test passes. Confirmed that three existing failures in `test_faithfulness_checker.py` are pre-existing and unrelated to this change.
+
+**Next steps:**
+Run `make test-unit` and `make check`, review the final code changes, commit the implementation, open a draft PR, and request peer or mentor feedback.
+
+**Blockers:**
+None.
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** None
+
+**Branch:** `feat/153-faithfulness-check`
+
+**What you built:**
+Implemented a fix for Issue #153 so that `FaithfulnessChecker` no longer raises a `TypeError` when a context chunk contains `"text": None`. The implementation safely treats `None` as an empty string while preserving the existing behavior for valid context chunks.
+
+**Tests added or updated:**
+Verified that the existing regression test for context chunks containing `"text": None` passes after implementing the fix. Also confirmed that the remaining failing tests are pre-existing and unrelated to this change.
+
+**Self-review confirmation:** [X] make check passes  [X] make test-unit passes
+
+**Draft PR feedback received from:** None

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -48,7 +48,7 @@ None.
 
 ### Check-in 2 (end of week)
 
-**PR link:** None
+**PR link:** https://github.com/ascherj/pathreview/pull/1033 
 
 **Branch:** `feat/153-faithfulness-check`
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,76 @@
+## Solution plan
+
+**Issue:** Faithfulness check — https://github.com/ascherj/pathreview/issues/153
+
+### Understand
+The root cause of this issue is that `FaithfulnessChecker.check()` assumes that every context chunk contains a string value under the `text` field. When a context chunk contains `{"text": None}`, the current implementation uses `chunk.get("text", "")`, which returns `None` because the key exists. This `None` value is then passed into `" ".join()`, causing a `TypeError` because `join()` only accepts strings.
+
+The expected behavior is for the faithfulness checker to handle `None`-valued context text gracefully without crashing. Valid text values should continue to be concatenated and evaluated normally.
+
+### Map
+The main files involved are:
+
+- `rag/evaluator/faithfulness_checker.py`
+  - `FaithfulnessChecker.check()`
+  - Context extraction and text concatenation logic where `context_text` is generated.
+
+- `tests/unit/test_faithfulness_checker.py`
+  - `TestFaithfulnessChecker.test_none_context_chunk_text`
+  - Existing tests covering faithfulness evaluation behavior.
+
+Expected files to touch:
+- `rag/evaluator/faithfulness_checker.py`
+- Potentially `tests/unit/test_faithfulness_checker.py` if additional regression coverage is needed.
+
+### Plan
+1. Reproduce the current failure by running `test_none_context_chunk_text` and confirm that `None` values in context chunks cause a `TypeError`.
+2. Update the context text extraction logic in `FaithfulnessChecker.check()` to normalize `None` values into a safe string representation before joining.
+3. Run the existing `test_none_context_chunk_text` test to confirm the issue is resolved.
+4. Run the full faithfulness checker test suite to ensure the change does not affect existing behavior.
+5. Review edge cases and commit the implementation after confirming the fix.
+
+### Inputs & outputs
+
+Input example:
+
+```python
+feedback = "Has Python skills"
+context_chunks = [{"text": None}]
+```
+
+Current behavior:
+- The function extracts `None` as the context text.
+- `" ".join()` receives a non-string value.
+- The function raises a `TypeError`.
+
+Expected behavior:
+- `None` text values are handled safely.
+- The function completes without crashing.
+- Valid string context continues to work as before.
+
+### Risks & unknowns
+- It is unclear whether the `text` field is guaranteed to only contain `str` or `None`.
+- A broad fallback approach may hide unexpected invalid data types.
+- Empty context after filtering invalid values may affect later faithfulness scoring logic.
+- Additional validation may belong upstream depending on the intended data flow.
+
+### Edge cases
+The fix should handle:
+
+- Empty context:
+  - `[]`
+
+- Missing text field:
+  - `[{}]`
+
+- None text value:
+  - `[{"text": None}]`
+
+- Empty string:
+  - `[{"text": ""}]`
+
+- Mixed valid and invalid chunks:
+  - `[{"text": None}, {"text": "Valid context"}]`
+
+- Multiple valid chunks:
+  - `[{"text": "First"}, {"text": "Second"}]`

--- a/rag/evaluator/faithfulness_checker.py
+++ b/rag/evaluator/faithfulness_checker.py
@@ -1,6 +1,7 @@
 """Check if generated feedback is supported by retrieved context."""
 
 import re
+
 import structlog
 
 logger = structlog.get_logger()
@@ -20,8 +21,11 @@ class FaithfulnessChecker:
             Faithfulness score 0.0-1.0 (ratio of supported claims)
         """
         if not feedback or not context_chunks:
-            logger.info("faithfulness_empty_input", has_feedback=bool(feedback),
-                       has_chunks=bool(context_chunks))
+            logger.info(
+                "faithfulness_empty_input",
+                has_feedback=bool(feedback),
+                has_chunks=bool(context_chunks),
+            )
             return 0.0
 
         # Extract key claims from feedback (sentences)
@@ -31,9 +35,7 @@ class FaithfulnessChecker:
             return 0.5  # Default to neutral if no extractable claims
 
         # Concatenate context text
-        context_text = " ".join([
-            chunk.get("text", "") for chunk in context_chunks
-        ])
+        context_text = " ".join([chunk.get("text") or "" for chunk in context_chunks])
 
         # Check each claim for support
         supported = 0
@@ -43,8 +45,9 @@ class FaithfulnessChecker:
 
         score = supported / len(claims) if claims else 0.0
 
-        logger.info("faithfulness_checked", claims_count=len(claims),
-                   supported_count=supported, score=score)
+        logger.info(
+            "faithfulness_checked", claims_count=len(claims), supported_count=supported, score=score
+        )
 
         return score
 
@@ -59,7 +62,7 @@ class FaithfulnessChecker:
             List of claims (sentences)
         """
         # Split by sentence (simple regex)
-        sentences = re.split(r'[.!?]+', text)
+        sentences = re.split(r"[.!?]+", text)
         claims = [s.strip() for s in sentences if s.strip() and len(s.strip()) > 10]
         return claims[:10]  # Limit to 10 claims for scoring
 
@@ -81,8 +84,25 @@ class FaithfulnessChecker:
         # Require at least some meaningful overlap
         overlap = claim_tokens & context_tokens
         # Filter out common stop words
-        stop_words = {'a', 'an', 'the', 'is', 'are', 'was', 'were', 'be', 'been',
-                     'and', 'or', 'but', 'in', 'of', 'to', 'for', 'that'}
+        stop_words = {
+            "a",
+            "an",
+            "the",
+            "is",
+            "are",
+            "was",
+            "were",
+            "be",
+            "been",
+            "and",
+            "or",
+            "but",
+            "in",
+            "of",
+            "to",
+            "for",
+            "that",
+        }
         meaningful_overlap = overlap - stop_words
 
         return len(meaningful_overlap) >= 2


### PR DESCRIPTION
## Summary

Fixes Issue #153 by preventing `FaithfulnessChecker` from raising a `TypeError` when a context chunk contains `"text": None`. The implementation normalizes `None` values to an empty string before concatenating the context while preserving the existing behavior for valid context chunks and missing text keys.

## Issue

Closes #153

## Changes

- Normalize `None` context chunk text to an empty string before concatenating context.
- Preserve existing behavior for valid strings and missing `"text"` keys.
- Verified that the existing regression test for this edge case now passes.

## Testing

<!-- How did you verify your changes? -->

- [x] Unit tests pass (`make test-unit`)*
- [ ] Integration tests pass (`make test-integration`)
- [x] Linter passes (`make lint`)*
- [x] Type checker passes (`make typecheck`)
- [ ] New/updated tests cover the changes

\* `make test-unit` and `make check` report pre-existing unrelated failures elsewhere in the repository. I verified that these failures are present independently of this change and that this fix introduces no additional failures. The existing regression test for Issue #153 passes after the implementation.

## Screenshots / Demo

N/A

## Notes for Reviewers

This PR intentionally focuses only on Issue #153. It addresses the edge case where a context chunk contains `"text": None` and does not modify the existing scoring logic or other components.
