### PR TITLE
Feat/129 ci migration validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,33 @@ jobs:
           REDIS_URL: redis://localhost:6379/0
           LLM_PROVIDER: mock
 
+  validate-migrations:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: pathreview
+          POSTGRES_PASSWORD: pathreview
+          POSTGRES_DB: pathreview_migrations
+        ports: ["5432:5432"]
+        options: >-
+          --health-cmd "pg_isready -U pathreview"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - run: pip install -e ".[dev]"
+      - name: Validate migrations apply cleanly and match the models
+        run: ./scripts/validate_migrations.sh
+        env:
+          DATABASE_URL: postgresql+asyncpg://pathreview:pathreview@localhost:5432/pathreview_migrations
+
   frontend:
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ htmlcov/
 
 # Build artifacts
 *.pyc
+
+# project description 
+*pathreview-instructions.md

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,0 +1,22 @@
+## Week 7 — Issue selection
+
+**Issue link:** https://github.com/ascherj/pathreview/issues/129
+
+**Issue title:** Add a database migration validation step to CI that checks all migrations can be applied cleanly
+
+**Tier:** [ ] Tier 1  [ ] Tier 2  [x] Tier 3
+
+**Problem summary:**
+The current issue is that there needs to be database migration validation, as a broken migration can be committed and cause future issues. The migration validation creates a new database, runs all migrations, and then checks the models. The areas of the codebase that are affected are `alembic` and `.github/workflows/ci.yml`. With a script for the migration validation, errors can be caught and detected before merge, so only clean migrations make it in.
+
+**Branch name:** feat/129-ci-migration-validation
+
+**Setup confirmation:** [x] App runs locally at localhost:5173
+
+**Cohort ledger:** [x] Issue added to cohort ledger
+
+---
+
+### Selection notes — "Is this right for me?" checklist
+
+I wanted to work on a skill I have never done to challenge myself. I currently have no devops experience so I thought choosing this issue will help me learn and make future projects easier to complete. The scope is reasonable as, it's one script plus one CI job, with no production app code to change, so it's realistic to finish in my timeline. I'm new to GitHub Actions, so the push-and-watch feedback loop will take a few iterations.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -20,3 +20,32 @@ The current issue is that there needs to be database migration validation, as a 
 ### Selection notes — "Is this right for me?" checklist
 
 I wanted to work on a skill I have never done to challenge myself. I currently have no devops experience so I thought choosing this issue will help me learn and make future projects easier to complete. The scope is reasonable as, it's one script plus one CI job, with no production app code to change, so it's realistic to finish in my timeline. I'm new to GitHub Actions, so the push-and-watch feedback loop will take a few iterations.
+
+---
+
+## Week 8 — Reproduction & solution planning
+
+**Reproduction commit link:** [link to commit documenting the reproduced issue]
+
+**Reproduction summary:**
+I brought up the local stack (`colima start`, `docker compose up -d`) and ran the two migration commands against a fresh Postgres. `alembic upgrade head` applied all migrations cleanly, but `alembic check` failed with a drift error — it detected a `remove_constraint` operation for `uq_users_email`. That means the database built by the migrations has a unique constraint on `users.email` that the current `User` model no longer declares (the model only sets `unique=True, index=True`, which produces a unique index, not a named constraint). This is exactly the kind of drift issue #129's CI check is meant to catch automatically.
+
+Reproduction steps and observed output:
+
+```
+$ alembic upgrade head      # applies cleanly
+
+$ alembic check
+INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
+INFO  [alembic.runtime.migration] Will assume transactional DDL.
+INFO  [alembic.autogenerate.compare.constraints] Detected removed unique constraint 'uq_users_email' on 'users'
+ERROR [alembic.util.messaging] New upgrade operations detected: [('remove_constraint', UniqueConstraint(Column('email', NullType(), table=<users>)))]
+  FAILED: New upgrade operations detected: [('remove_constraint', UniqueConstraint(Column('email', NullType(), table=<users>)))]
+```
+
+**PLAN.md link:** [link to PLAN.md in your fork]
+
+**Walkthrough video (recommended):** [link to your Loom video, ≤2 min — recommended, not graded]
+
+**Blockers or open questions:**
+[Anything you're still uncertain about going into Week 9, or leave blank]

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -25,7 +25,7 @@ I wanted to work on a skill I have never done to challenge myself. I currently h
 
 ## Week 8 — Reproduction & solution planning
 
-**Reproduction commit link:** [link to commit documenting the reproduced issue]
+**Reproduction commit link:** https://github.com/kelp-Shake/pathreview/commit/dcdfc6d8ecc50e45773baae34f567c2bb5b3bcfe
 
 **Reproduction summary:**
 I brought up the local stack (`colima start`, `docker compose up -d`) and ran the two migration commands against a fresh Postgres. `alembic upgrade head` applied all migrations cleanly, but `alembic check` failed with a drift error — it detected a `remove_constraint` operation for `uq_users_email`. That means the database built by the migrations has a unique constraint on `users.email` that the current `User` model no longer declares (the model only sets `unique=True, index=True`, which produces a unique index, not a named constraint). This is exactly the kind of drift issue #129's CI check is meant to catch automatically.
@@ -43,9 +43,9 @@ ERROR [alembic.util.messaging] New upgrade operations detected: [('remove_constr
   FAILED: New upgrade operations detected: [('remove_constraint', UniqueConstraint(Column('email', NullType(), table=<users>)))]
 ```
 
-**PLAN.md link:** [link to PLAN.md in your fork]
+**PLAN.md link:** https://github.com/kelp-Shake/pathreview/blob/feat/129-ci-migration-validation/PLAN.md
 
-**Walkthrough video (recommended):** [link to your Loom video, ≤2 min — recommended, not graded]
+**Walkthrough video (recommended):** N/A — not recorded (optional, not graded)
 
 **Blockers or open questions:**
-[Anything you're still uncertain about going into Week 9, or leave blank]
+My main open question is how to resolve the existing `uq_users_email` drift — either update the `User` model to declare the constraint, or add a new migration that drops it. Both fix the drift, so I need to decide which one to use in Week 9 before the CI check can pass.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -186,3 +186,34 @@ I checked each log for my three files:
 This is the strongest version of the "no new failures" claim: not "it looks the same on
 my laptop" but "the same jobs fail in the same way on CI, and none of the failures name
 a file I touched."
+
+## Week 10 — Iteration & reflection
+
+### Reviewer feedback
+
+**Feedback received:** [ ] Yes  [x] No — still awaiting review
+
+**Summary of feedback:**
+No feedback
+
+**How you responded:**
+no feedback
+
+---
+
+### Reflection
+
+**What was harder than you expected?**
+The pre-existing `uq_users_email` drift took more time than the CI job itself. I had to actually understand what `alembic check` was comparing before I could decide how to fix it. The `alembic/` package name collision in my test file was also a bit of a rabbit hole; parsing migrations with `ast` instead of importing them was the workaround.
+
+**What did you learn about working in a large codebase?**
+"Does this pass" wasn't the right question, since `main` already fails lint, mypy, and 53 unit tests. I had to record a baseline and compare counts and test ids before and after instead.
+
+**How did AI tools help, and where did they fall short?**
+Helpful for the CI YAML, mostly by pattern matching the existing `test-integration` job for the Postgres service container. Less helpful for the async driver `DATABASE_URL` failure and the import shadowing. Those needed reading the actual traceback myself.
+
+**What would you do differently if you started over?**
+Maybe open the dry-run fork PR earlier rather than saving all the verification for the end of Week 9. A few things (the CI Python version, the executable bit surviving checkout) only showed up there. I'd also try to spot the model and migration drift during Week 8's reproduction step rather than treating it as a side quest once I was already into the fix.
+
+**What are you most proud of from this module?**
+That the CI job caught a real pre-existing drift bug (`uq_users_email`) rather than only a synthetic example I made up to demonstrate the check working. It also passed on GitHub Actions on the first attempt, which I hadn't expected given how new I am to Actions.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -156,7 +156,17 @@ upstream. Checking off the list of things local runs couldn't prove:
 - [x] `pip install -e ".[dev]"` succeeds on **Python 3.11.15** (I'd only built on 3.12), including asyncpg 0.31.0 and alembic 1.19.1.
 - [x] `scripts/validate_migrations.sh` is **executable in the checkout** — the `100755` mode survived, the step ran rather than dying on "permission denied".
 - [x] Both migrations applied to the fresh CI database and `alembic check` reported **"No new upgrade operations detected."** The whole job took 1m 1s.
-- [ ] The job **fails the PR** when a migration is bad. Still only proven locally (exit 255 on injected drift); I haven't watched GitHub turn that into a red check.
+- [x] The job **fails the PR** when a migration is bad. I pushed a commit adding a `drift_probe` column to the `Profile` model with no migration behind it, watched `validate-migrations` go red, then removed the commit from the branch. The log:
+
+      ```
+      INFO  [alembic.autogenerate.compare.tables] Detected added column 'profiles.drift_probe'
+      ERROR [alembic.util.messaging] New upgrade operations detected:
+        [('add_column', None, 'profiles', Column('drift_probe', String(length=50), table=<profiles>))]
+      ##[error]Process completed with exit code 255.
+      ```
+
+      Two things I checked in that run. The migrations still applied cleanly first, so the failure came from `alembic check` (drift) rather than a broken migration — the job tells those apart. And `lint`, `typecheck` and `test-unit` returned exactly the same numbers as before the drift: 182, 99, and 53/383. **Only `validate-migrations` changed state.** A well-typed column with no migration is invisible to ruff, black and mypy — the pre-commit hooks passed on that commit too. That gap is what this issue is filling.
+
 - [ ] `make check` / `make test-unit` run as the graders will run them (needs a populated `.venv`).
 
 **The overall run is red, but not because of my changes.** Five other jobs fail, and

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -79,15 +79,15 @@ With that decided, steps 1–4 of my PLAN.md are done:
 
 **Branch:** `feat/129-ci-migration-validation`
 
-> ⚠️ **DRAFT — do not submit as-is.** Everything below is written from local
-> verification only. The CI job has not run on GitHub Actions yet, so I can't
-> honestly claim it works there. Re-check every line once the Actions run is
-> green, then delete this note.
+> **Two blanks left before submitting:** the PR link above, and the peer-review
+> name at the bottom. Everything else in this entry is verified — the job has
+> run on GitHub Actions and been confirmed both green and red (see the CI
+> verification section below). Delete this note once those two are filled in.
 
 **What you built:**
 A `validate-migrations` CI job that runs every migration against a fresh, empty Postgres and then checks the resulting schema against the SQLAlchemy models, so drifted or broken migrations fail the PR instead of getting found by hand later. It also fixes the one piece of drift that was already in the repo: the `User` model now declares the `uq_users_email` constraint that migration 001 has been creating all along.
 
-[Once Actions has run: confirm the job appears in the PR checks, link the green run, and note how many attempts it took to get there.]
+The job passed on GitHub Actions on the first attempt — no fixing-the-Actions-run cycle, which I'd expected to need. I put that down to copying the Postgres service container and health check from the existing `test-integration` job rather than writing them from scratch, and to checking the YAML parsed before pushing. The one thing I did have to get right on my own was the asyncpg driver in `DATABASE_URL`; a sync URL fails in a confusing way because `alembic/env.py` builds an async engine, which is why the script guards against it.
 
 **Tests added or updated:**
 `tests/unit/test_migrations.py` (new, 8 tests). `TestMigrationChain` checks the revision chain statically — unique revision ids, exactly one head, exactly one base, every `down_revision` resolving to a real migration, and every migration defining both `upgrade()` and `downgrade()`. `TestModelMigrationParity` guards the drift fix from regressing by asserting the `User` model still declares `uq_users_email` and that `ix_users_email` is still unique.
@@ -96,12 +96,19 @@ I read the revision metadata with `ast` instead of importing the migration modul
 
 **Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
 
-[Not yet checked. The `.venv/` the Makefile expects is empty on my machine — my
-environment is the pyenv virtualenv `pathre` — so `make check` and `make
-test-unit` fail on a missing binary before running anything. I ran the
-underlying tools directly instead (see the table below). Before submitting:
-either populate `.venv` with `make setup` and run the real make targets, or say
-plainly in the PR that I ran the tools directly and how.]
+Both targets run. Output on this branch:
+
+```
+$ make check
+Found 182 errors.        # ruff
+make: *** [lint] Error 1
+
+$ make test-unit
+53 failed, 383 passed
+```
+
+The same 53 test ids fail on `main`, and `main` reports the same 182 ruff
+errors. See the comparison table below.
 
 **Pre-existing failures (per the Week 9 instructions):**
 This repo already fails its lint and unit-test checks on `main`, so I recorded a baseline before my changes and compared after. I ran the tools directly rather than through `make` (see above); these are the same commands the Makefile and CI invoke:

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -28,7 +28,7 @@ I wanted to work on a skill I have never done to challenge myself. I currently h
 **Reproduction commit link:** https://github.com/kelp-Shake/pathreview/commit/dcdfc6d8ecc50e45773baae34f567c2bb5b3bcfe
 
 **Reproduction summary:**
-I brought up the local stack (`colima start`, `docker compose up -d`) and ran the two migration commands against a fresh Postgres. `alembic upgrade head` applied all migrations cleanly, but `alembic check` failed with a drift error — it detected a `remove_constraint` operation for `uq_users_email`. That means the database built by the migrations has a unique constraint on `users.email` that the current `User` model no longer declares (the model only sets `unique=True, index=True`, which produces a unique index, not a named constraint). This is exactly the kind of drift issue #129's CI check is meant to catch automatically.
+I brought the local stack up (`colima start`, then `docker compose up -d`) and ran the two migration commands against a fresh Postgres. `alembic upgrade head` applied all the migrations fine, but `alembic check` failed with a drift error. It found a `remove_constraint` for `uq_users_email`, which means the database the migrations build has a unique constraint on `users.email` that the current `User` model doesn't declare anymore. The model just uses `unique=True, index=True`, which makes a unique index instead of a named constraint. This is the kind of drift that is the CI check is supposed to catch on its own.
 
 Reproduction steps and observed output:
 
@@ -45,7 +45,114 @@ ERROR [alembic.util.messaging] New upgrade operations detected: [('remove_constr
 
 **PLAN.md link:** https://github.com/kelp-Shake/pathreview/blob/feat/129-ci-migration-validation/PLAN.md
 
-**Walkthrough video (recommended):** N/A — not recorded (optional, not graded)
+**Walkthrough video (recommended):** N/A, not recorded (optional, not graded)
 
 **Blockers or open questions:**
-My main open question is how to resolve the existing `uq_users_email` drift — either update the `User` model to declare the constraint, or add a new migration that drops it. Both fix the drift, so I need to decide which one to use in Week 9 before the CI check can pass.
+My main open question is how to fix the existing `uq_users_email` drift. I can either update the `User` model to declare the constraint, or add a new migration that drops it. Both fix the drift, so I need to pick one in Week 9 before the CI check can pass.
+
+---
+
+## Week 9 — Solution building & PR submission
+
+### Check-in 1 (mid-week)
+
+**Current progress:**
+I answered the Week 8 open question first and went with updating the `User` model instead of adding a drop-constraint migration. The migration is what every existing database already has, so declaring `UniqueConstraint("email", name="uq_users_email")` in `__table_args__` makes the model match reality without changing anyone's schema. Adding a migration would have turned a CI-only PR into a data-layer one.
+
+With that decided, steps 1–4 of my PLAN.md are done:
+- `scripts/validate_migrations.sh`  runs `alembic upgrade head` then `alembic check` under `set -euo pipefail`, and refuses to run if `DATABASE_URL` is missing or isn't using the asyncpg driver (`alembic/env.py` builds an async engine, so a sync URL fails with a confusing error).
+- `validate-migrations` job in `.github/workflows/ci.yml` Postgres 16 service container copied from the existing `test-integration` job, pointed at its own empty `pathreview_migrations` database.
+- `tests/unit/test_migrations.py` 8 unit tests covering the parts of migration health that don't need a database.
+- Tested locally against the compose Postgres, including step 5's on-purpose drift check.
+
+**Next steps:**
+[Push the branch and get the Actions run green, open the draft PR, ask for peer review]
+
+**Blockers:**
+[Anything slowing you down? Or leave blank.]
+
+---
+
+### Check-in 2 (end of week)
+
+**PR link:** [link to your submitted pull request]
+
+**Branch:** `feat/129-ci-migration-validation`
+
+> ⚠️ **DRAFT — do not submit as-is.** Everything below is written from local
+> verification only. The CI job has not run on GitHub Actions yet, so I can't
+> honestly claim it works there. Re-check every line once the Actions run is
+> green, then delete this note.
+
+**What you built:**
+A `validate-migrations` CI job that runs every migration against a fresh, empty Postgres and then checks the resulting schema against the SQLAlchemy models, so drifted or broken migrations fail the PR instead of getting found by hand later. It also fixes the one piece of drift that was already in the repo: the `User` model now declares the `uq_users_email` constraint that migration 001 has been creating all along.
+
+[Once Actions has run: confirm the job appears in the PR checks, link the green run, and note how many attempts it took to get there.]
+
+**Tests added or updated:**
+`tests/unit/test_migrations.py` (new, 8 tests). `TestMigrationChain` checks the revision chain statically — unique revision ids, exactly one head, exactly one base, every `down_revision` resolving to a real migration, and every migration defining both `upgrade()` and `downgrade()`. `TestModelMigrationParity` guards the drift fix from regressing by asserting the `User` model still declares `uq_users_email` and that `ix_users_email` is still unique.
+
+I read the revision metadata with `ast` instead of importing the migration modules, because the repo has its own `alembic/` package directory that shadows the installed `alembic` once the repo root is on `sys.path` — so `from alembic import op` fails at pytest collection time.
+
+**Self-review confirmation:** [ ] make check passes  [ ] make test-unit passes
+
+[Not yet checked. The `.venv/` the Makefile expects is empty on my machine — my
+environment is the pyenv virtualenv `pathre` — so `make check` and `make
+test-unit` fail on a missing binary before running anything. I ran the
+underlying tools directly instead (see the table below). Before submitting:
+either populate `.venv` with `make setup` and run the real make targets, or say
+plainly in the PR that I ran the tools directly and how.]
+
+**Pre-existing failures (per the Week 9 instructions):**
+This repo already fails its lint and unit-test checks on `main`, so I recorded a baseline before my changes and compared after. I ran the tools directly rather than through `make` (see above); these are the same commands the Makefile and CI invoke:
+
+| Check | Baseline (unmodified) | With my changes |
+|---|---|---|
+| `ruff check .` | 182 errors | 182 errors (identical per-file) |
+| `black --check .` | 52 files | 52 files (identical) |
+| `mypy` | 1 error (numpy stub, local env) | same |
+| `pytest tests/unit -m unit` | 53 failed, 375 passed | 53 failed, 383 passed |
+
+The 53 failures are the same test ids before and after, and the +8 passing are my new tests. `ruff` and `black` are clean on the two files I touched. My changes introduce no new failures.
+
+**Draft PR feedback received from:** [name or Slack handle, or "none"]
+
+---
+
+### Verification notes
+
+**Scope:** everything below is the script run **by hand on my machine**, against the
+`docker compose` Postgres. It shows that the two Alembic commands behave correctly and
+that the drift fix is what makes them pass. It does **not** show that the GitHub Actions
+job works — that's still unverified (see the list at the end).
+
+```
+$ DATABASE_URL=postgresql+asyncpg://pathreview:pathreview@localhost:5433/pathreview_migrations \
+    ./scripts/validate_migrations.sh
+==> Applying all migrations to a fresh database
+INFO  [alembic.runtime.migration] Running upgrade  -> 001, Initial schema creation...
+INFO  [alembic.runtime.migration] Running upgrade 001 -> 002, Add error_message column to reviews table.
+==> Comparing the migrated schema against the models
+No new upgrade operations detected.
+==> Migrations apply cleanly and match the models
+```
+
+Then step 5 of my plan — confirming it actually goes red, not just green:
+
+1. **Without my model fix** (reverted `core/models/user.py`): fails with the same `remove_constraint uq_users_email` error from my Week 8 reproduction. So the fix is what makes the check pass.
+2. **With drift added on purpose** (a `fake_drift_column` on the `Profile` model with no migration): fails with `add_column ... fake_drift_column`, exit code 255, which is what fails the CI job. Reverted afterwards.
+3. **Guard clauses**: unset `DATABASE_URL` and a sync `postgresql://` URL both exit 1 with an explanatory message instead of a confusing async-engine traceback.
+
+---
+
+### Still unverified (must confirm before I submit)
+
+Local runs can't prove any of these. Each one is a way the Actions run could fail on
+the first push, which is the risk I already flagged in Week 7:
+
+- [ ] The workflow YAML parses and the `validate-migrations` job actually appears in the PR checks.
+- [ ] The Postgres **service container** comes up and the health check passes. Locally I used the already-running compose database on port 5433; CI starts its own on 5432. That port and the container wiring are untested.
+- [ ] `pip install -e ".[dev]"` succeeds on CI's **Python 3.11**. I ran everything on 3.12 locally, with newer versions of alembic, ruff and black than CI resolves.
+- [ ] `scripts/validate_migrations.sh` is **executable in the checkout**. It's `+x` on my machine, but if git records it as mode `100644` the step dies with "permission denied".
+- [ ] The job **fails the PR** when a migration is bad. I proved the script exits non-zero locally; I haven't seen GitHub turn that into a red check.
+- [ ] `make check` / `make test-unit` run as the graders will run them (needs a populated `.venv`).

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -145,14 +145,32 @@ Then step 5 of my plan — confirming it actually goes red, not just green:
 
 ---
 
-### Still unverified (must confirm before I submit)
+### CI verification (dry-run PR in my own fork)
 
-Local runs can't prove any of these. Each one is a way the Actions run could fail on
-the first push, which is the risk I already flagged in Week 7:
+Rather than find out on the real PR, I opened a PR from my branch into my own fork's
+`main`, which fires the identical workflow on GitHub's runners without touching
+upstream. Checking off the list of things local runs couldn't prove:
 
-- [ ] The workflow YAML parses and the `validate-migrations` job actually appears in the PR checks.
-- [ ] The Postgres **service container** comes up and the health check passes. Locally I used the already-running compose database on port 5433; CI starts its own on 5432. That port and the container wiring are untested.
-- [ ] `pip install -e ".[dev]"` succeeds on CI's **Python 3.11**. I ran everything on 3.12 locally, with newer versions of alembic, ruff and black than CI resolves.
-- [ ] `scripts/validate_migrations.sh` is **executable in the checkout**. It's `+x` on my machine, but if git records it as mode `100644` the step dies with "permission denied".
-- [ ] The job **fails the PR** when a migration is bad. I proved the script exits non-zero locally; I haven't seen GitHub turn that into a red check.
+- [x] The workflow YAML parses and `validate-migrations` appears in the checks list.
+- [x] The Postgres **service container** comes up and passes its health check (`postgres service is healthy` after ~6s). Locally I used the compose database on port 5433; CI started its own on 5432.
+- [x] `pip install -e ".[dev]"` succeeds on **Python 3.11.15** (I'd only built on 3.12), including asyncpg 0.31.0 and alembic 1.19.1.
+- [x] `scripts/validate_migrations.sh` is **executable in the checkout** — the `100755` mode survived, the step ran rather than dying on "permission denied".
+- [x] Both migrations applied to the fresh CI database and `alembic check` reported **"No new upgrade operations detected."** The whole job took 1m 1s.
+- [ ] The job **fails the PR** when a migration is bad. Still only proven locally (exit 255 on injected drift); I haven't watched GitHub turn that into a red check.
 - [ ] `make check` / `make test-unit` run as the graders will run them (needs a populated `.venv`).
+
+**The overall run is red, but not because of my changes.** Five other jobs fail, and
+I checked each log for my three files:
+
+| Job | Result | Mine? |
+|---|---|---|
+| `validate-migrations` | ✅ passed | — |
+| `lint` | ❌ 182 ruff errors | No — same 182 as my baseline, and neither `core/models/user.py` nor `tests/unit/test_migrations.py` appears anywhere in the output |
+| `typecheck` | ❌ 99 mypy errors in 25 files | No — `core/models/user.py` is not among them |
+| `test-unit` | ❌ 53 failed / 383 passed | No — exactly my baseline, and all 8 of my new tests **passed on CI** |
+| `test-integration` | ❌ exit code 5 | No — `collected 0 items`, "no tests ran"; the integration directory has no tests to run |
+| `frontend` | ❌ 2 suites | No — a missing `@testing-library/user-event` dependency and a `ReviewSection` assertion |
+
+This is the strongest version of the "no new failures" claim: not "it looks the same on
+my laptop" but "the same jobs fail in the same way on CI, and none of the failures name
+a file I touched."

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -79,10 +79,7 @@ With that decided, steps 1–4 of my PLAN.md are done:
 
 **Branch:** `feat/129-ci-migration-validation`
 
-> **Two blanks left before submitting:** the PR link above, and the peer-review
-> name at the bottom. Everything else in this entry is verified — the job has
-> run on GitHub Actions and been confirmed both green and red (see the CI
-> verification section below). Delete this note once those two are filled in.
+> **One blank left:** the PR link above. Delete this note once it's filled in.
 
 **What you built:**
 A `validate-migrations` CI job that runs every migration against a fresh, empty Postgres and then checks the resulting schema against the SQLAlchemy models, so drifted or broken migrations fail the PR instead of getting found by hand later. It also fixes the one piece of drift that was already in the repo: the `User` model now declares the `uq_users_email` constraint that migration 001 has been creating all along.
@@ -122,7 +119,7 @@ This repo already fails its lint and unit-test checks on `main`, so I recorded a
 
 The 53 failures are the same test ids before and after, and the +8 passing are my new tests. `ruff` and `black` are clean on the two files I touched. My changes introduce no new failures.
 
-**Draft PR feedback received from:** [name or Slack handle, or "none"]
+**Draft PR feedback received from:** none
 
 ---
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -75,11 +75,9 @@ With that decided, steps 1–4 of my PLAN.md are done:
 
 ### Check-in 2 (end of week)
 
-**PR link:** [link to your submitted pull request]
+**PR link:** https://github.com/ascherj/pathreview/pull/1034
 
 **Branch:** `feat/129-ci-migration-validation`
-
-> **One blank left:** the PR link above. Delete this note once it's filled in.
 
 **What you built:**
 A `validate-migrations` CI job that runs every migration against a fresh, empty Postgres and then checks the resulting schema against the SQLAlchemy models, so drifted or broken migrations fail the PR instead of getting found by hand later. It also fixes the one piece of drift that was already in the repo: the `User` model now declares the `uq_users_email` constraint that migration 001 has been creating all along.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,45 @@
+## Solution plan
+
+**Issue:** Add a database migration validation step to CI that checks all migrations can be applied cleanly — https://github.com/ascherj/pathreview/issues/129
+
+### Understand
+Right now the database migrations are only checked by hand before a PR is merged. Nothing in CI verifies that (a) all Alembic migrations apply cleanly on a fresh database, and (b) the schema they build still matches the SQLAlchemy models. Because there is no automated check, drift has already slipped in: migration `001_initial_schema.py` creates a unique constraint `uq_users_email` on `users.email`, but the current `User` model no longer declares that constraint — it only sets `unique=True, index=True`, which produces a unique index. So the migrations build one extra thing the model does not know about.
+
+- **Expected:** running the migrations from an empty database produces a schema that matches the models, and CI fails any PR where that is not true.
+- **Actual:** there is no CI enforcement, and running `alembic check` locally already fails with `remove_constraint uq_users_email` (see the reproduction in JOURNAL.md).
+
+### Map
+Files I expect to touch:
+- `.github/workflows/ci.yml` — add a new `validate-migrations` job.
+- `scripts/validate_migrations.sh` — new script that runs the two Alembic commands.
+- Resolve the existing drift in **one** of these:
+  - `core/models/user.py` — add the `uq_users_email` constraint to the model via `__table_args__`, **or**
+  - a new file in `alembic/versions/` — a migration that drops the redundant `uq_users_email` constraint.
+
+Files I need to read but not edit:
+- `alembic/env.py` — to confirm how Alembic reads the database URL.
+- `docker-compose.yml` and the existing `test-integration` job in `ci.yml` — the Postgres service-container pattern I will copy.
+
+### Plan
+1. Write `scripts/validate_migrations.sh` with `set -euo pipefail` that runs `alembic upgrade head` then `alembic check`.
+2. Add a `validate-migrations` job to `ci.yml`: a fresh Postgres service container (copied from `test-integration`), checkout, set up Python, install deps, set `DATABASE_URL`, and run the script.
+3. Resolve the existing `uq_users_email` drift so `alembic check` passes (decide between updating the model or adding a drop-constraint migration).
+4. Test locally — bring up the stack, run the script by hand, confirm `upgrade head` and `check` both pass.
+5. Push and iterate on the GitHub Actions run until it is green; then deliberately introduce a fake drift to confirm the job goes red, and revert it.
+
+### Inputs & outputs
+- **Input:** the repo's Alembic migrations and SQLAlchemy models, run against a fresh, empty Postgres provided by the CI service container (reached via `DATABASE_URL`).
+- **Output:** a CI job that exits `0` (green) when the migrations apply cleanly and match the models, and exits non-zero (red, blocking the PR) when a migration is broken or drifted. No production application code or runtime behavior changes.
+
+### Risks & unknowns
+- The existing `uq_users_email` drift means the check fails on day one, so resolving it is part of this PR — I need to pick the fix (model vs. new migration) without changing the actual email-uniqueness behavior.
+- I am new to GitHub Actions, so wiring the service container, `DATABASE_URL`, and the health check may take a few push-and-watch iterations (a common failure is "connection refused" if the job runs before Postgres is ready).
+- I need to confirm the script's `alembic` reads `DATABASE_URL` the same way the app does (through `alembic/env.py` / settings).
+- `alembic check` is confirmed available (Alembic 1.18.5), so no fallback is needed.
+
+### Edge cases
+- A migration that applies fine but drifts from the models (the current case) — `check` must catch it.
+- A migration that is broken and won't apply — `upgrade head` must fail and, via `set -e`, fail the whole job.
+- A fresh database with no prior state — migrations must run from base, not assume existing tables.
+- Future migrations added by other contributors — the job validates the full chain up to `head`, not a fixed revision.
+- Autogenerate blind spots — `alembic check` catches common drift but not 100% (some server-side defaults / check constraints), which is a known limitation to note.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,45 +1,49 @@
 ## Solution plan
 
-**Issue:** Add a database migration validation step to CI that checks all migrations can be applied cleanly — https://github.com/ascherj/pathreview/issues/129
+**Issue:** Add a database migration validation step to CI that checks all migrations can be applied cleanly (https://github.com/ascherj/pathreview/issues/129)
 
 ### Understand
-Right now the database migrations are only checked by hand before a PR is merged. Nothing in CI verifies that (a) all Alembic migrations apply cleanly on a fresh database, and (b) the schema they build still matches the SQLAlchemy models. Because there is no automated check, drift has already slipped in: migration `001_initial_schema.py` creates a unique constraint `uq_users_email` on `users.email`, but the current `User` model no longer declares that constraint — it only sets `unique=True, index=True`, which produces a unique index. So the migrations build one extra thing the model does not know about.
+Right now the migrations only get checked by hand before a PR is merged. Nothing in CI confirms that all the Alembic migrations apply cleanly on a fresh database, or that the schema they build still matches the SQLAlchemy models. Since there is no automated check, drift has already gotten in. Migration `001_initial_schema.py` creates a unique constraint called `uq_users_email` on `users.email`, but the current `User` model doesn't declare that constraint anymore. It only sets `unique=True, index=True`, which makes a unique index instead. So the migrations build one extra thing the model doesn't know about.
 
-- **Expected:** running the migrations from an empty database produces a schema that matches the models, and CI fails any PR where that is not true.
-- **Actual:** there is no CI enforcement, and running `alembic check` locally already fails with `remove_constraint uq_users_email` (see the reproduction in JOURNAL.md).
+The behavior I want: running the migrations from an empty database gives a schema that matches the models, and CI fails any PR where that isn't true. What actually happens: there is no CI check, and running `alembic check` locally already fails with a `remove_constraint uq_users_email` error (the reproduction is in JOURNAL.md).
 
 ### Map
-Files I expect to touch:
-- `.github/workflows/ci.yml` — add a new `validate-migrations` job.
-- `scripts/validate_migrations.sh` — new script that runs the two Alembic commands.
-- Resolve the existing drift in **one** of these:
-  - `core/models/user.py` — add the `uq_users_email` constraint to the model via `__table_args__`, **or**
-  - a new file in `alembic/versions/` — a migration that drops the redundant `uq_users_email` constraint.
+Files I expect to change:
+- `.github/workflows/ci.yml`, to add a new `validate-migrations` job.
+- `scripts/validate_migrations.sh`, a new script that runs the two Alembic commands.
+- To fix the existing drift, one of these two: `core/models/user.py` (add the `uq_users_email` constraint back to the model with `__table_args__`), or a new file in `alembic/versions/` (a migration that drops the redundant constraint).
 
-Files I need to read but not edit:
-- `alembic/env.py` — to confirm how Alembic reads the database URL.
-- `docker-compose.yml` and the existing `test-integration` job in `ci.yml` — the Postgres service-container pattern I will copy.
+Files I need to read but not change:
+- `alembic/env.py`, to see how Alembic gets the database URL.
+- `docker-compose.yml` and the existing `test-integration` job in `ci.yml`, since I'm copying their Postgres service container setup.
 
 ### Plan
-1. Write `scripts/validate_migrations.sh` with `set -euo pipefail` that runs `alembic upgrade head` then `alembic check`.
-2. Add a `validate-migrations` job to `ci.yml`: a fresh Postgres service container (copied from `test-integration`), checkout, set up Python, install deps, set `DATABASE_URL`, and run the script.
-3. Resolve the existing `uq_users_email` drift so `alembic check` passes (decide between updating the model or adding a drop-constraint migration).
-4. Test locally — bring up the stack, run the script by hand, confirm `upgrade head` and `check` both pass.
-5. Push and iterate on the GitHub Actions run until it is green; then deliberately introduce a fake drift to confirm the job goes red, and revert it.
+1. Write `scripts/validate_migrations.sh` with `set -euo pipefail` so it runs `alembic upgrade head` and then `alembic check`.
+2. Add a `validate-migrations` job to `ci.yml`. It starts a fresh Postgres service container (copied from `test-integration`), checks out the code, sets up Python, installs the deps, sets `DATABASE_URL`, and runs the script.
+3. Fix the existing `uq_users_email` drift so `alembic check` passes. I still need to decide between updating the model or adding a drop-constraint migration.
+4. Test it locally first. Bring up the stack, run the script by hand, and make sure both commands pass.
+5. Push it and keep fixing the Actions run until it's green. Then add a fake drift on purpose to confirm the job goes red, and undo it.
 
 ### Inputs & outputs
-- **Input:** the repo's Alembic migrations and SQLAlchemy models, run against a fresh, empty Postgres provided by the CI service container (reached via `DATABASE_URL`).
-- **Output:** a CI job that exits `0` (green) when the migrations apply cleanly and match the models, and exits non-zero (red, blocking the PR) when a migration is broken or drifted. No production application code or runtime behavior changes.
+Input: the repo's Alembic migrations and SQLAlchemy models, run against a fresh empty Postgres that the CI service container provides. Alembic reaches it through `DATABASE_URL`.
+
+Output: a CI job that passes when the migrations apply cleanly and match the models, and fails (blocking the PR) when a migration is broken or drifted. It doesn't change any of the actual app code or how the app behaves.
 
 ### Risks & unknowns
-- The existing `uq_users_email` drift means the check fails on day one, so resolving it is part of this PR — I need to pick the fix (model vs. new migration) without changing the actual email-uniqueness behavior.
-- I am new to GitHub Actions, so wiring the service container, `DATABASE_URL`, and the health check may take a few push-and-watch iterations (a common failure is "connection refused" if the job runs before Postgres is ready).
-- I need to confirm the script's `alembic` reads `DATABASE_URL` the same way the app does (through `alembic/env.py` / settings).
-- `alembic check` is confirmed available (Alembic 1.18.5), so no fallback is needed.
+- The existing `uq_users_email` drift means the check fails right away, so fixing it is part of this PR. I have to pick the fix without changing how email uniqueness actually works.
+- I've never used GitHub Actions, so getting the service container, `DATABASE_URL`, and health check wired up will probably take a few tries. 
+- I need to confirm the `alembic` in the script reads `DATABASE_URL` the same way the app does, through `alembic/env.py`.
+- I already checked that `alembic check` exists in this project (Alembic 1.18.5), so I don't need a fallback.
 
 ### Edge cases
-- A migration that applies fine but drifts from the models (the current case) — `check` must catch it.
-- A migration that is broken and won't apply — `upgrade head` must fail and, via `set -e`, fail the whole job.
-- A fresh database with no prior state — migrations must run from base, not assume existing tables.
-- Future migrations added by other contributors — the job validates the full chain up to `head`, not a fixed revision.
-- Autogenerate blind spots — `alembic check` catches common drift but not 100% (some server-side defaults / check constraints), which is a known limitation to note.
+- A migration that applies fine but drifts from the models (what's happening now). The check has to catch it.
+- A migration that's broken and won't apply. `upgrade head` has to fail, and `set -e` makes the whole job fail.
+- A fresh database with nothing in it. The migrations have to run from the start, not assume the tables already exist.
+- New migrations that other people add later. The job runs the whole chain up to `head`, not a fixed revision.
+- Things autogenerate can miss, like some server defaults or check constraints. `alembic check` catches the common drift but not everything, which is worth knowing.
+
+### Update (Week 9)
+
+Step 3 decided: I updated the `User` model rather than adding a drop-constraint migration. The migration is what every existing database already has, so declaring the constraint in `__table_args__` matches reality without changing anyone's schema, and keeps this a CI-only PR.
+
+One thing I didn't plan for: the repo has its own `alembic/` package directory, which shadows the installed `alembic` when the repo root is on `sys.path`. That doesn't affect the script or the CI job (the `alembic` CLI is fine), but it meant my unit tests had to read the migration files with `ast` instead of importing them.

--- a/PLAN.md
+++ b/PLAN.md
@@ -42,8 +42,26 @@ Output: a CI job that passes when the migrations apply cleanly and match the mod
 - New migrations that other people add later. The job runs the whole chain up to `head`, not a fixed revision.
 - Things autogenerate can miss, like some server defaults or check constraints. `alembic check` catches the common drift but not everything, which is worth knowing.
 
-### Update (Week 9)
+### Update (Week 9) — Step 3 decision
 
-Step 3 decided: I updated the `User` model rather than adding a drop-constraint migration. The migration is what every existing database already has, so declaring the constraint in `__table_args__` matches reality without changing anyone's schema, and keeps this a CI-only PR.
+Week 8 feedback pointed out that I left step 3 as an open question instead of committing to a direction. Writing it up properly as a decision:
 
-One thing I didn't plan for: the repo has its own `alembic/` package directory, which shadows the installed `alembic` when the repo root is on `sys.path`. That doesn't affect the script or the CI job (the `alembic` CLI is fine), but it meant my unit tests had to read the migration files with `ast` instead of importing them.
+**The two options:**
+
+| | Update the model | Add a drop-constraint migration |
+|---|---|---|
+| What it does | Declares `uq_users_email` in `__table_args__` so the model matches what migration 001 builds | Adds a migration dropping the constraint so the database matches the current model |
+| Effect on existing databases | None — the constraint is already there | Real schema change, runs against production data |
+| Effect on email uniqueness | Unchanged; the column's `unique=True, index=True` still makes a unique index | Unchanged, for the same reason |
+| Cost | One slightly redundant declaration (constraint *and* unique index) | A migration to review, plus a rollback path |
+| Scope | Keeps this a CI-only PR | Turns a CI PR into a data-layer PR |
+
+**Decision: update the model.** The constraint already exists in every database the migrations have touched, so declaring it makes the model describe reality. The alternative changes real schemas to satisfy a check I'm adding in the same PR, which is a lot of blast radius for a tooling change. Reviewers looking at a CI issue won't be expecting a production schema change, and the smallest honest fix keeps the diff on topic.
+
+**What would make me revisit it:** if a reviewer says the redundancy (a named unique constraint plus a unique index on the same column) is worse than the migration, I'd switch — the fix is roughly the same size either way, and they know the deployment story better than I do. I'd also revisit if it turned out some environment had the migrations applied *without* the constraint, since then the model would be describing something that isn't universally true.
+
+**Trade-off I'm accepting:** Postgres now has two overlapping guarantees on `users.email`. That's mild redundancy, not a correctness problem, and it's the state the database has been in the whole time — I'm making the model honest about it rather than introducing it.
+
+### Update (Week 9) — unplanned discovery
+
+The repo has its own `alembic/` package directory, which shadows the installed `alembic` when the repo root is on `sys.path`. That doesn't affect the script or the CI job (the `alembic` CLI is fine), but it meant my unit tests had to read the migration files with `ast` instead of importing them.

--- a/core/models/user.py
+++ b/core/models/user.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING
 from uuid import uuid4
 
-from sqlalchemy import Boolean, DateTime, Index, String
+from sqlalchemy import Boolean, DateTime, Index, String, UniqueConstraint
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -37,7 +37,12 @@ class User(Base):
         "Profile", back_populates="user", cascade="all, delete-orphan"
     )
 
-    __table_args__ = (Index("ix_users_email_active", "email", "is_active"),)
+    # uq_users_email is created by migration 001 and must stay declared here, or
+    # `alembic check` reports drift and tries to autogenerate a remove_constraint.
+    __table_args__ = (
+        UniqueConstraint("email", name="uq_users_email"),
+        Index("ix_users_email_active", "email", "is_active"),
+    )
 
     def __repr__(self) -> str:
         return f"<User(id={self.id}, email={self.email})>"

--- a/scripts/validate_migrations.sh
+++ b/scripts/validate_migrations.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# Validate that the Alembic migrations are healthy.
+#
+# Two checks, in order:
+#   1. `alembic upgrade head` — every migration applies cleanly to an empty
+#      database, so a broken or out-of-order revision fails here.
+#   2. `alembic check` — the schema the migrations just built matches the
+#      SQLAlchemy models, so model changes that never got a migration fail here.
+#
+# Expects DATABASE_URL to point at an EMPTY database using the asyncpg driver,
+# e.g. postgresql+asyncpg://user:pass@localhost:5432/pathreview_test — that is
+# the form alembic/env.py hands to create_async_engine via core.config.settings.
+#
+# Usage: DATABASE_URL=postgresql+asyncpg://... ./scripts/validate_migrations.sh
+
+set -euo pipefail
+
+if [[ -z "${DATABASE_URL:-}" ]]; then
+    echo "ERROR: DATABASE_URL is not set." >&2
+    echo "Point it at an empty database, e.g." >&2
+    echo "  DATABASE_URL=postgresql+asyncpg://pathreview:pathreview@localhost:5432/pathreview_test" >&2
+    exit 1
+fi
+
+if [[ "${DATABASE_URL}" != *"+asyncpg"* ]]; then
+    echo "ERROR: DATABASE_URL must use the asyncpg driver (postgresql+asyncpg://...)." >&2
+    echo "  alembic/env.py builds an async engine and will fail on a sync URL." >&2
+    echo "  Got: ${DATABASE_URL}" >&2
+    exit 1
+fi
+
+echo "==> Applying all migrations to a fresh database"
+alembic upgrade head
+
+echo "==> Comparing the migrated schema against the models"
+alembic check
+
+echo "==> Migrations apply cleanly and match the models"

--- a/tests/unit/test_migrations.py
+++ b/tests/unit/test_migrations.py
@@ -1,0 +1,151 @@
+"""Tests for the Alembic migration chain and model/migration parity.
+
+These cover the parts of migration health that can be checked without a
+database. The parts that need a real database — that every migration applies
+to an empty schema, and that the resulting schema matches the models — are
+covered by `scripts/validate_migrations.sh` in the `validate-migrations` CI job.
+
+The revision metadata is read with `ast` rather than by importing the migration
+modules: the repo ships its own `alembic/` package directory, which shadows the
+installed `alembic` distribution once the repo root is on `sys.path` (as it is
+under pytest), so `from alembic import op` fails at collection time.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+from sqlalchemy import UniqueConstraint
+
+from core.models import Base
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+VERSIONS_DIR = REPO_ROOT / "alembic" / "versions"
+
+
+class Migration:
+    """The revision metadata of a single Alembic migration file."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.module = ast.parse(path.read_text())
+        self.revision = self._assigned_value("revision")
+        self.down_revision = self._assigned_value("down_revision")
+        self.functions = {
+            node.name for node in self.module.body if isinstance(node, ast.FunctionDef)
+        }
+
+    def _assigned_value(self, name: str) -> str | None:
+        """Return the literal assigned to a module-level name, or None."""
+        for node in self.module.body:
+            if isinstance(node, ast.Assign) and any(
+                isinstance(target, ast.Name) and target.id == name for target in node.targets
+            ):
+                value = ast.literal_eval(node.value)
+                return None if value is None else str(value)
+        return None
+
+    def __repr__(self) -> str:
+        return f"<Migration {self.path.name} revision={self.revision}>"
+
+
+def load_migrations() -> list[Migration]:
+    """Load every migration in alembic/versions/, ignoring package files."""
+    return [
+        Migration(path)
+        for path in sorted(VERSIONS_DIR.glob("*.py"))
+        if not path.name.startswith("__")
+    ]
+
+
+@pytest.mark.unit
+class TestMigrationChain:
+    """Test suite for the structure of the Alembic revision chain."""
+
+    def test_migrations_are_present(self) -> None:
+        """Test the versions directory actually contains migrations.
+
+        Guards the rest of this suite from passing vacuously if the glob
+        stops matching.
+        """
+        assert load_migrations()
+
+    def test_revision_ids_are_unique(self) -> None:
+        """Test no two migrations claim the same revision id."""
+        revisions = [migration.revision for migration in load_migrations()]
+
+        assert len(revisions) == len(set(revisions)), f"duplicate revisions in {revisions}"
+
+    def test_single_head(self) -> None:
+        """Test exactly one migration is a head.
+
+        A head is a revision no other migration points back to. Two heads mean
+        two branches were never merged, and `alembic upgrade head` fails with
+        an ambiguous-head error.
+        """
+        migrations = load_migrations()
+        pointed_at = {migration.down_revision for migration in migrations}
+        heads = [
+            migration.revision for migration in migrations if migration.revision not in pointed_at
+        ]
+
+        assert len(heads) == 1, f"expected one head, found {heads}"
+
+    def test_single_base(self) -> None:
+        """Test exactly one migration starts the chain with down_revision = None."""
+        bases = [
+            migration.revision for migration in load_migrations() if migration.down_revision is None
+        ]
+
+        assert len(bases) == 1, f"expected one base revision, found {bases}"
+
+    def test_every_down_revision_resolves(self) -> None:
+        """Test each down_revision names a migration that exists.
+
+        A dangling down_revision breaks `alembic upgrade head` with a
+        "can't locate revision" error.
+        """
+        migrations = load_migrations()
+        known = {migration.revision for migration in migrations}
+
+        for migration in migrations:
+            if migration.down_revision is not None:
+                assert (
+                    migration.down_revision in known
+                ), f"{migration.path.name} points at unknown revision {migration.down_revision}"
+
+    def test_every_revision_has_upgrade_and_downgrade(self) -> None:
+        """Test each migration defines both upgrade() and downgrade()."""
+        for migration in load_migrations():
+            assert "upgrade" in migration.functions, f"{migration.path.name}: no upgrade()"
+            assert "downgrade" in migration.functions, f"{migration.path.name}: no downgrade()"
+
+
+@pytest.mark.unit
+class TestModelMigrationParity:
+    """Test suite for model declarations that the migrations depend on."""
+
+    def test_user_model_declares_uq_users_email(self) -> None:
+        """Test the User model declares the uq_users_email constraint.
+
+        Migration 001 creates this constraint. When the model doesn't declare
+        it, `alembic check` sees drift and autogenerates a remove_constraint —
+        the drift this issue's CI job exists to catch.
+        """
+        users = Base.metadata.tables["users"]
+
+        unique_constraints = {
+            constraint.name
+            for constraint in users.constraints
+            if isinstance(constraint, UniqueConstraint)
+        }
+
+        assert "uq_users_email" in unique_constraints
+
+    def test_user_email_index_is_unique(self) -> None:
+        """Test ix_users_email stays a unique index, as migration 001 creates it."""
+        users = Base.metadata.tables["users"]
+
+        email_index = next(index for index in users.indexes if index.name == "ix_users_email")
+
+        assert email_index.unique is True


### PR DESCRIPTION
## Summary

There was no automated check that the Alembic migrations still apply cleanly or that the schema they build matches the SQLAlchemy models, so drift could reach `main` unnoticed — and it already had. This adds a `validate-migrations` CI job that applies every migration to a fresh, empty Postgres and then compares the result against the models, failing the PR when a migration is broken or has drifted. It also fixes the one piece of drift that was already present, so the new check passes on `main`.

## Issue

Closes #129

## Changes

- **`core/models/user.py`** — declare `UniqueConstraint("email", name="uq_users_email")` in `__table_args__`. Migration 001 has always created this constraint, but the model only set `unique=True, index=True`, which produces a unique *index* instead. The constraint existed in every migrated database while being absent from the model metadata, so `alembic check` reported drift. This changes no database state — the constraint already exists wherever the migrations have run. I chose this over a drop-constraint migration deliberately: it keeps a CI-scoped PR from becoming a schema change against live data.
- **`scripts/validate_migrations.sh`** (new) — runs `alembic upgrade head` then `alembic check` under `set -euo pipefail`. It requires `DATABASE_URL` to use the asyncpg driver, because `alembic/env.py` builds an async engine and a sync URL otherwise fails with an unhelpful traceback.
- **`.github/workflows/ci.yml`** — new `validate-migrations` job with a Postgres 16 service container (health check and setup copied from the existing `test-integration` job), pointed at its own empty `pathreview_migrations` database.
- **`tests/unit/test_migrations.py`** (new, 8 tests) — the parts of migration health that don't need a database.

## Testing

- [x] New/updated tests cover the changes
- [ ] Unit tests pass (`make test-unit`) — 53 failures, all pre-existing; see below
- [ ] Integration tests pass (`make test-integration`) — not run
- [ ] Linter passes (`make lint`) — 182 errors, all pre-existing; clean on both files I touched
- [ ] Type checker passes (`make typecheck`) — 99 errors, all pre-existing; none in files I touched

Verified locally against a `docker compose` Postgres, using a scratch database:

```
$ DATABASE_URL=postgresql+asyncpg://...  ./scripts/validate_migrations.sh
==> Applying all migrations to a fresh database
==> Comparing the migrated schema against the models
No new upgrade operations detected.
==> Migrations apply cleanly and match the models
```

I also confirmed the check goes red, not just green:

1. **Without the model fix**, it fails with `remove_constraint uq_users_email` — the original drift, so the fix is what makes it pass.
2. **With drift added on purpose** (an extra column on the `Profile` model and no migration), it fails with `add_column ... ` and exits non-zero, which is what fails the job. Reverted afterwards.
3. **Guard clauses**: an unset `DATABASE_URL` and a sync `postgresql://` URL both exit 1 with an explanatory message.

### Pre-existing failures

This branch does not make `make check` or `make test-unit` green, because they aren't green on `main`. I recorded a baseline before my changes and compared after:

| Check | `main` (unmodified) | This branch |
|---|---|---|
| `ruff check .` | 182 errors | 182 errors, identical per file |
| `black --check .` | 52 files | 52 files, identical |
| `pytest tests/unit -m unit` | 53 failed, 375 passed | 53 failed, 383 passed |

The 53 failures are the same test ids before and after, and the 8 additional passes are the new tests. `ruff` and `black` are clean on both files I touched. **These changes introduce no new failures.**

These numbers line up with CI: the `lint` job reports the same **182 ruff errors**, and `test-unit` reports the same **53 failed / 383 passed**. None of the `lint` or `typecheck` output names `core/models/user.py` or `tests/unit/test_migrations.py`. The pinned pre-commit hooks (ruff, black, mypy) also pass on every commit in this branch.

### CI status

I ran the workflow before opening this PR, via a dry-run PR into my own fork, and `validate-migrations` **passes** — service container healthy, `pip install -e ".[dev]"` fine on Python 3.11.15, the script executable in the checkout, both migrations applied and `alembic check` clean, 1m 1s total.

I also confirmed it **fails** on CI, not just locally. I pushed a commit adding a column to the `Profile` model with no migration behind it, and the job went red:

```
INFO  [alembic.autogenerate.compare.tables] Detected added column 'profiles.drift_probe'
ERROR [alembic.util.messaging] New upgrade operations detected:
  [('add_column', None, 'profiles', Column('drift_probe', String(length=50), table=<profiles>))]
##[error]Process completed with exit code 255.
```

Two things that run confirms: the migrations still applied cleanly first, so the failure came from `alembic check` rather than a broken migration — the job distinguishes the two. And `lint`, `typecheck` and `test-unit` returned identical numbers with that column present, as did the pre-commit hooks. A well-typed column with no migration behind it is invisible to ruff, black and mypy; only this check sees it. That commit is not part of this branch.

The other five jobs fail, all of them pre-existing:

| Job | Result |
|---|---|
| `validate-migrations` | passes |
| `lint` | 182 ruff errors, unchanged from `main` |
| `typecheck` | 99 mypy errors across 25 files, none in files I touched |
| `test-unit` | 53 failed / 383 passed — the same 53 ids as `main`, plus my 8 new passes |
| `test-integration` | exits 5, `collected 0 items` — no tests present to run |
| `frontend` | missing `@testing-library/user-event`, plus a `ReviewSection` assertion |

Happy to open separate issues for any of these if that's useful — I left them alone to keep this PR scoped to #129.

## Screenshots / Demo

N/A

## Notes for Reviewers

- **The `uq_users_email` fix is the judgement call here.** Updating the model matches what deployed databases already contain; the alternative was a migration dropping the constraint. I went with the model change to avoid a schema change on live data in a CI-focused PR, but I'd happily switch if you'd rather the constraint go away — the column's `unique=True` already provides a unique index.
- **`alembic check` doesn't catch everything.** It reliably catches added/removed tables, columns, indexes and constraints, but can miss some server defaults and check constraints. It's a large improvement over no check at all, not a guarantee of perfect parity.
- **The new tests read migration metadata with `ast` instead of importing the modules.** The repo ships its own `alembic/` package directory, which shadows the installed `alembic` distribution once the repo root is on `sys.path` — as it is under pytest — so `from alembic import op` raises at collection time. Importing the migrations would have been the natural approach; this is the workaround. Happy to revisit if you'd prefer that shadowing addressed separately.
