### PR TITLE
fix: Health check Redis probe uses redis_url from Settings

### DIFF
--- a/api/routes/health.py
+++ b/api/routes/health.py
@@ -41,12 +41,8 @@ async def health_check(db=Depends(get_db)):
         import redis
         from core.config import settings
 
-        r = redis.Redis(
-            host=settings.redis_host,
-            port=settings.redis_port,
-            db=0,
-            decode_responses=True,
-        )
+        # Settings exposes redis_url (not redis_host/port).
+        r = redis.Redis.from_url(settings.redis_url, decode_responses=True)
         r.ping()
         health_status["dependencies"]["redis"] = "healthy"
         log.debug("redis_health_check_passed")


### PR DESCRIPTION
## Summary

Health check Redis probe uses redis_url from Settings

## Changes

- health Redis probe uses settings.redis_url via from_url

Fixes #155
